### PR TITLE
feat: implement batch wal for higher throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "tempfile",
  "toml",
  "ureq",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ sha2 = "0.10"
 sysinfo = "0.30"
 tempfile = "3"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0.8"
 ureq = { version = "2.10", features = ["json"] }
 urlencoding = "2"

--- a/crates/loon-api/src/checkpoint.rs
+++ b/crates/loon-api/src/checkpoint.rs
@@ -1,11 +1,12 @@
 use crate::digest::sha256_hex;
+use crate::v0::CommitOpResult;
 use crate::{ChangeSeq, ContentRef, FenceToken, InodeId, InodeKind, NamespaceId, RevisionNo};
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const CHECKPOINT_MANIFEST_FORMAT_VERSION: u32 = 1;
-pub const CHECKPOINT_SEGMENT_FORMAT_VERSION: u32 = 1;
+pub const CHECKPOINT_MANIFEST_FORMAT_VERSION: u32 = 2;
+pub const CHECKPOINT_SEGMENT_FORMAT_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -26,6 +27,7 @@ pub enum CheckpointTableFamily {
     Direntries,
     Revisions,
     Tombstones,
+    RequestReceipts,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -87,6 +89,13 @@ pub enum CheckpointRow {
         #[serde(default)]
         tombstone_op_index: u32,
     },
+    RequestReceipt {
+        request_id: String,
+        semantic_fingerprint_sha256: String,
+        committed_seq: ChangeSeq,
+        commit_id: String,
+        results: Vec<CommitOpResult>,
+    },
 }
 
 impl CheckpointRow {
@@ -141,6 +150,11 @@ impl CheckpointRow {
                     )
                 }
             }
+            Self::RequestReceipt {
+                request_id,
+                committed_seq,
+                ..
+            } => format!("request-receipt-{request_id}-{:020}", committed_seq.0),
         }
     }
 }
@@ -315,6 +329,12 @@ pub fn decode_checkpoint_manifest_json(
 ) -> Result<CheckpointManifestEnvelope, CheckpointManifestCodecError> {
     let envelope: CheckpointManifestEnvelope = serde_json::from_slice(bytes)
         .map_err(|err| CheckpointManifestCodecError::EnvelopeDecode(err.to_string()))?;
+    if envelope.format_version != CHECKPOINT_MANIFEST_FORMAT_VERSION {
+        return Err(CheckpointManifestCodecError::EnvelopeDecode(format!(
+            "unsupported checkpoint manifest format version `{}`",
+            envelope.format_version
+        )));
+    }
     let actual = checkpoint_manifest_payload_checksum_sha256(&envelope.payload)?;
 
     if actual != envelope.payload_checksum_sha256 {
@@ -344,6 +364,12 @@ pub fn decode_checkpoint_segment_envelope_zstd(
         .map_err(|err| CheckpointSegmentCodecError::Decompress(err.to_string()))?;
     let envelope: CheckpointSegmentEnvelope = from_reader(decompressed.as_slice())
         .map_err(|err| CheckpointSegmentCodecError::EnvelopeDecode(err.to_string()))?;
+    if envelope.format_version != CHECKPOINT_SEGMENT_FORMAT_VERSION {
+        return Err(CheckpointSegmentCodecError::EnvelopeDecode(format!(
+            "unsupported checkpoint segment format version `{}`",
+            envelope.format_version
+        )));
+    }
 
     let actual = checkpoint_segment_payload_checksum_sha256(&envelope.payload)?;
     if actual != envelope.payload_checksum_sha256 {

--- a/crates/loon-api/src/checkpoint.rs
+++ b/crates/loon-api/src/checkpoint.rs
@@ -5,8 +5,8 @@ use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const CHECKPOINT_MANIFEST_FORMAT_VERSION: u32 = 2;
-pub const CHECKPOINT_SEGMENT_FORMAT_VERSION: u32 = 2;
+pub const CHECKPOINT_MANIFEST_FORMAT_VERSION: u32 = 1;
+pub const CHECKPOINT_SEGMENT_FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -2,7 +2,7 @@ use crate::digest::sha256_hex;
 use crate::{ChangeSeq, ContentRef, ContentStoreId, FenceToken, InodeId, NamePolicy, NamespaceId};
 use serde::{Deserialize, Serialize};
 
-pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 1;
+pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -28,6 +28,15 @@ pub struct ContentStoreDescriptorState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalSegmentPointer {
+    pub object_key: String,
+    pub segment_id: String,
+    pub start_seq: ChangeSeq,
+    pub end_seq: ChangeSeq,
+    pub payload_checksum_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HeadState {
     pub namespace_id: NamespaceId,
     pub seq: ChangeSeq,
@@ -37,6 +46,8 @@ pub struct HeadState {
     pub name_policy: NamePolicy,
     pub snapshot_hint_seq: Option<ChangeSeq>,
     pub retention_floor_seq: ChangeSeq,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visible_wal_tip: Option<WalSegmentPointer>,
 }
 
 impl HeadState {
@@ -49,6 +60,7 @@ impl HeadState {
             name_policy: NamePolicy::default(),
             snapshot_hint_seq: None,
             retention_floor_seq: ChangeSeq(0),
+            visible_wal_tip: None,
         }
     }
 }

--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -2,7 +2,7 @@ use crate::digest::sha256_hex;
 use crate::{ChangeSeq, ContentRef, ContentStoreId, FenceToken, InodeId, NamePolicy, NamespaceId};
 use serde::{Deserialize, Serialize};
 
-pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 2;
+pub const CONTROL_OBJECT_FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -5,7 +5,7 @@ use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const WAL_FORMAT_VERSION: u32 = 2;
+pub const WAL_FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -124,8 +124,6 @@ pub struct WalSegmentEnvelope {
     pub payload: WalSegmentPayload,
 }
 
-pub type WalCommitEnvelope = WalSegmentEnvelope;
-
 impl WalSegmentEnvelope {
     pub fn from_payload(
         writer_version: impl Into<String>,
@@ -215,14 +213,4 @@ pub fn decode_wal_segment_envelope_zstd(bytes: &[u8]) -> Result<WalSegmentEnvelo
     }
 
     Ok(envelope)
-}
-
-pub fn encode_wal_commit_envelope_zstd(
-    envelope: &WalCommitEnvelope,
-) -> Result<Vec<u8>, WalCodecError> {
-    encode_wal_segment_envelope_zstd(envelope)
-}
-
-pub fn decode_wal_commit_envelope_zstd(bytes: &[u8]) -> Result<WalCommitEnvelope, WalCodecError> {
-    decode_wal_segment_envelope_zstd(bytes)
 }

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -5,12 +5,12 @@ use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const WAL_FORMAT_VERSION: u32 = 1;
+pub const WAL_FORMAT_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WalEnvelopeKind {
-    NamespaceWalCommit,
+    NamespaceWalSegment,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -88,6 +88,7 @@ pub struct WalCommitPayload {
     pub commit_id: String,
     pub request_id: String,
     pub request_checksum_sha256: String,
+    pub semantic_fingerprint_sha256: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_request_checksum_sha256: Option<String>,
     pub writer_id: String,
@@ -103,21 +104,35 @@ pub struct WalCommitPayload {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WalCommitEnvelope {
+pub struct WalSegmentPayload {
+    pub namespace_id: NamespaceId,
+    pub segment_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_visible_segment: Option<crate::WalSegmentPointer>,
+    pub base_head_seq: ChangeSeq,
+    pub start_seq: ChangeSeq,
+    pub end_seq: ChangeSeq,
+    pub records: Vec<WalCommitPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalSegmentEnvelope {
     pub kind: WalEnvelopeKind,
     pub format_version: u32,
     pub writer_version: String,
     pub payload_checksum_sha256: String,
-    pub payload: WalCommitPayload,
+    pub payload: WalSegmentPayload,
 }
 
-impl WalCommitEnvelope {
+pub type WalCommitEnvelope = WalSegmentEnvelope;
+
+impl WalSegmentEnvelope {
     pub fn from_payload(
         writer_version: impl Into<String>,
-        payload: WalCommitPayload,
+        payload: WalSegmentPayload,
     ) -> Result<Self, WalCodecError> {
         Ok(Self {
-            kind: WalEnvelopeKind::NamespaceWalCommit,
+            kind: WalEnvelopeKind::NamespaceWalSegment,
             format_version: WAL_FORMAT_VERSION,
             writer_version: writer_version.into(),
             payload_checksum_sha256: wal_payload_checksum_sha256(&payload)?,
@@ -127,6 +142,16 @@ impl WalCommitEnvelope {
 
     pub fn has_valid_payload_checksum(&self) -> Result<bool, WalCodecError> {
         Ok(self.payload_checksum_sha256 == wal_payload_checksum_sha256(&self.payload)?)
+    }
+
+    pub fn pointer(&self, object_key: String) -> crate::WalSegmentPointer {
+        crate::WalSegmentPointer {
+            object_key,
+            segment_id: self.payload.segment_id.clone(),
+            start_seq: self.payload.start_seq,
+            end_seq: self.payload.end_seq,
+            payload_checksum_sha256: self.payload_checksum_sha256.clone(),
+        }
     }
 }
 
@@ -142,23 +167,25 @@ pub enum WalCodecError {
     Compress(String),
     #[error("failed to decompress WAL envelope: {0}")]
     Decompress(String),
+    #[error("unsupported WAL format version `{0}`")]
+    UnsupportedFormatVersion(u32),
     #[error("WAL payload checksum mismatch: expected {expected}, actual {actual}")]
     ChecksumMismatch { expected: String, actual: String },
 }
 
-pub fn wal_payload_checksum_sha256(payload: &WalCommitPayload) -> Result<String, WalCodecError> {
+pub fn wal_payload_checksum_sha256(payload: &WalSegmentPayload) -> Result<String, WalCodecError> {
     Ok(sha256_hex(&encode_wal_payload_cbor(payload)?))
 }
 
-pub fn encode_wal_payload_cbor(payload: &WalCommitPayload) -> Result<Vec<u8>, WalCodecError> {
+pub fn encode_wal_payload_cbor(payload: &WalSegmentPayload) -> Result<Vec<u8>, WalCodecError> {
     let mut encoded = Vec::new();
     into_writer(payload, &mut encoded)
         .map_err(|err| WalCodecError::PayloadEncode(err.to_string()))?;
     Ok(encoded)
 }
 
-pub fn encode_wal_commit_envelope_zstd(
-    envelope: &WalCommitEnvelope,
+pub fn encode_wal_segment_envelope_zstd(
+    envelope: &WalSegmentEnvelope,
 ) -> Result<Vec<u8>, WalCodecError> {
     let mut encoded = Vec::new();
     into_writer(envelope, &mut encoded)
@@ -167,11 +194,17 @@ pub fn encode_wal_commit_envelope_zstd(
         .map_err(|err| WalCodecError::Compress(err.to_string()))
 }
 
-pub fn decode_wal_commit_envelope_zstd(bytes: &[u8]) -> Result<WalCommitEnvelope, WalCodecError> {
+pub fn decode_wal_segment_envelope_zstd(bytes: &[u8]) -> Result<WalSegmentEnvelope, WalCodecError> {
     let decompressed = zstd::stream::decode_all(bytes)
         .map_err(|err| WalCodecError::Decompress(err.to_string()))?;
-    let envelope: WalCommitEnvelope = from_reader(decompressed.as_slice())
+    let envelope: WalSegmentEnvelope = from_reader(decompressed.as_slice())
         .map_err(|err| WalCodecError::EnvelopeDecode(err.to_string()))?;
+
+    if envelope.format_version != WAL_FORMAT_VERSION {
+        return Err(WalCodecError::UnsupportedFormatVersion(
+            envelope.format_version,
+        ));
+    }
 
     let actual = wal_payload_checksum_sha256(&envelope.payload)?;
     if actual != envelope.payload_checksum_sha256 {
@@ -182,4 +215,14 @@ pub fn decode_wal_commit_envelope_zstd(bytes: &[u8]) -> Result<WalCommitEnvelope
     }
 
     Ok(envelope)
+}
+
+pub fn encode_wal_commit_envelope_zstd(
+    envelope: &WalCommitEnvelope,
+) -> Result<Vec<u8>, WalCodecError> {
+    encode_wal_segment_envelope_zstd(envelope)
+}
+
+pub fn decode_wal_commit_envelope_zstd(bytes: &[u8]) -> Result<WalCommitEnvelope, WalCodecError> {
+    decode_wal_segment_envelope_zstd(bytes)
 }

--- a/crates/loon-cli/Cargo.toml
+++ b/crates/loon-cli/Cargo.toml
@@ -22,6 +22,7 @@ loon-objectstore = { path = "../loon-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.39", features = ["json"] }

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -296,6 +296,7 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::LeaseConflict => "lease_conflict",
         CoreErrorKind::WouldCycle => "would_cycle",
         CoreErrorKind::RequestIdConflict => "request_id_conflict",
+        CoreErrorKind::CommitQueueFull => "commit_queue_full",
         CoreErrorKind::CheckpointUnavailable => "checkpoint_unavailable",
         CoreErrorKind::UploadNotFound => "upload_not_found",
         CoreErrorKind::UploadAlreadyCompleted => "upload_already_completed",

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -9,6 +9,7 @@ use loon_core::{
 };
 use loon_objectstore::ConfiguredObjectStore;
 use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
@@ -213,6 +214,7 @@ impl Backend for DirectBackend {
         } else {
             PutFileBehavior::CreateOnly
         };
+        let request_id = Uuid::new_v4().to_string();
         put_file_bytes(
             &self.store,
             &ns_id,
@@ -220,19 +222,20 @@ impl Backend for DirectBackend {
             bytes,
             behavior,
             &self.mutation_context(),
-            None,
+            Some(&request_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
+        let request_id = Uuid::new_v4().to_string();
         delete_path_non_recursive(
             &self.store,
             &ns_id,
             &spec.absolute_path,
             &self.mutation_context(),
-            None,
+            Some(&request_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
@@ -243,13 +246,14 @@ impl Backend for DirectBackend {
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
+        let request_id = Uuid::new_v4().to_string();
         move_path(
             &self.store,
             &ns_id,
             &from.absolute_path,
             &to.absolute_path,
             &self.mutation_context(),
-            None,
+            Some(&request_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
@@ -260,13 +264,14 @@ impl Backend for DirectBackend {
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
+        let request_id = Uuid::new_v4().to_string();
         copy_file_path(
             &self.store,
             &ns_id,
             &from.absolute_path,
             &to.absolute_path,
             &self.mutation_context(),
-            None,
+            Some(&request_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
@@ -442,10 +447,11 @@ impl RemoteTarget {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_core_error, LocalTarget, DEFAULT_LEASE_DURATION_MS};
+    use super::{map_core_error, Backend, LocalTarget, DEFAULT_LEASE_DURATION_MS};
     use crate::config::StoreConfig;
-    use loon_api::{InodeId, RevisionNo};
-    use loon_core::{commit::CommitValidationError, CoreError};
+    use loon_api::{ChangeSeq, InodeId, NamespaceId, RevisionNo};
+    use loon_client::NamespacePath;
+    use loon_core::{commit::CommitValidationError, list_changes_after, CoreError};
     use tempfile::tempdir;
 
     #[test]
@@ -486,5 +492,40 @@ mod tests {
             LocalTarget::new(&store, None, None, Some(12_345)).expect("build local target");
 
         assert_eq!(target.backend.lease_duration_ms, 12_345);
+    }
+
+    #[test]
+    fn direct_backend_generates_non_empty_request_id_for_local_put() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let store = StoreConfig::LocalFs {
+            root: temp_dir.path().display().to_string(),
+            key_prefix: None,
+        };
+        let target = LocalTarget::new(&store, None, None, None).expect("build local target");
+        target
+            .backend
+            .create_namespace("demo")
+            .expect("create namespace");
+
+        target
+            .backend
+            .put_file_bytes(
+                &NamespacePath {
+                    namespace: "demo".to_owned(),
+                    absolute_path: "/file.txt".to_owned(),
+                },
+                b"hello",
+                false,
+            )
+            .expect("put file");
+
+        let changes = list_changes_after(
+            &target.backend.store,
+            &NamespaceId::from("demo"),
+            ChangeSeq(0),
+        )
+        .expect("list changes");
+        assert_eq!(changes.changes.len(), 1);
+        assert!(!changes.changes[0].request_id.trim().is_empty());
     }
 }

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -521,7 +521,7 @@ default_profile = "default"
 
 [default]
 mode = "local"
-default_namespace = "   "
+default_namespace = "bad/name"
 
 [default.store]
 kind = "local-fs"

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -3,8 +3,8 @@
 use http::Uri;
 use loon_api::{
     v0::{
-        BeginUploadResponse, ChangesResponse, CommitRequest as V0CommitRequest,
-        CommitResponse as V0CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
+        BeginUploadResponse, ChangesResponse, CommitRequest as ApiCommitRequest,
+        CommitResponse as ApiCommitResponse, CompleteUploadRequest, CompleteUploadResponse,
         UploadContentResponse,
     },
     ApiError, AuthoritativePathEntry, ChangeSeq, ContentRef, CreateNamespaceRequest,
@@ -240,11 +240,11 @@ impl Client {
     pub fn commit_operations(
         &self,
         namespace: &str,
-        request: &V0CommitRequest,
-    ) -> Result<V0CommitResponse, ClientError> {
+        request: &ApiCommitRequest,
+    ) -> Result<ApiCommitResponse, ClientError> {
         let namespace = namespace_url_segment(namespace)?;
         let url = format!("{}/v0/namespaces/{namespace}/commits", self.base_url);
-        self.request_json::<_, V0CommitResponse>(self.agent.post(&url), Some(request))
+        self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
     pub fn list_changes(

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -2,11 +2,9 @@ use crate::checkpoint::{
     checkpoint_basis_head, load_verified_checkpoint_materialization, CheckpointLoadError,
 };
 use crate::genesis::bootstrap_basis_metadata_state;
-use crate::loading::{
-    read_content_store_descriptor_object, read_head_object, read_lease_object,
-    read_namespace_descriptor_object, ControlObjectLoadError,
-};
+use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
 use crate::metadata::MetadataState;
+use crate::namespace::catalog::{load_namespace_catalog_entry, NamespaceCatalogLoadError};
 use crate::wal::{replay_wal_tail_with_metadata, StoredWalObject, WalReplayError};
 use loon_api::{ContentStoreId, HeadState, NamespaceDescriptorState, NamespaceId};
 use loon_objectstore::ObjectStore;
@@ -67,15 +65,24 @@ pub enum BasisLoadError {
     },
 }
 
+impl From<NamespaceCatalogLoadError> for BasisLoadError {
+    fn from(value: NamespaceCatalogLoadError) -> Self {
+        match value {
+            NamespaceCatalogLoadError::LoadNamespaceDescriptor(error) => {
+                Self::LoadNamespaceDescriptor(error)
+            }
+            NamespaceCatalogLoadError::LoadContentStoreDescriptor(error) => {
+                Self::LoadContentStoreDescriptor(error)
+            }
+        }
+    }
+}
+
 pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<VerifiedNamespaceBasis, BasisLoadError> {
-    let loaded_descriptor = read_namespace_descriptor_object(store, expected_namespace)
-        .map_err(BasisLoadError::LoadNamespaceDescriptor)?;
-    let content_store_id = loaded_descriptor.envelope.state.content_store_id.clone();
-    read_content_store_descriptor_object(store, &content_store_id)
-        .map_err(BasisLoadError::LoadContentStoreDescriptor)?;
+    let catalog_entry = load_namespace_catalog_entry(store, expected_namespace)?;
 
     let loaded_head = read_head_object(store, expected_namespace)?;
     let loaded_lease =
@@ -115,8 +122,8 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     ensure_reconstructed_head_matches(&loaded_head.envelope.state, &replayed.resulting_head)?;
 
     Ok(VerifiedNamespaceBasis {
-        namespace_descriptor: loaded_descriptor.envelope.state,
-        content_store_id,
+        namespace_descriptor: catalog_entry.namespace_descriptor,
+        content_store_id: catalog_entry.content_store_id,
         head: loaded_head.envelope.state,
         head_etag,
         lease: loaded_lease.envelope.state,

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -6,7 +6,10 @@ use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError
 use crate::metadata::MetadataState;
 use crate::namespace::catalog::{load_namespace_catalog_entry, NamespaceCatalogLoadError};
 use crate::wal::{replay_wal_tail_with_metadata, StoredWalObject, WalReplayError};
-use loon_api::{ContentStoreId, HeadState, NamespaceDescriptorState, NamespaceId};
+use loon_api::{
+    decode_wal_segment_envelope_zstd, ChangeSeq, ContentStoreId, HeadState,
+    NamespaceDescriptorState, NamespaceId, WalSegmentPointer,
+};
 use loon_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -116,6 +119,7 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
         expected_namespace,
         initial_head.seq,
         loaded_head.envelope.state.seq,
+        loaded_head.envelope.state.visible_wal_tip.clone(),
     )?;
     let replayed = replay_wal_tail_with_metadata(&initial_head, &initial_metadata_state, &wal_tail)
         .map_err(BasisLoadError::WalReplay)?;
@@ -143,6 +147,8 @@ fn ensure_reconstructed_head_matches(
         || current_head.name_policy != reconstructed.name_policy
         || current_head.snapshot_hint_seq != reconstructed.snapshot_hint_seq
         || current_head.retention_floor_seq != reconstructed.retention_floor_seq
+        || (reconstructed.visible_wal_tip.is_some()
+            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
     {
         return Err(BasisLoadError::ReconstructedHeadMismatch {
             expected: Box::new(current_head.clone()),
@@ -155,67 +161,64 @@ fn ensure_reconstructed_head_matches(
 fn load_stored_wal_tail<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
-    from_seq_exclusive: loon_api::ChangeSeq,
-    through_seq_inclusive: loon_api::ChangeSeq,
+    from_seq_exclusive: ChangeSeq,
+    through_seq_inclusive: ChangeSeq,
+    visible_wal_tip: Option<WalSegmentPointer>,
 ) -> Result<Vec<StoredWalObject>, BasisLoadError> {
-    let prefix = format!("namespaces/{}/wal/", expected_namespace.as_str());
-    let listed = store
-        .list_prefix(&prefix)
-        .map_err(|err| BasisLoadError::ListWal {
-            prefix: prefix.clone(),
-            message: err.to_string(),
-        })?;
-
-    let mut wal_by_seq = std::collections::BTreeMap::new();
-    for object_key in listed {
-        let Some(seq) = wal_seq_from_key(&prefix, &object_key) else {
-            return Err(BasisLoadError::InvalidWalObjectKey { object_key });
-        };
-        if seq <= from_seq_exclusive || seq > through_seq_inclusive {
-            continue;
-        }
-        if let Some(existing) = wal_by_seq.insert(seq, object_key.clone()) {
-            return Err(BasisLoadError::DuplicateWalSeq {
-                seq,
-                first: existing,
-                second: object_key,
-            });
-        }
+    if through_seq_inclusive <= from_seq_exclusive {
+        return Ok(Vec::new());
     }
 
-    let mut wal_tail = Vec::new();
-    let mut expected = from_seq_exclusive.0.saturating_add(1);
-    while expected <= through_seq_inclusive.0 {
-        let seq = loon_api::ChangeSeq(expected);
-        let object_key =
-            wal_by_seq
-                .remove(&seq)
-                .ok_or_else(|| BasisLoadError::MissingWalObject {
-                    prefix: prefix.clone(),
-                    seq,
-                })?;
+    let prefix = format!("namespaces/{}/wal/", expected_namespace.as_str());
+    let mut pointer = visible_wal_tip.ok_or_else(|| BasisLoadError::MissingWalObject {
+        prefix: prefix.clone(),
+        seq: through_seq_inclusive,
+    })?;
+    let mut reversed = Vec::new();
+
+    loop {
+        if pointer.end_seq <= from_seq_exclusive {
+            break;
+        }
         let encoded_bytes = store
-            .get(&object_key, None)
+            .get(&pointer.object_key, None)
             .map_err(|err| BasisLoadError::ReadWal {
-                object_key: object_key.clone(),
+                object_key: pointer.object_key.clone(),
                 message: err.to_string(),
             })?
             .ok_or_else(|| BasisLoadError::MissingWalObjectAfterList {
-                object_key: object_key.clone(),
+                object_key: pointer.object_key.clone(),
             })?;
-        wal_tail.push(StoredWalObject {
-            object_key,
+        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
+            .map_err(|err| BasisLoadError::WalReplay(WalReplayError::Codec(err.to_string())))?;
+        if envelope.payload.namespace_id != *expected_namespace {
+            return Err(BasisLoadError::WalReplay(
+                WalReplayError::NamespaceMismatch {
+                    expected: expected_namespace.clone(),
+                    actual: envelope.payload.namespace_id.clone(),
+                },
+            ));
+        }
+        if envelope.payload.segment_id != pointer.segment_id
+            || envelope.payload.start_seq != pointer.start_seq
+            || envelope.payload.end_seq != pointer.end_seq
+            || envelope.payload_checksum_sha256 != pointer.payload_checksum_sha256
+        {
+            return Err(BasisLoadError::WalReplay(
+                WalReplayError::SegmentSummaryMismatch,
+            ));
+        }
+        let prev = envelope.payload.prev_visible_segment.clone();
+        reversed.push(StoredWalObject {
+            object_key: pointer.object_key.clone(),
             encoded_bytes,
         });
-        expected = expected.saturating_add(1);
+        let Some(prev) = prev else {
+            break;
+        };
+        pointer = prev;
     }
 
-    Ok(wal_tail)
-}
-
-fn wal_seq_from_key(prefix: &str, object_key: &str) -> Option<loon_api::ChangeSeq> {
-    let suffix = object_key.strip_prefix(prefix)?;
-    let (seq_part, _) = suffix.split_once('-')?;
-    let seq = seq_part.parse::<u64>().ok()?;
-    Some(loon_api::ChangeSeq(seq))
+    reversed.reverse();
+    Ok(reversed)
 }

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -4,7 +4,8 @@ use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::loading::read_head_object;
 use crate::metadata::{
-    DirentryRecord, InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord,
+    DirentryRecord, InodeRecord, MetadataState, RequestReceiptRecord, RevisionRecord,
+    SubtreeTombstoneRecord,
 };
 use loon_api::{
     checkpoint_page_checksum_sha256, checkpoint_segment_payload_checksum_sha256,
@@ -27,11 +28,12 @@ const HEAD_UPDATE_RETRY_LIMIT: usize = 8;
 // retention floor advances. This hook stays in place so future retention gates
 // can add progress requirements without restructuring the flow.
 const REQUIRED_RETENTION_PROGRESS_CLASSES: &[&str] = &[];
-const CHECKPOINT_TABLE_FAMILIES: [CheckpointTableFamily; 4] = [
+const CHECKPOINT_TABLE_FAMILIES: [CheckpointTableFamily; 5] = [
     CheckpointTableFamily::Inodes,
     CheckpointTableFamily::Direntries,
     CheckpointTableFamily::Revisions,
     CheckpointTableFamily::Tombstones,
+    CheckpointTableFamily::RequestReceipts,
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -323,6 +325,7 @@ pub fn advance_retention_floor<S: ObjectStore + ?Sized>(
             name_policy: head.name_policy,
             snapshot_hint_seq: head.snapshot_hint_seq,
             retention_floor_seq: target_floor,
+            visible_wal_tip: head.visible_wal_tip.clone(),
         };
         match compare_and_swap_head(
             store,
@@ -372,6 +375,7 @@ pub(crate) fn checkpoint_basis_head(
         name_policy: current_head.name_policy,
         snapshot_hint_seq: current_head.snapshot_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
+        visible_wal_tip: None,
     }
 }
 
@@ -552,6 +556,7 @@ fn publish_snapshot_hint_seq<S: ObjectStore + ?Sized>(
             name_policy: current_head.name_policy,
             snapshot_hint_seq: Some(checkpoint_seq),
             retention_floor_seq: current_head.retention_floor_seq,
+            visible_wal_tip: current_head.visible_wal_tip.clone(),
         };
         match compare_and_swap_head(
             store,
@@ -974,6 +979,22 @@ fn append_rows_to_metadata(
                     tombstone_seq: *tombstone_seq,
                     tombstone_op_index: *tombstone_op_index,
                 }),
+            (
+                CheckpointTableFamily::RequestReceipts,
+                CheckpointRow::RequestReceipt {
+                    request_id,
+                    semantic_fingerprint_sha256,
+                    committed_seq,
+                    commit_id,
+                    results,
+                },
+            ) => metadata_state.request_receipts.push(RequestReceiptRecord {
+                request_id: request_id.clone(),
+                semantic_fingerprint_sha256: semantic_fingerprint_sha256.clone(),
+                committed_seq: *committed_seq,
+                commit_id: commit_id.clone(),
+                results: results.clone(),
+            }),
             _ => {
                 return Err(CheckpointLoadError::TableRowKindMismatch {
                     object_key: object_key.to_owned(),
@@ -1038,6 +1059,17 @@ fn checkpoint_rows_for_family(
                 tombstone_op_index: tombstone.tombstone_op_index,
             })
             .collect::<Vec<_>>(),
+        CheckpointTableFamily::RequestReceipts => metadata_state
+            .request_receipts
+            .iter()
+            .map(|receipt| CheckpointRow::RequestReceipt {
+                request_id: receipt.request_id.clone(),
+                semantic_fingerprint_sha256: receipt.semantic_fingerprint_sha256.clone(),
+                committed_seq: receipt.committed_seq,
+                commit_id: receipt.commit_id.clone(),
+                results: receipt.results.clone(),
+            })
+            .collect::<Vec<_>>(),
     };
     rows.sort_by_key(CheckpointRow::row_key);
     rows
@@ -1049,6 +1081,7 @@ fn snapshot_table_family(family: CheckpointTableFamily) -> SnapshotTableFamily {
         CheckpointTableFamily::Direntries => SnapshotTableFamily::Direntries,
         CheckpointTableFamily::Revisions => SnapshotTableFamily::Revisions,
         CheckpointTableFamily::Tombstones => SnapshotTableFamily::Tombstones,
+        CheckpointTableFamily::RequestReceipts => SnapshotTableFamily::RequestReceipts,
     }
 }
 
@@ -1058,6 +1091,7 @@ fn checkpoint_row_kind(row: &CheckpointRow) -> &'static str {
         CheckpointRow::Direntry { .. } => "direntry",
         CheckpointRow::Revision { .. } => "revision",
         CheckpointRow::Tombstone { .. } => "tombstone",
+        CheckpointRow::RequestReceipt { .. } => "request_receipt",
     }
 }
 

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -1,9 +1,11 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
+use crate::content::write_immutable_object;
+use crate::context::MutationContext;
+use crate::error::CoreError;
 use crate::loading::read_head_object;
 use crate::metadata::{
     DirentryRecord, InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord,
 };
-use crate::services::{write_immutable_object, CoreError};
 use loon_api::{
     checkpoint_page_checksum_sha256, checkpoint_segment_payload_checksum_sha256,
     decode_checkpoint_manifest_json, decode_checkpoint_segment_envelope_zstd,
@@ -174,7 +176,7 @@ impl CheckpointLoadError {
 pub fn create_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    context: &crate::services::MutationContext,
+    context: &MutationContext,
 ) -> Result<CreateCheckpointResponse, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
     let checkpoint_seq = basis.head.seq;
@@ -290,7 +292,7 @@ pub(crate) fn write_verified_checkpoint_from_metadata<S: ObjectStore + ?Sized>(
 pub fn advance_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    context: &crate::services::MutationContext,
+    context: &MutationContext,
 ) -> Result<AdvanceRetentionResponse, CoreError> {
     for _attempt in 0..HEAD_UPDATE_RETRY_LIMIT {
         let loaded_head = read_head_object(store, namespace_id)

--- a/crates/loon-core/src/commit.rs
+++ b/crates/loon-core/src/commit.rs
@@ -302,4 +302,31 @@ impl CommitRequest {
         let bytes = serde_json::to_vec(self)?;
         Ok(loon_api::sha256_digest(&bytes))
     }
+
+    pub fn semantic_fingerprint_sha256(&self) -> Result<String, serde_json::Error> {
+        if let Some(source) = &self.source_request_checksum_sha256 {
+            return Ok(source.clone());
+        }
+        #[derive(Serialize)]
+        struct SemanticCommit<'a> {
+            namespace_id: &'a NamespaceId,
+            request_id: &'a str,
+            planned_head_seq: ChangeSeq,
+            ops: &'a [CommitOp],
+            preconditions: &'a [Precondition],
+            message: &'a Option<String>,
+            annotations: &'a Option<CommitAnnotations>,
+        }
+        let semantic = SemanticCommit {
+            namespace_id: &self.namespace_id,
+            request_id: &self.request_id,
+            planned_head_seq: self.planned_head_seq,
+            ops: &self.ops,
+            preconditions: &self.preconditions,
+            message: &self.message,
+            annotations: &self.annotations,
+        };
+        let bytes = serde_json::to_vec(&semantic)?;
+        Ok(loon_api::sha256_digest(&bytes))
+    }
 }

--- a/crates/loon-core/src/commit/frame.rs
+++ b/crates/loon-core/src/commit/frame.rs
@@ -27,14 +27,7 @@ pub(super) fn validate_commit_request_frame(
         });
     }
 
-    if request.planned_head_seq != context.head.seq {
-        return Err(CommitValidationError::PlannedHeadSeqMismatch {
-            expected: context.head.seq,
-            actual: request.planned_head_seq,
-        });
-    }
-
-    validate_head_seq_preconditions(&request.preconditions, request.planned_head_seq)?;
+    validate_head_seq_preconditions(&request.preconditions, context.head.seq)?;
 
     if request.writer_fence_token != context.head.active_fence_token {
         return Err(CommitValidationError::StaleWriterFenceToken {
@@ -62,26 +55,17 @@ pub(super) fn validate_commit_request_frame(
 
 fn validate_head_seq_preconditions(
     preconditions: &[Precondition],
-    planned_head_seq: ChangeSeq,
+    current_head_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
-    let mut saw_head_seq_precondition = false;
-
     for precondition in preconditions {
         if let Precondition::HeadSeqIs(actual) = precondition {
-            saw_head_seq_precondition = true;
-            if *actual != planned_head_seq {
+            if *actual != current_head_seq {
                 return Err(CommitValidationError::ConflictingHeadSeqPrecondition {
-                    expected: planned_head_seq,
+                    expected: current_head_seq,
                     actual: *actual,
                 });
             }
         }
-    }
-
-    if !saw_head_seq_precondition {
-        return Err(CommitValidationError::MissingHeadSeqPrecondition {
-            expected: planned_head_seq,
-        });
     }
 
     Ok(())

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -141,7 +141,7 @@ pub fn build_commit_plan(
     Ok(CommitPlan {
         namespace_id: request.namespace_id.clone(),
         commit_id: request.request_id.clone(),
-        base_head_seq: request.planned_head_seq,
+        base_head_seq: context.head.seq,
         next_seq: shape.next_seq,
         allocated_inode_ids: shape.allocated_inode_ids,
         resolved_restore_content_refs,

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -1,5 +1,5 @@
 use super::{push_unique_invariant, CommitHeadPublishError, CommitPlan, PreparedCommitHeadPublish};
-use loon_api::{ChangeSeq, ControlObjectKind, HeadState, HeadStateEnvelope};
+use loon_api::{ControlObjectKind, HeadState, HeadStateEnvelope, WalSegmentPointer};
 use loon_objectstore::keys::namespace_head;
 use loon_objectstore::ObjectStoreError;
 use loon_objectstore::{ObjectMetadata, ObjectStore};
@@ -7,6 +7,7 @@ use loon_objectstore::{ObjectMetadata, ObjectStore};
 pub fn prepare_commit_head_publish(
     current_head: &HeadState,
     plan: &CommitPlan,
+    visible_wal_tip: WalSegmentPointer,
     writer_version: &str,
 ) -> Result<PreparedCommitHeadPublish, CommitHeadPublishError> {
     if writer_version.trim().is_empty() {
@@ -20,14 +21,14 @@ pub fn prepare_commit_head_publish(
         });
     }
 
-    if current_head.seq != plan.base_head_seq {
+    if plan.base_head_seq < current_head.seq {
         return Err(CommitHeadPublishError::PlanBaseHeadSeqMismatch {
             head: current_head.seq,
             plan: plan.base_head_seq,
         });
     }
 
-    if current_head.seq.0.checked_add(1).map(ChangeSeq) != Some(plan.next_seq) {
+    if plan.next_seq <= current_head.seq {
         return Err(CommitHeadPublishError::PlanNextSeqMismatch {
             head: current_head.seq,
             plan: plan.next_seq,
@@ -42,6 +43,7 @@ pub fn prepare_commit_head_publish(
         name_policy: current_head.name_policy,
         snapshot_hint_seq: current_head.snapshot_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
+        visible_wal_tip: Some(visible_wal_tip),
     };
     let envelope = HeadStateEnvelope::from_state(
         ControlObjectKind::NamespaceHead,

--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -1,6 +1,6 @@
 use loon_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId};
 use loon_objectstore::keys::content_blob;
-use loon_objectstore::ObjectStore;
+use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -43,6 +43,12 @@ pub enum DurableContentValidationError {
     },
     #[error("object store error for `{object_key}`: {message}")]
     Store { object_key: String, message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub(crate) enum ImmutableObjectWriteError {
+    #[error("{0}")]
+    Store(String),
 }
 
 pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
@@ -105,6 +111,34 @@ pub fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
     let bytes = load_required_object(store, &validated.object_key)?;
 
     Ok(ReadDurableContent { validated, bytes })
+}
+
+pub(crate) fn write_immutable_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    object_key: &str,
+    expected_bytes: &[u8],
+) -> Result<(), ImmutableObjectWriteError> {
+    match store.put_if_absent(object_key, expected_bytes) {
+        Ok(_) => Ok(()),
+        Err(ObjectStoreError::PreconditionFailed) => {
+            let existing = store
+                .get(object_key, None)
+                .map_err(|err| ImmutableObjectWriteError::Store(err.to_string()))?
+                .ok_or_else(|| {
+                    ImmutableObjectWriteError::Store(format!(
+                        "missing immutable object `{object_key}` after precondition failure"
+                    ))
+                })?;
+            if existing == expected_bytes {
+                Ok(())
+            } else {
+                Err(ImmutableObjectWriteError::Store(format!(
+                    "immutable object `{object_key}` already exists with different bytes"
+                )))
+            }
+        }
+        Err(err) => Err(ImmutableObjectWriteError::Store(err.to_string())),
+    }
 }
 
 fn load_required_object<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/context.rs
+++ b/crates/loon-core/src/context.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutationContext {
+    pub writer_id: String,
+    pub writer_version: String,
+    pub now_ms: u64,
+    pub lease_duration_ms: u64,
+}

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -25,6 +25,7 @@ pub enum CoreErrorKind {
     LeaseConflict,
     WouldCycle,
     RequestIdConflict,
+    CommitQueueFull,
     CheckpointUnavailable,
     UploadNotFound,
     UploadAlreadyCompleted,
@@ -35,7 +36,7 @@ pub enum CoreErrorKind {
     ServerError,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum CoreError {
     #[error(transparent)]
     Basis(#[from] BasisLoadError),
@@ -73,6 +74,8 @@ pub enum CoreError {
     DestinationExists(String),
     #[error("request id conflict for `{0}`")]
     RequestIdConflict(String),
+    #[error("commit queue is full; slow down and retry")]
+    CommitQueueFull,
     #[error("{0}")]
     CheckpointUnavailable(String),
     #[error("upload session `{upload_id}` was not found")]
@@ -165,6 +168,7 @@ impl CoreError {
             CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
             CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
             CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
+            CoreError::CommitQueueFull => CoreErrorKind::CommitQueueFull,
             CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
             CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,
             CoreError::UploadAlreadyCompleted { .. } => CoreErrorKind::UploadAlreadyCompleted,

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -1,0 +1,329 @@
+use crate::basis::BasisLoadError;
+use crate::commit::{CommitHeadPublishError, CommitValidationError};
+use crate::content::{DurableContentValidationError, ImmutableObjectWriteError};
+use crate::lease::LeaseAcquireError;
+use crate::loading::ControlObjectLoadError;
+use crate::metadata::{MetadataApplyError, VisiblePathError};
+use crate::namespace::catalog::NamespaceCatalogLoadError;
+use crate::wal::WalBuildError;
+use loon_api::{ChangeSeq, InodeId, InodeKind, NamespaceId};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoreErrorKind {
+    InvalidPath,
+    NamespaceNotFound,
+    NamespaceExists,
+    NamespacePartial,
+    PathNotFound,
+    RevisionNotFound,
+    PathConflict,
+    StaleHead,
+    StaleRevision,
+    TombstoneConflict,
+    LeaseConflict,
+    WouldCycle,
+    RequestIdConflict,
+    CheckpointUnavailable,
+    UploadNotFound,
+    UploadAlreadyCompleted,
+    UploadContentConflict,
+    InvalidUploadContent,
+    RebootstrapRequired,
+    NamespaceCorrupt,
+    ServerError,
+}
+
+#[derive(Debug, Error)]
+pub enum CoreError {
+    #[error(transparent)]
+    Basis(#[from] BasisLoadError),
+    #[error(transparent)]
+    VisiblePath(#[from] VisiblePathError),
+    #[error(transparent)]
+    DurableContent(#[from] DurableContentValidationError),
+    #[error(transparent)]
+    Lease(#[from] LeaseAcquireError),
+    #[error("commit validation failed: {0:?}")]
+    CommitValidation(CommitValidationError),
+    #[error("wal build failed: {0:?}")]
+    WalBuild(WalBuildError),
+    #[error("metadata apply failed: {0:?}")]
+    MetadataApply(MetadataApplyError),
+    #[error("head publish failed: {0:?}")]
+    HeadPublish(CommitHeadPublishError),
+    #[error("failed to write wal object: {0}")]
+    WalWrite(String),
+    #[error("invalid absolute path `{0}`")]
+    InvalidPath(String),
+    #[error("path not found `{0}`")]
+    MissingPath(String),
+    #[error("expected file at `{path}` but found `{kind:?}`")]
+    ExpectedFile { path: String, kind: InodeKind },
+    #[error("expected directory at `{path}` but found `{kind:?}`")]
+    ExpectedDirectory { path: String, kind: InodeKind },
+    #[error("directory not empty `{0}`")]
+    DirectoryNotEmpty(String),
+    #[error("cannot mutate root path")]
+    RootMutationForbidden,
+    #[error("destination already exists at `{0}`")]
+    DestinationExists(String),
+    #[error("request id conflict for `{0}`")]
+    RequestIdConflict(String),
+    #[error("{0}")]
+    CheckpointUnavailable(String),
+    #[error("upload session `{upload_id}` was not found")]
+    UploadNotFound { upload_id: String },
+    #[error("upload session `{upload_id}` is already completed")]
+    UploadAlreadyCompleted { upload_id: String },
+    #[error("upload session `{upload_id}` content conflicts with prior content")]
+    UploadContentConflict { upload_id: String },
+    #[error("invalid upload content: {0}")]
+    InvalidUploadContent(String),
+    #[error(
+        "change feed cursor `{after_seq:?}` is older than retention floor `{retention_floor_seq:?}`"
+    )]
+    RebootstrapRequired {
+        after_seq: ChangeSeq,
+        retention_floor_seq: ChangeSeq,
+    },
+    #[error(
+        "path `{path}` is covered by subtree tombstone rooted at inode `{root_inode}` from seq `{tombstone_seq:?}`"
+    )]
+    TombstoneConflict {
+        path: String,
+        root_inode: InodeId,
+        tombstone_seq: ChangeSeq,
+    },
+    #[error("path component `{0}` is not a directory")]
+    NonDirectoryPathComponent(String),
+    #[error("object store error: {0}")]
+    Store(String),
+    #[error("namespace `{namespace_id}` already exists")]
+    NamespaceAlreadyExists { namespace_id: NamespaceId },
+    #[error("namespace `{namespace_id}` is partially initialized")]
+    NamespacePartiallyInitialized { namespace_id: NamespaceId },
+}
+
+impl From<CommitValidationError> for CoreError {
+    fn from(value: CommitValidationError) -> Self {
+        Self::CommitValidation(value)
+    }
+}
+
+impl From<WalBuildError> for CoreError {
+    fn from(value: WalBuildError) -> Self {
+        Self::WalBuild(value)
+    }
+}
+
+impl From<MetadataApplyError> for CoreError {
+    fn from(value: MetadataApplyError) -> Self {
+        Self::MetadataApply(value)
+    }
+}
+
+impl From<CommitHeadPublishError> for CoreError {
+    fn from(value: CommitHeadPublishError) -> Self {
+        Self::HeadPublish(value)
+    }
+}
+
+impl From<NamespaceCatalogLoadError> for CoreError {
+    fn from(value: NamespaceCatalogLoadError) -> Self {
+        Self::Basis(value.into())
+    }
+}
+
+impl From<ImmutableObjectWriteError> for CoreError {
+    fn from(value: ImmutableObjectWriteError) -> Self {
+        Self::Store(value.to_string())
+    }
+}
+
+impl CoreError {
+    pub fn kind(&self) -> CoreErrorKind {
+        match self {
+            CoreError::Basis(error) => classify_basis_load_error(error),
+            CoreError::VisiblePath(error) => classify_visible_path_error(error),
+            CoreError::DurableContent(error) => classify_durable_content_error(error),
+            CoreError::Lease(error) => classify_lease_acquire_error(error),
+            CoreError::CommitValidation(error) => classify_commit_validation_error(error),
+            CoreError::WalBuild(_)
+            | CoreError::MetadataApply(_)
+            | CoreError::WalWrite(_)
+            | CoreError::Store(_) => CoreErrorKind::ServerError,
+            CoreError::HeadPublish(error) => classify_head_publish_error(error),
+            CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
+                CoreErrorKind::InvalidPath
+            }
+            CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
+            CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
+            CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
+            CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
+            CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
+            CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,
+            CoreError::UploadAlreadyCompleted { .. } => CoreErrorKind::UploadAlreadyCompleted,
+            CoreError::UploadContentConflict { .. } => CoreErrorKind::UploadContentConflict,
+            CoreError::InvalidUploadContent(_) => CoreErrorKind::InvalidUploadContent,
+            CoreError::RebootstrapRequired { .. } => CoreErrorKind::RebootstrapRequired,
+            CoreError::ExpectedFile { .. }
+            | CoreError::ExpectedDirectory { .. }
+            | CoreError::DirectoryNotEmpty(_)
+            | CoreError::DestinationExists(_) => CoreErrorKind::PathConflict,
+            CoreError::TombstoneConflict { .. } => CoreErrorKind::TombstoneConflict,
+            CoreError::NonDirectoryPathComponent(_) => CoreErrorKind::InvalidPath,
+        }
+    }
+}
+
+fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErrorKind {
+    match error {
+        ControlObjectLoadError::MissingObject { .. }
+        | ControlObjectLoadError::MissingObjectAfterHead { .. } => CoreErrorKind::NamespaceNotFound,
+        ControlObjectLoadError::KindMismatch { .. }
+        | ControlObjectLoadError::NamespaceMismatch { .. }
+        | ControlObjectLoadError::ContentStoreMismatch { .. }
+        | ControlObjectLoadError::ChecksumMismatch { .. }
+        | ControlObjectLoadError::Codec { .. } => CoreErrorKind::NamespaceCorrupt,
+        ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
+    match error {
+        BasisLoadError::LoadNamespaceDescriptor(error) => classify_control_object_load_error(error),
+        BasisLoadError::LoadContentStoreDescriptor(error) => match error {
+            ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
+            _ => CoreErrorKind::NamespaceCorrupt,
+        },
+        BasisLoadError::LoadHead(error) | BasisLoadError::LoadLease(error) => match error {
+            ControlObjectLoadError::MissingObject { .. }
+            | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
+                CoreErrorKind::NamespaceCorrupt
+            }
+            _ => classify_control_object_load_error(error),
+        },
+        BasisLoadError::InvalidWalObjectKey { .. }
+        | BasisLoadError::DuplicateWalSeq { .. }
+        | BasisLoadError::MissingWalObject { .. }
+        | BasisLoadError::MissingWalObjectAfterList { .. }
+        | BasisLoadError::WalReplay(_)
+        | BasisLoadError::ReconstructedHeadMismatch { .. } => CoreErrorKind::NamespaceCorrupt,
+        BasisLoadError::CheckpointLoad(error) => match error.kind() {
+            crate::checkpoint::CheckpointLoadErrorKind::Corrupt => CoreErrorKind::NamespaceCorrupt,
+            crate::checkpoint::CheckpointLoadErrorKind::Store => CoreErrorKind::ServerError,
+        },
+        BasisLoadError::MissingHeadEtag { .. }
+        | BasisLoadError::ListWal { .. }
+        | BasisLoadError::ReadWal { .. } => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_visible_path_error(error: &VisiblePathError) -> CoreErrorKind {
+    match error {
+        VisiblePathError::InvalidAbsolutePath { .. } => CoreErrorKind::InvalidPath,
+        VisiblePathError::RootMissing => CoreErrorKind::NamespaceCorrupt,
+        VisiblePathError::PathNotFound { .. } => CoreErrorKind::PathNotFound,
+        VisiblePathError::PathComponentNotDirectory { .. } => CoreErrorKind::PathConflict,
+    }
+}
+
+fn classify_durable_content_error(error: &DurableContentValidationError) -> CoreErrorKind {
+    match error {
+        DurableContentValidationError::UnsupportedContentRefKind { .. }
+        | DurableContentValidationError::InvalidDigest { .. }
+        | DurableContentValidationError::MissingContentObject { .. }
+        | DurableContentValidationError::ContentLengthMismatch { .. }
+        | DurableContentValidationError::ContentDigestMismatch { .. } => {
+            CoreErrorKind::NamespaceCorrupt
+        }
+        DurableContentValidationError::Store { .. } => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_lease_acquire_error(error: &LeaseAcquireError) -> CoreErrorKind {
+    match error {
+        LeaseAcquireError::LoadHead(error) | LeaseAcquireError::LoadLease(error) => {
+            classify_control_object_load_error(error)
+        }
+        LeaseAcquireError::HeldByOtherWriter { .. } => CoreErrorKind::LeaseConflict,
+        LeaseAcquireError::UnexpectedControlState { .. } => CoreErrorKind::NamespaceCorrupt,
+        LeaseAcquireError::EmptyWriterId
+        | LeaseAcquireError::ZeroLeaseDuration
+        | LeaseAcquireError::MissingHeadEtag { .. }
+        | LeaseAcquireError::MissingLeaseEtag { .. }
+        | LeaseAcquireError::HeadFenceTakeover(_)
+        | LeaseAcquireError::HeadWrite(_)
+        | LeaseAcquireError::LeaseWrite(_)
+        | LeaseAcquireError::RetryExhausted { .. } => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorKind {
+    match error {
+        CommitValidationError::PlannedHeadSeqMismatch { .. }
+        | CommitValidationError::MissingHeadSeqPrecondition { .. }
+        | CommitValidationError::ConflictingHeadSeqPrecondition { .. } => CoreErrorKind::StaleHead,
+        CommitValidationError::ReplaceFileBaseRevisionMismatch { .. }
+        | CommitValidationError::RestoreRevisionBaseRevisionMismatch { .. } => {
+            CoreErrorKind::StaleRevision
+        }
+        CommitValidationError::RestoreRevisionSourceRevisionMissing { .. } => {
+            CoreErrorKind::RevisionNotFound
+        }
+        CommitValidationError::CreateUnderSubtreeTombstone { .. }
+        | CommitValidationError::ReplaceFileUnderSubtreeTombstone { .. }
+        | CommitValidationError::RestoreRevisionUnderSubtreeTombstone { .. }
+        | CommitValidationError::DeleteFileCoveredByTombstone { .. }
+        | CommitValidationError::RenameInodeUnderSubtreeTombstone { .. }
+        | CommitValidationError::RenameTargetParentUnderSubtreeTombstone { .. }
+        | CommitValidationError::DeleteSubtreeRootCoveredByTombstone { .. } => {
+            CoreErrorKind::TombstoneConflict
+        }
+        CommitValidationError::CreateChildNameCollision { .. }
+        | CommitValidationError::CreateParentNotDirectory { .. }
+        | CommitValidationError::ReplaceFileInodeNotFile { .. }
+        | CommitValidationError::RestoreRevisionInodeNotFile { .. }
+        | CommitValidationError::DeleteFileInodeNotFile { .. }
+        | CommitValidationError::RenameTargetParentNotDirectory { .. }
+        | CommitValidationError::RenameTargetNameCollision { .. }
+        | CommitValidationError::DeleteSubtreeRootNotDirectory { .. } => {
+            CoreErrorKind::PathConflict
+        }
+        CommitValidationError::CreateParentMissing { .. }
+        | CommitValidationError::ReplaceFileInodeMissing { .. }
+        | CommitValidationError::RestoreRevisionInodeMissing { .. }
+        | CommitValidationError::DeleteFileInodeMissing { .. }
+        | CommitValidationError::RenameInodeMissing { .. }
+        | CommitValidationError::RenameSourceBindingMissing { .. }
+        | CommitValidationError::RenameTargetParentMissing { .. }
+        | CommitValidationError::DeleteSubtreeRootMissing { .. } => CoreErrorKind::PathNotFound,
+        CommitValidationError::RenameWouldCycleDirectory { .. } => CoreErrorKind::WouldCycle,
+        CommitValidationError::StaleWriterFenceToken { .. }
+        | CommitValidationError::LeaseHolderMismatch { .. }
+        | CommitValidationError::LeaseExpired { .. } => CoreErrorKind::LeaseConflict,
+        CommitValidationError::EmptyCommit
+        | CommitValidationError::NamespaceMismatch
+        | CommitValidationError::HeadLeaseNamespaceMismatch
+        | CommitValidationError::HeadLeaseFenceMismatch { .. }
+        | CommitValidationError::RestoreRevisionOverflow { .. }
+        | CommitValidationError::ReplaceFileRevisionOverflow { .. }
+        | CommitValidationError::SeqOverflow
+        | CommitValidationError::NextInodeOverflow
+        | CommitValidationError::OpIndexOverflow => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_head_publish_error(error: &CommitHeadPublishError) -> CoreErrorKind {
+    match error {
+        CommitHeadPublishError::StaleHead => CoreErrorKind::StaleHead,
+        CommitHeadPublishError::EmptyWriterVersion
+        | CommitHeadPublishError::EmptyExpectedHeadEtag
+        | CommitHeadPublishError::NamespaceMismatch { .. }
+        | CommitHeadPublishError::PlanBaseHeadSeqMismatch { .. }
+        | CommitHeadPublishError::PlanNextSeqMismatch { .. }
+        | CommitHeadPublishError::Codec(_)
+        | CommitHeadPublishError::Store(_) => CoreErrorKind::ServerError,
+    }
+}

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -6,12 +6,13 @@ use crate::loading::ControlObjectLoadError;
 use crate::metadata::{MetadataApplyError, VisiblePathError};
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::wal::WalBuildError;
-use loon_api::{ChangeSeq, InodeId, InodeKind, NamespaceId};
+use loon_api::{ChangeSeq, InodeId, InodeKind, NamespaceId, NamespaceIdValidationError};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoreErrorKind {
     InvalidPath,
+    InvalidNamespaceId,
     NamespaceNotFound,
     NamespaceExists,
     NamespacePartial,
@@ -56,6 +57,8 @@ pub enum CoreError {
     WalWrite(String),
     #[error("invalid absolute path `{0}`")]
     InvalidPath(String),
+    #[error(transparent)]
+    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("path not found `{0}`")]
     MissingPath(String),
     #[error("expected file at `{path}` but found `{kind:?}`")]
@@ -157,6 +160,7 @@ impl CoreError {
             CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
                 CoreErrorKind::InvalidPath
             }
+            CoreError::InvalidNamespaceId(_) => CoreErrorKind::InvalidNamespaceId,
             CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
             CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
             CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
@@ -179,6 +183,7 @@ impl CoreError {
 
 fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErrorKind {
     match error {
+        ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
         ControlObjectLoadError::MissingObject { .. }
         | ControlObjectLoadError::MissingObjectAfterHead { .. } => CoreErrorKind::NamespaceNotFound,
         ControlObjectLoadError::KindMismatch { .. }
@@ -194,6 +199,7 @@ fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
     match error {
         BasisLoadError::LoadNamespaceDescriptor(error) => classify_control_object_load_error(error),
         BasisLoadError::LoadContentStoreDescriptor(error) => match error {
+            ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
             ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
             _ => CoreErrorKind::NamespaceCorrupt,
         },

--- a/crates/loon-core/src/genesis.rs
+++ b/crates/loon-core/src/genesis.rs
@@ -11,5 +11,6 @@ pub(crate) fn bootstrap_basis_metadata_state() -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
+        request_receipts: Vec::new(),
     }
 }

--- a/crates/loon-core/src/lease.rs
+++ b/crates/loon-core/src/lease.rs
@@ -1,6 +1,6 @@
+use crate::context::MutationContext;
 use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
 use crate::namespace::{next_takeover_head, HeadFenceTakeoverError};
-use crate::services::MutationContext;
 use loon_api::{
     ControlObjectKind, FenceToken, HeadStateEnvelope, LeaseState, LeaseStateEnvelope, NamespaceId,
 };

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -30,8 +30,8 @@ pub use protocol::{
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
-    NamespaceMutationCandidate, NamespaceMutationPublisher, PathMutationIntent,
-    PlannedNamespaceMutation, PlannedPathMutation, PublishOptions,
+    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation, PlannedPathMutation,
+    PublishOptions,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -13,6 +13,7 @@ mod loading;
 pub mod metadata;
 pub mod namespace;
 mod protocol;
+pub mod publisher;
 pub mod services;
 pub mod wal;
 
@@ -26,6 +27,11 @@ pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
 pub use protocol::{
     begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
     upload_content,
+};
+pub use publisher::{
+    publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
+    NamespaceMutationCandidate, NamespaceMutationPublisher, PathMutationIntent,
+    PlannedNamespaceMutation, PlannedPathMutation, PublishOptions,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -24,7 +24,8 @@ pub use context::MutationContext;
 pub use error::{CoreError, CoreErrorKind};
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
 pub use protocol::{
-    begin_upload, commit_operations, complete_upload, list_changes_after, upload_content,
+    begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
+    upload_content,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -4,6 +4,8 @@ mod basis;
 mod checkpoint;
 pub mod commit;
 pub mod content;
+mod context;
+mod error;
 mod genesis;
 pub mod invariants;
 mod lease;
@@ -18,6 +20,8 @@ pub use basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespace
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, CheckpointLoadError, CheckpointLoadErrorKind,
 };
+pub use context::MutationContext;
+pub use error::{CoreError, CoreErrorKind};
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
 pub use protocol::{
     begin_upload, commit_operations, complete_upload, list_changes_after, upload_content,
@@ -25,6 +29,6 @@ pub use protocol::{
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,
     list_namespaces, list_path, move_path, put_file_bytes, put_file_content_ref, read_file_bytes,
-    resolve_path, store_bytes_as_content, write_file_bytes, BootstrapNamespaceError, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior, StoredContent,
+    resolve_path, store_bytes_as_content, write_file_bytes, BootstrapNamespaceError,
+    PutFileBehavior, StoredContent,
 };

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,6 +1,7 @@
 use loon_api::{
     payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreId, ControlObjectKind,
     HeadStateEnvelope, LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceId,
+    CONTROL_OBJECT_FORMAT_VERSION,
 };
 use loon_objectstore::keys::{
     content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
@@ -231,6 +232,7 @@ fn validate_namespace_descriptor_envelope(
     object_key: &str,
     envelope: &NamespaceDescriptorEnvelope,
 ) -> Result<(), ControlObjectLoadError> {
+    validate_control_format_version(object_key, envelope.format_version)?;
     if envelope.kind != ControlObjectKind::NamespaceDescriptor {
         return Err(ControlObjectLoadError::KindMismatch {
             object_key: object_key.to_owned(),
@@ -257,6 +259,7 @@ fn validate_content_store_descriptor_envelope(
     object_key: &str,
     envelope: &ContentStoreDescriptorEnvelope,
 ) -> Result<(), ControlObjectLoadError> {
+    validate_control_format_version(object_key, envelope.format_version)?;
     if envelope.kind != ControlObjectKind::ContentStoreDescriptor {
         return Err(ControlObjectLoadError::KindMismatch {
             object_key: object_key.to_owned(),
@@ -283,6 +286,7 @@ fn validate_head_envelope(
     object_key: &str,
     envelope: &HeadStateEnvelope,
 ) -> Result<(), ControlObjectLoadError> {
+    validate_control_format_version(object_key, envelope.format_version)?;
     if envelope.kind != ControlObjectKind::NamespaceHead {
         return Err(ControlObjectLoadError::KindMismatch {
             object_key: object_key.to_owned(),
@@ -313,6 +317,7 @@ fn validate_lease_envelope(
     object_key: &str,
     envelope: &LeaseStateEnvelope,
 ) -> Result<(), ControlObjectLoadError> {
+    validate_control_format_version(object_key, envelope.format_version)?;
     if envelope.kind != ControlObjectKind::NamespaceLease {
         return Err(ControlObjectLoadError::KindMismatch {
             object_key: object_key.to_owned(),
@@ -335,6 +340,19 @@ fn validate_lease_envelope(
         });
     }
 
+    Ok(())
+}
+
+fn validate_control_format_version(
+    object_key: &str,
+    format_version: u32,
+) -> Result<(), ControlObjectLoadError> {
+    if format_version != CONTROL_OBJECT_FORMAT_VERSION {
+        return Err(ControlObjectLoadError::Codec {
+            object_key: object_key.to_owned(),
+            message: format!("unsupported control object format version `{format_version}`"),
+        });
+    }
     Ok(())
 }
 

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -1,6 +1,6 @@
 use loon_api::{
-    name_key_for_display_name, ChangeSeq, ContentRef, InodeId, InodeKind, NamePolicy, RevisionNo,
-    WalOp,
+    name_key_for_display_name, v0::CommitOpResult, ChangeSeq, ContentRef, InodeId, InodeKind,
+    NamePolicy, RevisionNo, WalCommitPayload, WalOp,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -16,6 +16,8 @@ pub struct MetadataState {
     pub revisions: Vec<RevisionRecord>,
     #[serde(default)]
     pub subtree_tombstones: Vec<SubtreeTombstoneRecord>,
+    #[serde(default)]
+    pub request_receipts: Vec<RequestReceiptRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -52,6 +54,15 @@ pub struct SubtreeTombstoneRecord {
     pub tombstone_seq: ChangeSeq,
     #[serde(default)]
     pub tombstone_op_index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestReceiptRecord {
+    pub request_id: String,
+    pub semantic_fingerprint_sha256: String,
+    pub committed_seq: ChangeSeq,
+    pub commit_id: String,
+    pub results: Vec<CommitOpResult>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -273,6 +284,28 @@ impl MetadataState {
             metadata_state,
             checked_invariants,
         })
+    }
+
+    pub fn apply_committed_wal_record(
+        &self,
+        record: &WalCommitPayload,
+    ) -> Result<AppliedMetadataState, MetadataApplyError> {
+        let mut applied = self.apply_committed_wal_ops(record.seq, &record.ops)?;
+        applied
+            .metadata_state
+            .request_receipts
+            .push(RequestReceiptRecord {
+                request_id: record.request_id.clone(),
+                semantic_fingerprint_sha256: record.semantic_fingerprint_sha256.clone(),
+                committed_seq: record.seq,
+                commit_id: record.commit_id.clone(),
+                results: record.results.clone(),
+            });
+        push_unique_invariant(
+            &mut applied.checked_invariants,
+            "wal_replay_records_request_receipt",
+        );
+        Ok(applied)
     }
 
     pub fn inode_at_seq(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {

--- a/crates/loon-core/src/namespace.rs
+++ b/crates/loon-core/src/namespace.rs
@@ -1,3 +1,5 @@
+pub(crate) mod catalog;
+
 use loon_api::FenceToken;
 pub use loon_api::{HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope};
 use thiserror::Error;

--- a/crates/loon-core/src/namespace.rs
+++ b/crates/loon-core/src/namespace.rs
@@ -29,5 +29,6 @@ pub fn next_takeover_head(current_head: &HeadState) -> Result<HeadState, HeadFen
         name_policy: current_head.name_policy,
         snapshot_hint_seq: current_head.snapshot_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
+        visible_wal_tip: current_head.visible_wal_tip.clone(),
     })
 }

--- a/crates/loon-core/src/namespace/catalog.rs
+++ b/crates/loon-core/src/namespace/catalog.rs
@@ -1,0 +1,110 @@
+use crate::loading::{
+    read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
+};
+use loon_api::{ContentStoreId, NamespaceDescriptorState, NamespaceId};
+use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
+use loon_objectstore::ObjectStore;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum NamespaceCatalogLoadError {
+    #[error("failed to load namespace descriptor: {0}")]
+    LoadNamespaceDescriptor(ControlObjectLoadError),
+    #[error("failed to load content store descriptor: {0}")]
+    LoadContentStoreDescriptor(ControlObjectLoadError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerifiedNamespaceCatalogEntry {
+    pub(crate) namespace_descriptor: NamespaceDescriptorState,
+    pub(crate) content_store_id: ContentStoreId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NamespaceInitializationState {
+    Absent,
+    Partial,
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum NamespaceInitializationError {
+    #[error("failed to inspect namespace descriptor object: {0}")]
+    InspectNamespaceDescriptor(String),
+    #[error("failed to inspect namespace head object: {0}")]
+    InspectNamespaceHead(String),
+    #[error("failed to inspect namespace lease object: {0}")]
+    InspectNamespaceLease(String),
+    #[error("failed to load namespace descriptor: {0}")]
+    LoadNamespaceDescriptor(ControlObjectLoadError),
+    #[error("failed to load content store descriptor: {0}")]
+    LoadContentStoreDescriptor(ControlObjectLoadError),
+}
+
+pub(crate) fn load_namespace_descriptor<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<NamespaceDescriptorState, NamespaceCatalogLoadError> {
+    let loaded_descriptor = read_namespace_descriptor_object(store, expected_namespace)
+        .map_err(NamespaceCatalogLoadError::LoadNamespaceDescriptor)?;
+    Ok(loaded_descriptor.envelope.state)
+}
+
+pub(crate) fn load_namespace_catalog_entry<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<VerifiedNamespaceCatalogEntry, NamespaceCatalogLoadError> {
+    let namespace_descriptor = load_namespace_descriptor(store, expected_namespace)?;
+    let content_store_id = namespace_descriptor.content_store_id.clone();
+    read_content_store_descriptor_object(store, &content_store_id)
+        .map_err(NamespaceCatalogLoadError::LoadContentStoreDescriptor)?;
+
+    Ok(VerifiedNamespaceCatalogEntry {
+        namespace_descriptor,
+        content_store_id,
+    })
+}
+
+pub(crate) fn load_namespace_content_store_id<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<ContentStoreId, NamespaceCatalogLoadError> {
+    Ok(load_namespace_catalog_entry(store, expected_namespace)?.content_store_id)
+}
+
+pub(crate) fn namespace_initialization_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<NamespaceInitializationState, NamespaceInitializationError> {
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+
+    let descriptor_exists = store
+        .head(&descriptor_key)
+        .map_err(|err| NamespaceInitializationError::InspectNamespaceDescriptor(err.to_string()))?
+        .is_some();
+    let head_exists = store
+        .head(&head_key)
+        .map_err(|err| NamespaceInitializationError::InspectNamespaceHead(err.to_string()))?
+        .is_some();
+    let lease_exists = store
+        .head(&lease_key)
+        .map_err(|err| NamespaceInitializationError::InspectNamespaceLease(err.to_string()))?
+        .is_some();
+
+    match (descriptor_exists, head_exists, lease_exists) {
+        (false, false, false) => Ok(NamespaceInitializationState::Absent),
+        (true, true, true) => {
+            let descriptor = read_namespace_descriptor_object(store, namespace_id)
+                .map_err(NamespaceInitializationError::LoadNamespaceDescriptor)?;
+            read_content_store_descriptor_object(
+                store,
+                &descriptor.envelope.state.content_store_id,
+            )
+            .map_err(NamespaceInitializationError::LoadContentStoreDescriptor)?;
+            Ok(NamespaceInitializationState::Complete)
+        }
+        _ => Ok(NamespaceInitializationState::Partial),
+    }
+}

--- a/crates/loon-core/src/namespace/catalog.rs
+++ b/crates/loon-core/src/namespace/catalog.rs
@@ -1,7 +1,7 @@
 use crate::loading::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
-use loon_api::{ContentStoreId, NamespaceDescriptorState, NamespaceId};
+use loon_api::{ContentStoreId, NamespaceDescriptorState, NamespaceId, NamespaceIdValidationError};
 use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loon_objectstore::ObjectStore;
 use thiserror::Error;
@@ -29,6 +29,8 @@ pub(crate) enum NamespaceInitializationState {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum NamespaceInitializationError {
+    #[error(transparent)]
+    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("failed to inspect namespace descriptor object: {0}")]
     InspectNamespaceDescriptor(String),
     #[error("failed to inspect namespace head object: {0}")]
@@ -76,6 +78,8 @@ pub(crate) fn namespace_initialization_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
 ) -> Result<NamespaceInitializationState, NamespaceInitializationError> {
+    NamespaceId::parse(namespace_id.as_str())?;
+
     let descriptor_key = namespace_descriptor(namespace_id.as_str());
     let head_key = namespace_head(namespace_id.as_str());
     let lease_key = namespace_lease(namespace_id.as_str());

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -10,7 +10,9 @@ use crate::error::CoreError;
 use crate::metadata::{MetadataState, RequestReceiptRecord};
 use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
-use crate::wal::{prepare_wal_segment, PreparedWalRecord, StoredWalObject};
+use crate::wal::{
+    build_wal_commit_payload, prepare_wal_segment, PreparedWalRecord, StoredWalObject,
+};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitOp as ApiCommitOp, CommitOpResult,
     CommitPrecondition as ApiCommitPrecondition, CommitRequest as ApiCommitRequest,
@@ -352,13 +354,8 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             plan: plan.clone(),
             results,
         };
-        let preview = match prepare_wal_segment(
-            namespace_id.clone(),
-            current_head.visible_wal_tip.clone(),
-            std::slice::from_ref(&record),
-            &context.writer_version,
-        ) {
-            Ok(segment) => segment.envelope.payload.records[0].clone(),
+        let preview = match build_wal_commit_payload(namespace_id, &record) {
+            Ok(payload) => payload,
             Err(error) => {
                 outcomes[index] = Some(Err(error.into()));
                 continue;

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -7,18 +7,19 @@ use crate::commit::{
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
-use crate::metadata::RequestReceiptRecord;
+use crate::metadata::{MetadataState, RequestReceiptRecord};
 use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
 use crate::wal::{prepare_wal_segment, PreparedWalRecord, StoredWalObject};
 use loon_api::v0::{
-    BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp, CommitOpResult,
-    CommitPrecondition as V0CommitPrecondition, CommitRequest as V0CommitRequest,
-    CommitResponse as V0CommitResponse, CommittedChange, CompleteUploadRequest,
+    BeginUploadResponse, ChangesResponse, CommitOp as ApiCommitOp, CommitOpResult,
+    CommitPrecondition as ApiCommitPrecondition, CommitRequest as ApiCommitRequest,
+    CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
     decode_wal_segment_envelope_zstd, ChangeSeq, CompletedUpload, ContentRef, ControlObjectKind,
-    InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
+    HeadState, InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -217,154 +218,107 @@ pub fn complete_upload<S: ObjectStore + ?Sized>(
 pub fn commit_operations<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    request: V0CommitRequest,
+    request: ApiCommitRequest,
     context: &MutationContext,
-) -> Result<V0CommitResponse, CoreError> {
+) -> Result<ApiCommitResponse, CoreError> {
     commit_operations_with_source_checksum(store, namespace_id, request, None, context)
 }
 
 pub fn commit_operations_batch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    requests: Vec<V0CommitRequest>,
+    requests: Vec<ApiCommitRequest>,
     context: &MutationContext,
-) -> Vec<Result<V0CommitResponse, CoreError>> {
-    commit_operations_batch_with_source_checksums(
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    publish_namespace_mutations_batch(
         store,
         namespace_id,
         requests
             .into_iter()
-            .map(|request| (request, None))
+            .map(NamespaceMutationCandidate::Commit)
             .collect(),
         context,
     )
 }
 
-pub(crate) fn commit_path_operations<S: ObjectStore + ?Sized>(
+pub(crate) fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    request: V0CommitRequest,
-    source_request_checksum_sha256: String,
+    candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Result<V0CommitResponse, CoreError> {
-    commit_operations_with_source_checksum(
-        store,
-        namespace_id,
-        request,
-        Some(source_request_checksum_sha256),
-        context,
-    )
-}
-
-pub(crate) fn retry_existing_path_request<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    request_id: &str,
-    source_request_checksum_sha256: &str,
-    context: &MutationContext,
-) -> Result<Option<V0CommitResponse>, CoreError> {
-    let _ = context;
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    let Some(receipt) = find_request_receipt(&basis.metadata_state, request_id) else {
-        return Ok(None);
-    };
-    if receipt.semantic_fingerprint_sha256 != source_request_checksum_sha256 {
-        return Err(CoreError::RequestIdConflict(request_id.to_owned()));
-    }
-    Ok(Some(commit_response_from_receipt(namespace_id, receipt)))
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    commit_namespace_mutations_batch(store, namespace_id, candidates, context)
 }
 
 fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    request: V0CommitRequest,
+    request: ApiCommitRequest,
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
-) -> Result<V0CommitResponse, CoreError> {
-    commit_operations_batch_with_source_checksums(
+) -> Result<ApiCommitResponse, CoreError> {
+    publish_namespace_mutations_batch(
         store,
         namespace_id,
-        vec![(request, source_request_checksum_sha256)],
+        vec![NamespaceMutationCandidate::Planned(
+            PlannedNamespaceMutation {
+                commit_request: request,
+                source_request_checksum_sha256,
+            },
+        )],
         context,
     )
     .pop()
     .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
 }
 
-fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
+fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    requests: Vec<(V0CommitRequest, Option<String>)>,
+    candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Vec<Result<V0CommitResponse, CoreError>> {
-    if requests.is_empty() {
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    if candidates.is_empty() {
         return Vec::new();
     }
     if let Err(error) = crate::acquire_or_renew_namespace_lease(store, namespace_id, context) {
-        return (0..requests.len())
+        return (0..candidates.len())
             .map(|_| Err(CoreError::Lease(error.clone())))
             .collect();
     }
     let basis = match load_verified_namespace_basis(store, namespace_id) {
         Ok(basis) => basis,
         Err(error) => {
-            return (0..requests.len())
+            return (0..candidates.len())
                 .map(|_| Err(CoreError::Basis(error.clone())))
                 .collect()
         }
     };
 
-    let mut outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>> =
-        (0..requests.len()).map(|_| None).collect();
+    let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
+        (0..candidates.len()).map(|_| None).collect();
     let mut current_head = basis.head.clone();
     let mut current_metadata_state = basis.metadata_state.clone();
     let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
     let mut in_batch_requests: HashMap<String, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
 
-    for (index, (request, source_request_checksum_sha256)) in requests.into_iter().enumerate() {
-        let request = map_commit_request(
+    for (index, candidate) in candidates.into_iter().enumerate() {
+        let Some(request) = prepare_candidate_request(
+            store,
             namespace_id,
             &basis,
-            request,
-            source_request_checksum_sha256,
+            &current_head,
+            &current_metadata_state,
+            candidate,
             context,
-        );
-        let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
-            Ok(value) => value,
-            Err(err) => {
-                outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
-                continue;
-            }
+            index,
+            &mut outcomes,
+            &mut in_batch_requests,
+            &mut aliases,
+        ) else {
+            continue;
         };
-        if let Some(existing) = find_request_receipt(&basis.metadata_state, &request.request_id) {
-            outcomes[index] = Some(
-                if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
-                    Err(CoreError::RequestIdConflict(request.request_id.clone()))
-                } else {
-                    Ok(commit_response_from_receipt(namespace_id, existing))
-                },
-            );
-            continue;
-        }
-        if let Some(existing) = in_batch_requests.get(&request.request_id) {
-            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
-                outcomes[index] = Some(Err(CoreError::RequestIdConflict(
-                    request.request_id.clone(),
-                )));
-            } else {
-                aliases.push((index, existing.primary_index));
-            }
-            continue;
-        }
-        in_batch_requests.insert(
-            request.request_id.clone(),
-            InBatchRequest {
-                primary_index: index,
-                semantic_fingerprint_sha256: semantic_fingerprint,
-            },
-        );
-
         let validation = CommitValidationContext {
             head: current_head.clone(),
             lease: basis.lease.clone(),
@@ -497,7 +451,7 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
     }
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
-        outcomes[outcome_index] = Some(Ok(V0CommitResponse {
+        outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
             namespace_id: namespace_id.clone(),
             commit_id: record.request.request_id,
             committed_seq: wal.envelope.payload.records[accepted_index].seq,
@@ -505,6 +459,158 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
         }));
     }
     finish_batch_outcomes_with_aliases(outcomes, &aliases)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_candidate_request<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    basis: &crate::VerifiedNamespaceBasis,
+    current_head: &HeadState,
+    current_metadata_state: &MetadataState,
+    candidate: NamespaceMutationCandidate,
+    context: &MutationContext,
+    index: usize,
+    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    in_batch_requests: &mut HashMap<String, InBatchRequest>,
+    aliases: &mut Vec<(usize, usize)>,
+) -> Option<CoreCommitRequest> {
+    match candidate {
+        NamespaceMutationCandidate::Commit(request) => {
+            let request = map_commit_request(namespace_id, basis, request, None, context);
+            let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
+                Ok(value) => value,
+                Err(err) => {
+                    outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
+                    return None;
+                }
+            };
+            if !record_primary_request_or_complete_idempotent(
+                namespace_id,
+                &basis.metadata_state,
+                outcomes,
+                in_batch_requests,
+                aliases,
+                index,
+                &request.request_id,
+                &semantic_fingerprint,
+            ) {
+                return None;
+            }
+            Some(request)
+        }
+        NamespaceMutationCandidate::Planned(planned) => {
+            let request = map_commit_request(
+                namespace_id,
+                basis,
+                planned.commit_request,
+                planned.source_request_checksum_sha256,
+                context,
+            );
+            let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
+                Ok(value) => value,
+                Err(err) => {
+                    outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
+                    return None;
+                }
+            };
+            if !record_primary_request_or_complete_idempotent(
+                namespace_id,
+                &basis.metadata_state,
+                outcomes,
+                in_batch_requests,
+                aliases,
+                index,
+                &request.request_id,
+                &semantic_fingerprint,
+            ) {
+                return None;
+            }
+            Some(request)
+        }
+        NamespaceMutationCandidate::Path(intent) => {
+            let semantic_fingerprint = match intent.source_request_checksum_sha256(namespace_id) {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(error));
+                    return None;
+                }
+            };
+            let request_id = intent.request_id().to_owned();
+            if !record_primary_request_or_complete_idempotent(
+                namespace_id,
+                &basis.metadata_state,
+                outcomes,
+                in_batch_requests,
+                aliases,
+                index,
+                &request_id,
+                &semantic_fingerprint,
+            ) {
+                return None;
+            }
+            let planned = match crate::services::plan_path_mutation_against_state(
+                store,
+                namespace_id,
+                &intent,
+                current_head,
+                current_metadata_state,
+                &basis.content_store_id,
+            ) {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(error));
+                    return None;
+                }
+            };
+            Some(map_commit_request(
+                namespace_id,
+                basis,
+                planned.commit_request,
+                Some(planned.source_request_checksum_sha256),
+                context,
+            ))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_primary_request_or_complete_idempotent(
+    namespace_id: &NamespaceId,
+    visible_metadata_state: &MetadataState,
+    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    in_batch_requests: &mut HashMap<String, InBatchRequest>,
+    aliases: &mut Vec<(usize, usize)>,
+    index: usize,
+    request_id: &str,
+    semantic_fingerprint: &str,
+) -> bool {
+    if let Some(existing) = find_request_receipt(visible_metadata_state, request_id) {
+        outcomes[index] = Some(
+            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
+                Err(CoreError::RequestIdConflict(request_id.to_owned()))
+            } else {
+                Ok(commit_response_from_receipt(namespace_id, existing))
+            },
+        );
+        return false;
+    }
+    if let Some(existing) = in_batch_requests.get(request_id) {
+        if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
+            outcomes[index] = Some(Err(CoreError::RequestIdConflict(request_id.to_owned())));
+        } else {
+            aliases.push((index, existing.primary_index));
+        }
+        return false;
+    }
+    in_batch_requests.insert(
+        request_id.to_owned(),
+        InBatchRequest {
+            primary_index: index,
+            semantic_fingerprint_sha256: semantic_fingerprint.to_owned(),
+        },
+    );
+    true
 }
 
 pub fn list_changes_after<S: ObjectStore + ?Sized>(
@@ -634,7 +740,7 @@ fn derive_commit_results(
 fn map_commit_request(
     namespace_id: &NamespaceId,
     basis: &crate::VerifiedNamespaceBasis,
-    request: V0CommitRequest,
+    request: ApiCommitRequest,
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
 ) -> CoreCommitRequest {
@@ -656,16 +762,16 @@ fn map_commit_request(
     }
 }
 
-fn map_commit_op(op: V0CommitOp) -> CommitOp {
+fn map_commit_op(op: ApiCommitOp) -> CommitOp {
     match op {
-        V0CommitOp::CreateDir {
+        ApiCommitOp::CreateDir {
             parent_inode,
             display_name,
         } => CommitOp::CreateDir {
             parent_inode,
             display_name,
         },
-        V0CommitOp::CreateFile {
+        ApiCommitOp::CreateFile {
             parent_inode,
             display_name,
             content_ref,
@@ -674,7 +780,7 @@ fn map_commit_op(op: V0CommitOp) -> CommitOp {
             display_name,
             content_ref,
         },
-        V0CommitOp::ReplaceFile {
+        ApiCommitOp::ReplaceFile {
             inode_id,
             base_revision_no,
             content_ref,
@@ -683,7 +789,7 @@ fn map_commit_op(op: V0CommitOp) -> CommitOp {
             base_revision: base_revision_no,
             content_ref,
         },
-        V0CommitOp::RestoreRevision {
+        ApiCommitOp::RestoreRevision {
             inode_id,
             source_revision_no,
             base_revision_no,
@@ -692,8 +798,8 @@ fn map_commit_op(op: V0CommitOp) -> CommitOp {
             source_revision: source_revision_no,
             base_revision: base_revision_no,
         },
-        V0CommitOp::DeleteFile { inode_id } => CommitOp::DeleteFile { inode_id },
-        V0CommitOp::Rename {
+        ApiCommitOp::DeleteFile { inode_id } => CommitOp::DeleteFile { inode_id },
+        ApiCommitOp::Rename {
             inode_id,
             new_parent_inode,
             new_display_name,
@@ -702,24 +808,24 @@ fn map_commit_op(op: V0CommitOp) -> CommitOp {
             new_parent_inode,
             new_display_name,
         },
-        V0CommitOp::DeleteSubtree { root_inode } => CommitOp::DeleteSubtree { root_inode },
+        ApiCommitOp::DeleteSubtree { root_inode } => CommitOp::DeleteSubtree { root_inode },
     }
 }
 
-fn map_commit_precondition(precondition: V0CommitPrecondition) -> Precondition {
+fn map_commit_precondition(precondition: ApiCommitPrecondition) -> Precondition {
     match precondition {
-        V0CommitPrecondition::HeadSeqIs { expected_seq } => Precondition::HeadSeqIs(expected_seq),
-        V0CommitPrecondition::InodeRevisionIs {
+        ApiCommitPrecondition::HeadSeqIs { expected_seq } => Precondition::HeadSeqIs(expected_seq),
+        ApiCommitPrecondition::InodeRevisionIs {
             inode_id,
             revision_no,
         } => Precondition::InodeRevisionIs {
             inode_id,
             revision: revision_no,
         },
-        V0CommitPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
+        ApiCommitPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
             Precondition::AncestorsNotSubtreeDeleted { inode_id }
         }
-        V0CommitPrecondition::ChildNameAbsent {
+        ApiCommitPrecondition::ChildNameAbsent {
             parent_inode,
             name_key,
         } => Precondition::ChildNameAbsent {
@@ -880,8 +986,8 @@ fn find_request_receipt<'a>(
 fn commit_response_from_receipt(
     namespace_id: &NamespaceId,
     receipt: &RequestReceiptRecord,
-) -> V0CommitResponse {
-    V0CommitResponse {
+) -> ApiCommitResponse {
+    ApiCommitResponse {
         namespace_id: namespace_id.clone(),
         commit_id: receipt.commit_id.clone(),
         committed_seq: receipt.committed_seq,
@@ -890,8 +996,8 @@ fn commit_response_from_receipt(
 }
 
 fn finish_batch_outcomes(
-    outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>>,
-) -> Vec<Result<V0CommitResponse, CoreError>> {
+    outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>>,
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
     outcomes
         .into_iter()
         .map(|outcome| {
@@ -901,9 +1007,9 @@ fn finish_batch_outcomes(
 }
 
 fn finish_batch_outcomes_with_aliases(
-    mut outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>>,
+    mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>>,
     aliases: &[(usize, usize)],
-) -> Vec<Result<V0CommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
     for (alias_index, primary_index) in aliases {
         let primary_outcome = outcomes
             .get(*primary_index)

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -7,8 +7,9 @@ use crate::commit::{
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
+use crate::metadata::RequestReceiptRecord;
 use crate::namespace::catalog::load_namespace_content_store_id;
-use crate::wal::prepare_wal_commit;
+use crate::wal::{prepare_wal_segment, PreparedWalRecord, StoredWalObject};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp, CommitOpResult,
     CommitPrecondition as V0CommitPrecondition, CommitRequest as V0CommitRequest,
@@ -16,10 +17,10 @@ use loon_api::v0::{
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
-    decode_wal_commit_envelope_zstd, ChangeSeq, CompletedUpload, ContentRef, ControlObjectKind,
+    decode_wal_segment_envelope_zstd, ChangeSeq, CompletedUpload, ContentRef, ControlObjectKind,
     InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
 };
-use loon_objectstore::keys::{content_blob, upload_session, wal_commit};
+use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use uuid::Uuid;
 
@@ -215,6 +216,23 @@ pub fn commit_operations<S: ObjectStore + ?Sized>(
     commit_operations_with_source_checksum(store, namespace_id, request, None, context)
 }
 
+pub fn commit_operations_batch<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    requests: Vec<V0CommitRequest>,
+    context: &MutationContext,
+) -> Vec<Result<V0CommitResponse, CoreError>> {
+    commit_operations_batch_with_source_checksums(
+        store,
+        namespace_id,
+        requests
+            .into_iter()
+            .map(|request| (request, None))
+            .collect(),
+        context,
+    )
+}
+
 pub(crate) fn commit_path_operations<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -238,26 +256,15 @@ pub(crate) fn retry_existing_path_request<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: &str,
     context: &MutationContext,
 ) -> Result<Option<V0CommitResponse>, CoreError> {
-    validate_namespace_id_for_protocol_key(namespace_id)?;
-    let Some(existing) =
-        find_existing_commit_payload_by_request_id(store, namespace_id, request_id)?
-    else {
+    let _ = context;
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    let Some(receipt) = find_request_receipt(&basis.metadata_state, request_id) else {
         return Ok(None);
     };
-
-    if existing.source_request_checksum_sha256.as_deref() != Some(source_request_checksum_sha256) {
+    if receipt.semantic_fingerprint_sha256 != source_request_checksum_sha256 {
         return Err(CoreError::RequestIdConflict(request_id.to_owned()));
     }
-
-    let request = request_from_payload(&existing);
-    commit_operations_with_source_checksum(
-        store,
-        namespace_id,
-        request,
-        existing.source_request_checksum_sha256.clone(),
-        context,
-    )
-    .map(Some)
+    Ok(Some(commit_response_from_receipt(namespace_id, receipt)))
 }
 
 fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
@@ -267,90 +274,211 @@ fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
 ) -> Result<V0CommitResponse, CoreError> {
-    validate_namespace_id_for_protocol_key(namespace_id)?;
-    crate::acquire_or_renew_namespace_lease(store, namespace_id, context)?;
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    let request = map_commit_request(
+    commit_operations_batch_with_source_checksums(
+        store,
         namespace_id,
-        &basis,
-        request,
-        source_request_checksum_sha256,
+        vec![(request, source_request_checksum_sha256)],
         context,
-    );
-    let next_seq = request
-        .planned_head_seq
-        .0
-        .checked_add(1)
-        .map(ChangeSeq)
-        .ok_or(crate::commit::CommitValidationError::SeqOverflow)?;
-    let wal_key = wal_commit(namespace_id.as_str(), next_seq.0, &request.request_id);
-    let request_checksum = request
-        .request_checksum_sha256()
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+    )
+    .pop()
+    .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
+}
 
-    if let Some(existing) = load_existing_commit_payload(store, &wal_key)? {
-        if existing.request_checksum_sha256 != request_checksum {
-            return Err(CoreError::RequestIdConflict(request.request_id.clone()));
+fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    requests: Vec<(V0CommitRequest, Option<String>)>,
+    context: &MutationContext,
+) -> Vec<Result<V0CommitResponse, CoreError>> {
+    if requests.is_empty() {
+        return Vec::new();
+    }
+    if let Err(error) = crate::acquire_or_renew_namespace_lease(store, namespace_id, context) {
+        return (0..requests.len())
+            .map(|_| Err(CoreError::Lease(error.clone())))
+            .collect();
+    }
+    let basis = match load_verified_namespace_basis(store, namespace_id) {
+        Ok(basis) => basis,
+        Err(error) => {
+            return (0..requests.len())
+                .map(|_| Err(CoreError::Basis(error.clone())))
+                .collect()
         }
-        if basis.head.seq >= existing.seq {
-            return Ok(commit_response_from_payload(&existing));
+    };
+
+    let mut outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>> =
+        (0..requests.len()).map(|_| None).collect();
+    let mut current_head = basis.head.clone();
+    let mut current_metadata_state = basis.metadata_state.clone();
+    let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
+
+    for (index, (request, source_request_checksum_sha256)) in requests.into_iter().enumerate() {
+        let request = map_commit_request(
+            namespace_id,
+            &basis,
+            request,
+            source_request_checksum_sha256,
+            context,
+        );
+        let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
+            Ok(value) => value,
+            Err(err) => {
+                outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
+                continue;
+            }
+        };
+        if let Some(existing) = find_request_receipt(&basis.metadata_state, &request.request_id) {
+            outcomes[index] = Some(
+                if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
+                    Err(CoreError::RequestIdConflict(request.request_id.clone()))
+                } else {
+                    Ok(commit_response_from_receipt(namespace_id, existing))
+                },
+            );
+            continue;
+        }
+
+        let validation = CommitValidationContext {
+            head: current_head.clone(),
+            lease: basis.lease.clone(),
+            now_ms: context.now_ms,
+            metadata_state: current_metadata_state.clone(),
+        };
+        let resolved_restore_content_refs = resolve_restore_content_refs(&request, &validation);
+        if let Err(error) = validate_commit_content_references(
+            store,
+            namespace_id,
+            &request,
+            &resolved_restore_content_refs,
+        ) {
+            outcomes[index] = Some(Err(error));
+            continue;
+        }
+        let plan = match build_commit_plan(&request, &validation) {
+            Ok(plan) => plan,
+            Err(error) => {
+                outcomes[index] = Some(Err(error.into()));
+                continue;
+            }
+        };
+        let results = derive_commit_results(
+            &request.ops,
+            &plan.allocated_inode_ids,
+            &plan.resolved_restore_content_refs,
+        );
+        let record = PreparedWalRecord {
+            request,
+            plan: plan.clone(),
+            results,
+        };
+        let preview = match prepare_wal_segment(
+            namespace_id.clone(),
+            current_head.visible_wal_tip.clone(),
+            std::slice::from_ref(&record),
+            &context.writer_version,
+        ) {
+            Ok(segment) => segment.envelope.payload.records[0].clone(),
+            Err(error) => {
+                outcomes[index] = Some(Err(error.into()));
+                continue;
+            }
+        };
+        match current_metadata_state.apply_committed_wal_record(&preview) {
+            Ok(applied) => {
+                current_metadata_state = applied.metadata_state;
+                current_head.seq = plan.next_seq;
+                current_head.next_inode_id = plan.resulting_next_inode_id;
+                accepted.push((index, record));
+            }
+            Err(error) => outcomes[index] = Some(Err(error.into())),
         }
     }
 
-    let validation = CommitValidationContext {
-        head: basis.head.clone(),
-        lease: basis.lease.clone(),
-        now_ms: context.now_ms,
-        metadata_state: basis.metadata_state.clone(),
+    if accepted.is_empty() {
+        return finish_batch_outcomes(outcomes);
+    }
+    let records = accepted
+        .iter()
+        .map(|(_, record)| record.clone())
+        .collect::<Vec<_>>();
+    let wal = match prepare_wal_segment(
+        namespace_id.clone(),
+        basis.head.visible_wal_tip.clone(),
+        &records,
+        &context.writer_version,
+    ) {
+        Ok(wal) => wal,
+        Err(error) => {
+            let message = format!("wal build failed: {error:?}");
+            for (index, _) in accepted {
+                outcomes[index] = Some(Err(CoreError::Store(message.clone())));
+            }
+            return finish_batch_outcomes(outcomes);
+        }
     };
-    let resolved_restore_content_refs = resolve_restore_content_refs(&request, &validation);
-    validate_commit_content_references(
-        store,
-        namespace_id,
-        &request,
-        &resolved_restore_content_refs,
-    )?;
-    let plan = build_commit_plan(&request, &validation)?;
-    debug_assert_eq!(
-        plan.resolved_restore_content_refs,
-        resolved_restore_content_refs
-    );
-    let results = derive_commit_results(
-        &request.ops,
-        &plan.allocated_inode_ids,
-        &plan.resolved_restore_content_refs,
-    );
-    let wal = prepare_wal_commit(&request, &plan, results.clone(), &context.writer_version)?;
-    let _applied = basis
-        .metadata_state
-        .apply_committed_wal_ops(plan.next_seq, &wal.envelope.payload.ops)?;
-
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
         Ok(_) => {}
         Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
-            let existing =
-                load_existing_commit_payload(store, &wal.object_key)?.ok_or_else(|| {
-                    CoreError::Store("commit WAL disappeared after conflict".to_owned())
-                })?;
-            if existing.request_checksum_sha256 != request_checksum {
-                return Err(CoreError::RequestIdConflict(request.request_id.clone()));
-            }
-            if basis.head.seq >= existing.seq {
-                return Ok(commit_response_from_payload(&existing));
+            match store.get(&wal.object_key, None) {
+                Ok(Some(existing)) if existing == wal.encoded_bytes => {}
+                Ok(_) => {
+                    for (index, _) in accepted {
+                        outcomes[index] = Some(Err(CoreError::WalWrite(
+                            "conflicting WAL segment object already exists".to_owned(),
+                        )));
+                    }
+                    return finish_batch_outcomes(outcomes);
+                }
+                Err(err) => {
+                    for (index, _) in accepted {
+                        outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
+                    }
+                    return finish_batch_outcomes(outcomes);
+                }
             }
         }
-        Err(err) => return Err(CoreError::WalWrite(err.to_string())),
+        Err(err) => {
+            for (index, _) in accepted {
+                outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
+            }
+            return finish_batch_outcomes(outcomes);
+        }
     }
 
-    let head_publish = prepare_commit_head_publish(&basis.head, &plan, &context.writer_version)?;
-    publish_commit_head(store, &basis.head_etag, &head_publish)?;
+    let last_plan = &records.last().expect("non-empty accepted records").plan;
+    let head_publish = prepare_commit_head_publish(
+        &basis.head,
+        last_plan,
+        wal.envelope.pointer(wal.object_key.clone()),
+        &context.writer_version,
+    );
+    let head_publish = match head_publish {
+        Ok(value) => value,
+        Err(error) => {
+            let message = format!("head publish preparation failed: {error:?}");
+            for (index, _) in accepted {
+                outcomes[index] = Some(Err(CoreError::Store(message.clone())));
+            }
+            return finish_batch_outcomes(outcomes);
+        }
+    };
+    if let Err(error) = publish_commit_head(store, &basis.head_etag, &head_publish) {
+        for (index, _) in accepted {
+            outcomes[index] = Some(Err(error.clone().into()));
+        }
+        return finish_batch_outcomes(outcomes);
+    }
 
-    Ok(V0CommitResponse {
-        namespace_id: namespace_id.clone(),
-        commit_id: request.request_id,
-        committed_seq: head_publish.resulting_head.seq,
-        results,
-    })
+    for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
+        outcomes[outcome_index] = Some(Ok(V0CommitResponse {
+            namespace_id: namespace_id.clone(),
+            commit_id: record.request.request_id,
+            committed_seq: wal.envelope.payload.records[accepted_index].seq,
+            results: record.results,
+        }));
+    }
+    finish_batch_outcomes(outcomes)
 }
 
 pub fn list_changes_after<S: ObjectStore + ?Sized>(
@@ -374,19 +502,23 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         });
     }
 
-    let wal_objects = load_wal_range(store, namespace_id, after_seq, basis.head.seq)?;
-    let mut changes = Vec::with_capacity(wal_objects.len());
+    let wal_objects = load_wal_range(store, namespace_id, after_seq, basis.head.seq, &basis.head)?;
+    let mut changes = Vec::new();
     for wal_object in wal_objects {
-        let envelope = decode_wal_commit_envelope_zstd(&wal_object.encoded_bytes)
+        let envelope = decode_wal_segment_envelope_zstd(&wal_object.encoded_bytes)
             .map_err(|err| CoreError::Store(err.to_string()))?;
-        changes.push(CommittedChange {
-            seq: envelope.payload.seq,
-            commit_id: envelope.payload.commit_id,
-            request_id: envelope.payload.request_id,
-            message: envelope.payload.message,
-            annotations: envelope.payload.annotations,
-            ops: envelope.payload.results,
-        });
+        for record in envelope.payload.records {
+            if record.seq > after_seq {
+                changes.push(CommittedChange {
+                    seq: record.seq,
+                    commit_id: record.commit_id,
+                    request_id: record.request_id,
+                    message: record.message,
+                    annotations: record.annotations,
+                    ops: record.results,
+                });
+            }
+        }
     }
 
     Ok(ChangesResponse {
@@ -498,22 +630,6 @@ fn map_commit_request(
     }
 }
 
-fn request_from_payload(payload: &loon_api::WalCommitPayload) -> V0CommitRequest {
-    V0CommitRequest {
-        request_id: payload.request_id.clone(),
-        planned_head_seq: payload.base_head_seq,
-        preconditions: payload
-            .preconditions
-            .iter()
-            .cloned()
-            .map(map_wal_precondition)
-            .collect(),
-        ops: payload.ops.iter().cloned().map(map_wal_op).collect(),
-        message: payload.message.clone(),
-        annotations: payload.annotations.clone(),
-    }
-}
-
 fn map_commit_op(op: V0CommitOp) -> CommitOp {
     match op {
         V0CommitOp::CreateDir {
@@ -587,87 +703,6 @@ fn map_commit_precondition(precondition: V0CommitPrecondition) -> Precondition {
     }
 }
 
-fn map_wal_op(op: loon_api::WalOp) -> V0CommitOp {
-    match op {
-        loon_api::WalOp::CreateDir {
-            parent_inode,
-            display_name,
-            ..
-        } => V0CommitOp::CreateDir {
-            parent_inode,
-            display_name,
-        },
-        loon_api::WalOp::CreateFile {
-            parent_inode,
-            display_name,
-            content_ref,
-            ..
-        } => V0CommitOp::CreateFile {
-            parent_inode,
-            display_name,
-            content_ref,
-        },
-        loon_api::WalOp::ReplaceFile {
-            inode_id,
-            base_revision,
-            content_ref,
-            ..
-        } => V0CommitOp::ReplaceFile {
-            inode_id,
-            base_revision_no: base_revision,
-            content_ref,
-        },
-        loon_api::WalOp::RestoreRevision {
-            inode_id,
-            source_revision_no,
-            base_revision,
-            ..
-        } => V0CommitOp::RestoreRevision {
-            inode_id,
-            source_revision_no,
-            base_revision_no: base_revision,
-        },
-        loon_api::WalOp::DeleteFile { inode_id, .. } => V0CommitOp::DeleteFile { inode_id },
-        loon_api::WalOp::Rename {
-            inode_id,
-            new_parent_inode,
-            new_display_name,
-            ..
-        } => V0CommitOp::Rename {
-            inode_id,
-            new_parent_inode,
-            new_display_name,
-        },
-        loon_api::WalOp::DeleteSubtree { root_inode, .. } => {
-            V0CommitOp::DeleteSubtree { root_inode }
-        }
-    }
-}
-
-fn map_wal_precondition(precondition: loon_api::WalPrecondition) -> V0CommitPrecondition {
-    match precondition {
-        loon_api::WalPrecondition::HeadSeqIs(expected_seq) => {
-            V0CommitPrecondition::HeadSeqIs { expected_seq }
-        }
-        loon_api::WalPrecondition::InodeRevisionIs { inode_id, revision } => {
-            V0CommitPrecondition::InodeRevisionIs {
-                inode_id,
-                revision_no: revision,
-            }
-        }
-        loon_api::WalPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
-            V0CommitPrecondition::AncestorsNotSubtreeDeleted { inode_id }
-        }
-        loon_api::WalPrecondition::ChildNameAbsent {
-            parent_inode,
-            name_key,
-        } => V0CommitPrecondition::ChildNameAbsent {
-            parent_inode,
-            name_key,
-        },
-    }
-}
-
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -710,7 +745,7 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &str,
 ) -> Result<LoadedUploadSessionObject, CoreError> {
-    validate_namespace_id_for_protocol_key(namespace_id)?;
+    NamespaceId::parse(namespace_id.as_str()).map_err(CoreError::from)?;
     let object_key = upload_session(namespace_id.as_str(), upload_id);
     let metadata = store
         .head(&object_key)
@@ -757,133 +792,84 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     })
 }
 
-fn load_existing_commit_payload<S: ObjectStore + ?Sized>(
-    store: &S,
-    wal_key: &str,
-) -> Result<Option<loon_api::WalCommitPayload>, CoreError> {
-    let Some(bytes) = store
-        .get(wal_key, None)
-        .map_err(|err| CoreError::Store(err.to_string()))?
-    else {
-        return Ok(None);
-    };
-    let envelope =
-        decode_wal_commit_envelope_zstd(&bytes).map_err(|err| CoreError::Store(err.to_string()))?;
-    Ok(Some(envelope.payload))
-}
-
-fn find_existing_commit_payload_by_request_id<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    request_id: &str,
-) -> Result<Option<loon_api::WalCommitPayload>, CoreError> {
-    validate_namespace_id_for_protocol_key(namespace_id)?;
-    let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
-    let mut matching_keys: Vec<String> = store
-        .list_prefix(&prefix)
-        .map_err(|err| CoreError::Store(err.to_string()))?
-        .into_iter()
-        .filter(|key| wal_request_id_from_key(&prefix, key) == Some(request_id))
-        .collect();
-    matching_keys.sort();
-
-    match matching_keys.as_slice() {
-        [] => Ok(None),
-        [only] => load_existing_commit_payload(store, only),
-        _ => Err(CoreError::Store(format!(
-            "multiple WAL commits found for request id `{request_id}`"
-        ))),
-    }
-}
-
-fn commit_response_from_payload(payload: &loon_api::WalCommitPayload) -> V0CommitResponse {
-    V0CommitResponse {
-        namespace_id: payload.namespace_id.clone(),
-        commit_id: payload.commit_id.clone(),
-        committed_seq: payload.seq,
-        results: payload.results.clone(),
-    }
-}
-
 fn load_wal_range<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     from_seq_exclusive: ChangeSeq,
     through_seq_inclusive: ChangeSeq,
+    head: &loon_api::HeadState,
 ) -> Result<Vec<crate::wal::StoredWalObject>, CoreError> {
-    validate_namespace_id_for_protocol_key(namespace_id)?;
-    let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
-    let listed = store
-        .list_prefix(&prefix)
-        .map_err(|err| BasisLoadError::ListWal {
-            prefix: prefix.clone(),
-            message: err.to_string(),
-        })?;
-
-    let mut wal_by_seq = std::collections::BTreeMap::new();
-    for object_key in listed {
-        let Some(seq) = wal_seq_from_key(&prefix, &object_key) else {
-            return Err(BasisLoadError::InvalidWalObjectKey { object_key }.into());
-        };
-        if seq <= from_seq_exclusive || seq > through_seq_inclusive {
-            continue;
-        }
-        if let Some(existing) = wal_by_seq.insert(seq, object_key.clone()) {
-            return Err(BasisLoadError::DuplicateWalSeq {
-                seq,
-                first: existing,
-                second: object_key,
-            }
-            .into());
-        }
+    if through_seq_inclusive <= from_seq_exclusive {
+        return Ok(Vec::new());
     }
-
+    let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
+    let mut pointer =
+        head.visible_wal_tip
+            .clone()
+            .ok_or_else(|| BasisLoadError::MissingWalObject {
+                prefix: prefix.clone(),
+                seq: through_seq_inclusive,
+            })?;
     let mut out = Vec::new();
-    let mut expected = from_seq_exclusive.0.saturating_add(1);
-    while expected <= through_seq_inclusive.0 {
-        let seq = ChangeSeq(expected);
-        let object_key =
-            wal_by_seq
-                .remove(&seq)
-                .ok_or_else(|| BasisLoadError::MissingWalObject {
-                    prefix: prefix.clone(),
-                    seq,
-                })?;
+    loop {
+        if pointer.end_seq <= from_seq_exclusive {
+            break;
+        }
         let encoded_bytes = store
-            .get(&object_key, None)
+            .get(&pointer.object_key, None)
             .map_err(|err| BasisLoadError::ReadWal {
-                object_key: object_key.clone(),
+                object_key: pointer.object_key.clone(),
                 message: err.to_string(),
             })?
             .ok_or_else(|| BasisLoadError::MissingWalObjectAfterList {
-                object_key: object_key.clone(),
+                object_key: pointer.object_key.clone(),
             })?;
-        out.push(crate::wal::StoredWalObject {
-            object_key,
+        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
+            .map_err(|err| CoreError::Store(err.to_string()))?;
+        let prev = envelope.payload.prev_visible_segment.clone();
+        out.push(StoredWalObject {
+            object_key: pointer.object_key,
             encoded_bytes,
         });
-        expected = expected.saturating_add(1);
+        let Some(prev) = prev else {
+            break;
+        };
+        pointer = prev;
     }
-
+    out.reverse();
     Ok(out)
 }
 
-fn validate_namespace_id_for_protocol_key(namespace_id: &NamespaceId) -> Result<(), CoreError> {
-    NamespaceId::parse(namespace_id.as_str())
-        .map(|_| ())
-        .map_err(CoreError::from)
+fn find_request_receipt<'a>(
+    metadata_state: &'a crate::metadata::MetadataState,
+    request_id: &str,
+) -> Option<&'a RequestReceiptRecord> {
+    metadata_state
+        .request_receipts
+        .iter()
+        .filter(|receipt| receipt.request_id == request_id)
+        .max_by_key(|receipt| receipt.committed_seq)
 }
 
-fn wal_seq_from_key(prefix: &str, object_key: &str) -> Option<ChangeSeq> {
-    let suffix = object_key.strip_prefix(prefix)?;
-    let (seq_part, _) = suffix.split_once('-')?;
-    let seq = seq_part.parse::<u64>().ok()?;
-    Some(ChangeSeq(seq))
+fn commit_response_from_receipt(
+    namespace_id: &NamespaceId,
+    receipt: &RequestReceiptRecord,
+) -> V0CommitResponse {
+    V0CommitResponse {
+        namespace_id: namespace_id.clone(),
+        commit_id: receipt.commit_id.clone(),
+        committed_seq: receipt.committed_seq,
+        results: receipt.results.clone(),
+    }
 }
 
-fn wal_request_id_from_key<'a>(prefix: &str, object_key: &'a str) -> Option<&'a str> {
-    let suffix = object_key.strip_prefix(prefix)?;
-    let suffix = suffix.strip_suffix(".cbor.zst")?;
-    let (_, request_id) = suffix.split_once('-')?;
-    Some(request_id)
+fn finish_batch_outcomes(
+    outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>>,
+) -> Vec<Result<V0CommitResponse, CoreError>> {
+    outcomes
+        .into_iter()
+        .map(|outcome| {
+            outcome.unwrap_or_else(|| Err(CoreError::Store("missing batch outcome".to_owned())))
+        })
+        .collect()
 }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -396,25 +396,6 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     };
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
         Ok(_) => {}
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
-            match store.get(&wal.object_key, None) {
-                Ok(Some(existing)) if existing == wal.encoded_bytes => {}
-                Ok(_) => {
-                    for (index, _) in accepted {
-                        outcomes[index] = Some(Err(CoreError::WalWrite(
-                            "conflicting WAL segment object already exists".to_owned(),
-                        )));
-                    }
-                    return finish_batch_outcomes_with_aliases(outcomes, &aliases);
-                }
-                Err(err) => {
-                    for (index, _) in accepted {
-                        outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
-                    }
-                    return finish_batch_outcomes_with_aliases(outcomes, &aliases);
-                }
-            }
-        }
         Err(err) => {
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -238,7 +238,7 @@ pub(crate) fn retry_existing_path_request<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: &str,
     context: &MutationContext,
 ) -> Result<Option<V0CommitResponse>, CoreError> {
-    validate_namespace_id_for_key_construction(namespace_id)?;
+    validate_namespace_id_for_protocol_key(namespace_id)?;
     let Some(existing) =
         find_existing_commit_payload_by_request_id(store, namespace_id, request_id)?
     else {
@@ -267,7 +267,7 @@ fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
 ) -> Result<V0CommitResponse, CoreError> {
-    validate_namespace_id_for_key_construction(namespace_id)?;
+    validate_namespace_id_for_protocol_key(namespace_id)?;
     crate::acquire_or_renew_namespace_lease(store, namespace_id, context)?;
     let basis = load_verified_namespace_basis(store, namespace_id)?;
     let request = map_commit_request(
@@ -710,7 +710,7 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &str,
 ) -> Result<LoadedUploadSessionObject, CoreError> {
-    validate_namespace_id_for_key_construction(namespace_id)?;
+    validate_namespace_id_for_protocol_key(namespace_id)?;
     let object_key = upload_session(namespace_id.as_str(), upload_id);
     let metadata = store
         .head(&object_key)
@@ -757,12 +757,6 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     })
 }
 
-fn validate_namespace_id_for_key_construction(namespace_id: &NamespaceId) -> Result<(), CoreError> {
-    NamespaceId::parse(namespace_id.as_str())
-        .map(|_| ())
-        .map_err(CoreError::from)
-}
-
 fn load_existing_commit_payload<S: ObjectStore + ?Sized>(
     store: &S,
     wal_key: &str,
@@ -783,6 +777,7 @@ fn find_existing_commit_payload_by_request_id<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     request_id: &str,
 ) -> Result<Option<loon_api::WalCommitPayload>, CoreError> {
+    validate_namespace_id_for_protocol_key(namespace_id)?;
     let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
     let mut matching_keys: Vec<String> = store
         .list_prefix(&prefix)
@@ -816,6 +811,7 @@ fn load_wal_range<S: ObjectStore + ?Sized>(
     from_seq_exclusive: ChangeSeq,
     through_seq_inclusive: ChangeSeq,
 ) -> Result<Vec<crate::wal::StoredWalObject>, CoreError> {
+    validate_namespace_id_for_protocol_key(namespace_id)?;
     let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
     let listed = store
         .list_prefix(&prefix)
@@ -870,6 +866,12 @@ fn load_wal_range<S: ObjectStore + ?Sized>(
     }
 
     Ok(out)
+}
+
+fn validate_namespace_id_for_protocol_key(namespace_id: &NamespaceId) -> Result<(), CoreError> {
+    NamespaceId::parse(namespace_id.as_str())
+        .map(|_| ())
+        .map_err(CoreError::from)
 }
 
 fn wal_seq_from_key(prefix: &str, object_key: &str) -> Option<ChangeSeq> {

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -4,21 +4,20 @@ use crate::commit::{
     resolve_restore_content_refs, CommitOp, CommitRequest as CoreCommitRequest,
     CommitValidationContext, Precondition,
 };
-use crate::content::validate_durable_content_reference;
-use crate::services::{
-    derive_commit_results, load_namespace_content_store_id, write_immutable_object, CoreError,
-    MutationContext,
-};
+use crate::content::{validate_durable_content_reference, write_immutable_object};
+use crate::context::MutationContext;
+use crate::error::CoreError;
+use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::wal::prepare_wal_commit;
 use loon_api::v0::{
-    BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp,
+    BeginUploadResponse, ChangesResponse, CommitOp as V0CommitOp, CommitOpResult,
     CommitPrecondition as V0CommitPrecondition, CommitRequest as V0CommitRequest,
     CommitResponse as V0CommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
     decode_wal_commit_envelope_zstd, ChangeSeq, CompletedUpload, ContentRef, ControlObjectKind,
-    NamespaceId, UploadSessionEnvelope, UploadSessionState,
+    InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
 };
 use loon_objectstore::keys::{content_blob, upload_session, wal_commit};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -396,6 +395,82 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         through_seq: basis.head.seq,
         changes,
     })
+}
+
+fn derive_commit_results(
+    ops: &[CommitOp],
+    allocated_inode_ids: &[InodeId],
+    resolved_restore_content_refs: &[Option<ContentRef>],
+) -> Vec<CommitOpResult> {
+    let mut allocated = allocated_inode_ids.iter().copied();
+    ops.iter()
+        .enumerate()
+        .map(|(index, op)| {
+            let op_index = u32::try_from(index).expect("commit op index should fit in u32");
+            match op {
+                CommitOp::CreateDir { .. } => CommitOpResult::CreateDir {
+                    op_index,
+                    inode_id: allocated
+                        .next()
+                        .expect("allocated inode ids should cover create ops"),
+                },
+                CommitOp::CreateFile { content_ref, .. } => CommitOpResult::CreateFile {
+                    op_index,
+                    inode_id: allocated
+                        .next()
+                        .expect("allocated inode ids should cover create ops"),
+                    revision_no: loon_api::RevisionNo(1),
+                    content_ref: content_ref.clone(),
+                },
+                CommitOp::ReplaceFile {
+                    inode_id,
+                    base_revision,
+                    content_ref,
+                } => CommitOpResult::ReplaceFile {
+                    op_index,
+                    inode_id: *inode_id,
+                    revision_no: loon_api::RevisionNo(
+                        base_revision
+                            .0
+                            .checked_add(1)
+                            .expect("replace_file revision increment validated"),
+                    ),
+                    content_ref: content_ref.clone(),
+                },
+                CommitOp::RestoreRevision {
+                    inode_id,
+                    source_revision,
+                    base_revision,
+                } => CommitOpResult::RestoreRevision {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_revision_no: *source_revision,
+                    revision_no: loon_api::RevisionNo(
+                        base_revision
+                            .0
+                            .checked_add(1)
+                            .expect("restore_revision increment validated"),
+                    ),
+                    content_ref: resolved_restore_content_refs[index]
+                        .as_ref()
+                        .expect("resolved restore content ref should be present")
+                        .clone(),
+                },
+                CommitOp::DeleteFile { inode_id } => CommitOpResult::DeleteFile {
+                    op_index,
+                    inode_id: *inode_id,
+                },
+                CommitOp::Rename { inode_id, .. } => CommitOpResult::Rename {
+                    op_index,
+                    inode_id: *inode_id,
+                },
+                CommitOp::DeleteSubtree { root_inode } => CommitOpResult::DeleteSubtree {
+                    op_index,
+                    root_inode: *root_inode,
+                },
+            }
+        })
+        .collect()
 }
 
 fn map_commit_request(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -22,6 +22,7 @@ use loon_api::{
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
@@ -31,6 +32,12 @@ struct LoadedUploadSessionObject {
     object_key: String,
     metadata: ObjectMetadata,
     envelope: UploadSessionEnvelope,
+}
+
+#[derive(Debug, Clone)]
+struct InBatchRequest {
+    primary_index: usize,
+    semantic_fingerprint_sha256: String,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -312,6 +319,8 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
     let mut current_head = basis.head.clone();
     let mut current_metadata_state = basis.metadata_state.clone();
     let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
+    let mut in_batch_requests: HashMap<String, InBatchRequest> = HashMap::new();
+    let mut aliases: Vec<(usize, usize)> = Vec::new();
 
     for (index, (request, source_request_checksum_sha256)) in requests.into_iter().enumerate() {
         let request = map_commit_request(
@@ -338,6 +347,23 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
             );
             continue;
         }
+        if let Some(existing) = in_batch_requests.get(&request.request_id) {
+            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
+                outcomes[index] = Some(Err(CoreError::RequestIdConflict(
+                    request.request_id.clone(),
+                )));
+            } else {
+                aliases.push((index, existing.primary_index));
+            }
+            continue;
+        }
+        in_batch_requests.insert(
+            request.request_id.clone(),
+            InBatchRequest {
+                primary_index: index,
+                semantic_fingerprint_sha256: semantic_fingerprint,
+            },
+        );
 
         let validation = CommitValidationContext {
             head: current_head.clone(),
@@ -396,7 +422,7 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
     }
 
     if accepted.is_empty() {
-        return finish_batch_outcomes(outcomes);
+        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
     }
     let records = accepted
         .iter()
@@ -414,7 +440,7 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes(outcomes);
+            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
         }
     };
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
@@ -428,13 +454,13 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
                             "conflicting WAL segment object already exists".to_owned(),
                         )));
                     }
-                    return finish_batch_outcomes(outcomes);
+                    return finish_batch_outcomes_with_aliases(outcomes, &aliases);
                 }
                 Err(err) => {
                     for (index, _) in accepted {
                         outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
                     }
-                    return finish_batch_outcomes(outcomes);
+                    return finish_batch_outcomes_with_aliases(outcomes, &aliases);
                 }
             }
         }
@@ -442,7 +468,7 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
             }
-            return finish_batch_outcomes(outcomes);
+            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
         }
     }
 
@@ -460,14 +486,14 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes(outcomes);
+            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
         }
     };
     if let Err(error) = publish_commit_head(store, &basis.head_etag, &head_publish) {
         for (index, _) in accepted {
             outcomes[index] = Some(Err(error.clone().into()));
         }
-        return finish_batch_outcomes(outcomes);
+        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
     }
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
@@ -478,7 +504,7 @@ fn commit_operations_batch_with_source_checksums<S: ObjectStore + ?Sized>(
             results: record.results,
         }));
     }
-    finish_batch_outcomes(outcomes)
+    finish_batch_outcomes_with_aliases(outcomes, &aliases)
 }
 
 pub fn list_changes_after<S: ObjectStore + ?Sized>(
@@ -872,4 +898,18 @@ fn finish_batch_outcomes(
             outcome.unwrap_or_else(|| Err(CoreError::Store("missing batch outcome".to_owned())))
         })
         .collect()
+}
+
+fn finish_batch_outcomes_with_aliases(
+    mut outcomes: Vec<Option<Result<V0CommitResponse, CoreError>>>,
+    aliases: &[(usize, usize)],
+) -> Vec<Result<V0CommitResponse, CoreError>> {
+    for (alias_index, primary_index) in aliases {
+        let primary_outcome = outcomes
+            .get(*primary_index)
+            .and_then(Clone::clone)
+            .unwrap_or_else(|| Err(CoreError::Store("missing primary batch outcome".to_owned())));
+        outcomes[*alias_index] = Some(primary_outcome);
+    }
+    finish_batch_outcomes(outcomes)
 }

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -91,30 +91,6 @@ impl Default for PublishOptions {
     }
 }
 
-pub trait NamespaceMutationPublisher {
-    fn submit_path_intent(
-        &self,
-        namespace_id: &NamespaceId,
-        intent: PathMutationIntent,
-        context: &MutationContext,
-        options: PublishOptions,
-    ) -> Result<MutationResult, CoreError>;
-
-    fn submit_commit_request(
-        &self,
-        namespace_id: &NamespaceId,
-        request: ApiCommitRequest,
-        context: &MutationContext,
-    ) -> Result<ApiCommitResponse, CoreError>;
-
-    fn submit_commit_batch(
-        &self,
-        namespace_id: &NamespaceId,
-        requests: Vec<ApiCommitRequest>,
-        context: &MutationContext,
-    ) -> Vec<Result<ApiCommitResponse, CoreError>>;
-}
-
 pub struct DirectObjectStorePublisher<'a, S: ObjectStore + ?Sized> {
     store: &'a S,
 }
@@ -131,10 +107,8 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
     ) -> Result<PlannedPathMutation, CoreError> {
         crate::services::plan_path_mutation(self.store, namespace_id, intent)
     }
-}
 
-impl<S: ObjectStore + ?Sized> NamespaceMutationPublisher for DirectObjectStorePublisher<'_, S> {
-    fn submit_path_intent(
+    pub fn submit_path_intent(
         &self,
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
@@ -175,7 +149,7 @@ impl<S: ObjectStore + ?Sized> NamespaceMutationPublisher for DirectObjectStorePu
         }))
     }
 
-    fn submit_commit_request(
+    pub fn submit_commit_request(
         &self,
         namespace_id: &NamespaceId,
         request: ApiCommitRequest,
@@ -184,7 +158,7 @@ impl<S: ObjectStore + ?Sized> NamespaceMutationPublisher for DirectObjectStorePu
         crate::protocol::commit_operations(self.store, namespace_id, request, context)
     }
 
-    fn submit_commit_batch(
+    pub fn submit_commit_batch(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<ApiCommitRequest>,

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -1,0 +1,204 @@
+use crate::context::MutationContext;
+use crate::error::{CoreError, CoreErrorKind};
+use crate::services::PutFileBehavior;
+use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
+use loon_api::{ContentRef, MutationResult, NamespaceId};
+use loon_objectstore::ObjectStore;
+
+const DEFAULT_STALE_HEAD_RETRY_LIMIT: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathMutationIntent {
+    PutFile {
+        request_id: String,
+        absolute_path: String,
+        content_ref: ContentRef,
+        behavior: PutFileBehavior,
+    },
+    DeletePath {
+        request_id: String,
+        absolute_path: String,
+        recursive: bool,
+    },
+    MovePath {
+        request_id: String,
+        from_path: String,
+        to_path: String,
+    },
+    CopyFilePath {
+        request_id: String,
+        from_path: String,
+        to_path: String,
+    },
+}
+
+impl PathMutationIntent {
+    pub fn request_id(&self) -> &str {
+        match self {
+            Self::PutFile { request_id, .. }
+            | Self::DeletePath { request_id, .. }
+            | Self::MovePath { request_id, .. }
+            | Self::CopyFilePath { request_id, .. } => request_id,
+        }
+    }
+
+    pub fn source_request_checksum_sha256(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<String, CoreError> {
+        crate::services::source_request_checksum_for_path_intent(namespace_id, self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedPathMutation {
+    pub request_id: String,
+    pub source_request_checksum_sha256: String,
+    pub commit_request: ApiCommitRequest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedNamespaceMutation {
+    pub commit_request: ApiCommitRequest,
+    pub source_request_checksum_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceMutationCandidate {
+    Commit(ApiCommitRequest),
+    Planned(PlannedNamespaceMutation),
+    Path(PathMutationIntent),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlushPolicy {
+    Immediate,
+    Coalesce { max_delay_ms: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublishOptions {
+    pub flush: FlushPolicy,
+    pub stale_head_retry_limit: usize,
+}
+
+impl Default for PublishOptions {
+    fn default() -> Self {
+        Self {
+            flush: FlushPolicy::Immediate,
+            stale_head_retry_limit: DEFAULT_STALE_HEAD_RETRY_LIMIT,
+        }
+    }
+}
+
+pub trait NamespaceMutationPublisher {
+    fn submit_path_intent(
+        &self,
+        namespace_id: &NamespaceId,
+        intent: PathMutationIntent,
+        context: &MutationContext,
+        options: PublishOptions,
+    ) -> Result<MutationResult, CoreError>;
+
+    fn submit_commit_request(
+        &self,
+        namespace_id: &NamespaceId,
+        request: ApiCommitRequest,
+        context: &MutationContext,
+    ) -> Result<ApiCommitResponse, CoreError>;
+
+    fn submit_commit_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<ApiCommitRequest>,
+        context: &MutationContext,
+    ) -> Vec<Result<ApiCommitResponse, CoreError>>;
+}
+
+pub struct DirectObjectStorePublisher<'a, S: ObjectStore + ?Sized> {
+    store: &'a S,
+}
+
+impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
+    pub fn new(store: &'a S) -> Self {
+        Self { store }
+    }
+
+    pub fn plan_path_intent(
+        &self,
+        namespace_id: &NamespaceId,
+        intent: &PathMutationIntent,
+    ) -> Result<PlannedPathMutation, CoreError> {
+        crate::services::plan_path_mutation(self.store, namespace_id, intent)
+    }
+}
+
+impl<S: ObjectStore + ?Sized> NamespaceMutationPublisher for DirectObjectStorePublisher<'_, S> {
+    fn submit_path_intent(
+        &self,
+        namespace_id: &NamespaceId,
+        intent: PathMutationIntent,
+        context: &MutationContext,
+        options: PublishOptions,
+    ) -> Result<MutationResult, CoreError> {
+        let attempts = options.stale_head_retry_limit.max(1);
+        let mut last_error = None;
+
+        for attempt in 0..attempts {
+            let mut results = publish_namespace_mutations_batch(
+                self.store,
+                namespace_id,
+                vec![NamespaceMutationCandidate::Path(intent.clone())],
+                context,
+            );
+            let result = results
+                .pop()
+                .unwrap_or_else(|| Err(CoreError::Store("empty path mutation batch".to_owned())));
+            match result {
+                Ok(response) => {
+                    return Ok(MutationResult {
+                        namespace_id: response.namespace_id,
+                        committed_seq: response.committed_seq,
+                    });
+                }
+                Err(error)
+                    if error.kind() == CoreErrorKind::StaleHead && attempt + 1 < attempts =>
+                {
+                    last_error = Some(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            CoreError::Store("path mutation stale-head retry exhausted".to_owned())
+        }))
+    }
+
+    fn submit_commit_request(
+        &self,
+        namespace_id: &NamespaceId,
+        request: ApiCommitRequest,
+        context: &MutationContext,
+    ) -> Result<ApiCommitResponse, CoreError> {
+        crate::protocol::commit_operations(self.store, namespace_id, request, context)
+    }
+
+    fn submit_commit_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<ApiCommitRequest>,
+        context: &MutationContext,
+    ) -> Vec<Result<ApiCommitResponse, CoreError>> {
+        crate::protocol::commit_operations_batch(self.store, namespace_id, requests, context)
+    }
+}
+
+pub fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    crate::protocol::publish_namespace_mutations_batch(store, namespace_id, candidates, context)
+}

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -13,11 +13,15 @@ use crate::namespace::catalog::{
     load_namespace_content_store_id, load_namespace_descriptor, namespace_initialization_state,
     NamespaceInitializationError, NamespaceInitializationState,
 };
+use crate::publisher::{
+    DirectObjectStorePublisher, NamespaceMutationPublisher, PathMutationIntent,
+    PlannedPathMutation, PublishOptions,
+};
 use loon_api::{
     name_key_for_display_name, payload_checksum_sha256,
     v0::{
-        CommitOp as V0CommitOp, CommitPrecondition as V0CommitPrecondition,
-        CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse,
+        CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
+        CommitRequest as ApiCommitRequest,
     },
     AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
     ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
@@ -545,21 +549,47 @@ fn source_request_checksum_sha256(identity: &PathRequestIdentity) -> Result<Stri
     payload_checksum_sha256(identity).map_err(|err| CoreError::Store(err.to_string()))
 }
 
-fn maybe_retry_existing_path_request<S: ObjectStore + ?Sized>(
-    store: &S,
+pub(crate) fn source_request_checksum_for_path_intent(
     namespace_id: &NamespaceId,
-    request_id: &str,
-    source_request_checksum_sha256: &str,
-    context: &MutationContext,
-) -> Result<Option<MutationResult>, CoreError> {
-    crate::protocol::retry_existing_path_request(
-        store,
-        namespace_id,
-        request_id,
-        source_request_checksum_sha256,
-        context,
-    )
-    .map(|response| response.map(mutation_result_from_commit_response))
+    intent: &PathMutationIntent,
+) -> Result<String, CoreError> {
+    let identity = match intent {
+        PathMutationIntent::PutFile {
+            absolute_path,
+            behavior,
+            content_ref,
+            ..
+        } => PathRequestIdentity::PutFile {
+            namespace_id: namespace_id.clone(),
+            absolute_path: absolute_path.clone(),
+            behavior: *behavior,
+            content_ref: content_ref.clone(),
+        },
+        PathMutationIntent::DeletePath {
+            absolute_path,
+            recursive,
+            ..
+        } => PathRequestIdentity::DeletePath {
+            namespace_id: namespace_id.clone(),
+            absolute_path: absolute_path.clone(),
+            recursive: *recursive,
+        },
+        PathMutationIntent::MovePath {
+            from_path, to_path, ..
+        } => PathRequestIdentity::MovePath {
+            namespace_id: namespace_id.clone(),
+            from_path: from_path.clone(),
+            to_path: to_path.clone(),
+        },
+        PathMutationIntent::CopyFilePath {
+            from_path, to_path, ..
+        } => PathRequestIdentity::CopyFilePath {
+            namespace_id: namespace_id.clone(),
+            from_path: from_path.clone(),
+            to_path: to_path.clone(),
+        },
+    };
+    source_request_checksum_sha256(&identity)
 }
 
 pub fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -573,9 +603,6 @@ pub fn put_file_bytes<S: ObjectStore + ?Sized>(
 ) -> Result<MutationResult, CoreError> {
     validate_path_for_mutation(absolute_path)?;
     let stored = store_bytes_as_content(store, namespace_id, bytes)?;
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
-    let _validated =
-        validate_durable_content_reference(store, &content_store_id, &stored.content_ref)?;
     put_file_content_ref(
         store,
         namespace_id,
@@ -615,65 +642,120 @@ pub fn put_file_content_ref<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
-    let _validated = validate_durable_content_reference(store, &content_store_id, &content_ref)?;
-    commit_file_content_ref(
-        store,
-        namespace_id,
-        absolute_path,
+    let request_id = normalized_request_id(request_id);
+    let intent = PathMutationIntent::PutFile {
+        request_id,
+        absolute_path: absolute_path.to_owned(),
         content_ref,
         behavior,
+    };
+    DirectObjectStorePublisher::new(store).submit_path_intent(
+        namespace_id,
+        intent,
         context,
-        request_id,
+        PublishOptions::default(),
     )
 }
 
-fn commit_file_content_ref<S: ObjectStore + ?Sized>(
+pub(crate) fn plan_path_mutation<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    intent: &PathMutationIntent,
+) -> Result<PlannedPathMutation, CoreError> {
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    plan_path_mutation_against_state(
+        store,
+        namespace_id,
+        intent,
+        &basis.head,
+        &basis.metadata_state,
+        &basis.content_store_id,
+    )
+}
+
+pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    intent: &PathMutationIntent,
+    head: &HeadState,
+    metadata_state: &MetadataState,
+    content_store_id: &ContentStoreId,
+) -> Result<PlannedPathMutation, CoreError> {
+    let request_id = intent.request_id().to_owned();
+    let source_request_checksum = source_request_checksum_for_path_intent(namespace_id, intent)?;
+    let view = PathPlanningView {
+        head,
+        metadata_state,
+        content_store_id,
+    };
+    let commit_request = match intent {
+        PathMutationIntent::PutFile {
+            absolute_path,
+            content_ref,
+            behavior,
+            ..
+        } => plan_put_file_content_ref(
+            store,
+            absolute_path,
+            content_ref.clone(),
+            *behavior,
+            &request_id,
+            &view,
+        )?,
+        PathMutationIntent::DeletePath {
+            absolute_path,
+            recursive,
+            ..
+        } => plan_delete_path(absolute_path, *recursive, &request_id, &view)?,
+        PathMutationIntent::MovePath {
+            from_path, to_path, ..
+        } => plan_move_path(from_path, to_path, &request_id, &view)?,
+        PathMutationIntent::CopyFilePath {
+            from_path, to_path, ..
+        } => plan_copy_file_path(store, from_path, to_path, &request_id, &view)?,
+    };
+    Ok(PlannedPathMutation {
+        request_id,
+        source_request_checksum_sha256: source_request_checksum,
+        commit_request,
+    })
+}
+
+struct PathPlanningView<'a> {
+    head: &'a HeadState,
+    metadata_state: &'a MetadataState,
+    content_store_id: &'a ContentStoreId,
+}
+
+fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
+    store: &S,
     absolute_path: &str,
     content_ref: ContentRef,
     behavior: PutFileBehavior,
-    context: &MutationContext,
-    request_id: Option<&str>,
-) -> Result<MutationResult, CoreError> {
+    request_id: &str,
+    view: &PathPlanningView<'_>,
+) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(absolute_path)?;
-    let request_id = normalized_request_id(request_id);
-    let source_request_checksum = source_request_checksum_sha256(&PathRequestIdentity::PutFile {
-        namespace_id: namespace_id.clone(),
-        absolute_path: absolute_path.to_owned(),
-        behavior,
-        content_ref: content_ref.clone(),
-    })?;
-    if let Some(existing) = maybe_retry_existing_path_request(
-        store,
-        namespace_id,
-        &request_id,
-        &source_request_checksum,
-        context,
-    )? {
-        return Ok(existing);
-    }
-
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    reject_tombstoned_path_ancestor(&basis.metadata_state, absolute_path, basis.head.seq)?;
-    let target = lookup_path(&basis.metadata_state, absolute_path, basis.head.seq);
+    let _validated =
+        validate_durable_content_reference(store, view.content_store_id, &content_ref)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, absolute_path, view.head.seq)?;
+    let target = lookup_path(view.metadata_state, absolute_path, view.head.seq);
 
     let mut ops = Vec::new();
-    let mut working = basis.metadata_state.clone();
-    let mut next_inode_id = basis.head.next_inode_id;
+    let mut working = view.metadata_state.clone();
+    let mut next_inode_id = view.head.next_inode_id;
     let mut op_index = 0u32;
     let final_parent_inode = ensure_parent_directories(
         absolute_path,
-        basis.head.seq,
+        view.head.seq,
         &mut working,
         &mut ops,
         &mut next_inode_id,
         &mut op_index,
     )?;
     let final_name = final_component(absolute_path)?;
-    let mut preconditions = vec![V0CommitPrecondition::HeadSeqIs {
-        expected_seq: basis.head.seq,
+    let mut preconditions = vec![ApiCommitPrecondition::HeadSeqIs {
+        expected_seq: view.head.seq,
     }];
 
     match target {
@@ -687,55 +769,48 @@ fn commit_file_content_ref<S: ObjectStore + ?Sized>(
                     kind: existing.inode_kind,
                 });
             }
-            let revision = basis
+            let revision = view
                 .metadata_state
-                .latest_revision_head_at_seq(existing.inode_id, basis.head.seq)
+                .latest_revision_head_at_seq(existing.inode_id, view.head.seq)
                 .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
-            ops.push(V0CommitOp::ReplaceFile {
+            ops.push(ApiCommitOp::ReplaceFile {
                 inode_id: existing.inode_id,
                 base_revision_no: revision.revision_no,
                 content_ref: content_ref.clone(),
             });
-            preconditions.push(V0CommitPrecondition::InodeRevisionIs {
+            preconditions.push(ApiCommitPrecondition::InodeRevisionIs {
                 inode_id: existing.inode_id,
                 revision_no: revision.revision_no,
             });
-            preconditions.push(V0CommitPrecondition::AncestorsNotSubtreeDeleted {
+            preconditions.push(ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
                 inode_id: existing.inode_id,
             });
         }
         Err(VisiblePathError::PathNotFound { .. }) => {
-            ops.push(V0CommitOp::CreateFile {
+            ops.push(ApiCommitOp::CreateFile {
                 parent_inode: final_parent_inode,
                 display_name: final_name.clone(),
                 content_ref,
             });
-            preconditions.push(V0CommitPrecondition::ChildNameAbsent {
+            preconditions.push(ApiCommitPrecondition::ChildNameAbsent {
                 parent_inode: final_parent_inode,
-                name_key: name_key_for_display_name(basis.head.name_policy, &final_name),
+                name_key: name_key_for_display_name(view.head.name_policy, &final_name),
             });
-            preconditions.push(V0CommitPrecondition::AncestorsNotSubtreeDeleted {
+            preconditions.push(ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
                 inode_id: final_parent_inode,
             });
         }
         Err(other) => return Err(other.into()),
     }
 
-    crate::protocol::commit_path_operations(
-        store,
-        namespace_id,
-        V0CommitRequest {
-            request_id,
-            planned_head_seq: basis.head.seq,
-            ops,
-            preconditions,
-            message: None,
-            annotations: None,
-        },
-        source_request_checksum,
-        context,
-    )
-    .map(mutation_result_from_commit_response)
+    Ok(ApiCommitRequest {
+        request_id: request_id.to_owned(),
+        planned_head_seq: view.head.seq,
+        ops,
+        preconditions,
+        message: None,
+        annotations: None,
+    })
 }
 
 pub fn delete_path<S: ObjectStore + ?Sized>(
@@ -745,59 +820,18 @@ pub fn delete_path<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    validate_path_for_mutation(absolute_path)?;
     let request_id = normalized_request_id(request_id);
-    let source_request_checksum =
-        source_request_checksum_sha256(&PathRequestIdentity::DeletePath {
-            namespace_id: namespace_id.clone(),
-            absolute_path: absolute_path.to_owned(),
-            recursive: true,
-        })?;
-    if let Some(existing) = maybe_retry_existing_path_request(
-        store,
-        namespace_id,
-        &request_id,
-        &source_request_checksum,
-        context,
-    )? {
-        return Ok(existing);
-    }
-
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    let resolved = basis
-        .metadata_state
-        .resolve_visible_path(absolute_path, basis.head.seq)?;
-    let op = match resolved.inode_kind {
-        InodeKind::File => V0CommitOp::DeleteFile {
-            inode_id: resolved.inode_id,
-        },
-        InodeKind::Dir => V0CommitOp::DeleteSubtree {
-            root_inode: resolved.inode_id,
-        },
-        kind => {
-            return Err(CoreError::ExpectedFile {
-                path: absolute_path.to_owned(),
-                kind,
-            });
-        }
+    let intent = PathMutationIntent::DeletePath {
+        request_id,
+        absolute_path: absolute_path.to_owned(),
+        recursive: true,
     };
-    crate::protocol::commit_path_operations(
-        store,
+    DirectObjectStorePublisher::new(store).submit_path_intent(
         namespace_id,
-        V0CommitRequest {
-            request_id,
-            planned_head_seq: basis.head.seq,
-            ops: vec![op],
-            preconditions: vec![V0CommitPrecondition::HeadSeqIs {
-                expected_seq: basis.head.seq,
-            }],
-            message: None,
-            annotations: None,
-        },
-        source_request_checksum,
+        intent,
         context,
+        PublishOptions::default(),
     )
-    .map(mutation_result_from_commit_response)
 }
 
 pub fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
@@ -807,68 +841,18 @@ pub fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    validate_path_for_mutation(absolute_path)?;
     let request_id = normalized_request_id(request_id);
-    let source_request_checksum =
-        source_request_checksum_sha256(&PathRequestIdentity::DeletePath {
-            namespace_id: namespace_id.clone(),
-            absolute_path: absolute_path.to_owned(),
-            recursive: false,
-        })?;
-    if let Some(existing) = maybe_retry_existing_path_request(
-        store,
-        namespace_id,
-        &request_id,
-        &source_request_checksum,
-        context,
-    )? {
-        return Ok(existing);
-    }
-
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    let resolved = basis
-        .metadata_state
-        .resolve_visible_path(absolute_path, basis.head.seq)?;
-
-    let op = match resolved.inode_kind {
-        InodeKind::File => V0CommitOp::DeleteFile {
-            inode_id: resolved.inode_id,
-        },
-        InodeKind::Dir => {
-            let children = basis
-                .metadata_state
-                .visible_children(resolved.inode_id, basis.head.seq);
-            if !children.is_empty() {
-                return Err(CoreError::DirectoryNotEmpty(absolute_path.to_owned()));
-            }
-            V0CommitOp::DeleteSubtree {
-                root_inode: resolved.inode_id,
-            }
-        }
-        kind => {
-            return Err(CoreError::ExpectedFile {
-                path: absolute_path.to_owned(),
-                kind,
-            });
-        }
+    let intent = PathMutationIntent::DeletePath {
+        request_id,
+        absolute_path: absolute_path.to_owned(),
+        recursive: false,
     };
-    crate::protocol::commit_path_operations(
-        store,
+    DirectObjectStorePublisher::new(store).submit_path_intent(
         namespace_id,
-        V0CommitRequest {
-            request_id,
-            planned_head_seq: basis.head.seq,
-            ops: vec![op],
-            preconditions: vec![V0CommitPrecondition::HeadSeqIs {
-                expected_seq: basis.head.seq,
-            }],
-            message: None,
-            annotations: None,
-        },
-        source_request_checksum,
+        intent,
         context,
+        PublishOptions::default(),
     )
-    .map(mutation_result_from_commit_response)
 }
 
 pub fn move_path<S: ObjectStore + ?Sized>(
@@ -879,56 +863,18 @@ pub fn move_path<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    validate_path_for_mutation(from_path)?;
-    validate_path_for_mutation(to_path)?;
     let request_id = normalized_request_id(request_id);
-    let source_request_checksum = source_request_checksum_sha256(&PathRequestIdentity::MovePath {
-        namespace_id: namespace_id.clone(),
+    let intent = PathMutationIntent::MovePath {
+        request_id,
         from_path: from_path.to_owned(),
         to_path: to_path.to_owned(),
-    })?;
-    if let Some(existing) = maybe_retry_existing_path_request(
-        store,
+    };
+    DirectObjectStorePublisher::new(store).submit_path_intent(
         namespace_id,
-        &request_id,
-        &source_request_checksum,
+        intent,
         context,
-    )? {
-        return Ok(existing);
-    }
-
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    reject_tombstoned_path_ancestor(&basis.metadata_state, from_path, basis.head.seq)?;
-    reject_tombstoned_path_ancestor(&basis.metadata_state, to_path, basis.head.seq)?;
-    let source = basis
-        .metadata_state
-        .resolve_visible_path(from_path, basis.head.seq)?;
-    let target_parent = resolve_parent_directory(&basis.metadata_state, to_path, basis.head.seq)?;
-    let target_name = final_component(to_path)?;
-    if lookup_path(&basis.metadata_state, to_path, basis.head.seq).is_ok() {
-        return Err(CoreError::DestinationExists(to_path.to_owned()));
-    }
-    crate::protocol::commit_path_operations(
-        store,
-        namespace_id,
-        V0CommitRequest {
-            request_id,
-            planned_head_seq: basis.head.seq,
-            ops: vec![V0CommitOp::Rename {
-                inode_id: source.inode_id,
-                new_parent_inode: target_parent,
-                new_display_name: target_name,
-            }],
-            preconditions: vec![V0CommitPrecondition::HeadSeqIs {
-                expected_seq: basis.head.seq,
-            }],
-            message: None,
-            annotations: None,
-        },
-        source_request_checksum,
-        context,
+        PublishOptions::default(),
     )
-    .map(mutation_result_from_commit_response)
 }
 
 pub fn copy_file_path<S: ObjectStore + ?Sized>(
@@ -939,32 +885,116 @@ pub fn copy_file_path<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     request_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
+    let request_id = normalized_request_id(request_id);
+    let intent = PathMutationIntent::CopyFilePath {
+        request_id,
+        from_path: from_path.to_owned(),
+        to_path: to_path.to_owned(),
+    };
+    DirectObjectStorePublisher::new(store).submit_path_intent(
+        namespace_id,
+        intent,
+        context,
+        PublishOptions::default(),
+    )
+}
+
+fn plan_delete_path(
+    absolute_path: &str,
+    recursive: bool,
+    request_id: &str,
+    view: &PathPlanningView<'_>,
+) -> Result<ApiCommitRequest, CoreError> {
+    validate_path_for_mutation(absolute_path)?;
+    let resolved = view
+        .metadata_state
+        .resolve_visible_path(absolute_path, view.head.seq)?;
+    let op = match resolved.inode_kind {
+        InodeKind::File => ApiCommitOp::DeleteFile {
+            inode_id: resolved.inode_id,
+        },
+        InodeKind::Dir if recursive => ApiCommitOp::DeleteSubtree {
+            root_inode: resolved.inode_id,
+        },
+        InodeKind::Dir => {
+            let children = view
+                .metadata_state
+                .visible_children(resolved.inode_id, view.head.seq);
+            if !children.is_empty() {
+                return Err(CoreError::DirectoryNotEmpty(absolute_path.to_owned()));
+            }
+            ApiCommitOp::DeleteSubtree {
+                root_inode: resolved.inode_id,
+            }
+        }
+        kind => {
+            return Err(CoreError::ExpectedFile {
+                path: absolute_path.to_owned(),
+                kind,
+            });
+        }
+    };
+    Ok(ApiCommitRequest {
+        request_id: request_id.to_owned(),
+        planned_head_seq: view.head.seq,
+        ops: vec![op],
+        preconditions: vec![ApiCommitPrecondition::HeadSeqIs {
+            expected_seq: view.head.seq,
+        }],
+        message: None,
+        annotations: None,
+    })
+}
+
+fn plan_move_path(
+    from_path: &str,
+    to_path: &str,
+    request_id: &str,
+    view: &PathPlanningView<'_>,
+) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(from_path)?;
     validate_path_for_mutation(to_path)?;
-    let request_id = normalized_request_id(request_id);
-    let source_request_checksum =
-        source_request_checksum_sha256(&PathRequestIdentity::CopyFilePath {
-            namespace_id: namespace_id.clone(),
-            from_path: from_path.to_owned(),
-            to_path: to_path.to_owned(),
-        })?;
-    if let Some(existing) = maybe_retry_existing_path_request(
-        store,
-        namespace_id,
-        &request_id,
-        &source_request_checksum,
-        context,
-    )? {
-        return Ok(existing);
-    }
-
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    reject_tombstoned_path_ancestor(&basis.metadata_state, from_path, basis.head.seq)?;
-    reject_tombstoned_path_ancestor(&basis.metadata_state, to_path, basis.head.seq)?;
-
-    let source = basis
+    reject_tombstoned_path_ancestor(view.metadata_state, from_path, view.head.seq)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, to_path, view.head.seq)?;
+    let source = view
         .metadata_state
-        .resolve_visible_path(from_path, basis.head.seq)?;
+        .resolve_visible_path(from_path, view.head.seq)?;
+    let target_parent = resolve_parent_directory(view.metadata_state, to_path, view.head.seq)?;
+    let target_name = final_component(to_path)?;
+    if lookup_path(view.metadata_state, to_path, view.head.seq).is_ok() {
+        return Err(CoreError::DestinationExists(to_path.to_owned()));
+    }
+    Ok(ApiCommitRequest {
+        request_id: request_id.to_owned(),
+        planned_head_seq: view.head.seq,
+        ops: vec![ApiCommitOp::Rename {
+            inode_id: source.inode_id,
+            new_parent_inode: target_parent,
+            new_display_name: target_name,
+        }],
+        preconditions: vec![ApiCommitPrecondition::HeadSeqIs {
+            expected_seq: view.head.seq,
+        }],
+        message: None,
+        annotations: None,
+    })
+}
+
+fn plan_copy_file_path<S: ObjectStore + ?Sized>(
+    store: &S,
+    from_path: &str,
+    to_path: &str,
+    request_id: &str,
+    view: &PathPlanningView<'_>,
+) -> Result<ApiCommitRequest, CoreError> {
+    validate_path_for_mutation(from_path)?;
+    validate_path_for_mutation(to_path)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, from_path, view.head.seq)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, to_path, view.head.seq)?;
+
+    let source = view
+        .metadata_state
+        .resolve_visible_path(from_path, view.head.seq)?;
     if source.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: from_path.to_owned(),
@@ -972,64 +1002,50 @@ pub fn copy_file_path<S: ObjectStore + ?Sized>(
         });
     }
 
-    if lookup_path(&basis.metadata_state, to_path, basis.head.seq).is_ok() {
+    if lookup_path(view.metadata_state, to_path, view.head.seq).is_ok() {
         return Err(CoreError::DestinationExists(to_path.to_owned()));
     }
 
-    let revision = basis
+    let revision = view
         .metadata_state
-        .latest_revision_head_at_seq(source.inode_id, basis.head.seq)
+        .latest_revision_head_at_seq(source.inode_id, view.head.seq)
         .ok_or_else(|| CoreError::MissingPath(from_path.to_owned()))?;
     let _validated =
-        validate_durable_content_reference(store, &basis.content_store_id, &revision.content_ref)?;
+        validate_durable_content_reference(store, view.content_store_id, &revision.content_ref)?;
 
-    let target_parent = resolve_parent_directory(&basis.metadata_state, to_path, basis.head.seq)?;
+    let target_parent = resolve_parent_directory(view.metadata_state, to_path, view.head.seq)?;
     let target_name = final_component(to_path)?;
-    let target_name_key = name_key_for_display_name(basis.head.name_policy, &target_name);
-    crate::protocol::commit_path_operations(
-        store,
-        namespace_id,
-        V0CommitRequest {
-            request_id,
-            planned_head_seq: basis.head.seq,
-            ops: vec![V0CommitOp::CreateFile {
+    let target_name_key = name_key_for_display_name(view.head.name_policy, &target_name);
+    Ok(ApiCommitRequest {
+        request_id: request_id.to_owned(),
+        planned_head_seq: view.head.seq,
+        ops: vec![ApiCommitOp::CreateFile {
+            parent_inode: target_parent,
+            display_name: target_name.clone(),
+            content_ref: revision.content_ref,
+        }],
+        preconditions: vec![
+            ApiCommitPrecondition::HeadSeqIs {
+                expected_seq: view.head.seq,
+            },
+            ApiCommitPrecondition::ChildNameAbsent {
                 parent_inode: target_parent,
-                display_name: target_name.clone(),
-                content_ref: revision.content_ref,
-            }],
-            preconditions: vec![
-                V0CommitPrecondition::HeadSeqIs {
-                    expected_seq: basis.head.seq,
-                },
-                V0CommitPrecondition::ChildNameAbsent {
-                    parent_inode: target_parent,
-                    name_key: target_name_key,
-                },
-                V0CommitPrecondition::AncestorsNotSubtreeDeleted {
-                    inode_id: target_parent,
-                },
-            ],
-            message: None,
-            annotations: None,
-        },
-        source_request_checksum,
-        context,
-    )
-    .map(mutation_result_from_commit_response)
-}
-
-fn mutation_result_from_commit_response(response: V0CommitResponse) -> MutationResult {
-    MutationResult {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    }
+                name_key: target_name_key,
+            },
+            ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                inode_id: target_parent,
+            },
+        ],
+        message: None,
+        annotations: None,
+    })
 }
 
 fn ensure_parent_directories(
     absolute_path: &str,
     committed_seq: ChangeSeq,
     working: &mut MetadataState,
-    ops: &mut Vec<V0CommitOp>,
+    ops: &mut Vec<ApiCommitOp>,
     next_inode_id: &mut InodeId,
     op_index: &mut u32,
 ) -> Result<InodeId, CoreError> {
@@ -1051,7 +1067,7 @@ fn ensure_parent_directories(
             continue;
         }
 
-        ops.push(V0CommitOp::CreateDir {
+        ops.push(ApiCommitOp::CreateDir {
             parent_inode: current_inode,
             display_name: component.clone(),
         });

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -14,8 +14,7 @@ use crate::namespace::catalog::{
     NamespaceInitializationError, NamespaceInitializationState,
 };
 use crate::publisher::{
-    DirectObjectStorePublisher, NamespaceMutationPublisher, PathMutationIntent,
-    PlannedPathMutation, PublishOptions,
+    DirectObjectStorePublisher, PathMutationIntent, PlannedPathMutation, PublishOptions,
 };
 use loon_api::{
     name_key_for_display_name, payload_checksum_sha256,

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -3,28 +3,27 @@ use crate::checkpoint::{
     create_checkpoint, load_verified_checkpoint_materialization,
     write_verified_checkpoint_from_metadata, CheckpointMetadataWriteRequest,
 };
-use crate::commit::{CommitHeadPublishError, CommitOp, CommitValidationError};
 use crate::content::{
-    read_durable_content_bytes, validate_durable_content_reference, DurableContentValidationError,
+    read_durable_content_bytes, validate_durable_content_reference, write_immutable_object,
 };
 use crate::genesis::bootstrap_basis_metadata_state;
-use crate::lease::LeaseAcquireError;
-use crate::loading::{
-    read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
+use crate::loading::ControlObjectLoadError;
+use crate::metadata::{MetadataState, ResolvedVisiblePath, VisiblePathError};
+use crate::namespace::catalog::{
+    load_namespace_content_store_id, load_namespace_descriptor, namespace_initialization_state,
+    NamespaceInitializationError, NamespaceInitializationState,
 };
-use crate::metadata::{MetadataApplyError, MetadataState, ResolvedVisiblePath, VisiblePathError};
-use crate::wal::WalBuildError;
 use loon_api::{
     name_key_for_display_name, payload_checksum_sha256,
     v0::{
-        CommitOp as V0CommitOp, CommitOpResult, CommitPrecondition as V0CommitPrecondition,
+        CommitOp as V0CommitOp, CommitPrecondition as V0CommitPrecondition,
         CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse,
     },
     AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
     ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
     FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
     MutationResult, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
-    NamespaceIdValidationError, NamespaceSummary,
+    NamespaceSummary,
 };
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
@@ -34,13 +33,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MutationContext {
-    pub writer_id: String,
-    pub writer_version: String,
-    pub now_ms: u64,
-    pub lease_duration_ms: u64,
-}
+pub use crate::context::MutationContext;
+pub use crate::error::{CoreError, CoreErrorKind};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredContent {
@@ -57,36 +51,8 @@ pub enum PutFileBehavior {
     ReplaceExisting,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CoreErrorKind {
-    InvalidPath,
-    InvalidNamespaceId,
-    NamespaceNotFound,
-    NamespaceExists,
-    NamespacePartial,
-    PathNotFound,
-    RevisionNotFound,
-    PathConflict,
-    StaleHead,
-    StaleRevision,
-    TombstoneConflict,
-    LeaseConflict,
-    WouldCycle,
-    RequestIdConflict,
-    CheckpointUnavailable,
-    UploadNotFound,
-    UploadAlreadyCompleted,
-    UploadContentConflict,
-    InvalidUploadContent,
-    RebootstrapRequired,
-    NamespaceCorrupt,
-    ServerError,
-}
-
 #[derive(Debug, Error)]
 pub enum BootstrapNamespaceError {
-    #[error(transparent)]
-    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("holder id must not be empty")]
     EmptyHolderId,
     #[error("writer version must not be empty")]
@@ -109,136 +75,20 @@ pub enum BootstrapNamespaceError {
     LeaseWrite(String),
 }
 
-#[derive(Debug, Error)]
-pub enum CoreError {
-    #[error(transparent)]
-    InvalidNamespaceId(#[from] NamespaceIdValidationError),
-    #[error(transparent)]
-    Basis(#[from] BasisLoadError),
-    #[error(transparent)]
-    VisiblePath(#[from] VisiblePathError),
-    #[error(transparent)]
-    DurableContent(#[from] DurableContentValidationError),
-    #[error(transparent)]
-    Lease(#[from] LeaseAcquireError),
-    #[error("commit validation failed: {0:?}")]
-    CommitValidation(CommitValidationError),
-    #[error("wal build failed: {0:?}")]
-    WalBuild(WalBuildError),
-    #[error("metadata apply failed: {0:?}")]
-    MetadataApply(MetadataApplyError),
-    #[error("head publish failed: {0:?}")]
-    HeadPublish(CommitHeadPublishError),
-    #[error("failed to write wal object: {0}")]
-    WalWrite(String),
-    #[error("invalid absolute path `{0}`")]
-    InvalidPath(String),
-    #[error("path not found `{0}`")]
-    MissingPath(String),
-    #[error("expected file at `{path}` but found `{kind:?}`")]
-    ExpectedFile { path: String, kind: InodeKind },
-    #[error("expected directory at `{path}` but found `{kind:?}`")]
-    ExpectedDirectory { path: String, kind: InodeKind },
-    #[error("directory not empty `{0}`")]
-    DirectoryNotEmpty(String),
-    #[error("cannot mutate root path")]
-    RootMutationForbidden,
-    #[error("destination already exists at `{0}`")]
-    DestinationExists(String),
-    #[error("request id conflict for `{0}`")]
-    RequestIdConflict(String),
-    #[error("{0}")]
-    CheckpointUnavailable(String),
-    #[error("upload session `{upload_id}` was not found")]
-    UploadNotFound { upload_id: String },
-    #[error("upload session `{upload_id}` is already completed")]
-    UploadAlreadyCompleted { upload_id: String },
-    #[error("upload session `{upload_id}` content conflicts with prior content")]
-    UploadContentConflict { upload_id: String },
-    #[error("invalid upload content: {0}")]
-    InvalidUploadContent(String),
-    #[error(
-        "change feed cursor `{after_seq:?}` is older than retention floor `{retention_floor_seq:?}`"
-    )]
-    RebootstrapRequired {
-        after_seq: ChangeSeq,
-        retention_floor_seq: ChangeSeq,
-    },
-    #[error(
-        "path `{path}` is covered by subtree tombstone rooted at inode `{root_inode}` from seq `{tombstone_seq:?}`"
-    )]
-    TombstoneConflict {
-        path: String,
-        root_inode: InodeId,
-        tombstone_seq: ChangeSeq,
-    },
-    #[error("path component `{0}` is not a directory")]
-    NonDirectoryPathComponent(String),
-    #[error("object store error: {0}")]
-    Store(String),
-    #[error("namespace `{namespace_id}` already exists")]
-    NamespaceAlreadyExists { namespace_id: NamespaceId },
-    #[error("namespace `{namespace_id}` is partially initialized")]
-    NamespacePartiallyInitialized { namespace_id: NamespaceId },
-}
-
-impl From<CommitValidationError> for CoreError {
-    fn from(value: CommitValidationError) -> Self {
-        Self::CommitValidation(value)
-    }
-}
-
-impl From<WalBuildError> for CoreError {
-    fn from(value: WalBuildError) -> Self {
-        Self::WalBuild(value)
-    }
-}
-
-impl From<MetadataApplyError> for CoreError {
-    fn from(value: MetadataApplyError) -> Self {
-        Self::MetadataApply(value)
-    }
-}
-
-impl From<CommitHeadPublishError> for CoreError {
-    fn from(value: CommitHeadPublishError) -> Self {
-        Self::HeadPublish(value)
-    }
-}
-
-impl CoreError {
-    pub fn kind(&self) -> CoreErrorKind {
-        match self {
-            CoreError::InvalidNamespaceId(_) => CoreErrorKind::InvalidNamespaceId,
-            CoreError::Basis(error) => classify_basis_load_error(error),
-            CoreError::VisiblePath(error) => classify_visible_path_error(error),
-            CoreError::DurableContent(error) => classify_durable_content_error(error),
-            CoreError::Lease(error) => classify_lease_acquire_error(error),
-            CoreError::CommitValidation(error) => classify_commit_validation_error(error),
-            CoreError::WalBuild(_)
-            | CoreError::MetadataApply(_)
-            | CoreError::WalWrite(_)
-            | CoreError::Store(_) => CoreErrorKind::ServerError,
-            CoreError::HeadPublish(error) => classify_head_publish_error(error),
-            CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
-                CoreErrorKind::InvalidPath
+impl From<NamespaceInitializationError> for BootstrapNamespaceError {
+    fn from(value: NamespaceInitializationError) -> Self {
+        match value {
+            NamespaceInitializationError::InspectNamespaceDescriptor(message) => {
+                Self::DescriptorWrite(message)
             }
-            CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
-            CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
-            CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
-            CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
-            CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
-            CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,
-            CoreError::UploadAlreadyCompleted { .. } => CoreErrorKind::UploadAlreadyCompleted,
-            CoreError::UploadContentConflict { .. } => CoreErrorKind::UploadContentConflict,
-            CoreError::InvalidUploadContent(_) => CoreErrorKind::InvalidUploadContent,
-            CoreError::RebootstrapRequired { .. } => CoreErrorKind::RebootstrapRequired,
-            CoreError::ExpectedFile { .. }
-            | CoreError::ExpectedDirectory { .. }
-            | CoreError::DirectoryNotEmpty(_)
-            | CoreError::DestinationExists(_) => CoreErrorKind::PathConflict,
-            CoreError::TombstoneConflict { .. } => CoreErrorKind::TombstoneConflict,
-            CoreError::NonDirectoryPathComponent(_) => CoreErrorKind::InvalidPath,
+            NamespaceInitializationError::InspectNamespaceHead(message) => Self::HeadWrite(message),
+            NamespaceInitializationError::InspectNamespaceLease(message) => {
+                Self::LeaseWrite(message)
+            }
+            NamespaceInitializationError::LoadNamespaceDescriptor(error)
+            | NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+                Self::Descriptor(error)
+            }
         }
     }
 }
@@ -275,6 +125,7 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         NamespaceInitializationState::Absent => {}
     }
 
+    let content_store_id = create_new_content_store(store, context)?;
     let initial_head = HeadState::initial(namespace_id.clone());
     let initial_lease = LeaseState {
         namespace_id: namespace_id.clone(),
@@ -298,18 +149,6 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
     let lease_bytes = serde_json::to_vec(&lease_envelope)
         .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
-
-    let head_key = namespace_head(namespace_id.as_str());
-    let lease_key = namespace_lease(namespace_id.as_str());
-    let descriptor_key = namespace_descriptor(namespace_id.as_str());
-    store
-        .put_if_absent(&head_key, &head_bytes)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
-    store
-        .put_if_absent(&lease_key, &lease_bytes)
-        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
-
-    let content_store_id = create_new_content_store(store, context)?;
     let namespace_descriptor_envelope = NamespaceDescriptorEnvelope::from_state(
         ControlObjectKind::NamespaceDescriptor,
         &context.writer_version,
@@ -321,6 +160,16 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
     let namespace_descriptor_bytes = serde_json::to_vec(&namespace_descriptor_envelope)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
+
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+    let descriptor_key = namespace_descriptor(namespace_id.as_str());
+    store
+        .put_if_absent(&head_key, &head_bytes)
+        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
+    store
+        .put_if_absent(&lease_key, &lease_bytes)
+        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
     store
         .put_if_absent(&descriptor_key, &namespace_descriptor_bytes)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
@@ -330,52 +179,6 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     Ok(NamespaceSummary {
         namespace_id: namespace_id.clone(),
     })
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NamespaceInitializationState {
-    Absent,
-    Partial,
-    Complete,
-}
-
-fn namespace_initialization_state<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> Result<NamespaceInitializationState, BootstrapNamespaceError> {
-    NamespaceId::parse(namespace_id.as_str())?;
-
-    let descriptor_key = namespace_descriptor(namespace_id.as_str());
-    let head_key = namespace_head(namespace_id.as_str());
-    let lease_key = namespace_lease(namespace_id.as_str());
-
-    let descriptor_exists = store
-        .head(&descriptor_key)
-        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?
-        .is_some();
-    let head_exists = store
-        .head(&head_key)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?
-        .is_some();
-    let lease_exists = store
-        .head(&lease_key)
-        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?
-        .is_some();
-
-    match (descriptor_exists, head_exists, lease_exists) {
-        (false, false, false) => Ok(NamespaceInitializationState::Absent),
-        (true, true, true) => {
-            let descriptor = read_namespace_descriptor_object(store, namespace_id)
-                .map_err(BootstrapNamespaceError::Descriptor)?;
-            read_content_store_descriptor_object(
-                store,
-                &descriptor.envelope.state.content_store_id,
-            )
-            .map_err(BootstrapNamespaceError::Descriptor)?;
-            Ok(NamespaceInitializationState::Complete)
-        }
-        _ => Ok(NamespaceInitializationState::Partial),
-    }
 }
 
 const CONTENT_STORE_ID_RETRY_LIMIT: usize = 8;
@@ -409,18 +212,6 @@ fn create_new_content_store<S: ObjectStore + ?Sized>(
     ))
 }
 
-pub(crate) fn load_namespace_content_store_id<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> Result<ContentStoreId, CoreError> {
-    let descriptor = read_namespace_descriptor_object(store, namespace_id)
-        .map_err(|err| CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(err)))?;
-    let content_store_id = descriptor.envelope.state.content_store_id;
-    read_content_store_descriptor_object(store, &content_store_id)
-        .map_err(|err| CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(err)))?;
-    Ok(content_store_id)
-}
-
 pub fn fork_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     source_namespace_id: &NamespaceId,
@@ -428,7 +219,8 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<NamespaceSummary, CoreError> {
     match namespace_initialization_state(store, new_namespace_id)
-        .map_err(map_namespace_initialization_error_to_core)?
+        .map_err(BootstrapNamespaceError::from)
+        .map_err(|err| CoreError::Store(err.to_string()))?
     {
         NamespaceInitializationState::Absent => {}
         NamespaceInitializationState::Complete => {
@@ -449,6 +241,19 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     let source_checkpoint =
         load_verified_checkpoint_materialization(store, source_namespace_id, fork_seq)
             .map_err(|err| CoreError::Basis(BasisLoadError::CheckpointLoad(err)))?;
+
+    write_verified_checkpoint_from_metadata(
+        store,
+        CheckpointMetadataWriteRequest {
+            namespace_id: new_namespace_id,
+            checkpoint_seq: fork_seq,
+            active_fence_token: FenceToken(0),
+            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
+            retention_floor_seq: fork_seq,
+            metadata_state: &source_checkpoint.metadata_state,
+            writer_version: &context.writer_version,
+        },
+    )?;
 
     let initial_head = HeadState {
         namespace_id: new_namespace_id.clone(),
@@ -490,77 +295,29 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     let head_key = namespace_head(new_namespace_id.as_str());
     let lease_key = namespace_lease(new_namespace_id.as_str());
     let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
-    put_target_namespace_control_object(
-        store,
-        new_namespace_id,
-        &head_key,
-        &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
-    )?;
-    write_verified_checkpoint_from_metadata(
-        store,
-        CheckpointMetadataWriteRequest {
-            namespace_id: new_namespace_id,
-            checkpoint_seq: fork_seq,
-            active_fence_token: FenceToken(0),
-            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
-            retention_floor_seq: fork_seq,
-            metadata_state: &source_checkpoint.metadata_state,
-            writer_version: &context.writer_version,
-        },
-    )?;
-    put_target_namespace_control_object(
-        store,
-        new_namespace_id,
-        &lease_key,
-        &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
-    )?;
-    put_target_namespace_control_object(
-        store,
-        new_namespace_id,
-        &descriptor_key,
-        &serde_json::to_vec(&namespace_descriptor_envelope)
-            .map_err(|err| CoreError::Store(err.to_string()))?,
-    )?;
+    store
+        .put_if_absent(
+            &head_key,
+            &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    store
+        .put_if_absent(
+            &lease_key,
+            &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    store
+        .put_if_absent(
+            &descriptor_key,
+            &serde_json::to_vec(&namespace_descriptor_envelope)
+                .map_err(|err| CoreError::Store(err.to_string()))?,
+        )
+        .map_err(|err| CoreError::Store(err.to_string()))?;
 
     Ok(NamespaceSummary {
         namespace_id: new_namespace_id.clone(),
     })
-}
-
-fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    object_key: &str,
-    bytes: &[u8],
-) -> Result<(), CoreError> {
-    match store.put_if_absent(object_key, bytes) {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
-            match namespace_initialization_state(store, namespace_id)
-                .map_err(map_namespace_initialization_error_to_core)?
-            {
-                NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
-                    namespace_id: namespace_id.clone(),
-                }),
-                NamespaceInitializationState::Partial => {
-                    Err(CoreError::NamespacePartiallyInitialized {
-                        namespace_id: namespace_id.clone(),
-                    })
-                }
-                NamespaceInitializationState::Absent => Err(CoreError::Store(format!(
-                    "target namespace control object `{object_key}` write failed, but namespace remains absent"
-                ))),
-            }
-        }
-        Err(err) => Err(CoreError::Store(err.to_string())),
-    }
-}
-
-fn map_namespace_initialization_error_to_core(error: BootstrapNamespaceError) -> CoreError {
-    match error {
-        BootstrapNamespaceError::InvalidNamespaceId(error) => CoreError::InvalidNamespaceId(error),
-        other => CoreError::Store(other.to_string()),
-    }
 }
 
 pub fn list_namespaces<S: ObjectStore + ?Sized>(
@@ -581,8 +338,7 @@ pub fn list_namespaces<S: ObjectStore + ?Sized>(
             continue;
         }
         let namespace_id = NamespaceId::from(namespace.to_owned());
-        read_namespace_descriptor_object(store, &namespace_id)
-            .map_err(|err| CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(err)))?;
+        load_namespace_descriptor(store, &namespace_id)?;
         names.insert(namespace_id);
     }
     Ok(names
@@ -1227,82 +983,6 @@ fn mutation_result_from_commit_response(response: V0CommitResponse) -> MutationR
     }
 }
 
-pub(crate) fn derive_commit_results(
-    ops: &[CommitOp],
-    allocated_inode_ids: &[InodeId],
-    resolved_restore_content_refs: &[Option<ContentRef>],
-) -> Vec<CommitOpResult> {
-    let mut allocated = allocated_inode_ids.iter().copied();
-    ops.iter()
-        .enumerate()
-        .map(|(index, op)| {
-            let op_index = u32::try_from(index).expect("commit op index should fit in u32");
-            match op {
-                CommitOp::CreateDir { .. } => CommitOpResult::CreateDir {
-                    op_index,
-                    inode_id: allocated
-                        .next()
-                        .expect("allocated inode ids should cover create ops"),
-                },
-                CommitOp::CreateFile { content_ref, .. } => CommitOpResult::CreateFile {
-                    op_index,
-                    inode_id: allocated
-                        .next()
-                        .expect("allocated inode ids should cover create ops"),
-                    revision_no: loon_api::RevisionNo(1),
-                    content_ref: content_ref.clone(),
-                },
-                CommitOp::ReplaceFile {
-                    inode_id,
-                    base_revision,
-                    content_ref,
-                } => CommitOpResult::ReplaceFile {
-                    op_index,
-                    inode_id: *inode_id,
-                    revision_no: loon_api::RevisionNo(
-                        base_revision
-                            .0
-                            .checked_add(1)
-                            .expect("replace_file revision increment validated"),
-                    ),
-                    content_ref: content_ref.clone(),
-                },
-                CommitOp::RestoreRevision {
-                    inode_id,
-                    source_revision,
-                    base_revision,
-                } => CommitOpResult::RestoreRevision {
-                    op_index,
-                    inode_id: *inode_id,
-                    source_revision_no: *source_revision,
-                    revision_no: loon_api::RevisionNo(
-                        base_revision
-                            .0
-                            .checked_add(1)
-                            .expect("restore_revision increment validated"),
-                    ),
-                    content_ref: resolved_restore_content_refs[index]
-                        .as_ref()
-                        .expect("resolved restore content ref should be present")
-                        .clone(),
-                },
-                CommitOp::DeleteFile { inode_id } => CommitOpResult::DeleteFile {
-                    op_index,
-                    inode_id: *inode_id,
-                },
-                CommitOp::Rename { inode_id, .. } => CommitOpResult::Rename {
-                    op_index,
-                    inode_id: *inode_id,
-                },
-                CommitOp::DeleteSubtree { root_inode } => CommitOpResult::DeleteSubtree {
-                    op_index,
-                    root_inode: *root_inode,
-                },
-            }
-        })
-        .collect()
-}
-
 fn ensure_parent_directories(
     absolute_path: &str,
     committed_seq: ChangeSeq,
@@ -1404,34 +1084,6 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
         size_bytes,
         content_ref,
     })
-}
-
-pub(crate) fn write_immutable_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_bytes: &[u8],
-) -> Result<(), CoreError> {
-    match store.put_if_absent(object_key, expected_bytes) {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed) => {
-            let existing = store
-                .get(object_key, None)
-                .map_err(|err| CoreError::Store(err.to_string()))?
-                .ok_or_else(|| {
-                    CoreError::Store(format!(
-                        "missing immutable object `{object_key}` after precondition failure"
-                    ))
-                })?;
-            if existing == expected_bytes {
-                Ok(())
-            } else {
-                Err(CoreError::Store(format!(
-                    "immutable object `{object_key}` already exists with different bytes"
-                )))
-            }
-        }
-        Err(err) => Err(CoreError::Store(err.to_string())),
-    }
 }
 
 fn lookup_path(
@@ -1550,157 +1202,4 @@ fn tombstoned_path_ancestor(
     }
 
     Ok(None)
-}
-
-fn classify_control_object_load_error(error: &ControlObjectLoadError) -> CoreErrorKind {
-    match error {
-        ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
-        ControlObjectLoadError::MissingObject { .. }
-        | ControlObjectLoadError::MissingObjectAfterHead { .. } => CoreErrorKind::NamespaceNotFound,
-        ControlObjectLoadError::KindMismatch { .. }
-        | ControlObjectLoadError::NamespaceMismatch { .. }
-        | ControlObjectLoadError::ContentStoreMismatch { .. }
-        | ControlObjectLoadError::ChecksumMismatch { .. }
-        | ControlObjectLoadError::Codec { .. } => CoreErrorKind::NamespaceCorrupt,
-        ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
-    }
-}
-
-fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
-    match error {
-        BasisLoadError::LoadNamespaceDescriptor(error) => classify_control_object_load_error(error),
-        BasisLoadError::LoadContentStoreDescriptor(error) => match error {
-            ControlObjectLoadError::Store(_) => CoreErrorKind::ServerError,
-            _ => CoreErrorKind::NamespaceCorrupt,
-        },
-        BasisLoadError::LoadHead(error) | BasisLoadError::LoadLease(error) => match error {
-            ControlObjectLoadError::InvalidNamespaceId { .. } => CoreErrorKind::InvalidNamespaceId,
-            ControlObjectLoadError::MissingObject { .. }
-            | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
-                CoreErrorKind::NamespaceCorrupt
-            }
-            _ => classify_control_object_load_error(error),
-        },
-        BasisLoadError::InvalidWalObjectKey { .. }
-        | BasisLoadError::DuplicateWalSeq { .. }
-        | BasisLoadError::MissingWalObject { .. }
-        | BasisLoadError::MissingWalObjectAfterList { .. }
-        | BasisLoadError::WalReplay(_)
-        | BasisLoadError::ReconstructedHeadMismatch { .. } => CoreErrorKind::NamespaceCorrupt,
-        BasisLoadError::CheckpointLoad(error) => match error.kind() {
-            crate::CheckpointLoadErrorKind::Corrupt => CoreErrorKind::NamespaceCorrupt,
-            crate::CheckpointLoadErrorKind::Store => CoreErrorKind::ServerError,
-        },
-        BasisLoadError::MissingHeadEtag { .. }
-        | BasisLoadError::ListWal { .. }
-        | BasisLoadError::ReadWal { .. } => CoreErrorKind::ServerError,
-    }
-}
-
-fn classify_visible_path_error(error: &VisiblePathError) -> CoreErrorKind {
-    match error {
-        VisiblePathError::InvalidAbsolutePath { .. } => CoreErrorKind::InvalidPath,
-        VisiblePathError::RootMissing => CoreErrorKind::NamespaceCorrupt,
-        VisiblePathError::PathNotFound { .. } => CoreErrorKind::PathNotFound,
-        VisiblePathError::PathComponentNotDirectory { .. } => CoreErrorKind::PathConflict,
-    }
-}
-
-fn classify_durable_content_error(error: &DurableContentValidationError) -> CoreErrorKind {
-    match error {
-        DurableContentValidationError::UnsupportedContentRefKind { .. }
-        | DurableContentValidationError::InvalidDigest { .. }
-        | DurableContentValidationError::MissingContentObject { .. }
-        | DurableContentValidationError::ContentLengthMismatch { .. }
-        | DurableContentValidationError::ContentDigestMismatch { .. } => {
-            CoreErrorKind::NamespaceCorrupt
-        }
-        DurableContentValidationError::Store { .. } => CoreErrorKind::ServerError,
-    }
-}
-
-fn classify_lease_acquire_error(error: &LeaseAcquireError) -> CoreErrorKind {
-    match error {
-        LeaseAcquireError::LoadHead(error) | LeaseAcquireError::LoadLease(error) => {
-            classify_control_object_load_error(error)
-        }
-        LeaseAcquireError::HeldByOtherWriter { .. } => CoreErrorKind::LeaseConflict,
-        LeaseAcquireError::UnexpectedControlState { .. } => CoreErrorKind::NamespaceCorrupt,
-        LeaseAcquireError::EmptyWriterId
-        | LeaseAcquireError::ZeroLeaseDuration
-        | LeaseAcquireError::MissingHeadEtag { .. }
-        | LeaseAcquireError::MissingLeaseEtag { .. }
-        | LeaseAcquireError::HeadFenceTakeover(_)
-        | LeaseAcquireError::HeadWrite(_)
-        | LeaseAcquireError::LeaseWrite(_)
-        | LeaseAcquireError::RetryExhausted { .. } => CoreErrorKind::ServerError,
-    }
-}
-
-fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorKind {
-    match error {
-        CommitValidationError::PlannedHeadSeqMismatch { .. }
-        | CommitValidationError::MissingHeadSeqPrecondition { .. }
-        | CommitValidationError::ConflictingHeadSeqPrecondition { .. } => CoreErrorKind::StaleHead,
-        CommitValidationError::ReplaceFileBaseRevisionMismatch { .. }
-        | CommitValidationError::RestoreRevisionBaseRevisionMismatch { .. } => {
-            CoreErrorKind::StaleRevision
-        }
-        CommitValidationError::RestoreRevisionSourceRevisionMissing { .. } => {
-            CoreErrorKind::RevisionNotFound
-        }
-        CommitValidationError::CreateUnderSubtreeTombstone { .. }
-        | CommitValidationError::ReplaceFileUnderSubtreeTombstone { .. }
-        | CommitValidationError::RestoreRevisionUnderSubtreeTombstone { .. }
-        | CommitValidationError::DeleteFileCoveredByTombstone { .. }
-        | CommitValidationError::RenameInodeUnderSubtreeTombstone { .. }
-        | CommitValidationError::RenameTargetParentUnderSubtreeTombstone { .. }
-        | CommitValidationError::DeleteSubtreeRootCoveredByTombstone { .. } => {
-            CoreErrorKind::TombstoneConflict
-        }
-        CommitValidationError::CreateChildNameCollision { .. }
-        | CommitValidationError::CreateParentNotDirectory { .. }
-        | CommitValidationError::ReplaceFileInodeNotFile { .. }
-        | CommitValidationError::RestoreRevisionInodeNotFile { .. }
-        | CommitValidationError::DeleteFileInodeNotFile { .. }
-        | CommitValidationError::RenameTargetParentNotDirectory { .. }
-        | CommitValidationError::RenameTargetNameCollision { .. }
-        | CommitValidationError::DeleteSubtreeRootNotDirectory { .. } => {
-            CoreErrorKind::PathConflict
-        }
-        CommitValidationError::CreateParentMissing { .. }
-        | CommitValidationError::ReplaceFileInodeMissing { .. }
-        | CommitValidationError::RestoreRevisionInodeMissing { .. }
-        | CommitValidationError::DeleteFileInodeMissing { .. }
-        | CommitValidationError::RenameInodeMissing { .. }
-        | CommitValidationError::RenameSourceBindingMissing { .. }
-        | CommitValidationError::RenameTargetParentMissing { .. }
-        | CommitValidationError::DeleteSubtreeRootMissing { .. } => CoreErrorKind::PathNotFound,
-        CommitValidationError::RenameWouldCycleDirectory { .. } => CoreErrorKind::WouldCycle,
-        CommitValidationError::StaleWriterFenceToken { .. }
-        | CommitValidationError::LeaseHolderMismatch { .. }
-        | CommitValidationError::LeaseExpired { .. } => CoreErrorKind::LeaseConflict,
-        CommitValidationError::EmptyCommit
-        | CommitValidationError::NamespaceMismatch
-        | CommitValidationError::HeadLeaseNamespaceMismatch
-        | CommitValidationError::HeadLeaseFenceMismatch { .. }
-        | CommitValidationError::RestoreRevisionOverflow { .. }
-        | CommitValidationError::ReplaceFileRevisionOverflow { .. }
-        | CommitValidationError::SeqOverflow
-        | CommitValidationError::NextInodeOverflow
-        | CommitValidationError::OpIndexOverflow => CoreErrorKind::ServerError,
-    }
-}
-
-fn classify_head_publish_error(error: &CommitHeadPublishError) -> CoreErrorKind {
-    match error {
-        CommitHeadPublishError::StaleHead => CoreErrorKind::StaleHead,
-        CommitHeadPublishError::EmptyWriterVersion
-        | CommitHeadPublishError::EmptyExpectedHeadEtag
-        | CommitHeadPublishError::NamespaceMismatch { .. }
-        | CommitHeadPublishError::PlanBaseHeadSeqMismatch { .. }
-        | CommitHeadPublishError::PlanNextSeqMismatch { .. }
-        | CommitHeadPublishError::Codec(_)
-        | CommitHeadPublishError::Store(_) => CoreErrorKind::ServerError,
-    }
 }

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -242,19 +242,6 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
         load_verified_checkpoint_materialization(store, source_namespace_id, fork_seq)
             .map_err(|err| CoreError::Basis(BasisLoadError::CheckpointLoad(err)))?;
 
-    write_verified_checkpoint_from_metadata(
-        store,
-        CheckpointMetadataWriteRequest {
-            namespace_id: new_namespace_id,
-            checkpoint_seq: fork_seq,
-            active_fence_token: FenceToken(0),
-            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
-            retention_floor_seq: fork_seq,
-            metadata_state: &source_checkpoint.metadata_state,
-            writer_version: &context.writer_version,
-        },
-    )?;
-
     let initial_head = HeadState {
         namespace_id: new_namespace_id.clone(),
         seq: fork_seq,
@@ -295,29 +282,71 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     let head_key = namespace_head(new_namespace_id.as_str());
     let lease_key = namespace_lease(new_namespace_id.as_str());
     let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
-    store
-        .put_if_absent(
-            &head_key,
-            &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    store
-        .put_if_absent(
-            &lease_key,
-            &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    store
-        .put_if_absent(
-            &descriptor_key,
-            &serde_json::to_vec(&namespace_descriptor_envelope)
-                .map_err(|err| CoreError::Store(err.to_string()))?,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &head_key,
+        &serde_json::to_vec(&head).map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
+    write_verified_checkpoint_from_metadata(
+        store,
+        CheckpointMetadataWriteRequest {
+            namespace_id: new_namespace_id,
+            checkpoint_seq: fork_seq,
+            active_fence_token: FenceToken(0),
+            next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
+            retention_floor_seq: fork_seq,
+            metadata_state: &source_checkpoint.metadata_state,
+            writer_version: &context.writer_version,
+        },
+    )?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &lease_key,
+        &serde_json::to_vec(&lease).map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &descriptor_key,
+        &serde_json::to_vec(&namespace_descriptor_envelope)
+            .map_err(|err| CoreError::Store(err.to_string()))?,
+    )?;
 
     Ok(NamespaceSummary {
         namespace_id: new_namespace_id.clone(),
     })
+}
+
+fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    object_key: &str,
+    bytes: &[u8],
+) -> Result<(), CoreError> {
+    match store.put_if_absent(object_key, bytes) {
+        Ok(_) => Ok(()),
+        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+            match namespace_initialization_state(store, namespace_id)
+                .map_err(BootstrapNamespaceError::from)
+                .map_err(|err| CoreError::Store(err.to_string()))?
+            {
+                NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
+                    namespace_id: namespace_id.clone(),
+                }),
+                NamespaceInitializationState::Partial => {
+                    Err(CoreError::NamespacePartiallyInitialized {
+                        namespace_id: namespace_id.clone(),
+                    })
+                }
+                NamespaceInitializationState::Absent => Err(CoreError::Store(format!(
+                    "target namespace control object `{object_key}` write failed, but namespace remains absent"
+                ))),
+            }
+        }
+        Err(err) => Err(CoreError::Store(err.to_string())),
+    }
 }
 
 pub fn list_namespaces<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -23,7 +23,7 @@ use loon_api::{
     ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
     FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
     MutationResult, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
-    NamespaceSummary,
+    NamespaceIdValidationError, NamespaceSummary,
 };
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
@@ -53,6 +53,8 @@ pub enum PutFileBehavior {
 
 #[derive(Debug, Error)]
 pub enum BootstrapNamespaceError {
+    #[error(transparent)]
+    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("holder id must not be empty")]
     EmptyHolderId,
     #[error("writer version must not be empty")]
@@ -78,6 +80,9 @@ pub enum BootstrapNamespaceError {
 impl From<NamespaceInitializationError> for BootstrapNamespaceError {
     fn from(value: NamespaceInitializationError) -> Self {
         match value {
+            NamespaceInitializationError::InvalidNamespaceId(error) => {
+                Self::InvalidNamespaceId(error)
+            }
             NamespaceInitializationError::InspectNamespaceDescriptor(message) => {
                 Self::DescriptorWrite(message)
             }
@@ -219,8 +224,7 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<NamespaceSummary, CoreError> {
     match namespace_initialization_state(store, new_namespace_id)
-        .map_err(BootstrapNamespaceError::from)
-        .map_err(|err| CoreError::Store(err.to_string()))?
+        .map_err(map_namespace_initialization_error_to_core)?
     {
         NamespaceInitializationState::Absent => {}
         NamespaceInitializationState::Complete => {
@@ -329,8 +333,7 @@ fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
         Ok(_) => Ok(()),
         Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
             match namespace_initialization_state(store, namespace_id)
-                .map_err(BootstrapNamespaceError::from)
-                .map_err(|err| CoreError::Store(err.to_string()))?
+                .map_err(map_namespace_initialization_error_to_core)?
             {
                 NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
                     namespace_id: namespace_id.clone(),
@@ -346,6 +349,15 @@ fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
             }
         }
         Err(err) => Err(CoreError::Store(err.to_string())),
+    }
+}
+
+fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        other => CoreError::Store(BootstrapNamespaceError::from(other).to_string()),
     }
 }
 

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -134,7 +134,6 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         NamespaceInitializationState::Absent => {}
     }
 
-    let content_store_id = create_new_content_store(store, context)?;
     let initial_head = HeadState::initial(namespace_id.clone());
     let initial_lease = LeaseState {
         namespace_id: namespace_id.clone(),
@@ -158,6 +157,17 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
     let lease_bytes = serde_json::to_vec(&lease_envelope)
         .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+
+    let head_key = namespace_head(namespace_id.as_str());
+    let lease_key = namespace_lease(namespace_id.as_str());
+    store
+        .put_if_absent(&head_key, &head_bytes)
+        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
+    store
+        .put_if_absent(&lease_key, &lease_bytes)
+        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
+
+    let content_store_id = create_new_content_store(store, context)?;
     let namespace_descriptor_envelope = NamespaceDescriptorEnvelope::from_state(
         ControlObjectKind::NamespaceDescriptor,
         &context.writer_version,
@@ -170,15 +180,7 @@ pub fn bootstrap_namespace<S: ObjectStore + ?Sized>(
     let namespace_descriptor_bytes = serde_json::to_vec(&namespace_descriptor_envelope)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
 
-    let head_key = namespace_head(namespace_id.as_str());
-    let lease_key = namespace_lease(namespace_id.as_str());
     let descriptor_key = namespace_descriptor(namespace_id.as_str());
-    store
-        .put_if_absent(&head_key, &head_bytes)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
-    store
-        .put_if_absent(&lease_key, &lease_bytes)
-        .map_err(|err| BootstrapNamespaceError::LeaseWrite(err.to_string()))?;
     store
         .put_if_absent(&descriptor_key, &namespace_descriptor_bytes)
         .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -254,6 +254,7 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
         name_policy: source_basis.head.name_policy,
         snapshot_hint_seq: Some(fork_seq),
         retention_floor_seq: fork_seq,
+        visible_wal_tip: None,
     };
     let initial_lease = LeaseState {
         namespace_id: new_namespace_id.clone(),

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -1,26 +1,37 @@
 use crate::commit::{CommitOp, CommitPlan, CommitRequest, Precondition};
 use crate::metadata::{MetadataApplyError, MetadataState};
 use loon_api::{
-    decode_wal_commit_envelope_zstd, encode_wal_commit_envelope_zstd, v0::CommitOpResult,
-    ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitEnvelope, WalCommitPayload, WalOp,
-    WalPrecondition,
+    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, v0::CommitOpResult,
+    ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitPayload, WalOp, WalPrecondition,
+    WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
 };
-use loon_objectstore::keys::wal_commit;
+use loon_objectstore::keys::wal_segment;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedWalCommit {
+pub struct PreparedWalRecord {
+    pub request: CommitRequest,
+    pub plan: CommitPlan,
+    pub results: Vec<CommitOpResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedWalSegment {
     pub object_key: String,
-    pub commit_id: String,
-    pub envelope: WalCommitEnvelope,
+    pub segment_id: String,
+    pub envelope: WalSegmentEnvelope,
     pub encoded_bytes: Vec<u8>,
     pub checked_invariants: Vec<String>,
 }
+
+pub type PreparedWalCommit = PreparedWalSegment;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WalBuildError {
     EmptyWriterVersion,
     WalWriteNotRequired,
+    EmptySegment,
     NamespaceMismatch {
         request: NamespaceId,
         plan: NamespaceId,
@@ -33,6 +44,10 @@ pub enum WalBuildError {
         request_create_ops: usize,
         plan_allocated_count: usize,
     },
+    NonContiguousSeq {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
     Codec(String),
 }
 
@@ -43,21 +58,25 @@ pub struct StoredWalObject {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReplayedWalCommit {
+pub struct ReplayedWalSegment {
     pub object_key: String,
-    pub envelope: WalCommitEnvelope,
+    pub envelope: WalSegmentEnvelope,
     pub resulting_head: HeadState,
     pub checked_invariants: Vec<String>,
 }
 
+pub type ReplayedWalCommit = ReplayedWalSegment;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReplayedWalCommitWithMetadata {
+pub struct ReplayedWalSegmentWithMetadata {
     pub object_key: String,
-    pub envelope: WalCommitEnvelope,
+    pub envelope: WalSegmentEnvelope,
     pub resulting_head: HeadState,
     pub resulting_metadata_state: MetadataState,
     pub checked_invariants: Vec<String>,
 }
+
+pub type ReplayedWalCommitWithMetadata = ReplayedWalSegmentWithMetadata;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplayedWalTail {
@@ -85,6 +104,8 @@ pub enum WalReplayError {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    EmptySegment,
+    SegmentSummaryMismatch,
     MetadataApply(MetadataApplyError),
     SeqOverflow,
 }
@@ -95,63 +116,135 @@ pub fn prepare_wal_commit(
     results: Vec<CommitOpResult>,
     writer_version: &str,
 ) -> Result<PreparedWalCommit, WalBuildError> {
+    prepare_wal_segment(
+        plan.namespace_id.clone(),
+        None,
+        &[PreparedWalRecord {
+            request: request.clone(),
+            plan: plan.clone(),
+            results,
+        }],
+        writer_version,
+    )
+}
+
+pub fn prepare_wal_segment(
+    namespace_id: NamespaceId,
+    prev_visible_segment: Option<WalSegmentPointer>,
+    records: &[PreparedWalRecord],
+    writer_version: &str,
+) -> Result<PreparedWalSegment, WalBuildError> {
     if writer_version.trim().is_empty() {
         return Err(WalBuildError::EmptyWriterVersion);
     }
-
-    if !plan.wal_object_must_be_written {
-        return Err(WalBuildError::WalWriteNotRequired);
+    if records.is_empty() {
+        return Err(WalBuildError::EmptySegment);
     }
 
-    if request.namespace_id != plan.namespace_id {
-        return Err(WalBuildError::NamespaceMismatch {
-            request: request.namespace_id.clone(),
-            plan: plan.namespace_id.clone(),
+    let mut payload_records: Vec<WalCommitPayload> = Vec::with_capacity(records.len());
+    for (index, record) in records.iter().enumerate() {
+        if !record.plan.wal_object_must_be_written {
+            return Err(WalBuildError::WalWriteNotRequired);
+        }
+        if record.request.namespace_id != record.plan.namespace_id {
+            return Err(WalBuildError::NamespaceMismatch {
+                request: record.request.namespace_id.clone(),
+                plan: record.plan.namespace_id.clone(),
+            });
+        }
+        if record.plan.namespace_id != namespace_id {
+            return Err(WalBuildError::NamespaceMismatch {
+                request: record.plan.namespace_id.clone(),
+                plan: namespace_id,
+            });
+        }
+        if index > 0 {
+            let expected = payload_records[index - 1]
+                .seq
+                .0
+                .checked_add(1)
+                .map(ChangeSeq)
+                .ok_or_else(|| WalBuildError::Codec("seq overflow".to_owned()))?;
+            if record.plan.next_seq != expected {
+                return Err(WalBuildError::NonContiguousSeq {
+                    expected,
+                    actual: record.plan.next_seq,
+                });
+            }
+            if record.plan.base_head_seq != payload_records[index - 1].seq {
+                return Err(WalBuildError::BaseHeadSeqMismatch {
+                    request: record.plan.base_head_seq,
+                    plan: payload_records[index - 1].seq,
+                });
+            }
+        }
+        payload_records.push(WalCommitPayload {
+            namespace_id: record.plan.namespace_id.clone(),
+            seq: record.plan.next_seq,
+            base_head_seq: record.plan.base_head_seq,
+            commit_id: record.plan.commit_id.clone(),
+            request_id: record.request.request_id.clone(),
+            request_checksum_sha256: record
+                .request
+                .request_checksum_sha256()
+                .map_err(|err| WalBuildError::Codec(err.to_string()))?,
+            semantic_fingerprint_sha256: record
+                .request
+                .semantic_fingerprint_sha256()
+                .map_err(|err| WalBuildError::Codec(err.to_string()))?,
+            source_request_checksum_sha256: record.request.source_request_checksum_sha256.clone(),
+            writer_id: record.request.writer_id.clone(),
+            writer_fence_token: record.request.writer_fence_token,
+            message: record.request.message.clone(),
+            annotations: record.request.annotations.clone(),
+            ops: build_wal_ops(&record.request, &record.plan)?,
+            preconditions: record
+                .request
+                .preconditions
+                .iter()
+                .map(WalPrecondition::from)
+                .collect(),
+            results: record.results.clone(),
         });
     }
 
-    if request.planned_head_seq != plan.base_head_seq {
-        return Err(WalBuildError::BaseHeadSeqMismatch {
-            request: request.planned_head_seq,
-            plan: plan.base_head_seq,
-        });
-    }
-
-    let payload = WalCommitPayload {
-        namespace_id: plan.namespace_id.clone(),
-        seq: plan.next_seq,
-        base_head_seq: plan.base_head_seq,
-        commit_id: plan.commit_id.clone(),
-        request_id: request.request_id.clone(),
-        request_checksum_sha256: request
-            .request_checksum_sha256()
-            .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-        source_request_checksum_sha256: request.source_request_checksum_sha256.clone(),
-        writer_id: request.writer_id.clone(),
-        writer_fence_token: request.writer_fence_token,
-        message: request.message.clone(),
-        annotations: request.annotations.clone(),
-        ops: build_wal_ops(request, plan)?,
-        preconditions: request
-            .preconditions
-            .iter()
-            .map(WalPrecondition::from)
-            .collect(),
-        results,
+    let start_seq = payload_records
+        .first()
+        .map(|record| record.seq)
+        .ok_or(WalBuildError::EmptySegment)?;
+    let end_seq = payload_records
+        .last()
+        .map(|record| record.seq)
+        .ok_or(WalBuildError::EmptySegment)?;
+    let segment_id = format!("seg_{}", Uuid::new_v4().simple());
+    let payload = WalSegmentPayload {
+        namespace_id,
+        segment_id: segment_id.clone(),
+        prev_visible_segment,
+        base_head_seq: payload_records[0].base_head_seq,
+        start_seq,
+        end_seq,
+        records: payload_records,
     };
-    let envelope = WalCommitEnvelope::from_payload(writer_version, payload)
+    let envelope = WalSegmentEnvelope::from_payload(writer_version, payload)
         .map_err(|err| WalBuildError::Codec(err.to_string()))?;
-    let encoded_bytes = encode_wal_commit_envelope_zstd(&envelope)
+    let encoded_bytes = encode_wal_segment_envelope_zstd(&envelope)
         .map_err(|err| WalBuildError::Codec(err.to_string()))?;
+    let object_key = wal_segment(
+        envelope.payload.namespace_id.as_str(),
+        start_seq.0,
+        end_seq.0,
+        &segment_id,
+    );
 
-    Ok(PreparedWalCommit {
-        object_key: wal_commit(plan.namespace_id.as_str(), plan.next_seq.0, &plan.commit_id),
-        commit_id: plan.commit_id.clone(),
+    Ok(PreparedWalSegment {
+        object_key,
+        segment_id,
         envelope,
         encoded_bytes,
         checked_invariants: vec![
             "wal_payload_checksum_matches_payload".to_owned(),
-            "wal_key_matches_committed_seq".to_owned(),
+            "wal_key_matches_segment_seq_range".to_owned(),
             "head_publish_requires_durable_wal".to_owned(),
         ],
     })
@@ -161,23 +254,29 @@ pub fn replay_wal_commit(
     current_head: &HeadState,
     wal_object: &StoredWalObject,
 ) -> Result<ReplayedWalCommit, WalReplayError> {
-    let envelope = decode_and_validate_replayed_wal(current_head, wal_object)?;
+    replay_wal_segment(current_head, wal_object)
+}
 
-    Ok(ReplayedWalCommit {
+pub fn replay_wal_segment(
+    current_head: &HeadState,
+    wal_object: &StoredWalObject,
+) -> Result<ReplayedWalSegment, WalReplayError> {
+    let envelope = decode_and_validate_replayed_wal(current_head, wal_object)?;
+    let mut resulting_head = current_head.clone();
+    for record in &envelope.payload.records {
+        resulting_head.seq = record.seq;
+        resulting_head.next_inode_id =
+            replay_next_inode_id(resulting_head.next_inode_id, &record.ops);
+    }
+    resulting_head.visible_wal_tip = Some(envelope.pointer(wal_object.object_key.clone()));
+
+    Ok(ReplayedWalSegment {
         object_key: wal_object.object_key.clone(),
-        envelope: envelope.clone(),
-        resulting_head: HeadState {
-            namespace_id: current_head.namespace_id.clone(),
-            seq: envelope.payload.seq,
-            active_fence_token: envelope.payload.writer_fence_token,
-            next_inode_id: replay_next_inode_id(current_head.next_inode_id, &envelope.payload.ops),
-            name_policy: current_head.name_policy,
-            snapshot_hint_seq: current_head.snapshot_hint_seq,
-            retention_floor_seq: current_head.retention_floor_seq,
-        },
+        envelope,
+        resulting_head,
         checked_invariants: vec![
             "wal_payload_checksum_matches_payload".to_owned(),
-            "wal_key_matches_committed_seq".to_owned(),
+            "wal_key_matches_segment_seq_range".to_owned(),
             "wal_replay_requires_matching_namespace".to_owned(),
             "wal_replay_requires_matching_base_head_seq".to_owned(),
             "wal_tail_seq_is_contiguous".to_owned(),
@@ -190,22 +289,31 @@ pub fn replay_wal_commit_with_metadata(
     current_metadata_state: &MetadataState,
     wal_object: &StoredWalObject,
 ) -> Result<ReplayedWalCommitWithMetadata, WalReplayError> {
-    let replayed = replay_wal_commit(current_head, wal_object)?;
-    let applied_metadata = current_metadata_state
-        .apply_committed_wal_ops(replayed.resulting_head.seq, &replayed.envelope.payload.ops)
-        .map_err(WalReplayError::MetadataApply)?;
-    let mut checked_invariants = replayed.checked_invariants.clone();
-    push_invariant(&mut checked_invariants, "wal_replay_applies_metadata_rows");
-    extend_invariants(
-        &mut checked_invariants,
-        &applied_metadata.checked_invariants,
-    );
+    replay_wal_segment_with_metadata(current_head, current_metadata_state, wal_object)
+}
 
-    Ok(ReplayedWalCommitWithMetadata {
+pub fn replay_wal_segment_with_metadata(
+    current_head: &HeadState,
+    current_metadata_state: &MetadataState,
+    wal_object: &StoredWalObject,
+) -> Result<ReplayedWalSegmentWithMetadata, WalReplayError> {
+    let replayed = replay_wal_segment(current_head, wal_object)?;
+    let mut current_metadata_state = current_metadata_state.clone();
+    let mut checked_invariants = replayed.checked_invariants.clone();
+    for record in &replayed.envelope.payload.records {
+        let applied = current_metadata_state
+            .apply_committed_wal_record(record)
+            .map_err(WalReplayError::MetadataApply)?;
+        current_metadata_state = applied.metadata_state;
+        push_invariant(&mut checked_invariants, "wal_replay_applies_metadata_rows");
+        extend_invariants(&mut checked_invariants, &applied.checked_invariants);
+    }
+
+    Ok(ReplayedWalSegmentWithMetadata {
         object_key: replayed.object_key,
         envelope: replayed.envelope,
         resulting_head: replayed.resulting_head,
-        resulting_metadata_state: applied_metadata.metadata_state,
+        resulting_metadata_state: current_metadata_state,
         checked_invariants,
     })
 }
@@ -217,7 +325,7 @@ pub fn replay_wal_tail(
     let mut current_head = basis_head.clone();
 
     for wal_object in wal_tail {
-        current_head = replay_wal_commit(&current_head, wal_object)?.resulting_head;
+        current_head = replay_wal_segment(&current_head, wal_object)?.resulting_head;
     }
 
     Ok(current_head)
@@ -234,7 +342,7 @@ pub fn replay_wal_tail_with_metadata(
 
     for wal_object in wal_tail {
         let replayed =
-            replay_wal_commit_with_metadata(&current_head, &current_metadata_state, wal_object)?;
+            replay_wal_segment_with_metadata(&current_head, &current_metadata_state, wal_object)?;
         current_head = replayed.resulting_head;
         current_metadata_state = replayed.resulting_metadata_state;
         extend_invariants(&mut checked_invariants, &replayed.checked_invariants);
@@ -247,8 +355,8 @@ pub fn replay_wal_tail_with_metadata(
     })
 }
 
-impl From<&PreparedWalCommit> for StoredWalObject {
-    fn from(value: &PreparedWalCommit) -> Self {
+impl From<&PreparedWalSegment> for StoredWalObject {
+    fn from(value: &PreparedWalSegment) -> Self {
         Self {
             object_key: value.object_key.clone(),
             encoded_bytes: value.encoded_bytes.clone(),
@@ -365,13 +473,14 @@ fn build_wal_ops(request: &CommitRequest, plan: &CommitPlan) -> Result<Vec<WalOp
 fn decode_and_validate_replayed_wal(
     current_head: &HeadState,
     wal_object: &StoredWalObject,
-) -> Result<WalCommitEnvelope, WalReplayError> {
-    let envelope = decode_wal_commit_envelope_zstd(&wal_object.encoded_bytes)
+) -> Result<WalSegmentEnvelope, WalReplayError> {
+    let envelope = decode_wal_segment_envelope_zstd(&wal_object.encoded_bytes)
         .map_err(|err| WalReplayError::Codec(err.to_string()))?;
-    let expected_object_key = wal_commit(
+    let expected_object_key = wal_segment(
         envelope.payload.namespace_id.as_str(),
-        envelope.payload.seq.0,
-        &envelope.payload.commit_id,
+        envelope.payload.start_seq.0,
+        envelope.payload.end_seq.0,
+        &envelope.payload.segment_id,
     );
 
     if wal_object.object_key != expected_object_key {
@@ -395,18 +504,48 @@ fn decode_and_validate_replayed_wal(
         });
     }
 
-    let expected_seq = current_head
+    let expected_start = current_head
         .seq
         .0
         .checked_add(1)
         .map(ChangeSeq)
         .ok_or(WalReplayError::SeqOverflow)?;
 
-    if envelope.payload.seq != expected_seq {
+    if envelope.payload.start_seq != expected_start {
         return Err(WalReplayError::NonContiguousSeq {
-            expected: expected_seq,
-            actual: envelope.payload.seq,
+            expected: expected_start,
+            actual: envelope.payload.start_seq,
         });
+    }
+    if envelope.payload.records.is_empty() {
+        return Err(WalReplayError::EmptySegment);
+    }
+    if envelope.payload.records.first().map(|record| record.seq) != Some(envelope.payload.start_seq)
+        || envelope.payload.records.last().map(|record| record.seq)
+            != Some(envelope.payload.end_seq)
+    {
+        return Err(WalReplayError::SegmentSummaryMismatch);
+    }
+    for (offset, record) in envelope.payload.records.iter().enumerate() {
+        let expected = envelope
+            .payload
+            .start_seq
+            .0
+            .checked_add(offset as u64)
+            .map(ChangeSeq)
+            .ok_or(WalReplayError::SeqOverflow)?;
+        if record.seq != expected {
+            return Err(WalReplayError::NonContiguousSeq {
+                expected,
+                actual: record.seq,
+            });
+        }
+        if record.namespace_id != current_head.namespace_id {
+            return Err(WalReplayError::NamespaceMismatch {
+                expected: current_head.namespace_id.clone(),
+                actual: record.namespace_id.clone(),
+            });
+        }
     }
 
     Ok(envelope)

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -118,70 +118,29 @@ pub fn prepare_wal_segment(
     }
 
     let mut payload_records: Vec<WalCommitPayload> = Vec::with_capacity(records.len());
-    for (index, record) in records.iter().enumerate() {
-        if !record.plan.wal_object_must_be_written {
-            return Err(WalBuildError::WalWriteNotRequired);
-        }
-        if record.request.namespace_id != record.plan.namespace_id {
-            return Err(WalBuildError::NamespaceMismatch {
-                request: record.request.namespace_id.clone(),
-                plan: record.plan.namespace_id.clone(),
-            });
-        }
-        if record.plan.namespace_id != namespace_id {
-            return Err(WalBuildError::NamespaceMismatch {
-                request: record.plan.namespace_id.clone(),
-                plan: namespace_id,
-            });
-        }
-        if index > 0 {
-            let expected = payload_records[index - 1]
+    for record in records {
+        let payload_record = build_wal_commit_payload(&namespace_id, record)?;
+        if let Some(previous) = payload_records.last() {
+            let expected = previous
                 .seq
                 .0
                 .checked_add(1)
                 .map(ChangeSeq)
                 .ok_or_else(|| WalBuildError::Codec("seq overflow".to_owned()))?;
-            if record.plan.next_seq != expected {
+            if payload_record.seq != expected {
                 return Err(WalBuildError::NonContiguousSeq {
                     expected,
-                    actual: record.plan.next_seq,
+                    actual: payload_record.seq,
                 });
             }
-            if record.plan.base_head_seq != payload_records[index - 1].seq {
+            if payload_record.base_head_seq != previous.seq {
                 return Err(WalBuildError::BaseHeadSeqMismatch {
-                    request: record.plan.base_head_seq,
-                    plan: payload_records[index - 1].seq,
+                    request: payload_record.base_head_seq,
+                    plan: previous.seq,
                 });
             }
         }
-        payload_records.push(WalCommitPayload {
-            namespace_id: record.plan.namespace_id.clone(),
-            seq: record.plan.next_seq,
-            base_head_seq: record.plan.base_head_seq,
-            commit_id: record.plan.commit_id.clone(),
-            request_id: record.request.request_id.clone(),
-            request_checksum_sha256: record
-                .request
-                .request_checksum_sha256()
-                .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-            semantic_fingerprint_sha256: record
-                .request
-                .semantic_fingerprint_sha256()
-                .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-            source_request_checksum_sha256: record.request.source_request_checksum_sha256.clone(),
-            writer_id: record.request.writer_id.clone(),
-            writer_fence_token: record.request.writer_fence_token,
-            message: record.request.message.clone(),
-            annotations: record.request.annotations.clone(),
-            ops: build_wal_ops(&record.request, &record.plan)?,
-            preconditions: record
-                .request
-                .preconditions
-                .iter()
-                .map(WalPrecondition::from)
-                .collect(),
-            results: record.results.clone(),
-        });
+        payload_records.push(payload_record);
     }
 
     let start_seq = payload_records
@@ -223,6 +182,56 @@ pub fn prepare_wal_segment(
             "wal_key_matches_segment_seq_range".to_owned(),
             "head_publish_requires_durable_wal".to_owned(),
         ],
+    })
+}
+
+pub(crate) fn build_wal_commit_payload(
+    namespace_id: &NamespaceId,
+    record: &PreparedWalRecord,
+) -> Result<WalCommitPayload, WalBuildError> {
+    if !record.plan.wal_object_must_be_written {
+        return Err(WalBuildError::WalWriteNotRequired);
+    }
+    if record.request.namespace_id != record.plan.namespace_id {
+        return Err(WalBuildError::NamespaceMismatch {
+            request: record.request.namespace_id.clone(),
+            plan: record.plan.namespace_id.clone(),
+        });
+    }
+    if record.plan.namespace_id != *namespace_id {
+        return Err(WalBuildError::NamespaceMismatch {
+            request: record.plan.namespace_id.clone(),
+            plan: namespace_id.clone(),
+        });
+    }
+
+    Ok(WalCommitPayload {
+        namespace_id: record.plan.namespace_id.clone(),
+        seq: record.plan.next_seq,
+        base_head_seq: record.plan.base_head_seq,
+        commit_id: record.plan.commit_id.clone(),
+        request_id: record.request.request_id.clone(),
+        request_checksum_sha256: record
+            .request
+            .request_checksum_sha256()
+            .map_err(|err| WalBuildError::Codec(err.to_string()))?,
+        semantic_fingerprint_sha256: record
+            .request
+            .semantic_fingerprint_sha256()
+            .map_err(|err| WalBuildError::Codec(err.to_string()))?,
+        source_request_checksum_sha256: record.request.source_request_checksum_sha256.clone(),
+        writer_id: record.request.writer_id.clone(),
+        writer_fence_token: record.request.writer_fence_token,
+        message: record.request.message.clone(),
+        annotations: record.request.annotations.clone(),
+        ops: build_wal_ops(&record.request, &record.plan)?,
+        preconditions: record
+            .request
+            .preconditions
+            .iter()
+            .map(WalPrecondition::from)
+            .collect(),
+        results: record.results.clone(),
     })
 }
 
@@ -562,5 +571,58 @@ impl From<&Precondition> for WalPrecondition {
                 name_key: name_key.clone(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loon_api::{v0::CommitOpResult, FenceToken};
+
+    #[test]
+    fn build_wal_commit_payload_matches_segment_record_payload() {
+        let namespace_id = NamespaceId::from("demo");
+        let record = PreparedWalRecord {
+            request: CommitRequest {
+                namespace_id: namespace_id.clone(),
+                request_id: "req-wal-payload".to_owned(),
+                writer_id: "writer-a".to_owned(),
+                writer_fence_token: FenceToken(1),
+                planned_head_seq: ChangeSeq(0),
+                source_request_checksum_sha256: None,
+                ops: vec![CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "docs".to_owned(),
+                }],
+                preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+                message: Some("create docs".to_owned()),
+                annotations: None,
+            },
+            plan: CommitPlan {
+                namespace_id: namespace_id.clone(),
+                commit_id: "commit-wal-payload".to_owned(),
+                base_head_seq: ChangeSeq(0),
+                next_seq: ChangeSeq(1),
+                allocated_inode_ids: vec![InodeId(2)],
+                resolved_restore_content_refs: vec![None],
+                resulting_next_inode_id: InodeId(3),
+                durable_content_required: false,
+                wal_object_must_be_written: true,
+                head_cas_must_succeed: true,
+                metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+                checked_invariants: Vec::new(),
+            },
+            results: vec![CommitOpResult::CreateDir {
+                op_index: 0,
+                inode_id: InodeId(2),
+            }],
+        };
+
+        let payload =
+            build_wal_commit_payload(&namespace_id, &record).expect("build commit payload");
+        let segment = prepare_wal_segment(namespace_id, None, &[record], "test-writer")
+            .expect("prepare wal segment");
+
+        assert_eq!(payload, segment.envelope.payload.records[0]);
     }
 }

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -25,8 +25,6 @@ pub struct PreparedWalSegment {
     pub checked_invariants: Vec<String>,
 }
 
-pub type PreparedWalCommit = PreparedWalSegment;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WalBuildError {
     EmptyWriterVersion,
@@ -65,8 +63,6 @@ pub struct ReplayedWalSegment {
     pub checked_invariants: Vec<String>,
 }
 
-pub type ReplayedWalCommit = ReplayedWalSegment;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplayedWalSegmentWithMetadata {
     pub object_key: String,
@@ -75,8 +71,6 @@ pub struct ReplayedWalSegmentWithMetadata {
     pub resulting_metadata_state: MetadataState,
     pub checked_invariants: Vec<String>,
 }
-
-pub type ReplayedWalCommitWithMetadata = ReplayedWalSegmentWithMetadata;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplayedWalTail {
@@ -108,24 +102,6 @@ pub enum WalReplayError {
     SegmentSummaryMismatch,
     MetadataApply(MetadataApplyError),
     SeqOverflow,
-}
-
-pub fn prepare_wal_commit(
-    request: &CommitRequest,
-    plan: &CommitPlan,
-    results: Vec<CommitOpResult>,
-    writer_version: &str,
-) -> Result<PreparedWalCommit, WalBuildError> {
-    prepare_wal_segment(
-        plan.namespace_id.clone(),
-        None,
-        &[PreparedWalRecord {
-            request: request.clone(),
-            plan: plan.clone(),
-            results,
-        }],
-        writer_version,
-    )
 }
 
 pub fn prepare_wal_segment(
@@ -250,13 +226,6 @@ pub fn prepare_wal_segment(
     })
 }
 
-pub fn replay_wal_commit(
-    current_head: &HeadState,
-    wal_object: &StoredWalObject,
-) -> Result<ReplayedWalCommit, WalReplayError> {
-    replay_wal_segment(current_head, wal_object)
-}
-
 pub fn replay_wal_segment(
     current_head: &HeadState,
     wal_object: &StoredWalObject,
@@ -282,14 +251,6 @@ pub fn replay_wal_segment(
             "wal_tail_seq_is_contiguous".to_owned(),
         ],
     })
-}
-
-pub fn replay_wal_commit_with_metadata(
-    current_head: &HeadState,
-    current_metadata_state: &MetadataState,
-    wal_object: &StoredWalObject,
-) -> Result<ReplayedWalCommitWithMetadata, WalReplayError> {
-    replay_wal_segment_with_metadata(current_head, current_metadata_state, wal_object)
 }
 
 pub fn replay_wal_segment_with_metadata(

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -211,6 +211,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
+        request_receipts: Vec::new(),
     }
 }
 

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -19,8 +19,7 @@ use loon_core::{
     list_namespaces, load_verified_namespace_basis, move_path, publish_namespace_mutations_batch,
     put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
     CoreError, CoreErrorKind, DirectObjectStorePublisher, MutationContext,
-    NamespaceMutationCandidate, NamespaceMutationPublisher, PathMutationIntent, PublishOptions,
-    PutFileBehavior,
+    NamespaceMutationCandidate, PathMutationIntent, PublishOptions, PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,7 +1,7 @@
 use loon_api::{
     decode_wal_segment_envelope_zstd, sha256_digest,
     v0::{
-        CommitOp as V0CommitOp, CommitPrecondition, CommitRequest as V0CommitRequest,
+        CommitOp as ApiCommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest,
         CompleteUploadRequest,
     },
     ChangeSeq, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope, ControlObjectKind,
@@ -16,9 +16,11 @@ use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
     bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
     copy_file_path, delete_path, delete_path_non_recursive, fork_namespace, list_changes_after,
-    list_namespaces, load_verified_namespace_basis, move_path, put_file_bytes, read_file_bytes,
-    resolve_path, store_bytes_as_content, write_file_bytes, CoreError, CoreErrorKind,
-    MutationContext, PutFileBehavior,
+    list_namespaces, load_verified_namespace_basis, move_path, publish_namespace_mutations_batch,
+    put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
+    CoreError, CoreErrorKind, DirectObjectStorePublisher, MutationContext,
+    NamespaceMutationCandidate, NamespaceMutationPublisher, PathMutationIntent, PublishOptions,
+    PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
@@ -748,22 +750,22 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
         &store,
         &namespace_id,
         vec![
-            V0CommitRequest {
+            ApiCommitRequest {
                 request_id: "req-batch-a".to_owned(),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
-                ops: vec![V0CommitOp::CreateDir {
+                ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "alpha".to_owned(),
                 }],
                 message: None,
                 annotations: None,
             },
-            V0CommitRequest {
+            ApiCommitRequest {
                 request_id: "req-batch-b".to_owned(),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
-                ops: vec![V0CommitOp::CreateDir {
+                ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "beta".to_owned(),
                 }],
@@ -809,11 +811,11 @@ fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
-    let request = V0CommitRequest {
+    let request = ApiCommitRequest {
         request_id: "req-duplicate".to_owned(),
         planned_head_seq: ChangeSeq(0),
         preconditions: Vec::new(),
-        ops: vec![V0CommitOp::CreateDir {
+        ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
             display_name: "alpha".to_owned(),
         }],
@@ -857,22 +859,22 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
         &store,
         &namespace_id,
         vec![
-            V0CommitRequest {
+            ApiCommitRequest {
                 request_id: "req-conflict".to_owned(),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
-                ops: vec![V0CommitOp::CreateDir {
+                ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "alpha".to_owned(),
                 }],
                 message: None,
                 annotations: None,
             },
-            V0CommitRequest {
+            ApiCommitRequest {
                 request_id: "req-conflict".to_owned(),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
-                ops: vec![V0CommitOp::CreateDir {
+                ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "beta".to_owned(),
                 }],
@@ -902,6 +904,178 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(changes.changes[0].request_id, "req-conflict");
+}
+
+#[test]
+fn direct_publisher_path_intents_cover_basic_mutations() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let publisher = DirectObjectStorePublisher::new(&store);
+
+    let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
+    let put = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::PutFile {
+                request_id: "put-path".to_owned(),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("put path");
+    assert_eq!(put.committed_seq, ChangeSeq(1));
+
+    let moved = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::MovePath {
+                request_id: "move-path".to_owned(),
+                from_path: "/docs/a.txt".to_owned(),
+                to_path: "/docs/b.txt".to_owned(),
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("move path");
+    assert_eq!(moved.committed_seq, ChangeSeq(2));
+
+    let copied = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::CopyFilePath {
+                request_id: "copy-path".to_owned(),
+                from_path: "/docs/b.txt".to_owned(),
+                to_path: "/docs/c.txt".to_owned(),
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("copy path");
+    assert_eq!(copied.committed_seq, ChangeSeq(3));
+
+    let deleted = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::DeletePath {
+                request_id: "delete-path".to_owned(),
+                absolute_path: "/docs/b.txt".to_owned(),
+                recursive: false,
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("delete path");
+    assert_eq!(deleted.committed_seq, ChangeSeq(4));
+
+    let copied_bytes =
+        read_file_bytes(&store, &namespace_id, "/docs/c.txt").expect("read copied file");
+    assert_eq!(copied_bytes.bytes, b"hello");
+}
+
+#[test]
+fn direct_publisher_uses_durable_path_request_id_receipts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let publisher = DirectObjectStorePublisher::new(&store);
+    let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
+
+    let intent = PathMutationIntent::PutFile {
+        request_id: "same-path-request".to_owned(),
+        absolute_path: "/same.txt".to_owned(),
+        content_ref: content.content_ref.clone(),
+        behavior: PutFileBehavior::CreateOnly,
+    };
+    let first = publisher
+        .submit_path_intent(
+            &namespace_id,
+            intent.clone(),
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("first publish");
+    let retry = publisher
+        .submit_path_intent(&namespace_id, intent, &context, PublishOptions::default())
+        .expect("idempotent retry");
+    assert_eq!(retry.committed_seq, first.committed_seq);
+
+    let conflict = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::DeletePath {
+                request_id: "same-path-request".to_owned(),
+                absolute_path: "/same.txt".to_owned(),
+                recursive: false,
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect_err("conflicting retry");
+    assert!(matches!(
+        conflict,
+        CoreError::RequestIdConflict(request_id) if request_id == "same-path-request"
+    ));
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+}
+
+#[test]
+fn path_intents_in_one_batch_see_tentative_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
+
+    let responses = publish_namespace_mutations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                request_id: "put-batched-path".to_owned(),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref,
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
+                request_id: "move-batched-path".to_owned(),
+                from_path: "/docs/a.txt".to_owned(),
+                to_path: "/docs/b.txt".to_owned(),
+            }),
+        ],
+        &context,
+    );
+
+    assert_eq!(
+        responses[0].as_ref().expect("put").committed_seq,
+        ChangeSeq(1)
+    );
+    assert_eq!(
+        responses[1].as_ref().expect("move").committed_seq,
+        ChangeSeq(2)
+    );
+    let moved_bytes =
+        read_file_bytes(&store, &namespace_id, "/docs/b.txt").expect("read moved file");
+    assert_eq!(moved_bytes.bytes, b"hello");
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    let wal_bytes = store
+        .get(&wal_keys[0], None)
+        .expect("read wal")
+        .expect("wal exists");
+    let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
+    assert_eq!(segment.payload.records.len(), 2);
 }
 
 #[test]
@@ -1247,13 +1421,13 @@ fn restore_revision_revalidates_durable_content_before_publish() {
     let create = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "restore-create".to_owned(),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
             }],
-            ops: vec![V0CommitOp::CreateFile {
+            ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "restore.txt".to_owned(),
                 content_ref: first.content_ref.clone(),
@@ -1273,13 +1447,13 @@ fn restore_revision_revalidates_durable_content_before_publish() {
     commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "restore-replace".to_owned(),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
             }],
-            ops: vec![V0CommitOp::ReplaceFile {
+            ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no: RevisionNo(1),
                 content_ref: second.content_ref,
@@ -1301,13 +1475,13 @@ fn restore_revision_revalidates_durable_content_before_publish() {
     let error = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "restore-missing-content".to_owned(),
             planned_head_seq: ChangeSeq(2),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(2),
             }],
-            ops: vec![V0CommitOp::RestoreRevision {
+            ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
                 source_revision_no: RevisionNo(1),
                 base_revision_no: RevisionNo(2),
@@ -1381,13 +1555,13 @@ fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
     let error = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "create-missing-parent-missing-content".to_owned(),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
             }],
-            ops: vec![V0CommitOp::CreateFile {
+            ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(99),
                 display_name: "missing.txt".to_owned(),
                 content_ref: content_ref("missing-content"),
@@ -1428,13 +1602,13 @@ fn replace_file_prioritizes_missing_durable_content_over_stale_revision() {
     let error = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "replace-stale-missing-content".to_owned(),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
             }],
-            ops: vec![V0CommitOp::ReplaceFile {
+            ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no: RevisionNo(99),
                 content_ref: content_ref("missing-content"),
@@ -1475,13 +1649,13 @@ fn restore_revision_missing_source_is_revision_not_found() {
     let error = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "restore-missing-source".to_owned(),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
             }],
-            ops: vec![V0CommitOp::RestoreRevision {
+            ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
                 source_revision_no: RevisionNo(99),
                 base_revision_no: RevisionNo(1),
@@ -1506,13 +1680,13 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
     let create = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "resolve-before-durable-check-create".to_owned(),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
             }],
-            ops: vec![V0CommitOp::CreateFile {
+            ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "restore.txt".to_owned(),
                 content_ref: first.content_ref.clone(),
@@ -1539,19 +1713,19 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
     let error = commit_operations(
         &store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "resolve-before-durable-check-commit".to_owned(),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
             }],
             ops: vec![
-                V0CommitOp::ReplaceFile {
+                ApiCommitOp::ReplaceFile {
                     inode_id,
                     base_revision_no: RevisionNo(1),
                     content_ref: second.content_ref.clone(),
                 },
-                V0CommitOp::RestoreRevision {
+                ApiCommitOp::RestoreRevision {
                     inode_id,
                     source_revision_no: RevisionNo(2),
                     base_revision_no: RevisionNo(2),

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1523,13 +1523,13 @@ fn metadata_only_commit_does_not_validate_content_store_refs() {
     let response = commit_operations(
         &guarded_store,
         &namespace_id(),
-        V0CommitRequest {
+        ApiCommitRequest {
             request_id: "metadata-only-delete".to_owned(),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
             }],
-            ops: vec![V0CommitOp::DeleteFile { inode_id }],
+            ops: vec![ApiCommitOp::DeleteFile { inode_id }],
             message: None,
             annotations: None,
         },

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -6,7 +6,7 @@ use loon_api::{
     },
     ChangeSeq, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope, ControlObjectKind,
     FenceToken, HeadState, InodeId, InodeKind, LeaseState, NamespaceDescriptorEnvelope,
-    NamespaceId, RevisionNo,
+    NamespaceDescriptorState, NamespaceId, RevisionNo,
 };
 use loon_core::commit::{
     build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
@@ -814,6 +814,11 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     assert_eq!(clone_basis.head.snapshot_hint_seq, Some(ChangeSeq(1)));
     assert_eq!(clone_basis.head.retention_floor_seq, ChangeSeq(1));
 
+    let duplicate_error =
+        fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+            .expect_err("duplicate fork target");
+    assert_eq!(duplicate_error.kind(), CoreErrorKind::NamespaceExists);
+
     let source_entry =
         resolve_path(&store, &source_namespace_id, "/docs/shared.txt").expect("source stat");
     let clone_entry =
@@ -1025,7 +1030,7 @@ fn fork_target_control_conflict_rechecks_complete_namespace() {
     let descriptor = NamespaceDescriptorEnvelope::from_state(
         ControlObjectKind::NamespaceDescriptor,
         &context.writer_version,
-        loon_api::NamespaceDescriptorState {
+        NamespaceDescriptorState {
             namespace_id: clone_namespace_id.clone(),
             content_store_id,
         },

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -802,6 +802,109 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 }
 
 #[test]
+fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let request = V0CommitRequest {
+        request_id: "req-duplicate".to_owned(),
+        planned_head_seq: ChangeSeq(0),
+        preconditions: Vec::new(),
+        ops: vec![V0CommitOp::CreateDir {
+            parent_inode: InodeId(1),
+            display_name: "alpha".to_owned(),
+        }],
+        message: None,
+        annotations: None,
+    };
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![request.clone(), request],
+        &context,
+    );
+    let first = responses[0].as_ref().expect("primary commit");
+    let duplicate = responses[1].as_ref().expect("duplicate commit");
+    assert_eq!(first, duplicate);
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    let wal_bytes = store
+        .get(&wal_keys[0], None)
+        .expect("read wal")
+        .expect("wal exists");
+    let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
+    assert_eq!(segment.payload.records.len(), 1);
+
+    let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
+    assert_eq!(changes.changes.len(), 1);
+    assert_eq!(changes.changes[0].request_id, "req-duplicate");
+}
+
+#[test]
+fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            V0CommitRequest {
+                request_id: "req-conflict".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: Vec::new(),
+                ops: vec![V0CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "alpha".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+            V0CommitRequest {
+                request_id: "req-conflict".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: Vec::new(),
+                ops: vec![V0CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "beta".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+        &context,
+    );
+
+    responses[0].as_ref().expect("primary commit");
+    let error = responses[1].as_ref().expect_err("duplicate conflict");
+    assert!(matches!(
+        error,
+        CoreError::RequestIdConflict(request_id) if request_id == "req-conflict"
+    ));
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    let wal_bytes = store
+        .get(&wal_keys[0], None)
+        .expect("read wal")
+        .expect("wal exists");
+    let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
+    assert_eq!(segment.payload.records.len(), 1);
+
+    let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
+    assert_eq!(changes.changes.len(), 1);
+    assert_eq!(changes.changes[0].request_id, "req-conflict");
+}
+
+#[test]
 fn namespace_descriptor_checksum_is_validated() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -804,6 +804,68 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 }
 
 #[test]
+fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    let store = StaleHeadAfterWalWriteStore::new(temp_dir.path(), &namespace_id);
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"retry").expect("stage content");
+    let publisher = DirectObjectStorePublisher::new(&store);
+
+    let result = publisher
+        .submit_path_intent(
+            &namespace_id,
+            PathMutationIntent::PutFile {
+                request_id: "retry-after-orphan".to_owned(),
+                absolute_path: "/retry.txt".to_owned(),
+                content_ref: content.content_ref,
+                behavior: PutFileBehavior::CreateOnly,
+            },
+            &context,
+            PublishOptions::default(),
+        )
+        .expect("path intent retries stale head");
+    assert_eq!(result.committed_seq, ChangeSeq(1));
+    assert!(store.injected_stale_head());
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 2);
+
+    let basis = load_verified_namespace_basis(&store, &namespace_id).expect("load basis");
+    assert_eq!(basis.head.seq, ChangeSeq(1));
+    let visible_tip = basis
+        .head
+        .visible_wal_tip
+        .as_ref()
+        .expect("visible wal tip");
+    assert!(wal_keys.contains(&visible_tip.object_key));
+    let orphan_keys = wal_keys
+        .iter()
+        .filter(|key| *key != &visible_tip.object_key)
+        .collect::<Vec<_>>();
+    assert_eq!(orphan_keys.len(), 1);
+
+    let visible_wal = store
+        .get(&visible_tip.object_key, None)
+        .expect("read visible wal")
+        .expect("visible wal exists");
+    let visible_segment =
+        decode_wal_segment_envelope_zstd(&visible_wal).expect("decode visible segment");
+    assert_eq!(visible_segment.payload.start_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload.end_seq, ChangeSeq(1));
+    assert_eq!(visible_segment.payload.records.len(), 1);
+    assert_eq!(
+        visible_segment.payload.records[0].request_id,
+        "retry-after-orphan"
+    );
+
+    let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
+    assert_eq!(changes.changes.len(), 1);
+    assert_eq!(changes.changes[0].request_id, "retry-after-orphan");
+}
+
+#[test]
 fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -2306,6 +2368,80 @@ impl ObjectStore for ContentStoreAccessLimitStore {
         bytes: &[u8],
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
+    }
+}
+
+struct StaleHeadAfterWalWriteStore {
+    inner: LocalFsStore,
+    head_key: String,
+    injected_stale_head: Mutex<bool>,
+}
+
+impl StaleHeadAfterWalWriteStore {
+    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            head_key: namespace_head(namespace_id.as_str()),
+            injected_stale_head: Mutex::new(false),
+        }
+    }
+
+    fn injected_stale_head(&self) -> bool {
+        *self
+            .injected_stale_head
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl ObjectStore for StaleHeadAfterWalWriteStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
+            let should_inject = {
+                let mut injected = self
+                    .injected_stale_head
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if *injected {
+                    false
+                } else {
+                    *injected = true;
+                    true
+                }
+            };
+            if should_inject {
+                if let Some(existing) = self.inner.get(key, None)? {
+                    self.inner.put_overwrite(key, &existing)?;
+                }
+                return Err(ObjectStoreError::PreconditionFailed);
+            }
+        }
         self.inner.put(key, bytes, mode)
     }
 

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,5 +1,5 @@
 use loon_api::{
-    sha256_digest,
+    decode_wal_segment_envelope_zstd, sha256_digest,
     v0::{
         CommitOp as V0CommitOp, CommitPrecondition, CommitRequest as V0CommitRequest,
         CompleteUploadRequest,
@@ -14,11 +14,11 @@ use loon_core::commit::{
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
-    bootstrap_namespace, commit_operations, complete_upload, copy_file_path, delete_path,
-    delete_path_non_recursive, fork_namespace, list_changes_after, list_namespaces,
-    load_verified_namespace_basis, move_path, put_file_bytes, read_file_bytes, resolve_path,
-    store_bytes_as_content, write_file_bytes, CoreError, CoreErrorKind, MutationContext,
-    PutFileBehavior,
+    bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
+    copy_file_path, delete_path, delete_path_non_recursive, fork_namespace, list_changes_after,
+    list_namespaces, load_verified_namespace_basis, move_path, put_file_bytes, read_file_bytes,
+    resolve_path, store_bytes_as_content, write_file_bytes, CoreError, CoreErrorKind,
+    MutationContext, PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
@@ -555,6 +555,7 @@ fn restore_revision_overflow_is_rejected() {
             content_ref: content_ref("content-max"),
         }],
         subtree_tombstones: Vec::new(),
+        request_receipts: Vec::new(),
     };
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
@@ -733,6 +734,71 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
             .expect("list namespace objects"),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn batch_commit_writes_one_segment_and_expands_change_feed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            V0CommitRequest {
+                request_id: "req-batch-a".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: Vec::new(),
+                ops: vec![V0CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "alpha".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+            V0CommitRequest {
+                request_id: "req-batch-b".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: Vec::new(),
+                ops: vec![V0CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "beta".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+        &context,
+    );
+    let first = responses[0].as_ref().expect("first commit");
+    let second = responses[1].as_ref().expect("second commit");
+    assert_eq!(first.committed_seq, ChangeSeq(1));
+    assert_eq!(second.committed_seq, ChangeSeq(2));
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    let wal_bytes = store
+        .get(&wal_keys[0], None)
+        .expect("read wal")
+        .expect("wal exists");
+    let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
+    assert_eq!(segment.payload.start_seq, ChangeSeq(1));
+    assert_eq!(segment.payload.end_seq, ChangeSeq(2));
+    assert_eq!(segment.payload.records.len(), 2);
+    store
+        .put_if_absent(
+            "namespaces/demo/wal/00000000000000000999-00000000000000000999-orphan.cbor.zst",
+            &wal_bytes,
+        )
+        .expect("write unreachable orphan");
+
+    let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
+    assert_eq!(changes.changes.len(), 2);
+    assert_eq!(changes.changes[0].request_id, "req-batch-a");
+    assert_eq!(changes.changes[1].request_id, "req-batch-b");
 }
 
 #[test]
@@ -1843,6 +1909,7 @@ fn metadata_state_after(sequences: &[Vec<loon_api::WalOp>]) -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
+        request_receipts: Vec::new(),
     };
 
     for (index, ops) in sequences.iter().enumerate() {
@@ -1869,6 +1936,7 @@ fn validation_context(
         name_policy: loon_api::NamePolicy::default(),
         snapshot_hint_seq: Some(ChangeSeq(0)),
         retention_floor_seq: ChangeSeq(0),
+        visible_wal_tip: None,
     };
     let lease = LeaseState {
         namespace_id,

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -6,6 +6,7 @@ pub enum SnapshotTableFamily {
     Direntries,
     Revisions,
     Tombstones,
+    RequestReceipts,
 }
 
 impl SnapshotTableFamily {
@@ -15,6 +16,7 @@ impl SnapshotTableFamily {
             Self::Direntries => "direntries",
             Self::Revisions => "revisions",
             Self::Tombstones => "tombstones",
+            Self::RequestReceipts => "request-receipts",
         }
     }
 }
@@ -33,6 +35,10 @@ pub fn namespace_lease(namespace: &str) -> String {
 
 pub fn wal_commit(namespace: &str, seq: u64, commit_id: &str) -> String {
     format!("namespaces/{namespace}/wal/{seq:020}-{commit_id}.cbor.zst")
+}
+
+pub fn wal_segment(namespace: &str, start_seq: u64, end_seq: u64, segment_id: &str) -> String {
+    format!("namespaces/{namespace}/wal/{start_seq:020}-{end_seq:020}-{segment_id}.cbor.zst")
 }
 
 pub fn content_store_descriptor(content_store: &str) -> String {
@@ -111,7 +117,7 @@ mod tests {
         conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
         derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
         sha256_hex_from_digest, snapshot_manifest, snapshot_table, upload_session,
-        upload_session_prefix, wal_commit, SnapshotTableFamily,
+        upload_session_prefix, wal_commit, wal_segment, SnapshotTableFamily,
     };
 
     #[test]
@@ -129,6 +135,10 @@ mod tests {
         assert_eq!(
             wal_commit("ns-1", 420, "commit-123"),
             "namespaces/ns-1/wal/00000000000000000420-commit-123.cbor.zst"
+        );
+        assert_eq!(
+            wal_segment("ns-1", 420, 425, "seg-123"),
+            "namespaces/ns-1/wal/00000000000000000420-00000000000000000425-seg-123.cbor.zst"
         );
         assert_eq!(
             snapshot_manifest("ns-1", 400),

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -1,4 +1,5 @@
 use crate::config::{ServerConfig, ServerConfigError};
+use crate::publisher::PublisherRegistry;
 use axum::body::Bytes;
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -17,11 +18,11 @@ use loon_api::{
     NamespaceIdValidationError,
 };
 use loon_core::{
-    advance_retention_floor, begin_upload, bootstrap_namespace, commit_operations, complete_upload,
-    copy_file_path, create_checkpoint, delete_path_non_recursive, fork_namespace,
-    list_changes_after, list_namespaces, list_path, move_path, put_file_content_ref,
-    read_file_bytes, resolve_path, upload_content, BootstrapNamespaceError, CoreError,
-    CoreErrorKind, MutationContext, PutFileBehavior,
+    advance_retention_floor, begin_upload, bootstrap_namespace, complete_upload, copy_file_path,
+    create_checkpoint, delete_path_non_recursive, fork_namespace, list_changes_after,
+    list_namespaces, list_path, move_path, put_file_content_ref, read_file_bytes, resolve_path,
+    upload_content, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
+    PutFileBehavior,
 };
 use loon_objectstore::ObjectStore;
 use std::net::SocketAddr;
@@ -35,6 +36,7 @@ type SharedStore = Arc<dyn ObjectStore + Send + Sync>;
 struct AppState {
     config: Arc<ServerConfig>,
     store: SharedStore,
+    publisher: PublisherRegistry,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -53,9 +55,12 @@ pub fn app(config: ServerConfig) -> Result<Router, ServerConfigError> {
 }
 
 fn app_with_store(config: ServerConfig, store: SharedStore) -> Router {
+    let config = Arc::new(config);
+    let publisher = PublisherRegistry::new(store.clone(), config.clone());
     let state = AppState {
-        config: Arc::new(config),
+        config,
         store,
+        publisher,
     };
     Router::new()
         .route("/healthz", get(healthz))
@@ -370,19 +375,12 @@ async fn commit_operations_handler(
     Json(request): Json<V0CommitRequest>,
 ) -> Result<Json<V0CommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let store = state.store.clone();
-    let config = state.config.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        commit_operations(
-            store.as_ref(),
-            &namespace_id,
-            request,
-            &mutation_context(&config),
-        )
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .publisher
+        .submit_commit(namespace_id.clone(), request)
+        .await
+        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -559,7 +557,10 @@ impl ApiResponseError {
             CoreErrorKind::TombstoneConflict => (StatusCode::CONFLICT, "tombstone_conflict"),
             CoreErrorKind::LeaseConflict => (StatusCode::CONFLICT, "lease_conflict"),
             CoreErrorKind::WouldCycle => (StatusCode::CONFLICT, "would_cycle"),
-            CoreErrorKind::RequestIdConflict => (StatusCode::CONFLICT, "request_id_conflict"),
+            CoreErrorKind::RequestIdConflict => (StatusCode::CONFLICT, "idempotency_key_conflict"),
+            CoreErrorKind::CommitQueueFull => {
+                (StatusCode::SERVICE_UNAVAILABLE, "commit_queue_full")
+            }
             CoreErrorKind::CheckpointUnavailable => {
                 (StatusCode::CONFLICT, "checkpoint_unavailable")
             }

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -8,8 +8,8 @@ use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use loon_api::{
     v0::{
-        BeginUploadResponse, ChangesResponse, CommitRequest as V0CommitRequest,
-        CommitResponse as V0CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
+        BeginUploadResponse, ChangesResponse, CommitRequest as ApiCommitRequest,
+        CommitResponse as ApiCommitResponse, CompleteUploadRequest, CompleteUploadResponse,
         UploadContentResponse,
     },
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
@@ -18,11 +18,10 @@ use loon_api::{
     NamespaceIdValidationError,
 };
 use loon_core::{
-    advance_retention_floor, begin_upload, bootstrap_namespace, complete_upload, copy_file_path,
-    create_checkpoint, delete_path_non_recursive, fork_namespace, list_changes_after,
-    list_namespaces, list_path, move_path, put_file_content_ref, read_file_bytes, resolve_path,
+    advance_retention_floor, begin_upload, bootstrap_namespace, complete_upload, create_checkpoint,
+    fork_namespace, list_changes_after, list_namespaces, list_path, read_file_bytes, resolve_path,
     upload_content, BootstrapNamespaceError, CoreError, CoreErrorKind, MutationContext,
-    PutFileBehavior,
+    PathMutationIntent, PutFileBehavior,
 };
 use loon_objectstore::ObjectStore;
 use std::net::SocketAddr;
@@ -253,52 +252,47 @@ async fn filesystem_operation(
     Json(request): Json<FilesystemOperationRequest>,
 ) -> Result<Json<FilesystemOperationResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let store = state.store.clone();
-    let config = state.config.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let result = run_blocking(move || {
-        let result = match request.operation {
-            FilesystemOperation::PutFile {
-                path,
-                content_ref,
-                behavior,
-            } => put_file_content_ref(
-                store.as_ref(),
-                &namespace_id,
-                &path,
-                content_ref,
-                map_filesystem_put_behavior(behavior),
-                &mutation_context(&config),
-                Some(&request.request_id),
-            ),
-            FilesystemOperation::DeletePath { path } => delete_path_non_recursive(
-                store.as_ref(),
-                &namespace_id,
-                &path,
-                &mutation_context(&config),
-                Some(&request.request_id),
-            ),
-            FilesystemOperation::MovePath { from_path, to_path } => move_path(
-                store.as_ref(),
-                &namespace_id,
-                &from_path,
-                &to_path,
-                &mutation_context(&config),
-                Some(&request.request_id),
-            ),
-            FilesystemOperation::CopyPath { from_path, to_path } => copy_file_path(
-                store.as_ref(),
-                &namespace_id,
-                &from_path,
-                &to_path,
-                &mutation_context(&config),
-                Some(&request.request_id),
-            ),
-        }
+    let FilesystemOperationRequest {
+        request_id,
+        operation,
+    } = request;
+    let intent = match operation {
+        FilesystemOperation::PutFile {
+            path,
+            content_ref,
+            behavior,
+        } => PathMutationIntent::PutFile {
+            request_id,
+            absolute_path: path,
+            content_ref,
+            behavior: map_filesystem_put_behavior(behavior),
+        },
+        FilesystemOperation::DeletePath { path } => PathMutationIntent::DeletePath {
+            request_id,
+            absolute_path: path,
+            recursive: false,
+        },
+        FilesystemOperation::MovePath { from_path, to_path } => PathMutationIntent::MovePath {
+            request_id,
+            from_path,
+            to_path,
+        },
+        FilesystemOperation::CopyPath { from_path, to_path } => PathMutationIntent::CopyFilePath {
+            request_id,
+            from_path,
+            to_path,
+        },
+    };
+    let response = state
+        .publisher
+        .submit_path_intent(namespace_id.clone(), intent)
+        .await
         .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
-        Ok(FilesystemOperationResponse::from(result))
-    })
-    .await?;
+    let result = FilesystemOperationResponse {
+        namespace_id: response.namespace_id,
+        committed_seq: response.committed_seq,
+    };
     Ok(Json(result))
 }
 
@@ -372,8 +366,8 @@ async fn commit_operations_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Json(request): Json<V0CommitRequest>,
-) -> Result<Json<V0CommitResponse>, ApiResponseError> {
+    Json(request): Json<ApiCommitRequest>,
+) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let response = state
@@ -606,6 +600,8 @@ impl IntoResponse for ApiResponseError {
 mod tests {
     use super::{app_with_store, SharedStore};
     use crate::{ServerConfig, StoreConfig};
+    use loon_api::v0::{CommitOp, CommitPrecondition, CommitRequest};
+    use loon_api::{ChangeSeq, InodeId};
     use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
     use loon_core::{bootstrap_namespace, delete_path, write_file_bytes, MutationContext};
     use loon_objectstore::fs::LocalFsStore;
@@ -879,7 +875,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn http_stale_head_conflict_surfaces_as_409() {
+    async fn http_path_mutation_retries_transient_stale_head_cas() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(StaleHeadOnceStore::new(temp_dir.path(), "demo")) as SharedStore;
         let now_ms = now_ms();
@@ -894,8 +890,48 @@ mod tests {
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
             let target = NamespacePath::parse("demo:/notes/race.txt").expect("target");
+            let result = harness
+                .client
+                .write_file_bytes(&target, b"race")
+                .expect("path write retries stale head");
+            assert_eq!(result.committed_seq, ChangeSeq(1));
+        })
+        .await
+        .expect("join blocking task");
+
+        harness.server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn http_explicit_stale_head_precondition_surfaces_as_409() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let now_ms = now_ms();
+        bootstrap_namespace(
+            store.as_ref(),
+            &"demo".into(),
+            &context("server-writer", now_ms),
+            false,
+        )
+        .expect("bootstrap namespace");
+
+        let harness = start_server(store, temp_dir.path(), "server-writer").await;
+        tokio::task::spawn_blocking(move || {
+            let request = CommitRequest {
+                request_id: "stale-explicit".to_owned(),
+                planned_head_seq: ChangeSeq(1),
+                preconditions: vec![CommitPrecondition::HeadSeqIs {
+                    expected_seq: ChangeSeq(1),
+                }],
+                ops: vec![CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "late".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            };
             assert_api_error(
-                harness.client.write_file_bytes(&target, b"race"),
+                harness.client.commit_operations("demo", &request),
                 409,
                 "stale_head",
                 None,

--- a/crates/loon-server/src/lib.rs
+++ b/crates/loon-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod http;
+mod publisher;
 
 pub use config::{load_server_config, ServerConfig, ServerConfigError, StoreConfig};
 pub use http::{app, serve};

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,8 +1,9 @@
 use crate::config::ServerConfig;
-use loon_api::v0::{CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse};
+use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::{payload_checksum_sha256, NamespaceId};
 use loon_core::{
-    commit::CommitHeadPublishError, commit_operations_batch, CoreError, MutationContext,
+    commit::CommitHeadPublishError, publish_namespace_mutations_batch, CoreError, MutationContext,
+    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation,
 };
 use loon_objectstore::ObjectStore;
 use serde::Serialize;
@@ -13,7 +14,7 @@ use tokio::sync::{oneshot, Notify};
 use tokio::time::{Duration, Instant};
 
 type SharedStore = Arc<dyn ObjectStore + Send + Sync>;
-type CommitResult = Result<V0CommitResponse, CoreError>;
+type CommitResult = Result<ApiCommitResponse, CoreError>;
 
 const MAX_BATCH_CANDIDATES: usize = 1024;
 const COALESCING_DELAY: Duration = Duration::from_millis(100);
@@ -39,7 +40,25 @@ impl PublisherRegistry {
     pub(crate) async fn submit_commit(
         &self,
         namespace_id: NamespaceId,
-        request: V0CommitRequest,
+        request: ApiCommitRequest,
+    ) -> CommitResult {
+        self.submit_candidate(namespace_id, NamespaceMutationCandidate::Commit(request))
+            .await
+    }
+
+    pub(crate) async fn submit_path_intent(
+        &self,
+        namespace_id: NamespaceId,
+        intent: PathMutationIntent,
+    ) -> CommitResult {
+        self.submit_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
+            .await
+    }
+
+    async fn submit_candidate(
+        &self,
+        namespace_id: NamespaceId,
+        candidate: NamespaceMutationCandidate,
     ) -> CommitResult {
         let publisher = {
             let mut publishers = self
@@ -57,7 +76,7 @@ impl PublisherRegistry {
                 })
                 .clone()
         };
-        publisher.submit(request).await
+        publisher.submit(candidate).await
     }
 }
 
@@ -84,7 +103,7 @@ struct OpenBatch {
 #[derive(Clone)]
 struct BatchCandidate {
     request_id: String,
-    request: V0CommitRequest,
+    candidate: NamespaceMutationCandidate,
 }
 
 struct InFlightRequest {
@@ -107,11 +126,11 @@ impl NamespacePublisher {
         }
     }
 
-    async fn submit(&self, request: V0CommitRequest) -> CommitResult {
-        let fingerprint = semantic_fingerprint(&self.namespace_id, &request)
-            .map_err(|err| CoreError::Store(err.to_string()))?;
+    async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
+        let request_id = candidate_request_id(&candidate).to_owned();
+        let fingerprint = candidate_fingerprint(&self.namespace_id, &candidate)?;
         let (sender, receiver) = oneshot::channel();
-        self.admit(request, fingerprint, sender)?;
+        self.admit(request_id, candidate, fingerprint, sender)?;
         receiver
             .await
             .unwrap_or_else(|_| Err(CoreError::Store("publisher task stopped".to_owned())))
@@ -119,7 +138,8 @@ impl NamespacePublisher {
 
     fn admit(
         &self,
-        request: V0CommitRequest,
+        request_id: String,
+        candidate: NamespaceMutationCandidate,
         fingerprint: String,
         waiter: oneshot::Sender<CommitResult>,
     ) -> Result<(), CoreError> {
@@ -130,9 +150,9 @@ impl NamespacePublisher {
                 .state
                 .lock()
                 .expect("namespace publisher mutex poisoned");
-            if let Some(existing) = state.in_flight.get_mut(&request.request_id) {
+            if let Some(existing) = state.in_flight.get_mut(&request_id) {
                 if existing.fingerprint != fingerprint {
-                    return Err(CoreError::RequestIdConflict(request.request_id));
+                    return Err(CoreError::RequestIdConflict(request_id));
                 }
                 existing.waiters.push(waiter);
                 return Ok(());
@@ -156,13 +176,13 @@ impl NamespacePublisher {
                     return Err(CoreError::CommitQueueFull);
                 }
                 batch.candidates.push(BatchCandidate {
-                    request_id: request.request_id.clone(),
-                    request: request.clone(),
+                    request_id: request_id.clone(),
+                    candidate: candidate.clone(),
                 });
                 (batch.candidates.len(), batch.notify.clone())
             };
             state.in_flight.insert(
-                request.request_id,
+                request_id,
                 InFlightRequest {
                     fingerprint,
                     waiters: vec![waiter],
@@ -234,15 +254,20 @@ impl NamespacePublisher {
 
         let mut results = Vec::new();
         for attempt in 0..HEAD_CAS_RETRY_LIMIT {
-            let requests = candidates
+            let batch_candidates = candidates
                 .iter()
-                .map(|candidate| candidate.request.clone())
+                .map(|candidate| candidate.candidate.clone())
                 .collect::<Vec<_>>();
             let namespace_id = self.namespace_id.clone();
             let store = self.store.clone();
             let context = mutation_context(&self.config);
             results = tokio::task::spawn_blocking(move || {
-                commit_operations_batch(store.as_ref(), &namespace_id, requests, &context)
+                publish_namespace_mutations_batch(
+                    store.as_ref(),
+                    &namespace_id,
+                    batch_candidates,
+                    &context,
+                )
             })
             .await
             .unwrap_or_else(|err| vec![Err(CoreError::Store(err.to_string())); candidates.len()]);
@@ -310,6 +335,38 @@ fn is_head_publish_stale(result: &CommitResult) -> bool {
     )
 }
 
+fn candidate_request_id(candidate: &NamespaceMutationCandidate) -> &str {
+    match candidate {
+        NamespaceMutationCandidate::Commit(request) => &request.request_id,
+        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
+            commit_request, ..
+        }) => &commit_request.request_id,
+        NamespaceMutationCandidate::Path(intent) => intent.request_id(),
+    }
+}
+
+fn candidate_fingerprint(
+    namespace_id: &NamespaceId,
+    candidate: &NamespaceMutationCandidate,
+) -> Result<String, CoreError> {
+    match candidate {
+        NamespaceMutationCandidate::Commit(request) => semantic_fingerprint(namespace_id, request)
+            .map_err(|err| CoreError::Store(err.to_string())),
+        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
+            source_request_checksum_sha256: Some(source),
+            ..
+        }) => Ok(source.clone()),
+        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
+            commit_request,
+            source_request_checksum_sha256: None,
+        }) => semantic_fingerprint(namespace_id, commit_request)
+            .map_err(|err| CoreError::Store(err.to_string())),
+        NamespaceMutationCandidate::Path(intent) => {
+            intent.source_request_checksum_sha256(namespace_id)
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct SemanticCommit<'a> {
     namespace_id: &'a NamespaceId,
@@ -323,7 +380,7 @@ struct SemanticCommit<'a> {
 
 fn semantic_fingerprint(
     namespace_id: &NamespaceId,
-    request: &V0CommitRequest,
+    request: &ApiCommitRequest,
 ) -> Result<String, serde_json::Error> {
     payload_checksum_sha256(&SemanticCommit {
         namespace_id,
@@ -355,7 +412,9 @@ mod tests {
     use crate::config::StoreConfig;
     use loon_api::v0::{CommitOp, CommitRequest};
     use loon_api::{ChangeSeq, InodeId};
-    use loon_core::bootstrap_namespace;
+    use loon_core::{
+        bootstrap_namespace, store_bytes_as_content, PathMutationIntent, PutFileBehavior,
+    };
     use loon_objectstore::fs::LocalFsStore;
     use tempfile::tempdir;
 
@@ -416,5 +475,74 @@ mod tests {
 
         let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
         assert_eq!(wal_keys.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_batches_explicit_commit_and_path_intent_together() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let config = Arc::new(ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            auth_token: None,
+            writer_id: "writer-a".to_owned(),
+            writer_version: "test".to_owned(),
+            lease_duration_ms: 60_000,
+            store: StoreConfig::LocalFs {
+                root: temp_dir.path().display().to_string(),
+                key_prefix: None,
+            },
+        });
+        let namespace_id = NamespaceId::from("demo");
+        bootstrap_namespace(
+            store.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let content =
+            store_bytes_as_content(store.as_ref(), &namespace_id, b"hello").expect("stage content");
+        let registry = PublisherRegistry::new(store.clone(), config);
+
+        let explicit = CommitRequest {
+            request_id: "explicit-commit".to_owned(),
+            planned_head_seq: ChangeSeq(0),
+            preconditions: Vec::new(),
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "alpha".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        };
+        let path_intent = PathMutationIntent::PutFile {
+            request_id: "path-put".to_owned(),
+            absolute_path: "/file.txt".to_owned(),
+            content_ref: content.content_ref,
+            behavior: PutFileBehavior::CreateOnly,
+        };
+
+        let (explicit_response, path_response) = tokio::join!(
+            registry.submit_commit(namespace_id.clone(), explicit),
+            registry.submit_path_intent(namespace_id.clone(), path_intent)
+        );
+        assert_eq!(
+            explicit_response.expect("explicit response").committed_seq,
+            ChangeSeq(1)
+        );
+        assert_eq!(
+            path_response.expect("path response").committed_seq,
+            ChangeSeq(2)
+        );
+
+        let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+        assert_eq!(wal_keys.len(), 1);
+        let wal_bytes = store
+            .get(&wal_keys[0], None)
+            .expect("read wal")
+            .expect("wal exists");
+        let segment =
+            loon_api::decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode wal segment");
+        assert_eq!(segment.payload.records.len(), 2);
     }
 }

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -158,12 +158,8 @@ impl NamespacePublisher {
                 return Ok(());
             }
 
-            if state.publishing {
-                return Err(CoreError::CommitQueueFull);
-            }
-
             if state.batch.is_none() {
-                should_spawn = true;
+                should_spawn = !state.publishing;
                 state.batch = Some(OpenBatch {
                     candidates: Vec::new(),
                     notify: Arc::new(Notify::new()),
@@ -194,10 +190,7 @@ impl NamespacePublisher {
         }
 
         if should_spawn {
-            let publisher = self.clone();
-            tokio::spawn(async move {
-                publisher.publish_open_batch().await;
-            });
+            self.spawn_publish_task();
         }
         if let Some(notify) = notify_full {
             notify.notify_one();
@@ -205,22 +198,33 @@ impl NamespacePublisher {
         Ok(())
     }
 
+    fn spawn_publish_task(&self) {
+        let publisher = self.clone();
+        tokio::spawn(async move {
+            publisher.publish_open_batch().await;
+        });
+    }
+
     async fn publish_open_batch(self) {
-        let notify = {
+        let (notify, already_full) = {
             let state = self
                 .state
                 .lock()
                 .expect("namespace publisher mutex poisoned");
-            state
-                .batch
-                .as_ref()
-                .map(|batch| batch.notify.clone())
-                .expect("publish task requires an open batch")
+            let Some(batch) = state.batch.as_ref() else {
+                return;
+            };
+            (
+                batch.notify.clone(),
+                batch.candidates.len() >= MAX_BATCH_CANDIDATES,
+            )
         };
 
-        tokio::select! {
-            _ = tokio::time::sleep(COALESCING_DELAY) => {}
-            _ = notify.notified() => {}
+        if !already_full {
+            tokio::select! {
+                _ = tokio::time::sleep(COALESCING_DELAY) => {}
+                _ = notify.notified() => {}
+            }
         }
 
         loop {
@@ -245,11 +249,11 @@ impl NamespacePublisher {
                 .expect("namespace publisher mutex poisoned");
             state.publishing = true;
             state.next_allowed_cas_at = Instant::now() + MIN_NAMESPACE_CAS_INTERVAL;
-            state
-                .batch
-                .take()
-                .map(|batch| batch.candidates)
-                .unwrap_or_default()
+            let Some(batch) = state.batch.take() else {
+                state.publishing = false;
+                return;
+            };
+            batch.candidates
         };
 
         let mut results = Vec::new();
@@ -307,23 +311,37 @@ impl NamespacePublisher {
 
     fn complete_batch(&self, candidates: Vec<BatchCandidate>, results: Vec<CommitResult>) {
         let mut deliveries = Vec::new();
-        {
+        let should_spawn_next = {
             let mut state = self
                 .state
                 .lock()
                 .expect("namespace publisher mutex poisoned");
             state.publishing = false;
-            for (candidate, result) in candidates.into_iter().zip(results.into_iter()) {
+            let mut results = results.into_iter();
+            for candidate in candidates {
+                let result = results.next().unwrap_or_else(|| {
+                    Err(CoreError::Store(
+                        "publisher returned too few batch results".to_owned(),
+                    ))
+                });
                 if let Some(in_flight) = state.in_flight.remove(&candidate.request_id) {
                     for waiter in in_flight.waiters {
                         deliveries.push((waiter, result.clone()));
                     }
                 }
             }
-        }
+            state
+                .batch
+                .as_ref()
+                .is_some_and(|batch| !batch.candidates.is_empty())
+        };
 
         for (waiter, result) in deliveries {
             let _ = waiter.send(result);
+        }
+
+        if should_spawn_next {
+            self.spawn_publish_task();
         }
     }
 }
@@ -416,7 +434,400 @@ mod tests {
         bootstrap_namespace, store_bytes_as_content, PathMutationIntent, PutFileBehavior,
     };
     use loon_objectstore::fs::LocalFsStore;
+    use loon_objectstore::keys::namespace_head;
+    use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
+    use std::path::Path;
+    use std::sync::Condvar;
     use tempfile::tempdir;
+
+    #[derive(Debug)]
+    struct BlockingHeadCasStore {
+        inner: LocalFsStore,
+        head_key: String,
+        gate: Arc<HeadCasGate>,
+    }
+
+    #[derive(Debug)]
+    struct HeadCasGate {
+        state: Mutex<HeadCasGateState>,
+        cvar: Condvar,
+    }
+
+    #[derive(Debug)]
+    struct HeadCasGateState {
+        blocks_remaining: usize,
+        entered: usize,
+        released: bool,
+    }
+
+    impl BlockingHeadCasStore {
+        fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+            Self {
+                inner: LocalFsStore::new(root.as_ref()).expect("store"),
+                head_key: namespace_head(namespace_id.as_str()),
+                gate: Arc::new(HeadCasGate {
+                    state: Mutex::new(HeadCasGateState {
+                        blocks_remaining: 0,
+                        entered: 0,
+                        released: false,
+                    }),
+                    cvar: Condvar::new(),
+                }),
+            }
+        }
+
+        fn arm_next_head_cas(&self) {
+            let mut state = self.gate.state.lock().expect("head gate mutex poisoned");
+            state.blocks_remaining = 1;
+            state.released = false;
+        }
+
+        async fn wait_for_blocked_head_cas(&self) {
+            let gate = self.gate.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut state = gate.state.lock().expect("head gate mutex poisoned");
+                while state.entered < 1 {
+                    state = gate.cvar.wait(state).expect("head gate mutex poisoned");
+                }
+            })
+            .await
+            .expect("wait for blocked head CAS");
+        }
+
+        fn release_head_cas(&self) {
+            let mut state = self.gate.state.lock().expect("head gate mutex poisoned");
+            state.released = true;
+            self.gate.cvar.notify_all();
+        }
+    }
+
+    impl ObjectStore for BlockingHeadCasStore {
+        fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key)
+        }
+
+        fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+            self.inner.get(key, range)
+        }
+
+        fn put(
+            &self,
+            key: &str,
+            bytes: &[u8],
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
+                let mut state = self.gate.state.lock().expect("head gate mutex poisoned");
+                if state.blocks_remaining > 0 {
+                    state.blocks_remaining -= 1;
+                    state.entered += 1;
+                    self.gate.cvar.notify_all();
+                    while !state.released {
+                        state = self
+                            .gate
+                            .cvar
+                            .wait(state)
+                            .expect("head gate mutex poisoned");
+                    }
+                }
+            }
+            self.inner.put(key, bytes, mode)
+        }
+
+        fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key)
+        }
+
+        fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+            self.inner.list_prefix(prefix)
+        }
+    }
+
+    fn test_config(root: &Path) -> Arc<ServerConfig> {
+        Arc::new(ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            auth_token: None,
+            writer_id: "writer-a".to_owned(),
+            writer_version: "test".to_owned(),
+            lease_duration_ms: 60_000,
+            store: StoreConfig::LocalFs {
+                root: root.display().to_string(),
+                key_prefix: None,
+            },
+        })
+    }
+
+    fn create_dir_request(
+        request_id: impl Into<String>,
+        display_name: impl Into<String>,
+    ) -> CommitRequest {
+        CommitRequest {
+            request_id: request_id.into(),
+            planned_head_seq: ChangeSeq(0),
+            preconditions: Vec::new(),
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: display_name.into(),
+            }],
+            message: None,
+            annotations: None,
+        }
+    }
+
+    fn admit_commit(
+        publisher: &NamespacePublisher,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> oneshot::Receiver<CommitResult> {
+        try_admit_commit(publisher, namespace_id, request).expect("admit commit")
+    }
+
+    fn try_admit_commit(
+        publisher: &NamespacePublisher,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
+        let request_id = request.request_id.clone();
+        let candidate = NamespaceMutationCandidate::Commit(request);
+        let fingerprint = candidate_fingerprint(namespace_id, &candidate)?;
+        let (sender, receiver) = oneshot::channel();
+        publisher.admit(request_id, candidate, fingerprint, sender)?;
+        Ok(receiver)
+    }
+
+    async fn recv_commit(
+        receiver: oneshot::Receiver<CommitResult>,
+        label: &str,
+    ) -> ApiCommitResponse {
+        receiver
+            .await
+            .unwrap_or_else(|err| panic!("{label} receiver dropped: {err}"))
+            .unwrap_or_else(|err| panic!("{label} failed: {err}"))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_admits_pending_batch_while_active_publish_blocks() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        store.arm_next_head_cas();
+        let active = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("active", "active"),
+        );
+        store.wait_for_blocked_head_cas().await;
+
+        let pending = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("pending", "pending"),
+        );
+        {
+            let state = publisher
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            assert!(state.publishing);
+            assert_eq!(
+                state
+                    .batch
+                    .as_ref()
+                    .expect("pending batch")
+                    .candidates
+                    .len(),
+                1
+            );
+        }
+
+        store.release_head_cas();
+        let active_response = recv_commit(active, "active").await;
+        let pending_response = recv_commit(pending, "pending").await;
+        assert_eq!(active_response.committed_seq, ChangeSeq(1));
+        assert_eq!(pending_response.committed_seq, ChangeSeq(2));
+
+        let wal_keys = shared
+            .list_prefix("namespaces/demo/wal/")
+            .expect("list wal");
+        assert_eq!(wal_keys.len(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        store.arm_next_head_cas();
+        let active = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("active", "active"),
+        );
+        store.wait_for_blocked_head_cas().await;
+
+        let duplicate = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("active", "active"),
+        );
+        let conflict = try_admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("active", "different-active"),
+        );
+        assert!(matches!(
+            conflict,
+            Err(CoreError::RequestIdConflict(request_id)) if request_id == "active"
+        ));
+
+        store.release_head_cas();
+        let active_response = recv_commit(active, "active").await;
+        let duplicate_response = recv_commit(duplicate, "duplicate").await;
+        assert_eq!(active_response.committed_seq, ChangeSeq(1));
+        assert_eq!(duplicate_response.committed_seq, ChangeSeq(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        store.arm_next_head_cas();
+        let active = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("active", "active"),
+        );
+        store.wait_for_blocked_head_cas().await;
+
+        let mut pending = Vec::with_capacity(MAX_BATCH_CANDIDATES);
+        for index in 0..MAX_BATCH_CANDIDATES {
+            pending.push(admit_commit(
+                &publisher,
+                &namespace_id,
+                create_dir_request(format!("pending-{index}"), format!("pending-{index}")),
+            ));
+        }
+
+        let duplicate = admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("pending-0", "pending-0"),
+        );
+        let conflict = try_admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("pending-0", "different-pending"),
+        );
+        assert!(matches!(
+            conflict,
+            Err(CoreError::RequestIdConflict(request_id)) if request_id == "pending-0"
+        ));
+
+        let overflow = try_admit_commit(
+            &publisher,
+            &namespace_id,
+            create_dir_request("overflow", "overflow"),
+        );
+        assert!(matches!(overflow, Err(CoreError::CommitQueueFull)));
+
+        store.release_head_cas();
+        assert_eq!(
+            recv_commit(active, "active").await.committed_seq,
+            ChangeSeq(1)
+        );
+        for (index, receiver) in pending.into_iter().enumerate() {
+            assert_eq!(
+                recv_commit(receiver, "pending").await.committed_seq,
+                ChangeSeq(index as u64 + 2)
+            );
+        }
+        assert_eq!(
+            recv_commit(duplicate, "duplicate").await.committed_seq,
+            ChangeSeq(2)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn publisher_full_batch_does_not_wait_on_missed_full_notification() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        store.arm_next_head_cas();
+        let mut receivers = Vec::with_capacity(MAX_BATCH_CANDIDATES);
+        for index in 0..MAX_BATCH_CANDIDATES {
+            receivers.push(admit_commit(
+                &publisher,
+                &namespace_id,
+                create_dir_request(format!("full-{index}"), format!("full-{index}")),
+            ));
+        }
+
+        tokio::task::yield_now().await;
+        {
+            let state = publisher
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            assert!(state.publishing);
+            assert!(state.batch.is_none());
+        }
+        store.release_head_cas();
+        for (index, receiver) in receivers.into_iter().enumerate() {
+            assert_eq!(
+                recv_commit(receiver, "full").await.committed_seq,
+                ChangeSeq(index as u64 + 1)
+            );
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -248,11 +248,11 @@ impl NamespacePublisher {
                 .lock()
                 .expect("namespace publisher mutex poisoned");
             state.publishing = true;
-            state.next_allowed_cas_at = Instant::now() + MIN_NAMESPACE_CAS_INTERVAL;
             let Some(batch) = state.batch.take() else {
                 state.publishing = false;
                 return;
             };
+            state.next_allowed_cas_at = Instant::now() + MIN_NAMESPACE_CAS_INTERVAL;
             batch.candidates
         };
 

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,0 +1,420 @@
+use crate::config::ServerConfig;
+use loon_api::v0::{CommitRequest as V0CommitRequest, CommitResponse as V0CommitResponse};
+use loon_api::{payload_checksum_sha256, NamespaceId};
+use loon_core::{
+    commit::CommitHeadPublishError, commit_operations_batch, CoreError, MutationContext,
+};
+use loon_objectstore::ObjectStore;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{oneshot, Notify};
+use tokio::time::{Duration, Instant};
+
+type SharedStore = Arc<dyn ObjectStore + Send + Sync>;
+type CommitResult = Result<V0CommitResponse, CoreError>;
+
+const MAX_BATCH_CANDIDATES: usize = 1024;
+const COALESCING_DELAY: Duration = Duration::from_millis(100);
+const MIN_NAMESPACE_CAS_INTERVAL: Duration = Duration::from_secs(1);
+const HEAD_CAS_RETRY_LIMIT: usize = 8;
+
+#[derive(Clone)]
+pub(crate) struct PublisherRegistry {
+    inner: Arc<Mutex<HashMap<NamespaceId, NamespacePublisher>>>,
+    store: SharedStore,
+    config: Arc<ServerConfig>,
+}
+
+impl PublisherRegistry {
+    pub(crate) fn new(store: SharedStore, config: Arc<ServerConfig>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            store,
+            config,
+        }
+    }
+
+    pub(crate) async fn submit_commit(
+        &self,
+        namespace_id: NamespaceId,
+        request: V0CommitRequest,
+    ) -> CommitResult {
+        let publisher = {
+            let mut publishers = self
+                .inner
+                .lock()
+                .expect("publisher registry mutex poisoned");
+            publishers
+                .entry(namespace_id.clone())
+                .or_insert_with(|| {
+                    NamespacePublisher::new(
+                        namespace_id.clone(),
+                        self.store.clone(),
+                        self.config.clone(),
+                    )
+                })
+                .clone()
+        };
+        publisher.submit(request).await
+    }
+}
+
+#[derive(Clone)]
+struct NamespacePublisher {
+    namespace_id: NamespaceId,
+    store: SharedStore,
+    config: Arc<ServerConfig>,
+    state: Arc<Mutex<NamespacePublisherState>>,
+}
+
+struct NamespacePublisherState {
+    batch: Option<OpenBatch>,
+    in_flight: HashMap<String, InFlightRequest>,
+    publishing: bool,
+    next_allowed_cas_at: Instant,
+}
+
+struct OpenBatch {
+    candidates: Vec<BatchCandidate>,
+    notify: Arc<Notify>,
+}
+
+#[derive(Clone)]
+struct BatchCandidate {
+    request_id: String,
+    request: V0CommitRequest,
+}
+
+struct InFlightRequest {
+    fingerprint: String,
+    waiters: Vec<oneshot::Sender<CommitResult>>,
+}
+
+impl NamespacePublisher {
+    fn new(namespace_id: NamespaceId, store: SharedStore, config: Arc<ServerConfig>) -> Self {
+        Self {
+            namespace_id,
+            store,
+            config,
+            state: Arc::new(Mutex::new(NamespacePublisherState {
+                batch: None,
+                in_flight: HashMap::new(),
+                publishing: false,
+                next_allowed_cas_at: Instant::now(),
+            })),
+        }
+    }
+
+    async fn submit(&self, request: V0CommitRequest) -> CommitResult {
+        let fingerprint = semantic_fingerprint(&self.namespace_id, &request)
+            .map_err(|err| CoreError::Store(err.to_string()))?;
+        let (sender, receiver) = oneshot::channel();
+        self.admit(request, fingerprint, sender)?;
+        receiver
+            .await
+            .unwrap_or_else(|_| Err(CoreError::Store("publisher task stopped".to_owned())))
+    }
+
+    fn admit(
+        &self,
+        request: V0CommitRequest,
+        fingerprint: String,
+        waiter: oneshot::Sender<CommitResult>,
+    ) -> Result<(), CoreError> {
+        let mut should_spawn = false;
+        let mut notify_full = None;
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            if let Some(existing) = state.in_flight.get_mut(&request.request_id) {
+                if existing.fingerprint != fingerprint {
+                    return Err(CoreError::RequestIdConflict(request.request_id));
+                }
+                existing.waiters.push(waiter);
+                return Ok(());
+            }
+
+            if state.publishing {
+                return Err(CoreError::CommitQueueFull);
+            }
+
+            if state.batch.is_none() {
+                should_spawn = true;
+                state.batch = Some(OpenBatch {
+                    candidates: Vec::new(),
+                    notify: Arc::new(Notify::new()),
+                });
+            }
+
+            let (batch_len, batch_notify) = {
+                let batch = state.batch.as_mut().expect("open batch should exist");
+                if batch.candidates.len() >= MAX_BATCH_CANDIDATES {
+                    return Err(CoreError::CommitQueueFull);
+                }
+                batch.candidates.push(BatchCandidate {
+                    request_id: request.request_id.clone(),
+                    request: request.clone(),
+                });
+                (batch.candidates.len(), batch.notify.clone())
+            };
+            state.in_flight.insert(
+                request.request_id,
+                InFlightRequest {
+                    fingerprint,
+                    waiters: vec![waiter],
+                },
+            );
+            if batch_len >= MAX_BATCH_CANDIDATES {
+                notify_full = Some(batch_notify);
+            }
+        }
+
+        if should_spawn {
+            let publisher = self.clone();
+            tokio::spawn(async move {
+                publisher.publish_open_batch().await;
+            });
+        }
+        if let Some(notify) = notify_full {
+            notify.notify_one();
+        }
+        Ok(())
+    }
+
+    async fn publish_open_batch(self) {
+        let notify = {
+            let state = self
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            state
+                .batch
+                .as_ref()
+                .map(|batch| batch.notify.clone())
+                .expect("publish task requires an open batch")
+        };
+
+        tokio::select! {
+            _ = tokio::time::sleep(COALESCING_DELAY) => {}
+            _ = notify.notified() => {}
+        }
+
+        loop {
+            let sleep_until = {
+                let state = self
+                    .state
+                    .lock()
+                    .expect("namespace publisher mutex poisoned");
+                state.next_allowed_cas_at
+            };
+            let now = Instant::now();
+            if sleep_until <= now {
+                break;
+            }
+            tokio::time::sleep_until(sleep_until).await;
+        }
+
+        let candidates = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            state.publishing = true;
+            state.next_allowed_cas_at = Instant::now() + MIN_NAMESPACE_CAS_INTERVAL;
+            state
+                .batch
+                .take()
+                .map(|batch| batch.candidates)
+                .unwrap_or_default()
+        };
+
+        let mut results = Vec::new();
+        for attempt in 0..HEAD_CAS_RETRY_LIMIT {
+            let requests = candidates
+                .iter()
+                .map(|candidate| candidate.request.clone())
+                .collect::<Vec<_>>();
+            let namespace_id = self.namespace_id.clone();
+            let store = self.store.clone();
+            let context = mutation_context(&self.config);
+            results = tokio::task::spawn_blocking(move || {
+                commit_operations_batch(store.as_ref(), &namespace_id, requests, &context)
+            })
+            .await
+            .unwrap_or_else(|err| vec![Err(CoreError::Store(err.to_string())); candidates.len()]);
+            if !results.iter().any(is_head_publish_stale) {
+                break;
+            }
+            if attempt + 1 == HEAD_CAS_RETRY_LIMIT {
+                break;
+            }
+            self.wait_for_next_cas_token().await;
+        }
+
+        self.complete_batch(candidates, results);
+    }
+
+    async fn wait_for_next_cas_token(&self) {
+        loop {
+            let sleep_until = {
+                let state = self
+                    .state
+                    .lock()
+                    .expect("namespace publisher mutex poisoned");
+                state.next_allowed_cas_at
+            };
+            let now = Instant::now();
+            if sleep_until <= now {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("namespace publisher mutex poisoned");
+                state.next_allowed_cas_at = Instant::now() + MIN_NAMESPACE_CAS_INTERVAL;
+                break;
+            }
+            tokio::time::sleep_until(sleep_until).await;
+        }
+    }
+
+    fn complete_batch(&self, candidates: Vec<BatchCandidate>, results: Vec<CommitResult>) {
+        let mut deliveries = Vec::new();
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("namespace publisher mutex poisoned");
+            state.publishing = false;
+            for (candidate, result) in candidates.into_iter().zip(results.into_iter()) {
+                if let Some(in_flight) = state.in_flight.remove(&candidate.request_id) {
+                    for waiter in in_flight.waiters {
+                        deliveries.push((waiter, result.clone()));
+                    }
+                }
+            }
+        }
+
+        for (waiter, result) in deliveries {
+            let _ = waiter.send(result);
+        }
+    }
+}
+
+fn is_head_publish_stale(result: &CommitResult) -> bool {
+    matches!(
+        result,
+        Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+    )
+}
+
+#[derive(Serialize)]
+struct SemanticCommit<'a> {
+    namespace_id: &'a NamespaceId,
+    request_id: &'a str,
+    planned_head_seq: loon_api::ChangeSeq,
+    preconditions: &'a [loon_api::v0::CommitPrecondition],
+    ops: &'a [loon_api::v0::CommitOp],
+    message: &'a Option<String>,
+    annotations: &'a Option<loon_api::v0::CommitAnnotations>,
+}
+
+fn semantic_fingerprint(
+    namespace_id: &NamespaceId,
+    request: &V0CommitRequest,
+) -> Result<String, serde_json::Error> {
+    payload_checksum_sha256(&SemanticCommit {
+        namespace_id,
+        request_id: &request.request_id,
+        planned_head_seq: request.planned_head_seq,
+        preconditions: &request.preconditions,
+        ops: &request.ops,
+        message: &request.message,
+        annotations: &request.annotations,
+    })
+}
+
+fn mutation_context(config: &ServerConfig) -> MutationContext {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+    MutationContext {
+        writer_id: config.writer_id.clone(),
+        writer_version: config.writer_version.clone(),
+        now_ms,
+        lease_duration_ms: config.lease_duration_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use loon_api::v0::{CommitOp, CommitRequest};
+    use loon_api::{ChangeSeq, InodeId};
+    use loon_core::bootstrap_namespace;
+    use loon_objectstore::fs::LocalFsStore;
+    use tempfile::tempdir;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let config = Arc::new(ServerConfig {
+            bind: "127.0.0.1:0".to_owned(),
+            auth_token: None,
+            writer_id: "writer-a".to_owned(),
+            writer_version: "test".to_owned(),
+            lease_duration_ms: 60_000,
+            store: StoreConfig::LocalFs {
+                root: temp_dir.path().display().to_string(),
+                key_prefix: None,
+            },
+        });
+        let namespace_id = NamespaceId::from("demo");
+        bootstrap_namespace(
+            store.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let registry = PublisherRegistry::new(store.clone(), config);
+
+        let request_a = CommitRequest {
+            request_id: "req-a".to_owned(),
+            planned_head_seq: ChangeSeq(0),
+            preconditions: Vec::new(),
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "alpha".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        };
+        let request_b = CommitRequest {
+            request_id: "req-b".to_owned(),
+            planned_head_seq: ChangeSeq(0),
+            preconditions: Vec::new(),
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "beta".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        };
+
+        let (response_a, response_b) = tokio::join!(
+            registry.submit_commit(namespace_id.clone(), request_a),
+            registry.submit_commit(namespace_id.clone(), request_b)
+        );
+        assert_eq!(response_a.expect("response a").committed_seq, ChangeSeq(1));
+        assert_eq!(response_b.expect("response b").committed_seq, ChangeSeq(2));
+
+        let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+        assert_eq!(wal_keys.len(), 1);
+    }
+}

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -1,7 +1,7 @@
 use loon_api::{
     v0::{
         CommitAnnotations, CommitOp, CommitOpResult, CommitPrecondition,
-        CommitRequest as V0CommitRequest, CompleteUploadRequest,
+        CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, ContentRef, CreateCheckpointResponse, InodeId,
     RevisionNo,
@@ -296,7 +296,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         let mut annotations = CommitAnnotations::new();
         annotations.insert("source".to_owned(), json!("http-smoke"));
         annotations.insert("kind".to_owned(), json!("service-proxied"));
-        let commit_request = V0CommitRequest {
+        let commit_request = ApiCommitRequest {
             request_id: "req-phase-2a-create-file".to_owned(),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -397,7 +397,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .client
             .commit_operations(
                 namespace,
-                &V0CommitRequest {
+                &ApiCommitRequest {
                     request_id: "req-restore-create".to_owned(),
                     planned_head_seq: ChangeSeq(0),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -424,7 +424,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .client
             .commit_operations(
                 namespace,
-                &V0CommitRequest {
+                &ApiCommitRequest {
                     request_id: "req-restore-replace".to_owned(),
                     planned_head_seq: ChangeSeq(1),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -446,7 +446,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .client
             .commit_operations(
                 namespace,
-                &V0CommitRequest {
+                &ApiCommitRequest {
                     request_id: "req-restore-restore".to_owned(),
                     planned_head_seq: ChangeSeq(2),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -524,7 +524,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             .client
             .commit_operations(
                 namespace,
-                &V0CommitRequest {
+                &ApiCommitRequest {
                     request_id: "req-restore-missing-source-create".to_owned(),
                     planned_head_seq: ChangeSeq(0),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -547,7 +547,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
 
         match harness.client.commit_operations(
             namespace,
-            &V0CommitRequest {
+            &ApiCommitRequest {
                 request_id: "req-restore-missing-source-restore".to_owned(),
                 planned_head_seq: ChangeSeq(1),
                 preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -595,7 +595,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
 
         let first_content_ref =
             stage_uploaded_content_ref(&harness.client, namespace, b"first payload\n");
-        let first_request = V0CommitRequest {
+        let first_request = ApiCommitRequest {
             request_id: "req-phase-2a-conflict".to_owned(),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
@@ -618,7 +618,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
             stage_uploaded_content_ref(&harness.client, namespace, b"second payload\n");
         let mut changed_annotations = BTreeMap::new();
         changed_annotations.insert("source".to_owned(), json!("changed"));
-        let conflicting_request = V0CommitRequest {
+        let conflicting_request = ApiCommitRequest {
             request_id: first_request.request_id.clone(),
             planned_head_seq: ChangeSeq(0),
             preconditions: first_request.preconditions.clone(),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -635,8 +635,10 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
             .client
             .commit_operations(namespace, &conflicting_request)
         {
-            Err(ClientError::Api { code, .. }) => assert_eq!(code, "request_id_conflict"),
-            other => panic!("expected request_id_conflict, got {other:?}"),
+            Err(ClientError::Api { code, .. }) => {
+                assert_eq!(code, "idempotency_key_conflict")
+            }
+            other => panic!("expected idempotency_key_conflict, got {other:?}"),
         }
     })
     .await
@@ -687,8 +689,10 @@ async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
             false,
             request_id,
         ) {
-            Err(ClientError::Api { code, .. }) => assert_eq!(code, "request_id_conflict"),
-            other => panic!("expected request_id_conflict, got {other:?}"),
+            Err(ClientError::Api { code, .. }) => {
+                assert_eq!(code, "idempotency_key_conflict")
+            }
+            other => panic!("expected idempotency_key_conflict, got {other:?}"),
         }
     })
     .await


### PR DESCRIPTION
This PR makes namespace publication explicitly batched. Instead of every mutation publishing its own single-commit WAL object (max 1 commit per second on R2/GCS), the namespace publisher coalesces accepted candidates into ordered WAL segments, writes the segment durably, and only makes it visible once the namespace head CAS points at that segment tip. 

Note that this keeps the WAL-before-head boundary strict: orphan WAL segments from failed or ambiguous CAS attempts are ignored, and readers replay only the visible chain from HeadState.visible_wal_tip.

This also routes path-oriented mutations through the same publisher path as explicit commit requests. Local mode uses an immediate direct publisher (which will still be limited to 1 WAL entry per second, but will follow the same publisher code path for simplicity) with durable request-id receipts and stale-head retry for path intents. Server mode uses the same durable semantics plus per-namespace batching, duplicate waiter joining, bounded pending admission, and contiguous seq assignment within each visible segment (which doesn't make sense in local mode, unless we change local mode to behave more like a client over a local server).

Some details on the batching behavior:
Server-side publishing batches on a short coalescing window rather than trying to publish every request immediately (this is because it's logical to expect a few rapid commits during a normal PUT operation, and it would be frustrating as a user if the WAL batch eagerly committed as soon as the first one arrives, "locking out" fast-follow commits for 1s). The first admitted mutation opens a namespace batch; the publisher waits up to 100ms to coalesce more work (we may want to tune this... 250ms?), or publishes sooner if the batch reaches the cap. Each pending batch admits at most 1024 distinct request IDs. With double buffering, one sealed batch can be publishing while one pending batch is filling (this prevents the server from rejecting commits during publishing which was a frustrating experience during testing), so the practical per-namespace in-memory bound is 1024 active candidates plus 1024 pending candidates, excluding duplicate waiters. Head/lease CAS attempts remain rate-limited to one namespace CAS attempt per second. We should expect the batch size to be able to increase as we benchmark performance and memory usage (10k commits/s per namespace is a good target). 