### PR TITLE
fix: clarify missing namespace errors

### DIFF
--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -263,13 +263,14 @@ fn map_core_error(error: CoreError) -> CliError {
 }
 
 fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliError {
-    match error.kind() {
-        CoreErrorKind::NamespaceNotFound => CliError::new(
+    if matches!(error.kind(), CoreErrorKind::NamespaceNotFound) {
+        return CliError::new(
             "namespace_not_found",
             format!("namespace `{namespace}` does not exist"),
-        ),
-        _ => map_core_error(error),
+        );
     }
+
+    map_core_error(error)
 }
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -151,18 +151,20 @@ impl Backend for DirectBackend {
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
         let ns_id = NamespaceId::from(spec.namespace.clone());
-        list_path(&self.store, &ns_id, &spec.absolute_path).map_err(map_core_error)
+        list_path(&self.store, &ns_id, &spec.absolute_path)
+            .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
         let ns_id = NamespaceId::from(spec.namespace.clone());
-        resolve_path(&self.store, &ns_id, &spec.absolute_path).map_err(map_core_error)
+        resolve_path(&self.store, &ns_id, &spec.absolute_path)
+            .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
         let ns_id = NamespaceId::from(spec.namespace.clone());
-        let result =
-            read_file_bytes(&self.store, &ns_id, &spec.absolute_path).map_err(map_core_error)?;
+        let result = read_file_bytes(&self.store, &ns_id, &spec.absolute_path)
+            .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))?;
         Ok(result.bytes)
     }
 
@@ -187,7 +189,7 @@ impl Backend for DirectBackend {
             &self.mutation_context(),
             None,
         )
-        .map_err(map_core_error)
+        .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
@@ -199,7 +201,7 @@ impl Backend for DirectBackend {
             &self.mutation_context(),
             None,
         )
-        .map_err(map_core_error)
+        .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn move_path(
@@ -216,7 +218,7 @@ impl Backend for DirectBackend {
             &self.mutation_context(),
             None,
         )
-        .map_err(map_core_error)
+        .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
 
     fn copy_path(
@@ -233,7 +235,7 @@ impl Backend for DirectBackend {
             &self.mutation_context(),
             None,
         )
-        .map_err(map_core_error)
+        .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
 }
 
@@ -258,6 +260,16 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::ServerError => "server_error",
     };
     CliError::new(code, error.to_string())
+}
+
+fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliError {
+    match error.kind() {
+        CoreErrorKind::NamespaceNotFound => CliError::new(
+            "namespace_not_found",
+            format!("namespace `{namespace}` does not exist"),
+        ),
+        _ => map_core_error(error),
+    }
 }
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -538,6 +538,43 @@ fn external_remote_profile_executes_through_http() {
     assert_eq!(namespaces[0]["name"], "demo");
 }
 
+#[test]
+fn local_profile_missing_namespace_reports_user_facing_message() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let output = harness.run(&["--json", "filesystem", "ls", "missing"]);
+    assert_failure(&output);
+    let error = json_error(&output);
+    assert_eq!(error["code"], "namespace_not_found");
+    assert_eq!(error["message"], "namespace `missing` does not exist");
+}
+
+#[test]
+fn remote_profile_missing_namespace_reports_user_facing_message() {
+    let harness = Harness::new();
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "remote-missing-ns"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "add",
+        "remote",
+        "default",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    let output = harness.run(&["--json", "filesystem", "ls", "missing"]);
+    assert_failure(&output);
+    let error = json_error(&output);
+    assert_eq!(error["code"], "namespace_not_found");
+    assert_eq!(error["message"], "namespace `missing` does not exist");
+}
+
 struct Harness {
     temp_dir: TempDir,
     home_dir: PathBuf,

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -159,7 +159,8 @@ async fn list_entries(
     let namespace_id = NamespaceId::from(namespace);
     let path = query.path;
     let entries = run_blocking(move || {
-        list_path(store.as_ref(), &namespace_id, &path).map_err(ApiResponseError::core)
+        list_path(store.as_ref(), &namespace_id, &path)
+            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(entries))
@@ -176,7 +177,8 @@ async fn stat_entry(
     let namespace_id = NamespaceId::from(namespace);
     let path = query.path;
     let entry = run_blocking(move || {
-        resolve_path(store.as_ref(), &namespace_id, &path).map_err(ApiResponseError::core)
+        resolve_path(store.as_ref(), &namespace_id, &path)
+            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(entry))
@@ -193,7 +195,8 @@ async fn get_content(
     let namespace_id = NamespaceId::from(namespace);
     let path = query.path;
     let file = run_blocking(move || {
-        read_file_bytes(store.as_ref(), &namespace_id, &path).map_err(ApiResponseError::core)
+        read_file_bytes(store.as_ref(), &namespace_id, &path)
+            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok((StatusCode::OK, file.bytes).into_response())
@@ -248,7 +251,7 @@ async fn filesystem_operation(
                 Some(&request.request_id),
             ),
         }
-        .map_err(ApiResponseError::core)?;
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
         Ok(FilesystemOperationResponse::from(result))
     })
     .await?;
@@ -266,7 +269,7 @@ async fn begin_upload_handler(
     let namespace_id = NamespaceId::from(namespace);
     let response = run_blocking(move || {
         begin_upload(store.as_ref(), &namespace_id, &mutation_context(&config))
-            .map_err(ApiResponseError::core)
+            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(response))
@@ -292,7 +295,7 @@ async fn upload_block_handler(
             &bytes,
             &mutation_context(&config),
         )
-        .map_err(ApiResponseError::core)
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(response))
@@ -316,7 +319,7 @@ async fn complete_upload_handler(
             &request,
             &mutation_context(&config),
         )
-        .map_err(ApiResponseError::core)
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(response))
@@ -339,7 +342,7 @@ async fn commit_operations_handler(
             request,
             &mutation_context(&config),
         )
-        .map_err(ApiResponseError::core)
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(response))
@@ -356,7 +359,8 @@ async fn list_changes_handler(
     let namespace_id = NamespaceId::from(namespace);
     let after_seq = loon_api::ChangeSeq(query.after_seq);
     let response = run_blocking(move || {
-        list_changes_after(store.as_ref(), &namespace_id, after_seq).map_err(ApiResponseError::core)
+        list_changes_after(store.as_ref(), &namespace_id, after_seq)
+            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok(Json(response))
@@ -481,6 +485,18 @@ impl ApiResponseError {
         };
         Self::new(status, code, &error.to_string())
     }
+
+    fn core_for_namespace(namespace: &NamespaceId, error: CoreError) -> Self {
+        if matches!(error.kind(), CoreErrorKind::NamespaceNotFound) {
+            return Self::new(
+                StatusCode::NOT_FOUND,
+                "namespace_not_found",
+                &format!("namespace `{}` does not exist", namespace.as_str()),
+            );
+        }
+
+        Self::core(error)
+    }
 }
 
 impl IntoResponse for ApiResponseError {
@@ -572,17 +588,41 @@ mod tests {
                 harness.client.write_file_bytes(&target, b"hello"),
                 404,
                 "namespace_not_found",
+                Some("namespace `missing` does not exist"),
             );
             assert_api_error(
                 harness.client.delete_path(&target),
                 404,
                 "namespace_not_found",
+                Some("namespace `missing` does not exist"),
             );
             let destination = NamespacePath::parse("missing:/notes/renamed.txt").expect("target");
             assert_api_error(
                 harness.client.move_path(&target, &destination),
                 404,
                 "namespace_not_found",
+                Some("namespace `missing` does not exist"),
+            );
+        })
+        .await
+        .expect("join blocking task");
+
+        harness.server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn http_missing_namespace_reads_return_namespace_not_found() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let harness = start_server(store, temp_dir.path(), "server-writer").await;
+
+        tokio::task::spawn_blocking(move || {
+            let target = NamespacePath::parse("missing:/").expect("target");
+            assert_api_error(
+                harness.client.list_path(&target),
+                404,
+                "namespace_not_found",
+                Some("namespace `missing` does not exist"),
             );
         })
         .await
@@ -607,7 +647,12 @@ mod tests {
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
             let target = NamespacePath::parse("demo:/missing.txt").expect("target");
-            assert_api_error(harness.client.delete_path(&target), 404, "path_not_found");
+            assert_api_error(
+                harness.client.delete_path(&target),
+                404,
+                "path_not_found",
+                None,
+            );
         })
         .await
         .expect("join blocking task");
@@ -658,11 +703,17 @@ mod tests {
                 harness.client.write_file_bytes(&dir_target, b"not a file"),
                 409,
                 "path_conflict",
+                None,
             );
 
             let from = NamespacePath::parse("demo:/tmp/a.txt").expect("from");
             let to = NamespacePath::parse("demo:/docs/a.txt").expect("to");
-            assert_api_error(harness.client.move_path(&from, &to), 409, "path_conflict");
+            assert_api_error(
+                harness.client.move_path(&from, &to),
+                409,
+                "path_conflict",
+                None,
+            );
         })
         .await
         .expect("join blocking task");
@@ -712,6 +763,7 @@ mod tests {
                 harness.client.write_file_bytes(&put_target, b"new"),
                 409,
                 "tombstone_conflict",
+                None,
             );
 
             let from = NamespacePath::parse("demo:/tmp/source.txt").expect("from");
@@ -720,6 +772,7 @@ mod tests {
                 harness.client.move_path(&from, &to),
                 409,
                 "tombstone_conflict",
+                None,
             );
         })
         .await
@@ -748,6 +801,7 @@ mod tests {
                 harness.client.write_file_bytes(&target, b"race"),
                 409,
                 "stale_head",
+                None,
             );
         })
         .await
@@ -776,6 +830,7 @@ mod tests {
                 harness.client.write_file_bytes(&target, b"blocked"),
                 409,
                 "lease_conflict",
+                None,
             );
         })
         .await
@@ -843,15 +898,20 @@ mod tests {
         result: Result<T, ClientError>,
         status: u16,
         code: &str,
+        message: Option<&str>,
     ) {
         match result {
             Err(ClientError::Api {
                 status: actual_status,
                 code: actual_code,
+                message: actual_message,
                 ..
             }) => {
                 assert_eq!(actual_status, status);
                 assert_eq!(actual_code, code);
+                if let Some(expected_message) = message {
+                    assert_eq!(actual_message, expected_message);
+                }
             }
             other => panic!("expected api error {status} {code}, got {other:?}"),
         }


### PR DESCRIPTION
## Summary
- rewrite missing-namespace errors at the CLI backend edge to show a namespace-facing message
- rewrite namespace-bound HTTP error responses to return the same message without changing the error code or status
- add local CLI, remote CLI, and server regression coverage for the exact message

## Testing
- cargo fmt --all
- cargo test -p loon-cli missing_namespace_reports_user_facing_message
- cargo test -p loon-server missing_namespace