### PR TITLE
Prepare repo for open-source release

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,365 @@
+# LoonDB — System Overview & Orientation
+
+## What is LoonDB?
+
+LoonDB is a **Dropbox/Google-Drive-style file sync engine** whose only durable backend is **object storage** (S3, R2, local filesystem). There is no traditional database server — all authoritative state lives as immutable objects (blocks, WAL entries) and a small set of mutable control objects (head, lease, queue) in the object store.
+
+---
+
+## Core Design Principles
+
+1. **Object storage is the only system of record** — no separate database. All durability comes from S3-compatible stores.
+2. **Inode-keyed metadata** — files/dirs are identified by numeric inode IDs, never by path. Paths are derived views.
+3. **Serialized namespace commits** — mutations within a namespace are strictly ordered via a monotonic sequence number and fencing tokens.
+4. **Content-before-metadata** — file content must be durably stored before a metadata revision references it.
+5. **Determinism-first testing** — concurrency is tested via deterministic simulation, not flaky timing-dependent tests.
+6. **Spec → Model → Implementation** — design specs are written first, then a pure reference model, then production code.
+
+---
+
+## Repository Layout (13 Rust crates)
+
+```
+crates/
+├── loon-types        # Shared IDs, wire types, envelopes (foundation — no internal deps)
+├── loon-objectstore  # ObjectStore trait + providers (S3, R2, local FS)
+├── loon-core         # Canonical metadata engine: commit planning, WAL, checkpoints
+├── loon-model        # Pure reference model for state-machine testing
+├── loon-queue        # Durable background work queue (snapshots, GC, indexing)
+├── loon-client       # Client-side sync: SQLite state, planner, executor, uploads/downloads
+├── loon-server       # Server-side mutation execution (lease → validate → commit → publish)
+├── loon-ops          # Shared operability contract (import, observe, sync)
+├── loon-cli          # Thin CLI frontend (`loon ops`, `loon doctor`, etc.)
+├── loon-testkit      # Scenario fixtures, rendering, replay infrastructure
+├── loon-sim          # Deterministic simulator (clock, scheduler, fault injection)
+├── loon-macos        # macOS File Provider bridge (read-only spike)
+└── xtask/            # Build automation (rc-local, render-case, replay-seed)
+```
+
+### Dependency Flow (bottom-up)
+
+```
+loon-types  ←  loon-objectstore  ←  loon-core  ←  loon-server
+                                  ←  loon-model
+                                  ←  loon-queue
+                                  ←  loon-client  ←  loon-ops  ←  loon-cli
+                                  ←  loon-testkit ←  loon-sim
+                                  ←  loon-macos
+```
+
+---
+
+## Data Model at a Glance
+
+### Metadata (inode-keyed, 4 record types)
+| Record | Key Fields | Purpose |
+|---|---|---|
+| `InodeRecord` | inode_id, kind, created_seq | Identity of a file/dir/symlink/mount |
+| `DirentryRecord` | parent_inode_id, name_key, child_inode_id | Binds a name in a directory to a child inode |
+| `RevisionRecord` | inode_id, revision_no, content_manifest_digest | Points a file revision to its content |
+| `SubtreeTombstoneRecord` | root_inode_id, tombstone_seq | Marks a subtree as deleted |
+
+### Control Objects (mutable, in object store)
+- **HeadState** — current namespace seq, active fence token, next inode ID, retention floor
+- **LeaseState** — write lease holder, fence token, expiry (prevents concurrent writers)
+- **ProgressState** — background work high-water marks per work class
+
+### Content Storage
+- Files are split into **16 MB fixed blocks**, content-addressed by SHA-256
+- A **ContentManifest** (JSON) lists block descriptors for a file
+- Revisions point to manifests by digest
+
+### Write-Ahead Log (WAL)
+- 7 operation types: CreateDir, CreateFile, ReplaceFile, DeleteFile, Rename, DeleteSubtree, RestoreRevision
+- Serialized as CBOR + Zstd, stored at `namespaces/{ns}/wal/{seq}-{id}.cbor.zst`
+- Each commit carries preconditions that are checked atomically
+
+### Checkpoints / Snapshots
+- Periodic snapshots of all 4 metadata tables, compressed with Zstd
+- Allow new readers to start from a recent snapshot instead of replaying the full WAL
+
+---
+
+## Mutation Flow (Server-Side)
+
+```
+Client Request
+  → Load basis (head + metadata from checkpoint + WAL replay)
+  → Acquire/renew write lease (fencing token)
+  → Validate preconditions
+  → Build commit plan (allocate inode IDs, compute next seq)
+  → Write WAL entry to object store
+  → Apply metadata changes
+  → Publish new head (compare-and-swap on head object)
+```
+
+Key file: `crates/loon-server/src/mutation.rs` (~45KB)
+
+---
+
+## Client Architecture
+
+The client (`loon-client`) maintains a **SQLite database** as local durable state and runs a planner/executor loop:
+
+- **Observe** remote namespace changes and local filesystem events
+- **Plan** what needs to upload, download, or reconcile
+- **Execute** uploads (content blocks → manifest → server mutation) and downloads (fetch manifest → blocks → materialize)
+- **Conflict resolution** — 6 conflict classes (stale edits, path collisions, delete-vs-edit, rename-vs-edit, subtree conflicts)
+
+Key file: `crates/loon-client/src/planner.rs`, `executor.rs`, `state_db.rs`
+
+---
+
+## Testing Strategy (3 layers)
+
+1. **Pure model tests** (`loon-model`) — state-machine semantics verified against a reference implementation
+2. **Deterministic simulation** (`loon-sim`) — concurrency and failure scenarios with reproducible seeds (28+ scenarios)
+3. **Native/conformance tests** — real provider tests, 200+ YAML scenario fixtures across `tests/scenarios/`
+
+Scenarios are human-readable YAML files treated as product artifacts, not just test internals.
+
+Run the full local check: `cargo run -p xtask -- rc-local`
+
+---
+
+## Documentation Map
+
+| Path | Content |
+|---|---|
+| `docs/specs/000-overview.md` | System overview |
+| `docs/specs/030-namespace-metadata.md` | Metadata model deep-dive |
+| `docs/specs/040-namespace-commit.md` | Commit protocol (45KB, most detailed) |
+| `docs/specs/070-client-architecture.md` | Client architecture (129KB, largest) |
+| `docs/adr/` | 20 architectural decision records |
+| `docs/roadmap/` | Implementation phases |
+| `docs/runbooks/` | Operational guides |
+| `AGENTS.md` | Non-negotiable rules and dev workflow |
+| `README.md` | Quick start and command reference |
+
+---
+
+## Deep Dive: Object Store Layer
+
+The object store is the **only durable backend** — there is no database server. Everything (metadata, content, control state) maps to keys in an S3-compatible store.
+
+### The ObjectStore Trait
+
+Defined in `crates/loon-objectstore/src/lib.rs`, five operations:
+
+| Method | Semantics |
+|---|---|
+| `head(key)` | Returns `Option<ObjectMetadata>` (etag + size) |
+| `get(key, range?)` | Returns `Option<Vec<u8>>`; supports byte-range reads |
+| `put(key, bytes, mode)` | Three modes: Overwrite, CreateIfAbsent, CompareAndSwap |
+| `delete(key)` | Idempotent — deleting a missing key succeeds |
+| `list_prefix(prefix)` | Returns sorted keys under a prefix |
+
+Key semantic: `etag` is an **opaque CAS token**, not content identity. It's only valid for compare-and-swap on the same key immediately after reading.
+
+### Three Providers
+
+| Provider | Module | Notes |
+|---|---|---|
+| **Local FS** | `fs.rs` | Atomic writes via temp+rename; etag = size+mtime; write-serialized via Mutex |
+| **AWS S3** | `s3.rs` → `s3_compatible.rs` | AWS SDK; conditional headers for CAS; strong consistency |
+| **Cloudflare R2** | `r2.rs` → `s3_compatible.rs` | S3-compatible; region="auto"; shares SDK impl with S3 |
+
+S3 and R2 are thin wrappers around a shared `S3CompatibleStore` that handles conditional puts, pagination, and error mapping.
+
+### Object Key Layout (`keys.rs`)
+
+All keys are namespace-scoped. The full keyspace:
+
+```
+namespaces/{ns}/head.json                                          # HeadState (CAS)
+namespaces/{ns}/lease.json                                         # LeaseState (CAS)
+namespaces/{ns}/wal/{seq:020}-{commit_id}.cbor.zst                 # WAL commits (immutable)
+namespaces/{ns}/blobs/sha256:{hex}                                 # Content blocks (immutable, 16MB)
+namespaces/{ns}/manifests/{digest}.json                            # Content manifests (immutable)
+namespaces/{ns}/snapshots/{seq:020}/manifest.json                  # Checkpoint manifest
+namespaces/{ns}/snapshots/{seq:020}/tables/{family}-{idx:05}.sst.zst  # Checkpoint segments
+namespaces/{ns}/derived/{work_class}/progress.json                 # Background work progress
+namespaces/{ns}/conflicts/{conflict_id}.json                       # Conflict artifacts
+namespaces/{ns}/conflict-archives/{conflict_id}.json               # Archived conflicts
+queue/shards/{shard_index:05}.json                                 # Global work queue shards
+```
+
+**Two categories of objects:**
+- **Immutable** (blobs, manifests, WAL entries, checkpoint segments): written via `CreateIfAbsent`, never updated
+- **Mutable** (head, lease, progress, queue shards): updated via `CompareAndSwap` only
+
+### Key Isolation & Safety (`keyspace.rs`)
+
+All keys are validated to reject path traversal (`..`, `.`, empty segments). Providers can be scoped with a `key_prefix` — the scoping layer guarantees keys never leak outside the configured prefix.
+
+### Serialization Formats
+
+| Object Type | Format | Compression |
+|---|---|---|
+| WAL commits | CBOR | Zstd |
+| Checkpoint segments | SST (custom) | Zstd |
+| Content blocks | Raw bytes | None |
+| Content manifests | JSON | None |
+| Control objects (head, lease) | JSON | None |
+| Checkpoint manifests | JSON | None |
+
+All envelopes carry: `kind`, `format_version`, `writer_version`, `payload_checksum_sha256`.
+
+### Conformance Test Suite
+
+Located at `crates/loon-objectstore/tests/conformance.rs`, 10 test cases validate every provider against the contract:
+
+1. `create_if_absent` — second write rejected, first bytes preserved
+2. `compare_and_swap_stale_reject` — stale etag rejected after overwrite
+3. `compare_and_swap_missing_object_reject` — CAS on missing key fails
+4. `overwrite_visibility_and_head_freshness` — immediate read-after-write
+5. `delete_idempotent` — deleting missing key succeeds
+6. `list_visibility_after_write_and_delete` — list reflects mutations immediately
+7. `sorted_list_prefix` — results sorted at trait boundary
+8. `range_read_and_invalid_range` — byte range semantics
+9. `invalid_key_and_traversal_rejection` — path traversal blocked
+10. `scoped_key_prefixing` — keys isolated to prefix
+
+LocalFS runs by default. S3/R2 require env vars and are `#[ignore]`'d.
+
+### Provider Profiles (`provider.rs`)
+
+Each provider declares its expected capabilities via a `ProviderProfile` struct. Capabilities can be `ExpectedYes`, `ExpectedNo`, or `VerifyByConformance`. This lets the system know what to test vs. assume for each backend.
+
+### How It All Fits Together
+
+```
+Content upload:
+  Split file → 16MB blocks → put_if_absent(blob key) → put_if_absent(manifest key)
+
+Namespace mutation:
+  Load head → acquire lease (CAS) → validate → write WAL (put_if_absent)
+  → publish head (CAS with old etag)
+
+Checkpoint:
+  Build 4 table families → put_if_absent(segments) → put_if_absent(manifest)
+  → update head.snapshot_hint_seq (CAS)
+
+New reader bootstrap:
+  get(head) → get(latest checkpoint manifest) → get(segments)
+  → replay WAL entries from checkpoint seq to head seq
+```
+
+---
+
+## Deep Dive: Commit Protocol
+
+The commit protocol is how mutations become visible. It's a linear pipeline with a single atomicity point: the CAS-update of `head.json`.
+
+### The 10-Step Mutation Pipeline
+
+```
+ClientMutationRequest
+  │
+  ├─ 1. Validate durable content    — manifest + blocks exist in object store
+  ├─ 2. Acquire/renew lease         — CAS on lease.json; fence token rotation on takeover
+  ├─ 3. Load basis                  — head.json → checkpoint → WAL replay → MetadataState
+  ├─ 4. Translate request           — ClientMutationOp → CommitOp + explicit preconditions
+  ├─ 5. Build commit plan           — validate preconditions, allocate inode IDs
+  ├─ 6. Prepare WAL entry           — serialize ops + preconditions → CBOR + Zstd
+  ├─ 7. Apply metadata (in-memory)  — transform MetadataState with ops
+  ├─ 8. Prepare new head            — advance seq and next_inode_id
+  ├─ 9. Write WAL                   — put_if_absent (immutable, durable)
+  └─ 10. Publish head               — CAS head.json with old etag ← SINGLE VISIBILITY POINT
+```
+
+Entry point: `execute_client_mutation()` in `crates/loon-server/src/mutation.rs`
+
+### Key Types
+
+**`CommitRequest`** — the validated mutation request:
+- `ops: Vec<CommitOp>` — 7 op types: CreateDir, CreateFile, ReplaceFile, DeleteFile, Rename, DeleteSubtree, RestoreRevision
+- `preconditions: Vec<Precondition>` — explicit CAS conditions (HeadSeqIs, InodeRevisionIs, AncestorsNotSubtreeDeleted, ChildNameAbsent)
+- `writer_fence_token` — must match head's active fence
+
+**`CommitPlan`** — output of validation:
+- `next_seq` — the seq this commit will occupy
+- `allocated_inode_ids` — consumed from head's next_inode_id cursor
+- `checked_invariants` — all validation rules verified
+
+**`WalCommitPayload`** — what gets persisted:
+- `namespace_id, seq, base_head_seq, commit_id, request_id, writer_id`
+- `ops: Vec<WalOp>` — each op tagged with `op_index` for deterministic same-seq ordering
+- `preconditions: Vec<WalPrecondition>`
+
+### Basis Loading (Step 3)
+
+The basis is always reconstructed fresh — never cached across requests:
+
+1. Read `head.json` (get etag for later CAS)
+2. Read `lease.json`, verify fence tokens match
+3. If `head.snapshot_hint_seq` exists → load checkpoint at that seq
+4. Replay WAL entries from checkpoint seq through `head.seq`
+5. Result: fully reconstructed `MetadataState` at head seq
+
+Checkpoint optimization: without checkpoints, every mutation replays the entire WAL from seq 0. Checkpoints let new readers start from a recent snapshot.
+
+### Metadata State
+
+`MetadataState` holds 4 append-only record vectors:
+
+| Record | What it tracks |
+|---|---|
+| `InodeRecord` | Inode existence: id, kind (Dir/File), created_seq |
+| `DirentryRecord` | Name bindings: parent → child, with bind_seq and op_index |
+| `RevisionRecord` | File versions: inode → revision_no → content_manifest_digest |
+| `SubtreeTombstoneRecord` | Deletions: root_inode, tombstone_seq |
+
+Visibility is computed via functions like `visible_inode(id, seq)`, `visible_child(parent, name, seq)`, `current_revision_head(id, seq)`. These check that the record exists at or before `seq` and isn't covered by a tombstone.
+
+### Fencing & Lease Mechanics
+
+- **LeaseState** holds the write lock: `holder_id`, `fence_token`, `lease_expires_at_ms`
+- **HeadState** carries `active_fence_token` — must match lease's fence token
+- On lease takeover: fence token is rotated, preventing the old writer from publishing
+- Every commit validates: `request.writer_fence_token == head.active_fence_token == lease.fence_token`
+
+This is the system's concurrency control: fencing tokens make stale writers fail at the CAS step.
+
+### Invariants Enforced
+
+The protocol records named invariants at each step. Key ones:
+
+- `stale_writer_cannot_publish` — fence token validation
+- `create_mutation_consumes_next_inode_id` — allocation correctness
+- `create_file_requires_durable_content` — content before metadata
+- `subtree_tombstone_blocks_descendant_mutation` — no orphaned operations
+- `head_publish_requires_durable_wal` — WAL before head
+- `wal_payload_checksum_matches_payload` — integrity on read
+
+### Failure & Retry
+
+- If CAS on head.json fails → concurrent mutation detected → retry from step 2
+- WAL write is idempotent (put_if_absent) — safe to retry
+- Lease expiry → must re-acquire (new fence token → new basis load)
+- Content not durable → rejected before any state mutation
+
+### How Metadata Gets Applied (Step 7)
+
+`apply_committed_wal_ops(committed_seq, ops)` transforms metadata:
+
+| Op | Effect |
+|---|---|
+| CreateDir | Append InodeRecord + DirentryRecord |
+| CreateFile | Append InodeRecord + DirentryRecord + RevisionRecord(rev=1) |
+| ReplaceFile | Append RevisionRecord(rev=base+1) |
+| DeleteFile | Append SubtreeTombstoneRecord |
+| Rename | Append new DirentryRecord (old binding stays; latest wins by bind_seq) |
+| DeleteSubtree | Append SubtreeTombstoneRecord |
+| RestoreRevision | Look up historical revision, append new RevisionRecord with its digest |
+
+All records are append-only. No rewrites, no deletions. Visibility is determined by seq ordering and tombstone coverage.
+
+---
+
+## Current Development Focus
+
+Recent commits show active work on:
+1. **macOS File Provider integration** — read-only bridge spike, sample app, C ABI boundary
+2. **Client sync hardening** — same-path replacement ordering, local delete/move observation
+3. **Server foundations** — lease acquisition/renewal, namespace bootstrapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+Initial open-source release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ edition = "2021"
 version = "0.1.0"
 license = "Apache-2.0 OR MIT"
 rust-version = "1.83"
+description = "File sync engine with object-storage-only backend"
+repository = "https://github.com/prequel-co/loonfs"
+homepage = "https://github.com/prequel-co/loonfs"
+keywords = ["sync", "object-storage", "s3"]
+categories = ["filesystem"]
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -1,136 +1,116 @@
 # LoonDB
 
-LoonDB is a Dropbox/GDrive-like sync engine with an object-storage-only durable backend.
-For now, this repository is a **development bootstrap**, not a finished product. It is structured so we can start implementing in small, testable steps without losing the design intent we already established.
+[![CI](https://github.com/prequel-co/loonfs/actions/workflows/ci.yml/badge.svg)](https://github.com/prequel-co/loonfs/actions/workflows/ci.yml)
 
-## What this repo is trying to optimize for
+LoonDB is a file sync engine whose only durable backend is object storage (S3, R2, local
+filesystem). There is no traditional database server — all authoritative state lives as immutable
+objects and a small set of mutable control objects in the object store. The project is under active
+development and not yet production-ready.
 
-- correctness before feature count
-- deterministic behavior before raw throughput
-- small changes with high reviewability
-- object-storage portability earned through conformance tests
-- a test suite that is understandable by both engineers and product-minded reviewers
+## Design principles
 
-## Intended product shape
+- Correctness before feature count
+- Deterministic behavior before raw throughput
+- Small changes with high reviewability
+- Object-storage portability earned through conformance tests
+- A test suite understandable by both engineers and product-minded reviewers
 
-- Rust server
-- macOS client
-- local-server mode and remote-server mode
-- object storage as the only durable system of record
-- inode-keyed metadata
-- multiple namespaces per account
-- deterministic background work built on rebuildable state
+## Product shape
 
-## Current implemented surfaces
+- Rust server and macOS client
+- Local-server mode and remote-server mode
+- Object storage as the only durable system of record
+- Inode-keyed metadata (paths are derived views, never canonical identity)
+- Multiple namespaces per account
+- Deterministic background work built on rebuildable state
 
-- `loon-core`, `loon-model`, and `loon-objectstore` hold the active protocol and storage logic
-- `loon-server::mutation` is the current authoritative server-side execution surface
-- `loon-client` contains the active SQLite/planner/executor work
-- `loon-ops` owns the shared operability command/config/rendering contract
-- `xtask ops ...` and `loon ops ...` are the active local operability frontends
-- `loon-cli` also owns built-in help, manpage generation, config inspection, and `doctor`
-- `xtask rc-local` remains the canonical repo release-candidate path
-- `loon-testkit` remains the active review and debugging toolkit
-- the `loond` binary shell and `loon-macos` are still reserved later-phase delivery surfaces
-
-## Start here
-
-1. Read `AGENTS.md`.
-2. Read `docs/specs/000-overview.md`.
-3. Read `docs/specs/060-testing-strategy.md`.
-4. Read `docs/specs/090-major-implementation-decisions.md`.
-5. Read `docs/adr/` in numerical order.
-6. Read `docs/roadmap/020-semantic-core-reset.md` for the current execution order.
-7. Read `docs/roadmap/000-bootstrap.md` and `docs/roadmap/010-foundation-workstreams.md` only for historical context.
-
-## Repository map
+## Crate map
 
 ```text
-docs/
-  adr/              locked architectural decisions
-  context/          source context and original prompt
-  references/       public research links and notes
-  roadmap/          implementation phases
-  runbooks/         operational/debugging checklists
-  specs/            readable design specs
-
-spec/tla/           protocol-level model-checking seeds
-
 crates/
   loon-types/       shared IDs and wire/domain types
   loon-objectstore/ object-store trait, provider profiles, conformance surface
   loon-core/        canonical metadata rules and commit planning
   loon-model/       pure reference model for state-machine testing
   loon-queue/       durable background-work coordination
+  loon-client/      client-side sync: SQLite state, planner, executor
+  loon-server/      authoritative mutation surface (binary/HTTP shell quarantined)
+  loon-ops/         shared operability command/config/rendering contract
+  loon-cli/         thin CLI frontend over loon-ops
   loon-testkit/     scenario fixtures, rendering, helpers
   loon-sim/         deterministic simulator scaffolding
-  loon-server/      authoritative mutation surface; binary/http shell quarantined for now
-  loon-cli/         active thin CLI frontend over loon-ops
-  loon-client/      active client state, planner, and executor implementation
-  loon-macos/       reserved macOS integration placeholder for later File Provider work
+  loon-macos/       macOS File Provider bridge (experimental spike)
 
 tests/
-  scenarios/        readable test cases
+  scenarios/        readable test cases (YAML fixtures)
   conformance/      storage-provider contract tests
   snapshots/        expected rendered outputs
 
 xtask/              repository automation entrypoints
 ```
 
-## Recommended first implementation order
-
-1. `loon-objectstore`: local adapter + conformance harness
-2. `loon-core`: head/lease/commit rules
-3. `loon-model`: pure namespace model + state-machine tests
-4. `loon-queue`: one sharded queue class, probably `BuildSnapshot`
-5. `loon-sim`: deterministic clock, scheduler, mock object store
-6. `loon-server`: authoritative mutation surface before widening binary or HTTP shells
-7. `loon-client`: durable local truth, planner, and executor paths
-8. `loon-macos`: File Provider bridge after mirror semantics are stable
-
-## Commands to wire up first
+## Getting started
 
 ```bash
-# Format all Rust code in the workspace (rustfmt)
-cargo fmt --all
+# Build all crates
+cargo build --workspace
 
-# Lint every crate and target; all warnings are errors
-cargo clippy --workspace --all-targets -- -D warnings
-
-# Run the built-in test runner across all crates
+# Run the full test suite
 cargo test --workspace
 
-# Run the canonical local release-candidate path
-cargo run -p xtask -- rc-local --config ./loondb-demo.toml --namespace demo
+# Lint
+cargo clippy --workspace --all-targets -- -D warnings
 
-# Run the active thin CLI frontend over the same loon-ops contract
-cargo run -p loon-cli -- ops smoke --config ./loondb-demo.toml --namespace demo
+# Explore the CLI
+cargo run -p loon-cli -- help
 
-# Discover the active CLI surface and validate a local config
-cargo run -p loon-cli -- help ops bootstrap-namespace
+# Validate a local config
 cargo run -p loon-cli -- config validate --config ./loondb-demo.toml
 cargo run -p loon-cli -- doctor --config ./loondb-demo.toml
 
-# Run the same tests with nextest (optional, if installed)
-cargo nextest run
+# Run the canonical local release-candidate path
+cargo run -p xtask -- rc-local --config ./loondb-demo.toml --namespace demo
 
 # Render a YAML scenario fixture into human-readable form
 cargo run -p xtask -- render-case tests/scenarios/model/delete_then_stale_local_edit.yaml
 ```
 
-## Definition of “done” for an early feature
+## Configuration
 
-A feature is not done when the code compiles. A feature is done when all of the following are true:
+Example configuration templates are in [`configs/`](configs/):
 
-- the relevant spec section exists or was updated
-- an ADR exists if the decision is architectural
-- the reference model has the behavior
-- at least one readable scenario fixture covers the behavior
-- invariants are named explicitly
-- the implementation and tests agree on the same vocabulary
+- [`loondb-demo.local-fs.example.toml`](configs/loondb-demo.local-fs.example.toml) — local filesystem backend
+- [`loondb-demo.aws-s3.example.toml`](configs/loondb-demo.aws-s3.example.toml) — AWS S3 backend
+- [`loondb-demo.cloudflare-r2.example.toml`](configs/loondb-demo.cloudflare-r2.example.toml) — Cloudflare R2 backend
+
+Copy one of these to `./loondb-demo.toml` and edit to match your setup.
+
+## Architecture
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for a comprehensive system overview covering the data
+model, mutation flow, object-store layer, commit protocol, client architecture, and testing
+strategy.
+
+## Documentation
+
+| Path | Content |
+|------|---------|
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | System overview and orientation |
+| [`AGENTS.md`](AGENTS.md) | Non-negotiable rules and development workflow |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch/PR guidance, formatting, documentation style |
+| [`docs/specs/`](docs/specs/) | Readable design specifications |
+| [`docs/adr/`](docs/adr/) | Architectural decision records |
+| [`docs/roadmap/`](docs/roadmap/) | Implementation phases |
+| [`docs/runbooks/`](docs/runbooks/) | Operational and debugging guides |
+
+### Recommended reading order
+
+1. [`AGENTS.md`](AGENTS.md)
+2. [`docs/specs/000-overview.md`](docs/specs/000-overview.md)
+3. [`docs/specs/060-testing-strategy.md`](docs/specs/060-testing-strategy.md)
+4. [`docs/specs/090-major-implementation-decisions.md`](docs/specs/090-major-implementation-decisions.md)
+5. [`docs/adr/`](docs/adr/) in numerical order
 
 ## CLI manual
 
-The current operator-facing CLI manual is:
-
-- [docs/runbooks/loon-cli.md](/Users/conormccarter/Code/loondb/docs/runbooks/loon-cli.md)
+The operator-facing CLI manual is at [`docs/runbooks/loon-cli.md`](docs/runbooks/loon-cli.md).

--- a/crates/loon-cli/README.md
+++ b/crates/loon-cli/README.md
@@ -28,4 +28,4 @@ Broader CLI work should continue to reuse those existing layers rather than re-i
 
 The checked-in manual for the active surface is:
 
-- [docs/runbooks/loon-cli.md](/Users/conormccarter/Code/loondb/docs/runbooks/loon-cli.md)
+- [docs/runbooks/loon-cli.md](../../docs/runbooks/loon-cli.md)

--- a/crates/loon-cli/README.md
+++ b/crates/loon-cli/README.md
@@ -2,7 +2,23 @@
 
 Active thin CLI frontend over `crates/loon-ops`.
 
-Current scope:
+## Quick start
+
+```bash
+# See available commands
+cargo run -p loon-cli -- help
+
+# Validate a local configuration file
+cargo run -p loon-cli -- config validate --config ./loondb-demo.toml
+
+# Run diagnostics
+cargo run -p loon-cli -- doctor --config ./loondb-demo.toml
+
+# Run operability commands (delegates to loon-ops)
+cargo run -p loon-cli -- ops --help
+```
+
+## Current scope
 
 - `loon ops ...` reuses the shared `loon-ops` subcommand grammar and output semantics unchanged
 - `loon config ...` and `loon doctor` are CLI-only discovery/diagnostic affordances over the same
@@ -11,12 +27,14 @@ Current scope:
 - `xtask ops ...` remains supported in parallel for repo/dev workflows
 - `xtask rc-local` remains repo automation and does not move into `loon-cli`
 
-Deliberate non-goals in the current slice:
+## Deliberate non-goals in the current slice
 
 - no profiles or token auth
 - no separate `~/.config/loon/config.toml` model
 - no endpoint or HTTP transport abstraction
 - no public `namespace`, `ls`, `cat`, `put`, or `get` families yet
+
+## Local filesystem semantics
 
 The local filesystem semantics underneath the `ops` commands continue to live in `crates/loon-client`:
 
@@ -26,6 +44,7 @@ The local filesystem semantics underneath the `ops` commands continue to live in
 Broader CLI work should continue to reuse those existing layers rather than re-implementing them in
 `loon-cli`.
 
-The checked-in manual for the active surface is:
+## Manual
 
-- [docs/runbooks/loon-cli.md](../../docs/runbooks/loon-cli.md)
+The checked-in manual for the active surface is at
+[docs/runbooks/loon-cli.md](../../docs/runbooks/loon-cli.md).

--- a/crates/loon-cli/src/main.rs
+++ b/crates/loon-cli/src/main.rs
@@ -1,3 +1,8 @@
+//! Thin CLI frontend for LoonDB, built over `loon-ops`.
+//!
+//! Provides the `loon` binary with subcommands for operability (`ops`), configuration
+//! validation (`config`), diagnostics (`doctor`), shell completions, and manpage generation.
+
 mod app;
 mod cmd;
 mod error;

--- a/crates/loon-client/README.md
+++ b/crates/loon-client/README.md
@@ -1,3 +1,37 @@
 # loon-client
 
-Client-side daemon scaffolding for mirror sync, later hydration, and local durability.
+Client-side daemon scaffolding for mirror sync, hydration, and local durability.
+
+This crate implements the client half of the LoonDB sync protocol: observing remote namespace
+changes, planning uploads and downloads, executing content transfers, and managing conflicts. Local
+durable state is maintained in a SQLite database.
+
+`#![forbid(unsafe_code)]`
+
+## Architecture
+
+The client runs a planner/executor loop:
+
+1. **Observe** — detect remote namespace changes and local filesystem events
+2. **Plan** — decide what needs to upload, download, or reconcile
+3. **Execute** — transfer content blocks, materialize files, and apply metadata
+
+## Key modules
+
+| Module | Purpose |
+|--------|---------|
+| `state_db` | SQLite-backed local state (namespace tracking, sync progress, file registry) |
+| `planner` | Action selection: what to upload, download, or reconcile next |
+| `executor` | Content transfer execution and local state updates |
+| `download` | Content block and manifest downloading |
+| `upload` | Content block splitting, hashing, and uploading |
+| `local_fs` | Filesystem event observation and path normalization |
+| `provider` | Materialization of remote files into local mirror roots |
+| `conflict` | Conflict artifact creation, archival, and restoration |
+| `testing` | `FaultController` for deterministic fault injection in tests |
+
+## Conflict resolution
+
+Six conflict classes are handled: stale edits, path collisions, delete-vs-edit, rename-vs-edit,
+subtree conflicts, and local-only binding ambiguity. Conflicts produce durable artifacts that can be
+inspected, restored, or archived.

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -1,3 +1,9 @@
+//! Client-side daemon scaffolding for mirror sync, hydration, and local durability.
+//!
+//! Implements the client half of the LoonDB sync protocol: observing remote namespace changes,
+//! planning uploads and downloads, executing content transfers, and managing conflicts. Local
+//! durable state is maintained in a SQLite database.
+
 #![forbid(unsafe_code)]
 
 mod conflict;

--- a/crates/loon-core/README.md
+++ b/crates/loon-core/README.md
@@ -1,3 +1,40 @@
 # loon-core
 
-Canonical metadata rules, commit planning, path resolution, and invariants.
+Canonical metadata rules, commit planning, path resolution, and invariants for the LoonDB protocol.
+
+This crate encodes the authoritative rules for how namespace state changes — what preconditions must
+hold, how inode IDs are allocated, how WAL entries are serialized, and how checkpoints are built and
+verified.
+
+`#![forbid(unsafe_code)]`
+
+## What this crate owns
+
+- **Metadata state machine** — the four append-only record types (inodes, direntries, revisions,
+  tombstones) and their visibility rules
+- **Commit planning** — precondition validation, inode ID allocation, WAL entry construction
+- **WAL serialization** — CBOR + Zstd encoding/decoding of commit payloads
+- **Checkpoint logic** — snapshot building, segment serialization, and checkpoint verification
+- **Path resolution** — derived path computation from inode-keyed metadata
+- **Named invariants** — explicit, named invariants checked at each protocol step
+- **Progress tracking** — background work high-water mark management
+
+## What this crate does not own
+
+- I/O or storage operations (see `loon-objectstore`)
+- HTTP, RPC, or transport concerns (see `loon-server`)
+- Client-side state or sync logic (see `loon-client`)
+
+## Public modules
+
+| Module | Purpose |
+|--------|---------|
+| `checkpoint` | Checkpoint building, loading, and verification |
+| `commit` | Commit plan construction and validation |
+| `content` | Content manifest handling and block management |
+| `invariants` | Named invariant definitions and checking |
+| `metadata` | Metadata state construction and record visibility |
+| `namespace` | Namespace-level state loading (head + checkpoint + WAL replay) |
+| `path` | Derived path resolution from inode-keyed records |
+| `progress` | Background work progress tracking |
+| `wal` | WAL entry serialization, deserialization, and replay |

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -1,3 +1,9 @@
+//! Canonical metadata rules, commit planning, path resolution, and invariants.
+//!
+//! This crate encodes the authoritative rules for how namespace state changes: precondition
+//! validation, inode ID allocation, WAL serialization, checkpoint construction, and named
+//! invariant checking. It does not perform I/O — storage operations are in `loon-objectstore`.
+
 #![forbid(unsafe_code)]
 
 pub mod checkpoint;

--- a/crates/loon-macos/README.md
+++ b/crates/loon-macos/README.md
@@ -1,19 +1,24 @@
 # loon-macos
 
-Read-only macOS File Provider bridge spike.
+**Status: Experimental spike**
+
+Read-only macOS File Provider bridge.
 
 This crate projects Finder-style provider items from the existing client SQLite state and reuses
 the same client truth model rather than inventing a second sync model.
 
-Current scope:
+`#![deny(unsafe_op_in_unsafe_fn)]` — this is the only crate in the workspace with unsafe code,
+confined to the C FFI boundary.
 
-- one account/root projection with namespaces as top-level directories
+## Current scope
+
+- One account/root projection with namespaces as top-level directories
 - DB-backed enumeration only
-- targeted hydration into the existing client mirror root
-- static-library C ABI with UTF-8 JSON payloads for a native macOS sample
-- checked-in developer sample app and extension shell under `native/macos/LoonFileProviderSample/`
+- Targeted hydration into the existing client mirror root
+- Static-library C ABI with UTF-8 JSON payloads for a native macOS sample
+- Checked-in developer sample app and extension shell under `native/macos/LoonFileProviderSample/`
 
-Current non-goals:
+## Current non-goals
 
-- no create/modify/delete/rename support
-- no implicit import, sync, watcher, or daemon loop
+- No create/modify/delete/rename support
+- No implicit import, sync, watcher, or daemon loop

--- a/crates/loon-macos/src/lib.rs
+++ b/crates/loon-macos/src/lib.rs
@@ -1,3 +1,9 @@
+//! Read-only macOS File Provider bridge (experimental spike).
+//!
+//! Projects Finder-style provider items from the existing client SQLite state, reusing the
+//! same client truth model rather than inventing a second sync model. Exports a static-library
+//! C ABI with UTF-8 JSON payloads for a native macOS host app.
+
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use loon_client::local_fs::{join_under_mirror_root, NamespacePathIndex};

--- a/crates/loon-model/README.md
+++ b/crates/loon-model/README.md
@@ -1,3 +1,22 @@
 # loon-model
 
-Pure reference model for namespace and queue semantics. This crate should stay side-effect free.
+Pure reference model for namespace and queue semantics.
+
+This crate serves as the specification-in-code for LoonDB's protocol behavior. It defines the
+expected outcomes for every mutation, precondition check, conflict scenario, and queue operation —
+without performing any I/O or side effects. The reference model is the authority that production
+code is tested against.
+
+This crate must remain side-effect free.
+
+`#![forbid(unsafe_code)]`
+
+## Key types
+
+- `ModelNamespace` — reference namespace state (head, fence token, inode cursor, metadata)
+- `ModelWalCommit` — expected WAL commit structure
+- `ModelCheckpoint` — expected checkpoint structure and table families
+- `ModelMetadataMutation` — the 6 mutation types (CreateDir, CreateFile, ReplaceFile, Rename,
+  RestoreRevision, DeleteSubtree)
+- `ModelError` — exhaustive error variants covering every protocol rejection
+- `ModelQueueShard`, `ModelQueueJob` — reference queue behavior

--- a/crates/loon-model/src/lib.rs
+++ b/crates/loon-model/src/lib.rs
@@ -1,3 +1,9 @@
+//! Pure reference model for namespace and queue semantics.
+//!
+//! This crate defines the expected outcomes for every mutation, precondition check, conflict
+//! scenario, and queue operation — without performing any I/O or side effects. It serves as
+//! the specification-in-code that production implementations are tested against.
+
 #![forbid(unsafe_code)]
 
 use loon_types::{

--- a/crates/loon-objectstore/Cargo.toml
+++ b/crates/loon-objectstore/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+description = "Object-store trait abstraction with S3, R2, and local filesystem providers"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/loon-objectstore/README.md
+++ b/crates/loon-objectstore/README.md
@@ -5,7 +5,33 @@ behavior depends on.
 
 This crate is the only layer that should know provider quirks.
 
-Its provider profiles should distinguish between:
+`#![forbid(unsafe_code)]`
+
+## Status
+
+Implemented providers:
+
+- **Local filesystem** (`fs`) — atomic writes via temp+rename, etag derived from size+mtime
+- **AWS S3** (`s3`) — conditional headers for CAS, strong read-after-write consistency
+- **Cloudflare R2** (`r2`) — S3-compatible via shared implementation with region="auto"
+
+Conformance suite: 10 test cases covering create-if-absent, compare-and-swap, idempotent delete,
+list visibility, sorted prefix listing, byte-range reads, key validation, and scoped prefixing.
+LocalFS runs by default; S3/R2 require environment variables.
+
+## Public API surface
+
+- **`ObjectStore`** trait — 5 core methods: `head`, `get`, `put`, `delete`, `list_prefix`; plus
+  convenience methods `put_overwrite`, `put_if_absent`, `compare_and_swap`
+- **`ObjectMetadata`** — etag (opaque CAS token) and size
+- **`PutMode`** — `Overwrite`, `CreateIfAbsent`, `CompareAndSwap`
+- **`ByteRange`** — byte-range read support
+- **`ObjectStoreError`** — stable error enum (`PreconditionFailed`, `InvalidKey`, etc.)
+- **`ConfiguredObjectStore`** — unified wrapper that dispatches to the configured provider
+
+## Provider contract
+
+Provider profiles distinguish between:
 
 - active contract fields that other crates may rely on now
 - future capability flags that stay informational until the trait and conformance suite grow

--- a/crates/loon-objectstore/src/lib.rs
+++ b/crates/loon-objectstore/src/lib.rs
@@ -1,3 +1,10 @@
+//! Object-store abstraction layer for LoonDB.
+//!
+//! This crate defines the [`ObjectStore`] trait and provides implementations for local
+//! filesystem, AWS S3, and Cloudflare R2. It is the only layer that should know provider
+//! quirks — higher layers depend only on the trait, its error types, and opaque compare
+//! tokens.
+
 #![forbid(unsafe_code)]
 
 mod configured;
@@ -14,6 +21,7 @@ use crate::error::ObjectStoreError;
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 use serde::{Deserialize, Serialize};
 
+/// Metadata returned by a successful `head` or `put` call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObjectMetadata {
     /// Opaque compare token for one object version.
@@ -24,16 +32,23 @@ pub struct ObjectMetadata {
     pub size_bytes: u64,
 }
 
+/// Controls the write semantics of a `put` call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PutMode {
+    /// Unconditionally overwrite any existing object.
     Overwrite,
+    /// Write only if the key does not already exist. Returns `PreconditionFailed` if it does.
     CreateIfAbsent,
+    /// Write only if the current etag matches. Returns `PreconditionFailed` on mismatch.
     CompareAndSwap { expected_etag: String },
 }
 
+/// A byte range for partial object reads.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ByteRange {
+    /// First byte to read (inclusive, zero-based).
     pub start_inclusive: u64,
+    /// First byte to exclude (exclusive, zero-based).
     pub end_exclusive: u64,
 }
 

--- a/crates/loon-ops/README.md
+++ b/crates/loon-ops/README.md
@@ -1,0 +1,17 @@
+# loon-ops
+
+Shared operability command, config, and rendering contract for LoonDB.
+
+This crate implements the core operations (import, observe, sync) consumed by both `loon-cli` and
+`xtask`. It is the integration point that composes `loon-client`, `loon-server`, and
+`loon-objectstore` into user-facing workflows.
+
+`#![forbid(unsafe_code)]`
+
+## Public API
+
+- **Config types** — `OpsConfig`, `OpsObjectStoreSpec`, and related TOML-driven configuration
+- **Import** — `import_authoritative_remote_observations` for bootstrapping client state
+- **Observe** — `observe_local_path`, `observe_delete_path`, `observe_move_path`,
+  `observe_subtree_path` for feeding filesystem events into the sync pipeline
+- **Sync** — `sync_once` and `sync_until_idle` for running the upload/download loop

--- a/crates/loon-ops/src/lib.rs
+++ b/crates/loon-ops/src/lib.rs
@@ -1,3 +1,9 @@
+//! Shared operability command, config, and rendering contract for LoonDB.
+//!
+//! Implements the core operations (import, observe, sync) consumed by both `loon-cli` and
+//! `xtask`. This is the integration point that composes `loon-client`, `loon-server`, and
+//! `loon-objectstore` into user-facing workflows.
+
 #![forbid(unsafe_code)]
 
 mod import;

--- a/crates/loon-queue/README.md
+++ b/crates/loon-queue/README.md
@@ -1,3 +1,23 @@
 # loon-queue
 
 Sharded, object-storage-backed background-work coordination.
+
+This crate manages durable job queues for background work that must survive process restarts and
+be distributed across workers. Queue state is stored as JSON objects in the object store, using
+compare-and-swap for consistency.
+
+`#![forbid(unsafe_code)]`
+
+## Work classes
+
+- **BuildSnapshot** — checkpoint/snapshot construction triggered by WAL growth
+
+## Key modules
+
+| Module | Purpose |
+|--------|---------|
+| `broker` | Broker lease acquisition and epoch management |
+| `durable` | Durable shard state persistence and compare-and-swap updates |
+| `repair` | Queue repair: enqueue missing work, promote stale follow-ups |
+| `types` | Queue data types (shards, jobs, claims, payloads) |
+| `worker` | Worker claim/complete/heartbeat lifecycle |

--- a/crates/loon-queue/src/lib.rs
+++ b/crates/loon-queue/src/lib.rs
@@ -1,3 +1,9 @@
+//! Sharded, object-storage-backed background-work coordination.
+//!
+//! Manages durable job queues for background work (snapshots, GC) that must survive process
+//! restarts. Queue state is stored as JSON objects in the object store, using compare-and-swap
+//! for consistency.
+
 #![forbid(unsafe_code)]
 
 pub mod broker;

--- a/crates/loon-server/README.md
+++ b/crates/loon-server/README.md
@@ -1,8 +1,22 @@
 # loon-server
 
-Thin server integration crate.
+Thin server integration crate for the LoonDB mutation pipeline.
 
-The current real surface here is `mutation`, which composes `loon-core` and related crates into the
-authoritative create/replace execution path. The binary, app, and HTTP shells are intentionally
-quarantined during the semantic-core reset so the repo does not imply a fuller server surface than
-actually exists.
+`#![forbid(unsafe_code)]`
+
+## Status
+
+**Active surface**: `mutation` — composes `loon-core` and related crates into the authoritative
+create/replace execution path (lease acquisition, precondition validation, WAL write, head publish).
+
+**Active surface**: `ops` — namespace bootstrapping and state summary loading.
+
+**Quarantined**: The `loond` binary shell and HTTP transport layer are intentionally unavailable
+during the semantic-core reset. The repo does not imply a fuller server surface than actually exists.
+
+## Public modules
+
+| Module | Purpose |
+|--------|---------|
+| `mutation` | Authoritative mutation execution: lease, validate, commit, publish |
+| `ops` | Namespace bootstrap and state inspection |

--- a/crates/loon-server/src/lib.rs
+++ b/crates/loon-server/src/lib.rs
@@ -1,3 +1,9 @@
+//! Thin server integration crate for the LoonDB mutation pipeline.
+//!
+//! The active surface is [`mutation`], which composes `loon-core` and related crates into the
+//! authoritative create/replace execution path. The binary and HTTP shells are intentionally
+//! quarantined during the semantic-core reset.
+
 #![forbid(unsafe_code)]
 
 pub(crate) mod genesis;

--- a/crates/loon-sim/Cargo.toml
+++ b/crates/loon-sim/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+description = "Deterministic simulation runtime for LoonDB"
 
 [dependencies]
 serde.workspace = true

--- a/crates/loon-sim/README.md
+++ b/crates/loon-sim/README.md
@@ -2,3 +2,24 @@
 
 Deterministic simulator runtime for fault injection, actor stepping, delivery ordering,
 restart events, and replay traces.
+
+This crate provides a controlled execution environment for testing LoonDB's concurrent and
+failure-sensitive paths with reproducible seeds. Every test run with the same seed produces
+identical behavior, making failures debuggable and regressions catchable.
+
+`#![forbid(unsafe_code)]`
+
+## Key exports
+
+- `SimRuntime` — deterministic scheduler with controlled clock and delivery ordering
+- `SimTraceEvent` — structured trace events for replay and debugging
+- `SimActorId` — typed actor identifiers for multi-party simulation
+- `SimDelivery` — delivery-ordering control for message and I/O simulation
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `runtime` | Core deterministic scheduler and clock |
+| `faults` | Fault injection definitions (crashes, delays, reordering) |
+| `trace` | Structured trace recording and replay |

--- a/crates/loon-sim/src/lib.rs
+++ b/crates/loon-sim/src/lib.rs
@@ -1,3 +1,9 @@
+//! Deterministic simulator runtime for fault injection, actor stepping, delivery ordering,
+//! restart events, and replay traces.
+//!
+//! Provides a controlled execution environment for testing concurrent and failure-sensitive
+//! paths with reproducible seeds. Every test run with the same seed produces identical behavior.
+
 #![forbid(unsafe_code)]
 
 pub mod faults;

--- a/crates/loon-testkit/Cargo.toml
+++ b/crates/loon-testkit/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+description = "Scenario fixtures and testing infrastructure for LoonDB"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/loon-testkit/README.md
+++ b/crates/loon-testkit/README.md
@@ -1,3 +1,25 @@
 # loon-testkit
 
-Readable scenario fixture types and simple rendering helpers.
+Readable scenario fixture types, rendering helpers, and test infrastructure for LoonDB.
+
+Scenario fixtures are YAML files under `tests/scenarios/` that describe expected protocol behavior
+in human-readable form. They are treated as product artifacts — not just test internals — and are
+reviewed alongside specs and ADRs.
+
+`#![forbid(unsafe_code)]`
+
+## Key modules
+
+| Module | Purpose |
+|--------|---------|
+| `fixtures` | YAML fixture parsing and typed scenario definitions |
+| `scenario` | Scenario execution against the reference model |
+| `render` | Human-readable rendering of scenario outcomes |
+| `replay` | Deterministic replay of recorded traces |
+| `seed` | Reproducible seed generation for randomized testing |
+| `minimize` | Failure case minimization for debugging |
+| `invariants` | Cross-scenario invariant checking |
+| `explore` | Exploratory state-space traversal |
+| `snapshots` | Expected-output snapshot management |
+| `client` | Client-specific test helpers |
+| `tempdir` | Temporary directory management for tests |

--- a/crates/loon-testkit/src/lib.rs
+++ b/crates/loon-testkit/src/lib.rs
@@ -1,3 +1,9 @@
+//! Readable scenario fixture types, rendering helpers, and test infrastructure.
+//!
+//! Scenario fixtures are YAML files under `tests/scenarios/` that describe expected protocol
+//! behavior in human-readable form. They are treated as product artifacts and reviewed alongside
+//! specs and ADRs.
+
 #![forbid(unsafe_code)]
 
 pub mod client;

--- a/crates/loon-types/README.md
+++ b/crates/loon-types/README.md
@@ -1,3 +1,29 @@
 # loon-types
 
-Shared IDs, enums, and plain data structures used across the workspace.
+Shared IDs, enums, and plain data structures used across the LoonDB workspace.
+
+This is the foundation crate — it has no internal dependencies and is imported by every other crate
+in the workspace. All types here are pure data: serializable, cloneable, and side-effect free.
+
+`#![forbid(unsafe_code)]`
+
+## What this crate owns
+
+- **Identity types** — `InodeId`, `NamespaceId`, `ChangeSeq`, `FenceToken`, `RevisionNo`, and other
+  strongly-typed IDs used throughout the protocol
+- **WAL types** — commit envelopes, operation payloads, and precondition definitions
+- **Checkpoint types** — snapshot manifests, segment metadata, and table family descriptors
+- **Content types** — content manifest envelopes, block descriptors, and digest utilities
+- **Control types** — `HeadState`, `LeaseState`, and progress tracking structures
+- **Client types** — mutation request/response envelopes for the client-server protocol
+- **Conflict types** — conflict artifact definitions and resolution metadata
+
+## What this crate does not own
+
+- Protocol rules or validation logic (see `loon-core`)
+- I/O, storage, or network operations (see `loon-objectstore`, `loon-client`, `loon-server`)
+
+## Public API
+
+All internal modules are private and re-exported at the crate root via `pub use`. Types are accessed
+directly as `loon_types::InodeId`, `loon_types::ChangeSeq`, etc.

--- a/crates/loon-types/src/ids.rs
+++ b/crates/loon-types/src/ids.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
+/// Unique identifier for a namespace (a logical sync boundary).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NamespaceId(pub String);
 
@@ -44,18 +45,23 @@ impl<'de> Deserialize<'de> for NamespaceId {
     }
 }
 
+/// Numeric identity of a file, directory, symlink, or mount within a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InodeId(pub u64);
 
+/// Monotonically increasing file revision counter within an inode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RevisionNo(pub u64);
 
+/// Monotonically increasing namespace commit sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ChangeSeq(pub u64);
 
+/// Fencing token for write-lease concurrency control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct FenceToken(pub u64);
 
+/// Case-normalized directory entry name used as a lookup key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NameKey(pub String);
 

--- a/crates/loon-types/src/lib.rs
+++ b/crates/loon-types/src/lib.rs
@@ -1,3 +1,10 @@
+//! Shared IDs, enums, and plain data structures used across the LoonDB workspace.
+//!
+//! This is the foundation crate with no internal dependencies. All types are pure data:
+//! serializable, cloneable, and side-effect free. Identity types like [`InodeId`],
+//! [`NamespaceId`], [`ChangeSeq`], and [`FenceToken`] are the vocabulary shared by every
+//! other crate in the workspace.
+
 #![forbid(unsafe_code)]
 
 mod checkpoint;

--- a/docs/runbooks/loon-cli.md
+++ b/docs/runbooks/loon-cli.md
@@ -139,5 +139,5 @@ cargo run -p loon-cli -- doctor --config ./loondb-demo.local.toml
 
 ## Related runbooks
 
-- RC path: [local-rc.md](/Users/conormccarter/Code/loondb/docs/runbooks/local-rc.md)
-- Provider-backed conformance: [provider-conformance.md](/Users/conormccarter/Code/loondb/docs/runbooks/provider-conformance.md)
+- RC path: [local-rc.md](local-rc.md)
+- Provider-backed conformance: [provider-conformance.md](provider-conformance.md)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+description = "Build automation for the LoonDB workspace"
 
 [dependencies]
 anyhow.workspace = true

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,13 @@
+# xtask
+
+Build automation entrypoints for the LoonDB workspace.
+
+This crate is not intended for external use. It provides repository-level automation commands
+following the [cargo-xtask](https://github.com/matklad/cargo-xtask) convention.
+
+## Commands
+
+- `rc-local` — canonical local release-candidate path (fmt, clippy, tests, conformance, smoke)
+- `render-case` — render a YAML scenario fixture into human-readable form
+- `replay-seed` — replay a deterministic simulation seed
+- `ops` — run operability commands (parallel to `loon-cli ops`)


### PR DESCRIPTION
## Summary

- Add workspace-level Cargo.toml metadata (description, repository, homepage, keywords, categories) and per-crate description overrides
- Commit `overview.md` as `ARCHITECTURE.md` for external system orientation
- Rewrite root `README.md` for an open-source audience (design principles, crate map, getting started, config, docs)
- Fix all hardcoded absolute paths with relative links
- Add `CHANGELOG.md` (Keep a Changelog format)
- Expand all 13 crate READMEs with implementation status, public API surfaces, module tables, and ownership boundaries (2 new: `loon-ops`, `xtask`)
- Add `//!` crate-level doc comments to all 12 lib.rs/main.rs files
- Add `///` doc comments to key public types in `loon-types` and `loon-objectstore`

## Not included

- License files (license choice still being decided)