### PR TITLE
feat: add local recursive get and rm support to cli

### DIFF
--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -11,6 +11,7 @@ pub enum ControlObjectKind {
     NamespaceLease,
     NamespaceProgress,
     UploadSession,
+    ReadSession,
     QueueShard,
 }
 
@@ -88,6 +89,15 @@ pub struct UploadSessionState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadSessionState {
+    pub namespace_id: NamespaceId,
+    pub session_id: String,
+    pub pinned_seq: ChangeSeq,
+    pub root_inode_id: InodeId,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlObjectEnvelope<T> {
     pub kind: ControlObjectKind,
     pub format_version: u32,
@@ -123,6 +133,7 @@ pub type HeadStateEnvelope = ControlObjectEnvelope<HeadState>;
 pub type LeaseStateEnvelope = ControlObjectEnvelope<LeaseState>;
 pub type ProgressStateEnvelope = ControlObjectEnvelope<ProgressState>;
 pub type UploadSessionEnvelope = ControlObjectEnvelope<UploadSessionState>;
+pub type ReadSessionEnvelope = ControlObjectEnvelope<ReadSessionState>;
 
 pub fn payload_checksum_sha256<T>(value: &T) -> Result<String, serde_json::Error>
 where

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -45,6 +45,8 @@ pub enum FilesystemOperation {
     },
     DeletePath {
         path: String,
+        #[serde(default)]
+        recursive: bool,
     },
     MovePath {
         from_path: String,

--- a/crates/loon-api/src/server.rs
+++ b/crates/loon-api/src/server.rs
@@ -21,3 +21,11 @@ pub struct AuthoritativeFileBytes {
     pub entry: AuthoritativePathEntry,
     pub bytes: Vec<u8>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadSession {
+    pub namespace_id: NamespaceId,
+    pub session_id: String,
+    pub pinned_seq: ChangeSeq,
+    pub root: AuthoritativePathEntry,
+}

--- a/crates/loon-cli/README.md
+++ b/crates/loon-cli/README.md
@@ -169,6 +169,8 @@ Behavior notes
 
   If `loon get -r` omits the local destination, the CLI writes to `./<remote-dirname>`
 
+  `loon get -r /` requires an explicit local destination because `/` has no natural basename to use as a local folder name
+
   `--json` is rejected for streaming output commands
 
   If `loon put` omits the remote path, the CLI uses `/<local-filename>`

--- a/crates/loon-cli/README.md
+++ b/crates/loon-cli/README.md
@@ -79,13 +79,13 @@ Filesystem operations
   loon cat [--profile <name>] [--namespace <name>] <path>
     Print file contents to stdout
 
-  loon get [--profile <name>] [--namespace <name>] <remote-path> [local-destination]
-    Download a remote file
+  loon get [--profile <name>] [--namespace <name>] [-r, --recursive] <remote-path> [local-destination]
+    Download a remote file or directory tree
 
   loon put [--profile <name>] [--namespace <name>] <local-path> [remote-path] [--force]
     Upload a local file
 
-  loon rm [--profile <name>] [--namespace <name>] <path>
+  loon rm [--profile <name>] [--namespace <name>] [-r, --recursive] <path>
     Remove a path
 
   loon mv [--profile <name>] [--namespace <name>] <source-path> <dest-path>
@@ -165,11 +165,19 @@ Behavior notes
 
   `loon get ... -` streams raw bytes to stdout
 
+  `loon get -r` downloads a pinned directory tree and cannot stream to stdout
+
+  If `loon get -r` omits the local destination, the CLI writes to `./<remote-dirname>`
+
   `--json` is rejected for streaming output commands
 
   If `loon put` omits the remote path, the CLI uses `/<local-filename>`
 
   If `loon get` omits the local destination, the CLI writes to `./<remote-filename>`
 
-  File-oriented commands do not support directory transfers
+  `loon mv` supports both file and directory moves
+
+  `loon rm -r` removes non-empty directories
+
+  `loon put` and `loon cp` are file-only
 ```

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -30,7 +30,7 @@ pub enum Command {
     Cat(FilesystemPathArgs),
     Get(FilesystemGetArgs),
     Put(FilesystemPutArgs),
-    Rm(FilesystemPathArgs),
+    Rm(FilesystemRmArgs),
     Mv(FilesystemMoveArgs),
     Cp(FilesystemMoveArgs),
     Config {
@@ -207,6 +207,8 @@ pub struct FilesystemPathArgs {
 pub struct FilesystemGetArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    #[arg(short = 'r', long)]
+    pub recursive: bool,
     pub remote_path: String,
     pub local_destination: Option<String>,
 }
@@ -219,6 +221,15 @@ pub struct FilesystemPutArgs {
     pub remote_path: Option<String>,
     #[arg(long)]
     pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemRmArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    #[arg(short = 'r', long)]
+    pub recursive: bool,
+    pub path: String,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -1,11 +1,15 @@
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
-use loon_api::{AuthoritativePathEntry, MutationResult, NamespaceId, NamespaceSummary};
+use loon_api::{
+    AuthoritativeFileBytes, AuthoritativePathEntry, InodeId, MutationResult, NamespaceId,
+    NamespaceSummary, ReadSession,
+};
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_core::{
-    bootstrap_namespace, copy_file_path, delete_path_non_recursive, list_namespaces, list_path,
-    move_path, put_file_bytes, read_file_bytes, resolve_path, BootstrapNamespaceError, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior,
+    begin_read_session, bootstrap_namespace, close_read_session, copy_file_path, delete_path,
+    delete_path_non_recursive, list_namespaces, list_path, list_read_session_children, move_path,
+    put_file_bytes, read_file_bytes, read_read_session_file, resolve_path, BootstrapNamespaceError,
+    CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
 };
 use loon_objectstore::ConfiguredObjectStore;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -24,7 +28,11 @@ pub trait Backend {
         bytes: &[u8],
         force: bool,
     ) -> Result<MutationResult, CliError>;
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError>;
+    fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        recursive: bool,
+    ) -> Result<MutationResult, CliError>;
     fn move_path(
         &self,
         from: &NamespacePath,
@@ -35,6 +43,21 @@ pub trait Backend {
         from: &NamespacePath,
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError>;
+    fn begin_read_session(&self, spec: &NamespacePath) -> Result<ReadSession, CliError>;
+    fn list_read_session_children(
+        &self,
+        namespace: &NamespaceId,
+        session_id: &str,
+        parent_inode_id: InodeId,
+    ) -> Result<Vec<AuthoritativePathEntry>, CliError>;
+    fn read_read_session_file(
+        &self,
+        namespace: &NamespaceId,
+        session_id: &str,
+        inode_id: InodeId,
+    ) -> Result<AuthoritativeFileBytes, CliError>;
+    fn close_read_session(&self, namespace: &NamespaceId, session_id: &str)
+        -> Result<(), CliError>;
 }
 
 // --- Remote backend (HTTP via loon-client) ---
@@ -75,8 +98,17 @@ impl Backend for RemoteBackend {
             .map_err(map_client_error)
     }
 
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
-        self.client.delete_path(spec).map_err(map_client_error)
+    fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        recursive: bool,
+    ) -> Result<MutationResult, CliError> {
+        let result = if recursive {
+            self.client.delete_path_recursive(spec)
+        } else {
+            self.client.delete_path(spec)
+        };
+        result.map_err(map_client_error)
     }
 
     fn move_path(
@@ -93,6 +125,36 @@ impl Backend for RemoteBackend {
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
         self.client.copy_path(from, to).map_err(map_client_error)
+    }
+
+    fn begin_read_session(&self, _spec: &NamespacePath) -> Result<ReadSession, CliError> {
+        Err(unsupported_recursive_get())
+    }
+
+    fn list_read_session_children(
+        &self,
+        _namespace: &NamespaceId,
+        _session_id: &str,
+        _parent_inode_id: InodeId,
+    ) -> Result<Vec<AuthoritativePathEntry>, CliError> {
+        Err(unsupported_recursive_get())
+    }
+
+    fn read_read_session_file(
+        &self,
+        _namespace: &NamespaceId,
+        _session_id: &str,
+        _inode_id: InodeId,
+    ) -> Result<AuthoritativeFileBytes, CliError> {
+        Err(unsupported_recursive_get())
+    }
+
+    fn close_read_session(
+        &self,
+        _namespace: &NamespaceId,
+        _session_id: &str,
+    ) -> Result<(), CliError> {
+        Err(unsupported_recursive_get())
     }
 }
 
@@ -192,9 +254,18 @@ impl Backend for DirectBackend {
         .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
+    fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        recursive: bool,
+    ) -> Result<MutationResult, CliError> {
         let ns_id = NamespaceId::from(spec.namespace.clone());
-        delete_path_non_recursive(
+        let delete = if recursive {
+            delete_path
+        } else {
+            delete_path_non_recursive
+        };
+        delete(
             &self.store,
             &ns_id,
             &spec.absolute_path,
@@ -237,6 +308,44 @@ impl Backend for DirectBackend {
         )
         .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
+
+    fn begin_read_session(&self, spec: &NamespacePath) -> Result<ReadSession, CliError> {
+        let ns_id = NamespaceId::from(spec.namespace.clone());
+        begin_read_session(
+            &self.store,
+            &ns_id,
+            &spec.absolute_path,
+            &self.mutation_context(),
+        )
+        .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
+    }
+
+    fn list_read_session_children(
+        &self,
+        namespace: &NamespaceId,
+        session_id: &str,
+        parent_inode_id: InodeId,
+    ) -> Result<Vec<AuthoritativePathEntry>, CliError> {
+        list_read_session_children(&self.store, namespace, session_id, parent_inode_id)
+            .map_err(map_core_error)
+    }
+
+    fn read_read_session_file(
+        &self,
+        namespace: &NamespaceId,
+        session_id: &str,
+        inode_id: InodeId,
+    ) -> Result<AuthoritativeFileBytes, CliError> {
+        read_read_session_file(&self.store, namespace, session_id, inode_id).map_err(map_core_error)
+    }
+
+    fn close_read_session(
+        &self,
+        namespace: &NamespaceId,
+        session_id: &str,
+    ) -> Result<(), CliError> {
+        close_read_session(&self.store, namespace, session_id).map_err(map_core_error)
+    }
 }
 
 fn map_core_error(error: CoreError) -> CliError {
@@ -257,6 +366,8 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::UploadAlreadyCompleted => "upload_already_completed",
         CoreErrorKind::UploadBlockConflict => "upload_block_conflict",
         CoreErrorKind::InvalidUploadBlock => "invalid_upload_block",
+        CoreErrorKind::ReadSessionNotFound => "read_session_not_found",
+        CoreErrorKind::InvalidReadSessionTarget => "invalid_read_session_target",
         CoreErrorKind::RebootstrapRequired => "rebootstrap_required",
         CoreErrorKind::NamespaceCorrupt => "namespace_corrupt",
         CoreErrorKind::ServerError => "server_error",
@@ -295,6 +406,13 @@ fn default_writer_id() -> String {
         .ok()
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "loon-cli".to_owned())
+}
+
+fn unsupported_recursive_get() -> CliError {
+    CliError::new(
+        "unsupported_operation",
+        "recursive `get` is not supported for remote profiles yet",
+    )
 }
 
 // --- Target resolution ---

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -649,14 +649,15 @@ fn run_filesystem_get(
         ));
     }
 
-    let spec = namespace_path(&context.namespace, &args.remote_path, args.recursive).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec =
+        namespace_path(&context.namespace, &args.remote_path, args.recursive).map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
     let entry = context.target.backend().stat_path(&spec).map_err(|error| {
         fail(
             kind,

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -649,7 +649,7 @@ fn run_filesystem_get(
         ));
     }
 
-    let spec = namespace_path(&context.namespace, &args.remote_path, false).map_err(|error| {
+    let spec = namespace_path(&context.namespace, &args.remote_path, args.recursive).map_err(|error| {
         fail(
             kind,
             Some(context.profile_name.clone()),
@@ -1625,6 +1625,17 @@ fn destination_root_for_recursive_get(
     remote_path: &str,
     explicit_destination: Option<&str>,
 ) -> Result<PathBuf, CliError> {
+    if remote_path == "/" {
+        let Some(path) = explicit_destination else {
+            return Err(CliError::invalid_input(
+                "recursive `get` of `/` requires an explicit local destination",
+            ));
+        };
+        let destination = PathBuf::from(path);
+        validate_recursive_get_root_destination(&destination)?;
+        return Ok(destination);
+    }
+
     let root_name = Path::new(remote_path).file_name().ok_or_else(|| {
         CliError::invalid_input(format!(
             "unable to derive local destination from `{remote_path}`"

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -1,8 +1,8 @@
 use crate::args::{
     Cli, Command, CommandKind, ConfigCommand, CurrentArgs, FilesystemGetArgs, FilesystemLsArgs,
-    FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs, InitArgs, NamespaceCommand,
-    NamespaceCreateArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand, ProfileCreateArgs,
-    ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
+    FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs, FilesystemRmArgs, InitArgs,
+    NamespaceCommand, NamespaceCreateArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand,
+    ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
 };
 use crate::config::{
     default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
@@ -17,7 +17,7 @@ use crate::prompt;
 use crate::resolve::{
     load_cli_config, resolve_namespace, resolve_target_profile, resolve_target_profile_from_config,
 };
-use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceSummary};
+use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceSummary, ReadSession};
 use loon_client::NamespacePath;
 use serde::Serialize;
 use std::fs;
@@ -665,13 +665,85 @@ fn run_filesystem_get(
             error,
         )
     })?;
+    if args.recursive && args.local_destination.as_deref() == Some("-") {
+        return Err(fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            CliError::invalid_input("recursive `get` cannot stream to stdout"),
+        ));
+    }
+    if args.recursive && entry.inode_kind == InodeKind::Dir {
+        let destination = destination_root_for_recursive_get(
+            &spec.absolute_path,
+            args.local_destination.as_deref(),
+        )
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+        let session = context
+            .target
+            .backend()
+            .begin_read_session(&spec)
+            .map_err(|error| {
+                fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    error,
+                )
+            })?;
+        let download = download_read_session_tree(context.target.backend(), &session, &destination);
+        let close = context
+            .target
+            .backend()
+            .close_read_session(&session.namespace_id, &session.session_id);
+        let bytes_written = match download {
+            Ok(bytes_written) => {
+                close.map_err(|error| {
+                    fail(
+                        kind,
+                        Some(context.profile_name.clone()),
+                        Some(context.mode.clone()),
+                        error,
+                    )
+                })?;
+                bytes_written
+            }
+            Err(error) => {
+                let _ = close;
+                return Err(fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    error,
+                ));
+            }
+        };
+
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::FileTransfer {
+                target: render_target(&context.namespace, &spec.absolute_path),
+                destination: destination.display().to_string(),
+                bytes_written,
+            },
+        });
+    }
     if entry.inode_kind == InodeKind::Dir {
         return Err(fail(
             kind,
             Some(context.profile_name.clone()),
             Some(context.mode.clone()),
             CliError::invalid_input(format!(
-                "directory operations are not available for `{}`",
+                "use `get -r` to download directories: `{}`",
                 spec.absolute_path
             )),
         ));
@@ -814,7 +886,7 @@ fn run_filesystem_put(
 
 fn run_filesystem_rm(
     kind: CommandKind,
-    args: FilesystemPathArgs,
+    args: FilesystemRmArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target)?;
     let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
@@ -828,7 +900,7 @@ fn run_filesystem_rm(
     let result = context
         .target
         .backend()
-        .delete_path(&spec)
+        .delete_path(&spec, args.recursive)
         .map_err(|error| {
             fail(
                 kind,
@@ -1547,6 +1619,114 @@ fn destination_path_for_get(
             Ok(PathBuf::from(file_name))
         }
     }
+}
+
+fn destination_root_for_recursive_get(
+    remote_path: &str,
+    explicit_destination: Option<&str>,
+) -> Result<PathBuf, CliError> {
+    let root_name = Path::new(remote_path).file_name().ok_or_else(|| {
+        CliError::invalid_input(format!(
+            "unable to derive local destination from `{remote_path}`"
+        ))
+    })?;
+    match explicit_destination {
+        None => {
+            let destination = PathBuf::from(root_name);
+            validate_recursive_get_root_destination(&destination)?;
+            Ok(destination)
+        }
+        Some(path) => {
+            let destination = PathBuf::from(path);
+            if !destination.exists() {
+                return Ok(destination);
+            }
+            let metadata = fs::metadata(&destination).map_err(CliError::io)?;
+            if !metadata.is_dir() {
+                return Err(CliError::invalid_input(format!(
+                    "destination exists and is not a directory: `{}`",
+                    destination.display()
+                )));
+            }
+            let destination = destination.join(root_name);
+            validate_recursive_get_root_destination(&destination)?;
+            Ok(destination)
+        }
+    }
+}
+
+fn validate_recursive_get_root_destination(path: &Path) -> Result<(), CliError> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let metadata = fs::metadata(path).map_err(CliError::io)?;
+    if metadata.is_dir() {
+        return Ok(());
+    }
+    Err(CliError::invalid_input(format!(
+        "destination exists and is not a directory: `{}`",
+        path.display()
+    )))
+}
+
+fn download_read_session_tree(
+    backend: &dyn crate::backend::Backend,
+    session: &ReadSession,
+    destination_root: &Path,
+) -> Result<u64, CliError> {
+    fs::create_dir_all(destination_root).map_err(CliError::io)?;
+    download_read_session_directory(backend, session, session.root.inode_id, destination_root)
+}
+
+fn download_read_session_directory(
+    backend: &dyn crate::backend::Backend,
+    session: &ReadSession,
+    parent_inode_id: loon_api::InodeId,
+    destination: &Path,
+) -> Result<u64, CliError> {
+    fs::create_dir_all(destination).map_err(CliError::io)?;
+    let entries = backend.list_read_session_children(
+        &session.namespace_id,
+        &session.session_id,
+        parent_inode_id,
+    )?;
+    let mut bytes_written = 0u64;
+    for entry in entries {
+        let child_destination = destination.join(&entry.display_name);
+        match entry.inode_kind {
+            InodeKind::Dir => {
+                bytes_written += download_read_session_directory(
+                    backend,
+                    session,
+                    entry.inode_id,
+                    &child_destination,
+                )?;
+            }
+            InodeKind::File => {
+                let read = backend.read_read_session_file(
+                    &session.namespace_id,
+                    &session.session_id,
+                    entry.inode_id,
+                )?;
+                write_local_file(&child_destination, &read.bytes)?;
+                bytes_written = bytes_written.saturating_add(read.bytes.len() as u64);
+            }
+            kind => {
+                return Err(CliError::invalid_input(format!(
+                    "recursive `get` does not support `{kind:?}` at `{}`",
+                    entry.absolute_path
+                )));
+            }
+        }
+    }
+    Ok(bytes_written)
+}
+
+fn write_local_file(path: &Path, bytes: &[u8]) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(CliError::io)?;
+    }
+    fs::write(path, bytes).map_err(CliError::io)
 }
 
 fn render_target(namespace: &str, path: &str) -> String {

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -257,6 +257,52 @@ fn local_profile_get_recursive_downloads_directory_tree() {
 }
 
 #[test]
+fn local_profile_get_recursive_downloads_namespace_root() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_one = harness.temp_dir.path().join("upload-one.txt");
+    let upload_two = harness.temp_dir.path().join("upload-two.txt");
+    fs::write(&upload_one, b"hello\n").expect("upload one");
+    fs::write(&upload_two, b"nested\n").expect("upload two");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_one.to_str().unwrap(), "/docs/hello.txt"]));
+    assert_success(&harness.run(&["put", upload_two.to_str().unwrap(), "/docs/sub/nested.txt"]));
+
+    let destination_root = harness.temp_dir.path().join("namespace-download");
+
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "-r",
+        "/",
+        destination_root.to_str().unwrap(),
+    ]);
+    assert_success(&get);
+
+    assert_eq!(
+        fs::read(destination_root.join("docs").join("hello.txt")).expect("downloaded hello"),
+        b"hello\n"
+    );
+    assert_eq!(
+        fs::read(
+            destination_root
+                .join("docs")
+                .join("sub")
+                .join("nested.txt")
+        )
+        .expect("downloaded nested"),
+        b"nested\n"
+    );
+    assert_eq!(
+        json_data(&get)["destination"],
+        destination_root.display().to_string()
+    );
+}
+
+#[test]
 fn recursive_get_cannot_stream_to_stdout() {
     let harness = Harness::new();
     harness.add_local_profile("default");

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -163,6 +163,155 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 }
 
 #[test]
+fn local_profile_rm_recursive_removes_non_empty_directory() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_path = harness.temp_dir.path().join("upload.txt");
+    fs::write(&upload_path, b"hello from direct core\n").expect("upload payload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/hello.txt"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/sub/nested.txt"]));
+
+    let non_recursive = harness.run(&["--json", "rm", "/docs"]);
+    assert_failure(&non_recursive);
+    assert_eq!(json_error(&non_recursive)["code"], "path_conflict");
+
+    let recursive = harness.run(&["--json", "rm", "-r", "/docs"]);
+    assert_success(&recursive);
+    assert_eq!(json_data(&recursive)["target"], "demo:/docs");
+
+    let stat = harness.run(&["--json", "stat", "/docs"]);
+    assert_failure(&stat);
+    assert_eq!(json_error(&stat)["code"], "path_not_found");
+}
+
+#[test]
+fn local_profile_mv_moves_directory_subtrees() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_path = harness.temp_dir.path().join("upload.txt");
+    fs::write(&upload_path, b"hello from direct core\n").expect("upload payload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/sub/hello.txt"]));
+
+    let mv = harness.run(&["--json", "mv", "/docs", "/archive"]);
+    assert_success(&mv);
+    assert_eq!(json_data(&mv)["from"], "demo:/docs");
+    assert_eq!(json_data(&mv)["to"], "demo:/archive");
+
+    let moved = harness.run(&["cat", "/archive/sub/hello.txt"]);
+    assert_success(&moved);
+    assert_eq!(moved.stdout, b"hello from direct core\n");
+
+    let source = harness.run(&["--json", "stat", "/docs"]);
+    assert_failure(&source);
+    assert_eq!(json_error(&source)["code"], "path_not_found");
+}
+
+#[test]
+fn local_profile_get_recursive_downloads_directory_tree() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_one = harness.temp_dir.path().join("upload-one.txt");
+    let upload_two = harness.temp_dir.path().join("upload-two.txt");
+    fs::write(&upload_one, b"hello\n").expect("upload one");
+    fs::write(&upload_two, b"nested\n").expect("upload two");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_one.to_str().unwrap(), "/docs/hello.txt"]));
+    assert_success(&harness.run(&["put", upload_two.to_str().unwrap(), "/docs/sub/nested.txt"]));
+
+    let destination_parent = harness.temp_dir.path().join("downloads");
+    fs::create_dir_all(&destination_parent).expect("create downloads dir");
+
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "-r",
+        "/docs",
+        destination_parent.to_str().unwrap(),
+    ]);
+    assert_success(&get);
+
+    let downloaded_root = destination_parent.join("docs");
+    assert_eq!(
+        fs::read(downloaded_root.join("hello.txt")).expect("downloaded hello"),
+        b"hello\n"
+    );
+    assert_eq!(
+        fs::read(downloaded_root.join("sub").join("nested.txt")).expect("downloaded nested"),
+        b"nested\n"
+    );
+    assert_eq!(
+        json_data(&get)["destination"],
+        downloaded_root.display().to_string()
+    );
+}
+
+#[test]
+fn recursive_get_cannot_stream_to_stdout() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_path = harness.temp_dir.path().join("upload.txt");
+    fs::write(&upload_path, b"hello from direct core\n").expect("upload payload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/hello.txt"]));
+
+    let output = harness.run(&["get", "-r", "/docs", "-"]);
+    assert_failure(&output);
+    assert!(stderr_string(&output).contains("recursive `get` cannot stream to stdout"));
+}
+
+#[test]
+fn remote_profile_recursive_get_is_unsupported() {
+    let harness = Harness::new();
+    let remote_server = harness
+        .start_external_server(harness.write_server_config("remote", "remote-recursive-get"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    let upload_path = harness.temp_dir.path().join("upload.txt");
+    fs::write(&upload_path, b"hello over http\n").expect("upload payload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/hello.txt"]));
+
+    let destination = harness.temp_dir.path().join("download");
+    let output = harness.run(&[
+        "--json",
+        "get",
+        "-r",
+        "/docs",
+        destination.to_str().unwrap(),
+    ]);
+    assert_failure(&output);
+    assert_eq!(json_error(&output)["code"], "unsupported_operation");
+}
+
+#[test]
 fn init_creates_local_profile_and_current_reports_namespace_unset() {
     let harness = Harness::new();
 

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -287,13 +287,8 @@ fn local_profile_get_recursive_downloads_namespace_root() {
         b"hello\n"
     );
     assert_eq!(
-        fs::read(
-            destination_root
-                .join("docs")
-                .join("sub")
-                .join("nested.txt")
-        )
-        .expect("downloaded nested"),
+        fs::read(destination_root.join("docs").join("sub").join("nested.txt"))
+            .expect("downloaded nested"),
         b"nested\n"
     );
     assert_eq!(

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -323,10 +323,34 @@ impl Client {
         self.delete_path_with_request_id(spec, &Uuid::new_v4().to_string())
     }
 
+    pub fn delete_path_recursive(
+        &self,
+        spec: &NamespacePath,
+    ) -> Result<MutationResult, ClientError> {
+        self.delete_path_recursive_with_request_id(spec, &Uuid::new_v4().to_string())
+    }
+
     pub fn delete_path_with_request_id(
         &self,
         spec: &NamespacePath,
         request_id: &str,
+    ) -> Result<MutationResult, ClientError> {
+        self.delete_path_with_request_id_and_mode(spec, request_id, false)
+    }
+
+    pub fn delete_path_recursive_with_request_id(
+        &self,
+        spec: &NamespacePath,
+        request_id: &str,
+    ) -> Result<MutationResult, ClientError> {
+        self.delete_path_with_request_id_and_mode(spec, request_id, true)
+    }
+
+    fn delete_path_with_request_id_and_mode(
+        &self,
+        spec: &NamespacePath,
+        request_id: &str,
+        recursive: bool,
     ) -> Result<MutationResult, ClientError> {
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -334,6 +358,7 @@ impl Client {
                 request_id: request_id.to_owned(),
                 operation: FilesystemOperation::DeletePath {
                     path: spec.absolute_path.clone(),
+                    recursive,
                 },
             },
         )?;

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -20,7 +20,8 @@ pub use checkpoint::{
 };
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
 pub use protocol::{
-    begin_upload, commit_operations, complete_upload, list_changes_after, upload_block,
+    begin_read_session, begin_upload, close_read_session, commit_operations, complete_upload,
+    list_changes_after, list_read_session_children, read_read_session_file, upload_block,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, list_namespaces,

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -582,6 +582,33 @@ impl MetadataState {
 
         false
     }
+
+    pub fn is_visible_descendant_or_self(
+        &self,
+        inode_id: InodeId,
+        ancestor_inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> bool {
+        let mut current = Some(inode_id);
+        let mut visited = BTreeSet::new();
+
+        while let Some(candidate_inode_id) = current {
+            if !visited.insert(candidate_inode_id.0) {
+                break;
+            }
+            if self.visible_inode(candidate_inode_id, base_seq).is_none() {
+                return false;
+            }
+            if candidate_inode_id == ancestor_inode_id {
+                return true;
+            }
+            current = self
+                .latest_parent_binding_for_child_at_seq(candidate_inode_id, base_seq)
+                .map(|direntry| direntry.parent_inode_id);
+        }
+
+        false
+    }
 }
 
 fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -4,8 +4,12 @@ use crate::commit::{
     resolve_restore_content_manifest_digests, CommitOp, CommitRequest as CoreCommitRequest,
     CommitValidationContext, Precondition,
 };
-use crate::content::validate_durable_content_reference;
-use crate::services::{derive_commit_results, write_immutable_object, CoreError, MutationContext};
+use crate::content::{read_durable_content_bytes, validate_durable_content_reference};
+use crate::metadata::ResolvedVisiblePath;
+use crate::services::{
+    build_authoritative_path_entry, derive_commit_results, write_immutable_object, CoreError,
+    MutationContext,
+};
 use crate::wal::prepare_wal_commit;
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp,
@@ -15,13 +19,15 @@ use loon_api::v0::{
 };
 use loon_api::{
     content_manifest_digest_sha256, decode_wal_commit_envelope_zstd, encode_content_manifest_json,
-    sha256_digest, ChangeSeq, CompletedUpload, ContentBlockDescriptor, ContentManifestEnvelope,
-    ContentManifestPayload, ControlObjectKind, NamespaceId, UploadSessionEnvelope,
-    UploadSessionState, UploadedBlock, CONTENT_BLOCK_SIZE_BYTES,
+    sha256_digest, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CompletedUpload,
+    ContentBlockDescriptor, ContentManifestEnvelope, ContentManifestPayload, ControlObjectKind,
+    InodeId, InodeKind, NamespaceId, ReadSession, ReadSessionEnvelope, ReadSessionState,
+    UploadSessionEnvelope, UploadSessionState, UploadedBlock, CONTENT_BLOCK_SIZE_BYTES,
 };
-use loon_objectstore::keys::{blob, content_manifest, upload_session, wal_commit};
+use loon_objectstore::keys::{blob, content_manifest, read_session, upload_session, wal_commit};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
 const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
@@ -31,6 +37,160 @@ struct LoadedUploadSessionObject {
     object_key: String,
     metadata: ObjectMetadata,
     envelope: UploadSessionEnvelope,
+}
+
+#[derive(Debug, Clone)]
+struct LoadedReadSessionObject {
+    envelope: ReadSessionEnvelope,
+}
+
+pub fn begin_read_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    context: &MutationContext,
+) -> Result<ReadSession, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let resolved = basis
+        .metadata_state
+        .resolve_visible_path(absolute_path, basis.head.seq)?;
+    let root = build_authoritative_path_entry(
+        store,
+        namespace_id,
+        basis.head.seq,
+        &basis.metadata_state,
+        &resolved,
+    )?;
+    let session_id = format!("rs_{}", Uuid::new_v4().simple());
+    let state = ReadSessionState {
+        namespace_id: namespace_id.clone(),
+        session_id: session_id.clone(),
+        pinned_seq: basis.head.seq,
+        root_inode_id: resolved.inode_id,
+        created_at_ms: context.now_ms,
+    };
+    let envelope = ReadSessionEnvelope::from_state(
+        ControlObjectKind::ReadSession,
+        &context.writer_version,
+        state,
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
+    let encoded = serde_json::to_vec(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+    let object_key = read_session(namespace_id.as_str(), &session_id);
+    store
+        .put_if_absent(&object_key, &encoded)
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+
+    Ok(ReadSession {
+        namespace_id: namespace_id.clone(),
+        session_id,
+        pinned_seq: basis.head.seq,
+        root,
+    })
+}
+
+pub fn list_read_session_children<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    session_id: &str,
+    parent_inode_id: InodeId,
+) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
+    let loaded = read_read_session_object(store, namespace_id, session_id)?;
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    ensure_read_session_target(
+        session_id,
+        &basis,
+        parent_inode_id,
+        loaded.envelope.state.root_inode_id,
+        loaded.envelope.state.pinned_seq,
+    )?;
+    let resolved =
+        resolve_visible_path_for_inode(&basis, parent_inode_id, loaded.envelope.state.pinned_seq)?;
+    if resolved.inode_kind != InodeKind::Dir {
+        return Err(CoreError::ExpectedDirectory {
+            path: resolved.absolute_path,
+            kind: resolved.inode_kind,
+        });
+    }
+
+    basis
+        .metadata_state
+        .visible_children(parent_inode_id, loaded.envelope.state.pinned_seq)
+        .into_iter()
+        .map(|direntry| {
+            let child = basis
+                .metadata_state
+                .visible_inode(direntry.child_inode_id, loaded.envelope.state.pinned_seq)
+                .expect("visible child listing should resolve inode");
+            build_authoritative_path_entry(
+                store,
+                namespace_id,
+                loaded.envelope.state.pinned_seq,
+                &basis.metadata_state,
+                &ResolvedVisiblePath {
+                    absolute_path: join_absolute_path(
+                        &resolved.absolute_path,
+                        &direntry.display_name,
+                    ),
+                    inode_id: direntry.child_inode_id,
+                    inode_kind: child.inode_kind,
+                    parent_inode_id: Some(direntry.parent_inode_id),
+                    display_name: direntry.display_name,
+                },
+            )
+        })
+        .collect()
+}
+
+pub fn read_read_session_file<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    session_id: &str,
+    inode_id: InodeId,
+) -> Result<AuthoritativeFileBytes, CoreError> {
+    let loaded = read_read_session_object(store, namespace_id, session_id)?;
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    ensure_read_session_target(
+        session_id,
+        &basis,
+        inode_id,
+        loaded.envelope.state.root_inode_id,
+        loaded.envelope.state.pinned_seq,
+    )?;
+    let entry = build_authoritative_path_entry(
+        store,
+        namespace_id,
+        loaded.envelope.state.pinned_seq,
+        &basis.metadata_state,
+        &resolve_visible_path_for_inode(&basis, inode_id, loaded.envelope.state.pinned_seq)?,
+    )?;
+    if entry.inode_kind != InodeKind::File {
+        return Err(CoreError::ExpectedFile {
+            path: entry.absolute_path,
+            kind: entry.inode_kind,
+        });
+    }
+    let manifest_digest = entry
+        .content_manifest_digest
+        .clone()
+        .ok_or_else(|| CoreError::MissingPath(entry.absolute_path.clone()))?;
+    let read = read_durable_content_bytes(store, namespace_id, &manifest_digest)?;
+    Ok(AuthoritativeFileBytes {
+        entry,
+        bytes: read.bytes,
+    })
+}
+
+pub fn close_read_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    session_id: &str,
+) -> Result<(), CoreError> {
+    let object_key = read_session(namespace_id.as_str(), session_id);
+    match store.delete(&object_key) {
+        Ok(()) | Err(ObjectStoreError::NotFound) => Ok(()),
+        Err(err) => Err(CoreError::Store(err.to_string())),
+    }
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -825,6 +985,139 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+fn read_read_session_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    session_id: &str,
+) -> Result<LoadedReadSessionObject, CoreError> {
+    let object_key = read_session(namespace_id.as_str(), session_id);
+    let encoded = store
+        .get(&object_key, None)
+        .map_err(|err| CoreError::Store(err.to_string()))?
+        .ok_or_else(|| CoreError::ReadSessionNotFound {
+            session_id: session_id.to_owned(),
+        })?;
+    let envelope: ReadSessionEnvelope =
+        serde_json::from_slice(&encoded).map_err(|err| CoreError::Store(err.to_string()))?;
+    if envelope.kind != ControlObjectKind::ReadSession {
+        return Err(CoreError::Store(format!(
+            "unexpected read session kind for `{object_key}`"
+        )));
+    }
+    if !envelope
+        .has_valid_payload_checksum()
+        .map_err(|err| CoreError::Store(err.to_string()))?
+    {
+        return Err(CoreError::Store(format!(
+            "read session checksum mismatch for `{object_key}`"
+        )));
+    }
+    if envelope.state.namespace_id != *namespace_id {
+        return Err(CoreError::Store(format!(
+            "read session namespace mismatch for `{object_key}`"
+        )));
+    }
+    if envelope.state.session_id != session_id {
+        return Err(CoreError::Store(format!(
+            "read session id mismatch for `{object_key}`"
+        )));
+    }
+
+    Ok(LoadedReadSessionObject { envelope })
+}
+
+fn ensure_read_session_target(
+    session_id: &str,
+    basis: &crate::VerifiedNamespaceBasis,
+    inode_id: InodeId,
+    root_inode_id: InodeId,
+    pinned_seq: ChangeSeq,
+) -> Result<(), CoreError> {
+    if basis
+        .metadata_state
+        .is_visible_descendant_or_self(inode_id, root_inode_id, pinned_seq)
+    {
+        return Ok(());
+    }
+
+    Err(CoreError::InvalidReadSessionTarget {
+        session_id: session_id.to_owned(),
+        inode_id,
+        root_inode_id,
+    })
+}
+
+fn resolve_visible_path_for_inode(
+    basis: &crate::VerifiedNamespaceBasis,
+    inode_id: InodeId,
+    pinned_seq: ChangeSeq,
+) -> Result<ResolvedVisiblePath, CoreError> {
+    let inode = basis
+        .metadata_state
+        .visible_inode(inode_id, pinned_seq)
+        .ok_or_else(|| CoreError::MissingPath(format!("inode `{}`", inode_id.0)))?;
+    if inode_id == InodeId(1) {
+        return Ok(ResolvedVisiblePath {
+            absolute_path: "/".to_owned(),
+            inode_id,
+            inode_kind: inode.inode_kind,
+            parent_inode_id: None,
+            display_name: String::new(),
+        });
+    }
+
+    let mut components = Vec::new();
+    let mut current_inode_id = inode_id;
+    let mut parent_inode_id = None;
+    let mut display_name = String::new();
+    let mut visited = BTreeSet::new();
+
+    while current_inode_id != InodeId(1) {
+        if !visited.insert(current_inode_id.0) {
+            return Err(CoreError::Store(format!(
+                "cycle while resolving pinned path for inode `{}`",
+                inode_id.0
+            )));
+        }
+        let binding = basis
+            .metadata_state
+            .current_parent_binding_for_child(current_inode_id, pinned_seq)
+            .ok_or_else(|| {
+                CoreError::Store(format!(
+                    "missing parent binding while resolving pinned path for inode `{}`",
+                    inode_id.0
+                ))
+            })?;
+        if current_inode_id == inode_id {
+            parent_inode_id = Some(binding.parent_inode_id);
+            display_name = binding.display_name.clone();
+        }
+        components.push(binding.display_name);
+        current_inode_id = binding.parent_inode_id;
+    }
+
+    components.reverse();
+    Ok(ResolvedVisiblePath {
+        absolute_path: if components.is_empty() {
+            "/".to_owned()
+        } else {
+            format!("/{}", components.join("/"))
+        },
+        inode_id,
+        inode_kind: inode.inode_kind,
+        parent_inode_id,
+        display_name,
+    })
+}
+
+fn join_absolute_path(base: &str, component: &str) -> String {
+    if base == "/" {
+        format!("/{component}")
+    } else {
+        format!("{base}/{component}")
+    }
 }
 
 fn load_existing_commit_payload<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -65,6 +65,8 @@ pub enum CoreErrorKind {
     UploadAlreadyCompleted,
     UploadBlockConflict,
     InvalidUploadBlock,
+    ReadSessionNotFound,
+    InvalidReadSessionTarget,
     RebootstrapRequired,
     NamespaceCorrupt,
     ServerError,
@@ -134,6 +136,16 @@ pub enum CoreError {
     UploadBlockConflict { upload_id: String, block_index: u32 },
     #[error("invalid upload block: {0}")]
     InvalidUploadBlock(String),
+    #[error("read session `{session_id}` was not found")]
+    ReadSessionNotFound { session_id: String },
+    #[error(
+        "inode `{inode_id}` is outside read session `{session_id}` rooted at inode `{root_inode_id}`"
+    )]
+    InvalidReadSessionTarget {
+        session_id: String,
+        inode_id: InodeId,
+        root_inode_id: InodeId,
+    },
     #[error(
         "change feed cursor `{after_seq:?}` is older than retention floor `{retention_floor_seq:?}`"
     )]
@@ -202,6 +214,8 @@ impl CoreError {
             CoreError::UploadAlreadyCompleted { .. } => CoreErrorKind::UploadAlreadyCompleted,
             CoreError::UploadBlockConflict { .. } => CoreErrorKind::UploadBlockConflict,
             CoreError::InvalidUploadBlock(_) => CoreErrorKind::InvalidUploadBlock,
+            CoreError::ReadSessionNotFound { .. } => CoreErrorKind::ReadSessionNotFound,
+            CoreError::InvalidReadSessionTarget { .. } => CoreErrorKind::InvalidReadSessionTarget,
             CoreError::RebootstrapRequired { .. } => CoreErrorKind::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
             | CoreError::ExpectedDirectory { .. }
@@ -1115,7 +1129,7 @@ fn resolve_parent_directory(
     Ok(resolved.inode_id)
 }
 
-fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
+pub(crate) fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     head_seq: ChangeSeq,

--- a/crates/loon-core/tests/read_sessions.rs
+++ b/crates/loon-core/tests/read_sessions.rs
@@ -1,0 +1,174 @@
+use loon_api::{InodeId, NamespaceId};
+use loon_core::{
+    begin_read_session, bootstrap_namespace, close_read_session, list_read_session_children,
+    read_read_session_file, resolve_path, write_file_bytes, CoreError, MutationContext,
+};
+use loon_objectstore::fs::LocalFsStore;
+use loon_objectstore::keys::read_session;
+use loon_objectstore::ObjectStore;
+use tempfile::tempdir;
+
+#[test]
+fn read_session_pins_listing_and_file_bytes_at_session_start() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap namespace");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha-v1",
+        &context,
+        Some("seed-alpha-v1"),
+    )
+    .expect("seed alpha");
+
+    let session =
+        begin_read_session(&store, &namespace_id, "/docs", &context).expect("begin read session");
+
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha-v2",
+        &context,
+        Some("seed-alpha-v2"),
+    )
+    .expect("replace alpha");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/beta.txt",
+        b"beta-v1",
+        &context,
+        Some("seed-beta-v1"),
+    )
+    .expect("seed beta");
+
+    let entries = list_read_session_children(
+        &store,
+        &namespace_id,
+        &session.session_id,
+        session.root.inode_id,
+    )
+    .expect("list pinned children");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].absolute_path, "/docs/alpha.txt");
+
+    let pinned_read = read_read_session_file(
+        &store,
+        &namespace_id,
+        &session.session_id,
+        entries[0].inode_id,
+    )
+    .expect("read pinned alpha");
+    assert_eq!(pinned_read.bytes, b"alpha-v1");
+
+    let live_beta = resolve_path(&store, &namespace_id, "/docs/beta.txt").expect("live beta");
+    assert_eq!(live_beta.display_name, "beta.txt");
+}
+
+#[test]
+fn read_session_rejects_inode_ids_outside_the_pinned_subtree() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap namespace");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/inside.txt",
+        b"inside",
+        &context,
+        Some("seed-inside"),
+    )
+    .expect("seed inside");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/other/outside.txt",
+        b"outside",
+        &context,
+        Some("seed-outside"),
+    )
+    .expect("seed outside");
+
+    let session =
+        begin_read_session(&store, &namespace_id, "/docs", &context).expect("begin read session");
+    let outside = resolve_path(&store, &namespace_id, "/other/outside.txt").expect("outside stat");
+
+    let error =
+        read_read_session_file(&store, &namespace_id, &session.session_id, outside.inode_id)
+            .expect_err("outside inode should be rejected");
+    assert!(matches!(
+        error,
+        CoreError::InvalidReadSessionTarget {
+            session_id,
+            inode_id,
+            root_inode_id,
+        } if session_id == session.session_id
+            && inode_id == outside.inode_id
+            && root_inode_id == session.root.inode_id
+    ));
+}
+
+#[test]
+fn close_read_session_removes_the_control_object_and_is_idempotent() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap namespace");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha-v1",
+        &context,
+        Some("seed-alpha-v1"),
+    )
+    .expect("seed alpha");
+
+    let session =
+        begin_read_session(&store, &namespace_id, "/docs", &context).expect("begin read session");
+    let session_key = read_session(namespace_id.as_str(), &session.session_id);
+    assert!(
+        store.head(&session_key).expect("session head").is_some(),
+        "session object should exist before close"
+    );
+
+    close_read_session(&store, &namespace_id, &session.session_id).expect("close session");
+    assert!(
+        store.head(&session_key).expect("session head").is_none(),
+        "session object should be removed after close"
+    );
+
+    close_read_session(&store, &namespace_id, &session.session_id)
+        .expect("repeated close stays cleanup-safe");
+
+    let error = list_read_session_children(&store, &namespace_id, &session.session_id, InodeId(2))
+        .expect_err("closed session should not be readable");
+    assert!(matches!(
+        error,
+        CoreError::ReadSessionNotFound { session_id } if session_id == session.session_id
+    ));
+}
+
+fn mutation_context() -> MutationContext {
+    MutationContext {
+        writer_id: "writer-a".to_owned(),
+        writer_version: "writer-a/0.1.0".to_owned(),
+        now_ms: 1_000,
+        lease_duration_ms: 60_000,
+    }
+}
+
+fn namespace_id() -> NamespaceId {
+    NamespaceId::from("demo")
+}

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -53,6 +53,14 @@ pub fn upload_session_prefix(namespace: &str) -> String {
     format!("namespaces/{namespace}/control/uploads/")
 }
 
+pub fn read_session(namespace: &str, session_id: &str) -> String {
+    format!("namespaces/{namespace}/control/read_sessions/{session_id}.json")
+}
+
+pub fn read_session_prefix(namespace: &str) -> String {
+    format!("namespaces/{namespace}/control/read_sessions/")
+}
+
 pub fn snapshot_manifest(namespace: &str, seq: u64) -> String {
     format!("namespaces/{namespace}/snapshots/{seq:020}/manifest.json")
 }
@@ -81,8 +89,9 @@ pub fn queue_shard(shard_index: u32) -> String {
 mod tests {
     use super::{
         blob, conflict_artifact, conflict_artifact_prefix, content_manifest, derived_progress,
-        namespace_head, namespace_lease, queue_shard, snapshot_manifest, snapshot_table,
-        upload_session, upload_session_prefix, wal_commit, SnapshotTableFamily,
+        namespace_head, namespace_lease, queue_shard, read_session, read_session_prefix,
+        snapshot_manifest, snapshot_table, upload_session, upload_session_prefix, wal_commit,
+        SnapshotTableFamily,
     };
 
     #[test]
@@ -129,6 +138,14 @@ mod tests {
         assert_eq!(
             upload_session_prefix("ns-1"),
             "namespaces/ns-1/control/uploads/"
+        );
+        assert_eq!(
+            read_session("ns-1", "rs_123"),
+            "namespaces/ns-1/control/read_sessions/rs_123.json"
+        );
+        assert_eq!(
+            read_session_prefix("ns-1"),
+            "namespaces/ns-1/control/read_sessions/"
         );
     }
 }

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -17,7 +17,7 @@ use loon_api::{
 };
 use loon_core::{
     advance_retention_floor, begin_upload, bootstrap_namespace, commit_operations, complete_upload,
-    copy_file_path, create_checkpoint, delete_path_non_recursive, list_changes_after,
+    copy_file_path, create_checkpoint, delete_path, delete_path_non_recursive, list_changes_after,
     list_namespaces, list_path, move_path, put_file_manifest, read_file_bytes, resolve_path,
     upload_block, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
     PutFileBehavior,
@@ -237,13 +237,20 @@ async fn filesystem_operation(
                 &mutation_context(&config),
                 Some(&request.request_id),
             ),
-            FilesystemOperation::DeletePath { path } => delete_path_non_recursive(
-                store.as_ref(),
-                &namespace_id,
-                &path,
-                &mutation_context(&config),
-                Some(&request.request_id),
-            ),
+            FilesystemOperation::DeletePath { path, recursive } => {
+                let delete = if recursive {
+                    delete_path
+                } else {
+                    delete_path_non_recursive
+                };
+                delete(
+                    store.as_ref(),
+                    &namespace_id,
+                    &path,
+                    &mutation_context(&config),
+                    Some(&request.request_id),
+                )
+            }
             FilesystemOperation::MovePath { from_path, to_path } => move_path(
                 store.as_ref(),
                 &namespace_id,
@@ -525,6 +532,10 @@ impl ApiResponseError {
             }
             CoreErrorKind::UploadBlockConflict => (StatusCode::CONFLICT, "upload_block_conflict"),
             CoreErrorKind::InvalidUploadBlock => (StatusCode::BAD_REQUEST, "invalid_upload_block"),
+            CoreErrorKind::ReadSessionNotFound => (StatusCode::NOT_FOUND, "read_session_not_found"),
+            CoreErrorKind::InvalidReadSessionTarget => {
+                (StatusCode::CONFLICT, "invalid_read_session_target")
+            }
             CoreErrorKind::RebootstrapRequired => (StatusCode::CONFLICT, "rebootstrap_required"),
             CoreErrorKind::NamespaceCorrupt => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "namespace_corrupt")

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -109,6 +109,50 @@ async fn http_put_create_only_and_copy_preserve_cli_semantics() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_recursive_delete_preserves_non_recursive_default_behavior() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loon-server-delete",
+        "http-delete-smoke",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create namespace");
+        let nested = NamespacePath::parse("demo:/docs/nested/file.txt").expect("nested");
+        harness
+            .client
+            .write_file_bytes(&nested, b"hello over http\n")
+            .expect("seed nested file");
+
+        let docs = NamespacePath::parse("demo:/docs").expect("docs");
+        match harness.client.delete_path(&docs) {
+            Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_conflict"),
+            other => panic!("expected path_conflict, got {other:?}"),
+        }
+
+        harness
+            .client
+            .delete_path_recursive(&docs)
+            .expect("recursive delete");
+
+        match harness.client.stat_path(&docs) {
+            Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
+            other => panic!("expected path_not_found, got {other:?}"),
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_upload_commit_and_change_feed_are_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(


### PR DESCRIPTION
- add `rm -r` support across the CLI, client, server, and core (preserves existing non-recursive delete behavior)
- add local-mode `get -r` backed by a durable `ReadSession` that pins a snapshot and drives recursive download from the cli