### PR TITLE
fix(ci): use supported intel macOS runner

### DIFF
--- a/.github/workflows/release-loon.yml
+++ b/.github/workflows/release-loon.yml
@@ -48,7 +48,7 @@ jobs:
         include:
           - runner: macos-14
             target: aarch64-apple-darwin
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- replace the unsupported `macos-13` runner label in the release workflow
- use `macos-15-intel` for the `x86_64-apple-darwin` build target

## Why
GitHub Actions no longer supports `macos-13` for this repository configuration, and release runs fail with `The configuration `macos-13-us-default` is not supported`.

## Testing
- workflow label update only