### PR TITLE
Core/add basic performance optimizations

### DIFF
--- a/crates/loon-core/src/commit.rs
+++ b/crates/loon-core/src/commit.rs
@@ -1,4 +1,4 @@
-use crate::metadata::MetadataState;
+use crate::metadata::{IndexedMetadataState, MetadataState};
 use loon_api::{
     v0::CommitAnnotations, ChangeSeq, ContentRef, FenceToken, HeadState, HeadStateEnvelope,
     InodeId, InodeKind, LeaseState, NamespaceId, RevisionNo,
@@ -10,7 +10,7 @@ mod ordered;
 mod publish;
 
 pub use self::ordered::build_commit_plan;
-pub(crate) use self::ordered::resolve_restore_content_refs;
+pub(crate) use self::ordered::{build_commit_plan_indexed, resolve_restore_content_refs_indexed};
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -103,6 +103,14 @@ pub struct CommitValidationContext {
     pub now_ms: u64,
     #[serde(default)]
     pub metadata_state: MetadataState,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IndexedCommitValidationContext<'a> {
+    pub head: &'a HeadState,
+    pub lease: &'a LeaseState,
+    pub now_ms: u64,
+    pub metadata_state: &'a IndexedMetadataState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-core/src/commit/frame.rs
+++ b/crates/loon-core/src/commit/frame.rs
@@ -27,7 +27,14 @@ pub(super) fn validate_commit_request_frame(
         });
     }
 
-    validate_head_seq_preconditions(&request.preconditions, context.head.seq)?;
+    if request.planned_head_seq != context.head.seq {
+        return Err(CommitValidationError::PlannedHeadSeqMismatch {
+            expected: context.head.seq,
+            actual: request.planned_head_seq,
+        });
+    }
+
+    validate_head_seq_preconditions(&request.preconditions, request.planned_head_seq)?;
 
     if request.writer_fence_token != context.head.active_fence_token {
         return Err(CommitValidationError::StaleWriterFenceToken {
@@ -55,17 +62,25 @@ pub(super) fn validate_commit_request_frame(
 
 fn validate_head_seq_preconditions(
     preconditions: &[Precondition],
-    current_head_seq: ChangeSeq,
+    planned_head_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
+    let mut saw_head_seq_precondition = false;
     for precondition in preconditions {
         if let Precondition::HeadSeqIs(actual) = precondition {
-            if *actual != current_head_seq {
+            saw_head_seq_precondition = true;
+            if *actual != planned_head_seq {
                 return Err(CommitValidationError::ConflictingHeadSeqPrecondition {
-                    expected: current_head_seq,
+                    expected: planned_head_seq,
                     actual: *actual,
                 });
             }
         }
+    }
+
+    if !saw_head_seq_precondition {
+        return Err(CommitValidationError::MissingHeadSeqPrecondition {
+            expected: planned_head_seq,
+        });
     }
 
     Ok(())

--- a/crates/loon-core/src/commit/frame.rs
+++ b/crates/loon-core/src/commit/frame.rs
@@ -1,59 +1,97 @@
-use super::{CommitRequest, CommitValidationContext, CommitValidationError, Precondition};
+use super::{
+    CommitRequest, CommitValidationContext, CommitValidationError, IndexedCommitValidationContext,
+    Precondition,
+};
 use crate::namespace::head_and_lease_fence_tokens_agree;
-use loon_api::ChangeSeq;
+use loon_api::{ChangeSeq, HeadState, LeaseState};
 
-pub(super) fn validate_commit_request_frame(
+pub(super) trait CommitFrameContext {
+    fn head(&self) -> &HeadState;
+    fn lease(&self) -> &LeaseState;
+    fn now_ms(&self) -> u64;
+}
+
+impl CommitFrameContext for CommitValidationContext {
+    fn head(&self) -> &HeadState {
+        &self.head
+    }
+
+    fn lease(&self) -> &LeaseState {
+        &self.lease
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.now_ms
+    }
+}
+
+impl CommitFrameContext for IndexedCommitValidationContext<'_> {
+    fn head(&self) -> &HeadState {
+        self.head
+    }
+
+    fn lease(&self) -> &LeaseState {
+        self.lease
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.now_ms
+    }
+}
+
+pub(super) fn validate_commit_request_frame<C: CommitFrameContext>(
     request: &CommitRequest,
-    context: &CommitValidationContext,
+    context: &C,
 ) -> Result<(), CommitValidationError> {
+    let head = context.head();
+    let lease = context.lease();
+
     if request.ops.is_empty() {
         return Err(CommitValidationError::EmptyCommit);
     }
 
-    if request.namespace_id != context.head.namespace_id
-        || request.namespace_id != context.lease.namespace_id
-    {
+    if request.namespace_id != head.namespace_id || request.namespace_id != lease.namespace_id {
         return Err(CommitValidationError::NamespaceMismatch);
     }
 
-    if context.head.namespace_id != context.lease.namespace_id {
+    if head.namespace_id != lease.namespace_id {
         return Err(CommitValidationError::HeadLeaseNamespaceMismatch);
     }
 
-    if !head_and_lease_fence_tokens_agree(&context.head, &context.lease) {
+    if !head_and_lease_fence_tokens_agree(head, lease) {
         return Err(CommitValidationError::HeadLeaseFenceMismatch {
-            head: context.head.active_fence_token,
-            lease: context.lease.fence_token,
+            head: head.active_fence_token,
+            lease: lease.fence_token,
         });
     }
 
-    if request.planned_head_seq != context.head.seq {
+    if request.planned_head_seq != head.seq {
         return Err(CommitValidationError::PlannedHeadSeqMismatch {
-            expected: context.head.seq,
+            expected: head.seq,
             actual: request.planned_head_seq,
         });
     }
 
     validate_head_seq_preconditions(&request.preconditions, request.planned_head_seq)?;
 
-    if request.writer_fence_token != context.head.active_fence_token {
+    if request.writer_fence_token != head.active_fence_token {
         return Err(CommitValidationError::StaleWriterFenceToken {
-            active: context.head.active_fence_token,
+            active: head.active_fence_token,
             requested: request.writer_fence_token,
         });
     }
 
-    if request.writer_id != context.lease.holder_id {
+    if request.writer_id != lease.holder_id {
         return Err(CommitValidationError::LeaseHolderMismatch {
-            expected: context.lease.holder_id.clone(),
+            expected: lease.holder_id.clone(),
             actual: request.writer_id.clone(),
         });
     }
 
-    if !context.lease.is_valid_at(context.now_ms) {
+    if !lease.is_valid_at(context.now_ms()) {
         return Err(CommitValidationError::LeaseExpired {
-            lease_expires_at_ms: context.lease.lease_expires_at_ms,
-            now_ms: context.now_ms,
+            lease_expires_at_ms: lease.lease_expires_at_ms,
+            now_ms: context.now_ms(),
         });
     }
 

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -1,10 +1,10 @@
 use super::frame::validate_commit_request_frame;
 use super::{
     push_unique_invariant, CommitOp, CommitPlan, CommitRequest, CommitValidationContext,
-    CommitValidationError,
+    CommitValidationError, IndexedCommitValidationContext,
 };
 use crate::invariants::INVARIANTS;
-use crate::metadata::MetadataState;
+use crate::metadata::{CurrentMetadataView, IndexedMetadataState, MetadataOverlay, RevisionRecord};
 use loon_api::{
     name_key_for_display_name, ChangeSeq, ContentRef, InodeId, InodeKind, NamePolicy, RevisionNo,
     WalOp,
@@ -17,9 +17,9 @@ struct CommitShape {
     resulting_next_inode_id: InodeId,
 }
 
-pub(crate) fn resolve_restore_content_refs(
+pub(crate) fn resolve_restore_content_refs_indexed(
     request: &CommitRequest,
-    context: &CommitValidationContext,
+    context: &IndexedCommitValidationContext<'_>,
 ) -> Vec<Option<ContentRef>> {
     let mut resolved_request_revisions = BTreeMap::<(InodeId, RevisionNo), ContentRef>::new();
 
@@ -49,7 +49,7 @@ pub(crate) fn resolve_restore_content_refs(
                     .or_else(|| {
                         context
                             .metadata_state
-                            .revision_at_seq(*inode_id, *source_revision, context.head.seq)
+                            .revision(*inode_id, *source_revision)
                             .map(|revision| revision.content_ref)
                     });
                 if let (Some(next_revision), Some(content_ref)) = (
@@ -69,6 +69,21 @@ pub fn build_commit_plan(
     request: &CommitRequest,
     context: &CommitValidationContext,
 ) -> Result<CommitPlan, CommitValidationError> {
+    let indexed =
+        IndexedMetadataState::from_metadata_state(context.metadata_state.clone(), context.head.seq);
+    let indexed_context = IndexedCommitValidationContext {
+        head: &context.head,
+        lease: &context.lease,
+        now_ms: context.now_ms,
+        metadata_state: &indexed,
+    };
+    build_commit_plan_indexed(request, &indexed_context)
+}
+
+pub(crate) fn build_commit_plan_indexed(
+    request: &CommitRequest,
+    context: &IndexedCommitValidationContext<'_>,
+) -> Result<CommitPlan, CommitValidationError> {
     validate_commit_request_frame(request, context)?;
 
     let mut checked_invariants = INVARIANTS
@@ -87,7 +102,7 @@ pub fn build_commit_plan(
     let shape = compute_commit_shape(request, context)?;
     let resolved_restore_content_refs = validate_metadata_preconditions(
         request,
-        &context.metadata_state,
+        context.metadata_state,
         shape.next_seq,
         &shape.allocated_inode_ids,
         &mut checked_invariants,
@@ -156,7 +171,7 @@ pub fn build_commit_plan(
 
 fn compute_commit_shape(
     request: &CommitRequest,
-    context: &CommitValidationContext,
+    context: &IndexedCommitValidationContext<'_>,
 ) -> Result<CommitShape, CommitValidationError> {
     let next_seq = context
         .head
@@ -202,12 +217,12 @@ fn compute_commit_shape(
 
 fn validate_metadata_preconditions(
     request: &CommitRequest,
-    metadata_state: &MetadataState,
+    metadata_state: &IndexedMetadataState,
     committed_seq: ChangeSeq,
     allocated_inode_ids: &[InodeId],
     checked_invariants: &mut Vec<String>,
 ) -> Result<Vec<Option<ContentRef>>, CommitValidationError> {
-    let mut ephemeral_metadata_state = metadata_state.clone();
+    let mut ephemeral_metadata_state = MetadataOverlay::new(metadata_state, committed_seq);
     let mut allocated_inode_ids = allocated_inode_ids.iter().copied();
     let mut resolved_restore_content_refs = Vec::with_capacity(request.ops.len());
 
@@ -220,17 +235,11 @@ fn validate_metadata_preconditions(
                 source_revision,
                 base_revision,
             } => {
-                validate_restore_target(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    *base_revision,
-                    committed_seq,
-                )?;
+                validate_restore_target(&ephemeral_metadata_state, *inode_id, *base_revision)?;
                 let source_revision = validate_restore_source_revision(
                     &ephemeral_metadata_state,
                     *inode_id,
                     *source_revision,
-                    committed_seq,
                 )?;
                 if base_revision.0.checked_add(1).is_none() {
                     return Err(CommitValidationError::RestoreRevisionOverflow {
@@ -241,7 +250,6 @@ fn validate_metadata_preconditions(
                 validate_restore_not_covered(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )?;
                 Some(source_revision.content_ref)
@@ -258,16 +266,10 @@ fn validate_metadata_preconditions(
                 display_name,
                 ..
             } => {
-                validate_child_name_absent(
-                    &ephemeral_metadata_state,
-                    *parent_inode,
-                    display_name,
-                    committed_seq,
-                )?;
+                validate_child_name_absent(&ephemeral_metadata_state, *parent_inode, display_name)?;
                 validate_ancestors_not_subtree_deleted(
                     &ephemeral_metadata_state,
                     *parent_inode,
-                    committed_seq,
                     checked_invariants,
                     true,
                 )?;
@@ -277,12 +279,7 @@ fn validate_metadata_preconditions(
                 base_revision,
                 ..
             } => {
-                validate_inode_revision_is(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    *base_revision,
-                    committed_seq,
-                )?;
+                validate_inode_revision_is(&ephemeral_metadata_state, *inode_id, *base_revision)?;
                 if base_revision.0.checked_add(1).is_none() {
                     return Err(CommitValidationError::ReplaceFileRevisionOverflow {
                         inode_id: *inode_id,
@@ -292,18 +289,16 @@ fn validate_metadata_preconditions(
                 validate_ancestors_not_subtree_deleted(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                     false,
                 )?;
             }
             CommitOp::RestoreRevision { .. } => {}
             CommitOp::DeleteFile { inode_id } => {
-                validate_delete_file_target(&ephemeral_metadata_state, *inode_id, committed_seq)?;
+                validate_delete_file_target(&ephemeral_metadata_state, *inode_id)?;
                 validate_delete_file_not_covered(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )?;
             }
@@ -312,60 +307,50 @@ fn validate_metadata_preconditions(
                 new_parent_inode,
                 new_display_name,
             } => {
-                validate_rename_source(&ephemeral_metadata_state, *inode_id, committed_seq)?;
+                validate_rename_source(&ephemeral_metadata_state, *inode_id)?;
                 validate_rename_target_name_absent(
                     &ephemeral_metadata_state,
                     *new_parent_inode,
                     new_display_name,
-                    committed_seq,
                 )?;
                 validate_rename_does_not_cycle(
                     &ephemeral_metadata_state,
                     *inode_id,
                     *new_parent_inode,
-                    committed_seq,
                 )?;
                 validate_rename_inode_not_covered(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )?;
                 validate_rename_target_parent_not_covered(
                     &ephemeral_metadata_state,
                     *new_parent_inode,
-                    committed_seq,
                     checked_invariants,
                 )?;
             }
             CommitOp::DeleteSubtree { root_inode } => {
-                validate_delete_subtree_root(
-                    &ephemeral_metadata_state,
-                    *root_inode,
-                    committed_seq,
-                )?;
+                validate_delete_subtree_root(&ephemeral_metadata_state, *root_inode)?;
                 validate_delete_subtree_not_covered(
                     &ephemeral_metadata_state,
                     *root_inode,
-                    committed_seq,
                     checked_invariants,
                 )?;
             }
         }
         resolved_restore_content_refs.push(resolved_restore_content_ref.clone());
 
-        let applied_metadata = ephemeral_metadata_state
-            .apply_committed_wal_ops(
+        ephemeral_metadata_state
+            .apply_committed_wal_op(
                 committed_seq,
-                &[materialize_simulated_wal_op(
+                &materialize_simulated_wal_op(
                     op,
                     op_index,
                     resolved_restore_content_ref.as_ref(),
                     &mut allocated_inode_ids,
-                )?],
+                )?,
             )
             .expect("validated commit ops should always apply into ephemeral metadata state");
-        ephemeral_metadata_state = applied_metadata.metadata_state;
     }
 
     Ok(resolved_restore_content_refs)
@@ -452,13 +437,12 @@ fn materialize_simulated_wal_op(
 }
 
 fn validate_child_name_absent(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     parent_inode: InodeId,
     display_name: &str,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
-        .inode_at_seq(parent_inode, base_seq)
+        .inode(parent_inode)
         .ok_or(CommitValidationError::CreateParentMissing { parent_inode })?;
     if parent.inode_kind != InodeKind::Dir {
         return Err(CommitValidationError::CreateParentNotDirectory {
@@ -467,7 +451,7 @@ fn validate_child_name_absent(
         });
     }
 
-    if let Some(existing) = metadata_state.visible_child(parent_inode, display_name, base_seq) {
+    if let Some(existing) = metadata_state.visible_child(parent_inode, display_name) {
         return Err(CommitValidationError::CreateChildNameCollision {
             parent_inode,
             name_key: name_key_for_display_name(NamePolicy::default(), display_name),
@@ -479,13 +463,12 @@ fn validate_child_name_absent(
 }
 
 fn validate_inode_revision_is(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
     expected_revision: RevisionNo,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
-        .inode_at_seq(inode_id, base_seq)
+        .inode(inode_id)
         .ok_or(CommitValidationError::ReplaceFileInodeMissing { inode_id })?;
     if inode.inode_kind != InodeKind::File {
         return Err(CommitValidationError::ReplaceFileInodeNotFile {
@@ -495,7 +478,7 @@ fn validate_inode_revision_is(
     }
 
     let actual_revision = metadata_state
-        .latest_revision_head_at_seq(inode_id, base_seq)
+        .latest_revision_head(inode_id)
         .map(|revision| revision.revision_no);
     if actual_revision != Some(expected_revision) {
         return Err(CommitValidationError::ReplaceFileBaseRevisionMismatch {
@@ -509,13 +492,12 @@ fn validate_inode_revision_is(
 }
 
 fn validate_restore_target(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
     expected_revision: RevisionNo,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
-        .inode_at_seq(inode_id, base_seq)
+        .inode(inode_id)
         .ok_or(CommitValidationError::RestoreRevisionInodeMissing { inode_id })?;
     if inode.inode_kind != InodeKind::File {
         return Err(CommitValidationError::RestoreRevisionInodeNotFile {
@@ -525,7 +507,7 @@ fn validate_restore_target(
     }
 
     let actual_revision = metadata_state
-        .latest_revision_head_at_seq(inode_id, base_seq)
+        .latest_revision_head(inode_id)
         .map(|revision| revision.revision_no);
     if actual_revision != Some(expected_revision) {
         return Err(CommitValidationError::RestoreRevisionBaseRevisionMismatch {
@@ -539,29 +521,25 @@ fn validate_restore_target(
 }
 
 fn validate_restore_source_revision(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
     source_revision: RevisionNo,
-    base_seq: ChangeSeq,
-) -> Result<crate::metadata::RevisionRecord, CommitValidationError> {
-    metadata_state
-        .revision_at_seq(inode_id, source_revision, base_seq)
-        .ok_or(
-            CommitValidationError::RestoreRevisionSourceRevisionMissing {
-                inode_id,
-                source_revision,
-            },
-        )
+) -> Result<RevisionRecord, CommitValidationError> {
+    metadata_state.revision(inode_id, source_revision).ok_or(
+        CommitValidationError::RestoreRevisionSourceRevisionMissing {
+            inode_id,
+            source_revision,
+        },
+    )
 }
 
 fn validate_ancestors_not_subtree_deleted(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
     is_create: bool,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id) {
         return if is_create {
             Err(CommitValidationError::CreateUnderSubtreeTombstone {
                 parent_inode: inode_id,
@@ -585,12 +563,11 @@ fn validate_ancestors_not_subtree_deleted(
 }
 
 fn validate_restore_not_covered(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id) {
         return Err(
             CommitValidationError::RestoreRevisionUnderSubtreeTombstone {
                 inode_id,
@@ -608,12 +585,11 @@ fn validate_restore_not_covered(
 }
 
 fn validate_delete_subtree_root(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     root_inode: InodeId,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
-        .inode_at_seq(root_inode, base_seq)
+        .inode(root_inode)
         .ok_or(CommitValidationError::DeleteSubtreeRootMissing { root_inode })?;
     if inode.inode_kind != InodeKind::Dir {
         return Err(CommitValidationError::DeleteSubtreeRootNotDirectory {
@@ -626,12 +602,11 @@ fn validate_delete_subtree_root(
 }
 
 fn validate_delete_file_target(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
-        .inode_at_seq(inode_id, base_seq)
+        .inode(inode_id)
         .ok_or(CommitValidationError::DeleteFileInodeMissing { inode_id })?;
     if inode.inode_kind != InodeKind::File {
         return Err(CommitValidationError::DeleteFileInodeNotFile {
@@ -644,12 +619,11 @@ fn validate_delete_file_target(
 }
 
 fn validate_delete_file_not_covered(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id) {
         return Err(CommitValidationError::DeleteFileCoveredByTombstone {
             inode_id,
             covering_root_inode: tombstone.root_inode_id,
@@ -665,12 +639,11 @@ fn validate_delete_file_not_covered(
 }
 
 fn validate_delete_subtree_not_covered(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     root_inode: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(root_inode, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(root_inode) {
         return Err(CommitValidationError::DeleteSubtreeRootCoveredByTombstone {
             root_inode,
             covering_root_inode: tombstone.root_inode_id,
@@ -686,15 +659,14 @@ fn validate_delete_subtree_not_covered(
 }
 
 fn validate_rename_source(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     metadata_state
-        .inode_at_seq(inode_id, base_seq)
+        .inode(inode_id)
         .ok_or(CommitValidationError::RenameInodeMissing { inode_id })?;
     if metadata_state
-        .current_parent_binding_for_child(inode_id, base_seq)
+        .current_parent_binding_for_child(inode_id)
         .is_none()
     {
         return Err(CommitValidationError::RenameSourceBindingMissing { inode_id });
@@ -704,13 +676,12 @@ fn validate_rename_source(
 }
 
 fn validate_rename_target_name_absent(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     parent_inode: InodeId,
     display_name: &str,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
-        .inode_at_seq(parent_inode, base_seq)
+        .inode(parent_inode)
         .ok_or(CommitValidationError::RenameTargetParentMissing { parent_inode })?;
     if parent.inode_kind != InodeKind::Dir {
         return Err(CommitValidationError::RenameTargetParentNotDirectory {
@@ -719,7 +690,7 @@ fn validate_rename_target_name_absent(
         });
     }
 
-    if let Some(existing) = metadata_state.visible_child(parent_inode, display_name, base_seq) {
+    if let Some(existing) = metadata_state.visible_child(parent_inode, display_name) {
         return Err(CommitValidationError::RenameTargetNameCollision {
             parent_inode,
             name_key: name_key_for_display_name(NamePolicy::default(), display_name),
@@ -731,18 +702,17 @@ fn validate_rename_target_name_absent(
 }
 
 fn validate_rename_does_not_cycle(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
     new_parent_inode: InodeId,
-    base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
-        .inode_at_seq(inode_id, base_seq)
+        .inode(inode_id)
         .ok_or(CommitValidationError::RenameInodeMissing { inode_id })?;
     if inode.inode_kind != InodeKind::Dir {
         return Ok(());
     }
-    if metadata_state.would_create_directory_cycle(inode_id, new_parent_inode, base_seq) {
+    if metadata_state.would_create_directory_cycle(inode_id, new_parent_inode) {
         return Err(CommitValidationError::RenameWouldCycleDirectory {
             inode_id,
             new_parent_inode,
@@ -753,12 +723,11 @@ fn validate_rename_does_not_cycle(
 }
 
 fn validate_rename_inode_not_covered(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     inode_id: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id) {
         return Err(CommitValidationError::RenameInodeUnderSubtreeTombstone {
             inode_id,
             root_inode: tombstone.root_inode_id,
@@ -774,12 +743,11 @@ fn validate_rename_inode_not_covered(
 }
 
 fn validate_rename_target_parent_not_covered(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     parent_inode: InodeId,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<String>,
 ) -> Result<(), CommitValidationError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(parent_inode, base_seq) {
+    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(parent_inode) {
         return Err(
             CommitValidationError::RenameTargetParentUnderSubtreeTombstone {
                 parent_inode,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -29,9 +29,10 @@ pub use protocol::{
     upload_content,
 };
 pub use publisher::{
-    publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
-    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation, PlannedPathMutation,
-    PublishOptions,
+    publish_namespace_mutations_batch, publish_namespace_mutations_batch_with_basis,
+    publish_namespace_mutations_batch_with_fresh_basis, DirectObjectStorePublisher, FlushPolicy,
+    NamespaceBatchPublishResult, NamespaceMutationCandidate, PathMutationIntent,
+    PlannedNamespaceMutation, PlannedPathMutation, PublishOptions,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -3,7 +3,7 @@ use loon_api::{
     NamePolicy, RevisionNo, WalCommitPayload, WalOp,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -104,6 +104,808 @@ pub enum MetadataApplyError {
         inode_id: InodeId,
         base_revision: RevisionNo,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexedMetadataState {
+    head_seq: ChangeSeq,
+    metadata_state: MetadataState,
+    index: MetadataIndexMaps,
+}
+
+#[derive(Debug)]
+pub struct MetadataOverlay<'a> {
+    base: &'a IndexedMetadataState,
+    visible_seq: ChangeSeq,
+    rows: MetadataDeltaRows,
+    index: MetadataIndexMaps,
+}
+
+#[derive(Debug, Clone, Default)]
+struct MetadataIndexMaps {
+    inode_by_id: HashMap<InodeId, InodeRecord>,
+    latest_revision_by_inode: HashMap<InodeId, RevisionRecord>,
+    revision_by_inode_no: HashMap<(InodeId, RevisionNo), RevisionRecord>,
+    latest_binding_by_parent_name: HashMap<(InodeId, String), DirentryRecord>,
+    latest_parent_binding_by_child: HashMap<InodeId, DirentryRecord>,
+    tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
+    request_receipt_by_id: HashMap<String, RequestReceiptRecord>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct MetadataDeltaRows {
+    inodes: Vec<InodeRecord>,
+    direntries: Vec<DirentryRecord>,
+    revisions: Vec<RevisionRecord>,
+    subtree_tombstones: Vec<SubtreeTombstoneRecord>,
+    request_receipts: Vec<RequestReceiptRecord>,
+}
+
+pub(crate) trait CurrentMetadataView {
+    fn head_seq(&self) -> ChangeSeq;
+    fn inode(&self, inode_id: InodeId) -> Option<InodeRecord>;
+    fn latest_revision_head(&self, inode_id: InodeId) -> Option<RevisionRecord>;
+    fn revision(&self, inode_id: InodeId, revision_no: RevisionNo) -> Option<RevisionRecord>;
+    fn bound_child(&self, parent_inode_id: InodeId, name_key: &str) -> Option<DirentryRecord>;
+    fn current_parent_binding_for_child(&self, child_inode_id: InodeId) -> Option<DirentryRecord>;
+    fn active_subtree_tombstone(&self, root_inode_id: InodeId) -> Option<SubtreeTombstoneRecord>;
+    fn child_bindings_for_parent(&self, parent_inode_id: InodeId) -> Vec<DirentryRecord>;
+    fn request_receipt(&self, request_id: &str) -> Option<RequestReceiptRecord>;
+
+    fn covering_subtree_tombstone(&self, inode_id: InodeId) -> Option<SubtreeTombstoneRecord> {
+        let mut current = Some(inode_id);
+        let mut visited = BTreeSet::new();
+
+        while let Some(candidate_inode_id) = current {
+            if !visited.insert(candidate_inode_id.0) {
+                break;
+            }
+
+            if let Some(tombstone) = self.active_subtree_tombstone(candidate_inode_id) {
+                return Some(tombstone);
+            }
+
+            current = self
+                .current_parent_binding_for_child(candidate_inode_id)
+                .map(|direntry| direntry.parent_inode_id);
+        }
+
+        None
+    }
+
+    fn visible_inode(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        let inode = self.inode(inode_id)?;
+        if self.covering_subtree_tombstone(inode_id).is_some() {
+            return None;
+        }
+
+        Some(inode)
+    }
+
+    fn current_revision_head(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        self.visible_inode(inode_id)?;
+        self.latest_revision_head(inode_id)
+    }
+
+    fn active_child_binding(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Option<DirentryRecord> {
+        let direntry = self.bound_child(parent_inode_id, name_key)?;
+        let latest_binding = self.current_parent_binding_for_child(direntry.child_inode_id)?;
+        if latest_binding.parent_inode_id != direntry.parent_inode_id
+            || latest_binding.name_key != direntry.name_key
+            || latest_binding.bind_seq != direntry.bind_seq
+            || latest_binding.bind_op_index != direntry.bind_op_index
+        {
+            return None;
+        }
+
+        Some(direntry)
+    }
+
+    fn visible_child(&self, parent_inode_id: InodeId, name_key: &str) -> Option<DirentryRecord> {
+        let parent = self.visible_inode(parent_inode_id)?;
+        if parent.inode_kind != InodeKind::Dir {
+            return None;
+        }
+
+        let direntry = self.active_child_binding(parent_inode_id, name_key)?;
+        self.visible_inode(direntry.child_inode_id)?;
+        Some(direntry)
+    }
+
+    fn visible_children(&self, parent_inode_id: InodeId) -> Vec<DirentryRecord> {
+        let Some(parent) = self.visible_inode(parent_inode_id) else {
+            return Vec::new();
+        };
+        if parent.inode_kind != InodeKind::Dir {
+            return Vec::new();
+        }
+
+        let mut children = self
+            .child_bindings_for_parent(parent_inode_id)
+            .into_iter()
+            .filter(|direntry| {
+                self.active_child_binding(parent_inode_id, &direntry.name_key)
+                    .map(|active| {
+                        active.child_inode_id == direntry.child_inode_id
+                            && active.bind_seq == direntry.bind_seq
+                            && active.bind_op_index == direntry.bind_op_index
+                    })
+                    .unwrap_or(false)
+            })
+            .filter(|direntry| self.visible_inode(direntry.child_inode_id).is_some())
+            .collect::<Vec<_>>();
+        children.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
+        });
+        children
+    }
+
+    fn resolve_visible_path(
+        &self,
+        absolute_path: &str,
+    ) -> Result<ResolvedVisiblePath, VisiblePathError> {
+        let components = parse_absolute_path_components(absolute_path)?;
+        let root_inode_id = InodeId(1);
+        let root = self
+            .visible_inode(root_inode_id)
+            .ok_or(VisiblePathError::RootMissing)?;
+        if components.is_empty() {
+            return Ok(ResolvedVisiblePath {
+                absolute_path: "/".to_owned(),
+                inode_id: root_inode_id,
+                inode_kind: root.inode_kind,
+                parent_inode_id: None,
+                display_name: String::new(),
+            });
+        }
+
+        let mut current_inode_id = root_inode_id;
+        let mut current_absolute_path = "/".to_owned();
+        let mut current_parent_inode_id = None;
+        let mut current_display_name = String::new();
+
+        for component in components {
+            let current_inode =
+                self.visible_inode(current_inode_id)
+                    .ok_or(VisiblePathError::PathNotFound {
+                        absolute_path: current_absolute_path.clone(),
+                    })?;
+            if current_inode.inode_kind != InodeKind::Dir {
+                return Err(VisiblePathError::PathComponentNotDirectory {
+                    absolute_path: current_absolute_path,
+                    inode_id: current_inode_id,
+                    inode_kind: current_inode.inode_kind,
+                });
+            }
+
+            let requested_absolute_path = join_absolute_path(&current_absolute_path, &component);
+            let direntry = self.visible_child(current_inode_id, &component).ok_or(
+                VisiblePathError::PathNotFound {
+                    absolute_path: requested_absolute_path,
+                },
+            )?;
+            current_inode_id = direntry.child_inode_id;
+            current_parent_inode_id = Some(direntry.parent_inode_id);
+            current_display_name = direntry.display_name.clone();
+            current_absolute_path =
+                join_absolute_path(&current_absolute_path, &direntry.display_name);
+        }
+
+        let inode =
+            self.visible_inode(current_inode_id)
+                .ok_or_else(|| VisiblePathError::PathNotFound {
+                    absolute_path: current_absolute_path.clone(),
+                })?;
+        Ok(ResolvedVisiblePath {
+            absolute_path: current_absolute_path,
+            inode_id: current_inode_id,
+            inode_kind: inode.inode_kind,
+            parent_inode_id: current_parent_inode_id,
+            display_name: current_display_name,
+        })
+    }
+
+    fn would_create_directory_cycle(&self, inode_id: InodeId, new_parent_inode: InodeId) -> bool {
+        let mut current = Some(new_parent_inode);
+        let mut visited = BTreeSet::new();
+
+        while let Some(candidate_inode_id) = current {
+            if !visited.insert(candidate_inode_id.0) {
+                break;
+            }
+            if candidate_inode_id == inode_id {
+                return true;
+            }
+            current = self
+                .current_parent_binding_for_child(candidate_inode_id)
+                .map(|direntry| direntry.parent_inode_id);
+        }
+
+        false
+    }
+}
+
+impl IndexedMetadataState {
+    pub fn from_metadata_state(metadata_state: MetadataState, head_seq: ChangeSeq) -> Self {
+        let mut index = MetadataIndexMaps::default();
+
+        for inode in metadata_state
+            .inodes
+            .iter()
+            .filter(|inode| inode.created_seq <= head_seq)
+        {
+            index.index_inode(inode.clone());
+        }
+        for direntry in metadata_state
+            .direntries
+            .iter()
+            .filter(|direntry| direntry.bind_seq <= head_seq)
+        {
+            index.index_direntry(direntry.clone());
+        }
+        for revision in metadata_state
+            .revisions
+            .iter()
+            .filter(|revision| revision.committed_seq <= head_seq)
+        {
+            index.index_revision(revision.clone());
+        }
+        for tombstone in metadata_state
+            .subtree_tombstones
+            .iter()
+            .filter(|tombstone| tombstone.tombstone_seq <= head_seq)
+        {
+            index.index_tombstone(tombstone.clone());
+        }
+        for receipt in metadata_state
+            .request_receipts
+            .iter()
+            .filter(|receipt| receipt.committed_seq <= head_seq)
+        {
+            index.index_request_receipt(receipt.clone());
+        }
+
+        Self {
+            head_seq,
+            metadata_state,
+            index,
+        }
+    }
+
+    pub fn metadata_state(&self) -> &MetadataState {
+        &self.metadata_state
+    }
+
+    pub fn into_metadata_state(self) -> MetadataState {
+        self.metadata_state
+    }
+
+    pub fn apply_committed_wal_record_in_place(
+        &mut self,
+        record: &WalCommitPayload,
+    ) -> Result<Vec<String>, MetadataApplyError> {
+        let mut overlay = MetadataOverlay::new(self, record.seq);
+        let mut checked_invariants = Vec::new();
+        for op in &record.ops {
+            for invariant in overlay.apply_committed_wal_op(record.seq, op)? {
+                push_unique_invariant(&mut checked_invariants, &invariant);
+            }
+        }
+        overlay.push_request_receipt(RequestReceiptRecord {
+            request_id: record.request_id.clone(),
+            semantic_fingerprint_sha256: record.semantic_fingerprint_sha256.clone(),
+            committed_seq: record.seq,
+            commit_id: record.commit_id.clone(),
+            results: record.results.clone(),
+        });
+        push_unique_invariant(
+            &mut checked_invariants,
+            "wal_replay_records_request_receipt",
+        );
+
+        let rows = overlay.into_rows();
+        self.append_rows(rows);
+        self.head_seq = record.seq;
+        Ok(checked_invariants)
+    }
+
+    fn append_rows(&mut self, rows: MetadataDeltaRows) {
+        for inode in rows.inodes {
+            self.index.index_inode(inode.clone());
+            self.metadata_state.inodes.push(inode);
+        }
+        for direntry in rows.direntries {
+            self.index.index_direntry(direntry.clone());
+            self.metadata_state.direntries.push(direntry);
+        }
+        for revision in rows.revisions {
+            self.index.index_revision(revision.clone());
+            self.metadata_state.revisions.push(revision);
+        }
+        for tombstone in rows.subtree_tombstones {
+            self.index.index_tombstone(tombstone.clone());
+            self.metadata_state.subtree_tombstones.push(tombstone);
+        }
+        for receipt in rows.request_receipts {
+            self.index.index_request_receipt(receipt.clone());
+            self.metadata_state.request_receipts.push(receipt);
+        }
+    }
+}
+
+impl<'a> MetadataOverlay<'a> {
+    pub fn new(base: &'a IndexedMetadataState, visible_seq: ChangeSeq) -> Self {
+        Self {
+            base,
+            visible_seq,
+            rows: MetadataDeltaRows::default(),
+            index: MetadataIndexMaps::default(),
+        }
+    }
+
+    pub fn apply_committed_wal_op(
+        &mut self,
+        committed_seq: ChangeSeq,
+        op: &WalOp,
+    ) -> Result<Vec<String>, MetadataApplyError> {
+        let mut checked_invariants = Vec::new();
+        match op {
+            WalOp::CreateDir {
+                op_index,
+                inode_id,
+                parent_inode,
+                display_name,
+            } => {
+                self.push_inode(InodeRecord {
+                    inode_id: *inode_id,
+                    inode_kind: InodeKind::Dir,
+                    created_seq: committed_seq,
+                });
+                self.push_direntry(DirentryRecord {
+                    parent_inode_id: *parent_inode,
+                    name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+                    display_name: display_name.clone(),
+                    child_inode_id: *inode_id,
+                    bind_seq: committed_seq,
+                    bind_op_index: *op_index,
+                });
+                push_unique_invariant(
+                    &mut checked_invariants,
+                    "create_dir_writes_inode_and_direntry_rows",
+                );
+            }
+            WalOp::CreateFile {
+                op_index,
+                inode_id,
+                parent_inode,
+                display_name,
+                content_ref,
+            } => {
+                self.push_inode(InodeRecord {
+                    inode_id: *inode_id,
+                    inode_kind: InodeKind::File,
+                    created_seq: committed_seq,
+                });
+                self.push_direntry(DirentryRecord {
+                    parent_inode_id: *parent_inode,
+                    name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+                    display_name: display_name.clone(),
+                    child_inode_id: *inode_id,
+                    bind_seq: committed_seq,
+                    bind_op_index: *op_index,
+                });
+                self.push_revision(RevisionRecord {
+                    inode_id: *inode_id,
+                    revision_no: RevisionNo(1),
+                    committed_seq,
+                    revision_op_index: *op_index,
+                    content_ref: content_ref.clone(),
+                });
+                push_unique_invariant(
+                    &mut checked_invariants,
+                    "create_file_writes_inode_direntry_and_initial_revision",
+                );
+            }
+            WalOp::ReplaceFile {
+                op_index,
+                inode_id,
+                base_revision,
+                content_ref,
+            } => {
+                let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    MetadataApplyError::RevisionOverflow {
+                        inode_id: *inode_id,
+                        base_revision: *base_revision,
+                    },
+                )?;
+                self.push_revision(RevisionRecord {
+                    inode_id: *inode_id,
+                    revision_no: next_revision,
+                    committed_seq,
+                    revision_op_index: *op_index,
+                    content_ref: content_ref.clone(),
+                });
+                push_unique_invariant(
+                    &mut checked_invariants,
+                    "replace_file_appends_new_revision_head",
+                );
+            }
+            WalOp::RestoreRevision {
+                op_index,
+                inode_id,
+                base_revision,
+                content_ref,
+                ..
+            } => {
+                let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    MetadataApplyError::RevisionOverflow {
+                        inode_id: *inode_id,
+                        base_revision: *base_revision,
+                    },
+                )?;
+                self.push_revision(RevisionRecord {
+                    inode_id: *inode_id,
+                    revision_no: next_revision,
+                    committed_seq,
+                    revision_op_index: *op_index,
+                    content_ref: content_ref.clone(),
+                });
+                push_unique_invariant(&mut checked_invariants, "restore_creates_new_revision_head");
+            }
+            WalOp::DeleteFile { op_index, inode_id } => {
+                self.push_tombstone(SubtreeTombstoneRecord {
+                    root_inode_id: *inode_id,
+                    tombstone_seq: committed_seq,
+                    tombstone_op_index: *op_index,
+                });
+                push_unique_invariant(&mut checked_invariants, "delete_file_writes_tombstone_row");
+            }
+            WalOp::Rename {
+                op_index,
+                inode_id,
+                new_parent_inode,
+                new_display_name,
+            } => {
+                self.push_direntry(DirentryRecord {
+                    parent_inode_id: *new_parent_inode,
+                    name_key: name_key_for_display_name(NamePolicy::default(), new_display_name),
+                    display_name: new_display_name.clone(),
+                    child_inode_id: *inode_id,
+                    bind_seq: committed_seq,
+                    bind_op_index: *op_index,
+                });
+                push_unique_invariant(
+                    &mut checked_invariants,
+                    "rename_appends_new_direntry_binding",
+                );
+            }
+            WalOp::DeleteSubtree {
+                op_index,
+                root_inode,
+            } => {
+                self.push_tombstone(SubtreeTombstoneRecord {
+                    root_inode_id: *root_inode,
+                    tombstone_seq: committed_seq,
+                    tombstone_op_index: *op_index,
+                });
+                push_unique_invariant(
+                    &mut checked_invariants,
+                    "delete_subtree_writes_tombstone_row",
+                );
+            }
+        }
+        Ok(checked_invariants)
+    }
+
+    fn push_inode(&mut self, inode: InodeRecord) {
+        self.index.index_inode(inode.clone());
+        self.rows.inodes.push(inode);
+    }
+
+    fn push_direntry(&mut self, direntry: DirentryRecord) {
+        self.index.index_direntry(direntry.clone());
+        self.rows.direntries.push(direntry);
+    }
+
+    fn push_revision(&mut self, revision: RevisionRecord) {
+        self.index.index_revision(revision.clone());
+        self.rows.revisions.push(revision);
+    }
+
+    fn push_tombstone(&mut self, tombstone: SubtreeTombstoneRecord) {
+        self.index.index_tombstone(tombstone.clone());
+        self.rows.subtree_tombstones.push(tombstone);
+    }
+
+    fn push_request_receipt(&mut self, receipt: RequestReceiptRecord) {
+        self.index.index_request_receipt(receipt.clone());
+        self.rows.request_receipts.push(receipt);
+    }
+
+    fn into_rows(self) -> MetadataDeltaRows {
+        self.rows
+    }
+}
+
+impl MetadataIndexMaps {
+    fn index_inode(&mut self, inode: InodeRecord) {
+        self.inode_by_id.entry(inode.inode_id).or_insert(inode);
+    }
+
+    fn index_direntry(&mut self, direntry: DirentryRecord) {
+        let parent_name = (direntry.parent_inode_id, direntry.name_key.clone());
+        if self
+            .latest_binding_by_parent_name
+            .get(&parent_name)
+            .map(|existing| direntry_is_newer(&direntry, existing))
+            .unwrap_or(true)
+        {
+            self.latest_binding_by_parent_name
+                .insert(parent_name, direntry.clone());
+        }
+
+        if self
+            .latest_parent_binding_by_child
+            .get(&direntry.child_inode_id)
+            .map(|existing| direntry_is_newer(&direntry, existing))
+            .unwrap_or(true)
+        {
+            self.latest_parent_binding_by_child
+                .insert(direntry.child_inode_id, direntry);
+        }
+    }
+
+    fn index_revision(&mut self, revision: RevisionRecord) {
+        let revision_key = (revision.inode_id, revision.revision_no);
+        if self
+            .revision_by_inode_no
+            .get(&revision_key)
+            .map(|existing| revision_instance_is_newer(&revision, existing))
+            .unwrap_or(true)
+        {
+            self.revision_by_inode_no
+                .insert(revision_key, revision.clone());
+        }
+
+        if self
+            .latest_revision_by_inode
+            .get(&revision.inode_id)
+            .map(|existing| revision_head_is_newer(&revision, existing))
+            .unwrap_or(true)
+        {
+            self.latest_revision_by_inode
+                .insert(revision.inode_id, revision);
+        }
+    }
+
+    fn index_tombstone(&mut self, tombstone: SubtreeTombstoneRecord) {
+        if self
+            .tombstone_by_root
+            .get(&tombstone.root_inode_id)
+            .map(|existing| tombstone_is_newer(&tombstone, existing))
+            .unwrap_or(true)
+        {
+            self.tombstone_by_root
+                .insert(tombstone.root_inode_id, tombstone);
+        }
+    }
+
+    fn index_request_receipt(&mut self, receipt: RequestReceiptRecord) {
+        if self
+            .request_receipt_by_id
+            .get(&receipt.request_id)
+            .map(|existing| receipt.committed_seq > existing.committed_seq)
+            .unwrap_or(true)
+        {
+            self.request_receipt_by_id
+                .insert(receipt.request_id.clone(), receipt);
+        }
+    }
+}
+
+impl CurrentMetadataView for IndexedMetadataState {
+    fn head_seq(&self) -> ChangeSeq {
+        self.head_seq
+    }
+
+    fn inode(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        self.index.inode_by_id.get(&inode_id).cloned()
+    }
+
+    fn latest_revision_head(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        self.index.latest_revision_by_inode.get(&inode_id).cloned()
+    }
+
+    fn revision(&self, inode_id: InodeId, revision_no: RevisionNo) -> Option<RevisionRecord> {
+        self.index
+            .revision_by_inode_no
+            .get(&(inode_id, revision_no))
+            .cloned()
+    }
+
+    fn bound_child(&self, parent_inode_id: InodeId, name_key: &str) -> Option<DirentryRecord> {
+        let canonical_name_key = name_key_for_display_name(NamePolicy::default(), name_key);
+        self.index
+            .latest_binding_by_parent_name
+            .get(&(parent_inode_id, canonical_name_key))
+            .cloned()
+    }
+
+    fn current_parent_binding_for_child(&self, child_inode_id: InodeId) -> Option<DirentryRecord> {
+        self.index
+            .latest_parent_binding_by_child
+            .get(&child_inode_id)
+            .cloned()
+    }
+
+    fn active_subtree_tombstone(&self, root_inode_id: InodeId) -> Option<SubtreeTombstoneRecord> {
+        self.index.tombstone_by_root.get(&root_inode_id).cloned()
+    }
+
+    fn child_bindings_for_parent(&self, parent_inode_id: InodeId) -> Vec<DirentryRecord> {
+        self.index
+            .latest_binding_by_parent_name
+            .values()
+            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+            .cloned()
+            .collect()
+    }
+
+    fn request_receipt(&self, request_id: &str) -> Option<RequestReceiptRecord> {
+        self.index.request_receipt_by_id.get(request_id).cloned()
+    }
+}
+
+impl CurrentMetadataView for MetadataOverlay<'_> {
+    fn head_seq(&self) -> ChangeSeq {
+        self.visible_seq
+    }
+
+    fn inode(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        self.index
+            .inode_by_id
+            .get(&inode_id)
+            .cloned()
+            .or_else(|| self.base.inode(inode_id))
+    }
+
+    fn latest_revision_head(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        match (
+            self.index.latest_revision_by_inode.get(&inode_id),
+            self.base.latest_revision_head(inode_id),
+        ) {
+            (Some(overlay), Some(base)) if revision_head_is_newer(&base, overlay) => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+
+    fn revision(&self, inode_id: InodeId, revision_no: RevisionNo) -> Option<RevisionRecord> {
+        match (
+            self.index
+                .revision_by_inode_no
+                .get(&(inode_id, revision_no)),
+            self.base.revision(inode_id, revision_no),
+        ) {
+            (Some(overlay), Some(base)) if revision_instance_is_newer(&base, overlay) => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+
+    fn bound_child(&self, parent_inode_id: InodeId, name_key: &str) -> Option<DirentryRecord> {
+        let canonical_name_key = name_key_for_display_name(NamePolicy::default(), name_key);
+        match (
+            self.index
+                .latest_binding_by_parent_name
+                .get(&(parent_inode_id, canonical_name_key.clone())),
+            self.base.bound_child(parent_inode_id, &canonical_name_key),
+        ) {
+            (Some(overlay), Some(base)) if direntry_is_newer(&base, overlay) => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+
+    fn current_parent_binding_for_child(&self, child_inode_id: InodeId) -> Option<DirentryRecord> {
+        match (
+            self.index
+                .latest_parent_binding_by_child
+                .get(&child_inode_id),
+            self.base.current_parent_binding_for_child(child_inode_id),
+        ) {
+            (Some(overlay), Some(base)) if direntry_is_newer(&base, overlay) => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+
+    fn active_subtree_tombstone(&self, root_inode_id: InodeId) -> Option<SubtreeTombstoneRecord> {
+        match (
+            self.index.tombstone_by_root.get(&root_inode_id),
+            self.base.active_subtree_tombstone(root_inode_id),
+        ) {
+            (Some(overlay), Some(base)) if tombstone_is_newer(&base, overlay) => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+
+    fn child_bindings_for_parent(&self, parent_inode_id: InodeId) -> Vec<DirentryRecord> {
+        let mut by_parent_name = self
+            .base
+            .child_bindings_for_parent(parent_inode_id)
+            .into_iter()
+            .map(|direntry| {
+                (
+                    (direntry.parent_inode_id, direntry.name_key.clone()),
+                    direntry,
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        for direntry in self
+            .index
+            .latest_binding_by_parent_name
+            .values()
+            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+        {
+            let key = (direntry.parent_inode_id, direntry.name_key.clone());
+            if by_parent_name
+                .get(&key)
+                .map(|existing| direntry_is_newer(direntry, existing))
+                .unwrap_or(true)
+            {
+                by_parent_name.insert(key, direntry.clone());
+            }
+        }
+        by_parent_name.into_values().collect()
+    }
+
+    fn request_receipt(&self, request_id: &str) -> Option<RequestReceiptRecord> {
+        match (
+            self.index.request_receipt_by_id.get(request_id),
+            self.base.request_receipt(request_id),
+        ) {
+            (Some(overlay), Some(base)) if base.committed_seq > overlay.committed_seq => Some(base),
+            (Some(overlay), _) => Some(overlay.clone()),
+            (None, base) => base,
+        }
+    }
+}
+
+fn direntry_is_newer(candidate: &DirentryRecord, existing: &DirentryRecord) -> bool {
+    (candidate.bind_seq, candidate.bind_op_index) > (existing.bind_seq, existing.bind_op_index)
+}
+
+fn revision_head_is_newer(candidate: &RevisionRecord, existing: &RevisionRecord) -> bool {
+    (
+        candidate.revision_no,
+        candidate.committed_seq,
+        candidate.revision_op_index,
+    ) > (
+        existing.revision_no,
+        existing.committed_seq,
+        existing.revision_op_index,
+    )
+}
+
+fn revision_instance_is_newer(candidate: &RevisionRecord, existing: &RevisionRecord) -> bool {
+    (candidate.committed_seq, candidate.revision_op_index)
+        > (existing.committed_seq, existing.revision_op_index)
+}
+
+fn tombstone_is_newer(
+    candidate: &SubtreeTombstoneRecord,
+    existing: &SubtreeTombstoneRecord,
+) -> bool {
+    (candidate.tombstone_seq, candidate.tombstone_op_index)
+        > (existing.tombstone_seq, existing.tombstone_op_index)
 }
 
 impl MetadataState {
@@ -651,5 +1453,321 @@ fn join_absolute_path(base: &str, component: &str) -> String {
         format!("/{component}")
     } else {
         format!("{base}/{component}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loon_api::{FenceToken, NamespaceId};
+
+    fn content(bytes: &[u8]) -> ContentRef {
+        ContentRef::whole_file_v0(bytes)
+    }
+
+    fn root_state() -> MetadataState {
+        MetadataState {
+            inodes: vec![InodeRecord {
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Dir,
+                created_seq: ChangeSeq(0),
+            }],
+            direntries: Vec::new(),
+            revisions: Vec::new(),
+            subtree_tombstones: Vec::new(),
+            request_receipts: Vec::new(),
+        }
+    }
+
+    fn state_after(sequences: &[Vec<WalOp>]) -> MetadataState {
+        let mut state = root_state();
+        for (offset, ops) in sequences.iter().enumerate() {
+            state = state
+                .apply_committed_wal_ops(ChangeSeq(offset as u64 + 1), ops)
+                .expect("test WAL ops should apply")
+                .metadata_state;
+        }
+        state
+    }
+
+    fn wal_record(seq: ChangeSeq, request_id: &str, ops: Vec<WalOp>) -> WalCommitPayload {
+        WalCommitPayload {
+            namespace_id: NamespaceId::from("test".to_owned()),
+            seq,
+            base_head_seq: ChangeSeq(seq.0.saturating_sub(1)),
+            commit_id: request_id.to_owned(),
+            request_id: request_id.to_owned(),
+            request_checksum_sha256: format!("checksum-{request_id}"),
+            semantic_fingerprint_sha256: format!("fingerprint-{request_id}"),
+            source_request_checksum_sha256: None,
+            writer_id: "writer".to_owned(),
+            writer_fence_token: FenceToken(0),
+            message: None,
+            annotations: None,
+            ops,
+            preconditions: Vec::new(),
+            results: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn indexed_current_head_queries_match_vector_semantics() {
+        let mut state = state_after(&[
+            vec![
+                WalOp::CreateDir {
+                    op_index: 0,
+                    inode_id: InodeId(2),
+                    parent_inode: InodeId(1),
+                    display_name: "docs".to_owned(),
+                },
+                WalOp::CreateFile {
+                    op_index: 1,
+                    inode_id: InodeId(3),
+                    parent_inode: InodeId(2),
+                    display_name: "b.txt".to_owned(),
+                    content_ref: content(b"one"),
+                },
+                WalOp::CreateDir {
+                    op_index: 2,
+                    inode_id: InodeId(4),
+                    parent_inode: InodeId(1),
+                    display_name: "archive".to_owned(),
+                },
+            ],
+            vec![WalOp::ReplaceFile {
+                op_index: 0,
+                inode_id: InodeId(3),
+                base_revision: RevisionNo(1),
+                content_ref: content(b"two"),
+            }],
+            vec![WalOp::Rename {
+                op_index: 0,
+                inode_id: InodeId(3),
+                new_parent_inode: InodeId(4),
+                new_display_name: "z.txt".to_owned(),
+            }],
+            vec![WalOp::CreateFile {
+                op_index: 0,
+                inode_id: InodeId(5),
+                parent_inode: InodeId(2),
+                display_name: "a.txt".to_owned(),
+                content_ref: content(b"three"),
+            }],
+            vec![WalOp::DeleteSubtree {
+                op_index: 0,
+                root_inode: InodeId(2),
+            }],
+        ]);
+        state.request_receipts.push(RequestReceiptRecord {
+            request_id: "durable-request".to_owned(),
+            semantic_fingerprint_sha256: "fingerprint".to_owned(),
+            committed_seq: ChangeSeq(5),
+            commit_id: "commit".to_owned(),
+            results: Vec::new(),
+        });
+
+        let seq = ChangeSeq(5);
+        let indexed = IndexedMetadataState::from_metadata_state(state.clone(), seq);
+
+        for inode_id in [InodeId(1), InodeId(2), InodeId(3), InodeId(4), InodeId(5)] {
+            assert_eq!(
+                state.inode_at_seq(inode_id, seq),
+                indexed.inode(inode_id),
+                "raw inode {inode_id:?}"
+            );
+            assert_eq!(
+                state.visible_inode(inode_id, seq),
+                indexed.visible_inode(inode_id),
+                "visible inode {inode_id:?}"
+            );
+            assert_eq!(
+                state.covering_subtree_tombstone(inode_id, seq),
+                indexed.covering_subtree_tombstone(inode_id),
+                "covering tombstone {inode_id:?}"
+            );
+        }
+
+        assert_eq!(
+            state.current_revision_head(InodeId(3), seq),
+            indexed.current_revision_head(InodeId(3))
+        );
+        assert_eq!(
+            state.revision_at_seq(InodeId(3), RevisionNo(1), seq),
+            indexed.revision(InodeId(3), RevisionNo(1))
+        );
+        assert_eq!(
+            state.visible_child(InodeId(4), "z.txt", seq),
+            indexed.visible_child(InodeId(4), "z.txt")
+        );
+        assert_eq!(
+            state.current_parent_binding_for_child(InodeId(3), seq),
+            indexed.current_parent_binding_for_child(InodeId(3))
+        );
+        assert_eq!(
+            state.visible_children(InodeId(4), seq),
+            indexed.visible_children(InodeId(4))
+        );
+        assert_eq!(
+            state.resolve_visible_path("/archive/z.txt", seq),
+            indexed.resolve_visible_path("/archive/z.txt")
+        );
+        assert_eq!(
+            indexed
+                .request_receipt("durable-request")
+                .map(|receipt| receipt.commit_id),
+            Some("commit".to_owned())
+        );
+    }
+
+    #[test]
+    fn metadata_overlay_reflects_intra_request_rows_without_mutating_base() {
+        let state = state_after(&[vec![WalOp::CreateDir {
+            op_index: 0,
+            inode_id: InodeId(2),
+            parent_inode: InodeId(1),
+            display_name: "docs".to_owned(),
+        }]]);
+        let indexed = IndexedMetadataState::from_metadata_state(state, ChangeSeq(1));
+        let mut overlay = MetadataOverlay::new(&indexed, ChangeSeq(2));
+
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::CreateDir {
+                    op_index: 0,
+                    inode_id: InodeId(3),
+                    parent_inode: InodeId(2),
+                    display_name: "drafts".to_owned(),
+                },
+            )
+            .expect("create dir should apply");
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::CreateFile {
+                    op_index: 1,
+                    inode_id: InodeId(4),
+                    parent_inode: InodeId(3),
+                    display_name: "note.txt".to_owned(),
+                    content_ref: content(b"one"),
+                },
+            )
+            .expect("create file should apply");
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::ReplaceFile {
+                    op_index: 2,
+                    inode_id: InodeId(4),
+                    base_revision: RevisionNo(1),
+                    content_ref: content(b"two"),
+                },
+            )
+            .expect("replace file should apply");
+        let source = overlay
+            .revision(InodeId(4), RevisionNo(1))
+            .expect("same-request source revision should resolve");
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::RestoreRevision {
+                    op_index: 3,
+                    inode_id: InodeId(4),
+                    source_revision_no: RevisionNo(1),
+                    base_revision: RevisionNo(2),
+                    content_ref: source.content_ref,
+                },
+            )
+            .expect("restore should apply");
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::Rename {
+                    op_index: 4,
+                    inode_id: InodeId(4),
+                    new_parent_inode: InodeId(1),
+                    new_display_name: "moved.txt".to_owned(),
+                },
+            )
+            .expect("rename should apply");
+        overlay
+            .apply_committed_wal_op(
+                ChangeSeq(2),
+                &WalOp::DeleteFile {
+                    op_index: 5,
+                    inode_id: InodeId(4),
+                },
+            )
+            .expect("delete should apply");
+
+        assert!(indexed.resolve_visible_path("/docs/drafts").is_err());
+        assert_eq!(
+            overlay
+                .resolve_visible_path("/docs/drafts")
+                .expect("created parent should be visible")
+                .inode_id,
+            InodeId(3)
+        );
+        assert!(overlay
+            .resolve_visible_path("/docs/drafts/note.txt")
+            .is_err());
+        assert!(overlay.visible_child(InodeId(1), "moved.txt").is_none());
+        assert_eq!(
+            overlay
+                .covering_subtree_tombstone(InodeId(4))
+                .map(|tombstone| tombstone.root_inode_id),
+            Some(InodeId(4))
+        );
+        assert_eq!(
+            overlay
+                .latest_revision_head(InodeId(4))
+                .map(|revision| revision.revision_no),
+            Some(RevisionNo(3))
+        );
+    }
+
+    #[test]
+    fn in_place_indexed_wal_apply_matches_vector_apply() {
+        let state = state_after(&[vec![WalOp::CreateDir {
+            op_index: 0,
+            inode_id: InodeId(2),
+            parent_inode: InodeId(1),
+            display_name: "docs".to_owned(),
+        }]]);
+        let record = wal_record(
+            ChangeSeq(2),
+            "req-2",
+            vec![WalOp::CreateFile {
+                op_index: 0,
+                inode_id: InodeId(3),
+                parent_inode: InodeId(2),
+                display_name: "file.txt".to_owned(),
+                content_ref: content(b"body"),
+            }],
+        );
+
+        let expected = state
+            .apply_committed_wal_record(&record)
+            .expect("vector apply should succeed")
+            .metadata_state;
+        let mut indexed = IndexedMetadataState::from_metadata_state(state, ChangeSeq(1));
+        indexed
+            .apply_committed_wal_record_in_place(&record)
+            .expect("indexed apply should succeed");
+
+        assert_eq!(indexed.metadata_state(), &expected);
+        assert_eq!(
+            indexed
+                .request_receipt("req-2")
+                .map(|receipt| receipt.committed_seq),
+            Some(ChangeSeq(2))
+        );
+        assert_eq!(
+            indexed
+                .resolve_visible_path("/docs/file.txt")
+                .expect("created file should resolve")
+                .inode_id,
+            InodeId(3)
+        );
     }
 }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,13 +1,13 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
 use crate::commit::{
-    build_commit_plan, prepare_commit_head_publish, publish_commit_head,
-    resolve_restore_content_refs, CommitOp, CommitRequest as CoreCommitRequest,
-    CommitValidationContext, Precondition,
+    build_commit_plan_indexed, prepare_commit_head_publish, publish_commit_head,
+    resolve_restore_content_refs_indexed, CommitOp, CommitRequest as CoreCommitRequest,
+    IndexedCommitValidationContext, Precondition,
 };
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
-use crate::metadata::{MetadataState, RequestReceiptRecord};
+use crate::metadata::{CurrentMetadataView, IndexedMetadataState, RequestReceiptRecord};
 use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::{
     NamespaceBatchPublishResult, NamespaceMutationCandidate, PlannedNamespaceMutation,
@@ -339,10 +339,19 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         };
     }
 
+    let VerifiedNamespaceBasis {
+        namespace_descriptor,
+        content_store_id,
+        head: basis_head,
+        head_etag,
+        lease,
+        metadata_state,
+    } = basis;
     let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
         (0..candidates.len()).map(|_| None).collect();
-    let mut current_head = basis.head.clone();
-    let mut current_metadata_state = basis.metadata_state.clone();
+    let mut current_head = basis_head.clone();
+    let mut current_metadata_state =
+        IndexedMetadataState::from_metadata_state(metadata_state, basis_head.seq);
     let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
     let mut in_batch_requests: HashMap<String, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
@@ -351,9 +360,10 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         let Some(request) = prepare_candidate_request(
             store,
             namespace_id,
-            &basis,
+            &basis_head,
             &current_head,
             &current_metadata_state,
+            &content_store_id,
             candidate,
             context,
             index,
@@ -363,23 +373,24 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         ) else {
             continue;
         };
-        let validation = CommitValidationContext {
-            head: current_head.clone(),
-            lease: basis.lease.clone(),
+        let validation = IndexedCommitValidationContext {
+            head: &current_head,
+            lease: &lease,
             now_ms: context.now_ms,
-            metadata_state: current_metadata_state.clone(),
+            metadata_state: &current_metadata_state,
         };
-        let resolved_restore_content_refs = resolve_restore_content_refs(&request, &validation);
+        let resolved_restore_content_refs =
+            resolve_restore_content_refs_indexed(&request, &validation);
         if let Err(error) = validate_commit_content_references(
             store,
-            namespace_id,
+            &content_store_id,
             &request,
             &resolved_restore_content_refs,
         ) {
             outcomes[index] = Some(Err(error));
             continue;
         }
-        let plan = match build_commit_plan(&request, &validation) {
+        let plan = match build_commit_plan_indexed(&request, &validation) {
             Ok(plan) => plan,
             Err(error) => {
                 outcomes[index] = Some(Err(error.into()));
@@ -403,9 +414,8 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
                 continue;
             }
         };
-        match current_metadata_state.apply_committed_wal_record(&preview) {
-            Ok(applied) => {
-                current_metadata_state = applied.metadata_state;
+        match current_metadata_state.apply_committed_wal_record_in_place(&preview) {
+            Ok(_) => {
                 current_head.seq = plan.next_seq;
                 current_head.next_inode_id = plan.resulting_next_inode_id;
                 accepted.push((index, record));
@@ -417,7 +427,14 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
     if accepted.is_empty() {
         return NamespaceBatchPublishResult {
             results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-            promoted_basis: Some(basis),
+            promoted_basis: Some(VerifiedNamespaceBasis {
+                namespace_descriptor,
+                content_store_id,
+                head: basis_head,
+                head_etag,
+                lease,
+                metadata_state: current_metadata_state.into_metadata_state(),
+            }),
             head_published: false,
         };
     }
@@ -427,7 +444,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         .collect::<Vec<_>>();
     let wal = match prepare_wal_segment(
         namespace_id.clone(),
-        basis.head.visible_wal_tip.clone(),
+        basis_head.visible_wal_tip.clone(),
         &records,
         &context.writer_version,
     ) {
@@ -460,7 +477,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
 
     let last_plan = &records.last().expect("non-empty accepted records").plan;
     let head_publish = prepare_commit_head_publish(
-        &basis.head,
+        &basis_head,
         last_plan,
         wal.envelope.pointer(wal.object_key.clone()),
         &context.writer_version,
@@ -479,7 +496,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
             };
         }
     };
-    let head_metadata = match publish_commit_head(store, &basis.head_etag, &head_publish) {
+    let head_metadata = match publish_commit_head(store, &head_etag, &head_publish) {
         Ok(metadata) => metadata,
         Err(error) => {
             for (index, _) in accepted {
@@ -496,12 +513,12 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         .etag
         .clone()
         .map(|head_etag| VerifiedNamespaceBasis {
-            namespace_descriptor: basis.namespace_descriptor,
-            content_store_id: basis.content_store_id,
+            namespace_descriptor,
+            content_store_id,
             head: head_publish.resulting_head.clone(),
             head_etag,
-            lease: basis.lease,
-            metadata_state: current_metadata_state,
+            lease,
+            metadata_state: current_metadata_state.into_metadata_state(),
         });
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
@@ -523,9 +540,10 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
 fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    basis: &crate::VerifiedNamespaceBasis,
+    basis_head: &HeadState,
     current_head: &HeadState,
-    current_metadata_state: &MetadataState,
+    current_metadata_state: &IndexedMetadataState,
+    content_store_id: &loon_api::ContentStoreId,
     candidate: NamespaceMutationCandidate,
     context: &MutationContext,
     index: usize,
@@ -535,7 +553,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
 ) -> Option<CoreCommitRequest> {
     match candidate {
         NamespaceMutationCandidate::Commit(request) => {
-            let request = map_commit_request(namespace_id, basis, request, None, context);
+            let request = map_commit_request(namespace_id, basis_head, request, None, context);
             let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
                 Ok(value) => value,
                 Err(err) => {
@@ -545,7 +563,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             };
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
-                &basis.metadata_state,
+                current_metadata_state,
                 outcomes,
                 in_batch_requests,
                 aliases,
@@ -560,7 +578,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         NamespaceMutationCandidate::Planned(planned) => {
             let request = map_commit_request(
                 namespace_id,
-                basis,
+                basis_head,
                 planned.commit_request,
                 planned.source_request_checksum_sha256,
                 context,
@@ -574,7 +592,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             };
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
-                &basis.metadata_state,
+                current_metadata_state,
                 outcomes,
                 in_batch_requests,
                 aliases,
@@ -597,7 +615,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             let request_id = intent.request_id().to_owned();
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
-                &basis.metadata_state,
+                current_metadata_state,
                 outcomes,
                 in_batch_requests,
                 aliases,
@@ -607,13 +625,13 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            let planned = match crate::services::plan_path_mutation_against_state(
+            let planned = match crate::services::plan_path_mutation_against_indexed_state(
                 store,
                 namespace_id,
                 &intent,
                 current_head,
                 current_metadata_state,
-                &basis.content_store_id,
+                content_store_id,
             ) {
                 Ok(value) => value,
                 Err(error) => {
@@ -623,7 +641,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             };
             Some(map_commit_request(
                 namespace_id,
-                basis,
+                basis_head,
                 planned.commit_request,
                 Some(planned.source_request_checksum_sha256),
                 context,
@@ -635,7 +653,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
 #[allow(clippy::too_many_arguments)]
 fn record_primary_request_or_complete_idempotent(
     namespace_id: &NamespaceId,
-    visible_metadata_state: &MetadataState,
+    visible_metadata_state: &IndexedMetadataState,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
     in_batch_requests: &mut HashMap<String, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
@@ -643,22 +661,22 @@ fn record_primary_request_or_complete_idempotent(
     request_id: &str,
     semantic_fingerprint: &str,
 ) -> bool {
-    if let Some(existing) = find_request_receipt(visible_metadata_state, request_id) {
-        outcomes[index] = Some(
-            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
-                Err(CoreError::RequestIdConflict(request_id.to_owned()))
-            } else {
-                Ok(commit_response_from_receipt(namespace_id, existing))
-            },
-        );
-        return false;
-    }
     if let Some(existing) = in_batch_requests.get(request_id) {
         if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
             outcomes[index] = Some(Err(CoreError::RequestIdConflict(request_id.to_owned())));
         } else {
             aliases.push((index, existing.primary_index));
         }
+        return false;
+    }
+    if let Some(existing) = visible_metadata_state.request_receipt(request_id) {
+        outcomes[index] = Some(
+            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
+                Err(CoreError::RequestIdConflict(request_id.to_owned()))
+            } else {
+                Ok(commit_response_from_receipt(namespace_id, &existing))
+            },
+        );
         return false;
     }
     in_batch_requests.insert(
@@ -797,7 +815,7 @@ fn derive_commit_results(
 
 fn map_commit_request(
     namespace_id: &NamespaceId,
-    basis: &crate::VerifiedNamespaceBasis,
+    basis_head: &HeadState,
     request: ApiCommitRequest,
     source_request_checksum_sha256: Option<String>,
     context: &MutationContext,
@@ -806,7 +824,7 @@ fn map_commit_request(
         namespace_id: namespace_id.clone(),
         request_id: request.request_id,
         writer_id: context.writer_id.clone(),
-        writer_fence_token: basis.head.active_fence_token,
+        writer_fence_token: basis_head.active_fence_token,
         planned_head_seq: request.planned_head_seq,
         source_request_checksum_sha256,
         ops: request.ops.into_iter().map(map_commit_op).collect(),
@@ -895,7 +913,7 @@ fn map_commit_precondition(precondition: ApiCommitPrecondition) -> Precondition 
 
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
+    content_store_id: &loon_api::ContentStoreId,
     request: &CoreCommitRequest,
     resolved_restore_content_refs: &[Option<ContentRef>],
 ) -> Result<(), CoreError> {
@@ -922,9 +940,8 @@ fn validate_commit_content_references<S: ObjectStore + ?Sized>(
         return Ok(());
     }
 
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
     for content_ref in content_refs {
-        validate_durable_content_reference(store, &content_store_id, content_ref)?;
+        validate_durable_content_reference(store, content_store_id, content_ref)?;
     }
 
     Ok(())
@@ -1028,17 +1045,6 @@ fn load_wal_range<S: ObjectStore + ?Sized>(
     }
     out.reverse();
     Ok(out)
-}
-
-fn find_request_receipt<'a>(
-    metadata_state: &'a crate::metadata::MetadataState,
-    request_id: &str,
-) -> Option<&'a RequestReceiptRecord> {
-    metadata_state
-        .request_receipts
-        .iter()
-        .filter(|receipt| receipt.request_id == request_id)
-        .max_by_key(|receipt| receipt.committed_seq)
 }
 
 fn commit_response_from_receipt(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,4 +1,4 @@
-use crate::basis::{load_verified_namespace_basis, BasisLoadError};
+use crate::basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
 use crate::commit::{
     build_commit_plan, prepare_commit_head_publish, publish_commit_head,
     resolve_restore_content_refs, CommitOp, CommitRequest as CoreCommitRequest,
@@ -9,7 +9,9 @@ use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, RequestReceiptRecord};
 use crate::namespace::catalog::load_namespace_content_store_id;
-use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
+use crate::publisher::{
+    NamespaceBatchPublishResult, NamespaceMutationCandidate, PlannedNamespaceMutation,
+};
 use crate::wal::{
     build_wal_commit_payload, prepare_wal_segment, PreparedWalRecord, StoredWalObject,
 };
@@ -249,7 +251,52 @@ pub(crate) fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse, CoreError>> {
-    commit_namespace_mutations_batch(store, namespace_id, candidates, context)
+    publish_namespace_mutations_batch_with_fresh_basis(store, namespace_id, candidates, context)
+        .results
+}
+
+pub(crate) fn publish_namespace_mutations_batch_with_fresh_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+) -> NamespaceBatchPublishResult {
+    if candidates.is_empty() {
+        return NamespaceBatchPublishResult {
+            results: Vec::new(),
+            promoted_basis: None,
+        };
+    }
+    if let Err(error) = crate::acquire_or_renew_namespace_lease(store, namespace_id, context) {
+        return NamespaceBatchPublishResult {
+            results: (0..candidates.len())
+                .map(|_| Err(CoreError::Lease(error.clone())))
+                .collect(),
+            promoted_basis: None,
+        };
+    }
+    let basis = match load_verified_namespace_basis(store, namespace_id) {
+        Ok(basis) => basis,
+        Err(error) => {
+            return NamespaceBatchPublishResult {
+                results: (0..candidates.len())
+                    .map(|_| Err(CoreError::Basis(error.clone())))
+                    .collect(),
+                promoted_basis: None,
+            }
+        }
+    };
+    publish_namespace_mutations_batch_with_basis(store, namespace_id, candidates, context, basis)
+}
+
+pub(crate) fn publish_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+    basis: VerifiedNamespaceBasis,
+) -> NamespaceBatchPublishResult {
+    commit_namespace_mutations_batch_with_basis(store, namespace_id, candidates, context, basis)
 }
 
 fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
@@ -274,28 +321,19 @@ fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
     .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
 }
 
-fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
+fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    basis: VerifiedNamespaceBasis,
+) -> NamespaceBatchPublishResult {
     if candidates.is_empty() {
-        return Vec::new();
+        return NamespaceBatchPublishResult {
+            results: Vec::new(),
+            promoted_basis: Some(basis),
+        };
     }
-    if let Err(error) = crate::acquire_or_renew_namespace_lease(store, namespace_id, context) {
-        return (0..candidates.len())
-            .map(|_| Err(CoreError::Lease(error.clone())))
-            .collect();
-    }
-    let basis = match load_verified_namespace_basis(store, namespace_id) {
-        Ok(basis) => basis,
-        Err(error) => {
-            return (0..candidates.len())
-                .map(|_| Err(CoreError::Basis(error.clone())))
-                .collect()
-        }
-    };
 
     let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
         (0..candidates.len()).map(|_| None).collect();
@@ -373,7 +411,10 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     }
 
     if accepted.is_empty() {
-        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+        return NamespaceBatchPublishResult {
+            results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            promoted_basis: Some(basis),
+        };
     }
     let records = accepted
         .iter()
@@ -391,7 +432,10 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return NamespaceBatchPublishResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                promoted_basis: None,
+            };
         }
     };
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
@@ -400,7 +444,10 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return NamespaceBatchPublishResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                promoted_basis: None,
+            };
         }
     }
 
@@ -418,15 +465,35 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return NamespaceBatchPublishResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                promoted_basis: None,
+            };
         }
     };
-    if let Err(error) = publish_commit_head(store, &basis.head_etag, &head_publish) {
-        for (index, _) in accepted {
-            outcomes[index] = Some(Err(error.clone().into()));
+    let head_metadata = match publish_commit_head(store, &basis.head_etag, &head_publish) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            for (index, _) in accepted {
+                outcomes[index] = Some(Err(error.clone().into()));
+            }
+            return NamespaceBatchPublishResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                promoted_basis: None,
+            };
         }
-        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
-    }
+    };
+    let promoted_basis = head_metadata
+        .etag
+        .clone()
+        .map(|head_etag| VerifiedNamespaceBasis {
+            namespace_descriptor: basis.namespace_descriptor,
+            content_store_id: basis.content_store_id,
+            head: head_publish.resulting_head.clone(),
+            head_etag,
+            lease: basis.lease,
+            metadata_state: current_metadata_state,
+        });
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
@@ -436,7 +503,10 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             results: record.results,
         }));
     }
-    finish_batch_outcomes_with_aliases(outcomes, &aliases)
+    NamespaceBatchPublishResult {
+        results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+        promoted_basis,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -265,6 +265,7 @@ pub(crate) fn publish_namespace_mutations_batch_with_fresh_basis<S: ObjectStore 
         return NamespaceBatchPublishResult {
             results: Vec::new(),
             promoted_basis: None,
+            head_published: false,
         };
     }
     if let Err(error) = crate::acquire_or_renew_namespace_lease(store, namespace_id, context) {
@@ -273,6 +274,7 @@ pub(crate) fn publish_namespace_mutations_batch_with_fresh_basis<S: ObjectStore 
                 .map(|_| Err(CoreError::Lease(error.clone())))
                 .collect(),
             promoted_basis: None,
+            head_published: false,
         };
     }
     let basis = match load_verified_namespace_basis(store, namespace_id) {
@@ -283,6 +285,7 @@ pub(crate) fn publish_namespace_mutations_batch_with_fresh_basis<S: ObjectStore 
                     .map(|_| Err(CoreError::Basis(error.clone())))
                     .collect(),
                 promoted_basis: None,
+                head_published: false,
             }
         }
     };
@@ -332,6 +335,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         return NamespaceBatchPublishResult {
             results: Vec::new(),
             promoted_basis: Some(basis),
+            head_published: false,
         };
     }
 
@@ -414,6 +418,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
         return NamespaceBatchPublishResult {
             results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
             promoted_basis: Some(basis),
+            head_published: false,
         };
     }
     let records = accepted
@@ -435,6 +440,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
             return NamespaceBatchPublishResult {
                 results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
                 promoted_basis: None,
+                head_published: false,
             };
         }
     };
@@ -447,6 +453,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
             return NamespaceBatchPublishResult {
                 results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
                 promoted_basis: None,
+                head_published: false,
             };
         }
     }
@@ -468,6 +475,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
             return NamespaceBatchPublishResult {
                 results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
                 promoted_basis: None,
+                head_published: false,
             };
         }
     };
@@ -480,6 +488,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
             return NamespaceBatchPublishResult {
                 results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
                 promoted_basis: None,
+                head_published: false,
             };
         }
     };
@@ -506,6 +515,7 @@ fn commit_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
     NamespaceBatchPublishResult {
         results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
         promoted_basis,
+        head_published: true,
     }
 }
 

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -75,6 +75,7 @@ pub enum NamespaceMutationCandidate {
 pub struct NamespaceBatchPublishResult {
     pub results: Vec<Result<ApiCommitResponse, CoreError>>,
     pub promoted_basis: Option<VerifiedNamespaceBasis>,
+    pub head_published: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -1,6 +1,7 @@
 use crate::context::MutationContext;
 use crate::error::{CoreError, CoreErrorKind};
 use crate::services::PutFileBehavior;
+use crate::VerifiedNamespaceBasis;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::{ContentRef, MutationResult, NamespaceId};
 use loon_objectstore::ObjectStore;
@@ -68,6 +69,12 @@ pub enum NamespaceMutationCandidate {
     Commit(ApiCommitRequest),
     Planned(PlannedNamespaceMutation),
     Path(PathMutationIntent),
+}
+
+#[derive(Debug, Clone)]
+pub struct NamespaceBatchPublishResult {
+    pub results: Vec<Result<ApiCommitResponse, CoreError>>,
+    pub promoted_basis: Option<VerifiedNamespaceBasis>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -175,4 +182,34 @@ pub fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse, CoreError>> {
     crate::protocol::publish_namespace_mutations_batch(store, namespace_id, candidates, context)
+}
+
+pub fn publish_namespace_mutations_batch_with_fresh_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+) -> NamespaceBatchPublishResult {
+    crate::protocol::publish_namespace_mutations_batch_with_fresh_basis(
+        store,
+        namespace_id,
+        candidates,
+        context,
+    )
+}
+
+pub fn publish_namespace_mutations_batch_with_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+    basis: VerifiedNamespaceBasis,
+) -> NamespaceBatchPublishResult {
+    crate::protocol::publish_namespace_mutations_batch_with_basis(
+        store,
+        namespace_id,
+        candidates,
+        context,
+        basis,
+    )
 }

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -8,7 +8,10 @@ use crate::content::{
 };
 use crate::genesis::bootstrap_basis_metadata_state;
 use crate::loading::ControlObjectLoadError;
-use crate::metadata::{MetadataState, ResolvedVisiblePath, VisiblePathError};
+use crate::metadata::{
+    CurrentMetadataView, IndexedMetadataState, MetadataOverlay, MetadataState, ResolvedVisiblePath,
+    VisiblePathError,
+};
 use crate::namespace::catalog::{
     load_namespace_content_store_id, load_namespace_descriptor, namespace_initialization_state,
     NamespaceInitializationError, NamespaceInitializationState,
@@ -682,6 +685,25 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataState,
     content_store_id: &ContentStoreId,
 ) -> Result<PlannedPathMutation, CoreError> {
+    let indexed = IndexedMetadataState::from_metadata_state(metadata_state.clone(), head.seq);
+    plan_path_mutation_against_indexed_state(
+        store,
+        namespace_id,
+        intent,
+        head,
+        &indexed,
+        content_store_id,
+    )
+}
+
+pub(crate) fn plan_path_mutation_against_indexed_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    intent: &PathMutationIntent,
+    head: &HeadState,
+    metadata_state: &IndexedMetadataState,
+    content_store_id: &ContentStoreId,
+) -> Result<PlannedPathMutation, CoreError> {
     let request_id = intent.request_id().to_owned();
     let source_request_checksum = source_request_checksum_for_path_intent(namespace_id, intent)?;
     let view = PathPlanningView {
@@ -724,7 +746,7 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
 
 struct PathPlanningView<'a> {
     head: &'a HeadState,
-    metadata_state: &'a MetadataState,
+    metadata_state: &'a IndexedMetadataState,
     content_store_id: &'a ContentStoreId,
 }
 
@@ -739,16 +761,15 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
     validate_path_for_mutation(absolute_path)?;
     let _validated =
         validate_durable_content_reference(store, view.content_store_id, &content_ref)?;
-    reject_tombstoned_path_ancestor(view.metadata_state, absolute_path, view.head.seq)?;
-    let target = lookup_path(view.metadata_state, absolute_path, view.head.seq);
+    reject_tombstoned_path_ancestor(view.metadata_state, absolute_path)?;
+    let target = lookup_path(view.metadata_state, absolute_path);
 
     let mut ops = Vec::new();
-    let mut working = view.metadata_state.clone();
+    let mut working = MetadataOverlay::new(view.metadata_state, view.head.seq);
     let mut next_inode_id = view.head.next_inode_id;
     let mut op_index = 0u32;
     let final_parent_inode = ensure_parent_directories(
         absolute_path,
-        view.head.seq,
         &mut working,
         &mut ops,
         &mut next_inode_id,
@@ -772,7 +793,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
             }
             let revision = view
                 .metadata_state
-                .latest_revision_head_at_seq(existing.inode_id, view.head.seq)
+                .current_revision_head(existing.inode_id)
                 .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
             ops.push(ApiCommitOp::ReplaceFile {
                 inode_id: existing.inode_id,
@@ -907,9 +928,7 @@ fn plan_delete_path(
     view: &PathPlanningView<'_>,
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(absolute_path)?;
-    let resolved = view
-        .metadata_state
-        .resolve_visible_path(absolute_path, view.head.seq)?;
+    let resolved = view.metadata_state.resolve_visible_path(absolute_path)?;
     let op = match resolved.inode_kind {
         InodeKind::File => ApiCommitOp::DeleteFile {
             inode_id: resolved.inode_id,
@@ -918,9 +937,7 @@ fn plan_delete_path(
             root_inode: resolved.inode_id,
         },
         InodeKind::Dir => {
-            let children = view
-                .metadata_state
-                .visible_children(resolved.inode_id, view.head.seq);
+            let children = view.metadata_state.visible_children(resolved.inode_id);
             if !children.is_empty() {
                 return Err(CoreError::DirectoryNotEmpty(absolute_path.to_owned()));
             }
@@ -955,14 +972,12 @@ fn plan_move_path(
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(from_path)?;
     validate_path_for_mutation(to_path)?;
-    reject_tombstoned_path_ancestor(view.metadata_state, from_path, view.head.seq)?;
-    reject_tombstoned_path_ancestor(view.metadata_state, to_path, view.head.seq)?;
-    let source = view
-        .metadata_state
-        .resolve_visible_path(from_path, view.head.seq)?;
-    let target_parent = resolve_parent_directory(view.metadata_state, to_path, view.head.seq)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, from_path)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, to_path)?;
+    let source = view.metadata_state.resolve_visible_path(from_path)?;
+    let target_parent = resolve_parent_directory(view.metadata_state, to_path)?;
     let target_name = final_component(to_path)?;
-    if lookup_path(view.metadata_state, to_path, view.head.seq).is_ok() {
+    if lookup_path(view.metadata_state, to_path).is_ok() {
         return Err(CoreError::DestinationExists(to_path.to_owned()));
     }
     Ok(ApiCommitRequest {
@@ -990,12 +1005,10 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(from_path)?;
     validate_path_for_mutation(to_path)?;
-    reject_tombstoned_path_ancestor(view.metadata_state, from_path, view.head.seq)?;
-    reject_tombstoned_path_ancestor(view.metadata_state, to_path, view.head.seq)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, from_path)?;
+    reject_tombstoned_path_ancestor(view.metadata_state, to_path)?;
 
-    let source = view
-        .metadata_state
-        .resolve_visible_path(from_path, view.head.seq)?;
+    let source = view.metadata_state.resolve_visible_path(from_path)?;
     if source.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: from_path.to_owned(),
@@ -1003,18 +1016,18 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
         });
     }
 
-    if lookup_path(view.metadata_state, to_path, view.head.seq).is_ok() {
+    if lookup_path(view.metadata_state, to_path).is_ok() {
         return Err(CoreError::DestinationExists(to_path.to_owned()));
     }
 
     let revision = view
         .metadata_state
-        .latest_revision_head_at_seq(source.inode_id, view.head.seq)
+        .current_revision_head(source.inode_id)
         .ok_or_else(|| CoreError::MissingPath(from_path.to_owned()))?;
     let _validated =
         validate_durable_content_reference(store, view.content_store_id, &revision.content_ref)?;
 
-    let target_parent = resolve_parent_directory(view.metadata_state, to_path, view.head.seq)?;
+    let target_parent = resolve_parent_directory(view.metadata_state, to_path)?;
     let target_name = final_component(to_path)?;
     let target_name_key = name_key_for_display_name(view.head.name_policy, &target_name);
     Ok(ApiCommitRequest {
@@ -1044,8 +1057,7 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
 
 fn ensure_parent_directories(
     absolute_path: &str,
-    committed_seq: ChangeSeq,
-    working: &mut MetadataState,
+    working: &mut MetadataOverlay<'_>,
     ops: &mut Vec<ApiCommitOp>,
     next_inode_id: &mut InodeId,
     op_index: &mut u32,
@@ -1057,9 +1069,9 @@ fn ensure_parent_directories(
 
     let mut current_inode = InodeId(1);
     for component in &components[..components.len() - 1] {
-        if let Some(child) = working.visible_child(current_inode, component, committed_seq) {
+        if let Some(child) = working.visible_child(current_inode, component) {
             let inode = working
-                .visible_inode(child.child_inode_id, committed_seq)
+                .visible_inode(child.child_inode_id)
                 .ok_or_else(|| CoreError::MissingPath(component.clone()))?;
             if inode.inode_kind != InodeKind::Dir {
                 return Err(CoreError::NonDirectoryPathComponent(component.clone()));
@@ -1074,16 +1086,15 @@ fn ensure_parent_directories(
         });
         let allocated = *next_inode_id;
         *next_inode_id = InodeId(next_inode_id.0.saturating_add(1));
-        let applied = working.apply_committed_wal_ops(
-            committed_seq,
-            &[loon_api::WalOp::CreateDir {
+        working.apply_committed_wal_op(
+            working.head_seq(),
+            &loon_api::WalOp::CreateDir {
                 op_index: *op_index,
                 inode_id: allocated,
                 parent_inode: current_inode,
                 display_name: component.clone(),
-            }],
+            },
         )?;
-        *working = applied.metadata_state;
         *op_index = op_index.saturating_add(1);
         current_inode = allocated;
     }
@@ -1091,16 +1102,15 @@ fn ensure_parent_directories(
 }
 
 fn resolve_parent_directory(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     absolute_path: &str,
-    seq: ChangeSeq,
 ) -> Result<InodeId, CoreError> {
     let components = path_components(absolute_path)?;
     if components.len() <= 1 {
         return Ok(InodeId(1));
     }
     let parent_path = format!("/{}", components[..components.len() - 1].join("/"));
-    let resolved = metadata_state.resolve_visible_path(&parent_path, seq)?;
+    let resolved = metadata_state.resolve_visible_path(&parent_path)?;
     if resolved.inode_kind != InodeKind::Dir {
         return Err(CoreError::ExpectedDirectory {
             path: parent_path,
@@ -1146,11 +1156,10 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
 }
 
 fn lookup_path(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     absolute_path: &str,
-    seq: ChangeSeq,
 ) -> Result<ResolvedVisiblePath, VisiblePathError> {
-    metadata_state.resolve_visible_path(absolute_path, seq)
+    metadata_state.resolve_visible_path(absolute_path)
 }
 
 fn validate_path_for_mutation(absolute_path: &str) -> Result<(), CoreError> {
@@ -1197,12 +1206,11 @@ fn join_absolute_path(base: &str, component: &str) -> String {
 }
 
 fn reject_tombstoned_path_ancestor(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     absolute_path: &str,
-    seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let Some((path, root_inode, tombstone_seq)) =
-        tombstoned_path_ancestor(metadata_state, absolute_path, seq)?
+        tombstoned_path_ancestor(metadata_state, absolute_path)?
     else {
         return Ok(());
     };
@@ -1214,21 +1222,19 @@ fn reject_tombstoned_path_ancestor(
 }
 
 fn tombstoned_path_ancestor(
-    metadata_state: &MetadataState,
+    metadata_state: &impl CurrentMetadataView,
     absolute_path: &str,
-    seq: ChangeSeq,
 ) -> Result<Option<(String, InodeId, ChangeSeq)>, CoreError> {
     let components = path_components(absolute_path)?;
     let mut current_inode = InodeId(1);
     let mut current_path = "/".to_owned();
 
     for component in components {
-        let Some(bound_child) = metadata_state.bound_child_at_seq(current_inode, &component, seq)
-        else {
+        let Some(bound_child) = metadata_state.bound_child(current_inode, &component) else {
             return Ok(None);
         };
         let Some(latest_binding) =
-            metadata_state.current_parent_binding_for_child(bound_child.child_inode_id, seq)
+            metadata_state.current_parent_binding_for_child(bound_child.child_inode_id)
         else {
             return Ok(None);
         };
@@ -1241,7 +1247,7 @@ fn tombstoned_path_ancestor(
         }
 
         if let Some(tombstone) =
-            metadata_state.covering_subtree_tombstone(bound_child.child_inode_id, seq)
+            metadata_state.covering_subtree_tombstone(bound_child.child_inode_id)
         {
             return Ok(Some((
                 join_absolute_path(&current_path, &bound_child.display_name),
@@ -1251,7 +1257,7 @@ fn tombstoned_path_ancestor(
         }
 
         if metadata_state
-            .visible_inode(bound_child.child_inode_id, seq)
+            .visible_inode(bound_child.child_inode_id)
             .is_none()
         {
             return Ok(None);

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1053,6 +1053,72 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
 }
 
 #[test]
+fn rejected_batch_candidate_does_not_mutate_preview_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            ApiCommitRequest {
+                request_id: "bad-parent".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: api_head_seq_is(ChangeSeq(0)),
+                ops: vec![ApiCommitOp::CreateDir {
+                    parent_inode: InodeId(999),
+                    display_name: "ghost".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+            ApiCommitRequest {
+                request_id: "good-root".to_owned(),
+                planned_head_seq: ChangeSeq(0),
+                preconditions: api_head_seq_is(ChangeSeq(0)),
+                ops: vec![ApiCommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "alpha".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+        &context,
+    );
+
+    let first_error = responses[0].as_ref().expect_err("first candidate rejected");
+    assert!(matches!(
+        first_error,
+        CoreError::CommitValidation(CommitValidationError::CreateParentMissing {
+            parent_inode: InodeId(999),
+        })
+    ));
+    assert_eq!(
+        responses[1]
+            .as_ref()
+            .expect("second candidate commits")
+            .committed_seq,
+        ChangeSeq(1)
+    );
+    let alpha = resolve_path(&store, &namespace_id, "/alpha").expect("alpha exists");
+    assert_eq!(alpha.inode_id, InodeId(2));
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    let wal_bytes = store
+        .get(&wal_keys[0], None)
+        .expect("read wal")
+        .expect("wal exists");
+    let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode segment");
+    assert_eq!(segment.payload.records.len(), 1);
+    assert_eq!(segment.payload.records[0].request_id, "good-root");
+}
+
+#[test]
 fn direct_publisher_path_intents_cover_basic_mutations() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -75,6 +75,91 @@ fn stale_head_precondition_is_rejected() {
 }
 
 #[test]
+fn missing_head_seq_precondition_is_rejected() {
+    let metadata_state = metadata_state_after(&[
+        vec![loon_api::WalOp::CreateDir {
+            op_index: 0,
+            inode_id: InodeId(2),
+            parent_inode: InodeId(1),
+            display_name: "docs".to_owned(),
+        }],
+        vec![loon_api::WalOp::CreateFile {
+            op_index: 0,
+            inode_id: InodeId(3),
+            parent_inode: InodeId(2),
+            display_name: "readme.txt".to_owned(),
+            content_ref: content_ref("content-1"),
+        }],
+    ]);
+    let context = validation_context(metadata_state, ChangeSeq(2), InodeId(4));
+    let request = CommitRequest {
+        namespace_id: namespace_id(),
+        request_id: "missing-head-seq".to_owned(),
+        writer_id: "writer-a".to_owned(),
+        writer_fence_token: FenceToken(1),
+        planned_head_seq: ChangeSeq(2),
+        source_request_checksum_sha256: None,
+        ops: vec![CommitOp::DeleteFile {
+            inode_id: InodeId(3),
+        }],
+        preconditions: Vec::new(),
+        message: None,
+        annotations: None,
+    };
+
+    let error = build_commit_plan(&request, &context).expect_err("missing head seq");
+    assert!(matches!(
+        error,
+        CommitValidationError::MissingHeadSeqPrecondition {
+            expected: ChangeSeq(2),
+        }
+    ));
+}
+
+#[test]
+fn planned_head_seq_mismatch_is_rejected() {
+    let metadata_state = metadata_state_after(&[
+        vec![loon_api::WalOp::CreateDir {
+            op_index: 0,
+            inode_id: InodeId(2),
+            parent_inode: InodeId(1),
+            display_name: "docs".to_owned(),
+        }],
+        vec![loon_api::WalOp::CreateFile {
+            op_index: 0,
+            inode_id: InodeId(3),
+            parent_inode: InodeId(2),
+            display_name: "readme.txt".to_owned(),
+            content_ref: content_ref("content-1"),
+        }],
+    ]);
+    let context = validation_context(metadata_state, ChangeSeq(2), InodeId(4));
+    let request = CommitRequest {
+        namespace_id: namespace_id(),
+        request_id: "planned-head-mismatch".to_owned(),
+        writer_id: "writer-a".to_owned(),
+        writer_fence_token: FenceToken(1),
+        planned_head_seq: ChangeSeq(1),
+        source_request_checksum_sha256: None,
+        ops: vec![CommitOp::DeleteFile {
+            inode_id: InodeId(3),
+        }],
+        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(1))],
+        message: None,
+        annotations: None,
+    };
+
+    let error = build_commit_plan(&request, &context).expect_err("planned head mismatch");
+    assert!(matches!(
+        error,
+        CommitValidationError::PlannedHeadSeqMismatch {
+            expected: ChangeSeq(2),
+            actual: ChangeSeq(1),
+        }
+    ));
+}
+
+#[test]
 fn stale_revision_precondition_is_rejected() {
     let metadata_state = metadata_state_after(&[
         vec![loon_api::WalOp::CreateDir {
@@ -752,7 +837,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
             ApiCommitRequest {
                 request_id: "req-batch-a".to_owned(),
                 planned_head_seq: ChangeSeq(0),
-                preconditions: Vec::new(),
+                preconditions: api_head_seq_is(ChangeSeq(0)),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "alpha".to_owned(),
@@ -762,8 +847,8 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
             },
             ApiCommitRequest {
                 request_id: "req-batch-b".to_owned(),
-                planned_head_seq: ChangeSeq(0),
-                preconditions: Vec::new(),
+                planned_head_seq: ChangeSeq(1),
+                preconditions: api_head_seq_is(ChangeSeq(1)),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "beta".to_owned(),
@@ -875,7 +960,7 @@ fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
     let request = ApiCommitRequest {
         request_id: "req-duplicate".to_owned(),
         planned_head_seq: ChangeSeq(0),
-        preconditions: Vec::new(),
+        preconditions: api_head_seq_is(ChangeSeq(0)),
         ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
             display_name: "alpha".to_owned(),
@@ -923,7 +1008,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
             ApiCommitRequest {
                 request_id: "req-conflict".to_owned(),
                 planned_head_seq: ChangeSeq(0),
-                preconditions: Vec::new(),
+                preconditions: api_head_seq_is(ChangeSeq(0)),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "alpha".to_owned(),
@@ -934,7 +1019,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
             ApiCommitRequest {
                 request_id: "req-conflict".to_owned(),
                 planned_head_seq: ChangeSeq(0),
-                preconditions: Vec::new(),
+                preconditions: api_head_seq_is(ChangeSeq(0)),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "beta".to_owned(),
@@ -2298,6 +2383,10 @@ fn mutation_context() -> MutationContext {
         now_ms: 1_000,
         lease_duration_ms: 60_000,
     }
+}
+
+fn api_head_seq_is(expected_seq: ChangeSeq) -> Vec<CommitPrecondition> {
+    vec![CommitPrecondition::HeadSeqIs { expected_seq }]
 }
 
 fn namespace_id() -> NamespaceId {

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -271,6 +271,7 @@ impl NamespacePublisher {
             let store = self.store.clone();
             let context = mutation_context(&self.config);
             let cached_basis = self.cached_basis_for_publish(&context);
+            let used_cached_basis = cached_basis.is_some();
             let publish_result = tokio::task::spawn_blocking(move || match cached_basis {
                 Some(basis) => publish_namespace_mutations_batch_with_basis(
                     store.as_ref(),
@@ -290,7 +291,16 @@ impl NamespacePublisher {
             .unwrap_or_else(|err| NamespaceBatchPublishResult {
                 results: vec![Err(CoreError::Store(err.to_string())); candidates.len()],
                 promoted_basis: None,
+                head_published: false,
             });
+            if used_cached_basis
+                && !publish_result.head_published
+                && publish_result.results.iter().any(Result::is_err)
+                && attempt + 1 < HEAD_CAS_RETRY_LIMIT
+            {
+                self.update_cached_basis(None);
+                continue;
+            }
             self.update_cached_basis(publish_result.promoted_basis.clone());
             let batch_results = publish_result.results;
             let stale_head = batch_results.iter().any(is_head_publish_stale);
@@ -493,10 +503,12 @@ fn mutation_context(config: &ServerConfig) -> MutationContext {
 mod tests {
     use super::*;
     use crate::config::StoreConfig;
-    use loon_api::v0::{CommitOp, CommitRequest};
+    use loon_api::v0::{CommitOp, CommitPrecondition, CommitRequest};
     use loon_api::{ChangeSeq, InodeId};
     use loon_core::{
-        bootstrap_namespace, store_bytes_as_content, PathMutationIntent, PutFileBehavior,
+        bootstrap_namespace, load_verified_namespace_basis,
+        publish_namespace_mutations_batch_with_fresh_basis, store_bytes_as_content,
+        PathMutationIntent, PutFileBehavior,
     };
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::namespace_head;
@@ -718,10 +730,18 @@ mod tests {
         request_id: impl Into<String>,
         display_name: impl Into<String>,
     ) -> CommitRequest {
+        create_dir_request_at(ChangeSeq(0), request_id, display_name)
+    }
+
+    fn create_dir_request_at(
+        expected_seq: ChangeSeq,
+        request_id: impl Into<String>,
+        display_name: impl Into<String>,
+    ) -> CommitRequest {
         CommitRequest {
             request_id: request_id.into(),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: Vec::new(),
+            planned_head_seq: expected_seq,
+            preconditions: vec![CommitPrecondition::HeadSeqIs { expected_seq }],
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: display_name.into(),
@@ -818,8 +838,10 @@ mod tests {
         store.reset_counts();
         allow_immediate_next_publish(&publisher);
         let second = publisher
-            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
-                "second", "second",
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request_at(
+                ChangeSeq(1),
+                "second",
+                "second",
             )))
             .await
             .expect("second commit");
@@ -906,8 +928,10 @@ mod tests {
         store.fail_next_head_cas();
         allow_immediate_next_publish(&publisher);
         let second = publisher
-            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
-                "second", "second",
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request_at(
+                ChangeSeq(1),
+                "second",
+                "second",
             )))
             .await
             .expect("second commit");
@@ -930,6 +954,79 @@ mod tests {
             .expect("changes");
         assert_eq!(changes.changes.len(), 2);
         assert_eq!(changes.through_seq, ChangeSeq(2));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_retries_cached_validation_error_against_fresh_basis() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(InstrumentedStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher =
+            NamespacePublisher::new(namespace_id.clone(), shared.clone(), config.clone());
+
+        publisher
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
+                "first", "first",
+            )))
+            .await
+            .expect("first commit");
+        assert_eq!(cached_basis(&publisher).head.seq, ChangeSeq(1));
+
+        let mut external_results = publish_namespace_mutations_batch_with_fresh_basis(
+            shared.as_ref(),
+            &namespace_id,
+            vec![NamespaceMutationCandidate::Commit(create_dir_request_at(
+                ChangeSeq(1),
+                "external",
+                "external",
+            ))],
+            &mutation_context(&config),
+        )
+        .results;
+        let external = external_results
+            .pop()
+            .expect("external result")
+            .expect("external commit");
+        assert_eq!(external.committed_seq, ChangeSeq(2));
+        assert_eq!(
+            load_verified_namespace_basis(shared.as_ref(), &namespace_id)
+                .expect("basis")
+                .head
+                .seq,
+            ChangeSeq(2)
+        );
+
+        store.reset_counts();
+        allow_immediate_next_publish(&publisher);
+        let deleted = publisher
+            .submit(NamespaceMutationCandidate::Path(
+                PathMutationIntent::DeletePath {
+                    request_id: "delete-external".to_owned(),
+                    absolute_path: "/external".to_owned(),
+                    recursive: false,
+                },
+            ))
+            .await
+            .expect("delete retries against fresh basis");
+        assert_eq!(deleted.committed_seq, ChangeSeq(3));
+        assert!(
+            store.head_calls() > 0,
+            "fresh retry should reload head after cached validation error"
+        );
+        assert!(
+            store.get_calls() > 0,
+            "fresh retry should reload basis after cached validation error"
+        );
+        assert_eq!(cached_basis(&publisher).head.seq, ChangeSeq(3));
     }
 
     #[test]
@@ -1022,7 +1119,7 @@ mod tests {
         let pending = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending", "pending"),
+            create_dir_request_at(ChangeSeq(1), "pending", "pending"),
         );
         {
             let state = publisher
@@ -1128,19 +1225,23 @@ mod tests {
             pending.push(admit_commit(
                 &publisher,
                 &namespace_id,
-                create_dir_request(format!("pending-{index}"), format!("pending-{index}")),
+                create_dir_request_at(
+                    ChangeSeq(index as u64 + 1),
+                    format!("pending-{index}"),
+                    format!("pending-{index}"),
+                ),
             ));
         }
 
         let duplicate = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending-0", "pending-0"),
+            create_dir_request_at(ChangeSeq(1), "pending-0", "pending-0"),
         );
         let conflict = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending-0", "different-pending"),
+            create_dir_request_at(ChangeSeq(1), "pending-0", "different-pending"),
         );
         assert!(matches!(
             conflict,
@@ -1150,7 +1251,11 @@ mod tests {
         let overflow = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("overflow", "overflow"),
+            create_dir_request_at(
+                ChangeSeq(MAX_BATCH_CANDIDATES as u64 + 1),
+                "overflow",
+                "overflow",
+            ),
         );
         assert!(matches!(overflow, Err(CoreError::CommitQueueFull)));
 
@@ -1193,7 +1298,11 @@ mod tests {
             receivers.push(admit_commit(
                 &publisher,
                 &namespace_id,
-                create_dir_request(format!("full-{index}"), format!("full-{index}")),
+                create_dir_request_at(
+                    ChangeSeq(index as u64),
+                    format!("full-{index}"),
+                    format!("full-{index}"),
+                ),
             ));
         }
 
@@ -1243,7 +1352,9 @@ mod tests {
         let request_a = CommitRequest {
             request_id: "req-a".to_owned(),
             planned_head_seq: ChangeSeq(0),
-            preconditions: Vec::new(),
+            preconditions: vec![CommitPrecondition::HeadSeqIs {
+                expected_seq: ChangeSeq(0),
+            }],
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "alpha".to_owned(),
@@ -1253,8 +1364,10 @@ mod tests {
         };
         let request_b = CommitRequest {
             request_id: "req-b".to_owned(),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: Vec::new(),
+            planned_head_seq: ChangeSeq(1),
+            preconditions: vec![CommitPrecondition::HeadSeqIs {
+                expected_seq: ChangeSeq(1),
+            }],
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "beta".to_owned(),
@@ -1304,7 +1417,9 @@ mod tests {
         let explicit = CommitRequest {
             request_id: "explicit-commit".to_owned(),
             planned_head_seq: ChangeSeq(0),
-            preconditions: Vec::new(),
+            preconditions: vec![CommitPrecondition::HeadSeqIs {
+                expected_seq: ChangeSeq(0),
+            }],
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "alpha".to_owned(),

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -2,8 +2,10 @@ use crate::config::ServerConfig;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::{payload_checksum_sha256, NamespaceId};
 use loon_core::{
-    commit::CommitHeadPublishError, publish_namespace_mutations_batch, CoreError, MutationContext,
-    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation,
+    commit::CommitHeadPublishError, publish_namespace_mutations_batch_with_basis,
+    publish_namespace_mutations_batch_with_fresh_basis, CoreError, MutationContext,
+    NamespaceBatchPublishResult, NamespaceMutationCandidate, PathMutationIntent,
+    PlannedNamespaceMutation, VerifiedNamespaceBasis,
 };
 use loon_objectstore::ObjectStore;
 use serde::Serialize;
@@ -20,6 +22,7 @@ const MAX_BATCH_CANDIDATES: usize = 1024;
 const COALESCING_DELAY: Duration = Duration::from_millis(100);
 const MIN_NAMESPACE_CAS_INTERVAL: Duration = Duration::from_secs(1);
 const HEAD_CAS_RETRY_LIMIT: usize = 8;
+const PUBLISH_LEASE_SAFETY_MARGIN_MS: u64 = 5_000;
 
 #[derive(Clone)]
 pub(crate) struct PublisherRegistry {
@@ -93,6 +96,7 @@ struct NamespacePublisherState {
     in_flight: HashMap<String, InFlightRequest>,
     publishing: bool,
     next_allowed_cas_at: Instant,
+    cached_basis: Option<VerifiedNamespaceBasis>,
 }
 
 struct OpenBatch {
@@ -122,6 +126,7 @@ impl NamespacePublisher {
                 in_flight: HashMap::new(),
                 publishing: false,
                 next_allowed_cas_at: Instant::now(),
+                cached_basis: None,
             })),
         }
     }
@@ -265,17 +270,32 @@ impl NamespacePublisher {
             let namespace_id = self.namespace_id.clone();
             let store = self.store.clone();
             let context = mutation_context(&self.config);
-            results = tokio::task::spawn_blocking(move || {
-                publish_namespace_mutations_batch(
+            let cached_basis = self.cached_basis_for_publish(&context);
+            let publish_result = tokio::task::spawn_blocking(move || match cached_basis {
+                Some(basis) => publish_namespace_mutations_batch_with_basis(
                     store.as_ref(),
                     &namespace_id,
                     batch_candidates,
                     &context,
-                )
+                    basis,
+                ),
+                None => publish_namespace_mutations_batch_with_fresh_basis(
+                    store.as_ref(),
+                    &namespace_id,
+                    batch_candidates,
+                    &context,
+                ),
             })
             .await
-            .unwrap_or_else(|err| vec![Err(CoreError::Store(err.to_string())); candidates.len()]);
-            if !results.iter().any(is_head_publish_stale) {
+            .unwrap_or_else(|err| NamespaceBatchPublishResult {
+                results: vec![Err(CoreError::Store(err.to_string())); candidates.len()],
+                promoted_basis: None,
+            });
+            self.update_cached_basis(publish_result.promoted_basis.clone());
+            let batch_results = publish_result.results;
+            let stale_head = batch_results.iter().any(is_head_publish_stale);
+            results = batch_results;
+            if !stale_head {
                 break;
             }
             if attempt + 1 == HEAD_CAS_RETRY_LIMIT {
@@ -285,6 +305,36 @@ impl NamespacePublisher {
         }
 
         self.complete_batch(candidates, results);
+    }
+
+    fn cached_basis_for_publish(
+        &self,
+        context: &MutationContext,
+    ) -> Option<VerifiedNamespaceBasis> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("namespace publisher mutex poisoned");
+        if state.cached_basis.as_ref().is_some_and(|basis| {
+            can_use_cached_basis(
+                basis,
+                &self.namespace_id,
+                &self.config.writer_id,
+                context.now_ms,
+            )
+        }) {
+            return state.cached_basis.clone();
+        }
+        state.cached_basis = None;
+        None
+    }
+
+    fn update_cached_basis(&self, promoted_basis: Option<VerifiedNamespaceBasis>) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("namespace publisher mutex poisoned");
+        state.cached_basis = promoted_basis;
     }
 
     async fn wait_for_next_cas_token(&self) {
@@ -344,6 +394,21 @@ impl NamespacePublisher {
             self.spawn_publish_task();
         }
     }
+}
+
+fn can_use_cached_basis(
+    basis: &VerifiedNamespaceBasis,
+    namespace_id: &NamespaceId,
+    writer_id: &str,
+    now_ms: u64,
+) -> bool {
+    basis.head.namespace_id == *namespace_id
+        && basis.namespace_descriptor.namespace_id == *namespace_id
+        && !basis.head_etag.trim().is_empty()
+        && basis.lease.holder_id == writer_id
+        && basis.lease.namespace_id == *namespace_id
+        && basis.lease.fence_token == basis.head.active_fence_token
+        && basis.lease.lease_expires_at_ms.saturating_sub(now_ms) >= PUBLISH_LEASE_SAFETY_MARGIN_MS
 }
 
 fn is_head_publish_stale(result: &CommitResult) -> bool {
@@ -437,6 +502,7 @@ mod tests {
     use loon_objectstore::keys::namespace_head;
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
     use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Condvar;
     use tempfile::tempdir;
 
@@ -547,6 +613,93 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct InstrumentedStore {
+        inner: LocalFsStore,
+        head_key: String,
+        counters: Arc<InstrumentedCounters>,
+        fail_next_head_cas: AtomicUsize,
+    }
+
+    #[derive(Debug, Default)]
+    struct InstrumentedCounters {
+        head_calls: AtomicUsize,
+        get_calls: AtomicUsize,
+        head_cas_calls: AtomicUsize,
+    }
+
+    impl InstrumentedStore {
+        fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+            Self {
+                inner: LocalFsStore::new(root.as_ref()).expect("store"),
+                head_key: namespace_head(namespace_id.as_str()),
+                counters: Arc::new(InstrumentedCounters::default()),
+                fail_next_head_cas: AtomicUsize::new(0),
+            }
+        }
+
+        fn reset_counts(&self) {
+            self.counters.head_calls.store(0, Ordering::SeqCst);
+            self.counters.get_calls.store(0, Ordering::SeqCst);
+            self.counters.head_cas_calls.store(0, Ordering::SeqCst);
+        }
+
+        fn head_calls(&self) -> usize {
+            self.counters.head_calls.load(Ordering::SeqCst)
+        }
+
+        fn get_calls(&self) -> usize {
+            self.counters.get_calls.load(Ordering::SeqCst)
+        }
+
+        fn head_cas_calls(&self) -> usize {
+            self.counters.head_cas_calls.load(Ordering::SeqCst)
+        }
+
+        fn fail_next_head_cas(&self) {
+            self.fail_next_head_cas.store(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ObjectStore for InstrumentedStore {
+        fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.counters.head_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.head(key)
+        }
+
+        fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+            self.counters.get_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.get(key, range)
+        }
+
+        fn put(
+            &self,
+            key: &str,
+            bytes: &[u8],
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
+                self.counters.head_cas_calls.fetch_add(1, Ordering::SeqCst);
+                if self.fail_next_head_cas.swap(0, Ordering::SeqCst) > 0 {
+                    return Err(ObjectStoreError::PreconditionFailed);
+                }
+            }
+            self.inner.put(key, bytes, mode)
+        }
+
+        fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key)
+        }
+
+        fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+            self.inner.list_prefix(prefix)
+        }
+    }
+
     fn test_config(root: &Path) -> Arc<ServerConfig> {
         Arc::new(ServerConfig {
             bind: "127.0.0.1:0".to_owned(),
@@ -607,6 +760,239 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("{label} receiver dropped: {err}"))
             .unwrap_or_else(|err| panic!("{label} failed: {err}"))
+    }
+
+    fn allow_immediate_next_publish(publisher: &NamespacePublisher) {
+        publisher
+            .state
+            .lock()
+            .expect("namespace publisher mutex poisoned")
+            .next_allowed_cas_at = Instant::now();
+    }
+
+    fn cached_basis(publisher: &NamespacePublisher) -> VerifiedNamespaceBasis {
+        publisher
+            .state
+            .lock()
+            .expect("namespace publisher mutex poisoned")
+            .cached_basis
+            .clone()
+            .expect("cached basis")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_promotes_and_reuses_cached_basis_for_sequential_batches() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(InstrumentedStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        let first = publisher
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
+                "first", "first",
+            )))
+            .await
+            .expect("first commit");
+        assert_eq!(first.committed_seq, ChangeSeq(1));
+
+        let first_basis = cached_basis(&publisher);
+        assert_eq!(first_basis.head.seq, ChangeSeq(1));
+        assert_eq!(first_basis.head.next_inode_id, InodeId(3));
+        assert!(first_basis.head.visible_wal_tip.is_some());
+        assert!(!first_basis.head_etag.trim().is_empty());
+        assert!(first_basis
+            .metadata_state
+            .request_receipts
+            .iter()
+            .any(|receipt| receipt.request_id == "first"));
+
+        store.reset_counts();
+        allow_immediate_next_publish(&publisher);
+        let second = publisher
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
+                "second", "second",
+            )))
+            .await
+            .expect("second commit");
+        assert_eq!(second.committed_seq, ChangeSeq(2));
+        assert_eq!(store.head_calls(), 0, "cached publish should not HEAD");
+        assert_eq!(store.get_calls(), 0, "cached publish should not GET");
+        assert_eq!(store.head_cas_calls(), 1);
+
+        let second_basis = cached_basis(&publisher);
+        assert_eq!(second_basis.head.seq, ChangeSeq(2));
+        assert_eq!(second_basis.head.next_inode_id, InodeId(4));
+        assert!(second_basis
+            .metadata_state
+            .request_receipts
+            .iter()
+            .any(|receipt| receipt.request_id == "second"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_serves_previous_request_id_from_cached_receipt() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(InstrumentedStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+        let request = create_dir_request("same-request", "same-dir");
+
+        let first = publisher
+            .submit(NamespaceMutationCandidate::Commit(request.clone()))
+            .await
+            .expect("first commit");
+        assert_eq!(first.committed_seq, ChangeSeq(1));
+
+        store.reset_counts();
+        allow_immediate_next_publish(&publisher);
+        let duplicate = publisher
+            .submit(NamespaceMutationCandidate::Commit(request))
+            .await
+            .expect("duplicate commit");
+        assert_eq!(duplicate.committed_seq, ChangeSeq(1));
+        assert_eq!(store.head_calls(), 0);
+        assert_eq!(store.get_calls(), 0);
+        assert_eq!(store.head_cas_calls(), 0);
+
+        let wal_keys = shared
+            .list_prefix("namespaces/demo/wal/")
+            .expect("list wal");
+        assert_eq!(wal_keys.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_clears_cached_basis_after_stale_head_and_retries_fresh() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = Arc::new(InstrumentedStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(
+            shared.as_ref(),
+            &namespace_id,
+            &mutation_context(&config),
+            false,
+        )
+        .expect("bootstrap");
+        let publisher = NamespacePublisher::new(namespace_id.clone(), shared.clone(), config);
+
+        publisher
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
+                "first", "first",
+            )))
+            .await
+            .expect("first commit");
+        assert_eq!(cached_basis(&publisher).head.seq, ChangeSeq(1));
+
+        store.reset_counts();
+        store.fail_next_head_cas();
+        allow_immediate_next_publish(&publisher);
+        let second = publisher
+            .submit(NamespaceMutationCandidate::Commit(create_dir_request(
+                "second", "second",
+            )))
+            .await
+            .expect("second commit");
+        assert_eq!(second.committed_seq, ChangeSeq(2));
+        assert!(
+            store.head_calls() > 0,
+            "retry after stale head should cold-load a fresh basis"
+        );
+        assert!(
+            store.get_calls() > 0,
+            "retry after stale head should read durable basis objects"
+        );
+        assert_eq!(cached_basis(&publisher).head.seq, ChangeSeq(2));
+
+        let wal_keys = shared
+            .list_prefix("namespaces/demo/wal/")
+            .expect("list wal");
+        assert_eq!(wal_keys.len(), 3, "first publish, orphan, retry");
+        let changes = loon_core::list_changes_after(shared.as_ref(), &namespace_id, ChangeSeq(0))
+            .expect("changes");
+        assert_eq!(changes.changes.len(), 2);
+        assert_eq!(changes.through_seq, ChangeSeq(2));
+    }
+
+    #[test]
+    fn cached_basis_safety_gate_rejects_unsafe_states() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let config = test_config(temp_dir.path());
+        bootstrap_namespace(&store, &namespace_id, &mutation_context(&config), false)
+            .expect("bootstrap");
+        let mut basis =
+            loon_core::load_verified_namespace_basis(&store, &namespace_id).expect("basis");
+        basis.lease.lease_expires_at_ms = 10_000;
+        assert!(can_use_cached_basis(
+            &basis,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
+
+        let mut near_expiry = basis.clone();
+        near_expiry.lease.lease_expires_at_ms = 8_999;
+        assert!(!can_use_cached_basis(
+            &near_expiry,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
+
+        let mut wrong_holder = basis.clone();
+        wrong_holder.lease.holder_id = "writer-b".to_owned();
+        assert!(!can_use_cached_basis(
+            &wrong_holder,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
+
+        let mut fence_mismatch = basis.clone();
+        fence_mismatch.lease.fence_token = loon_api::FenceToken(1);
+        assert!(!can_use_cached_basis(
+            &fence_mismatch,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
+
+        let mut empty_token = basis.clone();
+        empty_token.head_etag = " ".to_owned();
+        assert!(!can_use_cached_basis(
+            &empty_token,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
+
+        basis.head.namespace_id = NamespaceId::from("other");
+        assert!(!can_use_cached_basis(
+            &basis,
+            &namespace_id,
+            "writer-a",
+            4_000
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
This PR makes the server publisher reuse a verified namespace basis across sequential batches when it is still safe to do so. The goal is to avoid cold-loading the namespace descriptor, head, checkpoint/WAL basis, and metadata state before every publish when the same per-namespace publisher just advanced the head itself. (This was identified as about ~50%, 400ms, of latency in each batch)

Note that this is (a relatively simple) an optimization. The cached basis is accepted only when the namespace identity, descriptor identity, writer lease holder, fence token, non-empty head etag, and lease safety margin still line up. A successful publish promotes the resulting basis into the cache; stale head CAS failures, unsafe lease state, or ambiguous publish failures clear the cache and fall back to the fresh-basis path. However, in steady state, this is a very common path, and is expected to be used often. 

This also keeps cached validation errors from becoming authoritative. If a cached attempt produces any error without publishing a new head, the publisher discards the cache and retries once through the normal fresh load path. Cached idempotent receipt hits still stay fast: if the cached basis answers the request successfully without writing a head, the server returns that result without doing a HEAD/GET reload.

Core now exposes explicit fresh-basis and supplied-basis publish hooks, returning a `NamespaceBatchPublishResult` with the per-request results, an optional promoted basis, and a `head_published` flag. `head_published` is only true after the namespace head CAS succeeds, so the server can distinguish “we actually advanced visibility” from “we only evaluated against cached state.”

This PR also restores the stricter explicit commit framing that batching should not weaken. Explicit `/commits` requests must have `planned_head_seq` equal to the validation head and must include a matching `HeadSeqIs` precondition. Path-oriented mutations remain server-planned against tentative batch state, so they can still batch naturally without relaxing the lower-level explicit commit contract.
