### PR TITLE
fix: resolve clippy warnings and add CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,18 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-clippy-
       - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+      - run: cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add clippy
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-
+      - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ Do not smuggle provider-specific behavior into `loon-core`.
 
 ## 8. Commit style
 
+Always use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (e.g. `fix:`, `feat:`, `refactor:`, `test:`, `docs:`, `chore:`). Scope is optional but encouraged when the change is confined to a single crate (e.g. `fix(loon-client):`, `refactor(loon-macos):`).
+
 Prefer small commits. Good commit shapes:
 
 - one spec + one fixture + one model change

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -689,6 +689,7 @@ fn write_demo_local_fs_config_with_paths(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_demo_local_fs_config_with_spec(
     base_dir: &Path,
     object_store_root: PathBuf,

--- a/crates/loon-client/src/local_fs/events.rs
+++ b/crates/loon-client/src/local_fs/events.rs
@@ -345,7 +345,7 @@ fn reduce_explicit_renames(
         if targets.len() > 1 {
             return Err(FsEventReductionError::AmbiguousRenameSource {
                 affected_relative_paths: vec![source.clone()],
-                suggested_subtree_roots: suggested_subtree_roots(&[source.clone()]),
+                suggested_subtree_roots: suggested_subtree_roots(std::slice::from_ref(source)),
             });
         }
     }
@@ -353,7 +353,7 @@ fn reduce_explicit_renames(
         if sources.len() > 1 {
             return Err(FsEventReductionError::AmbiguousRenameTarget {
                 affected_relative_paths: vec![target.clone()],
-                suggested_subtree_roots: suggested_subtree_roots(&[target.clone()]),
+                suggested_subtree_roots: suggested_subtree_roots(std::slice::from_ref(target)),
             });
         }
     }

--- a/crates/loon-client/src/local_fs/observe.rs
+++ b/crates/loon-client/src/local_fs/observe.rs
@@ -1051,10 +1051,7 @@ fn build_subtree_operations(
         &unmatched_present_dir_paths,
         &missing_tracked_dirs,
     )?;
-    let paired_directory_source_roots = directory_pairings
-        .keys()
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    let paired_directory_source_roots = directory_pairings.keys().cloned().collect::<BTreeSet<_>>();
     let paired_directory_target_roots = directory_pairings
         .values()
         .cloned()

--- a/crates/loon-client/src/local_fs/observe.rs
+++ b/crates/loon-client/src/local_fs/observe.rs
@@ -1052,8 +1052,8 @@ fn build_subtree_operations(
         &missing_tracked_dirs,
     )?;
     let paired_directory_source_roots = directory_pairings
-        .iter()
-        .map(|(source_relative_path, _)| source_relative_path.clone())
+        .keys()
+        .cloned()
         .collect::<BTreeSet<_>>();
     let paired_directory_target_roots = directory_pairings
         .values()

--- a/crates/loon-client/src/provider.rs
+++ b/crates/loon-client/src/provider.rs
@@ -189,20 +189,17 @@ pub fn materialize_inode_to_mirror_root<S: ObjectStore>(
         }
         PlannerDecision::DownloadRemoteEdit => {
             let mut applied_at_ms = now_ms;
-            loop {
-                match execute_download_remote_edit_to_path(
+            while let DownloadRemoteEditExecution::Progressed(_) =
+                execute_download_remote_edit_to_path(
                     db,
                     store,
                     namespace_id,
                     inode_id,
                     &absolute_path,
                     applied_at_ms,
-                )? {
-                    DownloadRemoteEditExecution::Progressed(_) => {
-                        applied_at_ms = applied_at_ms.saturating_add(1);
-                    }
-                    DownloadRemoteEditExecution::Completed(_) => break,
-                }
+                )?
+            {
+                applied_at_ms = applied_at_ms.saturating_add(1);
             }
         }
         _ => {}

--- a/crates/loon-client/src/state_db/txn.rs
+++ b/crates/loon-client/src/state_db/txn.rs
@@ -453,6 +453,7 @@ impl SqliteStateDb {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn observe_local_only_move_and_plan(
         &mut self,
         client_file_id: &ClientFileId,

--- a/crates/loon-client/tests/client_crash_restart_hardening.rs
+++ b/crates/loon-client/tests/client_crash_restart_hardening.rs
@@ -39,6 +39,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn dispatch_retry_reuses_pending_request_after_crash_after_response() {
     let namespace_id = NamespaceId::new("ns-1");
     let client_file_id = ClientFileId::new("temp-dir-1");
@@ -239,6 +240,7 @@ fn apply_remote_rename_retry_accepts_already_applied_winner() {
 }
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn download_remote_edit_retry_accepts_already_applied_winner() {
     let namespace_id = NamespaceId::new("ns-1");
     let fixture = ClientCrashFixture::new("crash-download-remote-edit");
@@ -377,6 +379,7 @@ fn download_remote_edit_retry_accepts_already_applied_winner() {
 }
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn same_inode_conflict_retry_reuses_existing_artifact_after_store_write_crash() {
     let namespace_id = NamespaceId::new("ns-1");
     let fixture = ClientCrashFixture::new("crash-conflict-artifact-after-store-write");
@@ -517,6 +520,7 @@ fn same_inode_conflict_retry_reuses_existing_artifact_after_store_write_crash() 
 }
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn archive_retry_reconciles_sidecar_after_store_write_crash() {
     let namespace_id = NamespaceId::new("ns-1");
     let fixture = ClientCrashFixture::new("crash-archive-after-store-write");
@@ -581,6 +585,7 @@ fn archive_retry_reconciles_sidecar_after_store_write_crash() {
 }
 
 #[test]
+#[allow(clippy::result_large_err)]
 fn subtree_restore_retry_is_absent_or_complete_after_stage_ready_crash() {
     let namespace_id = NamespaceId::new("ns-1");
     let fixture = ClientCrashFixture::new("crash-subtree-restore-stage");

--- a/crates/loon-client/tests/client_execute_next_client_action.rs
+++ b/crates/loon-client/tests/client_execute_next_client_action.rs
@@ -875,6 +875,7 @@ fn run_execute_next_client_action(
     .expect("execute next client action")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_execute_next_until_idle(
     db_path: &Path,
     store: &LocalFsStore,

--- a/crates/loon-macos/src/lib.rs
+++ b/crates/loon-macos/src/lib.rs
@@ -215,7 +215,6 @@ impl FileProviderBridge {
                 .config
                 .exposed_namespaces
                 .iter()
-                .cloned()
                 .map(|namespace_id| ProviderItemSnapshot {
                     item_id: ProviderItemId::NamespaceRoot {
                         namespace_id: namespace_id.clone(),
@@ -845,8 +844,14 @@ pub extern "C" fn loon_file_provider_bridge_materialize_item(
     ffi_call(request_json, interop_materialize_item)
 }
 
+/// Frees a string previously returned by a `loon_file_provider_*` FFI function.
+///
+/// # Safety
+///
+/// `value` must be a pointer returned by a `loon_file_provider_*` function in this library
+/// (i.e. produced via `CString::into_raw`), and it must not have been freed before.
 #[no_mangle]
-pub extern "C" fn loon_file_provider_string_free(value: *mut c_char) {
+pub unsafe extern "C" fn loon_file_provider_string_free(value: *mut c_char) {
     if value.is_null() {
         return;
     }

--- a/crates/loon-macos/tests/file_provider_bridge.rs
+++ b/crates/loon-macos/tests/file_provider_bridge.rs
@@ -513,7 +513,9 @@ fn ffi_response_json(response_ptr: *mut c_char) -> serde_json::Value {
         .to_str()
         .expect("response should be valid UTF-8")
         .to_owned();
-    loon_file_provider_string_free(response_ptr);
+    // SAFETY: `response_ptr` was returned by a `loon_file_provider_*` FFI call and has not been
+    // freed yet.
+    unsafe { loon_file_provider_string_free(response_ptr) };
     serde_json::from_str(&response_json).expect("response should be valid JSON")
 }
 

--- a/crates/loon-testkit/src/invariants.rs
+++ b/crates/loon-testkit/src/invariants.rs
@@ -3799,8 +3799,7 @@ fn check_create_mutation_consumes_next_inode_id(
     });
     let expected_next = initial_next_inode_id
         .0
-        .checked_add(create_ids.len() as u64)
-        .unwrap_or(u64::MAX);
+        .saturating_add(create_ids.len() as u64);
 
     InvariantCheck {
         name: "create_mutation_consumes_next_inode_id".to_owned(),

--- a/crates/loon-testkit/tests/common/queue_scheduler_support.rs
+++ b/crates/loon-testkit/tests/common/queue_scheduler_support.rs
@@ -113,8 +113,7 @@ pub fn run_queue_scenario_report(
         let mut observed_invariants = Vec::new();
         let mut saw_stolen_claim = false;
 
-        if initial.progress.is_some() {
-            let progress = initial.progress.as_ref().expect("progress should exist");
+        if let Some(progress) = initial.progress.as_ref() {
             let progress_report =
                 evaluate_progress_publish_invariants(ProgressPublishInvariantInputs {
                     expected_namespace: &progress.payload.namespace_id,


### PR DESCRIPTION
Resolve all clippy warnings and errors across all crates, and add GitHub Actions CI checks (rustfmt, clippy, tests) for PRs and pushes to main.

## Changes

**loon-macos/src/lib.rs:**
- Marked `loon_file_provider_string_free` as `unsafe extern "C"` and added `# Safety` doc
- Removed redundant `.cloned()` on the namespace iterator

**loon-macos/tests/file_provider_bridge.rs:**
- Wrapped the `loon_file_provider_string_free` call in an `unsafe` block

**loon-client/src/local_fs/events.rs:**
- Replaced `&[source.clone()]` / `&[target.clone()]` with `std::slice::from_ref`

**loon-client/src/local_fs/observe.rs:**
- Replaced `.iter().map(|(k, _)| k.clone())` with `.keys().cloned()`

**loon-client/src/provider.rs:**
- Converted `loop { match ... }` to `while let`

**loon-client/src/state_db/txn.rs:**
- Added `#[allow(clippy::too_many_arguments)]` on `observe_local_only_move_and_plan`

**loon-testkit/src/invariants.rs:**
- Replaced `checked_add(...).unwrap_or(u64::MAX)` with `saturating_add`

**loon-testkit/tests/common/queue_scheduler_support.rs:**
- Replaced `is_some()` + `expect()` with `if let Some`

**loon-client/tests/client_crash_restart_hardening.rs:**
- Added `#[allow(clippy::result_large_err)]` on 5 test functions with closures returning large error types

**loon-cli/tests/cli.rs & loon-client/tests/client_execute_next_client_action.rs:**
- Added `#[allow(clippy::too_many_arguments)]` on test helper functions