### PR TITLE
feat: add multi-platform release workflow and install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    name: build-${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            asset: loon-darwin-aarch64.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            asset: loon-darwin-x86_64.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            asset: loon-linux-x86_64.tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            asset: loon-linux-aarch64.tar.gz
+            cross: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: release-${{ matrix.target }}-
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            cargo build --release --target ${{ matrix.target }} -p loon-cli
+          else
+            cargo build --release -p loon-cli
+          fi
+
+      - name: Package
+        run: |
+          STAGING="$RUNNER_TEMP/staging"
+          mkdir -p "$STAGING/bin"
+
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            BIN_DIR="target/${{ matrix.target }}/release"
+          else
+            BIN_DIR="target/release"
+          fi
+
+          cp "$BIN_DIR/loon" "$STAGING/bin/loon"
+          chmod 755 "$STAGING/bin/loon"
+
+          tar -C "$STAGING" -czf "$RUNNER_TEMP/${{ matrix.asset }}" .
+
+          cd "$RUNNER_TEMP"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            ${{ runner.temp }}/${{ matrix.asset }}
+            ${{ runner.temp }}/${{ matrix.asset }}.sha256
+
+  release:
+    name: Upload release assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Consolidate checksums
+        run: cat artifacts/*.sha256 > artifacts/SHA256SUMS
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/loon-*.tar.gz
+            artifacts/SHA256SUMS
+          fail_on_unmatched_files: true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+set -eu
+
+REPO_SLUG="prequel-co/loonfs"
+BIN_DIR="${HOME:-}/.loonfs/bin"
+VERSION=""
+
+usage() {
+  cat <<'EOF'
+usage: install.sh [--version <tag>] [--bin-dir <path>] [--help]
+
+Installs the loon CLI into ~/.loonfs/bin by default.
+
+  curl -fsSL https://install.loonfs.com | sh
+  curl -fsSL https://install.loonfs.com | sh -s -- --version v0.2.0
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      shift
+      [ "$#" -gt 0 ] || die "missing value for --version"
+      VERSION=$1
+      ;;
+    --bin-dir)
+      shift
+      [ "$#" -gt 0 ] || die "missing value for --bin-dir"
+      BIN_DIR=$1
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+[ -n "${HOME:-}" ] || die "HOME is not set"
+
+for cmd in curl tar mktemp install awk uname mkdir; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    die "required command not found: $cmd"
+  fi
+done
+
+# --- platform detection ---
+
+detect_platform() {
+  OS=$(uname -s)
+  ARCH=$(uname -m)
+
+  case "$OS" in
+    Darwin) OS_NAME="darwin" ;;
+    Linux)  OS_NAME="linux" ;;
+    *)      die "unsupported OS: $OS (macOS and Linux are supported)" ;;
+  esac
+
+  case "$ARCH" in
+    x86_64|amd64)  ARCH_NAME="x86_64" ;;
+    arm64|aarch64)  ARCH_NAME="aarch64" ;;
+    *)              die "unsupported architecture: $ARCH (x86_64 and arm64/aarch64 are supported)" ;;
+  esac
+
+  ASSET_NAME="loon-${OS_NAME}-${ARCH_NAME}.tar.gz"
+}
+
+detect_platform
+
+# --- checksum tool detection ---
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256_CMD="shasum -a 256"
+else
+  die "neither sha256sum nor shasum found — cannot verify download"
+fi
+
+# --- download ---
+
+# LOONFS_RELEASE_BASE_URL lets CI exercise the installer against locally staged assets.
+if [ -n "${LOONFS_RELEASE_BASE_URL:-}" ]; then
+  RELEASE_BASE_URL=${LOONFS_RELEASE_BASE_URL%/}
+elif [ -n "$VERSION" ]; then
+  RELEASE_BASE_URL="https://github.com/$REPO_SLUG/releases/download/$VERSION"
+else
+  RELEASE_BASE_URL="https://github.com/$REPO_SLUG/releases/latest/download"
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+
+ARCHIVE_PATH="$TMP_DIR/$ASSET_NAME"
+CHECKSUMS_PATH="$TMP_DIR/SHA256SUMS"
+
+echo "Downloading $ASSET_NAME..."
+curl -fSL --output "$ARCHIVE_PATH" "$RELEASE_BASE_URL/$ASSET_NAME"
+curl -fSL --output "$CHECKSUMS_PATH" "$RELEASE_BASE_URL/SHA256SUMS"
+
+# --- verify checksum ---
+
+EXPECTED=$(awk -v asset="$ASSET_NAME" '$2 == asset || $2 == "./"asset { print $1 }' "$CHECKSUMS_PATH")
+[ -n "$EXPECTED" ] || die "missing checksum entry for $ASSET_NAME"
+ACTUAL=$($SHA256_CMD "$ARCHIVE_PATH" | awk '{ print $1 }')
+[ "$EXPECTED" = "$ACTUAL" ] || die "checksum verification failed for $ASSET_NAME (expected $EXPECTED, got $ACTUAL)"
+
+# --- install ---
+
+EXTRACT_DIR="$TMP_DIR/extract"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
+
+mkdir -p "$BIN_DIR"
+install -m 0755 "$EXTRACT_DIR/bin/loon" "$BIN_DIR/loon"
+
+echo "Installed loon to $BIN_DIR/loon"
+
+# --- PATH hint ---
+
+case ":${PATH:-}:" in
+  *:"$BIN_DIR":*)
+    ;;
+  *)
+    echo
+    echo "Add loon to your PATH:"
+    echo
+    if [ -f "$HOME/.zshrc" ] || [ "$(basename "${SHELL:-}")" = "zsh" ]; then
+      echo "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+    elif [ -f "$HOME/.bashrc" ] || [ "$(basename "${SHELL:-}")" = "bash" ]; then
+      echo "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+    else
+      echo "  export PATH=\"$BIN_DIR:\$PATH\""
+    fi
+    echo
+    ;;
+esac
+
+# --- next steps ---
+
+echo "Get started:"
+echo "  loon --help"


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow (`.github/workflows/release.yml`) that builds the `loon` CLI for 4 platforms when a release is published: darwin-aarch64, darwin-x86_64, linux-x86_64, linux-aarch64
- Add curl-installable script (`scripts/install.sh`) with auto platform detection, SHA256 checksum verification, and shell-aware PATH hints

## Design decisions
- **Trigger**: `release: published` (not tag push) so releases are explicitly controlled
- **Linux aarch64**: Cross-compiled with `gcc-aarch64-linux-gnu` rather than the `cross` tool — simpler for a pure-Rust project
- **macOS x86_64**: Built on `macos-13` (native x86_64 runner) rather than cross-compiling on arm64
- **`fail-fast: false`**: One platform failure doesn't block the others
- **Separate build/release jobs**: Matrix builds run in parallel, final job collects artifacts and consolidated SHA256SUMS
- **Install script**: Non-invasive — prints PATH export instead of editing dotfiles, no sudo required, `LOONFS_RELEASE_BASE_URL` override for CI testing

## Test plan
- [ ] Tag a test release and verify all 4 tarballs + SHA256SUMS appear on the GitHub Release
- [ ] Run `sh scripts/install.sh` on macOS (arm64 + x86_64) and Linux (x86_64 + aarch64)
- [ ] Verify checksum validation catches a tampered archive
- [ ] Confirm `loon --version` works after install via each method