### PR TITLE
chore: prune stale gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,6 @@
 /target/
 crates/loon-objectstore/tests/provider-conformance.env.local
-/.loondb-demo/
 configs/*.local.toml
 
 # macOS Finder metadata
 .DS_Store
-
-# Xcode sample artifacts
-native/macos/LoonFileProviderSample/Vendor/libloon_macos.a
-native/macos/LoonFileProviderSample/.build/
-native/macos/LoonFileProviderSample/.swiftpm/
-native/macos/LoonFileProviderSample/**/*.xcuserdata/
-native/macos/LoonFileProviderSample/**/xcuserdata/
-native/macos/LoonFileProviderSample/**/project.xcworkspace/xcuserdata/


### PR DESCRIPTION
## Summary
- remove stale ignore rules for the deleted Xcode sample artifacts
- remove the legacy .loondb-demo ignore entry now that that local demo workspace is gone
- keep active local ignore rules for build output and local-only config files

## Testing
- not run (metadata-only cleanup)