### PR TITLE
feat: make content store top level domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The LoonFS cli has two main modes: `local` and `remote`:
 
 ## Core concepts
 
-- Namespaces: a Loon namespace is the core unit of filesystem visibility, history, and durability. You can think of each namespace as a separate filesystem.
+- Namespaces: a Loon namespace is the core unit of filesystem visibility and history. You can think of each namespace as a separate filesystem.
+- Content stores: immutable file bytes live in content stores. A namespace points at one content store, and forked namespaces share that content store without copying bytes.
 
 ## Design philosophy
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ You will need access to an object storage bucket in the form of keys in order to
 ```bash
 loon init                   # creates your first Loon profile and sets it as the default. We recommend using 'local' mode to start, with an object storage store.
 
-loon namespace create {some_namespace}
-loon use {some_namespace}   # sets the newly created namespace as the default.
+loon namespace create {namespace_id}
+loon use {namespace_id}   # sets the newly created namespace as the default.
 ```
 
 You can add a `SKILL` to your agent of choice so that they know to use Loon when appropriate. See our [example `SKILL.md`](https://github.com.loonfs/loonfs/tree/main/examples/SKILL.md).

--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -1,5 +1,5 @@
 use crate::digest::sha256_hex;
-use crate::{ChangeSeq, ContentRef, FenceToken, InodeId, NamePolicy, NamespaceId};
+use crate::{ChangeSeq, ContentRef, ContentStoreId, FenceToken, InodeId, NamePolicy, NamespaceId};
 use serde::{Deserialize, Serialize};
 
 pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 1;
@@ -7,11 +7,24 @@ pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ControlObjectKind {
+    NamespaceDescriptor,
+    ContentStoreDescriptor,
     NamespaceHead,
     NamespaceLease,
     NamespaceProgress,
     UploadSession,
     QueueShard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceDescriptorState {
+    pub namespace_id: NamespaceId,
+    pub content_store_id: ContentStoreId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentStoreDescriptorState {
+    pub content_store_id: ContentStoreId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -113,6 +126,8 @@ pub type HeadStateEnvelope = ControlObjectEnvelope<HeadState>;
 pub type LeaseStateEnvelope = ControlObjectEnvelope<LeaseState>;
 pub type ProgressStateEnvelope = ControlObjectEnvelope<ProgressState>;
 pub type UploadSessionEnvelope = ControlObjectEnvelope<UploadSessionState>;
+pub type NamespaceDescriptorEnvelope = ControlObjectEnvelope<NamespaceDescriptorState>;
+pub type ContentStoreDescriptorEnvelope = ControlObjectEnvelope<ContentStoreDescriptorState>;
 
 pub fn payload_checksum_sha256<T>(value: &T) -> Result<String, serde_json::Error>
 where

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -13,6 +13,11 @@ pub struct CreateNamespaceRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForkNamespaceRequest {
+    pub new_namespace_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceSummary {
     pub name: NamespaceId,
 }

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -9,7 +9,7 @@ pub struct ApiError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CreateNamespaceRequest {
-    pub name: String,
+    pub namespace_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -19,7 +19,7 @@ pub struct ForkNamespaceRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceSummary {
-    pub name: NamespaceId,
+    pub namespace_id: NamespaceId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
+use thiserror::Error;
 
 /// Unique identifier for a namespace (a logical sync boundary).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -9,13 +10,92 @@ pub struct NamespaceId(pub String);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ContentStoreId(pub String);
 
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid namespace_id {value:?}: {reason}")]
+pub struct NamespaceIdValidationError {
+    value: String,
+    reason: &'static str,
+}
+
+impl NamespaceIdValidationError {
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn reason(&self) -> &'static str {
+        self.reason
+    }
+}
+
 impl NamespaceId {
+    /// Constructs a namespace id without validation. Use [`NamespaceId::parse`]
+    /// for user-supplied or durable-boundary input.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, NamespaceIdValidationError> {
+        let value = value.as_ref();
+        validate_namespace_id(value)?;
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn try_new(value: impl Into<String>) -> Result<Self, NamespaceIdValidationError> {
+        let value = value.into();
+        validate_namespace_id(&value)?;
+        Ok(Self(value))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+fn validate_namespace_id(value: &str) -> Result<(), NamespaceIdValidationError> {
+    if value.is_empty() {
+        return Err(namespace_id_error(value, "must not be empty"));
+    }
+    if value.len() > 128 {
+        return Err(namespace_id_error(value, "must be 128 bytes or fewer"));
+    }
+    if value.trim() != value {
+        return Err(namespace_id_error(
+            value,
+            "must not have leading or trailing whitespace",
+        ));
+    }
+    if matches!(value, "." | "..") {
+        return Err(namespace_id_error(value, "must not be `.` or `..`"));
+    }
+
+    let mut chars = value.chars();
+    let first = chars
+        .next()
+        .expect("empty namespace_id returned before char validation");
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(namespace_id_error(
+            value,
+            "must start with a lowercase ASCII letter or digit",
+        ));
+    }
+    if !chars.all(is_allowed_namespace_id_tail_char) {
+        return Err(namespace_id_error(
+            value,
+            "must contain only lowercase ASCII letters, digits, `.`, `_`, or `-`",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_allowed_namespace_id_tail_char(ch: char) -> bool {
+    ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-')
+}
+
+fn namespace_id_error(value: &str, reason: &'static str) -> NamespaceIdValidationError {
+    NamespaceIdValidationError {
+        value: value.to_owned(),
+        reason,
     }
 }
 
@@ -145,5 +225,40 @@ impl fmt::Display for ContentStoreId {
 impl fmt::Display for InodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "inode-{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NamespaceId;
+
+    #[test]
+    fn namespace_id_parse_accepts_allowed_grammar() {
+        let long_id = format!("a{}", "b".repeat(127));
+        for value in ["demo", "demo-1", "demo_1", "demo.v1", &long_id] {
+            let parsed = NamespaceId::parse(value).expect("valid namespace_id");
+            assert_eq!(parsed.as_str(), value);
+        }
+    }
+
+    #[test]
+    fn namespace_id_parse_rejects_invalid_values() {
+        let long_id = format!("a{}", "b".repeat(128));
+        for value in [
+            "", "/", "a/b", ".", "..", " demo", "demo ", "demo\n", "demo?", "demo#", "demo%",
+            "Demo", &long_id,
+        ] {
+            assert!(
+                NamespaceId::parse(value).is_err(),
+                "expected invalid namespace_id {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_id_unchecked_construction_remains_available() {
+        let namespace_id = NamespaceId::from("invalid/name");
+
+        assert_eq!(namespace_id.as_str(), "invalid/name");
     }
 }

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -5,7 +5,21 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NamespaceId(pub String);
 
+/// Unique identifier for an immutable content store.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ContentStoreId(pub String);
+
 impl NamespaceId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ContentStoreId {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
@@ -27,6 +41,18 @@ impl From<String> for NamespaceId {
     }
 }
 
+impl From<&str> for ContentStoreId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for ContentStoreId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
 impl Serialize for NamespaceId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -36,7 +62,25 @@ impl Serialize for NamespaceId {
     }
 }
 
+impl Serialize for ContentStoreId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
 impl<'de> Deserialize<'de> for NamespaceId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(String::deserialize(deserializer)?))
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentStoreId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -87,6 +131,12 @@ pub struct Identity {
 }
 
 impl fmt::Display for NamespaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for ContentStoreId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -173,6 +173,7 @@ pub struct CurrentArgs {
 #[derive(Debug, Subcommand)]
 pub enum NamespaceCommand {
     Create(NamespaceCreateArgs),
+    Fork(NamespaceForkArgs),
     List(NamespaceListArgs),
 }
 
@@ -181,6 +182,14 @@ pub struct NamespaceCreateArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
     pub name: String,
+}
+
+#[derive(Debug, Args)]
+pub struct NamespaceForkArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    pub source: String,
+    pub new_namespace_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -266,6 +275,7 @@ pub enum CommandKind {
     ProfileRemove,
     ProfileUse,
     NamespaceCreate,
+    NamespaceFork,
     NamespaceList,
     NamespaceUse,
     Current,
@@ -293,6 +303,7 @@ impl CommandKind {
             CommandKind::ProfileRemove => "profile_remove",
             CommandKind::ProfileUse => "profile_use",
             CommandKind::NamespaceCreate => "namespace_create",
+            CommandKind::NamespaceFork => "namespace_fork",
             CommandKind::NamespaceList => "namespace_list",
             CommandKind::NamespaceUse => "namespace_use",
             CommandKind::Current => "current",
@@ -329,6 +340,7 @@ impl Cli {
             },
             Command::Namespace { command } => match command {
                 NamespaceCommand::Create(_) => CommandKind::NamespaceCreate,
+                NamespaceCommand::Fork(_) => CommandKind::NamespaceFork,
                 NamespaceCommand::List(_) => CommandKind::NamespaceList,
             },
             Command::Use(_) => CommandKind::NamespaceUse,

--- a/crates/loon-cli/src/args.rs
+++ b/crates/loon-cli/src/args.rs
@@ -181,7 +181,7 @@ pub enum NamespaceCommand {
 pub struct NamespaceCreateArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
-    pub name: String,
+    pub namespace_id: String,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -157,7 +157,7 @@ impl DirectBackend {
 
 impl Backend for DirectBackend {
     fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
-        let ns_id = NamespaceId::from(namespace_id.to_owned());
+        let ns_id = parse_namespace_id(namespace_id)?;
         bootstrap_namespace(&self.store, &ns_id, &self.mutation_context(), false)
             .map_err(map_bootstrap_error)
     }
@@ -167,8 +167,8 @@ impl Backend for DirectBackend {
         source: &str,
         new_namespace_id: &str,
     ) -> Result<NamespaceSummary, CliError> {
-        let source_namespace_id = NamespaceId::from(source.to_owned());
-        let new_namespace_id = NamespaceId::from(new_namespace_id.to_owned());
+        let source_namespace_id = parse_namespace_id(source)?;
+        let new_namespace_id = parse_namespace_id(new_namespace_id)?;
         fork_namespace(
             &self.store,
             &source_namespace_id,
@@ -183,19 +183,19 @@ impl Backend for DirectBackend {
     }
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
-        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let ns_id = parse_namespace_id(&spec.namespace)?;
         list_path(&self.store, &ns_id, &spec.absolute_path)
             .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
-        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let ns_id = parse_namespace_id(&spec.namespace)?;
         resolve_path(&self.store, &ns_id, &spec.absolute_path)
             .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
-        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let ns_id = parse_namespace_id(&spec.namespace)?;
         let result = read_file_bytes(&self.store, &ns_id, &spec.absolute_path)
             .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))?;
         Ok(result.bytes)
@@ -207,7 +207,7 @@ impl Backend for DirectBackend {
         bytes: &[u8],
         force: bool,
     ) -> Result<MutationResult, CliError> {
-        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let ns_id = parse_namespace_id(&spec.namespace)?;
         let behavior = if force {
             PutFileBehavior::ReplaceExisting
         } else {
@@ -226,7 +226,7 @@ impl Backend for DirectBackend {
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
-        let ns_id = NamespaceId::from(spec.namespace.clone());
+        let ns_id = parse_namespace_id(&spec.namespace)?;
         delete_path_non_recursive(
             &self.store,
             &ns_id,
@@ -242,7 +242,7 @@ impl Backend for DirectBackend {
         from: &NamespacePath,
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
-        let ns_id = NamespaceId::from(from.namespace.clone());
+        let ns_id = parse_namespace_id(&from.namespace)?;
         move_path(
             &self.store,
             &ns_id,
@@ -259,7 +259,7 @@ impl Backend for DirectBackend {
         from: &NamespacePath,
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
-        let ns_id = NamespaceId::from(from.namespace.clone());
+        let ns_id = parse_namespace_id(&from.namespace)?;
         copy_file_path(
             &self.store,
             &ns_id,
@@ -272,9 +272,18 @@ impl Backend for DirectBackend {
     }
 }
 
+fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
+    NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))
+}
+
 fn map_core_error(error: CoreError) -> CliError {
+    if matches!(error.kind(), CoreErrorKind::InvalidNamespaceId) {
+        return CliError::invalid_input(error.to_string());
+    }
+
     let code = match error.kind() {
         CoreErrorKind::InvalidPath => "invalid_path",
+        CoreErrorKind::InvalidNamespaceId => unreachable!("handled before code mapping"),
         CoreErrorKind::NamespaceNotFound => "namespace_not_found",
         CoreErrorKind::NamespaceExists => "namespace_exists",
         CoreErrorKind::NamespacePartial => "namespace_partial",
@@ -312,6 +321,9 @@ fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliErro
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {
     match &error {
+        BootstrapNamespaceError::InvalidNamespaceId(_) => {
+            CliError::invalid_input(error.to_string())
+        }
         BootstrapNamespaceError::NamespaceAlreadyExists { .. } => {
             CliError::new("namespace_exists", error.to_string())
         }

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -3,9 +3,9 @@ use crate::error::CliError;
 use loon_api::{AuthoritativePathEntry, MutationResult, NamespaceId, NamespaceSummary};
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_core::{
-    bootstrap_namespace, copy_file_path, delete_path_non_recursive, list_namespaces, list_path,
-    move_path, put_file_bytes, read_file_bytes, resolve_path, BootstrapNamespaceError, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior,
+    bootstrap_namespace, copy_file_path, delete_path_non_recursive, fork_namespace,
+    list_namespaces, list_path, move_path, put_file_bytes, read_file_bytes, resolve_path,
+    BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
 };
 use loon_objectstore::ConfiguredObjectStore;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -14,6 +14,11 @@ const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
 pub trait Backend {
     fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, CliError>;
+    fn fork_namespace(
+        &self,
+        source: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, CliError>;
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError>;
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError>;
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError>;
@@ -46,6 +51,16 @@ pub struct RemoteBackend {
 impl Backend for RemoteBackend {
     fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, CliError> {
         self.client.create_namespace(name).map_err(map_client_error)
+    }
+
+    fn fork_namespace(
+        &self,
+        source: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, CliError> {
+        self.client
+            .fork_namespace(source, new_namespace_id)
+            .map_err(map_client_error)
     }
 
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
@@ -143,6 +158,22 @@ impl Backend for DirectBackend {
         let ns_id = NamespaceId::from(name.to_owned());
         bootstrap_namespace(&self.store, &ns_id, &self.mutation_context(), false)
             .map_err(map_bootstrap_error)
+    }
+
+    fn fork_namespace(
+        &self,
+        source: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, CliError> {
+        let source_namespace_id = NamespaceId::from(source.to_owned());
+        let new_namespace_id = NamespaceId::from(new_namespace_id.to_owned());
+        fork_namespace(
+            &self.store,
+            &source_namespace_id,
+            &new_namespace_id,
+            &self.mutation_context(),
+        )
+        .map_err(map_core_error)
     }
 
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
@@ -243,6 +274,8 @@ fn map_core_error(error: CoreError) -> CliError {
     let code = match error.kind() {
         CoreErrorKind::InvalidPath => "invalid_path",
         CoreErrorKind::NamespaceNotFound => "namespace_not_found",
+        CoreErrorKind::NamespaceExists => "namespace_exists",
+        CoreErrorKind::NamespacePartial => "namespace_partial",
         CoreErrorKind::PathNotFound => "path_not_found",
         CoreErrorKind::RevisionNotFound => "revision_not_found",
         CoreErrorKind::PathConflict => "path_conflict",

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -13,7 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
 pub trait Backend {
-    fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, CliError>;
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError>;
     fn fork_namespace(
         &self,
         source: &str,
@@ -49,8 +49,10 @@ pub struct RemoteBackend {
 }
 
 impl Backend for RemoteBackend {
-    fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, CliError> {
-        self.client.create_namespace(name).map_err(map_client_error)
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
+        self.client
+            .create_namespace(namespace_id)
+            .map_err(map_client_error)
     }
 
     fn fork_namespace(
@@ -154,8 +156,8 @@ impl DirectBackend {
 }
 
 impl Backend for DirectBackend {
-    fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, CliError> {
-        let ns_id = NamespaceId::from(name.to_owned());
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
+        let ns_id = NamespaceId::from(namespace_id.to_owned());
         bootstrap_namespace(&self.store, &ns_id, &self.mutation_context(), false)
             .map_err(map_bootstrap_error)
     }

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -1,8 +1,8 @@
 use crate::args::{
     Cli, Command, CommandKind, ConfigCommand, CurrentArgs, FilesystemGetArgs, FilesystemLsArgs,
     FilesystemMoveArgs, FilesystemPathArgs, FilesystemPutArgs, InitArgs, NamespaceCommand,
-    NamespaceCreateArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand, ProfileCreateArgs,
-    ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
+    NamespaceCreateArgs, NamespaceForkArgs, NamespaceListArgs, NamespaceUseArgs, ProfileCommand,
+    ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior, TargetSelectorArgs,
 };
 use crate::config::{
     default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
@@ -414,6 +414,7 @@ fn run_namespace_command(
 ) -> Result<CommandOutput, CommandFailure> {
     match command {
         NamespaceCommand::Create(args) => run_namespace_create(kind, args),
+        NamespaceCommand::Fork(args) => run_namespace_fork(kind, args),
         NamespaceCommand::List(args) => run_namespace_list(kind, args),
     }
 }
@@ -438,6 +439,51 @@ fn run_namespace_create(
         .target
         .backend()
         .create_namespace(&args.name)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(resolved.profile_name.clone()),
+                Some(mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::NamespaceSummary(namespace),
+    })
+}
+
+fn run_namespace_fork(
+    kind: CommandKind,
+    args: NamespaceForkArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(explicit_profile)
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    validate_namespace_name(&args.source).map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?;
+    validate_namespace_name(&args.new_namespace_id).map_err(|error| {
+        fail(
+            kind,
+            Some(resolved.profile_name.clone()),
+            Some(mode.clone()),
+            error,
+        )
+    })?;
+    let namespace = resolved
+        .target
+        .backend()
+        .fork_namespace(&args.source, &args.new_namespace_id)
         .map_err(|error| {
             fail(
                 kind,

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -427,7 +427,7 @@ fn run_namespace_create(
     let resolved = resolve_target_profile(explicit_profile)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_name(&args.name).map_err(|error| {
+    validate_namespace_id(&args.namespace_id).map_err(|error| {
         fail(
             kind,
             Some(resolved.profile_name.clone()),
@@ -438,7 +438,7 @@ fn run_namespace_create(
     let namespace = resolved
         .target
         .backend()
-        .create_namespace(&args.name)
+        .create_namespace(&args.namespace_id)
         .map_err(|error| {
             fail(
                 kind,
@@ -464,7 +464,7 @@ fn run_namespace_fork(
     let resolved = resolve_target_profile(explicit_profile)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_name(&args.source).map_err(|error| {
+    validate_namespace_id(&args.source).map_err(|error| {
         fail(
             kind,
             Some(resolved.profile_name.clone()),
@@ -472,7 +472,7 @@ fn run_namespace_fork(
             error,
         )
     })?;
-    validate_namespace_name(&args.new_namespace_id).map_err(|error| {
+    validate_namespace_id(&args.new_namespace_id).map_err(|error| {
         fail(
             kind,
             Some(resolved.profile_name.clone()),
@@ -540,7 +540,7 @@ fn run_namespace_use(
     let resolved = resolve_target_profile_from_config(&loaded.config, explicit_profile)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_name(&args.namespace).map_err(|error| {
+    validate_namespace_id(&args.namespace).map_err(|error| {
         fail(
             kind,
             Some(resolved.profile_name.clone()),
@@ -563,7 +563,7 @@ fn run_namespace_use(
         })?;
     if !namespaces
         .iter()
-        .any(|candidate| candidate.name.as_str() == args.namespace)
+        .any(|candidate| candidate.namespace_id.as_str() == args.namespace)
     {
         return Err(fail(
             kind,
@@ -1520,9 +1520,9 @@ fn run_filesystem_move(
 
 // --- general helpers ---
 
-fn validate_namespace_name(namespace: &str) -> Result<(), CliError> {
+fn validate_namespace_id(namespace: &str) -> Result<(), CliError> {
     if namespace.trim().is_empty() {
-        return Err(CliError::invalid_input("namespace name must not be empty"));
+        return Err(CliError::invalid_input("namespace_id must not be empty"));
     }
     Ok(())
 }
@@ -1532,7 +1532,7 @@ fn namespace_path(
     path: &str,
     allow_root: bool,
 ) -> Result<NamespacePath, CliError> {
-    validate_namespace_name(namespace)?;
+    validate_namespace_id(namespace)?;
     Ok(NamespacePath {
         namespace: namespace.to_owned(),
         absolute_path: normalize_absolute_path(path, allow_root)?,

--- a/crates/loon-cli/src/commands.rs
+++ b/crates/loon-cli/src/commands.rs
@@ -17,7 +17,7 @@ use crate::prompt;
 use crate::resolve::{
     load_cli_config, resolve_namespace, resolve_target_profile, resolve_target_profile_from_config,
 };
-use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceSummary};
+use loon_api::{AuthoritativePathEntry, InodeKind, NamespaceId, NamespaceSummary};
 use loon_client::NamespacePath;
 use serde::Serialize;
 use std::fs;
@@ -1521,10 +1521,9 @@ fn run_filesystem_move(
 // --- general helpers ---
 
 fn validate_namespace_id(namespace: &str) -> Result<(), CliError> {
-    if namespace.trim().is_empty() {
-        return Err(CliError::invalid_input("namespace_id must not be empty"));
-    }
-    Ok(())
+    NamespaceId::parse(namespace)
+        .map(|_| ())
+        .map_err(|error| CliError::invalid_input(error.to_string()))
 }
 
 fn namespace_path(

--- a/crates/loon-cli/src/config.rs
+++ b/crates/loon-cli/src/config.rs
@@ -1,5 +1,6 @@
 use crate::error::CliError;
 use http::Uri;
+use loon_api::NamespaceId;
 use loon_objectstore::r2::R2StoreConfig;
 use loon_objectstore::s3::AwsS3StoreConfig;
 use loon_objectstore::ConfiguredObjectStore;
@@ -149,7 +150,10 @@ impl ProfileConfig {
                 ..
             } => {
                 if let Some(namespace) = default_namespace {
-                    require_non_empty(&profile_field(name, "default_namespace"), namespace)?;
+                    validate_default_namespace(
+                        &profile_field(name, "default_namespace"),
+                        namespace,
+                    )?;
                 }
                 store.validate(name)
             }
@@ -160,7 +164,10 @@ impl ProfileConfig {
                 ..
             } => {
                 if let Some(namespace) = default_namespace {
-                    require_non_empty(&profile_field(name, "default_namespace"), namespace)?;
+                    validate_default_namespace(
+                        &profile_field(name, "default_namespace"),
+                        namespace,
+                    )?;
                 }
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
@@ -453,6 +460,12 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), CliError> {
         return Err(CliError::invalid_config(format!("missing `{field}`")));
     }
     Ok(())
+}
+
+fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> {
+    NamespaceId::parse(value)
+        .map(|_| ())
+        .map_err(|err| CliError::invalid_config(format!("invalid `{field}`: {err}")))
 }
 
 fn validate_http_url(field: &str, value: &str) -> Result<(), CliError> {

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -140,11 +140,11 @@ pub fn human_success(output: &CommandOutput) -> String {
             let namespace = namespace.as_deref().unwrap_or("-");
             format!("profile: {profile}\nnamespace: {namespace}")
         }
-        CommandData::NamespaceSummary(namespace) => namespace.name.to_string(),
+        CommandData::NamespaceSummary(namespace) => namespace.namespace_id.to_string(),
         CommandData::NamespaceList { namespaces } => {
-            let mut lines = vec!["NAME".to_owned()];
+            let mut lines = vec!["NAMESPACE_ID".to_owned()];
             for namespace in namespaces {
-                lines.push(namespace.name.to_string());
+                lines.push(namespace.namespace_id.to_string());
             }
             lines.join("\n")
         }
@@ -254,10 +254,10 @@ mod tests {
             data: CommandData::NamespaceList {
                 namespaces: vec![
                     NamespaceSummary {
-                        name: "alpha".into(),
+                        namespace_id: "alpha".into(),
                     },
                     NamespaceSummary {
-                        name: "prod".into(),
+                        namespace_id: "prod".into(),
                     },
                 ],
             },

--- a/crates/loon-cli/src/resolve.rs
+++ b/crates/loon-cli/src/resolve.rs
@@ -56,7 +56,7 @@ pub fn resolve_namespace(
 
 fn validate_namespace(namespace: &str) -> Result<ResolvedNamespace, CliError> {
     if namespace.trim().is_empty() {
-        return Err(CliError::invalid_input("namespace name must not be empty"));
+        return Err(CliError::invalid_input("namespace_id must not be empty"));
     }
     Ok(ResolvedNamespace {
         namespace: namespace.to_owned(),

--- a/crates/loon-cli/src/resolve.rs
+++ b/crates/loon-cli/src/resolve.rs
@@ -2,6 +2,7 @@ use crate::backend::ResolvedTarget;
 use crate::config::{default_config_path, load_config, CliConfig};
 use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
+use loon_api::NamespaceId;
 
 pub struct LoadedConfig {
     pub path: std::path::PathBuf,
@@ -55,9 +56,7 @@ pub fn resolve_namespace(
 }
 
 fn validate_namespace(namespace: &str) -> Result<ResolvedNamespace, CliError> {
-    if namespace.trim().is_empty() {
-        return Err(CliError::invalid_input("namespace_id must not be empty"));
-    }
+    NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))?;
     Ok(ResolvedNamespace {
         namespace: namespace.to_owned(),
     })

--- a/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_namespace_list_empty_snapshot.snap
+++ b/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_namespace_list_empty_snapshot.snap
@@ -2,4 +2,4 @@
 source: crates/loon-cli/src/render.rs
 expression: human_success(&output)
 ---
-NAME
+NAMESPACE_ID

--- a/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_namespace_list_snapshot.snap
+++ b/crates/loon-cli/src/snapshots/loon_cli__render__tests__human_namespace_list_snapshot.snap
@@ -2,6 +2,6 @@
 source: crates/loon-cli/src/render.rs
 expression: human_success(&output)
 ---
-NAME
+NAMESPACE_ID
 alpha
 prod

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -541,6 +541,57 @@ root = "{}"
 }
 
 #[test]
+fn local_namespace_commands_reject_invalid_namespace_ids() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let create = harness.run(&["--json", "namespace", "create", "bad/name"]);
+    assert_failure(&create);
+    assert_eq!(json_error(&create)["code"], "invalid_input");
+    assert!(json_error(&create)["message"]
+        .as_str()
+        .unwrap()
+        .contains("invalid namespace_id"));
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    let fork = harness.run(&["--json", "namespace", "fork", "demo", "bad/name"]);
+    assert_failure(&fork);
+    assert_eq!(json_error(&fork)["code"], "invalid_input");
+
+    let use_namespace = harness.run(&["--json", "use", "bad/name"]);
+    assert_failure(&use_namespace);
+    assert_eq!(json_error(&use_namespace)["code"], "invalid_input");
+}
+
+#[test]
+fn remote_namespace_commands_reject_invalid_namespace_ids_before_http() {
+    let harness = Harness::new();
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        "http://127.0.0.1:9",
+    ]);
+    assert_success(&add_remote);
+
+    let create = harness.run(&["--json", "namespace", "create", "bad/name"]);
+    assert_failure(&create);
+    assert_eq!(json_error(&create)["code"], "invalid_input");
+
+    let fork = harness.run(&["--json", "namespace", "fork", "demo", "bad/name"]);
+    assert_failure(&fork);
+    assert_eq!(json_error(&fork)["code"], "invalid_input");
+
+    let use_namespace = harness.run(&["--json", "use", "bad/name"]);
+    assert_failure(&use_namespace);
+    assert_eq!(json_error(&use_namespace)["code"], "invalid_input");
+}
+
+#[test]
 fn invalid_remote_urls_are_rejected() {
     let harness = Harness::new();
 

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -178,7 +178,7 @@ fn local_profile_namespace_fork_reads_shared_content_and_diverges() {
 
     let fork = harness.run(&["--json", "namespace", "fork", "demo", "clone"]);
     assert_success(&fork);
-    assert_eq!(json_data(&fork)["name"], "clone");
+    assert_eq!(json_data(&fork)["namespace_id"], "clone");
 
     let source = harness.run(&["--json", "stat", "/docs/shared.txt"]);
     let clone = harness.run(&["--json", "stat", "--namespace", "clone", "/docs/shared.txt"]);
@@ -598,7 +598,7 @@ fn external_remote_profile_executes_through_http() {
     assert_success(&create);
     let fork = harness.run(&["--json", "namespace", "fork", "demo", "clone"]);
     assert_success(&fork);
-    assert_eq!(json_data(&fork)["name"], "clone");
+    assert_eq!(json_data(&fork)["namespace_id"], "clone");
 
     let use_namespace = harness.run(&["--json", "use", "demo"]);
     assert_success(&use_namespace);
@@ -608,8 +608,8 @@ fn external_remote_profile_executes_through_http() {
     let list_data = json_data(&list);
     let namespaces = list_data["namespaces"].as_array().unwrap();
     assert_eq!(namespaces.len(), 2);
-    assert_eq!(namespaces[0]["name"], "clone");
-    assert_eq!(namespaces[1]["name"], "demo");
+    assert_eq!(namespaces[0]["namespace_id"], "clone");
+    assert_eq!(namespaces[1]["namespace_id"], "demo");
 }
 
 #[test]

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -163,6 +163,51 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 }
 
 #[test]
+fn local_profile_namespace_fork_reads_shared_content_and_diverges() {
+    let harness = Harness::new();
+    harness.add_local_profile("default");
+
+    let upload_path = harness.temp_dir.path().join("upload.txt");
+    let clone_upload_path = harness.temp_dir.path().join("clone-upload.txt");
+    fs::write(&upload_path, b"base from cli\n").expect("upload payload");
+    fs::write(&clone_upload_path, b"clone from cli\n").expect("clone upload payload");
+
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/shared.txt"]));
+
+    let fork = harness.run(&["--json", "namespace", "fork", "demo", "clone"]);
+    assert_success(&fork);
+    assert_eq!(json_data(&fork)["name"], "clone");
+
+    let source = harness.run(&["--json", "stat", "/docs/shared.txt"]);
+    let clone = harness.run(&["--json", "stat", "--namespace", "clone", "/docs/shared.txt"]);
+    assert_success(&source);
+    assert_success(&clone);
+    assert_eq!(
+        json_data(&source)["content_ref"],
+        json_data(&clone)["content_ref"]
+    );
+
+    assert_success(&harness.run(&[
+        "put",
+        "--namespace",
+        "clone",
+        clone_upload_path.to_str().unwrap(),
+        "/docs/shared.txt",
+        "--force",
+    ]));
+
+    let source_cat = harness.run(&["cat", "/docs/shared.txt"]);
+    assert_success(&source_cat);
+    assert_eq!(source_cat.stdout, b"base from cli\n");
+
+    let clone_cat = harness.run(&["cat", "--namespace", "clone", "/docs/shared.txt"]);
+    assert_success(&clone_cat);
+    assert_eq!(clone_cat.stdout, b"clone from cli\n");
+}
+
+#[test]
 fn init_creates_local_profile_and_current_reports_namespace_unset() {
     let harness = Harness::new();
 
@@ -551,6 +596,9 @@ fn external_remote_profile_executes_through_http() {
 
     let create = harness.run(&["--json", "namespace", "create", "demo"]);
     assert_success(&create);
+    let fork = harness.run(&["--json", "namespace", "fork", "demo", "clone"]);
+    assert_success(&fork);
+    assert_eq!(json_data(&fork)["name"], "clone");
 
     let use_namespace = harness.run(&["--json", "use", "demo"]);
     assert_success(&use_namespace);
@@ -559,8 +607,9 @@ fn external_remote_profile_executes_through_http() {
     assert_success(&list);
     let list_data = json_data(&list);
     let namespaces = list_data["namespaces"].as_array().unwrap();
-    assert_eq!(namespaces.len(), 1);
-    assert_eq!(namespaces[0]["name"], "demo");
+    assert_eq!(namespaces.len(), 2);
+    assert_eq!(namespaces[0]["name"], "clone");
+    assert_eq!(namespaces[1]["name"], "demo");
 }
 
 #[test]

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -9,7 +9,8 @@ use loon_api::{
     },
     ApiError, AuthoritativePathEntry, ChangeSeq, ContentRef, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    FilesystemPutBehavior, ListNamespacesResponse, MutationResult, NamespaceSummary,
+    FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, MutationResult,
+    NamespaceSummary,
 };
 use serde::Deserialize;
 use std::fs;
@@ -126,6 +127,20 @@ impl Client {
         Ok(self
             .request_json::<(), ListNamespacesResponse>(self.agent.get(&url), None)?
             .namespaces)
+    }
+
+    pub fn fork_namespace(
+        &self,
+        source_namespace: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, ClientError> {
+        let url = format!("{}/v0/namespaces/{source_namespace}/forks", self.base_url);
+        self.request_json::<_, NamespaceSummary>(
+            self.agent.post(&url),
+            Some(&ForkNamespaceRequest {
+                new_namespace_id: new_namespace_id.to_owned(),
+            }),
+        )
     }
 
     pub fn list_path(

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -10,7 +10,7 @@ use loon_api::{
     ApiError, AuthoritativePathEntry, ChangeSeq, ContentRef, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
     FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, MutationResult,
-    NamespaceSummary,
+    NamespaceId, NamespaceSummary,
 };
 use serde::Deserialize;
 use std::fs;
@@ -113,11 +113,12 @@ impl Client {
     }
 
     pub fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, ClientError> {
+        let namespace_id = NamespaceId::parse(namespace_id).map_err(invalid_namespace_id_error)?;
         let url = format!("{}/v0/namespaces", self.base_url);
         self.request_json::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&CreateNamespaceRequest {
-                namespace_id: namespace_id.to_owned(),
+                namespace_id: namespace_id.as_str().to_owned(),
             }),
         )
     }
@@ -134,11 +135,14 @@ impl Client {
         source_namespace: &str,
         new_namespace_id: &str,
     ) -> Result<NamespaceSummary, ClientError> {
+        let source_namespace = namespace_url_segment(source_namespace)?;
+        let new_namespace_id =
+            NamespaceId::parse(new_namespace_id).map_err(invalid_namespace_id_error)?;
         let url = format!("{}/v0/namespaces/{source_namespace}/forks", self.base_url);
         self.request_json::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&ForkNamespaceRequest {
-                new_namespace_id: new_namespace_id.to_owned(),
+                new_namespace_id: new_namespace_id.as_str().to_owned(),
             }),
         )
     }
@@ -147,30 +151,33 @@ impl Client {
         &self,
         spec: &NamespacePath,
     ) -> Result<Vec<AuthoritativePathEntry>, ClientError> {
+        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/list?path={}",
             self.base_url,
-            spec.namespace,
+            namespace,
             urlencoding::encode(&spec.absolute_path)
         );
         self.request_json::<(), Vec<AuthoritativePathEntry>>(self.agent.get(&url), None)
     }
 
     pub fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, ClientError> {
+        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/stat?path={}",
             self.base_url,
-            spec.namespace,
+            namespace,
             urlencoding::encode(&spec.absolute_path)
         );
         self.request_json::<(), AuthoritativePathEntry>(self.agent.get(&url), None)
     }
 
     pub fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, ClientError> {
+        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/content?path={}",
             self.base_url,
-            spec.namespace,
+            namespace,
             urlencoding::encode(&spec.absolute_path)
         );
         let request = self.authenticated(self.agent.get(&url));
@@ -190,6 +197,7 @@ impl Client {
     }
 
     pub fn begin_upload(&self, namespace: &str) -> Result<BeginUploadResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!("{}/v0/namespaces/{namespace}/uploads", self.base_url);
         self.request_json::<(), BeginUploadResponse>(self.agent.post(&url), None)
     }
@@ -200,6 +208,7 @@ impl Client {
         upload_id: &str,
         bytes: &[u8],
     ) -> Result<UploadContentResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/uploads/{upload_id}/content",
             self.base_url
@@ -220,6 +229,7 @@ impl Client {
         upload_id: &str,
         request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
             self.base_url
@@ -232,6 +242,7 @@ impl Client {
         namespace: &str,
         request: &V0CommitRequest,
     ) -> Result<V0CommitResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!("{}/v0/namespaces/{namespace}/commits", self.base_url);
         self.request_json::<_, V0CommitResponse>(self.agent.post(&url), Some(request))
     }
@@ -241,6 +252,7 @@ impl Client {
         namespace: &str,
         after_seq: ChangeSeq,
     ) -> Result<ChangesResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/changes?after_seq={}",
             self.base_url, after_seq.0
@@ -253,6 +265,7 @@ impl Client {
         namespace: &str,
         request: &FilesystemOperationRequest,
     ) -> Result<FilesystemOperationResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/filesystem/operations",
             self.base_url
@@ -575,7 +588,9 @@ impl NamespacePath {
         let (namespace, path) = value
             .split_once(':')
             .ok_or_else(|| ClientError::InvalidNamespacePath(value.to_owned()))?;
-        if namespace.trim().is_empty() || !path.starts_with('/') {
+        NamespaceId::parse(namespace)
+            .map_err(|err| ClientError::InvalidNamespacePath(err.to_string()))?;
+        if !path.starts_with('/') {
             return Err(ClientError::InvalidNamespacePath(value.to_owned()));
         }
         Ok(Self {
@@ -583,6 +598,16 @@ impl NamespacePath {
             absolute_path: path.to_owned(),
         })
     }
+}
+
+fn namespace_url_segment(namespace: &str) -> Result<&str, ClientError> {
+    NamespaceId::parse(namespace)
+        .map(|_| namespace)
+        .map_err(invalid_namespace_id_error)
+}
+
+fn invalid_namespace_id_error(error: loon_api::NamespaceIdValidationError) -> ClientError {
+    ClientError::InvalidNamespacePath(error.to_string())
 }
 
 fn file_name_for_path(path: &str) -> Result<String, ClientError> {
@@ -654,7 +679,7 @@ fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), Cl
 
 #[cfg(test)]
 mod tests {
-    use super::{ClientConfig, ClientError};
+    use super::{Client, ClientConfig, ClientError, NamespacePath};
     use std::fs;
     use tempfile::tempdir;
 
@@ -709,6 +734,40 @@ auth_token = "   "
         let error = ClientConfig::load(&path).expect_err("decode error");
 
         assert!(matches!(error, ClientError::ConfigDecode(_)));
+    }
+
+    #[test]
+    fn namespace_path_parse_rejects_invalid_namespace_id() {
+        for value in [
+            "bad/name:/notes.txt",
+            "Demo:/notes.txt",
+            "..:/notes.txt",
+            "demo?:/notes.txt",
+        ] {
+            assert!(
+                matches!(
+                    NamespacePath::parse(value),
+                    Err(ClientError::InvalidNamespacePath(_))
+                ),
+                "expected invalid namespace path {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn client_rejects_invalid_namespace_ids_before_http_requests() {
+        let client = Client::new(ClientConfig {
+            server_url: "http://127.0.0.1:9".to_owned(),
+            auth_token: None,
+        });
+
+        for result in [
+            client.create_namespace("bad/name").map(|_| ()),
+            client.fork_namespace("demo", "bad/name").map(|_| ()),
+            client.begin_upload("bad/name").map(|_| ()),
+        ] {
+            assert!(matches!(result, Err(ClientError::InvalidNamespacePath(_))));
+        }
     }
 
     fn write_config(contents: &str) -> std::path::PathBuf {

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -112,12 +112,12 @@ impl Client {
         }
     }
 
-    pub fn create_namespace(&self, name: &str) -> Result<NamespaceSummary, ClientError> {
+    pub fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, ClientError> {
         let url = format!("{}/v0/namespaces", self.base_url);
         self.request_json::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&CreateNamespaceRequest {
-                name: name.to_owned(),
+                namespace_id: namespace_id.to_owned(),
             }),
         )
     }

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -2,16 +2,21 @@ use crate::checkpoint::{
     checkpoint_basis_head, load_verified_checkpoint_materialization, CheckpointLoadError,
 };
 use crate::genesis::bootstrap_basis_metadata_state;
-use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
+use crate::loading::{
+    read_content_store_descriptor_object, read_head_object, read_lease_object,
+    read_namespace_descriptor_object, ControlObjectLoadError,
+};
 use crate::metadata::MetadataState;
 use crate::wal::{replay_wal_tail_with_metadata, StoredWalObject, WalReplayError};
-use loon_api::{HeadState, NamespaceId};
+use loon_api::{ContentStoreId, HeadState, NamespaceDescriptorState, NamespaceId};
 use loon_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerifiedNamespaceBasis {
+    pub namespace_descriptor: NamespaceDescriptorState,
+    pub content_store_id: ContentStoreId,
     pub head: HeadState,
     pub head_etag: String,
     pub lease: loon_api::LeaseState,
@@ -20,6 +25,10 @@ pub struct VerifiedNamespaceBasis {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum BasisLoadError {
+    #[error("failed to load namespace descriptor: {0}")]
+    LoadNamespaceDescriptor(ControlObjectLoadError),
+    #[error("failed to load content store descriptor: {0}")]
+    LoadContentStoreDescriptor(ControlObjectLoadError),
     #[error(transparent)]
     LoadHead(#[from] ControlObjectLoadError),
     #[error("failed to load lease object: {0}")]
@@ -62,6 +71,12 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<VerifiedNamespaceBasis, BasisLoadError> {
+    let loaded_descriptor = read_namespace_descriptor_object(store, expected_namespace)
+        .map_err(BasisLoadError::LoadNamespaceDescriptor)?;
+    let content_store_id = loaded_descriptor.envelope.state.content_store_id.clone();
+    read_content_store_descriptor_object(store, &content_store_id)
+        .map_err(BasisLoadError::LoadContentStoreDescriptor)?;
+
     let loaded_head = read_head_object(store, expected_namespace)?;
     let loaded_lease =
         read_lease_object(store, expected_namespace).map_err(BasisLoadError::LoadLease)?;
@@ -100,6 +115,8 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     ensure_reconstructed_head_matches(&loaded_head.envelope.state, &replayed.resulting_head)?;
 
     Ok(VerifiedNamespaceBasis {
+        namespace_descriptor: loaded_descriptor.envelope.state,
+        content_store_id,
         head: loaded_head.envelope.state,
         head_etag,
         lease: loaded_lease.envelope.state,

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -235,45 +235,49 @@ pub fn create_checkpoint<S: ObjectStore + ?Sized>(
     })
 }
 
+pub(crate) struct CheckpointMetadataWriteRequest<'a> {
+    pub(crate) namespace_id: &'a NamespaceId,
+    pub(crate) checkpoint_seq: ChangeSeq,
+    pub(crate) active_fence_token: FenceToken,
+    pub(crate) next_inode_id: InodeId,
+    pub(crate) retention_floor_seq: ChangeSeq,
+    pub(crate) metadata_state: &'a MetadataState,
+    pub(crate) writer_version: &'a str,
+}
+
 pub(crate) fn write_verified_checkpoint_from_metadata<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
-    checkpoint_seq: ChangeSeq,
-    active_fence_token: FenceToken,
-    next_inode_id: InodeId,
-    retention_floor_seq: ChangeSeq,
-    metadata_state: &MetadataState,
-    writer_version: &str,
+    request: CheckpointMetadataWriteRequest<'_>,
 ) -> Result<CheckpointManifestEnvelope, CoreError> {
     let tables = build_checkpoint_tables(
         store,
-        namespace_id,
-        checkpoint_seq,
-        metadata_state,
-        writer_version,
+        request.namespace_id,
+        request.checkpoint_seq,
+        request.metadata_state,
+        request.writer_version,
     )?;
     let materialized = load_checkpoint_materialization_from_tables(
         store,
-        namespace_id,
-        checkpoint_seq,
-        &snapshot_manifest(namespace_id.as_str(), checkpoint_seq.0),
+        request.namespace_id,
+        request.checkpoint_seq,
+        &snapshot_manifest(request.namespace_id.as_str(), request.checkpoint_seq.0),
         &tables,
     )
     .map_err(|error| CoreError::Basis(BasisLoadError::CheckpointLoad(error)))?;
-    if !metadata_states_equivalent(metadata_state, &materialized) {
+    if !metadata_states_equivalent(request.metadata_state, &materialized) {
         return Err(CoreError::Basis(BasisLoadError::CheckpointLoad(
             CheckpointLoadError::MetadataMismatch,
         )));
     }
 
     let manifest = CheckpointManifestEnvelope::from_payload(
-        writer_version,
+        request.writer_version,
         CheckpointManifestPayload {
-            namespace_id: namespace_id.clone(),
-            checkpoint_seq,
-            active_fence_token,
-            next_inode_id,
-            retention_floor_seq,
+            namespace_id: request.namespace_id.clone(),
+            checkpoint_seq: request.checkpoint_seq,
+            active_fence_token: request.active_fence_token,
+            next_inode_id: request.next_inode_id,
+            retention_floor_seq: request.retention_floor_seq,
             verified: true,
             tables,
         },

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -11,7 +11,7 @@ use loon_api::{
     AdvanceRetentionResponse, ChangeSeq, CheckpointManifestEnvelope, CheckpointManifestPayload,
     CheckpointPage, CheckpointRow, CheckpointSegmentDescriptor, CheckpointSegmentEnvelope,
     CheckpointSegmentPayload, CheckpointTableFamily, CheckpointTableManifest, ControlObjectKind,
-    CreateCheckpointResponse, HeadState, HeadStateEnvelope, NamespaceId,
+    CreateCheckpointResponse, FenceToken, HeadState, HeadStateEnvelope, InodeId, NamespaceId,
 };
 use loon_objectstore::keys::{
     derived_progress, snapshot_manifest, snapshot_table, SnapshotTableFamily,
@@ -233,6 +233,54 @@ pub fn create_checkpoint<S: ObjectStore + ?Sized>(
         snapshot_hint_points_at_checkpoint: resulting_head.snapshot_hint_seq
             == Some(checkpoint_seq),
     })
+}
+
+pub(crate) fn write_verified_checkpoint_from_metadata<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_seq: ChangeSeq,
+    active_fence_token: FenceToken,
+    next_inode_id: InodeId,
+    retention_floor_seq: ChangeSeq,
+    metadata_state: &MetadataState,
+    writer_version: &str,
+) -> Result<CheckpointManifestEnvelope, CoreError> {
+    let tables = build_checkpoint_tables(
+        store,
+        namespace_id,
+        checkpoint_seq,
+        metadata_state,
+        writer_version,
+    )?;
+    let materialized = load_checkpoint_materialization_from_tables(
+        store,
+        namespace_id,
+        checkpoint_seq,
+        &snapshot_manifest(namespace_id.as_str(), checkpoint_seq.0),
+        &tables,
+    )
+    .map_err(|error| CoreError::Basis(BasisLoadError::CheckpointLoad(error)))?;
+    if !metadata_states_equivalent(metadata_state, &materialized) {
+        return Err(CoreError::Basis(BasisLoadError::CheckpointLoad(
+            CheckpointLoadError::MetadataMismatch,
+        )));
+    }
+
+    let manifest = CheckpointManifestEnvelope::from_payload(
+        writer_version,
+        CheckpointManifestPayload {
+            namespace_id: namespace_id.clone(),
+            checkpoint_seq,
+            active_fence_token,
+            next_inode_id,
+            retention_floor_seq,
+            verified: true,
+            tables,
+        },
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
+    write_checkpoint_manifest(store, &manifest).map_err(CoreError::Basis)?;
+    Ok(manifest)
 }
 
 pub fn advance_retention_floor<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -1,4 +1,4 @@
-use loon_api::{sha256_digest, ContentRef, ContentRefKind, NamespaceId};
+use loon_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId};
 use loon_objectstore::keys::content_blob;
 use loon_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
@@ -47,7 +47,7 @@ pub enum DurableContentValidationError {
 
 pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
 ) -> Result<ValidatedDurableContent, DurableContentValidationError> {
     if content_ref.kind != ContentRefKind::WholeFileV0 {
@@ -56,12 +56,13 @@ pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
         });
     }
 
-    let object_key = content_blob(namespace_id.as_str(), &content_ref.digest).map_err(|err| {
-        DurableContentValidationError::InvalidDigest {
-            digest: content_ref.digest.clone(),
-            message: err.to_string(),
-        }
-    })?;
+    let object_key =
+        content_blob(content_store_id.as_str(), &content_ref.digest).map_err(|err| {
+            DurableContentValidationError::InvalidDigest {
+                digest: content_ref.digest.clone(),
+                message: err.to_string(),
+            }
+        })?;
     let bytes = load_required_object(store, &object_key)?;
     let actual_size = bytes.len() as u64;
     if actual_size != content_ref.size_bytes {
@@ -97,10 +98,10 @@ pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
 
 pub fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
 ) -> Result<ReadDurableContent, DurableContentValidationError> {
-    let validated = validate_durable_content_reference(store, namespace_id, content_ref)?;
+    let validated = validate_durable_content_reference(store, content_store_id, content_ref)?;
     let bytes = load_required_object(store, &validated.object_key)?;
 
     Ok(ReadDurableContent { validated, bytes })
@@ -128,7 +129,7 @@ mod tests {
         read_durable_content_bytes, validate_durable_content_reference,
         DurableContentValidationError,
     };
-    use loon_api::{ContentRef, ContentRefKind, NamespaceId};
+    use loon_api::{ContentRef, ContentRefKind, ContentStoreId};
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::content_blob;
     use loon_objectstore::ObjectStore;
@@ -136,12 +137,12 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_success() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let bytes = b"whole file bytes";
         let content_ref = ContentRef::whole_file_v0(bytes);
-        put_content_object(&store, &namespace_id, &content_ref, bytes);
+        put_content_object(&store, &content_store_id, &content_ref, bytes);
 
-        let validated = validate_durable_content_reference(&store, &namespace_id, &content_ref)
+        let validated = validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .expect("validate content ref");
         assert_eq!(validated.content_ref, content_ref);
         assert_eq!(validated.file_size_bytes, bytes.len() as u64);
@@ -150,12 +151,12 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_accepts_empty_files() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let bytes = b"";
         let content_ref = ContentRef::whole_file_v0(bytes);
-        put_content_object(&store, &namespace_id, &content_ref, bytes);
+        put_content_object(&store, &content_store_id, &content_ref, bytes);
 
-        let read = read_durable_content_bytes(&store, &namespace_id, &content_ref)
+        let read = read_durable_content_bytes(&store, &content_store_id, &content_ref)
             .expect("read empty content ref");
         assert_eq!(read.bytes, bytes);
         assert_eq!(read.validated.file_size_bytes, 0);
@@ -163,10 +164,10 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_rejects_missing_object() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let content_ref = ContentRef::whole_file_v0(b"missing");
 
-        let err = validate_durable_content_reference(&store, &namespace_id, &content_ref)
+        let err = validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .expect_err("missing object");
         assert!(matches!(
             err,
@@ -176,12 +177,12 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_rejects_size_mismatch() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let mut content_ref = ContentRef::whole_file_v0(b"abc");
-        put_content_object(&store, &namespace_id, &content_ref, b"abc");
+        put_content_object(&store, &content_store_id, &content_ref, b"abc");
         content_ref.size_bytes += 1;
 
-        let err = validate_durable_content_reference(&store, &namespace_id, &content_ref)
+        let err = validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .expect_err("size mismatch");
         assert!(matches!(
             err,
@@ -191,11 +192,11 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_rejects_digest_mismatch() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let content_ref = ContentRef::whole_file_v0(b"expected");
-        put_content_object(&store, &namespace_id, &content_ref, b"mismatch");
+        put_content_object(&store, &content_store_id, &content_ref, b"mismatch");
 
-        let err = validate_durable_content_reference(&store, &namespace_id, &content_ref)
+        let err = validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .expect_err("digest mismatch");
         assert!(matches!(
             err,
@@ -205,14 +206,14 @@ mod tests {
 
     #[test]
     fn validate_whole_file_content_ref_rejects_unsupported_kind() {
-        let (_temp_dir, store, namespace_id) = test_store();
+        let (_temp_dir, store, content_store_id) = test_store();
         let content_ref = ContentRef {
             kind: ContentRefKind::Unsupported,
             digest: ContentRef::whole_file_v0(b"bytes").digest,
             size_bytes: 5,
         };
 
-        let err = validate_durable_content_reference(&store, &namespace_id, &content_ref)
+        let err = validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .expect_err("unsupported content ref kind");
         assert!(matches!(
             err,
@@ -220,20 +221,21 @@ mod tests {
         ));
     }
 
-    fn test_store() -> (tempfile::TempDir, LocalFsStore, NamespaceId) {
+    fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("content-tests");
-        (temp_dir, store, namespace_id)
+        let content_store_id = ContentStoreId::from("content-tests");
+        (temp_dir, store, content_store_id)
     }
 
     fn put_content_object(
         store: &LocalFsStore,
-        namespace_id: &NamespaceId,
+        content_store_id: &ContentStoreId,
         content_ref: &ContentRef,
         bytes: &[u8],
     ) {
-        let key = content_blob(namespace_id.as_str(), &content_ref.digest).expect("content key");
+        let key =
+            content_blob(content_store_id.as_str(), &content_ref.digest).expect("content key");
         store.put_if_absent(&key, bytes).expect("put content");
     }
 }

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -23,8 +23,8 @@ pub use protocol::{
     begin_upload, commit_operations, complete_upload, list_changes_after, upload_content,
 };
 pub use services::{
-    bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, list_namespaces,
-    list_path, move_path, put_file_bytes, put_file_content_ref, read_file_bytes, resolve_path,
-    store_bytes_as_content, write_file_bytes, BootstrapNamespaceError, CoreError, CoreErrorKind,
-    MutationContext, PutFileBehavior, StoredContent,
+    bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,
+    list_namespaces, list_path, move_path, put_file_bytes, put_file_content_ref, read_file_bytes,
+    resolve_path, store_bytes_as_content, write_file_bytes, BootstrapNamespaceError, CoreError,
+    CoreErrorKind, MutationContext, PutFileBehavior, StoredContent,
 };

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,7 +1,10 @@
 use loon_api::{
-    payload_checksum_sha256, ControlObjectKind, HeadStateEnvelope, LeaseStateEnvelope, NamespaceId,
+    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreId, ControlObjectKind,
+    HeadStateEnvelope, LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceId,
 };
-use loon_objectstore::keys::{namespace_head, namespace_lease};
+use loon_objectstore::keys::{
+    content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
+};
 use loon_objectstore::ObjectStoreError;
 use loon_objectstore::{ObjectMetadata, ObjectStore};
 use serde::Serialize;
@@ -13,6 +16,20 @@ pub(crate) struct LoadedHeadObject {
     pub(crate) object_key: String,
     pub(crate) metadata: ObjectMetadata,
     pub(crate) envelope: HeadStateEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub(crate) struct LoadedNamespaceDescriptorObject {
+    pub(crate) object_key: String,
+    pub(crate) metadata: ObjectMetadata,
+    pub(crate) envelope: NamespaceDescriptorEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub(crate) struct LoadedContentStoreDescriptorObject {
+    pub(crate) object_key: String,
+    pub(crate) metadata: ObjectMetadata,
+    pub(crate) envelope: ContentStoreDescriptorEnvelope,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
@@ -45,6 +62,14 @@ pub enum ControlObjectLoadError {
         actual: NamespaceId,
     },
     #[error(
+        "control object content store mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
+    )]
+    ContentStoreMismatch {
+        object_key: String,
+        expected: ContentStoreId,
+        actual: ContentStoreId,
+    },
+    #[error(
         "control object checksum mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     ChecksumMismatch {
@@ -56,6 +81,68 @@ pub enum ControlObjectLoadError {
     Codec { object_key: String, message: String },
     #[error("control object store error: {0}")]
     Store(String),
+}
+
+pub(crate) fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedNamespaceDescriptorObject, ControlObjectLoadError> {
+    let object_key = namespace_descriptor(expected_namespace.as_str());
+    let metadata = store
+        .head(&object_key)
+        .map_err(map_store_load_error)?
+        .ok_or_else(|| ControlObjectLoadError::MissingObject {
+            object_key: object_key.clone(),
+        })?;
+    let encoded_bytes = store
+        .get(&object_key, None)
+        .map_err(map_store_load_error)?
+        .ok_or_else(|| ControlObjectLoadError::MissingObjectAfterHead {
+            object_key: object_key.clone(),
+        })?;
+    let envelope: NamespaceDescriptorEnvelope =
+        serde_json::from_slice(&encoded_bytes).map_err(|err| ControlObjectLoadError::Codec {
+            object_key: object_key.clone(),
+            message: err.to_string(),
+        })?;
+    validate_namespace_descriptor_envelope(expected_namespace, &object_key, &envelope)?;
+
+    Ok(LoadedNamespaceDescriptorObject {
+        object_key,
+        metadata,
+        envelope,
+    })
+}
+
+pub(crate) fn read_content_store_descriptor_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_content_store: &ContentStoreId,
+) -> Result<LoadedContentStoreDescriptorObject, ControlObjectLoadError> {
+    let object_key = content_store_descriptor(expected_content_store.as_str());
+    let metadata = store
+        .head(&object_key)
+        .map_err(map_store_load_error)?
+        .ok_or_else(|| ControlObjectLoadError::MissingObject {
+            object_key: object_key.clone(),
+        })?;
+    let encoded_bytes = store
+        .get(&object_key, None)
+        .map_err(map_store_load_error)?
+        .ok_or_else(|| ControlObjectLoadError::MissingObjectAfterHead {
+            object_key: object_key.clone(),
+        })?;
+    let envelope: ContentStoreDescriptorEnvelope =
+        serde_json::from_slice(&encoded_bytes).map_err(|err| ControlObjectLoadError::Codec {
+            object_key: object_key.clone(),
+            message: err.to_string(),
+        })?;
+    validate_content_store_descriptor_envelope(expected_content_store, &object_key, &envelope)?;
+
+    Ok(LoadedContentStoreDescriptorObject {
+        object_key,
+        metadata,
+        envelope,
+    })
 }
 
 pub(crate) fn read_head_object<S: ObjectStore + ?Sized>(
@@ -118,6 +205,58 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+fn validate_namespace_descriptor_envelope(
+    expected_namespace: &NamespaceId,
+    object_key: &str,
+    envelope: &NamespaceDescriptorEnvelope,
+) -> Result<(), ControlObjectLoadError> {
+    if envelope.kind != ControlObjectKind::NamespaceDescriptor {
+        return Err(ControlObjectLoadError::KindMismatch {
+            object_key: object_key.to_owned(),
+            expected: ControlObjectKind::NamespaceDescriptor,
+            actual: envelope.kind,
+        });
+    }
+    if envelope.state.namespace_id != *expected_namespace {
+        return Err(ControlObjectLoadError::NamespaceMismatch {
+            object_key: object_key.to_owned(),
+            expected: expected_namespace.clone(),
+            actual: envelope.state.namespace_id.clone(),
+        });
+    }
+    validate_control_checksum(
+        object_key,
+        &envelope.payload_checksum_sha256,
+        &envelope.state,
+    )
+}
+
+fn validate_content_store_descriptor_envelope(
+    expected_content_store: &ContentStoreId,
+    object_key: &str,
+    envelope: &ContentStoreDescriptorEnvelope,
+) -> Result<(), ControlObjectLoadError> {
+    if envelope.kind != ControlObjectKind::ContentStoreDescriptor {
+        return Err(ControlObjectLoadError::KindMismatch {
+            object_key: object_key.to_owned(),
+            expected: ControlObjectKind::ContentStoreDescriptor,
+            actual: envelope.kind,
+        });
+    }
+    if envelope.state.content_store_id != *expected_content_store {
+        return Err(ControlObjectLoadError::ContentStoreMismatch {
+            object_key: object_key.to_owned(),
+            expected: expected_content_store.clone(),
+            actual: envelope.state.content_store_id.clone(),
+        });
+    }
+    validate_control_checksum(
+        object_key,
+        &envelope.payload_checksum_sha256,
+        &envelope.state,
+    )
 }
 
 fn validate_head_envelope(

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -41,6 +41,11 @@ pub(crate) struct LoadedLeaseObject {
 
 #[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize, Error)]
 pub enum ControlObjectLoadError {
+    #[error("invalid namespace_id {namespace_id:?}: {message}")]
+    InvalidNamespaceId {
+        namespace_id: String,
+        message: String,
+    },
     #[error("missing control object `{object_key}`")]
     MissingObject { object_key: String },
     #[error("missing control object after head `{object_key}`")]
@@ -87,6 +92,7 @@ pub(crate) fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<LoadedNamespaceDescriptorObject, ControlObjectLoadError> {
+    validate_namespace_id_for_control_key(expected_namespace)?;
     let object_key = namespace_descriptor(expected_namespace.as_str());
     let metadata = store
         .head(&object_key)
@@ -149,6 +155,7 @@ pub(crate) fn read_head_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<LoadedHeadObject, ControlObjectLoadError> {
+    validate_namespace_id_for_control_key(expected_namespace)?;
     let object_key = namespace_head(expected_namespace.as_str());
     let metadata = store
         .head(&object_key)
@@ -180,6 +187,7 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<LoadedLeaseObject, ControlObjectLoadError> {
+    validate_namespace_id_for_control_key(expected_namespace)?;
     let object_key = namespace_lease(expected_namespace.as_str());
     let metadata = store
         .head(&object_key)
@@ -205,6 +213,17 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+fn validate_namespace_id_for_control_key(
+    namespace_id: &NamespaceId,
+) -> Result<(), ControlObjectLoadError> {
+    NamespaceId::parse(namespace_id.as_str())
+        .map(|_| ())
+        .map_err(|err| ControlObjectLoadError::InvalidNamespaceId {
+            namespace_id: namespace_id.as_str().to_owned(),
+            message: err.reason().to_owned(),
+        })
 }
 
 fn validate_namespace_descriptor_envelope(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -5,7 +5,10 @@ use crate::commit::{
     CommitValidationContext, Precondition,
 };
 use crate::content::validate_durable_content_reference;
-use crate::services::{derive_commit_results, write_immutable_object, CoreError, MutationContext};
+use crate::services::{
+    derive_commit_results, load_namespace_content_store_id, write_immutable_object, CoreError,
+    MutationContext,
+};
 use crate::wal::prepare_wal_commit;
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp,
@@ -70,8 +73,9 @@ pub fn upload_content<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     context: &MutationContext,
 ) -> Result<UploadContentResponse, CoreError> {
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
     let content_ref = ContentRef::whole_file_v0(bytes);
-    let object_key = content_blob(namespace_id.as_str(), &content_ref.digest)
+    let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
         .map_err(|err| CoreError::Store(err.to_string()))?;
 
     for _attempt in 0..UPLOAD_SESSION_RETRY_LIMIT {
@@ -164,7 +168,8 @@ pub fn complete_upload<S: ObjectStore + ?Sized>(
                 "completed content ref does not match staged content".to_owned(),
             ));
         }
-        validate_durable_content_reference(store, namespace_id, &request.content_ref)?;
+        let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+        validate_durable_content_reference(store, &content_store_id, &request.content_ref)?;
 
         let mut next_state = loaded.envelope.state.clone();
         next_state.completed = Some(CompletedUpload {
@@ -592,18 +597,19 @@ fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     request: &CoreCommitRequest,
     resolved_restore_content_refs: &[Option<ContentRef>],
 ) -> Result<(), CoreError> {
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
     for (index, op) in request.ops.iter().enumerate() {
         match op {
             CommitOp::CreateFile { content_ref, .. }
             | CommitOp::ReplaceFile { content_ref, .. } => {
-                validate_durable_content_reference(store, namespace_id, content_ref)?;
+                validate_durable_content_reference(store, &content_store_id, content_ref)?;
             }
             CommitOp::RestoreRevision { .. } => {
                 if let Some(content_ref) = resolved_restore_content_refs
                     .get(index)
                     .and_then(|content_ref| content_ref.as_ref())
                 {
-                    validate_durable_content_reference(store, namespace_id, content_ref)?;
+                    validate_durable_content_reference(store, &content_store_id, content_ref)?;
                 }
             }
             _ => {}

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -597,24 +597,34 @@ fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     request: &CoreCommitRequest,
     resolved_restore_content_refs: &[Option<ContentRef>],
 ) -> Result<(), CoreError> {
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+    let mut content_refs = Vec::new();
     for (index, op) in request.ops.iter().enumerate() {
         match op {
             CommitOp::CreateFile { content_ref, .. }
             | CommitOp::ReplaceFile { content_ref, .. } => {
-                validate_durable_content_reference(store, &content_store_id, content_ref)?;
+                content_refs.push(content_ref);
             }
             CommitOp::RestoreRevision { .. } => {
                 if let Some(content_ref) = resolved_restore_content_refs
                     .get(index)
                     .and_then(|content_ref| content_ref.as_ref())
                 {
-                    validate_durable_content_reference(store, &content_store_id, content_ref)?;
+                    content_refs.push(content_ref);
                 }
             }
             _ => {}
         }
     }
+
+    if content_refs.is_empty() {
+        return Ok(());
+    }
+
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+    for content_ref in content_refs {
+        validate_durable_content_reference(store, &content_store_id, content_ref)?;
+    }
+
     Ok(())
 }
 

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -239,6 +239,7 @@ pub(crate) fn retry_existing_path_request<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: &str,
     context: &MutationContext,
 ) -> Result<Option<V0CommitResponse>, CoreError> {
+    validate_namespace_id_for_key_construction(namespace_id)?;
     let Some(existing) =
         find_existing_commit_payload_by_request_id(store, namespace_id, request_id)?
     else {
@@ -267,6 +268,7 @@ fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
 ) -> Result<V0CommitResponse, CoreError> {
+    validate_namespace_id_for_key_construction(namespace_id)?;
     crate::acquire_or_renew_namespace_lease(store, namespace_id, context)?;
     let basis = load_verified_namespace_basis(store, namespace_id)?;
     let request = map_commit_request(
@@ -633,6 +635,7 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &str,
 ) -> Result<LoadedUploadSessionObject, CoreError> {
+    validate_namespace_id_for_key_construction(namespace_id)?;
     let object_key = upload_session(namespace_id.as_str(), upload_id);
     let metadata = store
         .head(&object_key)
@@ -677,6 +680,12 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+fn validate_namespace_id_for_key_construction(namespace_id: &NamespaceId) -> Result<(), CoreError> {
+    NamespaceId::parse(namespace_id.as_str())
+        .map(|_| ())
+        .map_err(CoreError::from)
 }
 
 fn load_existing_commit_payload<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -24,7 +24,7 @@ use loon_api::{
     ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
     FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
     MutationResult, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
-    NamespaceSummary,
+    NamespaceIdValidationError, NamespaceSummary,
 };
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
@@ -60,6 +60,7 @@ pub enum PutFileBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoreErrorKind {
     InvalidPath,
+    InvalidNamespaceId,
     NamespaceNotFound,
     NamespaceExists,
     NamespacePartial,
@@ -84,6 +85,8 @@ pub enum CoreErrorKind {
 
 #[derive(Debug, Error)]
 pub enum BootstrapNamespaceError {
+    #[error(transparent)]
+    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("holder id must not be empty")]
     EmptyHolderId,
     #[error("writer version must not be empty")]
@@ -108,6 +111,8 @@ pub enum BootstrapNamespaceError {
 
 #[derive(Debug, Error)]
 pub enum CoreError {
+    #[error(transparent)]
+    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error(transparent)]
     Basis(#[from] BasisLoadError),
     #[error(transparent)]
@@ -204,6 +209,7 @@ impl From<CommitHeadPublishError> for CoreError {
 impl CoreError {
     pub fn kind(&self) -> CoreErrorKind {
         match self {
+            CoreError::InvalidNamespaceId(_) => CoreErrorKind::InvalidNamespaceId,
             CoreError::Basis(error) => classify_basis_load_error(error),
             CoreError::VisiblePath(error) => classify_visible_path_error(error),
             CoreError::DurableContent(error) => classify_durable_content_error(error),
@@ -336,6 +342,8 @@ fn namespace_initialization_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<NamespaceInitializationState, BootstrapNamespaceError> {
+    NamespaceId::parse(namespace_id.as_str())?;
+
     let descriptor_key = namespace_descriptor(namespace_id.as_str());
     let head_key = namespace_head(namespace_id.as_str());
     let lease_key = namespace_lease(namespace_id.as_str());
@@ -419,7 +427,7 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<NamespaceSummary, CoreError> {
     match namespace_initialization_state(store, new_namespace_id)
-        .map_err(|err| CoreError::Store(err.to_string()))?
+        .map_err(map_namespace_initialization_error_to_core)?
     {
         NamespaceInitializationState::Absent => {}
         NamespaceInitializationState::Complete => {
@@ -440,19 +448,6 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     let source_checkpoint =
         load_verified_checkpoint_materialization(store, source_namespace_id, fork_seq)
             .map_err(|err| CoreError::Basis(BasisLoadError::CheckpointLoad(err)))?;
-
-    write_verified_checkpoint_from_metadata(
-        store,
-        CheckpointMetadataWriteRequest {
-            namespace_id: new_namespace_id,
-            checkpoint_seq: fork_seq,
-            active_fence_token: FenceToken(0),
-            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
-            retention_floor_seq: fork_seq,
-            metadata_state: &source_checkpoint.metadata_state,
-            writer_version: &context.writer_version,
-        },
-    )?;
 
     let initial_head = HeadState {
         namespace_id: new_namespace_id.clone(),
@@ -494,29 +489,77 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     let head_key = namespace_head(new_namespace_id.as_str());
     let lease_key = namespace_lease(new_namespace_id.as_str());
     let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
-    store
-        .put_if_absent(
-            &head_key,
-            &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    store
-        .put_if_absent(
-            &lease_key,
-            &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    store
-        .put_if_absent(
-            &descriptor_key,
-            &serde_json::to_vec(&namespace_descriptor_envelope)
-                .map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &head_key,
+        &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
+    write_verified_checkpoint_from_metadata(
+        store,
+        CheckpointMetadataWriteRequest {
+            namespace_id: new_namespace_id,
+            checkpoint_seq: fork_seq,
+            active_fence_token: FenceToken(0),
+            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
+            retention_floor_seq: fork_seq,
+            metadata_state: &source_checkpoint.metadata_state,
+            writer_version: &context.writer_version,
+        },
+    )?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &lease_key,
+        &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &descriptor_key,
+        &serde_json::to_vec(&namespace_descriptor_envelope)
+            .map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
 
     Ok(NamespaceSummary {
         namespace_id: new_namespace_id.clone(),
     })
+}
+
+fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    object_key: &str,
+    bytes: &[u8],
+) -> Result<(), CoreError> {
+    match store.put_if_absent(object_key, bytes) {
+        Ok(_) => Ok(()),
+        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+            match namespace_initialization_state(store, namespace_id)
+                .map_err(map_namespace_initialization_error_to_core)?
+            {
+                NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
+                    namespace_id: namespace_id.clone(),
+                }),
+                NamespaceInitializationState::Partial => {
+                    Err(CoreError::NamespacePartiallyInitialized {
+                        namespace_id: namespace_id.clone(),
+                    })
+                }
+                NamespaceInitializationState::Absent => Err(CoreError::Store(format!(
+                    "target namespace control object `{object_key}` write failed, but namespace remains absent"
+                ))),
+            }
+        }
+        Err(err) => Err(CoreError::Store(err.to_string())),
+    }
+}
+
+fn map_namespace_initialization_error_to_core(error: BootstrapNamespaceError) -> CoreError {
+    match error {
+        BootstrapNamespaceError::InvalidNamespaceId(error) => CoreError::InvalidNamespaceId(error),
+        other => CoreError::Store(other.to_string()),
+    }
 }
 
 pub fn list_namespaces<S: ObjectStore + ?Sized>(
@@ -1510,6 +1553,7 @@ fn tombstoned_path_ancestor(
 
 fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErrorKind {
     match error {
+        ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
         ControlObjectLoadError::MissingObject { .. }
         | ControlObjectLoadError::MissingObjectAfterHead { .. } => CoreErrorKind::NamespaceNotFound,
         ControlObjectLoadError::KindMismatch { .. }
@@ -1529,6 +1573,7 @@ fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
             _ => CoreErrorKind::NamespaceCorrupt,
         },
         BasisLoadError::LoadHead(error) | BasisLoadError::LoadLease(error) => match error {
+            ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
             ControlObjectLoadError::MissingObject { .. }
             | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
                 CoreErrorKind::NamespaceCorrupt

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -253,7 +253,7 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     match namespace_initialization_state(store, namespace_id)? {
         NamespaceInitializationState::Complete if allow_existing => {
             return Ok(NamespaceSummary {
-                name: namespace_id.clone(),
+                namespace_id: namespace_id.clone(),
             });
         }
         NamespaceInitializationState::Complete => {
@@ -321,7 +321,7 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     let _ = bootstrap_basis_metadata_state();
 
     Ok(NamespaceSummary {
-        name: namespace_id.clone(),
+        namespace_id: namespace_id.clone(),
     })
 }
 
@@ -513,7 +513,7 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
         .map_err(|err| CoreError::Store(err.to_string()))?;
 
     Ok(NamespaceSummary {
-        name: new_namespace_id.clone(),
+        namespace_id: new_namespace_id.clone(),
     })
 }
 
@@ -541,7 +541,7 @@ pub fn list_namespaces<S: ObjectStore + ?Sized>(
     }
     Ok(names
         .into_iter()
-        .map(|name| NamespaceSummary { name })
+        .map(|namespace_id| NamespaceSummary { namespace_id })
         .collect())
 }
 

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -1,7 +1,7 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
 use crate::checkpoint::{
     create_checkpoint, load_verified_checkpoint_materialization,
-    write_verified_checkpoint_from_metadata,
+    write_verified_checkpoint_from_metadata, CheckpointMetadataWriteRequest,
 };
 use crate::commit::{CommitHeadPublishError, CommitOp, CommitValidationError};
 use crate::content::{
@@ -443,13 +443,15 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
 
     write_verified_checkpoint_from_metadata(
         store,
-        new_namespace_id,
-        fork_seq,
-        FenceToken(0),
-        source_checkpoint.manifest.payload.next_inode_id,
-        fork_seq,
-        &source_checkpoint.metadata_state,
-        &context.writer_version,
+        CheckpointMetadataWriteRequest {
+            namespace_id: new_namespace_id,
+            checkpoint_seq: fork_seq,
+            active_fence_token: FenceToken(0),
+            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
+            retention_floor_seq: fork_seq,
+            metadata_state: &source_checkpoint.metadata_state,
+            writer_version: &context.writer_version,
+        },
     )?;
 
     let initial_head = HeadState {

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -1,11 +1,17 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
+use crate::checkpoint::{
+    create_checkpoint, load_verified_checkpoint_materialization,
+    write_verified_checkpoint_from_metadata,
+};
 use crate::commit::{CommitHeadPublishError, CommitOp, CommitValidationError};
 use crate::content::{
     read_durable_content_bytes, validate_durable_content_reference, DurableContentValidationError,
 };
 use crate::genesis::bootstrap_basis_metadata_state;
 use crate::lease::LeaseAcquireError;
-use crate::loading::ControlObjectLoadError;
+use crate::loading::{
+    read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
+};
 use crate::metadata::{MetadataApplyError, MetadataState, ResolvedVisiblePath, VisiblePathError};
 use crate::wal::WalBuildError;
 use loon_api::{
@@ -14,11 +20,15 @@ use loon_api::{
         CommitOp as V0CommitOp, CommitOpResult, CommitPrecondition as V0CommitPrecondition,
         CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse,
     },
-    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef, ControlObjectKind,
-    HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
-    MutationResult, NamespaceId, NamespaceSummary,
+    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
+    ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
+    FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
+    MutationResult, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
+    NamespaceSummary,
 };
-use loon_objectstore::keys::{content_blob, namespace_head, namespace_lease};
+use loon_objectstore::keys::{
+    content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
+};
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -34,6 +44,8 @@ pub struct MutationContext {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredContent {
+    pub content_store_id: ContentStoreId,
+    pub object_key: String,
     pub content_ref: ContentRef,
     pub file_digest_sha256: String,
     pub file_size_bytes: u64,
@@ -49,6 +61,8 @@ pub enum PutFileBehavior {
 pub enum CoreErrorKind {
     InvalidPath,
     NamespaceNotFound,
+    NamespaceExists,
+    NamespacePartial,
     PathNotFound,
     RevisionNotFound,
     PathConflict,
@@ -79,7 +93,13 @@ pub enum BootstrapNamespaceError {
     #[error("namespace `{namespace_id}` is partially initialized")]
     NamespacePartiallyInitialized { namespace_id: NamespaceId },
     #[error(transparent)]
-    Head(#[from] ControlObjectLoadError),
+    Descriptor(ControlObjectLoadError),
+    #[error("failed to write namespace descriptor object: {0}")]
+    DescriptorWrite(String),
+    #[error("failed to write content store descriptor object: {0}")]
+    ContentStoreWrite(String),
+    #[error(transparent)]
+    Head(ControlObjectLoadError),
     #[error("failed to write head object: {0}")]
     HeadWrite(String),
     #[error("failed to write lease object: {0}")]
@@ -151,6 +171,10 @@ pub enum CoreError {
     NonDirectoryPathComponent(String),
     #[error("object store error: {0}")]
     Store(String),
+    #[error("namespace `{namespace_id}` already exists")]
+    NamespaceAlreadyExists { namespace_id: NamespaceId },
+    #[error("namespace `{namespace_id}` is partially initialized")]
+    NamespacePartiallyInitialized { namespace_id: NamespaceId },
 }
 
 impl From<CommitValidationError> for CoreError {
@@ -194,6 +218,8 @@ impl CoreError {
                 CoreErrorKind::InvalidPath
             }
             CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
+            CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
+            CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
             CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
             CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
             CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,
@@ -224,36 +250,26 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         return Err(BootstrapNamespaceError::EmptyWriterVersion);
     }
 
-    let head_key = namespace_head(namespace_id.as_str());
-    let lease_key = namespace_lease(namespace_id.as_str());
-    let existing_head = store
-        .head(&head_key)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?
-        .is_some();
-    let existing_lease = store
-        .head(&lease_key)
-        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?
-        .is_some();
-
-    match (existing_head, existing_lease) {
-        (true, true) if allow_existing => {
+    match namespace_initialization_state(store, namespace_id)? {
+        NamespaceInitializationState::Complete if allow_existing => {
             return Ok(NamespaceSummary {
                 name: namespace_id.clone(),
             });
         }
-        (true, true) => {
+        NamespaceInitializationState::Complete => {
             return Err(BootstrapNamespaceError::NamespaceAlreadyExists {
                 namespace_id: namespace_id.clone(),
             });
         }
-        (true, false) | (false, true) => {
+        NamespaceInitializationState::Partial => {
             return Err(BootstrapNamespaceError::NamespacePartiallyInitialized {
                 namespace_id: namespace_id.clone(),
             });
         }
-        (false, false) => {}
+        NamespaceInitializationState::Absent => {}
     }
 
+    let content_store_id = create_new_content_store(store, context)?;
     let initial_head = HeadState::initial(namespace_id.clone());
     let initial_lease = LeaseState {
         namespace_id: namespace_id.clone(),
@@ -277,18 +293,227 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
     let lease_bytes = serde_json::to_vec(&lease_envelope)
         .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+    let namespace_descriptor_envelope = NamespaceDescriptorEnvelope::from_state(
+        ControlObjectKind::NamespaceDescriptor,
+        &context.writer_version,
+        NamespaceDescriptorState {
+            namespace_id: namespace_id.clone(),
+            content_store_id,
+        },
+    )
+    .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
+    let namespace_descriptor_bytes = serde_json::to_vec(&namespace_descriptor_envelope)
+        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
 
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
     store
         .put_if_absent(&head_key, &head_bytes)
         .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
     store
         .put_if_absent(&lease_key, &lease_bytes)
         .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+    store
+        .put_if_absent(&descriptor_key, &namespace_descriptor_bytes)
+        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
 
     let _ = bootstrap_basis_metadata_state();
 
     Ok(NamespaceSummary {
         name: namespace_id.clone(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NamespaceInitializationState {
+    Absent,
+    Partial,
+    Complete,
+}
+
+fn namespace_initialization_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<NamespaceInitializationState, BootstrapNamespaceError> {
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+
+    let descriptor_exists = store
+        .head(&descriptor_key)
+        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?
+        .is_some();
+    let head_exists = store
+        .head(&head_key)
+        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?
+        .is_some();
+    let lease_exists = store
+        .head(&lease_key)
+        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?
+        .is_some();
+
+    match (descriptor_exists, head_exists, lease_exists) {
+        (false, false, false) => Ok(NamespaceInitializationState::Absent),
+        (true, true, true) => {
+            let descriptor = read_namespace_descriptor_object(store, namespace_id)
+                .map_err(BootstrapNamespaceError::Descriptor)?;
+            read_content_store_descriptor_object(
+                store,
+                &descriptor.envelope.state.content_store_id,
+            )
+            .map_err(BootstrapNamespaceError::Descriptor)?;
+            Ok(NamespaceInitializationState::Complete)
+        }
+        _ => Ok(NamespaceInitializationState::Partial),
+    }
+}
+
+const CONTENT_STORE_ID_RETRY_LIMIT: usize = 8;
+
+fn create_new_content_store<S: ObjectStore + ?Sized>(
+    store: &S,
+    context: &MutationContext,
+) -> Result<ContentStoreId, BootstrapNamespaceError> {
+    for _attempt in 0..CONTENT_STORE_ID_RETRY_LIMIT {
+        let content_store_id = ContentStoreId::from(format!("cs_{}", Uuid::new_v4().simple()));
+        let descriptor = ContentStoreDescriptorEnvelope::from_state(
+            ControlObjectKind::ContentStoreDescriptor,
+            &context.writer_version,
+            ContentStoreDescriptorState {
+                content_store_id: content_store_id.clone(),
+            },
+        )
+        .map_err(|err| BootstrapNamespaceError::ContentStoreWrite(err.to_string()))?;
+        let bytes = serde_json::to_vec(&descriptor)
+            .map_err(|err| BootstrapNamespaceError::ContentStoreWrite(err.to_string()))?;
+        let key = content_store_descriptor(content_store_id.as_str());
+        match store.put_if_absent(&key, &bytes) {
+            Ok(_) => return Ok(content_store_id),
+            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
+            Err(err) => return Err(BootstrapNamespaceError::ContentStoreWrite(err.to_string())),
+        }
+    }
+
+    Err(BootstrapNamespaceError::ContentStoreWrite(
+        "content store id generation collided repeatedly".to_owned(),
+    ))
+}
+
+pub(crate) fn load_namespace_content_store_id<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<ContentStoreId, CoreError> {
+    let descriptor = read_namespace_descriptor_object(store, namespace_id)
+        .map_err(|err| CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(err)))?;
+    let content_store_id = descriptor.envelope.state.content_store_id;
+    read_content_store_descriptor_object(store, &content_store_id)
+        .map_err(|err| CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(err)))?;
+    Ok(content_store_id)
+}
+
+pub fn fork_namespace<S: ObjectStore + ?Sized>(
+    store: &S,
+    source_namespace_id: &NamespaceId,
+    new_namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<NamespaceSummary, CoreError> {
+    match namespace_initialization_state(store, new_namespace_id)
+        .map_err(|err| CoreError::Store(err.to_string()))?
+    {
+        NamespaceInitializationState::Absent => {}
+        NamespaceInitializationState::Complete => {
+            return Err(CoreError::NamespaceAlreadyExists {
+                namespace_id: new_namespace_id.clone(),
+            });
+        }
+        NamespaceInitializationState::Partial => {
+            return Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: new_namespace_id.clone(),
+            });
+        }
+    }
+
+    let checkpoint = create_checkpoint(store, source_namespace_id, context)?;
+    let fork_seq = checkpoint.checkpoint_seq;
+    let source_basis = load_verified_namespace_basis(store, source_namespace_id)?;
+    let source_checkpoint =
+        load_verified_checkpoint_materialization(store, source_namespace_id, fork_seq)
+            .map_err(|err| CoreError::Basis(BasisLoadError::CheckpointLoad(err)))?;
+
+    write_verified_checkpoint_from_metadata(
+        store,
+        new_namespace_id,
+        fork_seq,
+        FenceToken(0),
+        source_checkpoint.manifest.payload.next_inode_id,
+        fork_seq,
+        &source_checkpoint.metadata_state,
+        &context.writer_version,
+    )?;
+
+    let initial_head = HeadState {
+        namespace_id: new_namespace_id.clone(),
+        seq: fork_seq,
+        active_fence_token: FenceToken(0),
+        next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
+        name_policy: source_basis.head.name_policy,
+        snapshot_hint_seq: Some(fork_seq),
+        retention_floor_seq: fork_seq,
+    };
+    let initial_lease = LeaseState {
+        namespace_id: new_namespace_id.clone(),
+        holder_id: context.writer_id.clone(),
+        fence_token: initial_head.active_fence_token,
+        lease_expires_at_ms: context.now_ms.saturating_add(context.lease_duration_ms),
+    };
+    let namespace_descriptor_envelope = NamespaceDescriptorEnvelope::from_state(
+        ControlObjectKind::NamespaceDescriptor,
+        &context.writer_version,
+        NamespaceDescriptorState {
+            namespace_id: new_namespace_id.clone(),
+            content_store_id: source_basis.content_store_id,
+        },
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
+    let head = HeadStateEnvelope::from_state(
+        ControlObjectKind::NamespaceHead,
+        &context.writer_version,
+        initial_head,
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
+    let lease = LeaseStateEnvelope::from_state(
+        ControlObjectKind::NamespaceLease,
+        &context.writer_version,
+        initial_lease,
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
+
+    let head_key = namespace_head(new_namespace_id.as_str());
+    let lease_key = namespace_lease(new_namespace_id.as_str());
+    let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
+    store
+        .put_if_absent(
+            &head_key,
+            &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    store
+        .put_if_absent(
+            &lease_key,
+            &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    store
+        .put_if_absent(
+            &descriptor_key,
+            &serde_json::to_vec(&namespace_descriptor_envelope)
+                .map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+
+    Ok(NamespaceSummary {
+        name: new_namespace_id.clone(),
     })
 }
 
@@ -303,10 +528,16 @@ pub fn list_namespaces<S: ObjectStore + ?Sized>(
         let Some(rest) = key.strip_prefix("namespaces/") else {
             continue;
         };
-        let Some((namespace, _)) = rest.split_once('/') else {
+        let Some((namespace, leaf)) = rest.split_once('/') else {
             continue;
         };
-        names.insert(NamespaceId::from(namespace.to_owned()));
+        if leaf != "descriptor.json" {
+            continue;
+        }
+        let namespace_id = NamespaceId::from(namespace.to_owned());
+        read_namespace_descriptor_object(store, &namespace_id)
+            .map_err(|err| CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(err)))?;
+        names.insert(namespace_id);
     }
     Ok(names
         .into_iter()
@@ -326,6 +557,7 @@ pub fn resolve_path<S: ObjectStore + ?Sized>(
     build_authoritative_path_entry(
         store,
         namespace_id,
+        &basis.content_store_id,
         basis.head.seq,
         &basis.metadata_state,
         &resolved,
@@ -345,6 +577,7 @@ pub fn list_path<S: ObjectStore + ?Sized>(
         return Ok(vec![build_authoritative_path_entry(
             store,
             namespace_id,
+            &basis.content_store_id,
             basis.head.seq,
             &basis.metadata_state,
             &resolved,
@@ -369,6 +602,7 @@ pub fn list_path<S: ObjectStore + ?Sized>(
             build_authoritative_path_entry(
                 store,
                 namespace_id,
+                &basis.content_store_id,
                 basis.head.seq,
                 &basis.metadata_state,
                 &ResolvedVisiblePath {
@@ -402,7 +636,8 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
         .content_ref
         .clone()
         .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
-    let read = read_durable_content_bytes(store, namespace_id, &content_ref)?;
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+    let read = read_durable_content_bytes(store, &content_store_id, &content_ref)?;
     Ok(AuthoritativeFileBytes {
         entry,
         bytes: read.bytes,
@@ -414,12 +649,15 @@ pub fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     bytes: &[u8],
 ) -> Result<StoredContent, CoreError> {
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
     let content_ref = ContentRef::whole_file_v0(bytes);
-    let object_key = content_blob(namespace_id.as_str(), &content_ref.digest)
+    let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
         .map_err(|err| CoreError::Store(err.to_string()))?;
     write_immutable_object(store, &object_key, bytes)?;
 
     Ok(StoredContent {
+        content_store_id,
+        object_key,
         file_digest_sha256: content_ref.digest.clone(),
         file_size_bytes: content_ref.size_bytes,
         content_ref,
@@ -491,7 +729,9 @@ pub fn put_file_bytes<S: ObjectStore + ?Sized>(
 ) -> Result<MutationResult, CoreError> {
     validate_path_for_mutation(absolute_path)?;
     let stored = store_bytes_as_content(store, namespace_id, bytes)?;
-    let _validated = validate_durable_content_reference(store, namespace_id, &stored.content_ref)?;
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+    let _validated =
+        validate_durable_content_reference(store, &content_store_id, &stored.content_ref)?;
     put_file_content_ref(
         store,
         namespace_id,
@@ -531,7 +771,8 @@ pub fn put_file_content_ref<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let _validated = validate_durable_content_reference(store, namespace_id, &content_ref)?;
+    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
+    let _validated = validate_durable_content_reference(store, &content_store_id, &content_ref)?;
     commit_file_content_ref(
         store,
         namespace_id,
@@ -896,7 +1137,7 @@ pub fn copy_file_path<S: ObjectStore + ?Sized>(
         .latest_revision_head_at_seq(source.inode_id, basis.head.seq)
         .ok_or_else(|| CoreError::MissingPath(from_path.to_owned()))?;
     let _validated =
-        validate_durable_content_reference(store, namespace_id, &revision.content_ref)?;
+        validate_durable_content_reference(store, &basis.content_store_id, &revision.content_ref)?;
 
     let target_parent = resolve_parent_directory(&basis.metadata_state, to_path, basis.head.seq)?;
     let target_name = final_component(to_path)?;
@@ -1087,6 +1328,7 @@ fn resolve_parent_directory(
 fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
     head_seq: ChangeSeq,
     metadata_state: &MetadataState,
     resolved: &ResolvedVisiblePath,
@@ -1097,7 +1339,8 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
         .map(|revision| revision.content_ref.clone());
     let size_bytes = match content_ref.as_ref() {
         Some(content_ref) => {
-            let validated = validate_durable_content_reference(store, namespace_id, content_ref)?;
+            let validated =
+                validate_durable_content_reference(store, content_store_id, content_ref)?;
             Some(validated.file_size_bytes)
         }
         None => None,
@@ -1269,6 +1512,7 @@ fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErr
         | ControlObjectLoadError::MissingObjectAfterHead { .. } => CoreErrorKind::NamespaceNotFound,
         ControlObjectLoadError::KindMismatch { .. }
         | ControlObjectLoadError::NamespaceMismatch { .. }
+        | ControlObjectLoadError::ContentStoreMismatch { .. }
         | ControlObjectLoadError::ChecksumMismatch { .. }
         | ControlObjectLoadError::Codec { .. } => CoreErrorKind::NamespaceCorrupt,
         ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
@@ -1277,9 +1521,18 @@ fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErr
 
 fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
     match error {
-        BasisLoadError::LoadHead(error) | BasisLoadError::LoadLease(error) => {
-            classify_control_object_load_error(error)
-        }
+        BasisLoadError::LoadNamespaceDescriptor(error) => classify_control_object_load_error(error),
+        BasisLoadError::LoadContentStoreDescriptor(error) => match error {
+            ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
+            _ => CoreErrorKind::NamespaceCorrupt,
+        },
+        BasisLoadError::LoadHead(error) | BasisLoadError::LoadLease(error) => match error {
+            ControlObjectLoadError::MissingObject { .. }
+            | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
+                CoreErrorKind::NamespaceCorrupt
+            }
+            _ => classify_control_object_load_error(error),
+        },
         BasisLoadError::InvalidWalObjectKey { .. }
         | BasisLoadError::DuplicateWalSeq { .. }
         | BasisLoadError::MissingWalObject { .. }

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -275,7 +275,6 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         NamespaceInitializationState::Absent => {}
     }
 
-    let content_store_id = create_new_content_store(store, context)?;
     let initial_head = HeadState::initial(namespace_id.clone());
     let initial_lease = LeaseState {
         namespace_id: namespace_id.clone(),
@@ -299,6 +298,18 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
     let lease_bytes = serde_json::to_vec(&lease_envelope)
         .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    store
+        .put_if_absent(&head_key, &head_bytes)
+        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
+    store
+        .put_if_absent(&lease_key, &lease_bytes)
+        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+
+    let content_store_id = create_new_content_store(store, context)?;
     let namespace_descriptor_envelope = NamespaceDescriptorEnvelope::from_state(
         ControlObjectKind::NamespaceDescriptor,
         &context.writer_version,
@@ -310,16 +321,6 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
     let namespace_descriptor_bytes = serde_json::to_vec(&namespace_descriptor_envelope)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
-
-    let head_key = namespace_head(namespace_id.as_str());
-    let lease_key = namespace_lease(namespace_id.as_str());
-    let descriptor_key = namespace_descriptor(namespace_id.as_str());
-    store
-        .put_if_absent(&head_key, &head_bytes)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
-    store
-        .put_if_absent(&lease_key, &lease_bytes)
-        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
     store
         .put_if_absent(&descriptor_key, &namespace_descriptor_bytes)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -650,6 +650,36 @@ fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
 }
 
 #[test]
+fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Exact(namespace_head(namespace_id.as_str())),
+        InjectedCreateFailure::PreconditionFailed {
+            write_attempted_object: true,
+            additional_writes: Vec::new(),
+        },
+    );
+
+    let error = bootstrap_namespace(&store, &namespace_id, &context, false)
+        .expect_err("target head precondition should fail bootstrap");
+    assert!(matches!(
+        error,
+        loon_core::BootstrapNamespaceError::HeadWrite(_)
+    ));
+    assert!(
+        store
+            .list_prefix("content-stores/")
+            .expect("list content stores")
+            .is_empty(),
+        "content-store descriptor must not be allocated before namespace head reservation"
+    );
+    assert_namespace_partial(&store, &namespace_id, &context);
+}
+
+#[test]
 fn public_namespace_operations_reject_invalid_namespace_id_before_key_construction() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,7 +1,8 @@
 use loon_api::{
     sha256_digest,
     v0::{CommitOp as V0CommitOp, CommitPrecondition, CommitRequest as V0CommitRequest},
-    ChangeSeq, ContentRef, ContentRefKind, FenceToken, HeadState, InodeId, InodeKind, LeaseState,
+    ChangeSeq, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope, ControlObjectKind,
+    FenceToken, HeadState, InodeId, InodeKind, LeaseState, NamespaceDescriptorEnvelope,
     NamespaceId, RevisionNo,
 };
 use loon_core::commit::{
@@ -11,11 +12,14 @@ use loon_core::commit::{
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
     bootstrap_namespace, commit_operations, copy_file_path, delete_path, delete_path_non_recursive,
-    move_path, put_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior,
+    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
+    put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
+    CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
-use loon_objectstore::keys::content_blob;
+use loon_objectstore::keys::{
+    content_blob, content_store_descriptor, namespace_descriptor, namespace_head,
+};
 use loon_objectstore::ObjectStore;
 use tempfile::tempdir;
 
@@ -574,6 +578,232 @@ fn restore_revision_overflow_is_rejected() {
 }
 
 #[test]
+fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap namespace");
+
+    let basis = load_verified_namespace_basis(&store, &namespace_id).expect("load namespace basis");
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    let descriptor_bytes = store
+        .get(&descriptor_key, None)
+        .expect("read namespace descriptor")
+        .expect("namespace descriptor exists");
+    let descriptor: NamespaceDescriptorEnvelope =
+        serde_json::from_slice(&descriptor_bytes).expect("decode namespace descriptor");
+    assert_eq!(descriptor.kind, ControlObjectKind::NamespaceDescriptor);
+    assert_eq!(descriptor.state.namespace_id, namespace_id);
+    assert_eq!(descriptor.state.content_store_id, basis.content_store_id);
+    assert!(descriptor.has_valid_payload_checksum().expect("checksum"));
+
+    let content_descriptor_key = content_store_descriptor(basis.content_store_id.as_str());
+    let content_descriptor_bytes = store
+        .get(&content_descriptor_key, None)
+        .expect("read content-store descriptor")
+        .expect("content-store descriptor exists");
+    let content_descriptor: ContentStoreDescriptorEnvelope =
+        serde_json::from_slice(&content_descriptor_bytes).expect("decode content-store descriptor");
+    assert_eq!(
+        content_descriptor.kind,
+        ControlObjectKind::ContentStoreDescriptor
+    );
+    assert_eq!(
+        content_descriptor.state.content_store_id,
+        basis.content_store_id
+    );
+    assert!(content_descriptor
+        .has_valid_payload_checksum()
+        .expect("checksum"));
+
+    let content_store_descriptors = store
+        .list_prefix("content-stores/")
+        .expect("list content stores");
+    assert_eq!(
+        content_store_descriptors,
+        vec![content_descriptor_key],
+        "new root namespace should create exactly one content store descriptor"
+    );
+
+    store
+        .put_if_absent(&namespace_head("partial"), br#"{"not":"a descriptor"}"#)
+        .expect("write partial namespace key");
+    let listed = list_namespaces(&store).expect("list namespaces");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name.as_str(), "demo");
+
+    let partial_error = bootstrap_namespace(&store, &NamespaceId::from("partial"), &context, false)
+        .expect_err("partial namespace should be rejected");
+    assert!(matches!(
+        partial_error,
+        loon_core::BootstrapNamespaceError::NamespacePartiallyInitialized { .. }
+    ));
+}
+
+#[test]
+fn namespace_descriptor_checksum_is_validated() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap namespace");
+
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    let descriptor_bytes = store
+        .get(&descriptor_key, None)
+        .expect("read namespace descriptor")
+        .expect("namespace descriptor exists");
+    let mut descriptor: NamespaceDescriptorEnvelope =
+        serde_json::from_slice(&descriptor_bytes).expect("decode namespace descriptor");
+    descriptor.payload_checksum_sha256 = "not-the-payload-checksum".to_owned();
+    let corrupted = serde_json::to_vec(&descriptor).expect("encode corrupted descriptor");
+    store
+        .put_overwrite(&descriptor_key, &corrupted)
+        .expect("overwrite descriptor");
+
+    let error =
+        load_verified_namespace_basis(&store, &namespace_id).expect_err("descriptor checksum");
+    assert!(
+        error.to_string().contains("checksum mismatch"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn fork_namespace_reuses_content_store_and_isolates_metadata() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::from("clone");
+
+    bootstrap_namespace(&store, &source_namespace_id, &context, false)
+        .expect("bootstrap source namespace");
+    write_file_bytes(
+        &store,
+        &source_namespace_id,
+        "/docs/shared.txt",
+        b"base",
+        &context,
+        Some("seed-shared"),
+    )
+    .expect("seed shared file");
+
+    let source_basis =
+        load_verified_namespace_basis(&store, &source_namespace_id).expect("source basis");
+    assert_eq!(source_basis.head.seq, ChangeSeq(1));
+    let content_store_id = source_basis.content_store_id.clone();
+    let blobs_before = store
+        .list_prefix(&format!(
+            "content-stores/{}/blobs/",
+            content_store_id.as_str()
+        ))
+        .expect("list blobs before fork");
+
+    fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect("fork namespace");
+
+    let blobs_after = store
+        .list_prefix(&format!(
+            "content-stores/{}/blobs/",
+            content_store_id.as_str()
+        ))
+        .expect("list blobs after fork");
+    assert_eq!(blobs_after, blobs_before, "fork must not copy content");
+
+    let clone_basis =
+        load_verified_namespace_basis(&store, &clone_namespace_id).expect("clone basis");
+    assert_eq!(clone_basis.content_store_id, content_store_id);
+    assert_eq!(clone_basis.head.seq, ChangeSeq(1));
+    assert_eq!(clone_basis.head.snapshot_hint_seq, Some(ChangeSeq(1)));
+    assert_eq!(clone_basis.head.retention_floor_seq, ChangeSeq(1));
+
+    let source_entry =
+        resolve_path(&store, &source_namespace_id, "/docs/shared.txt").expect("source stat");
+    let clone_entry =
+        resolve_path(&store, &clone_namespace_id, "/docs/shared.txt").expect("clone stat");
+    assert_eq!(source_entry.content_ref, clone_entry.content_ref);
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("read clone")
+            .bytes,
+        b"base"
+    );
+
+    let stale_clone_changes =
+        list_changes_after(&store, &clone_namespace_id, ChangeSeq(0)).expect_err("old cursor");
+    assert_eq!(
+        stale_clone_changes.kind(),
+        CoreErrorKind::RebootstrapRequired
+    );
+    let empty_clone_changes =
+        list_changes_after(&store, &clone_namespace_id, ChangeSeq(1)).expect("empty changes");
+    assert!(empty_clone_changes.changes.is_empty());
+
+    write_file_bytes(
+        &store,
+        &source_namespace_id,
+        "/docs/shared.txt",
+        b"source-after-fork",
+        &context,
+        Some("source-after-fork"),
+    )
+    .expect("source replace");
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("read clone after source write")
+            .bytes,
+        b"base"
+    );
+
+    let clone_write = write_file_bytes(
+        &store,
+        &clone_namespace_id,
+        "/docs/shared.txt",
+        b"clone-after-fork",
+        &context,
+        Some("clone-after-fork"),
+    )
+    .expect("clone replace");
+    assert_eq!(clone_write.committed_seq, ChangeSeq(2));
+    assert_eq!(
+        read_file_bytes(&store, &source_namespace_id, "/docs/shared.txt")
+            .expect("read source")
+            .bytes,
+        b"source-after-fork"
+    );
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("read clone")
+            .bytes,
+        b"clone-after-fork"
+    );
+
+    let clone_changes =
+        list_changes_after(&store, &clone_namespace_id, ChangeSeq(1)).expect("clone changes");
+    assert_eq!(clone_changes.changes.len(), 1);
+    assert_eq!(clone_changes.changes[0].seq, ChangeSeq(2));
+
+    for key in store
+        .list_prefix(&format!("namespaces/{}/", source_namespace_id.as_str()))
+        .expect("list source namespace keys")
+    {
+        store
+            .delete(&key)
+            .expect("delete source namespace metadata");
+    }
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("clone remains readable")
+            .bytes,
+        b"clone-after-fork"
+    );
+}
+
+#[test]
 fn restore_revision_revalidates_durable_content_before_publish() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -630,7 +860,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
 
     store
         .delete(
-            &content_blob(namespace_id().as_str(), &first.content_ref.digest)
+            &content_blob(first.content_store_id.as_str(), &first.content_ref.digest)
                 .expect("first content key"),
         )
         .expect("delete first content");
@@ -823,7 +1053,7 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
     let second = store_bytes_as_content(&store, &namespace_id(), b"second").expect("stage second");
     store
         .delete(
-            &content_blob(namespace_id().as_str(), &second.content_ref.digest)
+            &content_blob(second.content_store_id.as_str(), &second.content_ref.digest)
                 .expect("second content key"),
         )
         .expect("delete second content");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -632,7 +632,7 @@ fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
         .expect("write partial namespace key");
     let listed = list_namespaces(&store).expect("list namespaces");
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].name.as_str(), "demo");
+    assert_eq!(listed[0].namespace_id.as_str(), "demo");
 
     let partial_error = bootstrap_namespace(&store, &NamespaceId::from("partial"), &context, false)
         .expect_err("partial namespace should be rejected");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -20,7 +20,9 @@ use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, namespace_descriptor, namespace_head,
 };
-use loon_objectstore::ObjectStore;
+use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
 
 #[test]
@@ -894,6 +896,51 @@ fn restore_revision_revalidates_durable_content_before_publish() {
 }
 
 #[test]
+fn metadata_only_commit_does_not_validate_content_store_refs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
+    write_file_bytes(
+        &store,
+        &namespace_id(),
+        "/docs/delete-me.txt",
+        b"hello",
+        &context,
+        Some("seed-metadata-only-delete"),
+    )
+    .expect("seed file");
+    let inode_id = resolve_path(&store, &namespace_id(), "/docs/delete-me.txt")
+        .expect("resolve seeded file")
+        .inode_id;
+
+    let guarded_store = ContentStoreAccessLimitStore::new(temp_dir.path(), 2);
+    let response = commit_operations(
+        &guarded_store,
+        &namespace_id(),
+        V0CommitRequest {
+            request_id: "metadata-only-delete".to_owned(),
+            planned_head_seq: ChangeSeq(1),
+            preconditions: vec![CommitPrecondition::HeadSeqIs {
+                expected_seq: ChangeSeq(1),
+            }],
+            ops: vec![V0CommitOp::DeleteFile { inode_id }],
+            message: None,
+            annotations: None,
+        },
+        &context,
+    )
+    .expect("metadata-only delete should not perform content validation");
+
+    assert_eq!(response.committed_seq, ChangeSeq(2));
+    assert_eq!(
+        guarded_store.content_store_access_count(),
+        2,
+        "basis loading performs one content-store descriptor head/get; metadata-only validation must not add another lookup",
+    );
+}
+
+#[test]
 fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -1427,5 +1474,72 @@ fn content_ref(seed: &str) -> ContentRef {
         kind: ContentRefKind::WholeFileV0,
         digest: sha256_digest(seed.as_bytes()),
         size_bytes: seed.len() as u64,
+    }
+}
+
+struct ContentStoreAccessLimitStore {
+    inner: LocalFsStore,
+    content_store_accesses: AtomicUsize,
+    max_content_store_accesses: usize,
+}
+
+impl ContentStoreAccessLimitStore {
+    fn new(root: impl AsRef<Path>, max_content_store_accesses: usize) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            content_store_accesses: AtomicUsize::new(0),
+            max_content_store_accesses,
+        }
+    }
+
+    fn content_store_access_count(&self) -> usize {
+        self.content_store_accesses.load(Ordering::SeqCst)
+    }
+
+    fn record_content_store_access(&self, key: &str) -> Result<(), ObjectStoreError> {
+        if !key.starts_with("content-stores/") {
+            return Ok(());
+        }
+
+        let previous = self.content_store_accesses.fetch_add(1, Ordering::SeqCst);
+        if previous >= self.max_content_store_accesses {
+            return Err(ObjectStoreError::Transport(format!(
+                "unexpected content-store descriptor access: {key}",
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl ObjectStore for ContentStoreAccessLimitStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.record_content_store_access(key)?;
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.record_content_store_access(key)?;
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
     }
 }

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,6 +1,9 @@
 use loon_api::{
     sha256_digest,
-    v0::{CommitOp as V0CommitOp, CommitPrecondition, CommitRequest as V0CommitRequest},
+    v0::{
+        CommitOp as V0CommitOp, CommitPrecondition, CommitRequest as V0CommitRequest,
+        CompleteUploadRequest,
+    },
     ChangeSeq, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope, ControlObjectKind,
     FenceToken, HeadState, InodeId, InodeKind, LeaseState, NamespaceDescriptorEnvelope,
     NamespaceId, RevisionNo,
@@ -11,18 +14,20 @@ use loon_core::commit::{
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
-    bootstrap_namespace, commit_operations, copy_file_path, delete_path, delete_path_non_recursive,
-    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
-    put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
-    CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
+    bootstrap_namespace, commit_operations, complete_upload, copy_file_path, delete_path,
+    delete_path_non_recursive, fork_namespace, list_changes_after, list_namespaces,
+    load_verified_namespace_basis, move_path, put_file_bytes, read_file_bytes, resolve_path,
+    store_bytes_as_content, write_file_bytes, CoreError, CoreErrorKind, MutationContext,
+    PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
-    content_blob, content_store_descriptor, namespace_descriptor, namespace_head,
+    content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
 };
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 use tempfile::tempdir;
 
 #[test]
@@ -645,6 +650,62 @@ fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
 }
 
 #[test]
+fn public_namespace_operations_reject_invalid_namespace_id_before_key_construction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let invalid_namespace = NamespaceId::from("bad/name");
+
+    let bootstrap_error = bootstrap_namespace(&store, &invalid_namespace, &context, false)
+        .expect_err("invalid namespace_id");
+    match bootstrap_error {
+        loon_core::BootstrapNamespaceError::InvalidNamespaceId(error) => {
+            assert_eq!(error.value(), "bad/name");
+        }
+        other => panic!("expected invalid namespace_id, got {other:?}"),
+    }
+    assert_eq!(
+        store
+            .list_prefix("namespaces/")
+            .expect("list namespace objects"),
+        Vec::<String>::new()
+    );
+
+    let read_error = resolve_path(&store, &invalid_namespace, "/")
+        .expect_err("invalid namespace_id should be rejected before lookup");
+    assert_eq!(read_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
+    let delete_error = delete_path_non_recursive(
+        &store,
+        &invalid_namespace,
+        "/missing.txt",
+        &context,
+        Some("invalid-delete"),
+    )
+    .expect_err("invalid namespace_id should be rejected before retry lookup");
+    assert_eq!(delete_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
+    let complete_error = complete_upload(
+        &store,
+        &invalid_namespace,
+        "upl_invalid",
+        &CompleteUploadRequest {
+            content_ref: ContentRef::whole_file_v0(b""),
+        },
+        &context,
+    )
+    .expect_err("invalid namespace_id should be rejected before upload key lookup");
+    assert_eq!(complete_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
+    assert_eq!(
+        store
+            .list_prefix("namespaces/")
+            .expect("list namespace objects"),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
 fn namespace_descriptor_checksum_is_validated() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -802,6 +863,172 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
             .expect("clone remains readable")
             .bytes,
         b"clone-after-fork"
+    );
+}
+
+#[test]
+fn fork_target_head_reservation_failure_writes_no_checkpoint_artifacts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::from("clone");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Exact(namespace_head(clone_namespace_id.as_str())),
+        InjectedCreateFailure::PreconditionFailed {
+            write_attempted_object: true,
+            additional_writes: Vec::new(),
+        },
+    );
+    seed_source_namespace_for_fork(&store, &source_namespace_id, &context);
+
+    let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("target head precondition should re-check partial namespace");
+    assert_eq!(error.kind(), CoreErrorKind::NamespacePartial);
+    assert!(
+        store
+            .list_prefix(&format!(
+                "namespaces/{}/snapshots/",
+                clone_namespace_id.as_str()
+            ))
+            .expect("list target snapshots")
+            .is_empty(),
+        "target checkpoint artifacts must not be written before target head reservation"
+    );
+    assert_namespace_partial(&store, &clone_namespace_id, &context);
+}
+
+#[test]
+fn fork_failure_after_target_head_reserves_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::from("clone");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Prefix(format!(
+            "namespaces/{}/snapshots/",
+            clone_namespace_id.as_str()
+        )),
+        InjectedCreateFailure::Transport {
+            message: "injected target checkpoint failure",
+        },
+    );
+    seed_source_namespace_for_fork(&store, &source_namespace_id, &context);
+
+    let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("target checkpoint write should fail");
+    assert_eq!(error.kind(), CoreErrorKind::ServerError);
+    assert!(
+        store
+            .head(&namespace_head(clone_namespace_id.as_str()))
+            .expect("head target head")
+            .is_some(),
+        "target head should reserve namespace before target checkpoint writes"
+    );
+    assert!(
+        store
+            .head(&namespace_descriptor(clone_namespace_id.as_str()))
+            .expect("head target descriptor")
+            .is_none(),
+        "descriptor must remain unpublished"
+    );
+    assert_namespace_partial(&store, &clone_namespace_id, &context);
+}
+
+#[test]
+fn fork_failure_after_target_checkpoint_artifacts_remains_partial() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::from("clone");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Exact(namespace_lease(clone_namespace_id.as_str())),
+        InjectedCreateFailure::Transport {
+            message: "injected target lease failure",
+        },
+    );
+    seed_source_namespace_for_fork(&store, &source_namespace_id, &context);
+
+    let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("target lease write should fail");
+    assert_eq!(error.kind(), CoreErrorKind::ServerError);
+    assert!(
+        store
+            .head(&namespace_head(clone_namespace_id.as_str()))
+            .expect("head target head")
+            .is_some(),
+        "target head should still reserve namespace"
+    );
+    assert!(
+        store
+            .head(&namespace_descriptor(clone_namespace_id.as_str()))
+            .expect("head target descriptor")
+            .is_none(),
+        "descriptor must remain unpublished"
+    );
+    let target_snapshot_keys = store
+        .list_prefix(&format!(
+            "namespaces/{}/snapshots/",
+            clone_namespace_id.as_str()
+        ))
+        .expect("list target snapshots");
+    assert!(
+        !target_snapshot_keys.is_empty(),
+        "target checkpoint artifacts should have been written before lease failure"
+    );
+    assert_namespace_partial(&store, &clone_namespace_id, &context);
+}
+
+#[test]
+fn fork_target_control_conflict_rechecks_complete_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::from("clone");
+    let context = mutation_context();
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_source_namespace_for_fork(&inner, &source_namespace_id, &context);
+    let content_store_id = load_verified_namespace_basis(&inner, &source_namespace_id)
+        .expect("source basis")
+        .content_store_id;
+    let descriptor = NamespaceDescriptorEnvelope::from_state(
+        ControlObjectKind::NamespaceDescriptor,
+        &context.writer_version,
+        loon_api::NamespaceDescriptorState {
+            namespace_id: clone_namespace_id.clone(),
+            content_store_id,
+        },
+    )
+    .expect("descriptor envelope");
+    let store = InjectCreateFailureStore::new(
+        inner,
+        KeyMatcher::Exact(namespace_head(clone_namespace_id.as_str())),
+        InjectedCreateFailure::Conflict {
+            write_attempted_object: true,
+            additional_writes: vec![
+                (
+                    namespace_lease(clone_namespace_id.as_str()),
+                    b"lease-present".to_vec(),
+                ),
+                (
+                    namespace_descriptor(clone_namespace_id.as_str()),
+                    serde_json::to_vec(&descriptor).expect("descriptor bytes"),
+                ),
+            ],
+        },
+    );
+
+    let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("target head conflict should re-check complete namespace");
+    assert_eq!(error.kind(), CoreErrorKind::NamespaceExists);
+    assert_eq!(
+        list_namespaces(&store)
+            .expect("list namespaces")
+            .into_iter()
+            .map(|summary| summary.namespace_id)
+            .collect::<Vec<_>>(),
+        vec![clone_namespace_id, source_namespace_id]
     );
 }
 
@@ -1402,6 +1629,173 @@ fn create_only_put_rejects_casefold_and_normalization_equivalent_name() {
     )
     .expect_err("create-only conflict");
     assert_eq!(error.kind(), CoreErrorKind::PathConflict);
+}
+
+fn seed_source_namespace_for_fork<S: ObjectStore + ?Sized>(
+    store: &S,
+    source_namespace_id: &NamespaceId,
+    context: &MutationContext,
+) {
+    bootstrap_namespace(store, source_namespace_id, context, false)
+        .expect("bootstrap source namespace");
+    write_file_bytes(
+        store,
+        source_namespace_id,
+        "/docs/shared.txt",
+        b"base",
+        context,
+        Some("seed-shared"),
+    )
+    .expect("seed shared file");
+}
+
+fn assert_namespace_partial<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) {
+    let partial_error =
+        bootstrap_namespace(store, namespace_id, context, false).expect_err("partial namespace");
+    assert!(matches!(
+        partial_error,
+        loon_core::BootstrapNamespaceError::NamespacePartiallyInitialized { .. }
+    ));
+}
+
+#[derive(Debug)]
+struct InjectCreateFailureStore {
+    inner: LocalFsStore,
+    matcher: KeyMatcher,
+    failure: InjectedCreateFailure,
+    injected: Mutex<bool>,
+}
+
+impl InjectCreateFailureStore {
+    fn new(inner: LocalFsStore, matcher: KeyMatcher, failure: InjectedCreateFailure) -> Self {
+        Self {
+            inner,
+            matcher,
+            failure,
+            injected: Mutex::new(false),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum KeyMatcher {
+    Exact(String),
+    Prefix(String),
+}
+
+impl KeyMatcher {
+    fn matches(&self, key: &str) -> bool {
+        match self {
+            Self::Exact(expected) => key == expected,
+            Self::Prefix(prefix) => key.starts_with(prefix),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum InjectedCreateFailure {
+    Transport {
+        message: &'static str,
+    },
+    Conflict {
+        write_attempted_object: bool,
+        additional_writes: Vec<(String, Vec<u8>)>,
+    },
+    PreconditionFailed {
+        write_attempted_object: bool,
+        additional_writes: Vec<(String, Vec<u8>)>,
+    },
+}
+
+impl InjectedCreateFailure {
+    fn apply_before_error(
+        &self,
+        inner: &LocalFsStore,
+        attempted_key: &str,
+        attempted_bytes: &[u8],
+    ) -> Result<(), ObjectStoreError> {
+        match self {
+            Self::Transport { .. } => Ok(()),
+            Self::Conflict {
+                write_attempted_object,
+                additional_writes,
+            }
+            | Self::PreconditionFailed {
+                write_attempted_object,
+                additional_writes,
+            } => {
+                if *write_attempted_object {
+                    inner.put_overwrite(attempted_key, attempted_bytes)?;
+                }
+                for (key, bytes) in additional_writes {
+                    inner.put_overwrite(key, bytes)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn error(&self) -> ObjectStoreError {
+        match self {
+            Self::Transport { message } => ObjectStoreError::Transport((*message).to_owned()),
+            Self::Conflict { .. } => ObjectStoreError::Conflict,
+            Self::PreconditionFailed { .. } => ObjectStoreError::PreconditionFailed,
+        }
+    }
+}
+
+impl ObjectStore for InjectCreateFailureStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if matches!(&mode, PutMode::CreateIfAbsent) && self.matcher.matches(key) {
+            let should_inject = {
+                let mut injected = self
+                    .injected
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if *injected {
+                    false
+                } else {
+                    *injected = true;
+                    true
+                }
+            };
+            if should_inject {
+                self.failure.apply_before_error(&self.inner, key, bytes)?;
+                return Err(self.failure.error());
+            }
+        }
+
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
+    }
 }
 
 fn metadata_state_after(sequences: &[Vec<loon_api::WalOp>]) -> MetadataState {

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -23,6 +23,10 @@ pub fn namespace_head(namespace: &str) -> String {
     format!("namespaces/{namespace}/head.json")
 }
 
+pub fn namespace_descriptor(namespace: &str) -> String {
+    format!("namespaces/{namespace}/descriptor.json")
+}
+
 pub fn namespace_lease(namespace: &str) -> String {
     format!("namespaces/{namespace}/lease.json")
 }
@@ -31,10 +35,14 @@ pub fn wal_commit(namespace: &str, seq: u64, commit_id: &str) -> String {
     format!("namespaces/{namespace}/wal/{seq:020}-{commit_id}.cbor.zst")
 }
 
-pub fn content_blob(namespace: &str, digest: &str) -> Result<String, ObjectStoreError> {
+pub fn content_store_descriptor(content_store: &str) -> String {
+    format!("content-stores/{content_store}/descriptor.json")
+}
+
+pub fn content_blob(content_store: &str, digest: &str) -> Result<String, ObjectStoreError> {
     let hex = sha256_hex_from_digest(digest)?;
     Ok(format!(
-        "namespaces/{namespace}/blobs/sha256/{}/{}/{}",
+        "content-stores/{content_store}/blobs/sha256/{}/{}/{}",
         &hex[0..2],
         &hex[2..4],
         hex
@@ -100,15 +108,24 @@ pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        conflict_artifact, conflict_artifact_prefix, content_blob, derived_progress,
-        namespace_head, namespace_lease, queue_shard, sha256_hex_from_digest, snapshot_manifest,
-        snapshot_table, upload_session, upload_session_prefix, wal_commit, SnapshotTableFamily,
+        conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
+        derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
+        sha256_hex_from_digest, snapshot_manifest, snapshot_table, upload_session,
+        upload_session_prefix, wal_commit, SnapshotTableFamily,
     };
 
     #[test]
     fn key_builders_match_spec_examples() {
         assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/head.json");
+        assert_eq!(
+            namespace_descriptor("ns-1"),
+            "namespaces/ns-1/descriptor.json"
+        );
         assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
+        assert_eq!(
+            content_store_descriptor("cs-1"),
+            "content-stores/cs-1/descriptor.json"
+        );
         assert_eq!(
             wal_commit("ns-1", 420, "commit-123"),
             "namespaces/ns-1/wal/00000000000000000420-commit-123.cbor.zst"
@@ -128,11 +145,11 @@ mod tests {
         assert_eq!(queue_shard(17), "queue/shards/00017.json");
         assert_eq!(
             content_blob(
-                "ns-1",
+                "cs-1",
                 "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
             )
             .expect("content key"),
-            "namespaces/ns-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            "content-stores/cs-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         );
         assert_eq!(
             conflict_artifact("ns-1", "conflict-deadbeef"),

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -2,8 +2,9 @@ mod provider_env;
 
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
-    derived_progress, namespace_head, namespace_lease, queue_shard, snapshot_manifest,
-    snapshot_table, wal_commit, SnapshotTableFamily,
+    content_blob, content_store_descriptor, derived_progress, namespace_descriptor, namespace_head,
+    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_commit,
+    SnapshotTableFamily,
 };
 use loon_objectstore::probes::run_contract_probes;
 use loon_objectstore::provider::{Expectation, AWS_S3, CLOUDFLARE_R2, LOCAL_FS};
@@ -126,8 +127,24 @@ fn provider_profiles_exist() {
 
 #[test]
 fn key_builders_cover_locked_object_families() {
+    assert_eq!(
+        namespace_descriptor("ns-1"),
+        "namespaces/ns-1/descriptor.json"
+    );
     assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/head.json");
     assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
+    assert_eq!(
+        content_store_descriptor("cs-1"),
+        "content-stores/cs-1/descriptor.json"
+    );
+    assert_eq!(
+        content_blob(
+            "cs-1",
+            "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+        .expect("content blob key"),
+        "content-stores/cs-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    );
     assert_eq!(
         wal_commit("ns-1", 420, "commit-1"),
         "namespaces/ns-1/wal/00000000000000000420-commit-1.cbor.zst"

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -14,6 +14,7 @@ use loon_api::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
     FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, NamespaceId,
+    NamespaceIdValidationError,
 };
 use loon_core::{
     advance_retention_floor, begin_upload, bootstrap_namespace, commit_operations, complete_upload,
@@ -136,7 +137,7 @@ async fn create_namespace(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(request.namespace_id);
+    let namespace_id = parse_namespace_id(request.namespace_id)?;
     let summary = run_blocking(move || {
         bootstrap_namespace(
             store.as_ref(),
@@ -171,8 +172,8 @@ async fn fork_namespace_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let source_namespace_id = NamespaceId::from(namespace);
-    let new_namespace_id = NamespaceId::from(request.new_namespace_id);
+    let source_namespace_id = parse_namespace_id(namespace)?;
+    let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
     let summary = run_blocking(move || {
         fork_namespace(
             store.as_ref(),
@@ -194,7 +195,7 @@ async fn list_entries(
 ) -> Result<Json<Vec<loon_api::AuthoritativePathEntry>>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let entries = run_blocking(move || {
         list_path(store.as_ref(), &namespace_id, &path)
@@ -212,7 +213,7 @@ async fn stat_entry(
 ) -> Result<Json<loon_api::AuthoritativePathEntry>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let entry = run_blocking(move || {
         resolve_path(store.as_ref(), &namespace_id, &path)
@@ -230,7 +231,7 @@ async fn get_content(
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let file = run_blocking(move || {
         read_file_bytes(store.as_ref(), &namespace_id, &path)
@@ -249,7 +250,7 @@ async fn filesystem_operation(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let result = run_blocking(move || {
         let result = match request.operation {
             FilesystemOperation::PutFile {
@@ -304,7 +305,7 @@ async fn begin_upload_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let response = run_blocking(move || {
         begin_upload(store.as_ref(), &namespace_id, &mutation_context(&config))
             .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
@@ -322,7 +323,7 @@ async fn upload_content_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let bytes = body.to_vec();
     let response = run_blocking(move || {
         upload_content(
@@ -347,7 +348,7 @@ async fn complete_upload_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let response = run_blocking(move || {
         complete_upload(
             store.as_ref(),
@@ -371,7 +372,7 @@ async fn commit_operations_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let response = run_blocking(move || {
         commit_operations(
             store.as_ref(),
@@ -393,7 +394,7 @@ async fn list_changes_handler(
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let after_seq = loon_api::ChangeSeq(query.after_seq);
     let response = run_blocking(move || {
         list_changes_after(store.as_ref(), &namespace_id, after_seq)
@@ -411,7 +412,7 @@ async fn create_checkpoint_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let response = run_blocking(move || {
         create_checkpoint(store.as_ref(), &namespace_id, &mutation_context(&config))
             .map_err(ApiResponseError::core)
@@ -428,7 +429,7 @@ async fn advance_retention_handler(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(namespace);
+    let namespace_id = parse_namespace_id(namespace)?;
     let response = run_blocking(move || {
         advance_retention_floor(store.as_ref(), &namespace_id, &mutation_context(&config))
             .map_err(ApiResponseError::core)
@@ -476,6 +477,10 @@ fn map_filesystem_put_behavior(value: FilesystemPutBehavior) -> PutFileBehavior 
     }
 }
 
+fn parse_namespace_id(value: String) -> Result<NamespaceId, ApiResponseError> {
+    NamespaceId::parse(&value).map_err(ApiResponseError::invalid_namespace_id)
+}
+
 async fn run_blocking<T, F>(operation: F) -> Result<T, ApiResponseError>
 where
     T: Send + 'static,
@@ -506,8 +511,17 @@ impl ApiResponseError {
         }
     }
 
+    fn invalid_namespace_id(error: NamespaceIdValidationError) -> Self {
+        Self::new(
+            StatusCode::BAD_REQUEST,
+            "invalid_namespace_id",
+            &error.to_string(),
+        )
+    }
+
     fn bootstrap(error: BootstrapNamespaceError) -> Self {
         match error {
+            BootstrapNamespaceError::InvalidNamespaceId(error) => Self::invalid_namespace_id(error),
             BootstrapNamespaceError::NamespaceAlreadyExists { .. } => {
                 Self::new(StatusCode::CONFLICT, "namespace_exists", &error.to_string())
             }
@@ -533,6 +547,7 @@ impl ApiResponseError {
     fn core(error: CoreError) -> Self {
         let (status, code) = match error.kind() {
             CoreErrorKind::InvalidPath => (StatusCode::BAD_REQUEST, "invalid_path"),
+            CoreErrorKind::InvalidNamespaceId => (StatusCode::BAD_REQUEST, "invalid_namespace_id"),
             CoreErrorKind::NamespaceNotFound => (StatusCode::NOT_FOUND, "namespace_not_found"),
             CoreErrorKind::NamespaceExists => (StatusCode::CONFLICT, "namespace_exists"),
             CoreErrorKind::NamespacePartial => (StatusCode::CONFLICT, "namespace_partial"),

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -136,7 +136,7 @@ async fn create_namespace(
     authorize(&state.config, &headers)?;
     let store = state.store.clone();
     let config = state.config.clone();
-    let namespace_id = NamespaceId::from(request.name);
+    let namespace_id = NamespaceId::from(request.namespace_id);
     let summary = run_blocking(move || {
         bootstrap_namespace(
             store.as_ref(),

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -13,14 +13,14 @@ use loon_api::{
     },
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    FilesystemPutBehavior, ListNamespacesResponse, NamespaceId,
+    FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, NamespaceId,
 };
 use loon_core::{
     advance_retention_floor, begin_upload, bootstrap_namespace, commit_operations, complete_upload,
-    copy_file_path, create_checkpoint, delete_path_non_recursive, list_changes_after,
-    list_namespaces, list_path, move_path, put_file_content_ref, read_file_bytes, resolve_path,
-    upload_content, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
-    PutFileBehavior,
+    copy_file_path, create_checkpoint, delete_path_non_recursive, fork_namespace,
+    list_changes_after, list_namespaces, list_path, move_path, put_file_content_ref,
+    read_file_bytes, resolve_path, upload_content, BootstrapNamespaceError, CoreError,
+    CoreErrorKind, MutationContext, PutFileBehavior,
 };
 use loon_objectstore::ObjectStore;
 use std::net::SocketAddr;
@@ -61,6 +61,10 @@ fn app_with_store(config: ServerConfig, store: SharedStore) -> Router {
         .route(
             "/v0/namespaces",
             post(create_namespace).get(list_namespaces_handler),
+        )
+        .route(
+            "/v0/namespaces/:namespace/forks",
+            post(fork_namespace_handler),
         )
         .route(
             "/v0/namespaces/:namespace/filesystem/list",
@@ -156,6 +160,30 @@ async fn list_namespaces_handler(
         run_blocking(move || list_namespaces(store.as_ref()).map_err(ApiResponseError::core))
             .await?;
     Ok(Json(ListNamespacesResponse { namespaces }))
+}
+
+async fn fork_namespace_handler(
+    State(state): State<AppState>,
+    AxumPath(namespace): AxumPath<String>,
+    headers: HeaderMap,
+    Json(request): Json<ForkNamespaceRequest>,
+) -> Result<Json<loon_api::NamespaceSummary>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let store = state.store.clone();
+    let config = state.config.clone();
+    let source_namespace_id = NamespaceId::from(namespace);
+    let new_namespace_id = NamespaceId::from(request.new_namespace_id);
+    let summary = run_blocking(move || {
+        fork_namespace(
+            store.as_ref(),
+            &source_namespace_id,
+            &new_namespace_id,
+            &mutation_context(&config),
+        )
+        .map_err(|error| ApiResponseError::core_for_namespace(&source_namespace_id, error))
+    })
+    .await?;
+    Ok(Json(summary))
 }
 
 async fn list_entries(
@@ -506,6 +534,8 @@ impl ApiResponseError {
         let (status, code) = match error.kind() {
             CoreErrorKind::InvalidPath => (StatusCode::BAD_REQUEST, "invalid_path"),
             CoreErrorKind::NamespaceNotFound => (StatusCode::NOT_FOUND, "namespace_not_found"),
+            CoreErrorKind::NamespaceExists => (StatusCode::CONFLICT, "namespace_exists"),
+            CoreErrorKind::NamespacePartial => (StatusCode::CONFLICT, "namespace_partial"),
             CoreErrorKind::PathNotFound => (StatusCode::NOT_FOUND, "path_not_found"),
             CoreErrorKind::RevisionNotFound => (StatusCode::CONFLICT, "revision_not_found"),
             CoreErrorKind::PathConflict => (StatusCode::CONFLICT, "path_conflict"),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -106,6 +106,95 @@ async fn http_put_create_only_and_copy_preserve_cli_semantics() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_namespace_fork_shares_content_and_diverges() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loon-server-fork",
+        "http-fork-smoke",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create namespace");
+        let source_path = NamespacePath::parse("demo:/docs/shared.txt").expect("source path");
+        let clone_path = NamespacePath::parse("clone:/docs/shared.txt").expect("clone path");
+        harness
+            .client
+            .write_file_bytes(&source_path, b"base\n")
+            .expect("write source");
+
+        let forked = harness
+            .client
+            .fork_namespace("demo", "clone")
+            .expect("fork namespace");
+        assert_eq!(forked.name.as_str(), "clone");
+
+        let source_entry = harness.client.stat_path(&source_path).expect("source stat");
+        let clone_entry = harness.client.stat_path(&clone_path).expect("clone stat");
+        assert_eq!(source_entry.content_ref, clone_entry.content_ref);
+        assert_eq!(
+            harness
+                .client
+                .read_file_bytes(&clone_path)
+                .expect("read clone"),
+            b"base\n"
+        );
+
+        harness
+            .client
+            .write_file_bytes(&source_path, b"source-after-fork\n")
+            .expect("replace source");
+        assert_eq!(
+            harness
+                .client
+                .read_file_bytes(&clone_path)
+                .expect("read clone after source write"),
+            b"base\n"
+        );
+
+        let clone_write = harness
+            .client
+            .write_file_bytes(&clone_path, b"clone-after-fork\n")
+            .expect("replace clone");
+        assert_eq!(clone_write.committed_seq, ChangeSeq(2));
+        assert_eq!(
+            harness
+                .client
+                .read_file_bytes(&source_path)
+                .expect("read source"),
+            b"source-after-fork\n"
+        );
+        assert_eq!(
+            harness
+                .client
+                .read_file_bytes(&clone_path)
+                .expect("read clone"),
+            b"clone-after-fork\n"
+        );
+
+        match harness.client.list_changes("clone", ChangeSeq(0)) {
+            Err(ClientError::Api { code, .. }) => assert_eq!(code, "rebootstrap_required"),
+            other => panic!("expected rebootstrap_required, got {other:?}"),
+        }
+        let clone_changes = harness
+            .client
+            .list_changes("clone", ChangeSeq(1))
+            .expect("clone changes");
+        assert_eq!(clone_changes.changes.len(), 1);
+        assert_eq!(clone_changes.changes[0].seq, ChangeSeq(2));
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_upload_commit_and_change_feed_are_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -132,7 +132,7 @@ async fn http_namespace_fork_shares_content_and_diverges() {
             .client
             .fork_namespace("demo", "clone")
             .expect("fork namespace");
-        assert_eq!(forked.name.as_str(), "clone");
+        assert_eq!(forked.namespace_id.as_str(), "clone");
 
         let source_entry = harness.client.stat_path(&source_path).expect("source stat");
         let clone_entry = harness.client.stat_path(&clone_path).expect("clone stat");

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -52,6 +52,39 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_rejects_invalid_namespace_ids_in_body_and_path() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loon-server-test",
+        "http-invalid-ns",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        assert_invalid_namespace_response(
+            ureq::post(&format!("{}/v0/namespaces", harness.server_url))
+                .set("authorization", "Bearer test-token")
+                .send_json(json!({ "namespace_id": "bad/name" })),
+        );
+
+        assert_invalid_namespace_response(
+            ureq::get(&format!(
+                "{}/v0/namespaces/bad%25/filesystem/list?path=/",
+                harness.server_url
+            ))
+            .set("authorization", "Bearer test-token")
+            .call(),
+        );
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_create_only_and_copy_preserve_cli_semantics() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
@@ -1018,6 +1051,19 @@ fn post_admin_json<T: serde::de::DeserializeOwned>(
             code: "transport".to_owned(),
             message: error.to_string(),
         }),
+    }
+}
+
+fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>) {
+    match result {
+        Err(ureq::Error::Status(status, response)) => {
+            assert_eq!(status, 400);
+            let error: ApiError =
+                serde_json::from_reader(response.into_reader()).expect("decode api error");
+            assert_eq!(error.code, "invalid_namespace_id");
+            assert!(error.message.contains("invalid namespace_id"));
+        }
+        other => panic!("expected invalid_namespace_id response, got {other:?}"),
     }
 }
 

--- a/docs/specs/020-architecture-overview.md
+++ b/docs/specs/020-architecture-overview.md
@@ -4,11 +4,13 @@
 
 | Part | Role |
 | --- | --- |
-| **Object store** | Holds every durable object: file content objects, WAL segments, checkpoints, and small control objects. |
+| **Object store** | Holds every durable object: content-store blobs, namespace WAL segments, checkpoints, descriptors, and small control objects. |
 | **Authoritative service** | Resolves paths, validates mutations, writes logical commits into WAL segments, advances heads, serves reads, and issues capabilities for upload or download. |
 | **Clients** | Use either direct filesystem operations or the lower-level upload, commit, and change-feed model. |
 | **Access-control service** | Evaluates ACLs and shares, then authorizes LoonFS operations. This may be part of the authoritative service in a simple deployment. |
 | **Background workers** | Build checkpoints, advance retention safely, clean up expired control objects, and reclaim unreachable content. |
+
+Namespaces and content stores are separate durable domains. A namespace owns filesystem metadata and history; a content store owns immutable file bytes. Each namespace descriptor names exactly one content store, and forked namespaces share that content store while keeping independent metadata history.
 
 ## 2. Data plane, metadata plane, and control plane
 

--- a/docs/specs/020-architecture-overview.md
+++ b/docs/specs/020-architecture-overview.md
@@ -10,7 +10,7 @@
 | **Access-control service** | Evaluates ACLs and shares, then authorizes LoonFS operations. This may be part of the authoritative service in a simple deployment. |
 | **Background workers** | Build checkpoints, advance retention safely, clean up expired control objects, and reclaim unreachable content. |
 
-Namespaces and content stores are separate durable domains. A namespace owns filesystem metadata and history; a content store owns immutable file bytes. Each namespace descriptor names exactly one content store, and forked namespaces share that content store while keeping independent metadata history.
+Namespaces and content stores are separate durable domains. A namespace owns filesystem metadata and history; a content store owns immutable file bytes. A namespace descriptor references exactly one content store, but that reference is not lifecycle ownership. Forked namespaces share the source namespace's content store while keeping independent metadata history and no durable parent/child relationship.
 
 ## 2. Data plane, metadata plane, and control plane
 

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -25,9 +25,11 @@ The required durable object families and standard key patterns are:
 
 | Family | Mutability | Purpose | Standard object key pattern |
 | --- | --- | --- | --- |
+| **Namespace descriptor** | Immutable | Record namespace identity and its immutable content-store relationship. | `namespaces/{namespace_id}/descriptor.json` |
 | **Namespace head** | Mutable | Record the current visible boundary, replay hints, and visible WAL tip. | `namespaces/{namespace_id}/head.json` |
 | **Namespace lease** | Mutable | Fence concurrent publishers when the deployment uses more than one possible writer. | `namespaces/{namespace_id}/lease.json` |
-| **Content objects** | Immutable | Store whole-file v0 bytes. | `namespaces/{namespace_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` |
+| **Content-store descriptor** | Immutable | Record content-store identity. | `content-stores/{content_store_id}/descriptor.json` |
+| **Content objects** | Immutable | Store whole-file v0 bytes. | `content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` |
 | **WAL segments** | Immutable | Record one or more logical commits with a contiguous sequence range. | `namespaces/{namespace_id}/wal/{start_seq}-{end_seq}-{segment_id}.cbor.zst` |
 | **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/manifest.json` |
 | **Checkpoint segments** | Immutable | Store verified checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/tables/{family}-{segment_index}.sst.zst` |
@@ -54,6 +56,8 @@ The content model has four rules.
 4. A metadata commit may reference a `content_ref` only after the referenced object is already durable.
 
 In v0, file content is stored as one whole-file object whose `content_ref.kind` is `whole_file_v0`. The digest remains serialized as `sha256:<64hex>`, while the object key partitions the hex as `sha256/ab/cd/<hex>`.
+
+A reader or writer resolves content through the namespace descriptor: `namespace_id -> content_store_id -> content-stores/{content_store_id}/...`. File revisions and change-feed payloads store only `content_ref`; they do not store content-store ids or object-store paths.
 
 ## 6. Mutable control-object rules
 

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -6,6 +6,7 @@ A namespace is the unit of visible metadata history.
 
 Each namespace has:
 
+- a descriptor that records its namespace id and content-store id
 - a current head
 - an ordered WAL of logical commits stored in immutable segments
 - zero or more checkpoints
@@ -14,6 +15,8 @@ Each namespace has:
 The head also carries the next monotonic inode id for that namespace. New inode ids are allocated from the head as part of commit publication.
 
 The canonical identity of an item is `(namespace_id, inode_id)`.
+
+Each namespace has exactly one immutable `content_store_id`. The content store is an immutable pool for file bytes and may be referenced by many namespaces. A new root namespace receives a new content store; a forked namespace reuses the source namespace's content store while starting an independent namespace metadata history.
 
 Two consequences follow:
 
@@ -123,7 +126,7 @@ A file is represented by one inode and a sequence of immutable revisions.
 
 Each revision points to exactly one immutable content reference. In v0, that reference names one whole-file object containing the complete plaintext file bytes.
 
-Content objects belong to the owning namespace. A file revision may reference only content that is durable under that namespace's content store.
+Content objects belong to the namespace's content store. A file revision may reference only content that is durable under the content store named by that namespace descriptor.
 
 LoonFS therefore uses a two-stage write model:
 
@@ -138,7 +141,7 @@ This separation is part of the core model.
 The stable immutable content families are:
 
 ```text
-namespaces/{namespace_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}
+content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}
 ```
 
 The core rules are:
@@ -147,6 +150,7 @@ The core rules are:
 - `content_ref.digest` uses `sha256:<64 lowercase hex>` over the complete plaintext file bytes;
 - `content_ref.size_bytes` records the complete byte length;
 - the object key leaf is the raw 64-character hex digest, while JSON keeps the full `sha256:<hex>` digest string; and
+- all content-object access resolves `namespace_id` through the namespace descriptor to its `content_store_id`;
 - future content strategies must use a new `content_ref.kind` and name their durability and validation rules before revisions may reference them.
 
 ### 4.2 Upload-before-publish
@@ -165,7 +169,15 @@ Deletion is logical first. When an item is deleted, LoonFS records tombstone met
 
 Physical reclamation is separate background work. It may happen only when retention and reference-safety rules allow it.
 
-## 6. Mounts
+Namespace deletion does not imply content-store deletion. In v0, content-store deletion and destructive content garbage collection are unsupported operator-only work.
+
+## 6. Forks
+
+Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, rewrites checkpoint artifacts under the new namespace id and object keys, creates the new namespace descriptor with the shared content-store id, and initializes the new head at the fork seq.
+
+No durable parent/child relationship is part of v0 namespace state. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
+
+## 7. Mounts
 
 A mount presents another namespace, or a subtree of another namespace, inside the current tree.
 
@@ -183,13 +195,13 @@ Two rules apply:
 
 A share grants access to a subtree. A mount presents that accessible subtree at a path. The two concepts are related, but they are not the same.
 
-## 7. Cross-namespace moves
+## 8. Cross-namespace moves
 
 Identity is namespace-local. A true inode-preserving rename is therefore namespace-local as well.
 
-Across namespaces, a move is modeled as a copy plus a delete from the source namespace. Content may still be reused internally, but inode identity does not cross the namespace boundary.
+Across namespaces, a move is modeled as a copy plus a delete from the source namespace. Same-content-store copies may reuse `content_ref`. Cross-content-store copies are not supported in v0 unless the content is first imported into the destination content store. Inode identity does not cross the namespace boundary.
 
-## 8. Recovery basis
+## 9. Recovery basis
 
 Readers reconstruct authoritative state from:
 

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -124,7 +124,7 @@ The v0 policy is `nfc_casefold_v0`, which defines sibling-name comparison by Uni
 
 A file is represented by one inode and a sequence of immutable revisions.
 
-Each revision points to exactly one immutable content reference. In v0, that reference names one whole-file object containing the complete plaintext file bytes.
+Each revision stores exactly one immutable `content_ref`. In v0, that reference names one whole-file object containing the complete plaintext file bytes. Revisions do not store object-store paths or `content_store_id`; readers resolve those through the namespace descriptor when bytes are needed.
 
 Content objects belong to the namespace's content store. A file revision may reference only content that is durable under the content store named by that namespace descriptor.
 
@@ -149,7 +149,7 @@ The core rules are:
 - `content_ref.kind` is `whole_file_v0` for the v0 content strategy;
 - `content_ref.digest` uses `sha256:<64 lowercase hex>` over the complete plaintext file bytes;
 - `content_ref.size_bytes` records the complete byte length;
-- the object key leaf is the raw 64-character hex digest, while JSON keeps the full `sha256:<hex>` digest string; and
+- the object key leaf is the raw 64-character hex digest, while JSON keeps the full `sha256:<hex>` digest string;
 - all content-object access resolves `namespace_id` through the namespace descriptor to its `content_store_id`;
 - future content strategies must use a new `content_ref.kind` and name their durability and validation rules before revisions may reference them.
 
@@ -173,7 +173,7 @@ Namespace deletion does not imply content-store deletion. In v0, content-store d
 
 ## 6. Forks
 
-Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, rewrites checkpoint artifacts under the new namespace id and object keys, creates the new namespace descriptor with the shared content-store id, and initializes the new head at the fork seq.
+Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, writes the target head first to reserve the namespace, rewrites checkpoint artifacts under the new namespace id and object keys, writes the target lease, and writes the namespace descriptor last as the publish/list marker.
 
 No durable parent/child relationship is part of v0 namespace state. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -9,8 +9,9 @@ A write has four phases: durably stage content (if a mutation contains content),
 Content must be durable before any metadata change can reference it.
 
 1. Compute the `sha256` digest of the complete plaintext file bytes.
-2. Upload the complete byte sequence to `namespaces/{namespace_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` with create-if-absent semantics.
-3. Build a content reference:
+2. Resolve the namespace descriptor to its `content_store_id`.
+3. Upload the complete byte sequence to `content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` with create-if-absent semantics.
+4. Build a content reference:
 
    ```json
    {
@@ -43,7 +44,7 @@ Content reference validation fails before metadata preconditions are evaluated w
 
 - `content_ref.kind` is unsupported;
 - `content_ref.digest` is not a valid `sha256:<64 lowercase hex>` digest;
-- the referenced object is missing from the namespace content store;
+- the referenced object is missing from the namespace's content store;
 - the object size differs from `content_ref.size_bytes`; or
 - the object bytes hash to a different digest than `content_ref.digest`.
 
@@ -80,9 +81,10 @@ A read reconstructs the visible filesystem state from durable artifacts on objec
 
 The reader builds an in-memory metadata state from two kinds of durable object:
 
-1. Read the namespace **head** object to learn the current `seq`, `snapshot_hint_seq`, and visible WAL tip.
-2. If `snapshot_hint_seq` is set, load the **verified checkpoint** at that `seq`. The checkpoint materializes metadata state through that `seq` across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
-3. Use the visible WAL tip named by the head to identify the visible segment chain after the checkpoint `seq` (or from genesis, if no checkpoint exists), then replay the logical commit records in ascending `seq` order through `head.seq`. Each logical commit appends rows to the same four tables.
+1. Read the namespace descriptor and content-store descriptor to learn the namespace's immutable content-store relationship.
+2. Read the namespace **head** object to learn the current `seq`, `snapshot_hint_seq`, and visible WAL tip.
+3. If `snapshot_hint_seq` is set, load the **verified checkpoint** at that `seq`. The checkpoint materializes metadata state through that `seq` across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
+4. Use the visible WAL tip named by the head to identify the visible segment chain after the checkpoint `seq` (or from genesis, if no checkpoint exists), then replay the logical commit records in ascending `seq` order through `head.seq`. Each logical commit appends rows to the same four tables.
 
 The result is a complete metadata state pinned to one `seq`.
 
@@ -108,9 +110,10 @@ To resolve an absolute path at seq N:
 Given a visible file inode at seq N:
 
 1. Look up the file's latest revision at N to obtain `content_ref`.
-2. Verify that `content_ref.kind` is supported by the reader.
-3. For `whole_file_v0`, fetch the object at `namespaces/{namespace_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}`, where `hex` is the digest suffix from `content_ref.digest`.
-4. Verify that the fetched bytes match `content_ref.size_bytes` and `content_ref.digest`.
+2. Resolve the namespace descriptor to its `content_store_id`.
+3. Verify that `content_ref.kind` is supported by the reader.
+4. For `whole_file_v0`, fetch the object at `content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}`, where `hex` is the digest suffix from `content_ref.digest`.
+5. Verify that the fetched bytes match `content_ref.size_bytes` and `content_ref.digest`.
 
 ### 2.5 Directory listing
 
@@ -201,7 +204,22 @@ Clients older than the retention floor must re-bootstrap from a fresh snapshot i
 
 The retention floor may advance only after the system has enough verified material to keep replay safe at or after that point.
 
-## 9. Long-running operations
+## 9. Namespace forks
+
+A fork creates a new namespace from the source namespace's current head. The request supplies only the new namespace id; the server supplies the mutation context.
+
+The fork protocol is:
+
+1. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
+2. Create or reuse a verified source checkpoint at the current source head.
+3. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
+4. Create the new namespace descriptor with the same `content_store_id` as the source namespace.
+5. Create the new namespace head at the fork seq, with `snapshot_hint_seq` and `retention_floor_seq` set to that seq.
+6. Start the new namespace WAL independently at `fork_seq + 1`.
+
+The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. It also does not create a durable parent/child relationship; provenance may be recorded later as audit metadata outside the core namespace model.
+
+## 10. Long-running operations
 
 Some operations are not well described by one request.
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -210,15 +210,17 @@ A fork creates a new namespace from the source namespace's current head. The req
 
 The fork protocol is:
 
-1. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
-2. Create or reuse a verified source checkpoint at the current source head.
-3. Reserve the target namespace by creating its head at the fork seq, with `snapshot_hint_seq` and `retention_floor_seq` set to that seq.
-4. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
-5. Create the target namespace lease.
-6. Create the new namespace descriptor with the same `content_store_id` as the source namespace. The descriptor is the publish/list marker and is written last.
-7. Start the new namespace WAL independently at `fork_seq + 1`.
+1. Check the target namespace initialization state. A complete target is rejected as existing, and a partial target is rejected as partially initialized.
+2. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
+3. Create or reuse a verified source checkpoint at the current source head.
+4. Build the target head, lease, and descriptor using the source namespace's `content_store_id`.
+5. Write the target `head.json` first to reserve the namespace.
+6. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
+7. Write the target `lease.json`.
+8. Write the target `descriptor.json` last as the publish/list marker.
+9. Start the new namespace WAL independently at `fork_seq + 1`.
 
-The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. It also does not create a durable parent/child relationship; provenance may be recorded later as audit metadata outside the core namespace model.
+The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. If initialization fails after the target head exists but before the descriptor is published, the target is partial. A successful fork has independent namespace history from the fork point. It also does not create a durable parent/child relationship; provenance may be recorded later as audit metadata outside the core namespace model.
 
 ## 10. Long-running operations
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -212,10 +212,11 @@ The fork protocol is:
 
 1. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
 2. Create or reuse a verified source checkpoint at the current source head.
-3. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
-4. Create the new namespace descriptor with the same `content_store_id` as the source namespace.
-5. Create the new namespace head at the fork seq, with `snapshot_hint_seq` and `retention_floor_seq` set to that seq.
-6. Start the new namespace WAL independently at `fork_seq + 1`.
+3. Reserve the target namespace by creating its head at the fork seq, with `snapshot_hint_seq` and `retention_floor_seq` set to that seq.
+4. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
+5. Create the target namespace lease.
+6. Create the new namespace descriptor with the same `content_store_id` as the source namespace. The descriptor is the publish/list marker and is written last.
+7. Start the new namespace WAL independently at `fork_seq + 1`.
 
 The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. It also does not create a durable parent/child relationship; provenance may be recorded later as audit metadata outside the core namespace model.
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -62,6 +62,7 @@ A representative v0 binding is shown below.
 
 | Purpose | Representative HTTP shape |
 | --- | --- |
+| Create a namespace | `POST /v0/namespaces` |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt` |
 | List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
@@ -74,6 +75,14 @@ A representative v0 binding is shown below.
 | Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
 
 Long-running transfers may additionally expose session resources. Implementations may also expose workflow helper resources, but those helpers are outside the core semantics. Once a multi-request interaction begins, the server-issued identifier is the stable in-flight identifier of that interaction.
+
+Namespace creation uses the namespace id directly. v0 has no namespace aliases or separate display names:
+
+```json
+{
+  "namespace_id": "demo"
+}
+```
 
 A few representative requests and responses are shown below. These examples are illustrative, not exhaustive.
 
@@ -341,7 +350,7 @@ Representative response:
 
 ```json
 {
-  "name": "demo-branch"
+  "namespace_id": "demo-branch"
 }
 ```
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -71,6 +71,7 @@ A representative v0 binding is shown below.
 | Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
 | Submit an explicit commit request | `POST /v0/namespaces/{ns}/commits` |
 | Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123` |
+| Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
 
 Long-running transfers may additionally expose session resources. Implementations may also expose workflow helper resources, but those helpers are outside the core semantics. Once a multi-request interaction begins, the server-issued identifier is the stable in-flight identifier of that interaction.
 
@@ -325,6 +326,26 @@ Representative response:
   ]
 }
 ```
+
+### 3.8 `POST /forks`
+
+Representative request:
+
+```json
+{
+  "new_namespace_id": "demo-branch"
+}
+```
+
+Representative response:
+
+```json
+{
+  "name": "demo-branch"
+}
+```
+
+The server forks from the source namespace's current head. The new namespace shares the source namespace's content store, starts with independent namespace metadata, and records no durable parent/child relationship in v0.
 
 ## 4. Client profiles
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -84,6 +84,8 @@ Namespace creation uses the namespace id directly. v0 has no namespace aliases o
 }
 ```
 
+The field name `namespace_id` is intentional API compatibility surface. Fork creation uses `new_namespace_id` for the target namespace. Route placeholders such as `{ns}`, `{source_ns}`, or an implementation-internal `:namespace` are only path parameter names for the same namespace id value; v0 does not accept or emit a namespace `name` alias.
+
 A few representative requests and responses are shown below. These examples are illustrative, not exhaustive.
 
 ### 3.1 `GET /filesystem/stat`

--- a/docs/specs/090-versioning-conformance-and-extensions.md
+++ b/docs/specs/090-versioning-conformance-and-extensions.md
@@ -12,6 +12,8 @@ A stable spec needs explicit versioning in three places.
 
 A new version should be introduced only when an old implementation could misread or misapply a new feature.
 
+The durable namespace descriptor and content-store descriptor are storage-format objects. The namespace descriptor is authoritative for the namespace-to-content-store relationship; a future catalog may index descriptors but must not replace their meaning.
+
 ## 2. Server requirements
 
 A conforming server must:
@@ -20,11 +22,12 @@ A conforming server must:
 2. publish visible metadata only through logical commits stored in visible WAL segments plus a successful head update;
 3. validate that referenced content is already durable before publish;
 4. preserve `(namespace_id, inode_id)` as canonical identity;
-5. implement tombstone-first delete;
-6. serve replay from verified checkpoints plus the visible WAL segment chain, replayed as logical commits;
-7. honor the namespace's `NamePolicy`;
-8. keep control-plane sessions and any implementation-specific coordinators out of namespace history and the change feed; and
-9. preserve per-request idempotency, ordering, and change-feed identity even when physically batching logical commits in a WAL segment.
+5. resolve namespace content through the immutable `content_store_id` in the namespace descriptor;
+6. implement tombstone-first delete;
+7. serve replay from verified checkpoints plus the visible WAL segment chain, replayed as logical commits;
+8. honor the namespace's `NamePolicy`;
+9. keep control-plane sessions and any implementation-specific coordinators out of namespace history and the change feed; and
+10. preserve per-request idempotency, ordering, and change-feed identity even when physically batching logical commits in a WAL segment.
 
 ## 3. Writer and client requirements
 


### PR DESCRIPTION
This PR moves content stores out of the namespace domain. Instead of storing file bytes under namespaces/{namespace_id}, each namespace now points at an immutable content_store_id, and bytes live under content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}.

Note that this is what makes namespace forks cheap and durable. A fork gets its own namespace metadata history, but reuses the source namespace's content store, so we do not copy file bytes when creating the fork. We do copy the metadata snapshot (which we can share in the future) but the copy is relatively cheap, so for simplicity, let's save that optimization for later. 

This also tightens namespace lifecycle correctness: descriptors are the publish/list marker, fork/bootstrap reserve the namespace before writing heavier artifacts, and externally supplied namespace IDs are validated before they are interpolated into object-store keys. Metadata-only commits also skip content-store validation work they do not need.

We also switch the namespace terminology from "name" to "namespace_id" since the behavior is much closer to an ID (uniqueness constraints, used in routes, referenced in storage, effectively immutable). As a future optimization, we could implement a catalog to support a mutable name that resolves to a namespace ID, but that's out of scope for this phase. 