### PR TITLE
docs: reduce core spec ops scope and clarify batch WAL

### DIFF
--- a/docs/appendices/095-operation-statefulness-matrix.md
+++ b/docs/appendices/095-operation-statefulness-matrix.md
@@ -8,7 +8,7 @@ LoonFS supports both one-shot operations and long-running operations. One-shot o
 
 This section standardizes:
 
-- which classes of operations require server-side control-plane objects;
+- which classes of operations may use server-side control-plane objects;
 - which classes of operations are normally single-request operations;
 - which part of each operation is authoritative on the server; and
 - which part of each operation is maintained by the client.
@@ -20,26 +20,28 @@ For the purposes of this specification:
 | Term | Meaning |
 | --- | --- |
 | **Single-request operation** | An operation that is fully described by a single request and does not require a server-side control object after the request completes. |
-| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. Examples include `UploadHandle`, and `PutIntent`. |
+| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. For large or resumable `put <file>`, an implementation may use a single `UploadHandle`. |
 | **Implementation-specific coordinator** | A helper resource or service that correlates multiple logical commits for one higher-level workflow. Coordinators are outside the core interoperable model and do not define namespace history. |
 | **Authoritative operation state** | The state that determines the correctness, visibility, and resumability of an operation. |
 | **Transfer progress** | Non-authoritative progress information such as completed bytes, completed files, local temporary outputs, or user-interface counters. |
 
 ### 095.3. Normative rules
 
-1. A LoonFS operation **MAY** be sessionless only when all of the following are true:
+1. A LoonFS operation **MAY** be a single-request operation only when all of the following are true:
    - the operation is fully described by one request;
    - the operation completes synchronously;
    - no pinned read snapshot is required after the request returns;
    - no stable destination binding is required after the request returns; and
    - the request can be retried by replaying the full request.
 
-2. A LoonFS operation **MUST** use a server-side handle when any of the following are true:
+2. A LoonFS operation **MAY** use a server-side control object when any of the following are true:
    - the client will continue the operation across multiple requests;
    - the operation requires a pinned snapshot for consistent reads;
    - the operation requires a stable destination binding across time;
    - the operation requires resumable multi-part upload; or
    - loss of server restart state would change correctness, retention safety, or promised resumability guarantees.
+
+   For large or resumable `put <file>`, an implementation that uses a server-side control object typically uses a single `UploadHandle`.
 
 3. The core specification does **NOT** require a server-side job object for recursive `put` or recursive `cp`. Those workflows may be realized as one or more logical commits, optionally coordinated by implementation-specific helpers outside the core model.
 
@@ -51,11 +53,11 @@ For the purposes of this specification:
 
 ### 095.4. Operation statefulness matrix
 
-| Operation | Typical execution shape | Core server-side control-plane object | Long-lived server state required? | Server is authoritative for | Client is authoritative for |
+| Operation | Typical execution shape | Typical server-side control-plane object | Long-lived server state required? | Server is authoritative for | Client is authoritative for |
 | --- | --- | --- | --- | --- | --- |
 | `get <file>` | Single-request read | none | No | path resolution, access check, selected file revision, content serving or delegated download | local download progress, temporary file, client retries |
 | `put <file>` (small, one-shot convenience) | Single request | none | No | destination resolution, validation, metadata commit | request payload, client retries |
-| `put <file>` (large or resumable) | Begin, upload, commit | `PutIntent` and `UploadHandle` | Yes | stable destination binding, expected slot or revision, upload handle validity, final publish | file reading, hashing, block upload progress, retry tokens |
+| `put <file>` (large or resumable) | Begin, upload, commit | `UploadHandle`, if used | Only if server-side resumability or stable binding is promised | stable destination binding, expected slot or revision, upload handle validity, final publish | file reading, hashing, block upload progress, retry tokens |
 | `cp <file>` (same server) | Single-request server-side copy | none | No | source resolution, destination resolution, metadata publication, content reference reuse | request retry |
 | `cp remote -> local` | Alias for `get` or `get -r` | same as `get` | same as `get` | same as `get` | same as `get` |
 | `cp local -> remote` | Alias for `put` or `put -r` | same as `put` | same as `put` | same as `put` | same as `put` |
@@ -68,7 +70,7 @@ The following table is the normative split of responsibility for the primary fil
 | --- | --- | --- |
 | `get <file>` | resolve the requested path or handle; authorize the read; select the file revision to read; serve bytes or delegated download targets | receive bytes; write local output; maintain local retry and resume state |
 | `put <file>` (one-shot) | resolve the destination; validate preconditions; publish the metadata change | supply bytes or content reference; retry the request if needed |
-| `put <file>` (resumable) | create the `PutIntent`; bind the destination; create or validate the `UploadHandle`; validate durable content and commit the final publish | read the local file; chunk and hash it; upload missing blocks; track upload progress; submit the final commit request |
+| `put <file>` (resumable) | if an `UploadHandle` is used, create or validate it; bind the destination; validate durable content and commit the final publish | read the local file; chunk and hash it; upload missing blocks; track upload progress; submit the final commit request |
 | `cp <file>` (same server) | resolve source and destination; authorize both sides; create the copied resource; publish the metadata change | submit the request; retry if appropriate |
 
 ### 095.6. When raw paths cease to identify the operation
@@ -78,26 +80,24 @@ LoonFS accepts path-oriented input because user intent is naturally expressed by
 | Operation | Raw path is used for | Stable in-flight identity after start |
 | --- | --- | --- |
 | `get <file>` | the request itself | none required |
-| `put <file>` (resumable) | `begin_put` only | `PutIntent` and `UploadHandle` |
+| `put <file>` (resumable) | `begin_put` only | server-issued `UploadHandle`, if used |
 
 ### 095.7. Control-plane durability guidance
 
-1. A control-object **MUST** be durably recorded if losing it on restart would change correctness, visibility, retention safety, or promised resumability.
+1. A control object **MUST** be durably recorded if losing it on restart would change correctness, visibility, retention safety, or promised resumability.
 
-2. At minimum, the following control-plane objects are normally durable:
-   - `PutIntent`;
-   - `UploadHandle`;
+2. At minimum, an `UploadHandle` is normally durable when an implementation uses one for stable destination binding across time or restart-safe resumability.
 
 3. Implementation-specific coordinators **MAY** also be stored durably, but they are not required by this specification.
 
-4. Control-objects and any implementation-specific coordinators **MUST** remain outside namespace-visible metadata. Their existence is authoritative for orchestration, not for filesystem history.
+4. Control objects and any implementation-specific coordinators **MUST** remain outside namespace-visible metadata. Their existence is authoritative for orchestration, not for filesystem history.
 
 ### 095.8. Recommended defaults
 
 A conforming implementation SHOULD use the following defaults unless a stronger mode is explicitly requested:
 
-- `get <file>` is sessionless;
-- `cp <file>` on the same service is sessionless;
-- large or resumable `put <file>` uses `PutIntent` and `UploadHandle`;
+- `get <file>` is a single-request operation;
+- `cp <file>` on the same service is a single-request operation;
+- if large or resumable `put <file>` uses a control object, it uses a single `UploadHandle`;
 
 These defaults preserve a simple model for single-request commands while allowing multi-request correctness and resumability where they actually matter.

--- a/docs/appendices/095-operation-statefulness-matrix.md
+++ b/docs/appendices/095-operation-statefulness-matrix.md
@@ -1,6 +1,6 @@
 ## 095. Operation Statefulness Matrix
 
-This section defines when a LoonFS operation is sessionless, when it uses a server-side session, and when it uses a server-side job. It also defines the split of responsibility between the client and server for common filesystem operations.
+This section defines when a LoonFS operation is a single-request operation and when it uses a control object. It also defines the split of responsibility between the client and server for common filesystem operations. Recursive `put` and recursive `cp` may also be coordinated by implementation-specific helpers, but those helpers are outside the core interoperable model.
 
 ### 095.1. Purpose
 
@@ -9,7 +9,7 @@ LoonFS supports both one-shot operations and long-running operations. One-shot o
 This section standardizes:
 
 - which classes of operations require server-side control-plane objects;
-- which classes of operations are normally sessionless;
+- which classes of operations are normally single-request operations;
 - which part of each operation is authoritative on the server; and
 - which part of each operation is maintained by the client.
 
@@ -19,9 +19,9 @@ For the purposes of this specification:
 
 | Term | Meaning |
 | --- | --- |
-| **Sessionless operation** | An operation that is fully described by a single request and does not require a server-side session or job after the request completes. |
-| **Session** | A server-side control-plane object used when the client continues driving an operation across multiple requests. Examples include `ReadSession`, `UploadSession`, and `PutIntent`. |
-| **Job** | A server-side control-plane object used when the server continues performing work after the initiating request returns. Examples include `CopyJob` and `ImportJob`. |
+| **Single-request operation** | An operation that is fully described by a single request and does not require a server-side control object after the request completes. |
+| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. Examples include `UploadHandle`, and `PutIntent`. |
+| **Implementation-specific coordinator** | A helper resource or service that correlates multiple logical commits for one higher-level workflow. Coordinators are outside the core interoperable model and do not define namespace history. |
 | **Authoritative operation state** | The state that determines the correctness, visibility, and resumability of an operation. |
 | **Transfer progress** | Non-authoritative progress information such as completed bytes, completed files, local temporary outputs, or user-interface counters. |
 
@@ -34,34 +34,31 @@ For the purposes of this specification:
    - no stable destination binding is required after the request returns; and
    - the request can be retried by replaying the full request.
 
-2. A LoonFS operation **MUST** use a server-side session when any of the following are true:
+2. A LoonFS operation **MUST** use a server-side handle when any of the following are true:
    - the client will continue the operation across multiple requests;
    - the operation requires a pinned snapshot for consistent reads;
    - the operation requires a stable destination binding across time;
    - the operation requires resumable multi-part upload; or
-   - loss of server restart state would change correctness, retention safety, or resumability guarantees.
+   - loss of server restart state would change correctness, retention safety, or promised resumability guarantees.
 
-3. A LoonFS operation **MUST** use a server-side job when the server continues executing work after the initiating request returns.
+3. The core specification does **NOT** require a server-side job object for recursive `put` or recursive `cp`. Those workflows may be realized as one or more logical commits, optionally coordinated by implementation-specific helpers outside the core model.
 
-4. When a server-side session or job is used, the authoritative identity of the operation **MUST** become the server-issued session or job identifier. After that point, the original path string is entry input only and **MUST NOT** remain the sole identifier of the in-flight operation.
+4. When a server-side control-plane object is used, the authoritative identity of the in-flight interaction **MUST** become the server-issued object identifier. After that point, the original path string is entry input only and **MUST NOT** remain the sole identifier of the in-flight interaction.
 
-5. Server-side sessions and jobs are control-plane objects. They **MUST NOT** advance namespace `seq`, **MUST NOT** appear as filesystem-visible resources, and **MUST NOT** appear in the namespace change feed.
+5. Server-side control-plane objects **MUST NOT** advance namespace `seq`, **MUST NOT** appear as filesystem-visible resources, and **MUST NOT** appear in the namespace change feed.
+
+6. Implementation-specific coordinators **MAY** exist, but they **MUST NOT** redefine logical commit boundaries or change-feed semantics.
 
 ### 095.4. Operation statefulness matrix
 
-| Operation | Typical execution shape | Server-side control-plane object | Long-lived server state required? | Server is authoritative for | Client is authoritative for |
+| Operation | Typical execution shape | Core server-side control-plane object | Long-lived server state required? | Server is authoritative for | Client is authoritative for |
 | --- | --- | --- | --- | --- | --- |
 | `get <file>` | Single-request read | none | No | path resolution, access check, selected file revision, content serving or delegated download | local download progress, temporary file, client retries |
-| `get -r <dir>` | Multi-request recursive snapshot read | `ReadSession` | Yes | resolved root, pinned snapshot, traversal policy, optional retention hold | traversal order, local materialization, completed files, local resume state |
 | `put <file>` (small, one-shot convenience) | Single request | none | No | destination resolution, validation, metadata commit | request payload, client retries |
-| `put <file>` (large or resumable) | Begin, upload, commit | `PutIntent` and `UploadSession` | Yes | stable destination binding, expected slot or revision, upload session validity, final publish | file reading, hashing, block upload progress, retry tokens |
-| `put -r <dir>` (small tree) | Upload then one batched commit | implementation-defined; often none | Usually no | final batched metadata commit | local traversal, file hashing, upload progress |
-| `put -r <dir>` (general or resumable) | Long-running import | `ImportJob`, or durable set of `PutIntent`s | Yes | destination root binding, per-item publish state, restart-safe import state | local traversal, file hashing, user-visible progress |
+| `put <file>` (large or resumable) | Begin, upload, commit | `PutIntent` and `UploadHandle` | Yes | stable destination binding, expected slot or revision, upload handle validity, final publish | file reading, hashing, block upload progress, retry tokens |
 | `cp <file>` (same server) | Single-request server-side copy | none | No | source resolution, destination resolution, metadata publication, content reference reuse | request retry |
-| `cp -r <dir>` (same server) | Long-running recursive server-side copy | `CopyJob` | Yes | source snapshot, destination binding, traversal, copy progress, final publish | start, poll, cancel, progress display |
 | `cp remote -> local` | Alias for `get` or `get -r` | same as `get` | same as `get` | same as `get` | same as `get` |
 | `cp local -> remote` | Alias for `put` or `put -r` | same as `put` | same as `put` | same as `put` | same as `put` |
-| `cp serverA -> serverB` | Cross-service transfer | source `ReadSession`; destination `PutIntent`, `UploadSession`, or `ImportJob` | Yes, but split across services | each service is authoritative for its own side only | end-to-end coordination, bridging retries, overall progress |
 
 ### 095.5. Client and server split for common commands
 
@@ -70,12 +67,9 @@ The following table is the normative split of responsibility for the primary fil
 | Command | Server responsibilities | Client responsibilities |
 | --- | --- | --- |
 | `get <file>` | resolve the requested path or handle; authorize the read; select the file revision to read; serve bytes or delegated download targets | receive bytes; write local output; maintain local retry and resume state |
-| `get -r <dir>` | create the `ReadSession`; pin the authoritative snapshot; enforce traversal policy such as mount-crossing rules; serve entry listings and file content within the session | traverse the returned directory tree; schedule downloads; create local directories and files; track completed outputs |
 | `put <file>` (one-shot) | resolve the destination; validate preconditions; publish the metadata change | supply bytes or content reference; retry the request if needed |
-| `put <file>` (resumable) | create the `PutIntent`; bind the destination; create or validate the `UploadSession`; validate durable content and commit the final publish | read the local file; chunk and hash it; upload missing blocks; track upload progress; submit the final commit request |
-| `put -r <dir>` | validate and publish the imported remote tree; if an `ImportJob` is used, maintain authoritative import state | walk the local tree; produce upload content; track local progress; optionally poll job state |
+| `put <file>` (resumable) | create the `PutIntent`; bind the destination; create or validate the `UploadHandle`; validate durable content and commit the final publish | read the local file; chunk and hash it; upload missing blocks; track upload progress; submit the final commit request |
 | `cp <file>` (same server) | resolve source and destination; authorize both sides; create the copied resource; publish the metadata change | submit the request; retry if appropriate |
-| `cp -r <dir>` (same server) | create the `CopyJob`; pin the source snapshot; bind the destination; execute traversal and publication; report progress and final result | initiate the job; poll status; cancel if supported; display progress |
 
 ### 095.6. When raw paths cease to identify the operation
 
@@ -84,24 +78,19 @@ LoonFS accepts path-oriented input because user intent is naturally expressed by
 | Operation | Raw path is used for | Stable in-flight identity after start |
 | --- | --- | --- |
 | `get <file>` | the request itself | none required |
-| `get -r <dir>` | opening the recursive read | `ReadSession` and session-scoped entry handles |
-| `put <file>` (resumable) | `begin_put` only | `PutIntent` and `UploadSession` |
-| `put -r <dir>` (resumable) | opening the import | `ImportJob`, or destination-root handle plus per-file intents |
-| `cp -r <dir>` (same server) | creating the copy operation | `CopyJob` |
+| `put <file>` (resumable) | `begin_put` only | `PutIntent` and `UploadHandle` |
 
 ### 095.7. Control-plane durability guidance
 
-1. A session or job **MUST** be durably recorded if losing it on restart would change correctness, visibility, retention safety, or promised resumability.
+1. A control-object **MUST** be durably recorded if losing it on restart would change correctness, visibility, retention safety, or promised resumability.
 
 2. At minimum, the following control-plane objects are normally durable:
    - `PutIntent`;
-   - `UploadSession`;
-   - `CopyJob`; and
-   - any `ReadSession` or `ImportJob` that promises restart-safe resumption or pins retention-sensitive content.
+   - `UploadHandle`;
 
-3. Sessions and jobs **MAY** be stored in object storage using the same create-if-absent, compare-and-swap, and read-after-write guarantees used elsewhere in LoonFS. A separate transactional database is not required by this specification.
+3. Implementation-specific coordinators **MAY** also be stored durably, but they are not required by this specification.
 
-4. Sessions and jobs **MUST** remain outside namespace-visible metadata. Their existence is authoritative for orchestration, not for filesystem history.
+4. Control-objects and any implementation-specific coordinators **MUST** remain outside namespace-visible metadata. Their existence is authoritative for orchestration, not for filesystem history.
 
 ### 095.8. Recommended defaults
 
@@ -109,9 +98,6 @@ A conforming implementation SHOULD use the following defaults unless a stronger 
 
 - `get <file>` is sessionless;
 - `cp <file>` on the same service is sessionless;
-- `get -r <dir>` uses a `ReadSession`;
-- large or resumable `put <file>` uses `PutIntent` and `UploadSession`;
-- same-service `cp -r <dir>` uses a `CopyJob`; and
-- recursive `put` uses an `ImportJob` once resumability, restart safety, or large-tree import is required.
+- large or resumable `put <file>` uses `PutIntent` and `UploadHandle`;
 
-These defaults preserve a simple model for single-request commands while providing stable identities for long-running operations.
+These defaults preserve a simple model for single-request commands while allowing multi-request correctness and resumability where they actually matter.

--- a/docs/specs/000-overview.md
+++ b/docs/specs/000-overview.md
@@ -8,7 +8,7 @@ The durable state consists of:
 
 - immutable content blocks
 - immutable content manifests
-- immutable metadata commits in a write-ahead log (WAL)
+- immutable metadata commits recorded in a write-ahead log (WAL)
 - immutable checkpoints
 - small mutable control objects such as the namespace head and leases
 
@@ -28,7 +28,7 @@ The design goals are:
 
 | Goal | Meaning |
 | --- | --- |
-| **Simple** | The durable model should fit in a small number of concepts: namespaces, inodes, revisions, content manifests, commits, and checkpoints. |
+| **Simple** | The durable model should fit in a small number of concepts: namespaces, inodes, revisions, content manifests, logical commits, WAL segments, and checkpoints. |
 | **Portable** | The only required durable dependency is object storage with a small set of well-defined guarantees. |
 | **Safe** | Writes are never partially visible. Metadata never points to content that is not already durable. |
 | **Readable** | A reader should be able to understand the system from a small public spec without reading client architecture or rollout plans. |
@@ -43,12 +43,12 @@ The design goals are:
 | Identity | The canonical identity of an item is `(namespace_id, inode_id)`. |
 | Names | Paths are lookup views built from directory bindings. They are not the identity model. |
 | Content publication | File content becomes visible only after its blocks and content manifest are already durable. |
-| Commit visibility | A metadata change becomes visible only when the namespace head advances successfully. |
+| Commit visibility | A logical commit becomes visible only when the namespace head advances successfully to a `seq` at or beyond that commit. |
 | Delete | Delete is logical first and creates tombstones. Physical reclamation is background garbage collection. |
-| Recovery | Readers reconstruct state from a verified checkpoint plus the WAL tail after that checkpoint. |
+| Recovery | Readers reconstruct state from a verified checkpoint plus the visible WAL segment chain after that checkpoint. |
 | Writes | A path-oriented filesystem API and an explicit upload/commit/change-feed API are both part of the core model. |
 | Access control | ACLs and shares are a separate control plane keyed by namespace or subtree identity, not by path text. |
-| Long-running operations | Recursive reads, resumable uploads, and server-side copy jobs may use control-plane sessions or jobs. These do not change namespace history. |
+| Long-running operations | Resumable uploads may use control-plane objects. |
 
 ## 4. System sketch
 
@@ -62,9 +62,9 @@ The design goals are:
              /                    |                 \
             /                     |                  \
            v                      v                   v
-  object-storage content   metadata history      control objects
-  blocks and manifests     WAL, head, checkpoints sessions, jobs,
-                                                shares, leases
+  object-storage content   metadata history      control objects,
+  blocks and manifests     WAL segments, head,    shares, leases
+                           checkpoints           
 ```
 
 ## 5. What this spec leaves to implementations
@@ -76,6 +76,7 @@ The following are intentionally outside the core spec:
 - queue shard layouts
 - platform-specific file-watcher integrations
 - exact binary encodings for large immutable metadata objects
+- whether recursive workflows use purely client-side orchestration or implementation-specific coordinators
 - whether one implementation uses a single process or several services internally
 
 Those choices are implementation-specific and do not change the filesystem model.

--- a/docs/specs/010-glossary.md
+++ b/docs/specs/010-glossary.md
@@ -2,14 +2,16 @@
 
 | Term | Meaning |
 | --- | --- |
-| **Namespace** | The unit of ordered metadata history. Each namespace has its own head, WAL, checkpoints, and retention policy. |
-| **Head** | A small mutable object that names the current visible sequence number (`seq`), the next inode id, and replay hints such as the latest checkpoint and retention floor. |
+| **Namespace** | The unit of ordered metadata history. Each namespace has its own head, WAL segments, checkpoints, and retention policy. |
+| **Head** | A small mutable object that names the current visible sequence number (`seq`), the next inode id, and replay hints such as the latest checkpoint, the retention floor, and the visible WAL tip. |
 | **Seq** | The namespace-local number that gives the visible order of committed metadata changes. |
+| **Commit** | One accepted client commit request that records one ordered set of metadata changes and is assigned a seq. |
+| **WAL segment** | One immutable WAL object containing one or more commits with a contiguous sequence range. |
+| **WAL** | The write-ahead log formed by the visible chain of immutable WAL segments. |
 | **Inode** | The durable identity of a filesystem item within one namespace. An inode stays the same when its path changes. |
 | **Direntry** | A directory binding that places one inode under one parent directory and one name. |
 | **Path** | A human-friendly name built by walking visible directory bindings. Paths can change; inode identity does not. |
 | **Revision** | One immutable committed version of a file's content. Revisions are ordered by `revision_no` within an inode. |
-| **WAL** | The write-ahead log of immutable metadata commit objects. |
 | **Checkpoint** | A verified snapshot of namespace metadata at one chosen `seq`. It lets readers avoid replaying the entire WAL history. |
 | **Content block** | One immutable block of file bytes. In v0, blocks are fixed-size except for the final partial block. |
 | **Content manifest** | The immutable object that describes a file's size, digest, block size, and ordered list of content blocks. |
@@ -22,5 +24,6 @@
 | **ACL** | An access-control rule granting a principal a role over a namespace or subtree. ACLs are not part of namespace metadata history. |
 | **Share** | An access grant to a namespace or subtree. A share may later be presented through a mount in another tree. |
 | **Precondition** | A rule that must still hold at an explicit namespace history point before a commit is accepted. |
-| **Request id** | A stable client-generated id used for idempotent retries. |
-| **Session / job** | A server-side control object used for long-running operations such as recursive reads, resumable uploads, and server-side copies. |
+| **Request id** | A stable client-generated id used for idempotent retries of one commit request. |
+| **Operation id** | Optional commit metadata used to correlate multiple commits that belong to one higher-level workflow. |
+| **Control object** | A server-side control-plane object used to preserve authoritative state across multiple requests, such as a pinned read snapshot, a resumable upload, or a stable destination binding. |

--- a/docs/specs/020-architecture-overview.md
+++ b/docs/specs/020-architecture-overview.md
@@ -4,8 +4,8 @@
 
 | Part | Role |
 | --- | --- |
-| **Object store** | Holds every durable object: content blocks, content manifests, WAL entries, checkpoints, and small control objects. |
-| **Authoritative service** | Resolves paths, validates mutations, writes WAL entries, advances heads, serves reads, and issues capabilities for upload or download. |
+| **Object store** | Holds every durable object: content blocks, content manifests, WAL segments, checkpoints, and small control objects. |
+| **Authoritative service** | Resolves paths, validates mutations, writes logical commits into WAL segments, advances heads, serves reads, and issues capabilities for upload or download. |
 | **Clients** | Use either direct filesystem operations or the lower-level upload, commit, and change-feed model. |
 | **Access-control service** | Evaluates ACLs and shares, then authorizes LoonFS operations. This may be part of the authoritative service in a simple deployment. |
 | **Background workers** | Build checkpoints, advance retention safely, clean up expired control objects, and reclaim unreachable content. |
@@ -17,8 +17,8 @@ This spec uses three terms.
 | Plane | Purpose | Examples | Namespace-visible history? |
 | --- | --- | --- | --- |
 | **Data plane** | Stores and serves file bytes. | Content blocks, content manifests, download streams. | No, by itself. |
-| **Metadata plane** | Defines the filesystem's durable truth. | WAL entries, namespace head, checkpoints, inode and direntry state. | Yes. |
-| **Control plane** | Coordinates long-running work and authorization. | Upload sessions, read sessions, copy jobs, ACLs, shares, leases. | No. |
+| **Metadata plane** | Defines the filesystem's durable truth. | WAL segments, namespace head, checkpoints, inode and direntry state. | Yes. |
+| **Control plane** | Coordinates multi-request work and authorization. | Upload handles, put intents, ACLs, shares, leases. | No. |
 
 Two rules follow from this split:
 
@@ -42,12 +42,13 @@ A CLI, desktop app, web app, SDK, or service may implement one or more of these 
 
 ## 4. Operation classes
 
-Most operations fall into one of three classes.
+Most core operations fall into one of two classes.
 
 | Class | Typical examples | Server-side state |
 | --- | --- | --- |
 | **One-shot** | `ls`, `stat`, `get <file>`, `put <small file>`, `cp <file>` on one service | Usually none after the request completes. |
-| **Client-driven long-running** | recursive `get`, resumable `put` | A session or intent may be used to pin a snapshot or destination across multiple requests. |
-| **Server-driven long-running** | recursive same-service `cp`, large import jobs | A job record may be used while the server continues the work. |
+| **Client-driven long-running** | recursive `get`, resumable `put`, recursive `put`, recursive `cp` realized as several commits | A handle or intent may be used to pin a snapshot or destination across multiple requests. Other orchestration may remain client-side. |
 
-Sessions and jobs preserve stable meaning across time. They do not create a second history model.
+Implementations may additionally expose coordinator-specific helpers for recursive workflows or admin work, but those helpers are outside the interoperable core model.
+
+Control-objects and any implementation-specific helpers preserve stable meaning across time. They do not create a second history model.

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -10,10 +10,10 @@ A conforming object-store layer must provide the following behavior.
 
 | Guarantee | Rationale |
 | --- | --- |
-| **Create-if-absent** for immutable objects | Content blocks, manifests, WAL entries, and checkpoints must never be silently overwritten. |
+| **Create-if-absent** for immutable objects | Content blocks, manifests, WAL segments, and checkpoints must never be silently overwritten. |
 | **Compare-and-swap update** for small mutable objects | The namespace head and similar control objects must be advanced safely in the presence of concurrent writers. |
 | **Strong consistency** | A successful put/delete operation must become authoritative immediately after it succeeds. |
-| **Prefix enumeration** | WAL discovery, checkpoint discovery, repair, and cleanup need a reliable way to enumerate objects by prefix. |
+| **Prefix enumeration** | Checkpoint discovery, WAL segment discovery for repair and cleanup, and general namespace inspection need a reliable way to enumerate objects by prefix. |
 | **Deterministic key scoping** | Providers must not allow objects outside the configured namespace or tenant prefix to leak into operations. |
 | **Consistent error signaling for failed preconditions** | Higher layers need one generic way to detect stale writes and retry or fail safely. |
 
@@ -25,17 +25,27 @@ The required durable object families and standard key patterns are:
 
 | Family | Mutability | Purpose | Standard object key pattern |
 | --- | --- | --- | --- |
-| **Namespace head** | Mutable | Record the current visible boundary and replay hints. | `namespaces/{namespace_id}/head.json` |
+| **Namespace head** | Mutable | Record the current visible boundary, replay hints, and visible WAL tip. | `namespaces/{namespace_id}/head.json` |
 | **Namespace lease** | Mutable | Fence concurrent publishers when the deployment uses more than one possible writer. | `namespaces/{namespace_id}/lease.json` |
 | **Content blocks** | Immutable | Store file bytes. | `namespaces/{namespace_id}/blobs/{block_digest_sha256}` |
 | **Content manifests** | Immutable | Describe file size, digest, block size, and the ordered block list. | `namespaces/{namespace_id}/manifests/{content_manifest_digest}.json` |
-| **WAL entries** | Immutable | Record committed metadata changes. | `namespaces/{namespace_id}/wal/{seq}-{commit_id}.cbor.zst` |
+| **WAL segments** | Immutable | Record one or more logical commits with a contiguous sequence range. | `namespaces/{namespace_id}/wal/{start_seq}-{end_seq}-{segment_id}.cbor.zst` |
 | **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/manifest.json` |
 | **Checkpoint segments** | Immutable | Store verified checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/tables/{family}-{segment_index}.sst.zst` |
 
 These key shapes are part of the interoperable storage contract. Implementations may add other control-plane objects.
 
-## 4. Immutable content rules
+## 4. WAL segment rules
+
+The metadata log has five important rules.
+
+1. A logical commit is the semantic record of one accepted client commit request.
+2. A WAL segment stores one or more logical commits with contiguous `seq` values.
+3. Distinct client commit requests remain distinct logical commits even when they are stored in the same WAL segment.
+4. The visible WAL chain must be deterministically recoverable from the head plus referenced segment metadata. A head field such as `wal_tip_segment_id`, together with segment metadata such as `segment_id`, `start_seq`, `end_seq`, `base_head_seq`, and `prev_visible_segment_id`, is one conforming shape. Equivalent semantics are acceptable.
+5. Orphan WAL segments are permitted and harmless when a writer loses the head compare-and-swap.
+
+## 5. Immutable content rules
 
 The content model has four rules.
 
@@ -46,13 +56,13 @@ The content model has four rules.
 
 In v0, file content is stored as fixed-size 16 MiB blocks, except for the final block which may be smaller.
 
-## 5. Mutable control-object rules
+## 6. Mutable control-object rules
 
 Small mutable objects such as the namespace head or a lease must use compare-and-swap semantics. These objects must remain small enough that guarded rewrite is practical.
 
 Large immutable file data may use multipart upload or another provider-specific optimization. Small mutable control objects should not depend on those mechanisms.
 
-## 6. Provider conformance
+## 7. Provider conformance
 
 The spec standardizes the required behaviors, not a brand name such as "S3 compatible." A provider is conforming only when those behaviors are verified by conformance tests.
 

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -7,7 +7,7 @@ A namespace is the unit of visible metadata history.
 Each namespace has:
 
 - a current head
-- an ordered WAL of commits
+- an ordered WAL of logical commits stored in immutable segments
 - zero or more checkpoints
 - a retention policy
 
@@ -44,8 +44,7 @@ Those facts live in other metadata families:
 
 ### 1.1 Example metadata shapes
 
-The inode itself is only one part of the metadata model. A complete visible file usually involves
-multiple logical records.
+The inode itself is only one part of the metadata model. A complete visible file usually involves multiple logical records.
 
 Illustrative inode row:
 
@@ -86,8 +85,7 @@ Together, those three records mean:
 - the file is currently visible under parent directory inode `9` as `Report.txt`; and
 - the current visible file bytes come from revision `7`.
 
-If the file is renamed, the direntry changes but the inode stays `42`. If the file contents are
-replaced, the revision row changes but the inode stays `42`.
+If the file is renamed, the direntry changes but the inode stays `42`. If the file contents are replaced, the revision row changes but the inode stays `42`.
 
 In v0, the root inode is created as `inode_id = 1` at `seq = 0`.
 
@@ -193,7 +191,7 @@ Readers reconstruct authoritative state from:
 
 1. the current head;
 2. the checkpoint named by the head, if any; and
-3. the contiguous WAL tail after that checkpoint through `head.seq`.
+3. the visible WAL segment chain after that checkpoint through `head.seq`, replayed as logical commits in ascending `seq` order.
 
 The head summarizes the current visible boundary and replay hints, including at minimum:
 
@@ -201,7 +199,8 @@ The head summarizes the current visible boundary and replay hints, including at 
 - `next_inode_id`
 - `snapshot_hint_seq`
 - `retention_floor_seq`
+- `wal_tip_segment_id` or an equivalent visible tail pointer
 
 A checkpoint is authoritative only when it has been verified against its durable objects and namespace summary. If verification fails, readers must not treat that checkpoint as authoritative.
 
-The WAL preserves ordered history. Checkpoints keep replay bounded. Together they provide recovery from durable artifacts alone without requiring unbounded WAL replay as history grows.
+The WAL preserves ordered history even when multiple logical commits are stored in one segment. Checkpoints keep replay bounded. Together they provide recovery from durable artifacts alone without requiring unbounded WAL replay as history grows.

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -2,7 +2,7 @@
 
 ## 1. Write protocol
 
-A write has four phases: durably stage content (if mutation contains content), reconstruct and validate, commit to the WAL, and advance the head. A metadata change becomes visible only after the head advances.
+A write has four phases: durably stage content (if a mutation contains content), reconstruct and validate, publish one or more logical commits into the WAL, and advance the head. A metadata change becomes visible only after the head advances.
 
 ### 1.1 Content staging
 
@@ -17,11 +17,11 @@ Content staging is idempotent and has no effect on the visible tree. If the call
 
 ### 1.2 Basis reconstruction
 
-Before evaluating a mutation, the server reconstructs the current metadata state using the same procedure described in §2.1: load the head, load the checkpoint (if any), and replay the WAL tail. The server never trusts caller-supplied metadata.
+Before evaluating commit requests, the server reconstructs the current metadata state using the same procedure described in §2.1: load the head, load the checkpoint (if any), and replay the visible WAL segment chain. The server never trusts caller-supplied metadata.
 
-### 1.3 Validation
+### 1.3 Validation and logical commits
 
-The server validates the mutation against the reconstructed state:
+The server validates each commit request against the reconstructed state:
 
 1. Resolve any operation-local references needed to identify referenced content.
 2. Verify that all referenced content (manifests and blocks) is already durable in object storage, and that digests and sizes match.
@@ -30,15 +30,32 @@ The server validates the mutation against the reconstructed state:
 
 If a request contains multiple operations, they are evaluated sequentially against ephemeral state advanced by earlier operations in the same request.
 
-### 1.4 WAL commit and head advance
+A successful client mutation request becomes one logical commit. Distinct client commit requests remain distinct logical commits even when they are published in the same WAL segment.
 
-This is the atomicity boundary.
+### 1.4 WAL segment publication and head advance
 
-1. Write one immutable **WAL entry** containing the validated operations, allocated inode ids, and preconditions. The WAL key includes the next `seq`.
-2. **CAS-update** the namespace head to advance `seq` and `next_inode_id`.
-3. If the CAS fails, the commit fails. The WAL entry is orphaned and harmless.
+This is the publication boundary.
 
-The change becomes visible only after step 2 succeeds.
+1. Collect one or more candidate commit requests.
+2. Choose publication order and validate those requests against ephemeral state advanced by earlier accepted logical commits in the same batch.
+3. Reject any request whose preconditions fail or whose mutation is otherwise invalid.
+4. Assign contiguous `seq` values to the accepted logical commits.
+5. Write one immutable **WAL segment** containing the accepted logical commits and the segment metadata needed to identify the visible segment chain.
+6. **CAS-update** the namespace head to advance `seq`, `next_inode_id`, and the visible WAL tip.
+7. If the CAS fails, the publication fails. The WAL segment is orphaned and harmless.
+
+Accepted logical commits become visible only after step 6 succeeds.
+
+### 1.5 Failure semantics inside a publication batch
+
+A publication batch is not an all-or-nothing multi-client transaction.
+
+The server may:
+
+- reject some candidate requests before publication; and
+- publish the remaining accepted requests in the same WAL segment.
+
+Each logical commit still has its own success or failure outcome.
 
 ## 2. Read protocol
 
@@ -48,9 +65,9 @@ A read reconstructs the visible filesystem state from durable artifacts on objec
 
 The reader builds an in-memory metadata state from two kinds of durable object:
 
-1. Read the namespace **head** object to learn the current `seq` and `snapshot_hint_seq`.
-2. If `snapshot_hint_seq` is set, load the **verified checkpoint** at that seq. The checkpoint materializes metadata state through that seq across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
-3. Load and replay every **WAL entry** contiguously after the checkpoint seq (or from genesis, if no checkpoint exists) through `head.seq`. Each WAL entry appends rows to the same four tables.
+1. Read the namespace **head** object to learn the current `seq`, `snapshot_hint_seq`, and visible WAL tip.
+2. If `snapshot_hint_seq` is set, load the **verified checkpoint** at that `seq`. The checkpoint materializes metadata state through that `seq` across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
+3. Use the visible WAL tip named by the head to identify the visible segment chain after the checkpoint `seq` (or from genesis, if no checkpoint exists), then replay the logical commit records in ascending `seq` order through `head.seq`. Each logical commit appends rows to the same four tables.
 
 The result is a complete metadata state pinned to one `seq`.
 
@@ -87,16 +104,22 @@ Given a visible directory inode at seq N:
 1. Collect all active directory bindings whose `parent_inode_id` matches the directory.
 2. For each binding, resolve the child inode. If the child is a file, its latest revision provides size and content digest via the manifest.
 
-## 3. One request, one visible sequence
+## 3. Logical commits, sequence numbers, and visibility
 
-A successful mutation request is published as one namespace `seq`.
+A successful client mutation request is one logical commit.
 
 A request may contain more than one operation, but:
 
-- the operations are evaluated in request order;
-- the request becomes visible as one committed step in namespace history.
+- the operations are evaluated in request order; and
+- the request becomes one ordered logical commit in namespace history.
 
-Each request has a single visibility and replay point.
+Each accepted logical commit receives exactly one namespace `seq`.
+
+One head update may publish one or more contiguous logical commits.
+
+A logical commit becomes visible only when the head advances to a value at or beyond that commit's `seq` and the visible WAL chain includes that commit.
+
+This gives each request one `seq` and one replay identity without requiring one object write or one head update per request.
 
 ## 4. Server authority
 
@@ -109,7 +132,7 @@ In particular, the server is responsible for:
 - validating name collisions according to the namespace's `NamePolicy`;
 - validating preconditions;
 - verifying that referenced content is already durable; and
-- publishing the final WAL entry and head update.
+- publishing logical commits into a WAL segment and advancing the head.
 
 Clients may assist with planning, hashing, upload, or retry, but they are not the authority for visible state.
 
@@ -126,8 +149,7 @@ The first standard lower-level mutation set includes:
 - `delete_subtree(root_inode_id)`
 - `restore_revision(inode_id, source_revision_no, base_revision_no)`
 
-The path-oriented filesystem surface may compile higher-level operations into these lower-level
-mutations.
+The path-oriented filesystem surface may compile higher-level operations into these lower-level mutations.
 
 ## 6. Preconditions
 
@@ -152,6 +174,8 @@ A namespace exposes an ordered change feed. The feed answers the question:
 
 This feed is the basis for sync engines, replication, and other incremental consumers.
 
+The change feed is ordered by logical commit, not by physical WAL segment. A segment containing N logical commits produces N ordered change events.
+
 ## 8. Retention floor
 
 A namespace may advance a retention floor to say:
@@ -168,11 +192,10 @@ Some operations are not well described by one request.
 
 Examples include:
 
-- recursive reads that need a pinned snapshot;
-- large or resumable uploads that need a stable destination binding;
-- same-service recursive copy jobs.
+- recursive reads that need a pinned snapshot; and
+- resumable uploads that need a stable destination binding.
 
-In those cases, the server may create control-plane objects such as read sessions, upload sessions, put intents, import jobs, or copy jobs.
+In those cases, the server may create control-plane objects such as read sessions, upload sessions, or put intents.
 
 Three rules apply:
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -2,7 +2,7 @@
 
 ## 1. Write protocol
 
-A write has four phases: durably stage content (if a mutation contains content), reconstruct and validate, publish one or more logical commits into the WAL, and advance the head. A metadata change becomes visible only after the head advances.
+A write has four phases: durably stage content (if a mutation contains content), reconstruct and validate, publish one or more logical commits into the WAL, and advance the head. A commit request may be rejected immediately, or tentatively accepted and written to a WAL segment, but it is committed and successful only if the WAL segment is durably stored and the head advances to reference it. A metadata change becomes visible only after the head advances.
 
 ### 1.1 Content staging
 
@@ -30,21 +30,21 @@ The server validates each commit request against the reconstructed state:
 
 If a request contains multiple operations, they are evaluated sequentially against ephemeral state advanced by earlier operations in the same request.
 
-A successful client mutation request becomes one logical commit. Distinct client commit requests remain distinct logical commits even when they are published in the same WAL segment.
+Passing validation does not by itself make the request committed or successful. If a client mutation request reaches the success boundary in §1.4, it becomes one logical commit. Distinct client commit requests remain distinct logical commits even when they are published in the same WAL segment.
 
 ### 1.4 WAL segment publication and head advance
 
-This is the publication boundary.
+This is the success boundary.
 
 1. Collect one or more candidate commit requests.
-2. Choose publication order and validate those requests against ephemeral state advanced by earlier accepted logical commits in the same batch.
-3. Reject any request whose preconditions fail or whose mutation is otherwise invalid.
-4. Assign contiguous `seq` values to the accepted logical commits.
-5. Write one immutable **WAL segment** containing the accepted logical commits and the segment metadata needed to identify the visible segment chain.
+2. Choose publication order and validate those requests against ephemeral state advanced by earlier tentatively accepted requests in the same batch.
+3. Reject immediately any request whose preconditions fail or whose mutation is otherwise invalid.
+4. Tentatively accept the remaining requests and assign contiguous `seq` values.
+5. Write one immutable **WAL segment** containing logical commit records for the tentatively accepted requests and the segment metadata needed to identify the visible segment chain.
 6. **CAS-update** the namespace head to advance `seq`, `next_inode_id`, and the visible WAL tip.
-7. If the CAS fails, the publication fails. The WAL segment is orphaned and harmless.
+7. If step 5 or step 6 fails, the publication fails. A WAL segment written before a failed CAS is orphaned and harmless.
 
-Accepted logical commits become visible only after step 6 succeeds.
+A tentatively accepted request is not yet committed or successful. A request becomes committed, successful, and visible only if step 5 durably stores the WAL segment and step 6 succeeds. A request rejected at step 3 receives no `seq` and creates no durable WAL record.
 
 ### 1.5 Failure semantics inside a publication batch
 
@@ -53,9 +53,9 @@ A publication batch is not an all-or-nothing multi-client transaction.
 The server may:
 
 - reject some candidate requests before publication; and
-- publish the remaining accepted requests in the same WAL segment.
+- tentatively accept other requests into the same batch and, if publication succeeds, publish them in the same WAL segment.
 
-Each logical commit still has its own success or failure outcome.
+Each request still has its own success or failure outcome. Tentative acceptance inside a batch is not success.
 
 ## 2. Read protocol
 
@@ -113,13 +113,13 @@ A request may contain more than one operation, but:
 - the operations are evaluated in request order; and
 - the request becomes one ordered logical commit in namespace history.
 
-Each accepted logical commit receives exactly one namespace `seq`.
+Each successful logical commit receives exactly one namespace `seq`. A request that is rejected receives no `seq`. A request may be assigned a `seq` while tentatively accepted into a batch, but it is not committed or successful unless the WAL segment is durable and the head update succeeds.
 
 One head update may publish one or more contiguous logical commits.
 
 A logical commit becomes visible only when the head advances to a value at or beyond that commit's `seq` and the visible WAL chain includes that commit.
 
-This gives each request one `seq` and one replay identity without requiring one object write or one head update per request.
+This gives each successful request one `seq` and one replay identity without requiring one object write or one head update per request.
 
 ## 4. Server authority
 
@@ -132,7 +132,7 @@ In particular, the server is responsible for:
 - validating name collisions according to the namespace's `NamePolicy`;
 - validating preconditions;
 - verifying that referenced content is already durable; and
-- publishing logical commits into a WAL segment and advancing the head.
+- publishing successful logical commits by durably writing a WAL segment and advancing the head.
 
 Clients may assist with planning, hashing, upload, or retry, but they are not the authority for visible state.
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -2,7 +2,7 @@
 
 ## 1. Two public operation surfaces
 
-LoonFS has two public surfaces.
+LoonFS has two peer public surfaces.
 
 | Surface | Purpose | Shape |
 | --- | --- | --- |
@@ -26,7 +26,7 @@ The lower-level writer surface has three stages:
 This split is deliberate:
 
 - content durability is not visibility;
-- WAL durability is not visibility;
+- WAL-segment durability is not visibility by itself; and
 - head advance is the visibility point.
 
 ### 2.1 Commit request envelope
@@ -38,21 +38,19 @@ A commit request carries the following logical fields:
 | `request_id` | Client-generated stable idempotency key for this logical commit request. The same value must be reused for safe retries. |
 | `planned_head_seq` | The history point the client planned against. Preconditions are evaluated against authoritative state at this boundary. |
 | `preconditions` | Explicit checks such as `HeadSeqIs`, `InodeRevisionIs`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
-| `ops` | Ordered list of mutation operations. Operation order is preserved through validation, commit, and change-feed output. |
+| `ops` | Ordered list of mutation operations. Operation order is preserved through validation, logical commit creation, and change-feed output. |
 | `message` | Optional human-readable description of the mutation event. |
-| `annotations` | Optional structured metadata attached to the commit request. |
+| `annotations` | Optional structured metadata attached to the logical commit request. |
 
-The server validates that request against authoritative namespace state, writes one immutable WAL
-entry, advances the head with compare-and-swap, and returns success only after the head update
-succeeds.
+The server validates each request against authoritative namespace state. Each accepted request becomes one logical commit with one assigned `seq`.
 
-The change feed returns ordered committed changes after an explicit cursor. If the requested cursor
-is older than the retention floor, the caller must re-bootstrap instead of expecting older
-incremental history to remain available.
+The server may publish multiple logical commits in one WAL segment and one head update, but it must preserve per-request idempotency, ordering, and change-feed identity.
 
-The standard lower-level mutation set is defined in the mutation and visibility model. The
-path-oriented filesystem surface may compile higher-level operations into that lower-level model,
-but both surfaces preserve the same identity, content-durability, and visibility rules.
+Annotations may be used to correlate multiple logical commits that belong to one higher-level workflow, for example with fields such as `operation_id`, `operation_kind`, or `operation_part`.
+
+The change feed returns ordered committed changes after an explicit cursor. If the requested cursor is older than the retention floor, the caller must re-bootstrap instead of expecting older incremental history to remain available.
+
+The standard lower-level mutation set is defined in the mutation and visibility model. The path-oriented filesystem surface may compile higher-level operations into that lower-level model, but both surfaces preserve the same identity, content-durability, and visibility rules.
 
 ## 3. Representative HTTP binding
 
@@ -71,7 +69,7 @@ A representative v0 binding is shown below.
 | Publish an explicit commit | `POST /v0/namespaces/{ns}/commits` |
 | Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123` |
 
-Long-running transfers may additionally expose session or job resources. Once a long-running operation begins, the server-issued session or job id is the stable in-flight identifier of that operation.
+Long-running transfers may additionally expose session resources. Implementations may also expose workflow helper resources, but those helpers are outside the core semantics. Once a multi-request interaction begins, the server-issued identifier is the stable in-flight identifier of that interaction.
 
 A few representative requests and responses are shown below. These examples are illustrative, not exhaustive.
 
@@ -116,8 +114,7 @@ A few representative requests and responses are shown below. These examples are 
 
 ### 3.3 `GET /filesystem/content`
 
-The response body is the authoritative file bytes. Metadata may be exposed in headers, but the
-body itself is raw content rather than JSON.
+The response body is the authoritative file bytes. Metadata may be exposed in headers, but the body itself is raw content rather than JSON.
 
 ### 3.4 `POST /filesystem/operations`
 
@@ -210,7 +207,8 @@ Representative request:
   "planned_head_seq": 418,
   "message": "replace report bytes",
   "annotations": {
-    "source": "sync"
+    "source": "sync",
+    "operation_id": "op_report_refresh_01"
   },
   "preconditions": [
     {
@@ -283,8 +281,7 @@ Representative response:
 
 ## 4. Client profiles
 
-These profiles are defined by the surface a client uses, not by whether the implementation is a
-CLI, desktop app, web app, SDK, or service. A single client may implement more than one profile.
+These profiles are defined by the surface a client uses, not by whether the implementation is a CLI, desktop app, web app, SDK, or service. A single client may implement more than one profile.
 
 ### 4.1 Path-oriented client
 
@@ -295,12 +292,10 @@ Typical behavior:
 - `ls`, `stat`, `get`, `put`, `mv`, and `cp` use user-visible paths;
 - the server remains authoritative for path resolution, canonical inode identity, and commit validation;
 - small commands are often sessionless;
-- large or recursive commands may use server-side sessions or jobs.
+- large or recursive commands may be realized as sequences of ordinary logical commits.
 
 This client does not require a sync database or full local mirror.
-Implementations may still keep durable local state such as auth/session state, retry journals,
-pinned snapshot ids, or inode context learned from prior responses when that improves usability,
-restart safety, or resumability.
+Implementations may still keep durable local state such as auth/session state, retry journals, pinned snapshot ids, or inode context learned from prior responses when that improves usability, restart safety, or resumability.
 
 ### 4.2 Sync client
 
@@ -315,8 +310,7 @@ Typical behavior:
 
 ### 4.3 Explicit-commit client
 
-This client uses the upload, commit, and change-feed surface more directly. It stages content and
-publishes explicit commits, but it does not necessarily maintain a long-lived local mirror.
+This client uses the upload, commit, and change-feed surface more directly. It stages content and publishes explicit commits, but it does not necessarily maintain a long-lived local mirror.
 
 Typical behavior:
 
@@ -337,9 +331,9 @@ The following table summarizes the core split. For more detailed command-oriente
 | `get <file>` | One request | None after the request completes. |
 | `get -r <dir>` | Multi-request snapshot read | A read session may pin a consistent snapshot. |
 | `put <file>` | One request for small files; staged upload for large files | A put intent and upload session may bind the destination and upload. |
-| `put -r <dir>` | Import-style operation | An import job may coordinate a large tree upload. |
+| `put -r <dir>` | Client- or coordinator-driven upload plus one or more commits | No core job is required. Implementation-specific helpers may exist outside the core model. |
 | `cp <file>` on one service | One request | Usually none after the request completes. |
-| `cp -r <dir>` on one service | Server-side job | A copy job may coordinate traversal and publication. |
+| `cp -r <dir>` on one service | Client- or coordinator-driven sequence of logical commits | No core job is required. Implementation-specific helpers may exist outside the core model. |
 
 ## 6. Client and server responsibilities
 
@@ -349,4 +343,4 @@ The following table summarizes the core split. For more detailed command-oriente
 | Content hashing and upload | May accept direct bytes, proxy uploads, or issue upload capabilities, but must verify that any content referenced by a commit is already durable. | Usually responsible for reading local bytes, computing content hashes, and uploading missing content when originating new data. |
 | Commit validation | Authoritative | Supplies preconditions and request ids where needed. |
 | Namespace visibility | Authoritative | Observes committed results. |
-| Long-running transfer progress | Authoritative for sessions or jobs that affect correctness | Responsible for local temp files, local progress, and retry behavior. |
+| Long-running transfer progress | Authoritative for sessions that affect correctness | Responsible for local temp files, local progress, retry behavior, and any higher-level orchestration outside the core model. |

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -20,7 +20,7 @@ Both surfaces share the same namespace, inode, content, and visibility rules.
 The lower-level writer surface has three stages:
 
 1. make content durable
-2. commit metadata visibility
+2. make metadata visible
 3. observe ordered changes through the change feed
 
 This split is deliberate:
@@ -28,6 +28,8 @@ This split is deliberate:
 - content durability is not visibility;
 - WAL-segment durability is not visibility by itself; and
 - head advance is the visibility point.
+
+A commit request may therefore be rejected immediately, or tentatively accepted into a WAL batch, without yet being a committed or successful change.
 
 ### 2.1 Commit request envelope
 
@@ -42,9 +44,9 @@ A commit request carries the following logical fields:
 | `message` | Optional human-readable description of the mutation event. |
 | `annotations` | Optional structured metadata attached to the logical commit request. |
 
-The server validates each request against authoritative namespace state. Each accepted request becomes one logical commit with one assigned `seq`.
+The server validates each request against authoritative namespace state. A request may be rejected immediately. If it is tentatively accepted into a publication batch, the server may assign it a `seq`, but the request is not yet committed or successful at that point. It becomes one committed logical commit only after its WAL segment is durably written and the head update succeeds. If the WAL segment is written but the head update fails, the segment is orphaned and the request is not committed.
 
-The server may publish multiple logical commits in one WAL segment and one head update, but it must preserve per-request idempotency, ordering, and change-feed identity.
+The server may publish multiple committed logical commits in one WAL segment and one head update, but it must preserve per-request idempotency, ordering, and change-feed identity.
 
 Annotations may be used to correlate multiple logical commits that belong to one higher-level workflow, for example with fields such as `operation_id`, `operation_kind`, or `operation_part`.
 
@@ -66,7 +68,7 @@ A representative v0 binding is shown below.
 | Apply path-oriented operations | `POST /v0/namespaces/{ns}/filesystem/operations` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
 | Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
-| Publish an explicit commit | `POST /v0/namespaces/{ns}/commits` |
+| Submit an explicit commit request | `POST /v0/namespaces/{ns}/commits` |
 | Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123` |
 
 Long-running transfers may additionally expose session resources. Implementations may also expose workflow helper resources, but those helpers are outside the core semantics. Once a multi-request interaction begins, the server-issued identifier is the stable in-flight identifier of that interaction.
@@ -141,6 +143,8 @@ Representative request:
   ]
 }
 ```
+
+A successful response is returned only after the underlying change is actually committed: the WAL segment is durable and the head has advanced.
 
 Representative response:
 
@@ -235,6 +239,8 @@ Representative request:
   ]
 }
 ```
+
+A request may be rejected immediately. A successful response is returned only after the request is actually committed: the WAL segment is durably stored and the head has been updated to reference it.
 
 Representative response:
 

--- a/docs/specs/080-background-jobs.md
+++ b/docs/specs/080-background-jobs.md
@@ -10,7 +10,7 @@ Background work reduces read cost, supports safe retention, and cleans up durabl
 
 A checkpoint summarizes namespace metadata at one chosen `seq`.
 
-A checkpoint is useful only after it is verified. Readers must prefer verified checkpoints plus the WAL tail over unverified or partial snapshots.
+A checkpoint is useful only after it is verified. Readers must prefer verified checkpoints plus the visible WAL segment chain over unverified or partial snapshots.
 
 ### 2.2 Retention management
 
@@ -26,11 +26,11 @@ Garbage collection must be conservative. It may reclaim an object only when:
 
 - no visible metadata references it;
 - no retained historical metadata still needs it; and
-- no active session, upload, or job still depends on it.
+- no active session, upload, or other control-plane object still depends on it.
 
 ### 2.4 Expired control-object cleanup
 
-Implementations may clean up expired sessions, uploads, leases, or jobs. This is control-plane maintenance, not namespace history.
+Implementations may clean up expired sessions, uploads, intents, leases, or other control-plane objects. This is control-plane maintenance, not namespace history.
 
 ## 3. Optional derived work
 

--- a/docs/specs/090-versioning-conformance-and-extensions.md
+++ b/docs/specs/090-versioning-conformance-and-extensions.md
@@ -17,13 +17,14 @@ A new version should be introduced only when an old implementation could misread
 A conforming server must:
 
 1. treat object storage as the authoritative durable foundation;
-2. publish visible metadata only through the WAL-plus-head rule;
+2. publish visible metadata only through logical commits stored in visible WAL segments plus a successful head update;
 3. validate that referenced content is already durable before publish;
 4. preserve `(namespace_id, inode_id)` as canonical identity;
 5. implement tombstone-first delete;
-6. serve replay from verified checkpoints plus the WAL tail;
+6. serve replay from verified checkpoints plus the visible WAL segment chain, replayed as logical commits;
 7. honor the namespace's `NamePolicy`;
-8. keep control-plane sessions and jobs out of namespace history and the change feed.
+8. keep control-plane sessions and any implementation-specific coordinators out of namespace history and the change feed; and
+9. preserve per-request idempotency, ordering, and change-feed identity even when physically batching logical commits in a WAL segment.
 
 ## 3. Writer and client requirements
 
@@ -32,7 +33,7 @@ A conforming writer or client must:
 1. treat paths as selectors, not as durable identity;
 2. upload or otherwise stage content before asking the server to publish it;
 3. use request ids or equivalent idempotency keys for safe retry;
-4. tolerate commit rejection when preconditions no longer hold;
+4. tolerate commit rejection when preconditions no longer hold; and
 5. re-bootstrap if its cursor falls behind the retention floor.
 
 A sync client must also maintain durable local state for its cursor and reconciliation logic.
@@ -42,10 +43,11 @@ A sync client must also maintain durable local state for its cursor and reconcil
 A commit may carry optional human or product metadata such as:
 
 - a commit message;
-- annotations or tags attached to the commit envelope; or
-- actor information.
+- annotations or tags attached to the commit envelope;
+- actor information; or
+- workflow-correlation fields such as `operation_id`, `operation_kind`, or `operation_part`.
 
-This metadata belongs to the commit, not to the resource itself.
+This metadata belongs to the logical commit, not to the resource itself.
 
 ## 5. Optional resource properties
 


### PR DESCRIPTION
- clarify server-side commit batching into WAL
- significantly reduce core operations for base spec
- rename "Session" control-objects to "Handle" for clarity