### PR TITLE
fix(loon-cli): tighten config initialization semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@ xtask/
 - `loon` owns CLI-managed profile state
 - `loond` owns operator-authored server configuration
 
-`loon` default config path when `--config` is omitted:
+`loon` always uses:
 
-- macOS: `~/Library/Application Support/loon/config.toml`
-- other Unix: `~/.config/loon/config.toml`
-- Windows: `%APPDATA%\\loon\\config.toml`
+- `~/.loonfs/config.toml`
 
 `loond` has no code-level default path. You pass a server config path explicitly when you start
 `loond` or when you create a local `loon` profile.
@@ -154,7 +152,6 @@ Global flags:
 - `--profile <NAME>`
 - `--json`
 - `--no-input`
-- `--config <PATH>`
 
 `filesystem cat` and `filesystem get ... -` stream raw bytes to stdout and reject `--json`.
 

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -1,6 +1,5 @@
 use clap::{Args, Parser, Subcommand};
 use std::io::IsTerminal;
-use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(name = "loon")]
@@ -11,8 +10,6 @@ pub struct Cli {
     pub json: bool,
     #[arg(long, global = true)]
     pub no_input: bool,
-    #[arg(long, global = true)]
-    pub config: Option<PathBuf>,
     #[command(subcommand)]
     pub command: Command,
 }

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -3,8 +3,8 @@ use crate::args::{
     ProfileAddCommand, ProfileCommand, ProfileUpdateArgs, RuntimeBehavior,
 };
 use crate::config::{
-    load_config, load_config_if_exists, load_or_default_config, save_config, ProfileConfig,
-    StoreConfig,
+    default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
+    ProfileConfig, StoreConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
@@ -12,7 +12,7 @@ use crate::profiles::{
     ProfileSummary,
 };
 use crate::prompt;
-use crate::resolve::{resolve_target_profile, resolved_config_path};
+use crate::resolve::resolve_target_profile;
 use loon_api::{AuthoritativePathEntry, NamespaceSummary};
 
 const AWS_REGIONS: &[&str] = &[
@@ -70,7 +70,7 @@ pub enum CommandData {
     Profile(ProfileConfig),
     ProfileSummary(ProfileSummary),
     ProfileList {
-        default_profile: String,
+        default_profile: Option<String>,
         profiles: Vec<ProfileSummary>,
     },
     DefaultProfile {
@@ -135,21 +135,15 @@ fn run_inner(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, Comman
                 version: env!("CARGO_PKG_VERSION").to_owned(),
             },
         }),
-        Command::Init(args) => run_init(kind, cli.config.as_deref(), args, runtime),
-        Command::Config { command } => run_config_command(kind, cli.config.as_deref(), command),
-        Command::Profile { command } => {
-            run_profile_command(kind, cli.config.as_deref(), command, runtime)
-        }
+        Command::Init(args) => run_init(kind, args, runtime),
+        Command::Config { command } => run_config_command(kind, command),
+        Command::Profile { command } => run_profile_command(kind, command, runtime),
         Command::Namespace { command } => {
-            run_namespace_command(kind, cli.config.as_deref(), cli.profile.as_deref(), command)
+            run_namespace_command(kind, cli.profile.as_deref(), command)
         }
-        Command::Filesystem { command } => run_filesystem_command(
-            kind,
-            cli.config.as_deref(),
-            cli.profile.as_deref(),
-            command,
-            runtime,
-        ),
+        Command::Filesystem { command } => {
+            run_filesystem_command(kind, cli.profile.as_deref(), command, runtime)
+        }
     }
 }
 
@@ -157,14 +151,18 @@ fn run_inner(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, Comman
 
 fn run_init(
     kind: CommandKind,
-    explicit_config: Option<&Path>,
     args: InitArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path =
-        resolved_config_path(explicit_config).map_err(|error| fail(kind, None, None, error))?;
+    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
 
     let result = (|| -> Result<(String, ProfileConfig), CliError> {
+        if config_path.exists() {
+            return Err(CliError::config_already_exists(
+                &config_path.display().to_string(),
+            ));
+        }
+
         let name = match &args.name {
             Some(n) => n.clone(),
             None if runtime.interactive => prompt::prompt_line_default("profile name", "default")?,
@@ -181,7 +179,7 @@ fn run_init(
 
         let mut config = load_or_default_config(&config_path)?;
         let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
-        config.default_profile = profile_name.clone();
+        config.default_profile = Some(profile_name.clone());
         save_config(&config_path, &config)?;
         Ok((profile_name, redacted))
     })()
@@ -283,11 +281,9 @@ fn require_or_prompt_region(
 
 fn run_config_command(
     kind: CommandKind,
-    explicit_config: Option<&Path>,
     command: ConfigCommand,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path =
-        resolved_config_path(explicit_config).map_err(|error| fail(kind, None, None, error))?;
+    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
     match command {
         ConfigCommand::Path => Ok(CommandOutput {
             kind,
@@ -316,12 +312,10 @@ fn run_config_command(
 
 fn run_profile_command(
     kind: CommandKind,
-    explicit_config: Option<&Path>,
     command: ProfileCommand,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path =
-        resolved_config_path(explicit_config).map_err(|error| fail(kind, None, None, error))?;
+    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
     match command {
         ProfileCommand::Add { command } => run_profile_add(kind, &config_path, command, runtime),
         ProfileCommand::List => {
@@ -332,10 +326,7 @@ fn run_profile_command(
                 profile: None,
                 mode: None,
                 data: CommandData::ProfileList {
-                    default_profile: config
-                        .as_ref()
-                        .map(|c| c.default_profile.clone())
-                        .unwrap_or_default(),
+                    default_profile: config.as_ref().and_then(|c| c.default_profile.clone()),
                     profiles: list_profiles(config.as_ref()),
                 },
             })
@@ -818,11 +809,10 @@ fn run_profile_make_default(
 
 fn run_namespace_command(
     kind: CommandKind,
-    explicit_config: Option<&Path>,
     global_profile: Option<&str>,
     command: NamespaceCommand,
 ) -> Result<CommandOutput, CommandFailure> {
-    let resolved = resolve_target_profile(explicit_config, global_profile)
+    let resolved = resolve_target_profile(global_profile)
         .map_err(|error| fail(kind, global_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let backend = resolved.target.backend();
@@ -871,12 +861,11 @@ fn run_namespace_command(
 
 fn run_filesystem_command(
     kind: CommandKind,
-    explicit_config: Option<&Path>,
     global_profile: Option<&str>,
     command: FilesystemCommand,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let resolved = resolve_target_profile(explicit_config, global_profile)
+    let resolved = resolve_target_profile(global_profile)
         .map_err(|error| fail(kind, global_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let backend = resolved.target.backend();

--- a/crates/loon-cli/src/config.rs
+++ b/crates/loon-cli/src/config.rs
@@ -14,7 +14,8 @@ pub const CONFIG_VERSION: u32 = 1;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CliConfig {
     pub config_version: u32,
-    pub default_profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_profile: Option<String>,
     #[serde(flatten)]
     pub profiles: BTreeMap<String, ProfileConfig>,
 }
@@ -75,7 +76,7 @@ impl CliConfig {
     pub fn new() -> Self {
         Self {
             config_version: CONFIG_VERSION,
-            default_profile: String::new(),
+            default_profile: None,
             profiles: BTreeMap::new(),
         }
     }
@@ -87,11 +88,13 @@ impl CliConfig {
                 self.config_version
             )));
         }
-        if !self.default_profile.is_empty() && !self.profiles.contains_key(&self.default_profile) {
-            return Err(CliError::invalid_config(format!(
-                "`default_profile` points to missing profile `{}`",
-                self.default_profile
-            )));
+        if let Some(default_profile) = &self.default_profile {
+            require_non_empty("default_profile", default_profile)?;
+            if !self.profiles.contains_key(default_profile) {
+                return Err(CliError::invalid_config(format!(
+                    "`default_profile` points to missing profile `{default_profile}`"
+                )));
+            }
         }
         for (name, profile) in &self.profiles {
             validate_profile_name(name).map_err(|error| CliError::invalid_config(error.message))?;

--- a/crates/loon-cli/src/error.rs
+++ b/crates/loon-cli/src/error.rs
@@ -40,6 +40,15 @@ impl CliError {
         )
     }
 
+    pub fn config_already_exists(path: &str) -> Self {
+        Self::new(
+            "config_already_exists",
+            format!(
+                "config file already exists at `{path}`. use `loon profile add` to create a new profile, `loon profile update` to modify an existing profile, or `loon profile make-default` to change the default profile"
+            ),
+        )
+    }
+
     pub fn non_interactive_input_required(field: &str) -> Self {
         Self::new(
             "non_interactive_input_required",

--- a/crates/loon-cli/src/profiles.rs
+++ b/crates/loon-cli/src/profiles.rs
@@ -31,8 +31,10 @@ pub fn show_profile(
 ) -> Result<(String, ProfileConfig), CliError> {
     let name = match explicit_name {
         Some(name) => name,
-        None if config.default_profile.is_empty() => return Err(CliError::no_default_profile()),
-        None => &config.default_profile,
+        None => config
+            .default_profile
+            .as_deref()
+            .ok_or_else(CliError::no_default_profile)?,
     };
     let profile = config
         .profiles
@@ -54,7 +56,7 @@ pub fn add_profile(
     let redacted = profile.redacted();
     config.profiles.insert(name.to_owned(), profile);
     if is_first {
-        config.default_profile = name.to_owned();
+        config.default_profile = Some(name.to_owned());
     }
     Ok((name.to_owned(), redacted))
 }
@@ -77,8 +79,8 @@ pub fn remove_profile(config: &mut CliConfig, name: &str) -> Result<ProfileSumma
         .profiles
         .remove(name)
         .ok_or_else(|| CliError::profile_not_found(name))?;
-    if config.default_profile == name {
-        config.default_profile.clear();
+    if config.default_profile.as_deref() == Some(name) {
+        config.default_profile = None;
     }
     Ok(ProfileSummary {
         name: name.to_owned(),
@@ -91,7 +93,7 @@ pub fn make_default_profile(config: &mut CliConfig, name: &str) -> Result<(), Cl
     if !config.profiles.contains_key(name) {
         return Err(CliError::profile_not_found(name));
     }
-    config.default_profile = name.to_owned();
+    config.default_profile = Some(name.to_owned());
     Ok(())
 }
 
@@ -101,8 +103,10 @@ pub fn resolve_profile<'a>(
 ) -> Result<(&'a str, &'a ProfileConfig), CliError> {
     let name = match explicit_name {
         Some(name) => name,
-        None if config.default_profile.is_empty() => return Err(CliError::no_default_profile()),
-        None => &config.default_profile,
+        None => config
+            .default_profile
+            .as_deref()
+            .ok_or_else(CliError::no_default_profile)?,
     };
     let profile = config
         .profiles

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -112,7 +112,7 @@ pub fn human_success(output: &CommandOutput) -> String {
             let mut lines = vec!["NAME\tMODE\tSTORE\tDEFAULT".to_owned()];
             for profile in profiles {
                 let store = profile.store_kind.as_deref().unwrap_or("-");
-                let default = if profile.name == *default_profile {
+                let default = if default_profile.as_deref() == Some(profile.name.as_str()) {
                     "*"
                 } else {
                     ""
@@ -207,7 +207,7 @@ mod tests {
             profile: None,
             mode: None,
             data: CommandData::ProfileList {
-                default_profile: "default".to_owned(),
+                default_profile: Some("default".to_owned()),
                 profiles: vec![
                     ProfileSummary {
                         name: "default".to_owned(),

--- a/crates/loon-cli/src/resolve.rs
+++ b/crates/loon-cli/src/resolve.rs
@@ -2,25 +2,14 @@ use crate::backend::ResolvedTarget;
 use crate::config::{default_config_path, load_config};
 use crate::error::CliError;
 use crate::profiles::resolve_profile;
-use std::path::{Path, PathBuf};
 
 pub struct ResolvedProfile {
     pub profile_name: String,
     pub target: ResolvedTarget,
 }
 
-pub fn resolved_config_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
-    match explicit {
-        Some(path) => Ok(path.to_path_buf()),
-        None => default_config_path(),
-    }
-}
-
-pub fn resolve_target_profile(
-    explicit_config: Option<&Path>,
-    explicit_profile: Option<&str>,
-) -> Result<ResolvedProfile, CliError> {
-    let config_path = resolved_config_path(explicit_config)?;
+pub fn resolve_target_profile(explicit_profile: Option<&str>) -> Result<ResolvedProfile, CliError> {
+    let config_path = default_config_path()?;
     let config = load_config(&config_path)?;
     let (profile_name, profile) = resolve_profile(&config, explicit_profile)?;
     let target = ResolvedTarget::resolve(profile_name, profile)?;

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -67,7 +67,7 @@ fn profile_add_list_show_remove_work() {
 
     let list_after_remove = harness.run(&["--json", "profile", "list"]);
     assert_success(&list_after_remove);
-    assert_eq!(json_data(&list_after_remove)["default_profile"], "");
+    assert!(json_data(&list_after_remove)["default_profile"].is_null());
 
     let show_without_default = harness.run(&["--json", "profile", "show"]);
     assert_failure(&show_without_default);
@@ -223,8 +223,12 @@ fn removing_last_profile_leaves_empty_config() {
     let list = harness.run(&["--json", "profile", "list"]);
     assert_success(&list);
     let data = json_data(&list);
-    assert_eq!(data["default_profile"], "");
+    assert!(data["default_profile"].is_null());
     assert_eq!(data["profiles"].as_array().unwrap().len(), 0);
+
+    let show_config = harness.run(&["config", "show"]);
+    assert_success(&show_config);
+    assert!(!stdout_string(&show_config).contains("default_profile"));
 
     let show = harness.run(&["--json", "profile", "show"]);
     assert_failure(&show);
@@ -243,7 +247,7 @@ fn removing_default_profile_requires_explicit_reselection() {
     let list = harness.run(&["--json", "profile", "list"]);
     assert_success(&list);
     let data = json_data(&list);
-    assert_eq!(data["default_profile"], "");
+    assert!(data["default_profile"].is_null());
     assert_eq!(data["profiles"].as_array().unwrap().len(), 1);
 
     let show = harness.run(&["--json", "profile", "show"]);
@@ -342,14 +346,53 @@ fn reserved_profile_names_are_rejected() {
 }
 
 #[test]
+fn init_rejects_existing_config_file() {
+    let harness = Harness::new();
+    harness.write_cli_config(&format!(
+        r#"
+config_version = 1
+default_profile = "default"
+
+[default]
+mode = "local"
+
+[default.store]
+kind = "local-fs"
+root = "{}"
+"#,
+        harness.store_root("default").display()
+    ));
+    let existing = fs::read_to_string(&harness.config_path).expect("read existing config");
+
+    let init = harness.run(&[
+        "--json",
+        "init",
+        "mystore",
+        "--store-kind",
+        "local-fs",
+        "--root",
+        harness.store_root("mystore").to_str().unwrap(),
+    ]);
+    assert_failure(&init);
+    let error = json_error(&init);
+    assert_eq!(error["code"], "config_already_exists");
+    let message = error["message"].as_str().unwrap();
+    assert!(message.contains("config file already exists"));
+    assert!(message.contains("loon profile add"));
+    assert!(message.contains("loon profile update"));
+    assert!(message.contains("loon profile make-default"));
+    assert_eq!(
+        fs::read_to_string(&harness.config_path).expect("read unchanged config"),
+        existing
+    );
+}
+
+#[test]
 fn reserved_profile_names_in_config_are_rejected() {
     let harness = Harness::new();
-    fs::write(
-        &harness.config_path,
-        format!(
-            r#"
+    harness.write_cli_config(format!(
+        r#"
 config_version = 1
-default_profile = ""
 
 [default_profile]
 mode = "local"
@@ -358,10 +401,8 @@ mode = "local"
 kind = "local-fs"
 root = "{}"
 "#,
-            harness.store_root("default_profile").display()
-        ),
-    )
-    .expect("write invalid config");
+        harness.store_root("default_profile").display()
+    ));
 
     let list = harness.run(&["--json", "profile", "list"]);
     assert_failure(&list);
@@ -369,10 +410,49 @@ root = "{}"
 }
 
 #[test]
+fn empty_default_profile_in_config_is_rejected() {
+    let harness = Harness::new();
+    harness.write_cli_config(
+        r#"
+config_version = 1
+default_profile = ""
+"#,
+    );
+
+    let list = harness.run(&["--json", "profile", "list"]);
+    assert_failure(&list);
+    let error = json_error(&list);
+    assert_eq!(error["code"], "invalid_config");
+    assert!(error["message"]
+        .as_str()
+        .unwrap()
+        .contains("default_profile"));
+}
+
+#[test]
+fn whitespace_default_profile_in_config_is_rejected() {
+    let harness = Harness::new();
+    harness.write_cli_config(
+        r#"
+config_version = 1
+default_profile = "   "
+"#,
+    );
+
+    let list = harness.run(&["--json", "profile", "list"]);
+    assert_failure(&list);
+    let error = json_error(&list);
+    assert_eq!(error["code"], "invalid_config");
+    assert!(error["message"]
+        .as_str()
+        .unwrap()
+        .contains("default_profile"));
+}
+
+#[test]
 fn invalid_store_field_messages_use_flattened_paths() {
     let harness = Harness::new();
-    fs::write(
-        &harness.config_path,
+    harness.write_cli_config(
         r#"
 config_version = 1
 default_profile = "default"
@@ -384,8 +464,7 @@ mode = "local"
 kind = "local-fs"
 root = ""
 "#,
-    )
-    .expect("write invalid config");
+    );
 
     let list = harness.run(&["--json", "profile", "list"]);
     assert_failure(&list);
@@ -461,22 +540,25 @@ fn external_remote_profile_executes_through_http() {
 
 struct Harness {
     temp_dir: TempDir,
+    home_dir: PathBuf,
     config_path: PathBuf,
 }
 
 impl Harness {
     fn new() -> Self {
         let temp_dir = tempfile::tempdir().expect("tempdir");
+        let home_dir = temp_dir.path().join("home");
+        fs::create_dir_all(&home_dir).expect("create temp home");
         Self {
-            config_path: temp_dir.path().join("config.toml"),
+            config_path: home_dir.join(".loonfs").join("config.toml"),
+            home_dir,
             temp_dir,
         }
     }
 
     fn run(&self, args: &[&str]) -> Output {
         Command::new(loon_binary_path())
-            .arg("--config")
-            .arg(&self.config_path)
+            .env("HOME", &self.home_dir)
             .args(args)
             .output()
             .expect("run loon")
@@ -497,6 +579,12 @@ impl Harness {
             self.store_root(name).to_str().unwrap(),
         ]);
         assert_success(&output);
+    }
+
+    fn write_cli_config(&self, contents: impl AsRef<[u8]>) {
+        fs::create_dir_all(self.config_path.parent().expect("config dir"))
+            .expect("create config dir");
+        fs::write(&self.config_path, contents).expect("write cli config");
     }
 
     fn write_server_config(&self, name: &str, key_prefix: &str) -> PathBuf {
@@ -532,6 +620,18 @@ key_prefix = "{key_prefix}"
         wait_for_healthz(&server_url);
         ExternalServer { child, server_url }
     }
+}
+
+#[test]
+fn help_omits_config_flag() {
+    let harness = Harness::new();
+    let output = Command::new(loon_binary_path())
+        .env("HOME", &harness.home_dir)
+        .arg("--help")
+        .output()
+        .expect("run help");
+    assert_success(&output);
+    assert!(!stdout_string(&output).contains("--config"));
 }
 
 struct ExternalServer {

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -348,7 +348,7 @@ fn reserved_profile_names_are_rejected() {
 #[test]
 fn init_rejects_existing_config_file() {
     let harness = Harness::new();
-    harness.write_cli_config(&format!(
+    harness.write_cli_config(format!(
         r#"
 config_version = 1
 default_profile = "default"


### PR DESCRIPTION
## Summary
- remove the global --config override so the CLI always uses ~/.loonfs/config.toml
- omit default_profile from TOML when unset and emit null in JSON output
- make loon init fail when a config file already exists and add coverage for the new behavior

## Testing
- cargo test -p loon-cli
