### PR TITLE
chore: rename loond server surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ state.
 
 The current implementation exposes two public surfaces over the same core model:
 
-- a path-oriented user surface through `loon` and `loond`
-- a lower-level `/v0` upload, explicit-commit, and ordered change-feed surface through `loond`
-  and `loon-client`
+- a path-oriented user surface through `loon` and `loon-server`
+- a lower-level `/v0` upload, explicit-commit, and ordered change-feed surface through
+  `loon-server` and `loon-client`
 
 The current runtime path is:
 
-`loon -> loon-client -> loond -> loon-core -> loon-objectstore`
+`loon -> loon-client -> loon-server -> loon-core -> loon-objectstore`
 
 Current product rules:
 
-- every CLI operation goes through `loond`, even in local mode
+- every CLI operation goes through `loon-server`, even in local mode
 - profile `mode` is `local` or `remote`
-- `local` means `loon` points at or manages a local `loond`
-- `remote` means `loon` points at an already-running `loond`
+- `local` means `loon` points at or manages a local `loon-server`
+- `remote` means `loon` points at an already-running `loon-server`
 - canonical sibling-name comparison uses `NamePolicy = nfc_casefold_v0`
 
 Not implemented yet relative to the current spec set:
@@ -49,7 +49,7 @@ crates/
   loon-objectstore/  object-store trait, providers, key builders, conformance surface
   loon-core/         authoritative metadata, lease, replay, and mutation logic
   loon-model/        pure metadata replay/model helpers for differential tests
-  loon-server/       `loond` HTTP server over core + object storage
+  loon-server/       `loon-server` HTTP server over core + object storage
   loon-client/       thin HTTP transport client
   loon-cli/          profile-based `loon` CLI
 xtask/
@@ -58,27 +58,27 @@ xtask/
 
 ## Config Ownership
 
-`loon` and `loond` do not share a config file.
+`loon` and `loon-server` do not share a config file.
 
 - `loon` owns CLI-managed profile state
-- `loond` owns operator-authored server configuration
+- `loon-server` owns operator-authored server configuration
 
 `loon` always uses:
 
 - `~/.loonfs/config.toml`
 
-`loond` has no code-level default path. You pass a server config path explicitly when you start
-`loond` or when you create a local `loon` profile.
+`loon-server` has no code-level default path. You pass a server config path explicitly when you
+start `loon-server` or when you create a local `loon` profile.
 
 Sanitized example configs live in [`configs/`](configs/):
 
 - [`configs/loon.local.example.toml`](configs/loon.local.example.toml)
 - [`configs/loon.remote.example.toml`](configs/loon.remote.example.toml)
-- [`configs/loond.local-fs.example.toml`](configs/loond.local-fs.example.toml)
-- [`configs/loond.aws-s3.example.toml`](configs/loond.aws-s3.example.toml)
-- [`configs/loond.cloudflare-r2.example.toml`](configs/loond.cloudflare-r2.example.toml)
+- [`configs/loon-server.local-fs.example.toml`](configs/loon-server.local-fs.example.toml)
+- [`configs/loon-server.aws-s3.example.toml`](configs/loon-server.aws-s3.example.toml)
+- [`configs/loon-server.cloudflare-r2.example.toml`](configs/loon-server.cloudflare-r2.example.toml)
 
-Copy example `loond` configs to a user-owned path outside the repository for real use.
+Copy example `loon-server` configs to a user-owned path outside the repository for real use.
 
 The current CLI schema is `config_version = 1`. JSON command envelopes use `format_version = 1`.
 
@@ -168,7 +168,7 @@ Smoke acceptance:
 
 ```bash
 cargo run -p xtask -- smoke local \
-  --server-config ./configs/loond.local-fs.example.toml \
+  --server-config ./configs/loon-server.local-fs.example.toml \
   --namespace demo
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,21 @@ state.
 
 The current implementation exposes two public surfaces over the same core model:
 
-- a path-oriented user surface through `loon` and `loon-server`
+- a path-oriented user surface through the `loon` CLI (`loon-cli`)
 - a lower-level `/v0` upload, explicit-commit, and ordered change-feed surface through
   `loon-server` and `loon-client`
 
-The current runtime path is:
+The current runtime path depends on the selected profile mode:
 
-`loon -> loon-client -> loon-server -> loon-core -> loon-objectstore`
+- local profile: `loon-cli -> loon-core -> loon-objectstore`
+- remote profile: `loon-cli -> loon-client -> loon-server -> loon-core -> loon-objectstore`
 
 Current product rules:
 
-- every CLI operation goes through `loon-server`, even in local mode
 - profile `mode` is `local` or `remote`
-- `local` means `loon` points at or manages a local `loon-server`
-- `remote` means `loon` points at an already-running `loon-server`
+- local profiles execute directly against the configured object store through `loon-core`
+- remote profiles execute through an already-running `loon-server`
+- `loon-client` is the HTTP transport client used for the remote path
 - canonical sibling-name comparison uses `NamePolicy = nfc_casefold_v0`
 
 Not implemented yet relative to the current spec set:
@@ -60,7 +61,7 @@ xtask/
 
 `loon` and `loon-server` do not share a config file.
 
-- `loon` owns CLI-managed profile state
+- `loon` owns CLI-managed profile state for local and remote profiles
 - `loon-server` owns operator-authored server configuration
 
 `loon` always uses:
@@ -68,7 +69,7 @@ xtask/
 - `~/.loonfs/config.toml`
 
 `loon-server` has no code-level default path. You pass a server config path explicitly when you
-start `loon-server` or when you create a local `loon` profile.
+start `loon-server`.
 
 Sanitized example configs live in [`configs/`](configs/):
 
@@ -78,7 +79,7 @@ Sanitized example configs live in [`configs/`](configs/):
 - [`configs/loon-server.aws-s3.example.toml`](configs/loon-server.aws-s3.example.toml)
 - [`configs/loon-server.cloudflare-r2.example.toml`](configs/loon-server.cloudflare-r2.example.toml)
 
-Copy example `loon-server` configs to a user-owned path outside the repository for real use.
+Copy example configs to user-owned paths outside the repository for real use.
 
 The current CLI schema is `config_version = 1`. JSON command envelopes use `format_version = 1`.
 

--- a/configs/loon-server.aws-s3.example.toml
+++ b/configs/loon-server.aws-s3.example.toml
@@ -1,14 +1,14 @@
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond-r2"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server-aws"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
-kind = "cloudflare-r2"
+kind = "aws-s3"
 bucket = "your-bucket"
-account_id = "YOUR_ACCOUNT_ID"
-endpoint_url = "https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com"
+region = "us-east-1"
 access_key_id = "YOUR_ACCESS_KEY_ID"
 secret_access_key = "YOUR_SECRET_ACCESS_KEY"
 key_prefix = "loon-demo"
+force_path_style = false

--- a/configs/loon-server.cloudflare-r2.example.toml
+++ b/configs/loon-server.cloudflare-r2.example.toml
@@ -1,14 +1,14 @@
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond-aws"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server-r2"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
-kind = "aws-s3"
+kind = "cloudflare-r2"
 bucket = "your-bucket"
-region = "us-east-1"
+account_id = "YOUR_ACCOUNT_ID"
+endpoint_url = "https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com"
 access_key_id = "YOUR_ACCESS_KEY_ID"
 secret_access_key = "YOUR_SECRET_ACCESS_KEY"
 key_prefix = "loon-demo"
-force_path_style = false

--- a/configs/loon-server.local-fs.example.toml
+++ b/configs/loon-server.local-fs.example.toml
@@ -1,7 +1,7 @@
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond-local"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server-local"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]

--- a/configs/loon.local.example.toml
+++ b/configs/loon.local.example.toml
@@ -1,8 +1,12 @@
 config_version = 1
-active_profile = "local"
+default_profile = "local"
 
-[profiles.local]
+[local]
 mode = "local"
+writer_id = "example-local-writer"
+writer_version = "loon/0.1.0"
 
-[profiles.local.local]
-server_config_path = "./loon-server.local-fs.example.toml"
+[local.store]
+kind = "local-fs"
+root = "./.loondb-store"
+key_prefix = "local-example"

--- a/configs/loon.local.example.toml
+++ b/configs/loon.local.example.toml
@@ -5,4 +5,4 @@ active_profile = "local"
 mode = "local"
 
 [profiles.local.local]
-server_config_path = "./loond.local-fs.example.toml"
+server_config_path = "./loon-server.local-fs.example.toml"

--- a/configs/loon.remote.example.toml
+++ b/configs/loon.remote.example.toml
@@ -1,9 +1,7 @@
 config_version = 1
-active_profile = "remote"
+default_profile = "remote"
 
-[profiles.remote]
+[remote]
 mode = "remote"
-
-[profiles.remote.remote]
 server_url = "http://127.0.0.1:9400"
 auth_token = "dev-token"

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -743,7 +743,10 @@ impl Harness {
 
     fn write_server_config(&self, name: &str, key_prefix: &str) -> PathBuf {
         let bind = format!("127.0.0.1:{}", available_port());
-        let path = self.temp_dir.path().join(format!("{name}.loond.toml"));
+        let path = self
+            .temp_dir
+            .path()
+            .join(format!("{name}.loon-server.toml"));
         let store_root = self.store_root(name);
         let contents = format!(
             r#"
@@ -766,11 +769,11 @@ key_prefix = "{key_prefix}"
 
     fn start_external_server(&self, server_config_path: PathBuf) -> ExternalServer {
         for _ in 0..5 {
-            let child = Command::new(loond_binary_path())
+            let child = Command::new(loon_server_binary_path())
                 .arg("--config")
                 .arg(&server_config_path)
                 .spawn()
-                .expect("spawn loond");
+                .expect("spawn loon-server");
             let server_url = server_url_from_config(&server_config_path);
             if wait_for_healthz_ready(&server_url) {
                 return ExternalServer { child, server_url };
@@ -820,8 +823,8 @@ fn loon_binary_path() -> PathBuf {
     candidate
 }
 
-fn loond_binary_path() -> PathBuf {
-    if let Some(path) = env::var_os("CARGO_BIN_EXE_loond") {
+fn loon_server_binary_path() -> PathBuf {
+    if let Some(path) = env::var_os("CARGO_BIN_EXE_loon-server") {
         return PathBuf::from(path);
     }
 
@@ -830,10 +833,14 @@ fn loond_binary_path() -> PathBuf {
         .parent()
         .and_then(|path| path.parent())
         .expect("target debug dir");
-    let candidate = debug_dir.join(if cfg!(windows) { "loond.exe" } else { "loond" });
+    let candidate = debug_dir.join(if cfg!(windows) {
+        "loon-server.exe"
+    } else {
+        "loon-server"
+    });
     assert!(
         candidate.exists(),
-        "expected loond binary at {}",
+        "expected loon-server binary at {}",
         candidate.display()
     );
     candidate

--- a/crates/loon-server/Cargo.toml
+++ b/crates/loon-server/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [[bin]]
-name = "loond"
+name = "loon-server"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/loon-server/src/config.rs
+++ b/crates/loon-server/src/config.rs
@@ -268,13 +268,13 @@ mod tests {
             r#"
 bind = "bad-bind"
 auth_token = "dev-token"
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
 kind = "local-fs"
-root = "/tmp/loond"
+root = "/tmp/loon-server"
 "#,
         );
 
@@ -289,13 +289,13 @@ root = "/tmp/loond"
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 0
 
 [store]
 kind = "local-fs"
-root = "/tmp/loond"
+root = "/tmp/loon-server"
 "#,
         );
 
@@ -311,12 +311,12 @@ root = "/tmp/loond"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
 writer_id = "   "
-writer_version = "loond/0.1.0"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
 kind = "local-fs"
-root = "/tmp/loond"
+root = "/tmp/loon-server"
 "#,
         );
 
@@ -331,13 +331,13 @@ root = "/tmp/loond"
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond"
+writer_id = "loon-server"
 writer_version = "   "
 lease_duration_ms = 60000
 
 [store]
 kind = "local-fs"
-root = "/tmp/loond"
+root = "/tmp/loon-server"
 "#,
         );
 
@@ -352,8 +352,8 @@ root = "/tmp/loond"
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
@@ -377,8 +377,8 @@ secret_access_key = "secret"
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
@@ -396,8 +396,8 @@ force_path_style = false
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
@@ -424,13 +424,13 @@ key_prefix = "demo"
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "   "
-writer_id = "loond"
-writer_version = "loond/0.1.0"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
 lease_duration_ms = 60000
 
 [store]
 kind = "local-fs"
-root = "/tmp/loond"
+root = "/tmp/loon-server"
 "#,
         );
 

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -22,7 +22,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-test",
+        "loon-server-test",
         "http-smoke",
         60_000,
     ))
@@ -56,7 +56,7 @@ async fn http_put_create_only_and_copy_preserve_cli_semantics() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-test",
+        "loon-server-test",
         "http-copy-smoke",
         60_000,
     ))
@@ -113,7 +113,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-current",
+        "loon-server-current",
         "http-current-smoke",
         60_000,
     ))
@@ -237,7 +237,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-restore",
+        "loon-server-restore",
         "http-restore",
         60_000,
     ))
@@ -367,7 +367,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-restore-missing-source",
+        "loon-server-restore-missing-source",
         "http-restore-missing-source",
         60_000,
     ))
@@ -441,7 +441,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-current-conflict",
+        "loon-server-current-conflict",
         "http-current-conflict",
         60_000,
     ))
@@ -511,7 +511,7 @@ async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-put",
+        "loon-server-put",
         "http-put",
         60_000,
     ))
@@ -563,7 +563,7 @@ async fn http_delete_move_and_copy_request_ids_are_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-ops",
+        "loon-server-ops",
         "http-ops",
         60_000,
     ))
@@ -640,7 +640,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-admin",
+        "loon-server-admin",
         "http-admin",
         60_000,
     ))
@@ -697,7 +697,7 @@ async fn http_admin_retention_advance_preserves_checkpoint_unavailable_error() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-admin-missing-checkpoint",
+        "loon-server-admin-missing-checkpoint",
         "http-admin-missing-checkpoint",
         60_000,
     ))
@@ -727,7 +727,7 @@ async fn http_checkpoint_consumption_is_strict_when_manifest_is_corrupted() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
-        "loond-admin-corrupt",
+        "loon-server-admin-corrupt",
         "http-admin-corrupt",
         60_000,
     ))
@@ -771,12 +771,18 @@ async fn two_servers_share_one_store_and_handoff_the_lease() {
     let store_root = temp_dir.path().join("store");
     let server_a = start_server(test_config(
         store_root.clone(),
-        "loond-a",
+        "loon-server-a",
         "two-server-smoke",
         200,
     ))
     .await;
-    let server_b = start_server(test_config(store_root, "loond-b", "two-server-smoke", 200)).await;
+    let server_b = start_server(test_config(
+        store_root,
+        "loon-server-b",
+        "two-server-smoke",
+        200,
+    ))
+    .await;
     let client_a = server_a.client.clone();
     let client_b = server_b.client.clone();
 


### PR DESCRIPTION
## Summary
- rename the canonical server surface from `loond` to `loon-server`
- update README, example config names, and server/config test fixtures
- update CLI integration tests to locate and spawn the renamed binary

## Testing
- cargo fmt --all
- cargo test -p loon-server
- cargo test -p loon-cli --test cli