### PR TITLE
feat(loon-cli): refresh profile and namespace UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,6 +2821,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -94,28 +94,26 @@ cargo install --path crates/loon-server
 Example local flow:
 
 ```bash
-cp ./configs/loond.local-fs.example.toml "$HOME/loond.local.toml"
-$EDITOR "$HOME/loond.local.toml"
+loon init local \
+  --mode local \
+  --store-kind local-fs \
+  --root "$HOME/loon-local-store"
 
-loon profile add local local \
-  --server-config "$HOME/loond.local.toml"
-
-loon --profile local local up
 loon namespace create demo
+loon use demo
 
 printf 'hello\n' > /tmp/loonfs-demo.txt
-loon filesystem put demo /tmp/loonfs-demo.txt /docs/hello.txt
-loon filesystem ls demo /docs
-loon filesystem stat demo /docs/hello.txt
-loon filesystem get demo /docs/hello.txt /tmp/loonfs-downloaded.txt
-
-loon --profile local local down
+loon put /tmp/loonfs-demo.txt /docs/hello.txt
+loon ls /docs
+loon stat /docs/hello.txt
+loon get /docs/hello.txt /tmp/loonfs-downloaded.txt
 ```
 
 Example remote profile:
 
 ```bash
-loon profile add remote prod \
+loon profile create prod \
+  --mode remote \
   --server-url http://127.0.0.1:9400 \
   --auth-token dev-token
 ```
@@ -124,36 +122,35 @@ loon profile add remote prod \
 
 Current path-oriented CLI commands:
 
-- `loon profile add local NAME --server-config <PATH>`
-- `loon profile add remote NAME --server-url <URL> [--auth-token <TOKEN>]`
+- `loon init [NAME] [--mode <MODE>] [profile creation flags]`
+- `loon profile create NAME --mode <MODE> [profile creation flags]`
 - `loon profile list`
 - `loon profile use NAME`
 - `loon profile show [NAME]`
+- `loon profile update NAME [flags]`
 - `loon profile remove NAME`
-- `loon local up`
-- `loon local status`
-- `loon local down`
-- `loon namespace create NAME`
-- `loon namespace list`
-- `loon filesystem ls NAMESPACE [PATH]`
-- `loon filesystem stat NAMESPACE PATH`
-- `loon filesystem cat NAMESPACE PATH`
-- `loon filesystem get NAMESPACE REMOTE_PATH [LOCAL_DESTINATION]`
-- `loon filesystem put NAMESPACE LOCAL_PATH [REMOTE_PATH] [--force]`
-- `loon filesystem rm NAMESPACE REMOTE_PATH`
-- `loon filesystem mv NAMESPACE SOURCE_PATH DEST_PATH`
-- `loon filesystem cp NAMESPACE SOURCE_PATH DEST_PATH`
+- `loon namespace create [--profile <NAME>] NAME`
+- `loon namespace list [--profile <NAME>]`
+- `loon use [--profile <NAME>] NAMESPACE`
+- `loon current [--profile <NAME>]`
+- `loon ls [--profile <NAME>] [--namespace <NAME>] [PATH]`
+- `loon stat [--profile <NAME>] [--namespace <NAME>] PATH`
+- `loon cat [--profile <NAME>] [--namespace <NAME>] PATH`
+- `loon get [--profile <NAME>] [--namespace <NAME>] REMOTE_PATH [LOCAL_DESTINATION]`
+- `loon put [--profile <NAME>] [--namespace <NAME>] LOCAL_PATH [REMOTE_PATH] [--force]`
+- `loon rm [--profile <NAME>] [--namespace <NAME>] REMOTE_PATH`
+- `loon mv [--profile <NAME>] [--namespace <NAME>] SOURCE_PATH DEST_PATH`
+- `loon cp [--profile <NAME>] [--namespace <NAME>] SOURCE_PATH DEST_PATH`
 - `loon config path`
 - `loon config show`
 - `loon version`
 
 Global flags:
 
-- `--profile <NAME>`
 - `--json`
 - `--no-input`
 
-`filesystem cat` and `filesystem get ... -` stream raw bytes to stdout and reject `--json`.
+`cat` and `get ... -` stream raw bytes to stdout and reject `--json`.
 
 The CLI is the current path-oriented client profile only. It does not expose first-class commands
 for the lower-level staged upload, explicit commit, or ordered change-feed surface yet.

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -5,8 +5,6 @@ use std::io::IsTerminal;
 #[command(name = "loon")]
 pub struct Cli {
     #[arg(long, global = true)]
-    pub profile: Option<String>,
-    #[arg(long, global = true)]
     pub json: bool,
     #[arg(long, global = true)]
     pub no_input: bool,
@@ -25,10 +23,16 @@ pub enum Command {
         #[command(subcommand)]
         command: NamespaceCommand,
     },
-    Filesystem {
-        #[command(subcommand)]
-        command: FilesystemCommand,
-    },
+    Use(NamespaceUseArgs),
+    Current(CurrentArgs),
+    Ls(FilesystemLsArgs),
+    Stat(FilesystemPathArgs),
+    Cat(FilesystemPathArgs),
+    Get(FilesystemGetArgs),
+    Put(FilesystemPutArgs),
+    Rm(FilesystemPathArgs),
+    Mv(FilesystemMoveArgs),
+    Cp(FilesystemMoveArgs),
     Config {
         #[command(subcommand)]
         command: ConfigCommand,
@@ -39,6 +43,8 @@ pub enum Command {
 #[derive(Debug, Args)]
 pub struct InitArgs {
     pub name: Option<String>,
+    #[arg(long)]
+    pub mode: Option<String>,
     #[arg(long)]
     pub store_kind: Option<String>,
     #[arg(long)]
@@ -54,90 +60,58 @@ pub struct InitArgs {
     #[arg(long)]
     pub endpoint_url: Option<String>,
     #[arg(long)]
+    pub session_token: Option<String>,
+    #[arg(long)]
     pub account_id: Option<String>,
     #[arg(long)]
     pub key_prefix: Option<String>,
+    #[arg(long)]
+    pub force_path_style: bool,
+    #[arg(long)]
+    pub server_url: Option<String>,
+    #[arg(long)]
+    pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
 pub enum ProfileCommand {
-    Add {
-        #[command(subcommand)]
-        command: Option<ProfileAddCommand>,
-    },
+    Create(ProfileCreateArgs),
     List,
-    Show {
-        name: Option<String>,
-    },
+    Show { name: Option<String> },
     Update(ProfileUpdateArgs),
-    Remove {
-        name: String,
-    },
-    MakeDefault {
-        name: String,
-    },
-}
-
-#[derive(Debug, Subcommand)]
-pub enum ProfileAddCommand {
-    LocalFs(ProfileAddLocalFsArgs),
-    AwsS3(ProfileAddAwsS3Args),
-    CloudflareR2(ProfileAddCloudflareR2Args),
-    Remote(ProfileAddRemoteArgs),
+    Remove { name: String },
+    Use { name: String },
 }
 
 #[derive(Debug, Args)]
-pub struct ProfileAddLocalFsArgs {
+pub struct ProfileCreateArgs {
     pub name: String,
     #[arg(long)]
-    pub root: String,
+    pub mode: Option<String>,
+    #[arg(long)]
+    pub store_kind: Option<String>,
+    #[arg(long)]
+    pub root: Option<String>,
     #[arg(long)]
     pub key_prefix: Option<String>,
-}
-
-#[derive(Debug, Args)]
-pub struct ProfileAddAwsS3Args {
-    pub name: String,
     #[arg(long)]
-    pub bucket: String,
+    pub bucket: Option<String>,
     #[arg(long)]
-    pub region: String,
+    pub region: Option<String>,
     #[arg(long)]
-    pub access_key_id: String,
+    pub access_key_id: Option<String>,
     #[arg(long)]
-    pub secret_access_key: String,
+    pub secret_access_key: Option<String>,
     #[arg(long)]
     pub endpoint_url: Option<String>,
     #[arg(long)]
     pub session_token: Option<String>,
     #[arg(long)]
-    pub key_prefix: Option<String>,
-    #[arg(long)]
     pub force_path_style: bool,
-}
-
-#[derive(Debug, Args)]
-pub struct ProfileAddCloudflareR2Args {
-    pub name: String,
     #[arg(long)]
-    pub bucket: String,
+    pub account_id: Option<String>,
     #[arg(long)]
-    pub account_id: String,
-    #[arg(long)]
-    pub endpoint_url: String,
-    #[arg(long)]
-    pub access_key_id: String,
-    #[arg(long)]
-    pub secret_access_key: String,
-    #[arg(long)]
-    pub key_prefix: Option<String>,
-}
-
-#[derive(Debug, Args)]
-pub struct ProfileAddRemoteArgs {
-    pub name: String,
-    #[arg(long)]
-    pub server_url: String,
+    pub server_url: Option<String>,
     #[arg(long)]
     pub auth_token: Option<String>,
 }
@@ -169,52 +143,90 @@ pub struct ProfileUpdateArgs {
     pub auth_token: Option<String>,
 }
 
-#[derive(Debug, Subcommand)]
-pub enum NamespaceCommand {
-    Create { name: String },
-    List,
+#[derive(Debug, Args, Clone)]
+pub struct ProfileSelectorArgs {
+    #[arg(long)]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct TargetSelectorArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    #[arg(long)]
+    pub namespace: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct NamespaceUseArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    pub namespace: String,
+}
+
+#[derive(Debug, Args)]
+pub struct CurrentArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum FilesystemCommand {
-    Ls {
-        namespace: String,
-        path: Option<String>,
-    },
-    Stat {
-        namespace: String,
-        path: String,
-    },
-    Cat {
-        namespace: String,
-        path: String,
-    },
-    Get {
-        namespace: String,
-        remote_path: String,
-        local_destination: Option<String>,
-    },
-    Put {
-        namespace: String,
-        local_path: String,
-        remote_path: Option<String>,
-        #[arg(long)]
-        force: bool,
-    },
-    Rm {
-        namespace: String,
-        remote_path: String,
-    },
-    Mv {
-        namespace: String,
-        source_path: String,
-        dest_path: String,
-    },
-    Cp {
-        namespace: String,
-        source_path: String,
-        dest_path: String,
-    },
+pub enum NamespaceCommand {
+    Create(NamespaceCreateArgs),
+    List(NamespaceListArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct NamespaceCreateArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    pub name: String,
+}
+
+#[derive(Debug, Args)]
+pub struct NamespaceListArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemLsArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemPathArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: String,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemGetArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub remote_path: String,
+    pub local_destination: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemPutArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub local_path: String,
+    pub remote_path: Option<String>,
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemMoveArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub source_path: String,
+    pub dest_path: String,
 }
 
 #[derive(Debug, Subcommand)]
@@ -247,14 +259,16 @@ impl RuntimeBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandKind {
     Init,
-    ProfileAdd,
+    ProfileCreate,
     ProfileList,
     ProfileShow,
     ProfileUpdate,
     ProfileRemove,
-    ProfileMakeDefault,
+    ProfileUse,
     NamespaceCreate,
     NamespaceList,
+    NamespaceUse,
+    Current,
     FilesystemLs,
     FilesystemStat,
     FilesystemCat,
@@ -272,14 +286,16 @@ impl CommandKind {
     pub fn as_str(self) -> &'static str {
         match self {
             CommandKind::Init => "init",
-            CommandKind::ProfileAdd => "profile_add",
+            CommandKind::ProfileCreate => "profile_create",
             CommandKind::ProfileList => "profile_list",
             CommandKind::ProfileShow => "profile_show",
             CommandKind::ProfileUpdate => "profile_update",
             CommandKind::ProfileRemove => "profile_remove",
-            CommandKind::ProfileMakeDefault => "profile_make_default",
+            CommandKind::ProfileUse => "profile_use",
             CommandKind::NamespaceCreate => "namespace_create",
             CommandKind::NamespaceList => "namespace_list",
+            CommandKind::NamespaceUse => "namespace_use",
+            CommandKind::Current => "current",
             CommandKind::FilesystemLs => "filesystem_ls",
             CommandKind::FilesystemStat => "filesystem_stat",
             CommandKind::FilesystemCat => "filesystem_cat",
@@ -304,27 +320,27 @@ impl Cli {
         match &self.command {
             Command::Init(_) => CommandKind::Init,
             Command::Profile { command } => match command {
-                ProfileCommand::Add { .. } => CommandKind::ProfileAdd,
+                ProfileCommand::Create(_) => CommandKind::ProfileCreate,
                 ProfileCommand::List => CommandKind::ProfileList,
                 ProfileCommand::Show { .. } => CommandKind::ProfileShow,
-                ProfileCommand::Update { .. } => CommandKind::ProfileUpdate,
+                ProfileCommand::Update(_) => CommandKind::ProfileUpdate,
                 ProfileCommand::Remove { .. } => CommandKind::ProfileRemove,
-                ProfileCommand::MakeDefault { .. } => CommandKind::ProfileMakeDefault,
+                ProfileCommand::Use { .. } => CommandKind::ProfileUse,
             },
             Command::Namespace { command } => match command {
-                NamespaceCommand::Create { .. } => CommandKind::NamespaceCreate,
-                NamespaceCommand::List => CommandKind::NamespaceList,
+                NamespaceCommand::Create(_) => CommandKind::NamespaceCreate,
+                NamespaceCommand::List(_) => CommandKind::NamespaceList,
             },
-            Command::Filesystem { command } => match command {
-                FilesystemCommand::Ls { .. } => CommandKind::FilesystemLs,
-                FilesystemCommand::Stat { .. } => CommandKind::FilesystemStat,
-                FilesystemCommand::Cat { .. } => CommandKind::FilesystemCat,
-                FilesystemCommand::Get { .. } => CommandKind::FilesystemGet,
-                FilesystemCommand::Put { .. } => CommandKind::FilesystemPut,
-                FilesystemCommand::Rm { .. } => CommandKind::FilesystemRm,
-                FilesystemCommand::Mv { .. } => CommandKind::FilesystemMv,
-                FilesystemCommand::Cp { .. } => CommandKind::FilesystemCp,
-            },
+            Command::Use(_) => CommandKind::NamespaceUse,
+            Command::Current(_) => CommandKind::Current,
+            Command::Ls(_) => CommandKind::FilesystemLs,
+            Command::Stat(_) => CommandKind::FilesystemStat,
+            Command::Cat(_) => CommandKind::FilesystemCat,
+            Command::Get(_) => CommandKind::FilesystemGet,
+            Command::Put(_) => CommandKind::FilesystemPut,
+            Command::Rm(_) => CommandKind::FilesystemRm,
+            Command::Mv(_) => CommandKind::FilesystemMv,
+            Command::Cp(_) => CommandKind::FilesystemCp,
             Command::Config { command } => match command {
                 ConfigCommand::Path => CommandKind::ConfigPath,
                 ConfigCommand::Show => CommandKind::ConfigShow,

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -320,6 +320,7 @@ impl ResolvedTarget {
                 writer_id,
                 writer_version,
                 lease_duration_ms,
+                ..
             } => Ok(Self::Local(Box::new(LocalTarget::new(
                 store,
                 writer_id.as_deref(),
@@ -329,6 +330,7 @@ impl ResolvedTarget {
             ProfileConfig::Remote {
                 server_url,
                 auth_token,
+                ..
             } => Ok(Self::Remote(RemoteTarget::new(
                 profile_name,
                 server_url,

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -153,7 +153,7 @@ fn run_inner(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, Comman
         Command::Namespace { command } => run_namespace_command(kind, command),
         Command::Use(args) => run_namespace_use(kind, args),
         Command::Current(args) => run_current(kind, args),
-        Command::Ls(args) => run_filesystem_ls(kind, args, runtime),
+        Command::Ls(args) => run_filesystem_ls(kind, args),
         Command::Stat(args) => run_filesystem_stat(kind, args),
         Command::Cat(args) => run_filesystem_cat(kind, args),
         Command::Get(args) => run_filesystem_get(kind, args, runtime),
@@ -564,25 +564,17 @@ fn run_current(kind: CommandKind, args: CurrentArgs) -> Result<CommandOutput, Co
     let explicit_profile = args.profile.profile.as_deref();
     let loaded = load_cli_config()
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
-    let resolved = resolve_target_profile_from_config(&loaded.config, explicit_profile)
-        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
-    let mode = resolved.target.mode_str().to_owned();
-    let (_, profile) =
-        crate::profiles::resolve_profile(&loaded.config, explicit_profile).map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+    let (profile_name, profile) =
+        crate::profiles::resolve_profile(&loaded.config, explicit_profile)
+            .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = profile.mode_str().to_owned();
 
     Ok(CommandOutput {
         kind,
-        profile: Some(resolved.profile_name.clone()),
+        profile: Some(profile_name.to_owned()),
         mode: Some(mode),
         data: CommandData::Current {
-            profile: resolved.profile_name,
+            profile: profile_name.to_owned(),
             namespace: default_namespace(profile).map(ToOwned::to_owned),
         },
     })
@@ -593,7 +585,6 @@ fn run_current(kind: CommandKind, args: CurrentArgs) -> Result<CommandOutput, Co
 fn run_filesystem_ls(
     kind: CommandKind,
     args: FilesystemLsArgs,
-    _runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target)?;
     let spec = namespace_path(

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -1,19 +1,27 @@
 use crate::args::{
-    Cli, Command, CommandKind, ConfigCommand, FilesystemCommand, InitArgs, NamespaceCommand,
-    ProfileAddCommand, ProfileCommand, ProfileUpdateArgs, RuntimeBehavior,
+    Cli, Command, CommandKind, ConfigCommand, CurrentArgs, FilesystemGetArgs, FilesystemLsArgs,
+    FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs, InitArgs, NamespaceCommand,
+    NamespaceCreateArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand, ProfileCreateArgs,
+    ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
 };
 use crate::config::{
     default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
-    ProfileConfig, StoreConfig,
+    CliConfig, ProfileConfig, StoreConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
-    add_profile, list_profiles, make_default_profile, remove_profile, show_profile, update_profile,
-    ProfileSummary,
+    add_profile, default_namespace, list_profiles, make_default_profile, remove_profile,
+    set_default_namespace, show_profile, update_profile, ProfileSummary,
 };
 use crate::prompt;
-use crate::resolve::resolve_target_profile;
-use loon_api::{AuthoritativePathEntry, NamespaceSummary};
+use crate::resolve::{
+    load_cli_config, resolve_namespace, resolve_target_profile, resolve_target_profile_from_config,
+};
+use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceSummary};
+use loon_client::NamespacePath;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 const AWS_REGIONS: &[&str] = &[
     "us-east-1",
@@ -45,10 +53,6 @@ const AWS_REGIONS: &[&str] = &[
     "af-south-1",
     "il-central-1",
 ];
-use loon_client::NamespacePath;
-use serde::Serialize;
-use std::fs;
-use std::path::{Path, PathBuf};
 
 pub struct CommandOutput {
     pub kind: CommandKind,
@@ -76,6 +80,14 @@ pub enum CommandData {
     DefaultProfile {
         name: String,
     },
+    DefaultNamespace {
+        profile: String,
+        namespace: String,
+    },
+    Current {
+        profile: String,
+        namespace: Option<String>,
+    },
     NamespaceSummary(NamespaceSummary),
     NamespaceList {
         namespaces: Vec<NamespaceSummary>,
@@ -102,7 +114,7 @@ pub enum CommandData {
         path: String,
     },
     ConfigShow {
-        config: crate::config::CliConfig,
+        config: CliConfig,
     },
     Version {
         version: String,
@@ -115,7 +127,7 @@ pub fn run(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, CommandF
     if runtime.json && !kind.supports_json() {
         return Err(CommandFailure {
             kind,
-            profile: cli.profile.clone(),
+            profile: None,
             mode: None,
             error: CliError::json_not_supported_for_streaming(),
         });
@@ -138,12 +150,17 @@ fn run_inner(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, Comman
         Command::Init(args) => run_init(kind, args, runtime),
         Command::Config { command } => run_config_command(kind, command),
         Command::Profile { command } => run_profile_command(kind, command, runtime),
-        Command::Namespace { command } => {
-            run_namespace_command(kind, cli.profile.as_deref(), command)
-        }
-        Command::Filesystem { command } => {
-            run_filesystem_command(kind, cli.profile.as_deref(), command, runtime)
-        }
+        Command::Namespace { command } => run_namespace_command(kind, command),
+        Command::Use(args) => run_namespace_use(kind, args),
+        Command::Current(args) => run_current(kind, args),
+        Command::Ls(args) => run_filesystem_ls(kind, args, runtime),
+        Command::Stat(args) => run_filesystem_stat(kind, args),
+        Command::Cat(args) => run_filesystem_cat(kind, args),
+        Command::Get(args) => run_filesystem_get(kind, args, runtime),
+        Command::Put(args) => run_filesystem_put(kind, args),
+        Command::Rm(args) => run_filesystem_rm(kind, args),
+        Command::Mv(args) => run_filesystem_mv(kind, args),
+        Command::Cp(args) => run_filesystem_cp(kind, args),
     }
 }
 
@@ -164,18 +181,11 @@ fn run_init(
         }
 
         let name = match &args.name {
-            Some(n) => n.clone(),
+            Some(name) => name.clone(),
             None if runtime.interactive => prompt::prompt_line_default("profile name", "default")?,
             None => "default".to_owned(),
         };
-
-        let store = build_local_store_interactive(&args, runtime)?;
-        let profile = ProfileConfig::Local {
-            store,
-            writer_id: None,
-            writer_version: None,
-            lease_duration_ms: None,
-        };
+        let profile = build_profile_from_create_spec(create_profile_spec_from_init(args), runtime)?;
 
         let mut config = load_or_default_config(&config_path)?;
         let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
@@ -183,98 +193,14 @@ fn run_init(
         save_config(&config_path, &config)?;
         Ok((profile_name, redacted))
     })()
-    .map_err(|error| fail(kind, None, Some("local".to_owned()), error))?;
+    .map_err(|error| fail(kind, None, None, error))?;
 
     Ok(CommandOutput {
         kind,
         profile: Some(result.0),
-        mode: Some("local".to_owned()),
+        mode: Some(result.1.mode_str().to_owned()),
         data: CommandData::Profile(result.1),
     })
-}
-
-fn build_local_store_interactive(
-    args: &InitArgs,
-    runtime: RuntimeBehavior,
-) -> Result<StoreConfig, CliError> {
-    let store_kind = match &args.store_kind {
-        Some(k) => k.clone(),
-        None if runtime.interactive => {
-            prompt::prompt_choice("store kind", &["aws-s3", "cloudflare-r2", "local-fs"])?
-        }
-        None => {
-            return Err(CliError::non_interactive_input_required("store-kind"));
-        }
-    };
-
-    match store_kind.as_str() {
-        "local-fs" => {
-            let root = require_or_prompt(&args.root, "root", runtime)?;
-            Ok(StoreConfig::LocalFs {
-                root,
-                key_prefix: args.key_prefix.clone(),
-            })
-        }
-        "aws-s3" => {
-            let bucket = require_or_prompt(&args.bucket, "bucket name", runtime)?;
-            let region = require_or_prompt_region(&args.region, runtime)?;
-            let access_key_id = require_or_prompt(&args.access_key_id, "access-key-id", runtime)?;
-            let secret_access_key =
-                require_or_prompt(&args.secret_access_key, "secret-access-key", runtime)?;
-            Ok(StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url: args.endpoint_url.clone(),
-                access_key_id,
-                secret_access_key,
-                session_token: None,
-                key_prefix: args.key_prefix.clone(),
-                force_path_style: None,
-            })
-        }
-        "cloudflare-r2" => {
-            let bucket = require_or_prompt(&args.bucket, "bucket name", runtime)?;
-            let account_id = require_or_prompt(&args.account_id, "account-id", runtime)?;
-            let endpoint_url = require_or_prompt(&args.endpoint_url, "endpoint-url", runtime)?;
-            let access_key_id = require_or_prompt(&args.access_key_id, "access-key-id", runtime)?;
-            let secret_access_key =
-                require_or_prompt(&args.secret_access_key, "secret-access-key", runtime)?;
-            Ok(StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                key_prefix: args.key_prefix.clone(),
-            })
-        }
-        other => Err(CliError::invalid_input(format!(
-            "unknown store kind: `{other}` (expected local-fs, aws-s3, or cloudflare-r2)"
-        ))),
-    }
-}
-
-fn require_or_prompt(
-    value: &Option<String>,
-    field: &str,
-    runtime: RuntimeBehavior,
-) -> Result<String, CliError> {
-    match value {
-        Some(v) if !v.trim().is_empty() => Ok(v.clone()),
-        _ if runtime.interactive => prompt::prompt_line(field),
-        _ => Err(CliError::non_interactive_input_required(field)),
-    }
-}
-
-fn require_or_prompt_region(
-    value: &Option<String>,
-    runtime: RuntimeBehavior,
-) -> Result<String, CliError> {
-    match value {
-        Some(v) if !v.trim().is_empty() => Ok(v.clone()),
-        _ if runtime.interactive => prompt::prompt_fuzzy_choice("region", AWS_REGIONS, 0),
-        _ => Err(CliError::non_interactive_input_required("region")),
-    }
 }
 
 // --- config ---
@@ -317,7 +243,7 @@ fn run_profile_command(
 ) -> Result<CommandOutput, CommandFailure> {
     let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
     match command {
-        ProfileCommand::Add { command } => run_profile_add(kind, &config_path, command, runtime),
+        ProfileCommand::Create(args) => run_profile_create(kind, &config_path, args, runtime),
         ProfileCommand::List => {
             let config = load_config_if_exists(&config_path)
                 .map_err(|error| fail(kind, None, None, error))?;
@@ -336,174 +262,42 @@ fn run_profile_command(
                 load_config(&config_path).map_err(|error| fail(kind, name.clone(), None, error))?;
             let (profile_name, redacted) = show_profile(&config, name.as_deref())
                 .map_err(|error| fail(kind, name.clone(), None, error))?;
-            let mode = redacted.mode_str().to_owned();
             Ok(CommandOutput {
                 kind,
                 profile: Some(profile_name),
-                mode: Some(mode),
+                mode: Some(redacted.mode_str().to_owned()),
                 data: CommandData::Profile(redacted),
             })
         }
         ProfileCommand::Update(args) => run_profile_update(kind, &config_path, args, runtime),
         ProfileCommand::Remove { name } => run_profile_remove(kind, &config_path, &name, runtime),
-        ProfileCommand::MakeDefault { name } => run_profile_make_default(kind, &config_path, &name),
+        ProfileCommand::Use { name } => run_profile_use(kind, &config_path, &name),
     }
 }
 
-fn run_profile_add(
+fn run_profile_create(
     kind: CommandKind,
     config_path: &Path,
-    command: Option<ProfileAddCommand>,
+    args: ProfileCreateArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let (name, profile) = match command {
-        Some(cmd) => build_profile_from_add_command(cmd),
-        None => {
-            build_profile_interactive(runtime).map_err(|error| fail(kind, None, None, error))?
-        }
-    };
+    let name = args.name.clone();
+    let result = (|| -> Result<(String, ProfileConfig), CliError> {
+        let profile =
+            build_profile_from_create_spec(create_profile_spec_from_create(args), runtime)?;
+        let mut config = load_or_default_config(config_path)?;
+        let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
+        save_config(config_path, &config)?;
+        Ok((profile_name, redacted))
+    })()
+    .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
 
-    let mode = profile.mode_str().to_owned();
-    let mut config = load_or_default_config(config_path)
-        .map_err(|error| fail(kind, Some(name.clone()), Some(mode.clone()), error))?;
-    let (profile_name, redacted) = add_profile(&mut config, &name, profile)
-        .map_err(|error| fail(kind, Some(name.clone()), Some(mode.clone()), error))?;
-    save_config(config_path, &config)
-        .map_err(|error| fail(kind, Some(name.clone()), Some(mode.clone()), error))?;
     Ok(CommandOutput {
         kind,
-        profile: Some(profile_name),
-        mode: Some(mode),
-        data: CommandData::Profile(redacted),
+        profile: Some(result.0),
+        mode: Some(result.1.mode_str().to_owned()),
+        data: CommandData::Profile(result.1),
     })
-}
-
-fn build_profile_from_add_command(command: ProfileAddCommand) -> (String, ProfileConfig) {
-    match command {
-        ProfileAddCommand::LocalFs(args) => {
-            let profile = ProfileConfig::Local {
-                store: StoreConfig::LocalFs {
-                    root: args.root,
-                    key_prefix: args.key_prefix,
-                },
-                writer_id: None,
-                writer_version: None,
-                lease_duration_ms: None,
-            };
-            (args.name, profile)
-        }
-        ProfileAddCommand::AwsS3(args) => {
-            let profile = ProfileConfig::Local {
-                store: StoreConfig::AwsS3 {
-                    bucket: args.bucket,
-                    region: args.region,
-                    endpoint_url: args.endpoint_url,
-                    access_key_id: args.access_key_id,
-                    secret_access_key: args.secret_access_key,
-                    session_token: args.session_token,
-                    key_prefix: args.key_prefix,
-                    force_path_style: if args.force_path_style {
-                        Some(true)
-                    } else {
-                        None
-                    },
-                },
-                writer_id: None,
-                writer_version: None,
-                lease_duration_ms: None,
-            };
-            (args.name, profile)
-        }
-        ProfileAddCommand::CloudflareR2(args) => {
-            let profile = ProfileConfig::Local {
-                store: StoreConfig::CloudflareR2 {
-                    bucket: args.bucket,
-                    account_id: args.account_id,
-                    endpoint_url: args.endpoint_url,
-                    access_key_id: args.access_key_id,
-                    secret_access_key: args.secret_access_key,
-                    key_prefix: args.key_prefix,
-                },
-                writer_id: None,
-                writer_version: None,
-                lease_duration_ms: None,
-            };
-            (args.name, profile)
-        }
-        ProfileAddCommand::Remote(args) => {
-            let profile = ProfileConfig::Remote {
-                server_url: args.server_url,
-                auth_token: args.auth_token,
-            };
-            (args.name, profile)
-        }
-    }
-}
-
-fn build_profile_interactive(
-    runtime: RuntimeBehavior,
-) -> Result<(String, ProfileConfig), CliError> {
-    if !runtime.interactive {
-        return Err(CliError::non_interactive_input_required(
-            "subcommand (local-fs, aws-s3, cloudflare-r2, or remote)",
-        ));
-    }
-
-    let name = prompt::prompt_line("profile name")?;
-    let mode = prompt::prompt_choice("mode", &["local", "remote"])?;
-
-    match mode.as_str() {
-        "local" => {
-            let store_kind =
-                prompt::prompt_choice("store kind", &["aws-s3", "cloudflare-r2", "local-fs"])?;
-            let store = match store_kind.as_str() {
-                "local-fs" => StoreConfig::LocalFs {
-                    root: prompt::prompt_line("root")?,
-                    key_prefix: prompt::prompt_optional("key prefix", None)?,
-                },
-                "aws-s3" => StoreConfig::AwsS3 {
-                    bucket: prompt::prompt_line("bucket name")?,
-                    region: prompt::prompt_fuzzy_choice("region", AWS_REGIONS, 0)?,
-                    access_key_id: prompt::prompt_line("access key id")?,
-                    secret_access_key: prompt::prompt_line("secret access key")?,
-                    endpoint_url: prompt::prompt_optional("endpoint url", None)?,
-                    session_token: None,
-                    key_prefix: prompt::prompt_optional("key prefix", None)?,
-                    force_path_style: None,
-                },
-                "cloudflare-r2" => StoreConfig::CloudflareR2 {
-                    bucket: prompt::prompt_line("bucket name")?,
-                    account_id: prompt::prompt_line("account id")?,
-                    endpoint_url: prompt::prompt_line("endpoint url")?,
-                    access_key_id: prompt::prompt_line("access key id")?,
-                    secret_access_key: prompt::prompt_line("secret access key")?,
-                    key_prefix: prompt::prompt_optional("key prefix", None)?,
-                },
-                _ => unreachable!(),
-            };
-            Ok((
-                name,
-                ProfileConfig::Local {
-                    store,
-                    writer_id: None,
-                    writer_version: None,
-                    lease_duration_ms: None,
-                },
-            ))
-        }
-        "remote" => {
-            let server_url = prompt::prompt_line("server url")?;
-            let auth_token = prompt::prompt_optional("auth token", None)?;
-            Ok((
-                name,
-                ProfileConfig::Remote {
-                    server_url,
-                    auth_token,
-                },
-            ))
-        }
-        _ => unreachable!(),
-    }
 }
 
 fn run_profile_update(
@@ -557,6 +351,790 @@ fn run_profile_update(
     })
 }
 
+fn run_profile_remove(
+    kind: CommandKind,
+    config_path: &Path,
+    name: &str,
+    runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    if runtime.interactive {
+        let confirmed = prompt::prompt_confirm(&format!("remove profile `{name}`?"))
+            .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+        if !confirmed {
+            return Err(fail(
+                kind,
+                Some(name.to_owned()),
+                None,
+                CliError::new("cancelled", "operation cancelled"),
+            ));
+        }
+    }
+
+    let mut config =
+        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    let removed = remove_profile(&mut config, name)
+        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    let mode = removed.mode.clone();
+    save_config(config_path, &config)
+        .map_err(|error| fail(kind, Some(name.to_owned()), Some(mode.clone()), error))?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(name.to_owned()),
+        mode: Some(mode),
+        data: CommandData::ProfileSummary(removed),
+    })
+}
+
+fn run_profile_use(
+    kind: CommandKind,
+    config_path: &Path,
+    name: &str,
+) -> Result<CommandOutput, CommandFailure> {
+    let mut config =
+        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    make_default_profile(&mut config, name)
+        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    save_config(config_path, &config)
+        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(name.to_owned()),
+        mode: None,
+        data: CommandData::DefaultProfile {
+            name: name.to_owned(),
+        },
+    })
+}
+
+// --- namespace ---
+
+fn run_namespace_command(
+    kind: CommandKind,
+    command: NamespaceCommand,
+) -> Result<CommandOutput, CommandFailure> {
+    match command {
+        NamespaceCommand::Create(args) => run_namespace_create(kind, args),
+        NamespaceCommand::List(args) => run_namespace_list(kind, args),
+    }
+}
+
+fn run_namespace_create(
+    kind: CommandKind,
+    args: NamespaceCreateArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    validate_namespace_name(&args.name).map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?;
+    let namespace = resolved
+        .target
+        .backend()
+        .create_namespace(&args.name)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::NamespaceSummary(namespace),
+    })
+}
+
+fn run_namespace_list(
+    kind: CommandKind,
+    args: NamespaceListArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let namespaces = resolved
+        .target
+        .backend()
+        .list_namespaces()
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::NamespaceList { namespaces },
+    })
+}
+
+fn run_namespace_use(
+    kind: CommandKind,
+    args: NamespaceUseArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let mut loaded = load_cli_config()
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let resolved = resolve_target_profile_from_config(&loaded.config, explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    validate_namespace_name(&args.namespace).map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?;
+
+    let namespaces = resolved
+        .target
+        .backend()
+        .list_namespaces()
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        })?;
+    if !namespaces
+        .iter()
+        .any(|candidate| candidate.name.as_str() == args.namespace)
+    {
+        return Err(fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            CliError::new(
+                "namespace_not_found",
+                format!("namespace `{}` does not exist", args.namespace),
+            ),
+        ));
+    }
+
+    set_default_namespace(&mut loaded.config, &resolved.profile_name, &args.namespace).map_err(
+        |error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        },
+    )?;
+    save_config(&loaded.path, &loaded.config).map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name.clone()),
+        mode: Some(mode),
+        data: CommandData::DefaultNamespace {
+            profile: resolved.profile_name,
+            namespace: args.namespace,
+        },
+    })
+}
+
+fn run_current(kind: CommandKind, args: CurrentArgs) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let loaded = load_cli_config()
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let resolved = resolve_target_profile_from_config(&loaded.config, explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let (_, profile) =
+        crate::profiles::resolve_profile(&loaded.config, explicit_profile).map_err(|error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name.clone()),
+        mode: Some(mode),
+        data: CommandData::Current {
+            profile: resolved.profile_name,
+            namespace: default_namespace(profile).map(ToOwned::to_owned),
+        },
+    })
+}
+
+// --- filesystem ---
+
+fn run_filesystem_ls(
+    kind: CommandKind,
+    args: FilesystemLsArgs,
+    _runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let spec = namespace_path(
+        &context.namespace,
+        args.path.as_deref().unwrap_or("/"),
+        true,
+    )
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let entries = context.target.backend().list_path(&spec).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::PathEntries { entries },
+    })
+}
+
+fn run_filesystem_stat(
+    kind: CommandKind,
+    args: FilesystemPathArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    run_filesystem_path_lookup(kind, args, |backend, spec| {
+        backend.stat_path(spec).map(CommandData::PathEntry)
+    })
+}
+
+fn run_filesystem_cat(
+    kind: CommandKind,
+    args: FilesystemPathArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    run_filesystem_path_lookup(kind, args, |backend, spec| {
+        backend.read_file_bytes(spec).map(CommandData::StreamBytes)
+    })
+}
+
+fn run_filesystem_get(
+    kind: CommandKind,
+    args: FilesystemGetArgs,
+    runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    if runtime.json && args.local_destination.as_deref() == Some("-") {
+        return Err(fail(
+            kind,
+            Some(context.profile_name),
+            Some(context.mode),
+            CliError::json_not_supported_for_streaming(),
+        ));
+    }
+
+    let spec = namespace_path(&context.namespace, &args.remote_path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let entry = context.target.backend().stat_path(&spec).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    if entry.inode_kind == InodeKind::Dir {
+        return Err(fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            CliError::invalid_input(format!(
+                "directory operations are not available for `{}`",
+                spec.absolute_path
+            )),
+        ));
+    }
+
+    let bytes = context
+        .target
+        .backend()
+        .read_file_bytes(&spec)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+    let data = match args.local_destination.as_deref() {
+        Some("-") => CommandData::StreamBytes(bytes),
+        other => {
+            let destination =
+                destination_path_for_get(&spec.absolute_path, other).map_err(|error| {
+                    fail(
+                        kind,
+                        Some(context.profile_name.clone()),
+                        Some(context.mode.clone()),
+                        error,
+                    )
+                })?;
+            fs::write(&destination, &bytes).map_err(|error| {
+                fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    CliError::io(error),
+                )
+            })?;
+            CommandData::FileTransfer {
+                target: render_target(&context.namespace, &spec.absolute_path),
+                destination: destination.display().to_string(),
+                bytes_written: bytes.len() as u64,
+            }
+        }
+    };
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data,
+    })
+}
+
+fn run_filesystem_put(
+    kind: CommandKind,
+    args: FilesystemPutArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let local_path = PathBuf::from(&args.local_path);
+    if local_path == Path::new("-") {
+        return Err(fail(
+            kind,
+            Some(context.profile_name),
+            Some(context.mode),
+            CliError::invalid_input("`-` is not supported for `put`"),
+        ));
+    }
+
+    let metadata = fs::metadata(&local_path).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            CliError::io(error),
+        )
+    })?;
+    if metadata.is_dir() {
+        return Err(fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            CliError::invalid_input(format!(
+                "directory operations are not available for `{}`",
+                local_path.display()
+            )),
+        ));
+    }
+
+    let remote_path = match args.remote_path {
+        Some(path) => normalize_absolute_path(&path, false),
+        None => default_remote_put_path(&local_path),
+    }
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let spec = namespace_path(&context.namespace, &remote_path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let bytes = fs::read(&local_path).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            CliError::io(error),
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .put_file_bytes(&spec, &bytes, args.force)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+        },
+    })
+}
+
+fn run_filesystem_rm(
+    kind: CommandKind,
+    args: FilesystemPathArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .delete_path(&spec)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+        },
+    })
+}
+
+fn run_filesystem_mv(
+    kind: CommandKind,
+    args: FilesystemMoveArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    run_filesystem_move(kind, args, false)
+}
+
+fn run_filesystem_cp(
+    kind: CommandKind,
+    args: FilesystemMoveArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    run_filesystem_move(kind, args, true)
+}
+
+// --- create/update helpers ---
+
+#[derive(Debug, Clone)]
+struct CreateProfileSpec {
+    mode: Option<String>,
+    store_kind: Option<String>,
+    root: Option<String>,
+    key_prefix: Option<String>,
+    bucket: Option<String>,
+    region: Option<String>,
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+    endpoint_url: Option<String>,
+    session_token: Option<String>,
+    force_path_style: bool,
+    account_id: Option<String>,
+    server_url: Option<String>,
+    auth_token: Option<String>,
+}
+
+fn create_profile_spec_from_init(args: InitArgs) -> CreateProfileSpec {
+    CreateProfileSpec {
+        mode: args.mode,
+        store_kind: args.store_kind,
+        root: args.root,
+        key_prefix: args.key_prefix,
+        bucket: args.bucket,
+        region: args.region,
+        access_key_id: args.access_key_id,
+        secret_access_key: args.secret_access_key,
+        endpoint_url: args.endpoint_url,
+        session_token: args.session_token,
+        force_path_style: args.force_path_style,
+        account_id: args.account_id,
+        server_url: args.server_url,
+        auth_token: args.auth_token,
+    }
+}
+
+fn create_profile_spec_from_create(args: ProfileCreateArgs) -> CreateProfileSpec {
+    CreateProfileSpec {
+        mode: args.mode,
+        store_kind: args.store_kind,
+        root: args.root,
+        key_prefix: args.key_prefix,
+        bucket: args.bucket,
+        region: args.region,
+        access_key_id: args.access_key_id,
+        secret_access_key: args.secret_access_key,
+        endpoint_url: args.endpoint_url,
+        session_token: args.session_token,
+        force_path_style: args.force_path_style,
+        account_id: args.account_id,
+        server_url: args.server_url,
+        auth_token: args.auth_token,
+    }
+}
+
+fn build_profile_from_create_spec(
+    spec: CreateProfileSpec,
+    runtime: RuntimeBehavior,
+) -> Result<ProfileConfig, CliError> {
+    let mode = match spec.mode.as_deref() {
+        Some("local") => "local".to_owned(),
+        Some("remote") => "remote".to_owned(),
+        Some(other) => {
+            return Err(CliError::invalid_input(format!(
+                "unknown mode: `{other}` (expected local or remote)"
+            )))
+        }
+        None if runtime.interactive => prompt::prompt_choice("mode", &["local", "remote"])?,
+        None => {
+            return Err(CliError::non_interactive_input_required("mode"));
+        }
+    };
+
+    match mode.as_str() {
+        "local" => build_local_profile(spec, runtime),
+        "remote" => build_remote_profile(spec, runtime),
+        _ => unreachable!(),
+    }
+}
+
+fn build_local_profile(
+    spec: CreateProfileSpec,
+    runtime: RuntimeBehavior,
+) -> Result<ProfileConfig, CliError> {
+    reject_create_flag("server-url", spec.server_url.is_some(), "local")?;
+    reject_create_flag("auth-token", spec.auth_token.is_some(), "local")?;
+
+    let store_kind = match spec.store_kind.as_deref() {
+        Some("local-fs") => "local-fs",
+        Some("aws-s3") => "aws-s3",
+        Some("cloudflare-r2") => "cloudflare-r2",
+        Some(other) => {
+            return Err(CliError::invalid_input(format!(
+                "unknown store kind: `{other}` (expected local-fs, aws-s3, or cloudflare-r2)"
+            )))
+        }
+        None if runtime.interactive => {
+            return prompt::prompt_choice("store kind", &["aws-s3", "cloudflare-r2", "local-fs"])
+                .and_then(|choice| {
+                    build_local_profile(
+                        CreateProfileSpec {
+                            store_kind: Some(choice),
+                            ..spec
+                        },
+                        runtime,
+                    )
+                });
+        }
+        None => return Err(CliError::non_interactive_input_required("store-kind")),
+    };
+
+    let store = match store_kind {
+        "local-fs" => {
+            reject_create_flag("bucket", spec.bucket.is_some(), "local-fs")?;
+            reject_create_flag("region", spec.region.is_some(), "local-fs")?;
+            reject_create_flag("access-key-id", spec.access_key_id.is_some(), "local-fs")?;
+            reject_create_flag(
+                "secret-access-key",
+                spec.secret_access_key.is_some(),
+                "local-fs",
+            )?;
+            reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "local-fs")?;
+            reject_create_flag("session-token", spec.session_token.is_some(), "local-fs")?;
+            reject_create_flag("account-id", spec.account_id.is_some(), "local-fs")?;
+            reject_create_flag("force-path-style", spec.force_path_style, "local-fs")?;
+            StoreConfig::LocalFs {
+                root: require_or_prompt(spec.root.as_ref(), "root", runtime)?,
+                key_prefix: spec.key_prefix,
+            }
+        }
+        "aws-s3" => {
+            reject_create_flag("root", spec.root.is_some(), "aws-s3")?;
+            reject_create_flag("account-id", spec.account_id.is_some(), "aws-s3")?;
+            StoreConfig::AwsS3 {
+                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+                region: require_or_prompt_region(spec.region.as_ref(), runtime)?,
+                endpoint_url: spec.endpoint_url,
+                access_key_id: require_or_prompt(
+                    spec.access_key_id.as_ref(),
+                    "access-key-id",
+                    runtime,
+                )?,
+                secret_access_key: require_or_prompt(
+                    spec.secret_access_key.as_ref(),
+                    "secret-access-key",
+                    runtime,
+                )?,
+                session_token: spec.session_token,
+                key_prefix: spec.key_prefix,
+                force_path_style: if spec.force_path_style {
+                    Some(true)
+                } else {
+                    None
+                },
+            }
+        }
+        "cloudflare-r2" => {
+            reject_create_flag("root", spec.root.is_some(), "cloudflare-r2")?;
+            reject_create_flag("region", spec.region.is_some(), "cloudflare-r2")?;
+            reject_create_flag(
+                "session-token",
+                spec.session_token.is_some(),
+                "cloudflare-r2",
+            )?;
+            reject_create_flag("force-path-style", spec.force_path_style, "cloudflare-r2")?;
+            StoreConfig::CloudflareR2 {
+                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+                account_id: require_or_prompt(spec.account_id.as_ref(), "account-id", runtime)?,
+                endpoint_url: require_or_prompt(
+                    spec.endpoint_url.as_ref(),
+                    "endpoint-url",
+                    runtime,
+                )?,
+                access_key_id: require_or_prompt(
+                    spec.access_key_id.as_ref(),
+                    "access-key-id",
+                    runtime,
+                )?,
+                secret_access_key: require_or_prompt(
+                    spec.secret_access_key.as_ref(),
+                    "secret-access-key",
+                    runtime,
+                )?,
+                key_prefix: spec.key_prefix,
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    Ok(ProfileConfig::Local {
+        store,
+        default_namespace: None,
+        writer_id: None,
+        writer_version: None,
+        lease_duration_ms: None,
+    })
+}
+
+fn build_remote_profile(
+    spec: CreateProfileSpec,
+    runtime: RuntimeBehavior,
+) -> Result<ProfileConfig, CliError> {
+    reject_create_flag("store-kind", spec.store_kind.is_some(), "remote")?;
+    reject_create_flag("root", spec.root.is_some(), "remote")?;
+    reject_create_flag("key-prefix", spec.key_prefix.is_some(), "remote")?;
+    reject_create_flag("bucket", spec.bucket.is_some(), "remote")?;
+    reject_create_flag("region", spec.region.is_some(), "remote")?;
+    reject_create_flag("access-key-id", spec.access_key_id.is_some(), "remote")?;
+    reject_create_flag(
+        "secret-access-key",
+        spec.secret_access_key.is_some(),
+        "remote",
+    )?;
+    reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "remote")?;
+    reject_create_flag("session-token", spec.session_token.is_some(), "remote")?;
+    reject_create_flag("force-path-style", spec.force_path_style, "remote")?;
+    reject_create_flag("account-id", spec.account_id.is_some(), "remote")?;
+
+    Ok(ProfileConfig::Remote {
+        server_url: require_or_prompt(spec.server_url.as_ref(), "server url", runtime)?,
+        default_namespace: None,
+        auth_token: match spec.auth_token {
+            Some(token) if token.trim().is_empty() => None,
+            other => other,
+        },
+    })
+}
+
+fn require_or_prompt(
+    value: Option<&String>,
+    field: &str,
+    runtime: RuntimeBehavior,
+) -> Result<String, CliError> {
+    match value {
+        Some(v) if !v.trim().is_empty() => Ok(v.clone()),
+        _ if runtime.interactive => prompt::prompt_line(field),
+        _ => Err(CliError::non_interactive_input_required(field)),
+    }
+}
+
+fn require_or_prompt_region(
+    value: Option<&String>,
+    runtime: RuntimeBehavior,
+) -> Result<String, CliError> {
+    match value {
+        Some(v) if !v.trim().is_empty() => Ok(v.clone()),
+        _ if runtime.interactive => prompt::prompt_fuzzy_choice("region", AWS_REGIONS, 0),
+        _ => Err(CliError::non_interactive_input_required("region")),
+    }
+}
+
+fn reject_create_flag(flag: &str, present: bool, profile_kind: &str) -> Result<(), CliError> {
+    if present {
+        return Err(CliError::invalid_input(format!(
+            "`--{flag}` does not apply to {profile_kind} profiles"
+        )));
+    }
+    Ok(())
+}
+
 fn apply_update_flags(
     existing: ProfileConfig,
     args: &ProfileUpdateArgs,
@@ -602,6 +1180,7 @@ fn apply_update_flags(
     match existing {
         ProfileConfig::Local {
             store,
+            default_namespace,
             writer_id,
             writer_version,
             lease_duration_ms,
@@ -648,6 +1227,7 @@ fn apply_update_flags(
             };
             Ok(ProfileConfig::Local {
                 store,
+                default_namespace,
                 writer_id,
                 writer_version,
                 lease_duration_ms,
@@ -655,9 +1235,11 @@ fn apply_update_flags(
         }
         ProfileConfig::Remote {
             server_url,
+            default_namespace,
             auth_token,
         } => Ok(ProfileConfig::Remote {
             server_url: args.server_url.clone().unwrap_or(server_url),
+            default_namespace,
             auth_token: args.auth_token.clone().or(auth_token),
         }),
     }
@@ -676,6 +1258,7 @@ fn apply_update_interactive(existing: ProfileConfig) -> Result<ProfileConfig, Cl
     match existing {
         ProfileConfig::Local {
             store,
+            default_namespace,
             writer_id,
             writer_version,
             lease_duration_ms,
@@ -735,6 +1318,7 @@ fn apply_update_interactive(existing: ProfileConfig) -> Result<ProfileConfig, Cl
             };
             Ok(ProfileConfig::Local {
                 store,
+                default_namespace,
                 writer_id,
                 writer_version,
                 lease_duration_ms,
@@ -742,272 +1326,162 @@ fn apply_update_interactive(existing: ProfileConfig) -> Result<ProfileConfig, Cl
         }
         ProfileConfig::Remote {
             server_url,
+            default_namespace,
             auth_token,
         } => Ok(ProfileConfig::Remote {
             server_url: prompt::prompt_line_default("server url", &server_url)?,
+            default_namespace,
             auth_token: prompt::prompt_optional("auth token", auth_token.as_deref())?,
         }),
     }
 }
 
-fn run_profile_remove(
-    kind: CommandKind,
-    config_path: &Path,
-    name: &str,
-    runtime: RuntimeBehavior,
-) -> Result<CommandOutput, CommandFailure> {
-    if runtime.interactive {
-        let confirmed = prompt::prompt_confirm(&format!("remove profile `{name}`?"))
-            .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-        if !confirmed {
-            return Err(fail(
-                kind,
-                Some(name.to_owned()),
-                None,
-                CliError::new("cancelled", "operation cancelled"),
-            ));
-        }
-    }
+// --- filesystem helpers ---
 
-    let mut config =
-        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    let removed = remove_profile(&mut config, name)
-        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    let mode = removed.mode.clone();
-    save_config(config_path, &config)
-        .map_err(|error| fail(kind, Some(name.to_owned()), Some(mode.clone()), error))?;
-    Ok(CommandOutput {
-        kind,
-        profile: Some(name.to_owned()),
-        mode: Some(mode),
-        data: CommandData::ProfileSummary(removed),
+struct CommandContext {
+    profile_name: String,
+    mode: String,
+    namespace: String,
+    target: crate::backend::ResolvedTarget,
+}
+
+fn resolve_command_context(
+    kind: CommandKind,
+    target: &TargetSelectorArgs,
+) -> Result<CommandContext, CommandFailure> {
+    let explicit_profile = target.profile.profile.as_deref();
+    let loaded = load_cli_config()
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let resolved = resolve_target_profile_from_config(&loaded.config, explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let namespace = resolve_namespace(
+        &loaded.config,
+        explicit_profile,
+        target.namespace.as_deref(),
+    )
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?
+    .namespace;
+
+    // Keep the loaded config alive long enough for the backend borrow to remain valid within the caller.
+    Ok(CommandContext {
+        profile_name: resolved.profile_name,
+        mode,
+        namespace,
+        target: resolved.target,
     })
 }
 
-fn run_profile_make_default(
+fn run_filesystem_path_lookup<F>(
     kind: CommandKind,
-    config_path: &Path,
-    name: &str,
-) -> Result<CommandOutput, CommandFailure> {
-    let mut config =
-        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    make_default_profile(&mut config, name)
-        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    save_config(config_path, &config)
-        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    args: FilesystemPathArgs,
+    op: F,
+) -> Result<CommandOutput, CommandFailure>
+where
+    F: FnOnce(&dyn crate::backend::Backend, &NamespacePath) -> Result<CommandData, CliError>,
+{
+    let context = resolve_command_context(kind, &args.target)?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let data = op(context.target.backend(), &spec).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+
     Ok(CommandOutput {
         kind,
-        profile: Some(name.to_owned()),
-        mode: None,
-        data: CommandData::DefaultProfile {
-            name: name.to_owned(),
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data,
+    })
+}
+
+fn run_filesystem_move(
+    kind: CommandKind,
+    args: FilesystemMoveArgs,
+    copy: bool,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let from = namespace_path(&context.namespace, &args.source_path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let to = namespace_path(&context.namespace, &args.dest_path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+
+    let result = if copy {
+        let entry = context.target.backend().stat_path(&from).map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+        if entry.inode_kind == InodeKind::Dir {
+            return Err(fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                CliError::invalid_input(format!(
+                    "directory operations are not available for `{}`",
+                    from.absolute_path
+                )),
+            ));
+        }
+        context.target.backend().copy_path(&from, &to)
+    } else {
+        context.target.backend().move_path(&from, &to)
+    }
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::PathMove {
+            from: render_target(&context.namespace, &from.absolute_path),
+            to: render_target(&context.namespace, &to.absolute_path),
+            committed_seq: result.committed_seq.0,
         },
     })
 }
 
-// --- namespace ---
-
-fn run_namespace_command(
-    kind: CommandKind,
-    global_profile: Option<&str>,
-    command: NamespaceCommand,
-) -> Result<CommandOutput, CommandFailure> {
-    let resolved = resolve_target_profile(global_profile)
-        .map_err(|error| fail(kind, global_profile.map(ToOwned::to_owned), None, error))?;
-    let mode = resolved.target.mode_str().to_owned();
-    let backend = resolved.target.backend();
-    let output = match command {
-        NamespaceCommand::Create { name } => {
-            validate_namespace_name(&name).map_err(|error| {
-                fail(
-                    kind,
-                    Some(resolved.profile_name.clone()),
-                    Some(mode.clone()),
-                    error,
-                )
-            })?;
-            let namespace = backend.create_namespace(&name).map_err(|error| {
-                fail(
-                    kind,
-                    Some(resolved.profile_name.clone()),
-                    Some(mode.clone()),
-                    error,
-                )
-            })?;
-            CommandData::NamespaceSummary(namespace)
-        }
-        NamespaceCommand::List => {
-            let namespaces = backend.list_namespaces().map_err(|error| {
-                fail(
-                    kind,
-                    Some(resolved.profile_name.clone()),
-                    Some(mode.clone()),
-                    error,
-                )
-            })?;
-            CommandData::NamespaceList { namespaces }
-        }
-    };
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(resolved.profile_name),
-        mode: Some(mode),
-        data: output,
-    })
-}
-
-// --- filesystem ---
-
-fn run_filesystem_command(
-    kind: CommandKind,
-    global_profile: Option<&str>,
-    command: FilesystemCommand,
-    runtime: RuntimeBehavior,
-) -> Result<CommandOutput, CommandFailure> {
-    let resolved = resolve_target_profile(global_profile)
-        .map_err(|error| fail(kind, global_profile.map(ToOwned::to_owned), None, error))?;
-    let mode = resolved.target.mode_str().to_owned();
-    let backend = resolved.target.backend();
-    let profile_name = resolved.profile_name.clone();
-
-    let output = (|| -> Result<CommandData, CliError> {
-        match command {
-            FilesystemCommand::Ls { namespace, path } => {
-                let spec = namespace_path(&namespace, path.as_deref().unwrap_or("/"), true)?;
-                let entries = backend.list_path(&spec)?;
-                Ok(CommandData::PathEntries { entries })
-            }
-            FilesystemCommand::Stat { namespace, path } => {
-                let spec = namespace_path(&namespace, &path, true)?;
-                let entry = backend.stat_path(&spec)?;
-                Ok(CommandData::PathEntry(entry))
-            }
-            FilesystemCommand::Cat { namespace, path } => {
-                let spec = namespace_path(&namespace, &path, false)?;
-                let bytes = backend.read_file_bytes(&spec)?;
-                Ok(CommandData::StreamBytes(bytes))
-            }
-            FilesystemCommand::Get {
-                namespace,
-                remote_path,
-                local_destination,
-            } => {
-                if runtime.json && local_destination.as_deref() == Some("-") {
-                    return Err(CliError::json_not_supported_for_streaming());
-                }
-                let spec = namespace_path(&namespace, &remote_path, false)?;
-                let entry = backend.stat_path(&spec)?;
-                if entry.inode_kind == loon_api::InodeKind::Dir {
-                    return Err(CliError::invalid_input(format!(
-                        "directory operations are not available for `{}`",
-                        spec.absolute_path
-                    )));
-                }
-                let bytes = backend.read_file_bytes(&spec)?;
-                match local_destination.as_deref() {
-                    Some("-") => Ok(CommandData::StreamBytes(bytes)),
-                    other => {
-                        let destination = destination_path_for_get(&spec.absolute_path, other)?;
-                        fs::write(&destination, &bytes).map_err(CliError::io)?;
-                        Ok(CommandData::FileTransfer {
-                            target: render_target(&namespace, &spec.absolute_path),
-                            destination: destination.display().to_string(),
-                            bytes_written: bytes.len() as u64,
-                        })
-                    }
-                }
-            }
-            FilesystemCommand::Put {
-                namespace,
-                local_path,
-                remote_path,
-                force,
-            } => {
-                let local_path = PathBuf::from(&local_path);
-                if local_path == Path::new("-") {
-                    return Err(CliError::invalid_input(
-                        "`-` is not supported for `filesystem put`",
-                    ));
-                }
-                let metadata = fs::metadata(&local_path).map_err(CliError::io)?;
-                if metadata.is_dir() {
-                    return Err(CliError::invalid_input(format!(
-                        "directory operations are not available for `{}`",
-                        local_path.display()
-                    )));
-                }
-                let remote_path = match remote_path {
-                    Some(path) => normalize_absolute_path(&path, false)?,
-                    None => default_remote_put_path(&local_path)?,
-                };
-                let spec = namespace_path(&namespace, &remote_path, false)?;
-                let bytes = fs::read(&local_path).map_err(CliError::io)?;
-                let result = backend.put_file_bytes(&spec, &bytes, force)?;
-                Ok(CommandData::FileMutation {
-                    target: render_target(&namespace, &spec.absolute_path),
-                    committed_seq: result.committed_seq.0,
-                })
-            }
-            FilesystemCommand::Rm {
-                namespace,
-                remote_path,
-            } => {
-                let spec = namespace_path(&namespace, &remote_path, false)?;
-                let result = backend.delete_path(&spec)?;
-                Ok(CommandData::FileMutation {
-                    target: render_target(&namespace, &spec.absolute_path),
-                    committed_seq: result.committed_seq.0,
-                })
-            }
-            FilesystemCommand::Mv {
-                namespace,
-                source_path,
-                dest_path,
-            } => {
-                let from = namespace_path(&namespace, &source_path, false)?;
-                let to = namespace_path(&namespace, &dest_path, false)?;
-                let result = backend.move_path(&from, &to)?;
-                Ok(CommandData::PathMove {
-                    from: render_target(&namespace, &from.absolute_path),
-                    to: render_target(&namespace, &to.absolute_path),
-                    committed_seq: result.committed_seq.0,
-                })
-            }
-            FilesystemCommand::Cp {
-                namespace,
-                source_path,
-                dest_path,
-            } => {
-                let from = namespace_path(&namespace, &source_path, false)?;
-                let entry = backend.stat_path(&from)?;
-                if entry.inode_kind == loon_api::InodeKind::Dir {
-                    return Err(CliError::invalid_input(format!(
-                        "directory operations are not available for `{}`",
-                        from.absolute_path
-                    )));
-                }
-                let to = namespace_path(&namespace, &dest_path, false)?;
-                let result = backend.copy_path(&from, &to)?;
-                Ok(CommandData::PathMove {
-                    from: render_target(&namespace, &from.absolute_path),
-                    to: render_target(&namespace, &to.absolute_path),
-                    committed_seq: result.committed_seq.0,
-                })
-            }
-        }
-    })()
-    .map_err(|error| fail(kind, Some(profile_name.clone()), Some(mode.clone()), error))?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(profile_name),
-        mode: Some(mode),
-        data: output,
-    })
-}
-
-// --- helpers ---
+// --- general helpers ---
 
 fn validate_namespace_name(namespace: &str) -> Result<(), CliError> {
     if namespace.trim().is_empty() {

--- a/crates/loon-cli/src/config.rs
+++ b/crates/loon-cli/src/config.rs
@@ -26,6 +26,8 @@ pub enum ProfileConfig {
     Local {
         store: StoreConfig,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_namespace: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         writer_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         writer_version: Option<String>,
@@ -34,6 +36,8 @@ pub enum ProfileConfig {
     },
     Remote {
         server_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_namespace: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         auth_token: Option<String>,
     },
@@ -139,12 +143,25 @@ impl ProfileConfig {
 
     pub(crate) fn validate(&self, name: &str) -> Result<(), CliError> {
         match self {
-            ProfileConfig::Local { store, .. } => store.validate(name),
+            ProfileConfig::Local {
+                store,
+                default_namespace,
+                ..
+            } => {
+                if let Some(namespace) = default_namespace {
+                    require_non_empty(&profile_field(name, "default_namespace"), namespace)?;
+                }
+                store.validate(name)
+            }
             ProfileConfig::Remote {
                 server_url,
+                default_namespace,
                 auth_token,
                 ..
             } => {
+                if let Some(namespace) = default_namespace {
+                    require_non_empty(&profile_field(name, "default_namespace"), namespace)?;
+                }
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
                     require_non_empty(&profile_field(name, "auth_token"), token)?;
@@ -158,20 +175,24 @@ impl ProfileConfig {
         match self {
             ProfileConfig::Local {
                 store,
+                default_namespace,
                 writer_id,
                 writer_version,
                 lease_duration_ms,
             } => ProfileConfig::Local {
                 store: store.redacted(),
+                default_namespace: default_namespace.clone(),
                 writer_id: writer_id.clone(),
                 writer_version: writer_version.clone(),
                 lease_duration_ms: *lease_duration_ms,
             },
             ProfileConfig::Remote {
                 server_url,
+                default_namespace,
                 auth_token,
             } => ProfileConfig::Remote {
                 server_url: server_url.clone(),
+                default_namespace: default_namespace.clone(),
                 auth_token: auth_token.as_ref().map(|_| "REDACTED".to_owned()),
             },
         }

--- a/crates/loon-cli/src/error.rs
+++ b/crates/loon-cli/src/error.rs
@@ -29,7 +29,16 @@ impl CliError {
     pub fn no_default_profile() -> Self {
         Self::new(
             "no_default_profile",
-            "no default profile is set; use `profile make-default` or `--profile`",
+            "no default profile is set; use `profile use` or `--profile`",
+        )
+    }
+
+    pub fn no_default_namespace(profile: &str) -> Self {
+        Self::new(
+            "no_default_namespace",
+            format!(
+                "no default namespace is set for profile `{profile}`; use `loon use <namespace>` or `--namespace`"
+            ),
         )
     }
 
@@ -44,7 +53,7 @@ impl CliError {
         Self::new(
             "config_already_exists",
             format!(
-                "config file already exists at `{path}`. use `loon profile add` to create a new profile, `loon profile update` to modify an existing profile, or `loon profile make-default` to change the default profile"
+                "config file already exists at `{path}`. use `loon profile create` to create a new profile, `loon profile update` to modify an existing profile, or `loon profile use` to change the default profile"
             ),
         )
     }

--- a/crates/loon-cli/src/profiles.rs
+++ b/crates/loon-cli/src/profiles.rs
@@ -114,3 +114,36 @@ pub fn resolve_profile<'a>(
         .ok_or_else(|| CliError::profile_not_found(name))?;
     Ok((name, profile))
 }
+
+pub fn default_namespace(profile: &ProfileConfig) -> Option<&str> {
+    match profile {
+        ProfileConfig::Local {
+            default_namespace, ..
+        }
+        | ProfileConfig::Remote {
+            default_namespace, ..
+        } => default_namespace.as_deref(),
+    }
+}
+
+pub fn set_default_namespace(
+    config: &mut CliConfig,
+    profile_name: &str,
+    namespace: &str,
+) -> Result<(), CliError> {
+    let profile = config
+        .profiles
+        .get_mut(profile_name)
+        .ok_or_else(|| CliError::profile_not_found(profile_name))?;
+    match profile {
+        ProfileConfig::Local {
+            default_namespace, ..
+        }
+        | ProfileConfig::Remote {
+            default_namespace, ..
+        } => {
+            *default_namespace = Some(namespace.to_owned());
+        }
+    }
+    Ok(())
+}

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -213,8 +213,8 @@ mod tests {
     use super::{human_success, json_error};
     use crate::args::CommandKind;
     use crate::commands::{CommandData, CommandFailure, CommandOutput};
-    use crate::error::CliError;
     use crate::config::{ProfileConfig, StoreConfig};
+    use crate::error::CliError;
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
     use loon_api::NamespaceSummary;

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -92,8 +92,16 @@ pub fn json_error(failure: &CommandFailure) -> io::Result<String> {
 
 pub fn human_success(output: &CommandOutput) -> String {
     match &output.data {
-        CommandData::Profile(profile) => toml::to_string_pretty(profile)
-            .unwrap_or_else(|_| format!("mode = \"{}\"", profile.mode_str())),
+        CommandData::Profile(profile) => {
+            let rendered = toml::to_string_pretty(profile)
+                .unwrap_or_else(|_| format!("mode = \"{}\"", profile.mode_str()));
+            if output.kind == CommandKind::ProfileShow {
+                let name = output.profile.as_deref().unwrap_or("<unknown>");
+                format!("name = \"{name}\"\n{rendered}")
+            } else {
+                rendered
+            }
+        }
         CommandData::ProfileSummary(profile) => match output.kind {
             CommandKind::ProfileRemove => format!("removed profile {}", profile.name),
             _ => {
@@ -125,6 +133,13 @@ pub fn human_success(output: &CommandOutput) -> String {
             lines.join("\n")
         }
         CommandData::DefaultProfile { name } => format!("default profile set to `{name}`"),
+        CommandData::DefaultNamespace { profile, namespace } => {
+            format!("default namespace for `{profile}` set to `{namespace}`")
+        }
+        CommandData::Current { profile, namespace } => {
+            let namespace = namespace.as_deref().unwrap_or("-");
+            format!("profile: {profile}\nnamespace: {namespace}")
+        }
         CommandData::NamespaceSummary(namespace) => namespace.name.to_string(),
         CommandData::NamespaceList { namespaces } => {
             let mut lines = vec!["NAME".to_owned()];
@@ -199,6 +214,7 @@ mod tests {
     use crate::args::CommandKind;
     use crate::commands::{CommandData, CommandFailure, CommandOutput};
     use crate::error::CliError;
+    use crate::config::{ProfileConfig, StoreConfig};
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
     use loon_api::NamespaceSummary;
@@ -257,6 +273,26 @@ mod tests {
             data: CommandData::NamespaceList {
                 namespaces: Vec::new(),
             },
+        };
+        assert_snapshot!(human_success(&output));
+    }
+
+    #[test]
+    fn human_profile_show_includes_name() {
+        let output = CommandOutput {
+            kind: CommandKind::ProfileShow,
+            profile: Some("default".to_owned()),
+            mode: Some("local".to_owned()),
+            data: CommandData::Profile(ProfileConfig::Local {
+                store: StoreConfig::LocalFs {
+                    root: "/tmp/store".to_owned(),
+                    key_prefix: None,
+                },
+                default_namespace: Some("demo".to_owned()),
+                writer_id: None,
+                writer_version: None,
+                lease_duration_ms: None,
+            }),
         };
         assert_snapshot!(human_success(&output));
     }

--- a/crates/loon-cli/src/resolve.rs
+++ b/crates/loon-cli/src/resolve.rs
@@ -1,20 +1,64 @@
 use crate::backend::ResolvedTarget;
-use crate::config::{default_config_path, load_config};
+use crate::config::{default_config_path, load_config, CliConfig};
 use crate::error::CliError;
-use crate::profiles::resolve_profile;
+use crate::profiles::{default_namespace, resolve_profile};
+
+pub struct LoadedConfig {
+    pub path: std::path::PathBuf,
+    pub config: CliConfig,
+}
 
 pub struct ResolvedProfile {
     pub profile_name: String,
     pub target: ResolvedTarget,
 }
 
+pub struct ResolvedNamespace {
+    pub namespace: String,
+}
+
+pub fn load_cli_config() -> Result<LoadedConfig, CliError> {
+    let path = default_config_path()?;
+    let config = load_config(&path)?;
+    Ok(LoadedConfig { path, config })
+}
+
 pub fn resolve_target_profile(explicit_profile: Option<&str>) -> Result<ResolvedProfile, CliError> {
-    let config_path = default_config_path()?;
-    let config = load_config(&config_path)?;
-    let (profile_name, profile) = resolve_profile(&config, explicit_profile)?;
+    let loaded = load_cli_config()?;
+    resolve_target_profile_from_config(&loaded.config, explicit_profile)
+}
+
+pub fn resolve_target_profile_from_config(
+    config: &CliConfig,
+    explicit_profile: Option<&str>,
+) -> Result<ResolvedProfile, CliError> {
+    let (profile_name, profile) = resolve_profile(config, explicit_profile)?;
     let target = ResolvedTarget::resolve(profile_name, profile)?;
     Ok(ResolvedProfile {
         profile_name: profile_name.to_owned(),
         target,
+    })
+}
+
+pub fn resolve_namespace(
+    config: &CliConfig,
+    explicit_profile: Option<&str>,
+    explicit_namespace: Option<&str>,
+) -> Result<ResolvedNamespace, CliError> {
+    if let Some(namespace) = explicit_namespace {
+        return validate_namespace(namespace);
+    }
+    let (profile_name, profile) = resolve_profile(config, explicit_profile)?;
+    let namespace =
+        default_namespace(profile).ok_or_else(|| CliError::no_default_namespace(profile_name))?;
+    validate_namespace(namespace)
+}
+
+fn validate_namespace(namespace: &str) -> Result<ResolvedNamespace, CliError> {
+    if namespace.trim().is_empty() {
+        return Err(CliError::invalid_input("namespace name must not be empty"));
+    }
+    Ok(ResolvedNamespace {
+        namespace: namespace.to_owned(),
     })
 }

--- a/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_profile_show_includes_name.snap
+++ b/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_profile_show_includes_name.snap
@@ -1,0 +1,12 @@
+---
+source: crates/loon-cli/src/render.rs
+assertion_line: 297
+expression: human_success(&output)
+---
+name = "default"
+mode = "local"
+default_namespace = "demo"
+
+[store]
+kind = "local-fs"
+root = "/tmp/store"

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -9,29 +9,33 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 #[test]
-fn profile_add_list_show_remove_work() {
+fn profile_create_list_show_remove_work() {
     let harness = Harness::new();
 
     let add_local = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "local-fs",
+        "create",
         "default",
+        "--mode",
+        "local",
+        "--store-kind",
+        "local-fs",
         "--root",
         harness.store_root("default").to_str().unwrap(),
     ]);
     assert_success(&add_local);
     assert_eq!(json_data(&add_local)["mode"], "local");
 
-    let external =
-        harness.start_external_server(harness.write_server_config("remote", "profile-add-remote"));
+    let external = harness
+        .start_external_server(harness.write_server_config("remote", "profile-create-remote"));
     let add_remote = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "remote",
+        "create",
         "prod",
+        "--mode",
+        "remote",
         "--server-url",
         &external.server_url,
         "--auth-token",
@@ -46,9 +50,7 @@ fn profile_add_list_show_remove_work() {
     let profiles = list_data["profiles"].as_array().unwrap();
     assert_eq!(profiles.len(), 2);
     assert_eq!(profiles[0]["name"], "default");
-    assert_eq!(profiles[0]["mode"], "local");
     assert_eq!(profiles[1]["name"], "prod");
-    assert_eq!(profiles[1]["mode"], "remote");
 
     let show = harness.run(&["config", "show"]);
     assert_success(&show);
@@ -87,12 +89,11 @@ fn local_profile_filesystem_flow_works_end_to_end() {
     fs::write(&upload_path, b"hello from direct core\n").expect("upload payload");
 
     assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
 
     let put = harness.run(&[
         "--json",
-        "filesystem",
         "put",
-        "demo",
         upload_path.to_str().unwrap(),
         "/docs/hello.txt",
     ]);
@@ -101,9 +102,7 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 
     let put_conflict = harness.run(&[
         "--json",
-        "filesystem",
         "put",
-        "demo",
         upload_path.to_str().unwrap(),
         "/docs/hello.txt",
     ]);
@@ -112,27 +111,18 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 
     let put_force = harness.run(&[
         "--json",
-        "filesystem",
         "put",
-        "demo",
         upload_path.to_str().unwrap(),
         "/docs/hello.txt",
         "--force",
     ]);
     assert_success(&put_force);
 
-    let cp = harness.run(&[
-        "--json",
-        "filesystem",
-        "cp",
-        "demo",
-        "/docs/hello.txt",
-        "/docs/copy.txt",
-    ]);
+    let cp = harness.run(&["--json", "cp", "/docs/hello.txt", "/docs/copy.txt"]);
     assert_success(&cp);
 
-    let source = harness.run(&["--json", "filesystem", "stat", "demo", "/docs/hello.txt"]);
-    let copy = harness.run(&["--json", "filesystem", "stat", "demo", "/docs/copy.txt"]);
+    let source = harness.run(&["--json", "stat", "/docs/hello.txt"]);
+    let copy = harness.run(&["--json", "stat", "/docs/copy.txt"]);
     assert_success(&source);
     assert_success(&copy);
     assert_ne!(json_data(&source)["inode_id"], json_data(&copy)["inode_id"]);
@@ -141,20 +131,17 @@ fn local_profile_filesystem_flow_works_end_to_end() {
         json_data(&copy)["content_manifest_digest"]
     );
 
-    let cat = harness.run(&["filesystem", "cat", "demo", "/docs/hello.txt"]);
+    let cat = harness.run(&["cat", "/docs/hello.txt"]);
     assert_success(&cat);
     assert_eq!(cat.stdout, b"hello from direct core\n");
-    assert!(cat.stderr.is_empty());
 
-    let get_stdout = harness.run(&["filesystem", "get", "demo", "/docs/hello.txt", "-"]);
+    let get_stdout = harness.run(&["get", "/docs/hello.txt", "-"]);
     assert_success(&get_stdout);
     assert_eq!(get_stdout.stdout, b"hello from direct core\n");
 
     let get_file = harness.run(&[
         "--json",
-        "filesystem",
         "get",
-        "demo",
         "/docs/hello.txt",
         download_path.to_str().unwrap(),
     ]);
@@ -164,32 +151,27 @@ fn local_profile_filesystem_flow_works_end_to_end() {
         b"hello from direct core\n"
     );
 
-    let mv = harness.run(&[
-        "--json",
-        "filesystem",
-        "mv",
-        "demo",
-        "/docs/copy.txt",
-        "/docs/final.txt",
-    ]);
+    let mv = harness.run(&["--json", "mv", "/docs/copy.txt", "/docs/final.txt"]);
     assert_success(&mv);
 
-    let rm_dir = harness.run(&["--json", "filesystem", "rm", "demo", "/docs"]);
+    let rm_dir = harness.run(&["--json", "rm", "/docs"]);
     assert_failure(&rm_dir);
     assert_eq!(json_error(&rm_dir)["code"], "path_conflict");
 
-    let rm = harness.run(&["--json", "filesystem", "rm", "demo", "/docs/final.txt"]);
+    let rm = harness.run(&["--json", "rm", "/docs/final.txt"]);
     assert_success(&rm);
 }
 
 #[test]
-fn init_creates_local_profile_and_sets_default() {
+fn init_creates_local_profile_and_current_reports_namespace_unset() {
     let harness = Harness::new();
 
     let init = harness.run(&[
         "--json",
         "init",
         "mystore",
+        "--mode",
+        "local",
         "--store-kind",
         "local-fs",
         "--root",
@@ -202,14 +184,15 @@ fn init_creates_local_profile_and_sets_default() {
     assert_success(&show);
     assert_eq!(json_data(&show)["mode"], "local");
 
+    let current = harness.run(&["--json", "current"]);
+    assert_success(&current);
+    assert_eq!(json_data(&current)["profile"], "mystore");
+    assert!(json_data(&current)["namespace"].is_null());
+
     assert_success(&harness.run(&["namespace", "create", "demo"]));
     let list = harness.run(&["--json", "namespace", "list"]);
     assert_success(&list);
-    let namespaces = json_data(&list)["namespaces"]
-        .as_array()
-        .unwrap()
-        .to_owned();
-    assert_eq!(namespaces.len(), 1);
+    assert_eq!(json_data(&list)["namespaces"].as_array().unwrap().len(), 1);
 }
 
 #[test]
@@ -250,20 +233,20 @@ fn removing_default_profile_requires_explicit_reselection() {
     assert!(data["default_profile"].is_null());
     assert_eq!(data["profiles"].as_array().unwrap().len(), 1);
 
-    let show = harness.run(&["--json", "profile", "show"]);
-    assert_failure(&show);
-    assert_eq!(json_error(&show)["code"], "no_default_profile");
+    let current = harness.run(&["--json", "current"]);
+    assert_failure(&current);
+    assert_eq!(json_error(&current)["code"], "no_default_profile");
 
     let namespace = harness.run(&["--json", "namespace", "list"]);
     assert_failure(&namespace);
     assert_eq!(json_error(&namespace)["code"], "no_default_profile");
 
-    let filesystem = harness.run(&["--json", "filesystem", "ls", "demo"]);
+    let filesystem = harness.run(&["--json", "ls", "/"]);
     assert_failure(&filesystem);
     assert_eq!(json_error(&filesystem)["code"], "no_default_profile");
 
-    let make_default = harness.run(&["--json", "profile", "make-default", "beta"]);
-    assert_success(&make_default);
+    let use_profile = harness.run(&["--json", "profile", "use", "beta"]);
+    assert_success(&use_profile);
 
     let show_after = harness.run(&["--json", "profile", "show"]);
     assert_success(&show_after);
@@ -293,25 +276,26 @@ fn profile_update_changes_fields() {
 }
 
 #[test]
-fn profile_make_default_switches_default() {
+fn profile_use_switches_default() {
     let harness = Harness::new();
     harness.add_local_profile("alpha");
     harness.add_local_profile("beta");
 
-    let make_default = harness.run(&["--json", "profile", "make-default", "beta"]);
-    assert_success(&make_default);
-    assert_eq!(json_data(&make_default)["name"], "beta");
+    let use_profile = harness.run(&["--json", "profile", "use", "beta"]);
+    assert_success(&use_profile);
+    assert_eq!(json_data(&use_profile)["name"], "beta");
 
-    let show = harness.run(&["--json", "profile", "show"]);
-    assert_success(&show);
+    let current = harness.run(&["--json", "current"]);
+    assert_success(&current);
+    assert_eq!(json_data(&current)["profile"], "beta");
 }
 
 #[test]
-fn profile_make_default_rejects_missing_profile() {
+fn profile_use_rejects_missing_profile() {
     let harness = Harness::new();
     harness.add_local_profile("default");
 
-    let result = harness.run(&["--json", "profile", "make-default", "nonexistent"]);
+    let result = harness.run(&["--json", "profile", "use", "nonexistent"]);
     assert_failure(&result);
     assert_eq!(json_error(&result)["code"], "profile_not_found");
 }
@@ -324,6 +308,8 @@ fn reserved_profile_names_are_rejected() {
         "--json",
         "init",
         "default_profile",
+        "--mode",
+        "local",
         "--store-kind",
         "local-fs",
         "--root",
@@ -335,9 +321,12 @@ fn reserved_profile_names_are_rejected() {
     let add_reserved = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "local-fs",
+        "create",
         "config_version",
+        "--mode",
+        "local",
+        "--store-kind",
+        "local-fs",
         "--root",
         harness.store_root("config_version").to_str().unwrap(),
     ]);
@@ -368,6 +357,8 @@ root = "{}"
         "--json",
         "init",
         "mystore",
+        "--mode",
+        "local",
         "--store-kind",
         "local-fs",
         "--root",
@@ -377,10 +368,9 @@ root = "{}"
     let error = json_error(&init);
     assert_eq!(error["code"], "config_already_exists");
     let message = error["message"].as_str().unwrap();
-    assert!(message.contains("config file already exists"));
-    assert!(message.contains("loon profile add"));
+    assert!(message.contains("loon profile create"));
     assert!(message.contains("loon profile update"));
-    assert!(message.contains("loon profile make-default"));
+    assert!(message.contains("loon profile use"));
     assert_eq!(
         fs::read_to_string(&harness.config_path).expect("read unchanged config"),
         existing
@@ -477,15 +467,45 @@ root = ""
 }
 
 #[test]
+fn invalid_default_namespace_in_config_is_rejected() {
+    let harness = Harness::new();
+    harness.write_cli_config(format!(
+        r#"
+config_version = 1
+default_profile = "default"
+
+[default]
+mode = "local"
+default_namespace = "   "
+
+[default.store]
+kind = "local-fs"
+root = "{}"
+"#,
+        harness.store_root("default").display()
+    ));
+
+    let current = harness.run(&["--json", "current"]);
+    assert_failure(&current);
+    let error = json_error(&current);
+    assert_eq!(error["code"], "invalid_config");
+    assert!(error["message"]
+        .as_str()
+        .unwrap()
+        .contains("default.default_namespace"));
+}
+
+#[test]
 fn invalid_remote_urls_are_rejected() {
     let harness = Harness::new();
 
     let missing_host_http = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "remote",
+        "create",
         "default",
+        "--mode",
+        "remote",
         "--server-url",
         "http://",
     ]);
@@ -499,9 +519,10 @@ fn invalid_remote_urls_are_rejected() {
     let missing_host_https = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "remote",
+        "create",
         "default",
+        "--mode",
+        "remote",
         "--server-url",
         "https://",
     ]);
@@ -517,9 +538,10 @@ fn external_remote_profile_executes_through_http() {
     let add_remote = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "remote",
+        "create",
         "default",
+        "--mode",
+        "remote",
         "--server-url",
         &remote_server.server_url,
         "--auth-token",
@@ -530,6 +552,9 @@ fn external_remote_profile_executes_through_http() {
     let create = harness.run(&["--json", "namespace", "create", "demo"]);
     assert_success(&create);
 
+    let use_namespace = harness.run(&["--json", "use", "demo"]);
+    assert_success(&use_namespace);
+
     let list = harness.run(&["--json", "namespace", "list"]);
     assert_success(&list);
     let list_data = json_data(&list);
@@ -539,11 +564,22 @@ fn external_remote_profile_executes_through_http() {
 }
 
 #[test]
+fn filesystem_requires_default_namespace_when_omitted() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let output = harness.run(&["--json", "ls", "/"]);
+    assert_failure(&output);
+    let error = json_error(&output);
+    assert_eq!(error["code"], "no_default_namespace");
+}
+
+#[test]
 fn local_profile_missing_namespace_reports_user_facing_message() {
     let harness = Harness::new();
     harness.add_local_profile("default");
 
-    let output = harness.run(&["--json", "filesystem", "ls", "missing"]);
+    let output = harness.run(&["--json", "ls", "--namespace", "missing", "/"]);
     assert_failure(&output);
     let error = json_error(&output);
     assert_eq!(error["code"], "namespace_not_found");
@@ -558,9 +594,10 @@ fn remote_profile_missing_namespace_reports_user_facing_message() {
     let add_remote = harness.run(&[
         "--json",
         "profile",
-        "add",
-        "remote",
+        "create",
         "default",
+        "--mode",
+        "remote",
         "--server-url",
         &remote_server.server_url,
         "--auth-token",
@@ -568,11 +605,63 @@ fn remote_profile_missing_namespace_reports_user_facing_message() {
     ]);
     assert_success(&add_remote);
 
-    let output = harness.run(&["--json", "filesystem", "ls", "missing"]);
+    let output = harness.run(&["--json", "ls", "--namespace", "missing", "/"]);
     assert_failure(&output);
     let error = json_error(&output);
     assert_eq!(error["code"], "namespace_not_found");
     assert_eq!(error["message"], "namespace `missing` does not exist");
+}
+
+#[test]
+fn current_reports_profile_specific_namespace() {
+    let harness = Harness::new();
+    harness.add_local_profile("alpha");
+    harness.add_local_profile("beta");
+
+    assert_success(&harness.run(&["namespace", "create", "--profile", "alpha", "alpha-ns"]));
+    assert_success(&harness.run(&["use", "--profile", "alpha", "alpha-ns"]));
+    assert_success(&harness.run(&["namespace", "create", "--profile", "beta", "beta-ns"]));
+    assert_success(&harness.run(&["use", "--profile", "beta", "beta-ns"]));
+    assert_success(&harness.run(&["profile", "use", "beta"]));
+
+    let current_default = harness.run(&["--json", "current"]);
+    assert_success(&current_default);
+    assert_eq!(json_data(&current_default)["profile"], "beta");
+    assert_eq!(json_data(&current_default)["namespace"], "beta-ns");
+
+    let current_alpha = harness.run(&["--json", "current", "--profile", "alpha"]);
+    assert_success(&current_alpha);
+    assert_eq!(json_data(&current_alpha)["profile"], "alpha");
+    assert_eq!(json_data(&current_alpha)["namespace"], "alpha-ns");
+}
+
+#[test]
+fn legacy_commands_are_rejected() {
+    let harness = Harness::new();
+
+    let add = harness.run(&["profile", "add"]);
+    assert_failure(&add);
+    assert!(stderr_string(&add).contains("unrecognized"));
+
+    let filesystem = harness.run(&["filesystem", "ls"]);
+    assert_failure(&filesystem);
+    assert!(stderr_string(&filesystem).contains("unrecognized"));
+}
+
+#[test]
+fn help_omits_legacy_commands_and_config_flag() {
+    let harness = Harness::new();
+    let output = Command::new(loon_binary_path())
+        .env("HOME", &harness.home_dir)
+        .arg("--help")
+        .output()
+        .expect("run help");
+    assert_success(&output);
+    let stdout = stdout_string(&output);
+    assert!(!stdout.contains("--config"));
+    assert!(!stdout.contains("filesystem"));
+    assert!(stdout.contains("current"));
+    assert!(stdout.contains("use"));
 }
 
 struct Harness {
@@ -609,9 +698,12 @@ impl Harness {
         let output = self.run(&[
             "--json",
             "profile",
-            "add",
-            "local-fs",
+            "create",
             name,
+            "--mode",
+            "local",
+            "--store-kind",
+            "local-fs",
             "--root",
             self.store_root(name).to_str().unwrap(),
         ]);
@@ -648,27 +740,28 @@ key_prefix = "{key_prefix}"
     }
 
     fn start_external_server(&self, server_config_path: PathBuf) -> ExternalServer {
-        let child = Command::new(loond_binary_path())
-            .arg("--config")
-            .arg(&server_config_path)
-            .spawn()
-            .expect("spawn loond");
-        let server_url = server_url_from_config(&server_config_path);
-        wait_for_healthz(&server_url);
-        ExternalServer { child, server_url }
-    }
-}
+        for _ in 0..5 {
+            let child = Command::new(loond_binary_path())
+                .arg("--config")
+                .arg(&server_config_path)
+                .spawn()
+                .expect("spawn loond");
+            let server_url = server_url_from_config(&server_config_path);
+            if wait_for_healthz_ready(&server_url) {
+                return ExternalServer { child, server_url };
+            }
 
-#[test]
-fn help_omits_config_flag() {
-    let harness = Harness::new();
-    let output = Command::new(loon_binary_path())
-        .env("HOME", &harness.home_dir)
-        .arg("--help")
-        .output()
-        .expect("run help");
-    assert_success(&output);
-    assert!(!stdout_string(&output).contains("--config"));
+            let mut child = child;
+            let _ = child.kill();
+            let _ = child.wait();
+            rewrite_server_bind(&server_config_path, available_port());
+        }
+
+        panic!(
+            "timed out waiting for external server from {}",
+            server_config_path.display()
+        );
+    }
 }
 
 struct ExternalServer {
@@ -732,15 +825,32 @@ fn server_url_from_config(path: &Path) -> String {
     format!("http://{bind}")
 }
 
-fn wait_for_healthz(server_url: &str) {
+fn wait_for_healthz_ready(server_url: &str) -> bool {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
         if ureq::get(&format!("{server_url}/healthz")).call().is_ok() {
-            return;
+            return true;
         }
         thread::sleep(Duration::from_millis(100));
     }
-    panic!("timed out waiting for {server_url}/healthz");
+    false
+}
+
+fn rewrite_server_bind(path: &Path, port: u16) {
+    let config = fs::read_to_string(path).expect("read server config for bind rewrite");
+    let bind = format!("127.0.0.1:{port}");
+    let rewritten = config
+        .lines()
+        .map(|line| {
+            if line.trim().starts_with("bind = ") {
+                format!("bind = \"{bind}\"")
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(path, rewritten).expect("rewrite server bind");
 }
 
 fn available_port() -> u16 {

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -636,6 +636,31 @@ fn current_reports_profile_specific_namespace() {
 }
 
 #[test]
+fn current_does_not_require_backend_resolution() {
+    let harness = Harness::new();
+    harness.write_cli_config(format!(
+        r#"config_version = 1
+default_profile = "broken"
+
+[broken]
+mode = "local"
+default_namespace = "demo"
+
+[broken.store]
+kind = "local-fs"
+root = "{}"
+key_prefix = "../bad"
+"#,
+        harness.store_root("broken").display()
+    ));
+
+    let current = harness.run(&["--json", "current"]);
+    assert_success(&current);
+    assert_eq!(json_data(&current)["profile"], "broken");
+    assert_eq!(json_data(&current)["namespace"], "demo");
+}
+
+#[test]
 fn legacy_commands_are_rejected() {
     let harness = Harness::new();
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,4 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+toml.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,7 +98,7 @@ impl LoonOutput {
 }
 
 trait LoonRunner {
-    fn run(&self, args: &[String]) -> Result<LoonOutput>;
+    fn run(&self, session: &SmokeSession, args: &[String]) -> Result<LoonOutput>;
 }
 
 struct CargoLoonRunner {
@@ -121,7 +121,7 @@ impl CargoLoonRunner {
 }
 
 impl LoonRunner for CargoLoonRunner {
-    fn run(&self, args: &[String]) -> Result<LoonOutput> {
+    fn run(&self, session: &SmokeSession, args: &[String]) -> Result<LoonOutput> {
         let output = Command::new(&self.cargo)
             .arg("run")
             .arg("--quiet")
@@ -129,6 +129,7 @@ impl LoonRunner for CargoLoonRunner {
             .arg("loon-cli")
             .arg("--")
             .args(args)
+            .env("HOME", &session.home_dir)
             .current_dir(&self.workspace_root)
             .output()
             .with_context(|| format!("run loon CLI with args `{}`", args.join(" ")))?;
@@ -143,16 +144,17 @@ impl LoonRunner for CargoLoonRunner {
 #[derive(Debug)]
 struct SmokeSession {
     _temp_dir: tempfile::TempDir,
-    config_path: PathBuf,
+    home_dir: PathBuf,
 }
 
 impl SmokeSession {
     fn new() -> Result<Self> {
         let temp_dir = tempdir().context("create tempdir for smoke session")?;
-        let config_path = temp_dir.path().join("loon-smoke.toml");
+        let home_dir = temp_dir.path().join("home");
+        fs::create_dir_all(&home_dir).context("create smoke home dir")?;
         Ok(Self {
             _temp_dir: temp_dir,
-            config_path,
+            home_dir,
         })
     }
 }
@@ -204,51 +206,30 @@ fn run_local_smoke_with_id(
     smoke_id: &str,
 ) -> Result<SmokeReport> {
     let session = SmokeSession::new()?;
-    let mut local_started = false;
+    let add_result = run_json_command(
+        runner,
+        &session,
+        profile_create_local_args(&session, &args.server_config)?,
+    )?;
+    let _ = expect_success(
+        add_result,
+        "profile_create",
+        Some(PROFILE_NAME),
+        Some("local"),
+    )?;
 
-    let result = (|| -> Result<SmokeReport> {
-        let add_result = run_json_command(
-            runner,
-            profile_add_local_args(&session, &args.server_config),
-        )?;
-        let _ = expect_success(add_result, "profile_add", Some(PROFILE_NAME), Some("local"))?;
-
-        let up_result = run_json_command(runner, local_control_args(&session, "up"))?;
-        let _ = expect_success(up_result, "local_up", Some(PROFILE_NAME), Some("local"))?;
-        local_started = true;
-
-        let steps = execute_smoke_sequence(
-            runner,
-            &session,
-            SmokeMode::Local,
-            &args.namespace,
-            smoke_id,
-        )?;
-        Ok(SmokeReport {
-            mode: SmokeMode::Local,
-            namespace: args.namespace.clone(),
-            steps,
-        })
-    })();
-
-    let cleanup = if local_started {
-        run_json_command(runner, local_control_args(&session, "down"))
-            .and_then(|result| {
-                expect_success(result, "local_down", Some(PROFILE_NAME), Some("local")).map(|_| ())
-            })
-            .map_err(|error| anyhow!("local down cleanup failed: {error}"))
-    } else {
-        Ok(())
-    };
-
-    match (result, cleanup) {
-        (Ok(report), Ok(())) => Ok(report),
-        (Ok(_), Err(cleanup_error)) => Err(cleanup_error),
-        (Err(main_error), Ok(())) => Err(main_error),
-        (Err(main_error), Err(cleanup_error)) => {
-            Err(anyhow!("{main_error}; additionally, {cleanup_error}"))
-        }
-    }
+    let steps = execute_smoke_sequence(
+        runner,
+        &session,
+        SmokeMode::Local,
+        &args.namespace,
+        smoke_id,
+    )?;
+    Ok(SmokeReport {
+        mode: SmokeMode::Local,
+        namespace: args.namespace.clone(),
+        steps,
+    })
 }
 
 fn run_remote_smoke_with(args: &RemoteSmokeArgs, runner: &dyn LoonRunner) -> Result<SmokeReport> {
@@ -264,11 +245,12 @@ fn run_remote_smoke_with_id(
     let session = SmokeSession::new()?;
     let add_result = run_json_command(
         runner,
-        profile_add_remote_args(&session, &args.server_url, args.auth_token.as_deref()),
+        &session,
+        profile_create_remote_args(&session, &args.server_url, args.auth_token.as_deref()),
     )?;
     let _ = expect_success(
         add_result,
-        "profile_add",
+        "profile_create",
         Some(PROFILE_NAME),
         Some("remote"),
     )?;
@@ -307,7 +289,8 @@ fn execute_smoke_sequence(
     fs::write(&upload_file, &payload)
         .with_context(|| format!("write smoke input file {}", upload_file.display()))?;
 
-    let create_result = run_json_command(runner, namespace_create_args(session, namespace))?;
+    let create_result =
+        run_json_command(runner, session, namespace_create_args(session, namespace))?;
     match create_result {
         JsonCommandResult::Success(envelope) => {
             let envelope = expect_envelope(
@@ -340,7 +323,7 @@ fn execute_smoke_sequence(
     }
 
     let list_envelope = expect_success(
-        run_json_command(runner, namespace_list_args(session))?,
+        run_json_command(runner, session, namespace_list_args(session))?,
         "namespace_list",
         Some(PROFILE_NAME),
         Some(mode.as_str()),
@@ -357,6 +340,7 @@ fn execute_smoke_sequence(
     let put_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_put_args(session, namespace, &upload_file, &uploaded_path),
         )?,
         "filesystem_put",
@@ -371,7 +355,11 @@ fn execute_smoke_sequence(
     }
 
     let ls_envelope = expect_success(
-        run_json_command(runner, filesystem_ls_args(session, namespace, &parent_path))?,
+        run_json_command(
+            runner,
+            session,
+            filesystem_ls_args(session, namespace, &parent_path),
+        )?,
         "filesystem_ls",
         Some(PROFILE_NAME),
         Some(mode.as_str()),
@@ -387,6 +375,7 @@ fn execute_smoke_sequence(
     let stat_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_stat_args(session, namespace, &uploaded_path),
         )?,
         "filesystem_stat",
@@ -409,6 +398,7 @@ fn execute_smoke_sequence(
 
     let cat_output = run_stream_command(
         runner,
+        session,
         filesystem_cat_args(session, namespace, &uploaded_path),
     )?;
     if cat_output.stdout != payload {
@@ -418,6 +408,7 @@ fn execute_smoke_sequence(
     let get_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_get_args(session, namespace, &uploaded_path, &downloaded_file),
         )?,
         "filesystem_get",
@@ -441,6 +432,7 @@ fn execute_smoke_sequence(
     let cp_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_cp_args(session, namespace, &uploaded_path, &copied_path),
         )?,
         "filesystem_cp",
@@ -461,6 +453,7 @@ fn execute_smoke_sequence(
     let copy_stat_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_stat_args(session, namespace, &copied_path),
         )?,
         "filesystem_stat",
@@ -476,6 +469,7 @@ fn execute_smoke_sequence(
     let mv_envelope = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_mv_args(session, namespace, &copied_path, &moved_path),
         )?,
         "filesystem_mv",
@@ -490,7 +484,11 @@ fn execute_smoke_sequence(
     }
 
     let rm_envelope = expect_success(
-        run_json_command(runner, filesystem_rm_args(session, namespace, &moved_path))?,
+        run_json_command(
+            runner,
+            session,
+            filesystem_rm_args(session, namespace, &moved_path),
+        )?,
         "filesystem_rm",
         Some(PROFILE_NAME),
         Some(mode.as_str()),
@@ -502,7 +500,11 @@ fn execute_smoke_sequence(
     }
 
     let final_ls_envelope = expect_success(
-        run_json_command(runner, filesystem_ls_args(session, namespace, &parent_path))?,
+        run_json_command(
+            runner,
+            session,
+            filesystem_ls_args(session, namespace, &parent_path),
+        )?,
         "filesystem_ls",
         Some(PROFILE_NAME),
         Some(mode.as_str()),
@@ -525,6 +527,7 @@ fn execute_smoke_sequence(
     let _ = expect_success(
         run_json_command(
             runner,
+            session,
             filesystem_stat_args(session, namespace, &uploaded_path),
         )?,
         "filesystem_stat",
@@ -534,6 +537,7 @@ fn execute_smoke_sequence(
 
     let removed_stat = run_json_command(
         runner,
+        session,
         filesystem_stat_args(session, namespace, &moved_path),
     )?;
     let removed_error = expect_failure(
@@ -573,8 +577,12 @@ fn render_report(report: &SmokeReport) -> String {
     )
 }
 
-fn run_json_command(runner: &dyn LoonRunner, args: Vec<String>) -> Result<JsonCommandResult> {
-    let output = runner.run(&args)?;
+fn run_json_command(
+    runner: &dyn LoonRunner,
+    session: &SmokeSession,
+    args: Vec<String>,
+) -> Result<JsonCommandResult> {
+    let output = runner.run(session, &args)?;
     if output.success() {
         Ok(JsonCommandResult::Success(parse_envelope(
             &output.stdout,
@@ -592,8 +600,12 @@ fn run_json_command(runner: &dyn LoonRunner, args: Vec<String>) -> Result<JsonCo
     }
 }
 
-fn run_stream_command(runner: &dyn LoonRunner, args: Vec<String>) -> Result<LoonOutput> {
-    let output = runner.run(&args)?;
+fn run_stream_command(
+    runner: &dyn LoonRunner,
+    session: &SmokeSession,
+    args: Vec<String>,
+) -> Result<LoonOutput> {
+    let output = runner.run(session, &args)?;
     if output.success() {
         Ok(output)
     } else {
@@ -761,15 +773,8 @@ fn id_field(value: &Value, field: &str) -> Result<u64> {
     }
 }
 
-fn base_args(session: &SmokeSession, profile: Option<&str>, json: bool) -> Vec<String> {
-    let mut args = vec![
-        "--config".to_owned(),
-        session.config_path.display().to_string(),
-    ];
-    if let Some(profile) = profile {
-        args.push("--profile".to_owned());
-        args.push(profile.to_owned());
-    }
+fn base_args(_session: &SmokeSession, json: bool) -> Vec<String> {
+    let mut args = Vec::new();
     if json {
         args.push("--json".to_owned());
     }
@@ -777,30 +782,147 @@ fn base_args(session: &SmokeSession, profile: Option<&str>, json: bool) -> Vec<S
     args
 }
 
-fn profile_add_local_args(session: &SmokeSession, server_config: &Path) -> Vec<String> {
-    let mut args = base_args(session, None, true);
-    args.extend([
-        "profile".to_owned(),
-        "add".to_owned(),
-        "local".to_owned(),
-        PROFILE_NAME.to_owned(),
-        "--server-config".to_owned(),
-        server_config.display().to_string(),
-    ]);
-    args
+#[derive(Debug, Deserialize)]
+struct SmokeServerConfig {
+    store: SmokeStoreConfig,
 }
 
-fn profile_add_remote_args(
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum SmokeStoreConfig {
+    LocalFs {
+        root: String,
+        key_prefix: Option<String>,
+    },
+    AwsS3 {
+        bucket: String,
+        region: String,
+        endpoint_url: Option<String>,
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+        key_prefix: Option<String>,
+        #[serde(default)]
+        force_path_style: bool,
+    },
+    CloudflareR2 {
+        bucket: String,
+        account_id: String,
+        endpoint_url: String,
+        access_key_id: String,
+        secret_access_key: String,
+        key_prefix: Option<String>,
+    },
+}
+
+fn profile_create_local_args(session: &SmokeSession, server_config: &Path) -> Result<Vec<String>> {
+    let config: SmokeServerConfig =
+        toml::from_str(&fs::read_to_string(server_config).with_context(|| {
+            format!("read local smoke server config {}", server_config.display())
+        })?)
+        .with_context(|| {
+            format!(
+                "decode local smoke server config {}",
+                server_config.display()
+            )
+        })?;
+    let mut args = base_args(session, true);
+    args.extend([
+        "profile".to_owned(),
+        "create".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--mode".to_owned(),
+        "local".to_owned(),
+    ]);
+    match config.store {
+        SmokeStoreConfig::LocalFs { root, key_prefix } => {
+            args.extend([
+                "--store-kind".to_owned(),
+                "local-fs".to_owned(),
+                "--root".to_owned(),
+                root,
+            ]);
+            if let Some(key_prefix) = key_prefix {
+                args.extend(["--key-prefix".to_owned(), key_prefix]);
+            }
+        }
+        SmokeStoreConfig::AwsS3 {
+            bucket,
+            region,
+            endpoint_url,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            key_prefix,
+            force_path_style,
+        } => {
+            args.extend([
+                "--store-kind".to_owned(),
+                "aws-s3".to_owned(),
+                "--bucket".to_owned(),
+                bucket,
+                "--region".to_owned(),
+                region,
+                "--access-key-id".to_owned(),
+                access_key_id,
+                "--secret-access-key".to_owned(),
+                secret_access_key,
+            ]);
+            if let Some(endpoint_url) = endpoint_url {
+                args.extend(["--endpoint-url".to_owned(), endpoint_url]);
+            }
+            if let Some(session_token) = session_token {
+                args.extend(["--session-token".to_owned(), session_token]);
+            }
+            if let Some(key_prefix) = key_prefix {
+                args.extend(["--key-prefix".to_owned(), key_prefix]);
+            }
+            if force_path_style {
+                args.push("--force-path-style".to_owned());
+            }
+        }
+        SmokeStoreConfig::CloudflareR2 {
+            bucket,
+            account_id,
+            endpoint_url,
+            access_key_id,
+            secret_access_key,
+            key_prefix,
+        } => {
+            args.extend([
+                "--store-kind".to_owned(),
+                "cloudflare-r2".to_owned(),
+                "--bucket".to_owned(),
+                bucket,
+                "--account-id".to_owned(),
+                account_id,
+                "--endpoint-url".to_owned(),
+                endpoint_url,
+                "--access-key-id".to_owned(),
+                access_key_id,
+                "--secret-access-key".to_owned(),
+                secret_access_key,
+            ]);
+            if let Some(key_prefix) = key_prefix {
+                args.extend(["--key-prefix".to_owned(), key_prefix]);
+            }
+        }
+    }
+    Ok(args)
+}
+
+fn profile_create_remote_args(
     session: &SmokeSession,
     server_url: &str,
     auth_token: Option<&str>,
 ) -> Vec<String> {
-    let mut args = base_args(session, None, true);
+    let mut args = base_args(session, true);
     args.extend([
         "profile".to_owned(),
-        "add".to_owned(),
-        "remote".to_owned(),
+        "create".to_owned(),
         PROFILE_NAME.to_owned(),
+        "--mode".to_owned(),
+        "remote".to_owned(),
         "--server-url".to_owned(),
         server_url.to_owned(),
     ]);
@@ -811,25 +933,26 @@ fn profile_add_remote_args(
     args
 }
 
-fn local_control_args(session: &SmokeSession, command: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
-    args.extend(["local".to_owned(), command.to_owned()]);
-    args
-}
-
 fn namespace_create_args(session: &SmokeSession, namespace: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
         "namespace".to_owned(),
         "create".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
         namespace.to_owned(),
     ]);
     args
 }
 
 fn namespace_list_args(session: &SmokeSession) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
-    args.extend(["namespace".to_owned(), "list".to_owned()]);
+    let mut args = base_args(session, true);
+    args.extend([
+        "namespace".to_owned(),
+        "list".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+    ]);
     args
 }
 
@@ -839,10 +962,12 @@ fn filesystem_put_args(
     local_path: &Path,
     remote_path: &str,
 ) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "put".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         local_path.display().to_string(),
         remote_path.to_owned(),
@@ -851,10 +976,12 @@ fn filesystem_put_args(
 }
 
 fn filesystem_ls_args(session: &SmokeSession, namespace: &str, path: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "ls".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         path.to_owned(),
     ]);
@@ -862,10 +989,12 @@ fn filesystem_ls_args(session: &SmokeSession, namespace: &str, path: &str) -> Ve
 }
 
 fn filesystem_stat_args(session: &SmokeSession, namespace: &str, path: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "stat".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         path.to_owned(),
     ]);
@@ -873,10 +1002,12 @@ fn filesystem_stat_args(session: &SmokeSession, namespace: &str, path: &str) -> 
 }
 
 fn filesystem_cat_args(session: &SmokeSession, namespace: &str, path: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), false);
+    let mut args = base_args(session, false);
     args.extend([
-        "filesystem".to_owned(),
         "cat".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         path.to_owned(),
     ]);
@@ -889,10 +1020,12 @@ fn filesystem_get_args(
     remote_path: &str,
     destination: &Path,
 ) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "get".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         remote_path.to_owned(),
         destination.display().to_string(),
@@ -906,10 +1039,12 @@ fn filesystem_cp_args(
     source_path: &str,
     dest_path: &str,
 ) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "cp".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         source_path.to_owned(),
         dest_path.to_owned(),
@@ -923,10 +1058,12 @@ fn filesystem_mv_args(
     source_path: &str,
     dest_path: &str,
 ) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "mv".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         source_path.to_owned(),
         dest_path.to_owned(),
@@ -935,10 +1072,12 @@ fn filesystem_mv_args(
 }
 
 fn filesystem_rm_args(session: &SmokeSession, namespace: &str, path: &str) -> Vec<String> {
-    let mut args = base_args(session, Some(PROFILE_NAME), true);
+    let mut args = base_args(session, true);
     args.extend([
-        "filesystem".to_owned(),
         "rm".to_owned(),
+        "--profile".to_owned(),
+        PROFILE_NAME.to_owned(),
+        "--namespace".to_owned(),
         namespace.to_owned(),
         path.to_owned(),
     ]);
@@ -959,6 +1098,8 @@ mod tests {
     use serde_json::json;
     use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn smoke_report_renders_compact_summary() {
@@ -979,9 +1120,9 @@ mod tests {
 
     #[test]
     fn local_smoke_runs_expected_cli_sequence() {
-        let server_config = PathBuf::from("/tmp/loond.toml");
+        let server_config = write_local_server_config();
         let args = LocalSmokeArgs {
-            server_config: server_config.clone(),
+            server_config: server_config.path().to_path_buf(),
             namespace: "demo".to_owned(),
         };
         let runner = RecordingRunner::new(local_success_outputs("demo"));
@@ -1006,34 +1147,25 @@ mod tests {
             ]
         );
         let calls = runner.calls();
-        assert_same_config_path(&calls);
         assert_command_suffix(
             &calls[0],
             &[
                 "--json",
                 "--no-input",
                 "profile",
-                "add",
-                "local",
+                "create",
                 "smoke",
-                "--server-config",
-                "/tmp/loond.toml",
+                "--mode",
+                "local",
+                "--store-kind",
+                "local-fs",
+                "--root",
+                "/tmp/xtask-loon-store",
             ],
         );
-        assert_command_suffix(
-            &calls[1],
-            &["--profile", "smoke", "--json", "--no-input", "local", "up"],
-        );
-        assert_command_suffix(
-            calls.last().expect("last call"),
-            &[
-                "--profile",
-                "smoke",
-                "--json",
-                "--no-input",
-                "local",
-                "down",
-            ],
+        assert_eq!(
+            calls.last().unwrap().first().map(String::as_str),
+            Some("--json")
         );
     }
 
@@ -1050,40 +1182,34 @@ mod tests {
 
         assert_eq!(report.mode, SmokeMode::Remote);
         let calls = runner.calls();
-        assert_same_config_path(&calls);
         assert_command_suffix(
             &calls[0],
             &[
                 "--json",
                 "--no-input",
                 "profile",
-                "add",
-                "remote",
+                "create",
                 "smoke",
+                "--mode",
+                "remote",
                 "--server-url",
                 "http://127.0.0.1:9400",
                 "--auth-token",
                 "dev-token",
             ],
         );
-        assert!(
-            !calls
-                .iter()
-                .any(|call| call.iter().any(|arg| *arg == "local")),
-            "remote smoke should not issue local lifecycle commands"
-        );
         assert_eq!(report.steps.first(), Some(&STEP_CREATE_NAMESPACE));
     }
 
     #[test]
-    fn local_smoke_always_runs_local_down_after_failure() {
-        let server_config = PathBuf::from("/tmp/loond.toml");
+    fn local_smoke_propagates_failures() {
+        let server_config = write_local_server_config();
         let args = LocalSmokeArgs {
-            server_config,
+            server_config: server_config.path().to_path_buf(),
             namespace: "demo".to_owned(),
         };
         let mut outputs = local_success_outputs("demo");
-        outputs[5] = json_failure(
+        outputs[4] = json_failure(
             "filesystem_ls",
             Some("smoke"),
             Some("local"),
@@ -1096,17 +1222,7 @@ mod tests {
 
         assert!(error.to_string().contains("boom"));
         let calls = runner.calls();
-        assert_command_suffix(
-            calls.last().expect("last call"),
-            &[
-                "--profile",
-                "smoke",
-                "--json",
-                "--no-input",
-                "local",
-                "down",
-            ],
-        );
+        assert!(calls.iter().any(|call| call.iter().any(|arg| arg == "ls")));
     }
 
     #[test]
@@ -1132,17 +1248,6 @@ mod tests {
         assert_eq!(report.steps[0], STEP_CREATE_NAMESPACE);
     }
 
-    fn assert_same_config_path(calls: &[Vec<String>]) {
-        let config_path = calls
-            .first()
-            .and_then(|call| call.get(1))
-            .expect("config path");
-        for call in calls {
-            assert_eq!(call.first().map(String::as_str), Some("--config"));
-            assert_eq!(call.get(1).map(String::as_str), Some(config_path.as_str()));
-        }
-    }
-
     fn assert_command_suffix(actual: &[String], suffix: &[&str]) {
         let actual_suffix = &actual[actual.len() - suffix.len()..];
         let expected = suffix
@@ -1152,47 +1257,36 @@ mod tests {
         assert_eq!(actual_suffix, expected.as_slice());
     }
 
+    fn write_local_server_config() -> NamedTempFile {
+        let mut file = NamedTempFile::new().expect("temp server config");
+        writeln!(
+            file,
+            r#"
+[store]
+kind = "local-fs"
+root = "/tmp/xtask-loon-store"
+"#
+        )
+        .expect("write temp server config");
+        file
+    }
+
     fn local_success_outputs(namespace: &str) -> Vec<LoonOutput> {
         let mut outputs = Vec::new();
         outputs.push(json_success(
-            "profile_add",
+            "profile_create",
             Some(PROFILE_NAME),
             Some("local"),
             json!({"type":"profile","name":"smoke","mode":"local","active":true}),
         ));
-        outputs.push(json_success(
-            "local_up",
-            Some(PROFILE_NAME),
-            Some("local"),
-            json!({
-                "type":"local_status",
-                "profile_name":"smoke",
-                "status":"running",
-                "server_url":"http://127.0.0.1:9400",
-                "server_config_path":"/tmp/loond.toml",
-                "pid":42
-            }),
-        ));
         outputs.extend(sequence_outputs(namespace, "local"));
-        outputs.push(json_success(
-            "local_down",
-            Some(PROFILE_NAME),
-            Some("local"),
-            json!({
-                "type":"local_status",
-                "profile_name":"smoke",
-                "status":"stopped",
-                "server_url":"http://127.0.0.1:9400",
-                "server_config_path":"/tmp/loond.toml"
-            }),
-        ));
         outputs
     }
 
     fn remote_success_outputs(namespace: &str) -> Vec<LoonOutput> {
         let mut outputs = Vec::new();
         outputs.push(json_success(
-            "profile_add",
+            "profile_create",
             Some(PROFILE_NAME),
             Some("remote"),
             json!({"type":"profile","name":"smoke","mode":"remote","active":true}),
@@ -1359,13 +1453,10 @@ mod tests {
     }
 
     impl LoonRunner for RecordingRunner {
-        fn run(&self, args: &[String]) -> Result<LoonOutput> {
+        fn run(&self, _session: &SmokeSession, args: &[String]) -> Result<LoonOutput> {
             self.calls.borrow_mut().push(args.to_vec());
 
-            if args
-                .windows(2)
-                .any(|window| window == ["filesystem", "get"])
-            {
+            if args.iter().any(|arg| arg == "get") {
                 let destination = args
                     .last()
                     .ok_or_else(|| anyhow!("missing get destination"))?;


### PR DESCRIPTION
## Summary
- replace the old filesystem subcommand tree with top-level path commands plus current and namespace selection
- add per-profile default namespace persistence and update profile/current rendering and errors
- update README, CLI tests, and xtask smoke coverage to the new surface

## New Commands
- loon init [NAME] [--mode <MODE>] [profile creation flags]
- loon profile create NAME --mode <MODE> [profile creation flags]
- loon profile list
- loon profile show [NAME]
- loon profile update NAME [flags]
- loon profile remove NAME
- loon profile use NAME
- loon namespace create [--profile <NAME>] NAME
- loon namespace list [--profile <NAME>]
- loon use [--profile <NAME>] NAMESPACE
- loon current [--profile <NAME>]
- loon ls [--profile <NAME>] [--namespace <NAME>] [PATH]
- loon stat [--profile <NAME>] [--namespace <NAME>] PATH
- loon cat [--profile <NAME>] [--namespace <NAME>] PATH
- loon get [--profile <NAME>] [--namespace <NAME>] REMOTE_PATH [LOCAL_DESTINATION]
- loon put [--profile <NAME>] [--namespace <NAME>] LOCAL_PATH [REMOTE_PATH] [--force]
- loon rm [--profile <NAME>] [--namespace <NAME>] REMOTE_PATH
- loon mv [--profile <NAME>] [--namespace <NAME>] SOURCE_PATH DEST_PATH
- loon cp [--profile <NAME>] [--namespace <NAME>] SOURCE_PATH DEST_PATH

## Testing
- cargo fmt --all
- cargo test -q -p xtask
- cargo test -q -p loon-cli
