### PR TITLE
feat: add file revision history reads

### DIFF
--- a/crates/loon-api/src/server.rs
+++ b/crates/loon-api/src/server.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, InodeId, InodeKind, NamespaceId, RevisionNo};
+use crate::{v0::CommitAnnotations, ChangeSeq, InodeId, InodeKind, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -19,5 +19,45 @@ pub struct AuthoritativePathEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthoritativeFileBytes {
     pub entry: AuthoritativePathEntry,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthoritativeFileRevision {
+    pub revision_no: RevisionNo,
+    pub committed_seq: ChangeSeq,
+    pub content_manifest_digest: String,
+    pub size_bytes: u64,
+    pub content_digest: String,
+    pub commit_id: String,
+    pub request_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<CommitAnnotations>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthoritativeFileRevisionList {
+    pub namespace_id: NamespaceId,
+    pub inode_id: InodeId,
+    pub authoritative_head_seq: ChangeSeq,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_absolute_path: Option<String>,
+    pub currently_visible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_before_revision_no: Option<RevisionNo>,
+    pub revisions: Vec<AuthoritativeFileRevision>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthoritativeFileRevisionBytes {
+    pub namespace_id: NamespaceId,
+    pub inode_id: InodeId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_absolute_path: Option<String>,
+    pub currently_visible: bool,
+    pub authoritative_head_seq: ChangeSeq,
+    pub revision: AuthoritativeFileRevision,
     pub bytes: Vec<u8>,
 }

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -27,7 +27,8 @@ pub enum Command {
     Current(CurrentArgs),
     Ls(FilesystemLsArgs),
     Stat(FilesystemPathArgs),
-    Cat(FilesystemPathArgs),
+    Versions(FilesystemVersionsArgs),
+    Cat(FilesystemCatArgs),
     Get(FilesystemGetArgs),
     Put(FilesystemPutArgs),
     Rm(FilesystemPathArgs),
@@ -204,10 +205,38 @@ pub struct FilesystemPathArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct FilesystemVersionsArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: Option<String>,
+    #[arg(long)]
+    pub inode: Option<u64>,
+    #[arg(long = "before-revision")]
+    pub before_revision: Option<u64>,
+    #[arg(long)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Args)]
+pub struct FilesystemCatArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: Option<String>,
+    #[arg(long)]
+    pub inode: Option<u64>,
+    #[arg(long)]
+    pub revision: Option<u64>,
+}
+
+#[derive(Debug, Args)]
 pub struct FilesystemGetArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    pub remote_path: String,
+    pub remote_path: Option<String>,
+    #[arg(long)]
+    pub inode: Option<u64>,
+    #[arg(long)]
+    pub revision: Option<u64>,
     pub local_destination: Option<String>,
 }
 
@@ -271,6 +300,7 @@ pub enum CommandKind {
     Current,
     FilesystemLs,
     FilesystemStat,
+    FilesystemVersions,
     FilesystemCat,
     FilesystemGet,
     FilesystemPut,
@@ -298,6 +328,7 @@ impl CommandKind {
             CommandKind::Current => "current",
             CommandKind::FilesystemLs => "filesystem_ls",
             CommandKind::FilesystemStat => "filesystem_stat",
+            CommandKind::FilesystemVersions => "filesystem_versions",
             CommandKind::FilesystemCat => "filesystem_cat",
             CommandKind::FilesystemGet => "filesystem_get",
             CommandKind::FilesystemPut => "filesystem_put",
@@ -335,6 +366,7 @@ impl Cli {
             Command::Current(_) => CommandKind::Current,
             Command::Ls(_) => CommandKind::FilesystemLs,
             Command::Stat(_) => CommandKind::FilesystemStat,
+            Command::Versions(_) => CommandKind::FilesystemVersions,
             Command::Cat(_) => CommandKind::FilesystemCat,
             Command::Get(_) => CommandKind::FilesystemGet,
             Command::Put(_) => CommandKind::FilesystemPut,

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -1,11 +1,16 @@
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
-use loon_api::{AuthoritativePathEntry, MutationResult, NamespaceId, NamespaceSummary};
+use loon_api::{
+    AuthoritativeFileRevisionList, AuthoritativePathEntry, InodeId, MutationResult, NamespaceId,
+    NamespaceSummary, RevisionNo,
+};
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_core::{
-    bootstrap_namespace, copy_file_path, delete_path_non_recursive, list_namespaces, list_path,
-    move_path, put_file_bytes, read_file_bytes, resolve_path, BootstrapNamespaceError, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior,
+    bootstrap_namespace, copy_file_path, delete_path_non_recursive, list_file_revisions_by_inode,
+    list_file_revisions_by_path, list_namespaces, list_path, move_path, put_file_bytes,
+    read_file_bytes, read_file_bytes_at_revision, read_file_bytes_by_inode_at_revision,
+    resolve_path, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
+    PutFileBehavior,
 };
 use loon_objectstore::ConfiguredObjectStore;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,6 +23,30 @@ pub trait Backend {
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError>;
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError>;
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError>;
+    fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError>;
+    fn list_file_revisions_by_inode(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError>;
+    fn read_file_bytes_at_revision(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError>;
+    fn read_file_bytes_by_inode_at_revision(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError>;
     fn put_file_bytes(
         &self,
         spec: &NamespacePath,
@@ -62,6 +91,50 @@ impl Backend for RemoteBackend {
 
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
         self.client.read_file_bytes(spec).map_err(map_client_error)
+    }
+
+    fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError> {
+        self.client
+            .list_file_revisions(spec, before_revision_no, limit)
+            .map_err(map_client_error)
+    }
+
+    fn list_file_revisions_by_inode(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError> {
+        self.client
+            .list_inode_revisions(namespace, inode_id, before_revision_no, limit)
+            .map_err(map_client_error)
+    }
+
+    fn read_file_bytes_at_revision(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError> {
+        self.client
+            .read_file_bytes_at_revision(spec, revision_no)
+            .map_err(map_client_error)
+    }
+
+    fn read_file_bytes_by_inode_at_revision(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError> {
+        self.client
+            .read_file_bytes_by_inode_at_revision(namespace, inode_id, revision_no)
+            .map_err(map_client_error)
     }
 
     fn put_file_bytes(
@@ -168,6 +241,60 @@ impl Backend for DirectBackend {
         Ok(result.bytes)
     }
 
+    fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError> {
+        let ns_id = NamespaceId::from(spec.namespace.clone());
+        list_file_revisions_by_path(
+            &self.store,
+            &ns_id,
+            &spec.absolute_path,
+            before_revision_no,
+            limit,
+        )
+        .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
+    }
+
+    fn list_file_revisions_by_inode(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, CliError> {
+        let ns_id = NamespaceId::from(namespace.to_owned());
+        list_file_revisions_by_inode(&self.store, &ns_id, inode_id, before_revision_no, limit)
+            .map_err(|error| map_namespace_scoped_core_error(namespace, error))
+    }
+
+    fn read_file_bytes_at_revision(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError> {
+        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let result =
+            read_file_bytes_at_revision(&self.store, &ns_id, &spec.absolute_path, revision_no)
+                .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))?;
+        Ok(result.bytes)
+    }
+
+    fn read_file_bytes_by_inode_at_revision(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, CliError> {
+        let ns_id = NamespaceId::from(namespace.to_owned());
+        let result =
+            read_file_bytes_by_inode_at_revision(&self.store, &ns_id, inode_id, revision_no)
+                .map_err(|error| map_namespace_scoped_core_error(namespace, error))?;
+        Ok(result.bytes)
+    }
+
     fn put_file_bytes(
         &self,
         spec: &NamespacePath,
@@ -244,6 +371,7 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::InvalidPath => "invalid_path",
         CoreErrorKind::NamespaceNotFound => "namespace_not_found",
         CoreErrorKind::PathNotFound => "path_not_found",
+        CoreErrorKind::InodeNotFound => "inode_not_found",
         CoreErrorKind::RevisionNotFound => "revision_not_found",
         CoreErrorKind::PathConflict => "path_conflict",
         CoreErrorKind::StaleHead => "stale_head",

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -1,8 +1,9 @@
 use crate::args::{
-    Cli, Command, CommandKind, ConfigCommand, CurrentArgs, FilesystemGetArgs, FilesystemLsArgs,
-    FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs, InitArgs, NamespaceCommand,
-    NamespaceCreateArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand, ProfileCreateArgs,
-    ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
+    Cli, Command, CommandKind, ConfigCommand, CurrentArgs, FilesystemCatArgs, FilesystemGetArgs,
+    FilesystemLsArgs, FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs,
+    FilesystemVersionsArgs, InitArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceListArgs,
+    NamespaceUseArgs, ProfileCommand, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior,
+    TargetSelectorArgs,
 };
 use crate::config::{
     default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
@@ -17,7 +18,10 @@ use crate::prompt;
 use crate::resolve::{
     load_cli_config, resolve_namespace, resolve_target_profile, resolve_target_profile_from_config,
 };
-use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceSummary};
+use loon_api::{
+    AuthoritativeFileRevisionList, AuthoritativePathEntry, InodeId, InodeKind, NamespaceSummary,
+    RevisionNo,
+};
 use loon_client::NamespacePath;
 use serde::Serialize;
 use std::fs;
@@ -92,6 +96,9 @@ pub enum CommandData {
     NamespaceList {
         namespaces: Vec<NamespaceSummary>,
     },
+    FileRevisionList {
+        revisions: AuthoritativeFileRevisionList,
+    },
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,
     },
@@ -120,6 +127,11 @@ pub enum CommandData {
         version: String,
     },
     StreamBytes(Vec<u8>),
+}
+
+enum HistorySelector {
+    Path(NamespacePath),
+    Inode(InodeId),
 }
 
 pub fn run(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, CommandFailure> {
@@ -155,6 +167,7 @@ fn run_inner(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, Comman
         Command::Current(args) => run_current(kind, args),
         Command::Ls(args) => run_filesystem_ls(kind, args),
         Command::Stat(args) => run_filesystem_stat(kind, args),
+        Command::Versions(args) => run_filesystem_versions(kind, args),
         Command::Cat(args) => run_filesystem_cat(kind, args),
         Command::Get(args) => run_filesystem_get(kind, args, runtime),
         Command::Put(args) => run_filesystem_put(kind, args),
@@ -625,12 +638,97 @@ fn run_filesystem_stat(
     })
 }
 
+fn run_filesystem_versions(
+    kind: CommandKind,
+    args: FilesystemVersionsArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let selector = resolve_history_selector(
+        &context.namespace,
+        args.path.as_deref(),
+        args.inode,
+        kind,
+        &context.profile_name,
+        &context.mode,
+    )?;
+    let before_revision = args.before_revision.map(RevisionNo);
+    let data = match selector {
+        HistorySelector::Path(spec) => context
+            .target
+            .backend()
+            .list_file_revisions(&spec, before_revision, args.limit)
+            .map(|revisions| CommandData::FileRevisionList { revisions }),
+        HistorySelector::Inode(inode_id) => context
+            .target
+            .backend()
+            .list_file_revisions_by_inode(&context.namespace, inode_id, before_revision, args.limit)
+            .map(|revisions| CommandData::FileRevisionList { revisions }),
+    }
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data,
+    })
+}
+
 fn run_filesystem_cat(
     kind: CommandKind,
-    args: FilesystemPathArgs,
+    args: FilesystemCatArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_path_lookup(kind, args, |backend, spec| {
-        backend.read_file_bytes(spec).map(CommandData::StreamBytes)
+    let context = resolve_command_context(kind, &args.target)?;
+    let selector = resolve_history_selector(
+        &context.namespace,
+        args.path.as_deref(),
+        args.inode,
+        kind,
+        &context.profile_name,
+        &context.mode,
+    )?;
+    let revision = args.revision.map(RevisionNo);
+    let data = match (selector, revision) {
+        (HistorySelector::Path(spec), Some(revision_no)) => context
+            .target
+            .backend()
+            .read_file_bytes_at_revision(&spec, revision_no)
+            .map(CommandData::StreamBytes),
+        (HistorySelector::Path(spec), None) => context
+            .target
+            .backend()
+            .read_file_bytes(&spec)
+            .map(CommandData::StreamBytes),
+        (HistorySelector::Inode(inode_id), Some(revision_no)) => context
+            .target
+            .backend()
+            .read_file_bytes_by_inode_at_revision(&context.namespace, inode_id, revision_no)
+            .map(CommandData::StreamBytes),
+        (HistorySelector::Inode(_), None) => Err(CliError::invalid_input(
+            "`--revision` is required when using `--inode`",
+        )),
+    }
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data,
     })
 }
 
@@ -640,7 +738,18 @@ fn run_filesystem_get(
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target)?;
-    if runtime.json && args.local_destination.as_deref() == Some("-") {
+    let inferred_local_destination = if args.inode.is_some() && args.local_destination.is_none() {
+        args.remote_path.as_deref()
+    } else {
+        args.local_destination.as_deref()
+    };
+    let selector_path = if args.inode.is_some() && args.local_destination.is_none() {
+        None
+    } else {
+        args.remote_path.as_deref()
+    };
+
+    if runtime.json && inferred_local_destination == Some("-") {
         return Err(fail(
             kind,
             Some(context.profile_name),
@@ -649,58 +758,81 @@ fn run_filesystem_get(
         ));
     }
 
-    let spec = namespace_path(&context.namespace, &args.remote_path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let entry = context.target.backend().stat_path(&spec).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    if entry.inode_kind == InodeKind::Dir {
+    let selector = resolve_history_selector(
+        &context.namespace,
+        selector_path,
+        args.inode,
+        kind,
+        &context.profile_name,
+        &context.mode,
+    )?;
+    if matches!(selector, HistorySelector::Inode(_)) && inferred_local_destination.is_none() {
         return Err(fail(
             kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            CliError::invalid_input(format!(
-                "directory operations are not available for `{}`",
-                spec.absolute_path
-            )),
+            Some(context.profile_name),
+            Some(context.mode),
+            CliError::invalid_input("`get --inode` requires an explicit local destination or `-`"),
         ));
     }
-
-    let bytes = context
-        .target
-        .backend()
-        .read_file_bytes(&spec)
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
-    let data = match args.local_destination.as_deref() {
+    let revision = args.revision.map(RevisionNo);
+    let bytes = match (&selector, revision) {
+        (HistorySelector::Path(spec), None) => {
+            let entry = context.target.backend().stat_path(spec).map_err(|error| {
+                fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    error,
+                )
+            })?;
+            if entry.inode_kind == InodeKind::Dir {
+                return Err(fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    CliError::invalid_input(format!(
+                        "directory operations are not available for `{}`",
+                        spec.absolute_path
+                    )),
+                ));
+            }
+            context.target.backend().read_file_bytes(spec)
+        }
+        (HistorySelector::Path(spec), Some(revision_no)) => context
+            .target
+            .backend()
+            .read_file_bytes_at_revision(spec, revision_no),
+        (HistorySelector::Inode(inode_id), Some(revision_no)) => context
+            .target
+            .backend()
+            .read_file_bytes_by_inode_at_revision(&context.namespace, *inode_id, revision_no),
+        (HistorySelector::Inode(_), None) => Err(CliError::invalid_input(
+            "`--revision` is required when using `--inode`",
+        )),
+    }
+    .map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let data = match inferred_local_destination {
         Some("-") => CommandData::StreamBytes(bytes),
         other => {
-            let destination =
-                destination_path_for_get(&spec.absolute_path, other).map_err(|error| {
-                    fail(
-                        kind,
-                        Some(context.profile_name.clone()),
-                        Some(context.mode.clone()),
-                        error,
-                    )
-                })?;
+            let remote_label = match &selector {
+                HistorySelector::Path(spec) => spec.absolute_path.as_str(),
+                HistorySelector::Inode(_) => "inode-selected revision",
+            };
+            let destination = destination_path_for_get(remote_label, other).map_err(|error| {
+                fail(
+                    kind,
+                    Some(context.profile_name.clone()),
+                    Some(context.mode.clone()),
+                    error,
+                )
+            })?;
             fs::write(&destination, &bytes).map_err(|error| {
                 fail(
                     kind,
@@ -710,7 +842,7 @@ fn run_filesystem_get(
                 )
             })?;
             CommandData::FileTransfer {
-                target: render_target(&context.namespace, &spec.absolute_path),
+                target: render_history_target(&context.namespace, &selector, revision),
                 destination: destination.display().to_string(),
                 bytes_written: bytes.len() as u64,
             }
@@ -1522,6 +1654,41 @@ fn normalize_absolute_path(path: &str, allow_root: bool) -> Result<String, CliEr
     Ok(format!("/{}", components.join("/")))
 }
 
+fn resolve_history_selector(
+    namespace: &str,
+    path: Option<&str>,
+    inode: Option<u64>,
+    kind: CommandKind,
+    profile_name: &str,
+    mode: &str,
+) -> Result<HistorySelector, CommandFailure> {
+    match (path, inode) {
+        (Some(path), None) => namespace_path(namespace, path, false)
+            .map(HistorySelector::Path)
+            .map_err(|error| {
+                fail(
+                    kind,
+                    Some(profile_name.to_owned()),
+                    Some(mode.to_owned()),
+                    error,
+                )
+            }),
+        (None, Some(inode)) => Ok(HistorySelector::Inode(InodeId(inode))),
+        (Some(_), Some(_)) => Err(fail(
+            kind,
+            Some(profile_name.to_owned()),
+            Some(mode.to_owned()),
+            CliError::invalid_input("provide either a path or `--inode`, not both"),
+        )),
+        (None, None) => Err(fail(
+            kind,
+            Some(profile_name.to_owned()),
+            Some(mode.to_owned()),
+            CliError::invalid_input("provide a path or `--inode`"),
+        )),
+    }
+}
+
 fn default_remote_put_path(local_path: &Path) -> Result<String, CliError> {
     let file_name = local_path.file_name().ok_or_else(|| {
         CliError::invalid_input(format!(
@@ -1551,6 +1718,21 @@ fn destination_path_for_get(
 
 fn render_target(namespace: &str, path: &str) -> String {
     format!("{namespace}:{path}")
+}
+
+fn render_history_target(
+    namespace: &str,
+    selector: &HistorySelector,
+    revision: Option<RevisionNo>,
+) -> String {
+    let base = match selector {
+        HistorySelector::Path(spec) => render_target(namespace, &spec.absolute_path),
+        HistorySelector::Inode(inode_id) => format!("{namespace}:inode/{}", inode_id.0),
+    };
+    match revision {
+        Some(revision_no) => format!("{base}@r{}", revision_no.0),
+        None => base,
+    }
 }
 
 fn fail(

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -148,6 +148,28 @@ pub fn human_success(output: &CommandOutput) -> String {
             }
             lines.join("\n")
         }
+        CommandData::FileRevisionList { revisions } => {
+            let mut lines = vec!["REVISION\tSEQ\tSIZE\tPATH\tMESSAGE".to_owned()];
+            for revision in &revisions.revisions {
+                let path = revisions.current_absolute_path.as_deref().unwrap_or("-");
+                let message = revision.message.as_deref().unwrap_or("-");
+                lines.push(format!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    revision.revision_no.0,
+                    revision.committed_seq.0,
+                    revision.size_bytes,
+                    path,
+                    message
+                ));
+            }
+            if let Some(next_before_revision_no) = revisions.next_before_revision_no {
+                lines.push(format!(
+                    "next_before_revision: {}",
+                    next_before_revision_no.0
+                ));
+            }
+            lines.join("\n")
+        }
         CommandData::PathEntries { entries } => entries
             .iter()
             .map(|entry| {

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -163,6 +163,73 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 }
 
 #[test]
+fn local_profile_versions_and_historical_reads_work() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let first_upload = harness.temp_dir.path().join("history-v1.txt");
+    let second_upload = harness.temp_dir.path().join("history-v2.txt");
+    let download_path = harness.temp_dir.path().join("history-v1-downloaded.txt");
+    fs::write(&first_upload, b"v1\n").expect("first upload");
+    fs::write(&second_upload, b"v2\n").expect("second upload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    assert_success(&harness.run(&[
+        "--json",
+        "put",
+        first_upload.to_str().unwrap(),
+        "/docs/history.txt",
+    ]));
+    assert_success(&harness.run(&[
+        "--json",
+        "put",
+        second_upload.to_str().unwrap(),
+        "/docs/history.txt",
+        "--force",
+    ]));
+
+    let stat = harness.run(&["--json", "stat", "/docs/history.txt"]);
+    assert_success(&stat);
+    let inode_id = json_data(&stat)["inode_id"].as_u64().expect("inode id");
+
+    let versions = harness.run(&["--json", "versions", "/docs/history.txt"]);
+    assert_success(&versions);
+    let versions_data = json_data(&versions);
+    assert_eq!(versions_data["type"], "file_revision_list");
+    assert_eq!(versions_data["revisions"]["inode_id"], inode_id);
+    assert_eq!(
+        versions_data["revisions"]["current_absolute_path"],
+        "/docs/history.txt"
+    );
+    assert_eq!(
+        versions_data["revisions"]["revisions"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(versions_data["revisions"]["revisions"][0]["revision_no"], 2);
+    assert_eq!(versions_data["revisions"]["revisions"][1]["revision_no"], 1);
+
+    let cat_old = harness.run(&["cat", "/docs/history.txt", "--revision", "1"]);
+    assert_success(&cat_old);
+    assert_eq!(cat_old.stdout, b"v1\n");
+
+    let get_old = harness.run(&[
+        "get",
+        "--inode",
+        &inode_id.to_string(),
+        "--revision",
+        "1",
+        download_path.to_str().unwrap(),
+    ]);
+    assert_success(&get_old);
+    assert_eq!(fs::read(&download_path).expect("downloaded"), b"v1\n");
+}
+
+#[test]
 fn init_creates_local_profile_and_current_reports_namespace_unset() {
     let harness = Harness::new();
 

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -8,9 +8,10 @@ use loon_api::{
         CommitResponse as V0CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
         UploadBlockResponse,
     },
-    ApiError, AuthoritativePathEntry, ChangeSeq, CreateNamespaceRequest, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FilesystemPutBehavior,
-    ListNamespacesResponse, MutationResult, NamespaceSummary, CONTENT_BLOCK_SIZE_BYTES,
+    ApiError, AuthoritativeFileRevisionList, AuthoritativePathEntry, ChangeSeq,
+    CreateNamespaceRequest, FilesystemOperation, FilesystemOperationRequest,
+    FilesystemOperationResponse, FilesystemPutBehavior, InodeId, ListNamespacesResponse,
+    MutationResult, NamespaceSummary, RevisionNo, CONTENT_BLOCK_SIZE_BYTES,
 };
 use serde::Deserialize;
 use std::fs;
@@ -159,6 +160,87 @@ impl Client {
             spec.namespace,
             urlencoding::encode(&spec.absolute_path)
         );
+        self.read_bytes(&url)
+    }
+
+    pub fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, ClientError> {
+        let mut url = format!(
+            "{}/v0/namespaces/{}/filesystem/versions?path={}",
+            self.base_url,
+            spec.namespace,
+            urlencoding::encode(&spec.absolute_path)
+        );
+        if let Some(before_revision_no) = before_revision_no {
+            url.push_str("&before_revision_no=");
+            url.push_str(&before_revision_no.0.to_string());
+        }
+        if let Some(limit) = limit {
+            url.push_str("&limit=");
+            url.push_str(&limit.to_string());
+        }
+        self.request_json::<(), AuthoritativeFileRevisionList>(self.agent.get(&url), None)
+    }
+
+    pub fn list_inode_revisions(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        before_revision_no: Option<RevisionNo>,
+        limit: Option<u32>,
+    ) -> Result<AuthoritativeFileRevisionList, ClientError> {
+        let mut url = format!(
+            "{}/v0/namespaces/{namespace}/inodes/{}/revisions",
+            self.base_url, inode_id.0
+        );
+        let mut separator = '?';
+        if let Some(before_revision_no) = before_revision_no {
+            url.push(separator);
+            separator = '&';
+            url.push_str("before_revision_no=");
+            url.push_str(&before_revision_no.0.to_string());
+        }
+        if let Some(limit) = limit {
+            url.push(separator);
+            url.push_str("limit=");
+            url.push_str(&limit.to_string());
+        }
+        self.request_json::<(), AuthoritativeFileRevisionList>(self.agent.get(&url), None)
+    }
+
+    pub fn read_file_bytes_at_revision(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, ClientError> {
+        let url = format!(
+            "{}/v0/namespaces/{}/filesystem/content?path={}&revision_no={}",
+            self.base_url,
+            spec.namespace,
+            urlencoding::encode(&spec.absolute_path),
+            revision_no.0
+        );
+        self.read_bytes(&url)
+    }
+
+    pub fn read_file_bytes_by_inode_at_revision(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, ClientError> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace}/inodes/{}/revisions/{}/content",
+            self.base_url, inode_id.0, revision_no.0
+        );
+        self.read_bytes(&url)
+    }
+
+    fn read_bytes(&self, url: &str) -> Result<Vec<u8>, ClientError> {
         let request = self.authenticated(self.agent.get(&url));
         let response = request.call().map_err(|err| self.map_error(err))?;
         let mut reader = response.into_reader();

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -241,7 +241,7 @@ impl Client {
     }
 
     fn read_bytes(&self, url: &str) -> Result<Vec<u8>, ClientError> {
-        let request = self.authenticated(self.agent.get(&url));
+        let request = self.authenticated(self.agent.get(url));
         let response = request.call().map_err(|err| self.map_error(err))?;
         let mut reader = response.into_reader();
         let mut bytes = Vec::new();

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -23,8 +23,10 @@ pub use protocol::{
     begin_upload, commit_operations, complete_upload, list_changes_after, upload_block,
 };
 pub use services::{
-    bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, list_namespaces,
-    list_path, move_path, put_file_bytes, put_file_manifest, read_file_bytes, resolve_path,
-    store_bytes_as_content, write_file_bytes, BootstrapNamespaceError, CoreError, CoreErrorKind,
-    MutationContext, PutFileBehavior, StoredContent,
+    bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive,
+    list_file_revisions_by_inode, list_file_revisions_by_path, list_namespaces, list_path,
+    move_path, put_file_bytes, put_file_manifest, read_file_bytes, read_file_bytes_at_revision,
+    read_file_bytes_by_inode_at_revision, resolve_path, store_bytes_as_content, write_file_bytes,
+    BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
+    StoredContent,
 };

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -60,6 +60,14 @@ struct RevisionCommitContext {
     annotations: Option<loon_api::v0::CommitAnnotations>,
 }
 
+struct HistoricalFileContext<'a> {
+    metadata_state: &'a MetadataState,
+    head_seq: ChangeSeq,
+    inode_id: InodeId,
+    current_absolute_path: Option<String>,
+    currently_visible: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoreErrorKind {
     InvalidPath,
@@ -458,11 +466,13 @@ pub fn list_file_revisions_by_path<S: ObjectStore + ?Sized>(
     build_authoritative_file_revision_list(
         store,
         namespace_id,
-        basis.head.seq,
-        &basis.metadata_state,
-        resolved.inode_id,
-        Some(resolved.absolute_path),
-        true,
+        HistoricalFileContext {
+            metadata_state: &basis.metadata_state,
+            head_seq: basis.head.seq,
+            inode_id: resolved.inode_id,
+            current_absolute_path: Some(resolved.absolute_path),
+            currently_visible: true,
+        },
         before_revision_no,
         limit,
     )
@@ -493,11 +503,13 @@ pub fn list_file_revisions_by_inode<S: ObjectStore + ?Sized>(
     build_authoritative_file_revision_list(
         store,
         namespace_id,
-        basis.head.seq,
-        &basis.metadata_state,
-        inode_id,
-        current_absolute_path,
-        currently_visible,
+        HistoricalFileContext {
+            metadata_state: &basis.metadata_state,
+            head_seq: basis.head.seq,
+            inode_id,
+            current_absolute_path,
+            currently_visible,
+        },
         before_revision_no,
         limit,
     )
@@ -523,11 +535,13 @@ pub fn read_file_bytes_at_revision<S: ObjectStore + ?Sized>(
     read_file_revision_bytes_for_inode(
         store,
         namespace_id,
-        basis.head.seq,
-        &basis.metadata_state,
-        resolved.inode_id,
-        Some(resolved.absolute_path),
-        true,
+        HistoricalFileContext {
+            metadata_state: &basis.metadata_state,
+            head_seq: basis.head.seq,
+            inode_id: resolved.inode_id,
+            current_absolute_path: Some(resolved.absolute_path),
+            currently_visible: true,
+        },
         revision_no,
     )
 }
@@ -556,11 +570,13 @@ pub fn read_file_bytes_by_inode_at_revision<S: ObjectStore + ?Sized>(
     read_file_revision_bytes_for_inode(
         store,
         namespace_id,
-        basis.head.seq,
-        &basis.metadata_state,
-        inode_id,
-        current_absolute_path,
-        currently_visible,
+        HistoricalFileContext {
+            metadata_state: &basis.metadata_state,
+            head_seq: basis.head.seq,
+            inode_id,
+            current_absolute_path,
+            currently_visible,
+        },
         revision_no,
     )
 }
@@ -1310,19 +1326,18 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
 fn build_authoritative_file_revision_list<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    head_seq: ChangeSeq,
-    metadata_state: &MetadataState,
-    inode_id: InodeId,
-    current_absolute_path: Option<String>,
-    currently_visible: bool,
+    file: HistoricalFileContext<'_>,
     before_revision_no: Option<RevisionNo>,
     limit: Option<u32>,
 ) -> Result<AuthoritativeFileRevisionList, CoreError> {
     let limit = normalize_revision_page_limit(limit);
-    let mut revisions = metadata_state
+    let mut revisions = file
+        .metadata_state
         .revisions
         .iter()
-        .filter(|revision| revision.inode_id == inode_id && revision.committed_seq <= head_seq)
+        .filter(|revision| {
+            revision.inode_id == file.inode_id && revision.committed_seq <= file.head_seq
+        })
         .filter(|revision| {
             before_revision_no
                 .map(|before| revision.revision_no < before)
@@ -1361,10 +1376,10 @@ fn build_authoritative_file_revision_list<S: ObjectStore + ?Sized>(
 
     Ok(AuthoritativeFileRevisionList {
         namespace_id: namespace_id.clone(),
-        inode_id,
-        authoritative_head_seq: head_seq,
-        current_absolute_path,
-        currently_visible,
+        inode_id: file.inode_id,
+        authoritative_head_seq: file.head_seq,
+        current_absolute_path: file.current_absolute_path,
+        currently_visible: file.currently_visible,
         next_before_revision_no,
         revisions,
     })
@@ -1373,17 +1388,14 @@ fn build_authoritative_file_revision_list<S: ObjectStore + ?Sized>(
 fn read_file_revision_bytes_for_inode<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    head_seq: ChangeSeq,
-    metadata_state: &MetadataState,
-    inode_id: InodeId,
-    current_absolute_path: Option<String>,
-    currently_visible: bool,
+    file: HistoricalFileContext<'_>,
     revision_no: RevisionNo,
 ) -> Result<AuthoritativeFileRevisionBytes, CoreError> {
-    let revision = metadata_state
-        .revision_at_seq(inode_id, revision_no, head_seq)
+    let revision = file
+        .metadata_state
+        .revision_at_seq(file.inode_id, revision_no, file.head_seq)
         .ok_or(CoreError::MissingRevision {
-            inode_id,
+            inode_id: file.inode_id,
             revision_no,
         })?;
     let mut wal_context_by_seq = BTreeMap::new();
@@ -1394,10 +1406,10 @@ fn read_file_revision_bytes_for_inode<S: ObjectStore + ?Sized>(
 
     Ok(AuthoritativeFileRevisionBytes {
         namespace_id: namespace_id.clone(),
-        inode_id,
-        current_absolute_path,
-        currently_visible,
-        authoritative_head_seq: head_seq,
+        inode_id: file.inode_id,
+        current_absolute_path: file.current_absolute_path,
+        currently_visible: file.currently_visible,
+        authoritative_head_seq: file.head_seq,
         revision: revision_entry,
         bytes: read.bytes,
     })

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -9,20 +9,22 @@ use crate::loading::ControlObjectLoadError;
 use crate::metadata::{MetadataApplyError, MetadataState, ResolvedVisiblePath, VisiblePathError};
 use crate::wal::WalBuildError;
 use loon_api::{
-    content_manifest_digest_sha256, encode_content_manifest_json, name_key_for_display_name,
-    payload_checksum_sha256,
+    content_manifest_digest_sha256, decode_wal_commit_envelope_zstd, encode_content_manifest_json,
+    name_key_for_display_name, payload_checksum_sha256,
     v0::{
         CommitOp as V0CommitOp, CommitOpResult, CommitPrecondition as V0CommitPrecondition,
         CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse,
     },
-    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentBlockDescriptor,
+    AuthoritativeFileBytes, AuthoritativeFileRevision, AuthoritativeFileRevisionBytes,
+    AuthoritativeFileRevisionList, AuthoritativePathEntry, ChangeSeq, ContentBlockDescriptor,
     ContentManifestEnvelope, ContentManifestPayload, ControlObjectKind, HeadState,
     HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope, MutationResult,
-    NamespaceId, NamespaceSummary, CONTENT_BLOCK_SIZE_BYTES,
+    NamespaceId, NamespaceSummary, RevisionNo, CONTENT_BLOCK_SIZE_BYTES,
 };
 use loon_objectstore::keys::{blob, content_manifest, namespace_head, namespace_lease};
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -47,11 +49,23 @@ pub enum PutFileBehavior {
     ReplaceExisting,
 }
 
+const DEFAULT_REVISION_PAGE_LIMIT: usize = 1_000;
+const MAX_REVISION_PAGE_LIMIT: usize = 1_000;
+
+#[derive(Debug, Clone)]
+struct RevisionCommitContext {
+    commit_id: String,
+    request_id: String,
+    message: Option<String>,
+    annotations: Option<loon_api::v0::CommitAnnotations>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoreErrorKind {
     InvalidPath,
     NamespaceNotFound,
     PathNotFound,
+    InodeNotFound,
     RevisionNotFound,
     PathConflict,
     StaleHead,
@@ -112,8 +126,17 @@ pub enum CoreError {
     InvalidPath(String),
     #[error("path not found `{0}`")]
     MissingPath(String),
+    #[error("inode `{inode_id}` not found")]
+    MissingInode { inode_id: InodeId },
+    #[error("revision `{revision_no:?}` not found for inode `{inode_id}`")]
+    MissingRevision {
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    },
     #[error("expected file at `{path}` but found `{kind:?}`")]
     ExpectedFile { path: String, kind: InodeKind },
+    #[error("expected file at inode `{inode_id}` but found `{kind:?}`")]
+    ExpectedFileInode { inode_id: InodeId, kind: InodeKind },
     #[error("expected directory at `{path}` but found `{kind:?}`")]
     ExpectedDirectory { path: String, kind: InodeKind },
     #[error("directory not empty `{0}`")]
@@ -196,6 +219,8 @@ impl CoreError {
                 CoreErrorKind::InvalidPath
             }
             CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
+            CoreError::MissingInode { .. } => CoreErrorKind::InodeNotFound,
+            CoreError::MissingRevision { .. } => CoreErrorKind::RevisionNotFound,
             CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
             CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
             CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,
@@ -204,6 +229,7 @@ impl CoreError {
             CoreError::InvalidUploadBlock(_) => CoreErrorKind::InvalidUploadBlock,
             CoreError::RebootstrapRequired { .. } => CoreErrorKind::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
+            | CoreError::ExpectedFileInode { .. }
             | CoreError::ExpectedDirectory { .. }
             | CoreError::DirectoryNotEmpty(_)
             | CoreError::DestinationExists(_) => CoreErrorKind::PathConflict,
@@ -409,6 +435,134 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
         entry,
         bytes: read.bytes,
     })
+}
+
+pub fn list_file_revisions_by_path<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    before_revision_no: Option<RevisionNo>,
+    limit: Option<u32>,
+) -> Result<AuthoritativeFileRevisionList, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let resolved = basis
+        .metadata_state
+        .resolve_visible_path(absolute_path, basis.head.seq)?;
+    if resolved.inode_kind != InodeKind::File {
+        return Err(CoreError::ExpectedFile {
+            path: resolved.absolute_path,
+            kind: resolved.inode_kind,
+        });
+    }
+
+    build_authoritative_file_revision_list(
+        store,
+        namespace_id,
+        basis.head.seq,
+        &basis.metadata_state,
+        resolved.inode_id,
+        Some(resolved.absolute_path),
+        true,
+        before_revision_no,
+        limit,
+    )
+}
+
+pub fn list_file_revisions_by_inode<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    inode_id: InodeId,
+    before_revision_no: Option<RevisionNo>,
+    limit: Option<u32>,
+) -> Result<AuthoritativeFileRevisionList, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let inode = basis
+        .metadata_state
+        .inode_at_seq(inode_id, basis.head.seq)
+        .ok_or(CoreError::MissingInode { inode_id })?;
+    if inode.inode_kind != InodeKind::File {
+        return Err(CoreError::ExpectedFileInode {
+            inode_id,
+            kind: inode.inode_kind,
+        });
+    }
+
+    let current_absolute_path =
+        visible_absolute_path_for_inode(&basis.metadata_state, inode_id, basis.head.seq);
+    let currently_visible = current_absolute_path.is_some();
+    build_authoritative_file_revision_list(
+        store,
+        namespace_id,
+        basis.head.seq,
+        &basis.metadata_state,
+        inode_id,
+        current_absolute_path,
+        currently_visible,
+        before_revision_no,
+        limit,
+    )
+}
+
+pub fn read_file_bytes_at_revision<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    revision_no: RevisionNo,
+) -> Result<AuthoritativeFileRevisionBytes, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let resolved = basis
+        .metadata_state
+        .resolve_visible_path(absolute_path, basis.head.seq)?;
+    if resolved.inode_kind != InodeKind::File {
+        return Err(CoreError::ExpectedFile {
+            path: resolved.absolute_path,
+            kind: resolved.inode_kind,
+        });
+    }
+
+    read_file_revision_bytes_for_inode(
+        store,
+        namespace_id,
+        basis.head.seq,
+        &basis.metadata_state,
+        resolved.inode_id,
+        Some(resolved.absolute_path),
+        true,
+        revision_no,
+    )
+}
+
+pub fn read_file_bytes_by_inode_at_revision<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    inode_id: InodeId,
+    revision_no: RevisionNo,
+) -> Result<AuthoritativeFileRevisionBytes, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let inode = basis
+        .metadata_state
+        .inode_at_seq(inode_id, basis.head.seq)
+        .ok_or(CoreError::MissingInode { inode_id })?;
+    if inode.inode_kind != InodeKind::File {
+        return Err(CoreError::ExpectedFileInode {
+            inode_id,
+            kind: inode.inode_kind,
+        });
+    }
+
+    let current_absolute_path =
+        visible_absolute_path_for_inode(&basis.metadata_state, inode_id, basis.head.seq);
+    let currently_visible = current_absolute_path.is_some();
+    read_file_revision_bytes_for_inode(
+        store,
+        namespace_id,
+        basis.head.seq,
+        &basis.metadata_state,
+        inode_id,
+        current_absolute_path,
+        currently_visible,
+        revision_no,
+    )
 }
 
 pub fn store_bytes_as_content<S: ObjectStore + ?Sized>(
@@ -1151,6 +1305,252 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
         content_digest,
         content_manifest_digest,
     })
+}
+
+fn build_authoritative_file_revision_list<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    head_seq: ChangeSeq,
+    metadata_state: &MetadataState,
+    inode_id: InodeId,
+    current_absolute_path: Option<String>,
+    currently_visible: bool,
+    before_revision_no: Option<RevisionNo>,
+    limit: Option<u32>,
+) -> Result<AuthoritativeFileRevisionList, CoreError> {
+    let limit = normalize_revision_page_limit(limit);
+    let mut revisions = metadata_state
+        .revisions
+        .iter()
+        .filter(|revision| revision.inode_id == inode_id && revision.committed_seq <= head_seq)
+        .filter(|revision| {
+            before_revision_no
+                .map(|before| revision.revision_no < before)
+                .unwrap_or(true)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    revisions.sort_by(|left, right| {
+        right
+            .revision_no
+            .cmp(&left.revision_no)
+            .then(right.committed_seq.cmp(&left.committed_seq))
+            .then(right.revision_op_index.cmp(&left.revision_op_index))
+    });
+
+    let has_more = revisions.len() > limit;
+    revisions.truncate(limit);
+    let next_before_revision_no = if has_more {
+        revisions.last().map(|revision| revision.revision_no)
+    } else {
+        None
+    };
+
+    let mut wal_context_by_seq = BTreeMap::new();
+    let revisions = revisions
+        .into_iter()
+        .map(|revision| {
+            build_authoritative_file_revision(
+                store,
+                namespace_id,
+                &revision,
+                &mut wal_context_by_seq,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(AuthoritativeFileRevisionList {
+        namespace_id: namespace_id.clone(),
+        inode_id,
+        authoritative_head_seq: head_seq,
+        current_absolute_path,
+        currently_visible,
+        next_before_revision_no,
+        revisions,
+    })
+}
+
+fn read_file_revision_bytes_for_inode<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    head_seq: ChangeSeq,
+    metadata_state: &MetadataState,
+    inode_id: InodeId,
+    current_absolute_path: Option<String>,
+    currently_visible: bool,
+    revision_no: RevisionNo,
+) -> Result<AuthoritativeFileRevisionBytes, CoreError> {
+    let revision = metadata_state
+        .revision_at_seq(inode_id, revision_no, head_seq)
+        .ok_or(CoreError::MissingRevision {
+            inode_id,
+            revision_no,
+        })?;
+    let mut wal_context_by_seq = BTreeMap::new();
+    let revision_entry =
+        build_authoritative_file_revision(store, namespace_id, &revision, &mut wal_context_by_seq)?;
+    let read =
+        read_durable_content_bytes(store, namespace_id, &revision_entry.content_manifest_digest)?;
+
+    Ok(AuthoritativeFileRevisionBytes {
+        namespace_id: namespace_id.clone(),
+        inode_id,
+        current_absolute_path,
+        currently_visible,
+        authoritative_head_seq: head_seq,
+        revision: revision_entry,
+        bytes: read.bytes,
+    })
+}
+
+fn build_authoritative_file_revision<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    revision: &crate::metadata::RevisionRecord,
+    wal_context_by_seq: &mut BTreeMap<ChangeSeq, RevisionCommitContext>,
+) -> Result<AuthoritativeFileRevision, CoreError> {
+    let validated =
+        validate_durable_content_reference(store, namespace_id, &revision.content_manifest_digest)?;
+    let commit_context =
+        load_revision_commit_context(store, namespace_id, revision, wal_context_by_seq)?;
+
+    Ok(AuthoritativeFileRevision {
+        revision_no: revision.revision_no,
+        committed_seq: revision.committed_seq,
+        content_manifest_digest: revision.content_manifest_digest.clone(),
+        size_bytes: validated.file_size_bytes,
+        content_digest: validated.file_digest_sha256,
+        commit_id: commit_context.commit_id,
+        request_id: commit_context.request_id,
+        message: commit_context.message,
+        annotations: commit_context.annotations,
+    })
+}
+
+fn load_revision_commit_context<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    revision: &crate::metadata::RevisionRecord,
+    wal_context_by_seq: &mut BTreeMap<ChangeSeq, RevisionCommitContext>,
+) -> Result<RevisionCommitContext, CoreError> {
+    if let Some(existing) = wal_context_by_seq.get(&revision.committed_seq) {
+        return Ok(existing.clone());
+    }
+
+    let envelope = load_wal_commit_envelope_for_seq(store, namespace_id, revision.committed_seq)?;
+    let matched = envelope.payload.results.iter().any(|result| match result {
+        CommitOpResult::CreateFile {
+            op_index,
+            inode_id,
+            revision_no,
+            ..
+        }
+        | CommitOpResult::ReplaceFile {
+            op_index,
+            inode_id,
+            revision_no,
+            ..
+        }
+        | CommitOpResult::RestoreRevision {
+            op_index,
+            inode_id,
+            revision_no,
+            ..
+        } => {
+            *op_index == revision.revision_op_index
+                && *inode_id == revision.inode_id
+                && *revision_no == revision.revision_no
+        }
+        _ => false,
+    });
+    if !matched {
+        return Err(CoreError::Store(format!(
+            "missing revision result for inode `{}` revision `{}` at seq `{}`",
+            revision.inode_id.0, revision.revision_no.0, revision.committed_seq.0
+        )));
+    }
+
+    let context = RevisionCommitContext {
+        commit_id: envelope.payload.commit_id,
+        request_id: envelope.payload.request_id,
+        message: envelope.payload.message,
+        annotations: envelope.payload.annotations,
+    };
+    wal_context_by_seq.insert(revision.committed_seq, context.clone());
+    Ok(context)
+}
+
+fn load_wal_commit_envelope_for_seq<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    seq: ChangeSeq,
+) -> Result<loon_api::WalCommitEnvelope, CoreError> {
+    let prefix = format!("namespaces/{}/wal/{:020}-", namespace_id.as_str(), seq.0);
+    let listed = store
+        .list_prefix(&prefix)
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    if listed.is_empty() {
+        return Err(CoreError::Store(format!(
+            "missing committed wal for seq `{}`",
+            seq.0
+        )));
+    }
+    if listed.len() > 1 {
+        return Err(CoreError::Store(format!(
+            "duplicate wal objects for seq `{}`: {}",
+            seq.0,
+            listed.join(", ")
+        )));
+    }
+
+    let object_key = listed[0].clone();
+    let encoded_bytes = store
+        .get(&object_key, None)
+        .map_err(|err| CoreError::Store(err.to_string()))?
+        .ok_or_else(|| CoreError::Store(format!("missing wal object `{object_key}` after list")))?;
+    decode_wal_commit_envelope_zstd(&encoded_bytes).map_err(|err| CoreError::Store(err.to_string()))
+}
+
+fn normalize_revision_page_limit(limit: Option<u32>) -> usize {
+    limit
+        .map(|value| value as usize)
+        .unwrap_or(DEFAULT_REVISION_PAGE_LIMIT)
+        .clamp(1, MAX_REVISION_PAGE_LIMIT)
+}
+
+fn visible_absolute_path_for_inode(
+    metadata_state: &MetadataState,
+    inode_id: InodeId,
+    seq: ChangeSeq,
+) -> Option<String> {
+    metadata_state.visible_inode(inode_id, seq)?;
+    if inode_id == InodeId(1) {
+        return Some("/".to_owned());
+    }
+
+    let mut current_inode = inode_id;
+    let mut components = Vec::new();
+    let mut visited = BTreeSet::new();
+
+    while current_inode != InodeId(1) {
+        if !visited.insert(current_inode.0) {
+            return None;
+        }
+        let binding = metadata_state.current_parent_binding_for_child(current_inode, seq)?;
+        let parent = metadata_state.visible_inode(binding.parent_inode_id, seq)?;
+        if parent.inode_kind != InodeKind::Dir {
+            return None;
+        }
+        components.push(binding.display_name);
+        current_inode = binding.parent_inode_id;
+    }
+
+    components.reverse();
+    if components.is_empty() {
+        Some("/".to_owned())
+    } else {
+        Some(format!("/{}", components.join("/")))
+    }
 }
 
 pub(crate) fn write_immutable_object<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/tests/history_reads.rs
+++ b/crates/loon-core/tests/history_reads.rs
@@ -1,0 +1,119 @@
+use loon_api::{NamespaceId, RevisionNo};
+use loon_core::{
+    bootstrap_namespace, delete_path_non_recursive, list_file_revisions_by_inode,
+    list_file_revisions_by_path, move_path, put_file_bytes, read_file_bytes_at_revision,
+    read_file_bytes_by_inode_at_revision, resolve_path, MutationContext, PutFileBehavior,
+};
+use loon_objectstore::fs::LocalFsStore;
+use tempfile::tempdir;
+
+#[test]
+fn path_history_follows_current_inode_after_rename() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace = NamespaceId::from("demo");
+
+    bootstrap_namespace(&store, &namespace, &context(), false).expect("bootstrap");
+    put_file_bytes(
+        &store,
+        &namespace,
+        "/docs/history.txt",
+        b"v1\n",
+        PutFileBehavior::CreateOnly,
+        &context(),
+        None,
+    )
+    .expect("create");
+    put_file_bytes(
+        &store,
+        &namespace,
+        "/docs/history.txt",
+        b"v2\n",
+        PutFileBehavior::ReplaceExisting,
+        &context(),
+        None,
+    )
+    .expect("replace");
+    move_path(
+        &store,
+        &namespace,
+        "/docs/history.txt",
+        "/docs/renamed.txt",
+        &context(),
+        None,
+    )
+    .expect("rename");
+
+    let revisions =
+        list_file_revisions_by_path(&store, &namespace, "/docs/renamed.txt", None, None)
+            .expect("list revisions");
+    assert_eq!(
+        revisions.current_absolute_path.as_deref(),
+        Some("/docs/renamed.txt")
+    );
+    assert!(revisions.currently_visible);
+    assert_eq!(revisions.revisions.len(), 2);
+    assert_eq!(revisions.revisions[0].revision_no, RevisionNo(2));
+    assert_eq!(revisions.revisions[1].revision_no, RevisionNo(1));
+
+    let first_revision =
+        read_file_bytes_at_revision(&store, &namespace, "/docs/renamed.txt", RevisionNo(1))
+            .expect("read revision");
+    assert_eq!(first_revision.bytes, b"v1\n");
+}
+
+#[test]
+fn inode_history_survives_delete_and_old_bytes_remain_readable() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace = NamespaceId::from("demo");
+
+    bootstrap_namespace(&store, &namespace, &context(), false).expect("bootstrap");
+    put_file_bytes(
+        &store,
+        &namespace,
+        "/docs/history.txt",
+        b"v1\n",
+        PutFileBehavior::CreateOnly,
+        &context(),
+        None,
+    )
+    .expect("create");
+    put_file_bytes(
+        &store,
+        &namespace,
+        "/docs/history.txt",
+        b"v2\n",
+        PutFileBehavior::ReplaceExisting,
+        &context(),
+        None,
+    )
+    .expect("replace");
+    let inode_id = resolve_path(&store, &namespace, "/docs/history.txt")
+        .expect("stat")
+        .inode_id;
+    delete_path_non_recursive(&store, &namespace, "/docs/history.txt", &context(), None)
+        .expect("delete");
+
+    let revisions = list_file_revisions_by_inode(&store, &namespace, inode_id, None, None)
+        .expect("list inode revisions");
+    assert_eq!(revisions.inode_id, inode_id);
+    assert!(!revisions.currently_visible);
+    assert!(revisions.current_absolute_path.is_none());
+    assert_eq!(revisions.revisions.len(), 2);
+    assert_eq!(revisions.revisions[0].size_bytes, 3);
+
+    let first_revision =
+        read_file_bytes_by_inode_at_revision(&store, &namespace, inode_id, RevisionNo(1))
+            .expect("read inode revision");
+    assert_eq!(first_revision.bytes, b"v1\n");
+}
+
+fn context() -> MutationContext {
+    MutationContext {
+        writer_id: "history-tests".to_owned(),
+        writer_version: "history-tests/0.1.0".to_owned(),
+        now_ms: 1,
+        lease_duration_ms: 1_000,
+    }
+}

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -13,14 +13,15 @@ use loon_api::{
     },
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    FilesystemPutBehavior, ListNamespacesResponse, NamespaceId,
+    FilesystemPutBehavior, ListNamespacesResponse, NamespaceId, RevisionNo,
 };
 use loon_core::{
     advance_retention_floor, begin_upload, bootstrap_namespace, commit_operations, complete_upload,
     copy_file_path, create_checkpoint, delete_path_non_recursive, list_changes_after,
-    list_namespaces, list_path, move_path, put_file_manifest, read_file_bytes, resolve_path,
-    upload_block, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
-    PutFileBehavior,
+    list_file_revisions_by_inode, list_file_revisions_by_path, list_namespaces, list_path,
+    move_path, put_file_manifest, read_file_bytes, read_file_bytes_at_revision,
+    read_file_bytes_by_inode_at_revision, resolve_path, upload_block, BootstrapNamespaceError,
+    CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
 };
 use loon_objectstore::ObjectStore;
 use std::net::SocketAddr;
@@ -39,6 +40,25 @@ struct AppState {
 #[derive(Debug, serde::Deserialize)]
 struct PathQuery {
     path: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct VersionsQuery {
+    path: String,
+    before_revision_no: Option<u64>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ContentQuery {
+    path: String,
+    revision_no: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InodeVersionsQuery {
+    before_revision_no: Option<u64>,
+    limit: Option<u32>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -66,10 +86,22 @@ fn app_with_store(config: ServerConfig, store: SharedStore) -> Router {
             "/v0/namespaces/:namespace/filesystem/list",
             get(list_entries),
         )
+        .route(
+            "/v0/namespaces/:namespace/filesystem/versions",
+            get(list_file_versions),
+        )
         .route("/v0/namespaces/:namespace/filesystem/stat", get(stat_entry))
         .route(
             "/v0/namespaces/:namespace/filesystem/content",
             get(get_content),
+        )
+        .route(
+            "/v0/namespaces/:namespace/inodes/:inode/revisions",
+            get(list_inode_revisions),
+        )
+        .route(
+            "/v0/namespaces/:namespace/inodes/:inode/revisions/:revision/content",
+            get(get_inode_revision_content),
         )
         .route(
             "/v0/namespaces/:namespace/filesystem/operations",
@@ -194,19 +226,96 @@ async fn stat_entry(
     Ok(Json(entry))
 }
 
+async fn list_file_versions(
+    State(state): State<AppState>,
+    AxumPath(namespace): AxumPath<String>,
+    headers: HeaderMap,
+    Query(query): Query<VersionsQuery>,
+) -> Result<Json<loon_api::AuthoritativeFileRevisionList>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let store = state.store.clone();
+    let namespace_id = NamespaceId::from(namespace);
+    let before_revision_no = query.before_revision_no.map(RevisionNo);
+    let limit = query.limit;
+    let path = query.path;
+    let revisions = run_blocking(move || {
+        list_file_revisions_by_path(
+            store.as_ref(),
+            &namespace_id,
+            &path,
+            before_revision_no,
+            limit,
+        )
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
+    })
+    .await?;
+    Ok(Json(revisions))
+}
+
 async fn get_content(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Query(query): Query<PathQuery>,
+    Query(query): Query<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let namespace_id = NamespaceId::from(namespace);
     let path = query.path;
+    let revision_no = query.revision_no.map(RevisionNo);
+    let bytes = run_blocking(move || {
+        match revision_no {
+            Some(revision_no) => {
+                read_file_bytes_at_revision(store.as_ref(), &namespace_id, &path, revision_no)
+                    .map(|file| file.bytes)
+            }
+            None => read_file_bytes(store.as_ref(), &namespace_id, &path).map(|file| file.bytes),
+        }
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
+    })
+    .await?;
+    Ok((StatusCode::OK, bytes).into_response())
+}
+
+async fn list_inode_revisions(
+    State(state): State<AppState>,
+    AxumPath((namespace, inode)): AxumPath<(String, u64)>,
+    headers: HeaderMap,
+    Query(query): Query<InodeVersionsQuery>,
+) -> Result<Json<loon_api::AuthoritativeFileRevisionList>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let store = state.store.clone();
+    let namespace_id = NamespaceId::from(namespace);
+    let revisions = run_blocking(move || {
+        list_file_revisions_by_inode(
+            store.as_ref(),
+            &namespace_id,
+            loon_api::InodeId(inode),
+            query.before_revision_no.map(RevisionNo),
+            query.limit,
+        )
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
+    })
+    .await?;
+    Ok(Json(revisions))
+}
+
+async fn get_inode_revision_content(
+    State(state): State<AppState>,
+    AxumPath((namespace, inode, revision)): AxumPath<(String, u64, u64)>,
+    headers: HeaderMap,
+) -> Result<Response, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let store = state.store.clone();
+    let namespace_id = NamespaceId::from(namespace);
     let file = run_blocking(move || {
-        read_file_bytes(store.as_ref(), &namespace_id, &path)
-            .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
+        read_file_bytes_by_inode_at_revision(
+            store.as_ref(),
+            &namespace_id,
+            loon_api::InodeId(inode),
+            RevisionNo(revision),
+        )
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
     })
     .await?;
     Ok((StatusCode::OK, file.bytes).into_response())
@@ -508,6 +617,7 @@ impl ApiResponseError {
             CoreErrorKind::InvalidPath => (StatusCode::BAD_REQUEST, "invalid_path"),
             CoreErrorKind::NamespaceNotFound => (StatusCode::NOT_FOUND, "namespace_not_found"),
             CoreErrorKind::PathNotFound => (StatusCode::NOT_FOUND, "path_not_found"),
+            CoreErrorKind::InodeNotFound => (StatusCode::NOT_FOUND, "inode_not_found"),
             CoreErrorKind::RevisionNotFound => (StatusCode::CONFLICT, "revision_not_found"),
             CoreErrorKind::PathConflict => (StatusCode::CONFLICT, "path_conflict"),
             CoreErrorKind::StaleHead => (StatusCode::CONFLICT, "stale_head"),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -437,6 +437,86 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_file_revision_listing_and_inode_history_reads_work() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loon-server-history",
+        "http-history",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = "demo";
+        harness
+            .client
+            .create_namespace(namespace)
+            .expect("create namespace");
+        let original = NamespacePath::parse("demo:/docs/history.txt").expect("original");
+        let renamed = NamespacePath::parse("demo:/docs/renamed.txt").expect("renamed");
+
+        harness
+            .client
+            .put_file_bytes(&original, b"v1\n", false)
+            .expect("create");
+        harness
+            .client
+            .put_file_bytes(&original, b"v2\n", true)
+            .expect("replace");
+        harness
+            .client
+            .move_path(&original, &renamed)
+            .expect("rename");
+
+        let renamed_stat = harness.client.stat_path(&renamed).expect("stat renamed");
+        let inode_id = renamed_stat.inode_id;
+        let revisions = harness
+            .client
+            .list_file_revisions(&renamed, None, None)
+            .expect("list path revisions");
+        assert_eq!(revisions.inode_id, inode_id);
+        assert_eq!(
+            revisions.current_absolute_path.as_deref(),
+            Some("/docs/renamed.txt")
+        );
+        assert!(revisions.currently_visible);
+        assert_eq!(revisions.revisions.len(), 2);
+        assert_eq!(revisions.revisions[0].revision_no, RevisionNo(2));
+        assert_eq!(revisions.revisions[1].revision_no, RevisionNo(1));
+
+        let first_bytes = harness
+            .client
+            .read_file_bytes_at_revision(&renamed, RevisionNo(1))
+            .expect("read historical bytes");
+        assert_eq!(first_bytes, b"v1\n");
+
+        harness
+            .client
+            .delete_path(&renamed)
+            .expect("delete renamed");
+
+        let inode_revisions = harness
+            .client
+            .list_inode_revisions(namespace, inode_id, None, None)
+            .expect("list inode revisions");
+        assert!(!inode_revisions.currently_visible);
+        assert!(inode_revisions.current_absolute_path.is_none());
+        assert_eq!(inode_revisions.revisions.len(), 2);
+
+        let inode_bytes = harness
+            .client
+            .read_file_bytes_by_inode_at_revision(namespace, inode_id, RevisionNo(1))
+            .expect("read inode revision bytes");
+        assert_eq!(inode_bytes, b"v1\n");
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_commit_rejects_same_request_id_with_different_payload() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -123,6 +123,11 @@ Each revision points to exactly one immutable content manifest. The manifest, in
 
 Blocks and manifests belong to the owning namespace. A file revision may reference only content that is durable under that namespace's content store.
 
+Revision history is therefore inode-scoped, not path-scoped. A rename changes the current derived
+path view but does not change which prior revisions belong to the file. A deleted file may lose
+its current visible path while its prior revisions remain addressable by `(namespace_id, inode_id,
+revision_no)`.
+
 LoonFS therefore uses a two-stage write model:
 
 ```text

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -80,12 +80,41 @@ Given a visible file inode at seq N:
 3. The manifest lists the file's ordered block digests. Fetch each block from `namespaces/{namespace_id}/blobs/{block_digest}`.
 4. Concatenate the blocks in manifest order to produce the file bytes.
 
+Historical file reads follow the same content procedure after selecting a specific revision:
+
+1. Identify the target file by current visible path at head or directly by `inode_id`.
+2. Resolve the desired `revision_no` for that inode at seq N.
+3. Read that revision's `content_manifest_digest`.
+4. Fetch the manifest and blocks exactly as for the current head revision.
+
+Path-based version reads are head-relative selectors: the path first resolves to the file currently
+visible there, and history is then read from that inode. Renamed or deleted files therefore
+require inode-based history lookup rather than historical-path search.
+
+### 2.4.1 File revision listing
+
+Given a file inode at seq N:
+
+1. Enumerate the inode's committed revisions with `committed_seq <= N`.
+2. Order them by descending `revision_no`.
+3. For each revision, derive size and file digest from the referenced manifest.
+4. Join the revision row back to the committed WAL entry at `(committed_seq, revision_op_index)`
+   to expose commit context such as `commit_id`, `request_id`, message, and annotations.
+
 ### 2.5 Directory listing
 
 Given a visible directory inode at seq N:
 
 1. Collect all active directory bindings whose `parent_inode_id` matches the directory.
 2. For each binding, resolve the child inode. If the child is a file, its latest revision provides size and content digest via the manifest.
+
+History-read failure modes must be explicit:
+
+- current path does not resolve to a visible item;
+- supplied inode id does not exist in namespace history;
+- supplied inode exists but is not a file;
+- supplied revision number does not exist for that inode; or
+- the referenced durable content or committed WAL object is missing or invalid.
 
 ## 3. One request, one visible sequence
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -64,7 +64,11 @@ A representative v0 binding is shown below.
 | --- | --- |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt` |
 | List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs` |
+| List current file versions by path | `GET /v0/namespaces/{ns}/filesystem/versions?path=/docs/report.txt` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
+| Read historical file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=7` |
+| List file versions by inode | `GET /v0/namespaces/{ns}/inodes/42/revisions` |
+| Read historical file content by inode | `GET /v0/namespaces/{ns}/inodes/42/revisions/7/content` |
 | Apply path-oriented operations | `POST /v0/namespaces/{ns}/filesystem/operations` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
 | Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
@@ -119,7 +123,38 @@ A few representative requests and responses are shown below. These examples are 
 The response body is the authoritative file bytes. Metadata may be exposed in headers, but the
 body itself is raw content rather than JSON.
 
-### 3.4 `POST /filesystem/operations`
+When `revision_no` is omitted, the body is the current visible file bytes for the inode currently
+selected by `path`. When `revision_no` is present, the body is the bytes for that specific
+revision of that inode.
+
+### 3.4 `GET /filesystem/versions`
+
+```json
+{
+  "namespace_id": "demo",
+  "inode_id": 42,
+  "authoritative_head_seq": 418,
+  "current_absolute_path": "/docs/report.txt",
+  "currently_visible": true,
+  "revisions": [
+    {
+      "revision_no": 7,
+      "committed_seq": 418,
+      "content_manifest_digest": "sha256:report-v7",
+      "size_bytes": 19482,
+      "content_digest": "sha256:file-v7",
+      "commit_id": "c_01J...",
+      "request_id": "req_01J...",
+      "message": "replace report bytes"
+    }
+  ]
+}
+
+Path-oriented history lookup is head-relative: the server first resolves the current visible path,
+then lists revisions for that inode. Renamed or deleted files should use the inode-based history
+surface.
+
+### 3.5 `POST /filesystem/operations`
 
 Representative request:
 
@@ -166,7 +201,7 @@ Representative response:
 }
 ```
 
-### 3.5 Upload transport
+### 3.6 Upload transport
 
 The upload transport standardizes staged content publication, not one specific byte path.
 
@@ -200,7 +235,7 @@ Representative complete-upload response:
 }
 ```
 
-### 3.6 `POST /commits`
+### 3.7 `POST /commits`
 
 Representative request:
 
@@ -255,7 +290,7 @@ Representative response:
 }
 ```
 
-### 3.7 `GET /changes`
+### 3.8 `GET /changes`
 
 ```json
 {


### PR DESCRIPTION
Add file revision listing and historical content reads across the core, HTTP, client, and CLI surfaces.

New API routes & cli commands
- `GET /v0/namespaces/{ns}/filesystem/versions?path=...&before_revision_no=...&limit=...`
- `GET /v0/namespaces/{ns}/filesystem/content?path=...&revision_no=...`
- `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?before_revision_no=...&limit=...`
- `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content`
- `loon versions <path>`
- `loon versions --inode <inode_id>`
- `loon cat <path> --revision <revision_no>`
- `loon cat --inode <inode_id> --revision <revision_no>`
- `loon get <path> --revision <revision_no> [destination|-]`
- `loon get --inode <inode_id> --revision <revision_no> <destination|->`

Design decisions:
- Version history is inode-scoped rather than path-scoped.
- Path-based history resolves the current visible path at head and then reads revisions for that inode.
- Inode-based history remains available after rename or delete.
- Historical path search across renames and deletes is intentionally not supported.
- Historical reads reuse existing immutable manifests and blobs; no new durable object families were added.
- Revision listings include commit context by joining revision rows back to committed WAL entries.
- The content read surface continues to return raw bytes; `revision_no` only changes which revision is read.