### PR TITLE
fix: align on single commit_id nomenclature, and remove request_id

### DIFF
--- a/crates/loon-api/src/checkpoint.rs
+++ b/crates/loon-api/src/checkpoint.rs
@@ -29,7 +29,7 @@ pub enum CheckpointTableFamily {
     Direntries,
     Revisions,
     Tombstones,
-    CommittedCommits,
+    CommitReceipts,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,7 +91,7 @@ pub enum CheckpointRow {
         #[serde(default)]
         tombstone_op_index: u32,
     },
-    CommittedCommit {
+    CommitReceipt {
         commit_id: CommitId,
         request_fingerprint_sha256: String,
         committed_seq: ChangeSeq,
@@ -151,11 +151,11 @@ impl CheckpointRow {
                     )
                 }
             }
-            Self::CommittedCommit {
+            Self::CommitReceipt {
                 committed_seq,
                 commit_id,
                 ..
-            } => format!("committed-commit-{commit_id}-{:020}", committed_seq.0),
+            } => format!("commit-receipt-{commit_id}-{:020}", committed_seq.0),
         }
     }
 }

--- a/crates/loon-api/src/checkpoint.rs
+++ b/crates/loon-api/src/checkpoint.rs
@@ -1,6 +1,8 @@
 use crate::digest::sha256_hex;
 use crate::v0::CommitOpResult;
-use crate::{ChangeSeq, ContentRef, FenceToken, InodeId, InodeKind, NamespaceId, RevisionNo};
+use crate::{
+    ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, InodeKind, NamespaceId, RevisionNo,
+};
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -27,7 +29,7 @@ pub enum CheckpointTableFamily {
     Direntries,
     Revisions,
     Tombstones,
-    RequestReceipts,
+    CommittedCommits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,11 +91,10 @@ pub enum CheckpointRow {
         #[serde(default)]
         tombstone_op_index: u32,
     },
-    RequestReceipt {
-        request_id: String,
-        semantic_fingerprint_sha256: String,
+    CommittedCommit {
+        commit_id: CommitId,
+        request_fingerprint_sha256: String,
         committed_seq: ChangeSeq,
-        commit_id: String,
         results: Vec<CommitOpResult>,
     },
 }
@@ -150,11 +151,11 @@ impl CheckpointRow {
                     )
                 }
             }
-            Self::RequestReceipt {
-                request_id,
+            Self::CommittedCommit {
                 committed_seq,
+                commit_id,
                 ..
-            } => format!("request-receipt-{request_id}-{:020}", committed_seq.0),
+            } => format!("committed-commit-{commit_id}-{:020}", committed_seq.0),
         }
     }
 }

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, ContentRef, NamespaceId};
+use crate::{ChangeSeq, CommitId, ContentRef, NamespaceId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,7 +63,7 @@ pub enum FilesystemOperation {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilesystemOperationRequest {
-    pub request_id: String,
+    pub commit_id: CommitId,
     pub operation: FilesystemOperation,
 }
 

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -10,6 +10,10 @@ pub struct NamespaceId(pub String);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ContentStoreId(pub String);
 
+/// Client-supplied stable identifier for one logical commit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CommitId(pub String);
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid namespace_id {value:?}: {reason}")]
 pub struct NamespaceIdValidationError {
@@ -17,7 +21,24 @@ pub struct NamespaceIdValidationError {
     reason: &'static str,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid commit_id {value:?}: {reason}")]
+pub struct CommitIdValidationError {
+    value: String,
+    reason: &'static str,
+}
+
 impl NamespaceIdValidationError {
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn reason(&self) -> &'static str {
+        self.reason
+    }
+}
+
+impl CommitIdValidationError {
     pub fn value(&self) -> &str {
         &self.value
     }
@@ -51,49 +72,79 @@ impl NamespaceId {
     }
 }
 
+impl CommitId {
+    /// Constructs a commit id without validation. Use [`CommitId::parse`]
+    /// for user-supplied or durable-boundary input.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, CommitIdValidationError> {
+        let value = value.as_ref();
+        validate_commit_id(value)?;
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn try_new(value: impl Into<String>) -> Result<Self, CommitIdValidationError> {
+        let value = value.into();
+        validate_commit_id(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 fn validate_namespace_id(value: &str) -> Result<(), NamespaceIdValidationError> {
+    validate_id_grammar(value).map_err(|reason| namespace_id_error(value, reason))
+}
+
+fn validate_commit_id(value: &str) -> Result<(), CommitIdValidationError> {
+    validate_id_grammar(value).map_err(|reason| commit_id_error(value, reason))
+}
+
+fn validate_id_grammar(value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
-        return Err(namespace_id_error(value, "must not be empty"));
+        return Err("must not be empty");
     }
     if value.len() > 128 {
-        return Err(namespace_id_error(value, "must be 128 bytes or fewer"));
+        return Err("must be 128 bytes or fewer");
     }
     if value.trim() != value {
-        return Err(namespace_id_error(
-            value,
-            "must not have leading or trailing whitespace",
-        ));
+        return Err("must not have leading or trailing whitespace");
     }
     if matches!(value, "." | "..") {
-        return Err(namespace_id_error(value, "must not be `.` or `..`"));
+        return Err("must not be `.` or `..`");
     }
 
     let mut chars = value.chars();
     let first = chars
         .next()
-        .expect("empty namespace_id returned before char validation");
+        .expect("empty id returned before char validation");
     if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
-        return Err(namespace_id_error(
-            value,
-            "must start with a lowercase ASCII letter or digit",
-        ));
+        return Err("must start with a lowercase ASCII letter or digit");
     }
-    if !chars.all(is_allowed_namespace_id_tail_char) {
-        return Err(namespace_id_error(
-            value,
-            "must contain only lowercase ASCII letters, digits, `.`, `_`, or `-`",
-        ));
+    if !chars.all(is_allowed_id_tail_char) {
+        return Err("must contain only lowercase ASCII letters, digits, `.`, `_`, or `-`");
     }
 
     Ok(())
 }
 
-fn is_allowed_namespace_id_tail_char(ch: char) -> bool {
+fn is_allowed_id_tail_char(ch: char) -> bool {
     ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-')
 }
 
 fn namespace_id_error(value: &str, reason: &'static str) -> NamespaceIdValidationError {
     NamespaceIdValidationError {
+        value: value.to_owned(),
+        reason,
+    }
+}
+
+fn commit_id_error(value: &str, reason: &'static str) -> CommitIdValidationError {
+    CommitIdValidationError {
         value: value.to_owned(),
         reason,
     }
@@ -133,6 +184,18 @@ impl From<String> for ContentStoreId {
     }
 }
 
+impl From<&str> for CommitId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for CommitId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
 impl Serialize for NamespaceId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -151,12 +214,31 @@ impl Serialize for ContentStoreId {
     }
 }
 
+impl Serialize for CommitId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
 impl<'de> Deserialize<'de> for NamespaceId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(String::deserialize(deserializer)?))
+    }
+}
+
+impl<'de> Deserialize<'de> for CommitId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        CommitId::try_new(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -222,6 +304,12 @@ impl fmt::Display for ContentStoreId {
     }
 }
 
+impl fmt::Display for CommitId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 impl fmt::Display for InodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "inode-{}", self.0)
@@ -230,7 +318,7 @@ impl fmt::Display for InodeId {
 
 #[cfg(test)]
 mod tests {
-    use super::NamespaceId;
+    use super::{CommitId, NamespaceId};
 
     #[test]
     fn namespace_id_parse_accepts_allowed_grammar() {
@@ -260,5 +348,14 @@ mod tests {
         let namespace_id = NamespaceId::from("invalid/name");
 
         assert_eq!(namespace_id.as_str(), "invalid/name");
+    }
+
+    #[test]
+    fn commit_id_parse_uses_same_allowed_grammar() {
+        let parsed = CommitId::parse("c_demo-1").expect("valid commit_id");
+
+        assert_eq!(parsed.as_str(), "c_demo-1");
+        assert!(CommitId::parse("c/demo").is_err());
+        assert!(CommitId::parse("C_demo").is_err());
     }
 }

--- a/crates/loon-api/src/v0.rs
+++ b/crates/loon-api/src/v0.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, ContentRef, InodeId, NamespaceId, RevisionNo};
+use crate::{ChangeSeq, CommitId, ContentRef, InodeId, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -39,7 +39,7 @@ pub struct CompleteUploadResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRequest {
-    pub request_id: String,
+    pub commit_id: CommitId,
     pub planned_head_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preconditions: Vec<CommitPrecondition>,
@@ -53,7 +53,7 @@ pub struct CommitRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitResponse {
     pub namespace_id: NamespaceId,
-    pub commit_id: String,
+    pub commit_id: CommitId,
     pub committed_seq: ChangeSeq,
     pub results: Vec<CommitOpResult>,
 }
@@ -155,8 +155,7 @@ pub enum CommitOpResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommittedChange {
     pub seq: ChangeSeq,
-    pub commit_id: String,
-    pub request_id: String,
+    pub commit_id: CommitId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -1,6 +1,6 @@
 use crate::digest::sha256_hex;
 use crate::v0::{CommitAnnotations, CommitOpResult};
-use crate::{ChangeSeq, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo};
+use crate::{ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo};
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -85,12 +85,8 @@ pub struct WalCommitPayload {
     pub namespace_id: NamespaceId,
     pub seq: ChangeSeq,
     pub base_head_seq: ChangeSeq,
-    pub commit_id: String,
-    pub request_id: String,
-    pub request_checksum_sha256: String,
-    pub semantic_fingerprint_sha256: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_request_checksum_sha256: Option<String>,
+    pub commit_id: CommitId,
+    pub request_fingerprint_sha256: String,
     pub writer_id: String,
     pub writer_fence_token: FenceToken,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -125,7 +125,9 @@ fn map_client_error(error: ClientError) -> CliError {
         ClientError::ConfigValidation { field, reason } => {
             CliError::invalid_config(format!("invalid `{field}`: {reason}"))
         }
-        ClientError::InvalidNamespacePath(message) => CliError::invalid_input(message),
+        ClientError::InvalidNamespacePath(message) | ClientError::InvalidCommitId(message) => {
+            CliError::invalid_input(message)
+        }
         ClientError::Http(message) | ClientError::Json(message) => CliError::client_error(message),
         ClientError::Api { code, message, .. } => CliError::new(code, message),
         ClientError::Io(message) => CliError::new("io_error", format!("i/o error: {message}")),
@@ -214,7 +216,7 @@ impl Backend for DirectBackend {
         } else {
             PutFileBehavior::CreateOnly
         };
-        let request_id = Uuid::new_v4().to_string();
+        let commit_id = generated_commit_id();
         put_file_bytes(
             &self.store,
             &ns_id,
@@ -222,20 +224,20 @@ impl Backend for DirectBackend {
             bytes,
             behavior,
             &self.mutation_context(),
-            Some(&request_id),
+            Some(&commit_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        let request_id = Uuid::new_v4().to_string();
+        let commit_id = generated_commit_id();
         delete_path_non_recursive(
             &self.store,
             &ns_id,
             &spec.absolute_path,
             &self.mutation_context(),
-            Some(&request_id),
+            Some(&commit_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&spec.namespace, error))
     }
@@ -246,14 +248,14 @@ impl Backend for DirectBackend {
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
-        let request_id = Uuid::new_v4().to_string();
+        let commit_id = generated_commit_id();
         move_path(
             &self.store,
             &ns_id,
             &from.absolute_path,
             &to.absolute_path,
             &self.mutation_context(),
-            Some(&request_id),
+            Some(&commit_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
@@ -264,14 +266,14 @@ impl Backend for DirectBackend {
         to: &NamespacePath,
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
-        let request_id = Uuid::new_v4().to_string();
+        let commit_id = generated_commit_id();
         copy_file_path(
             &self.store,
             &ns_id,
             &from.absolute_path,
             &to.absolute_path,
             &self.mutation_context(),
-            Some(&request_id),
+            Some(&commit_id),
         )
         .map_err(|error| map_namespace_scoped_core_error(&from.namespace, error))
     }
@@ -281,14 +283,22 @@ fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
     NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))
 }
 
+fn generated_commit_id() -> String {
+    format!("c_{}", Uuid::new_v4().simple())
+}
+
 fn map_core_error(error: CoreError) -> CliError {
-    if matches!(error.kind(), CoreErrorKind::InvalidNamespaceId) {
+    if matches!(
+        error.kind(),
+        CoreErrorKind::InvalidNamespaceId | CoreErrorKind::InvalidCommitId
+    ) {
         return CliError::invalid_input(error.to_string());
     }
 
     let code = match error.kind() {
         CoreErrorKind::InvalidPath => "invalid_path",
         CoreErrorKind::InvalidNamespaceId => unreachable!("handled before code mapping"),
+        CoreErrorKind::InvalidCommitId => unreachable!("handled before code mapping"),
         CoreErrorKind::NamespaceNotFound => "namespace_not_found",
         CoreErrorKind::NamespaceExists => "namespace_exists",
         CoreErrorKind::NamespacePartial => "namespace_partial",
@@ -300,7 +310,7 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::TombstoneConflict => "tombstone_conflict",
         CoreErrorKind::LeaseConflict => "lease_conflict",
         CoreErrorKind::WouldCycle => "would_cycle",
-        CoreErrorKind::RequestIdConflict => "request_id_conflict",
+        CoreErrorKind::CommitIdReuseConflict => "commit_id_reuse_conflict",
         CoreErrorKind::CommitQueueFull => "commit_queue_full",
         CoreErrorKind::CheckpointUnavailable => "checkpoint_unavailable",
         CoreErrorKind::UploadNotFound => "upload_not_found",
@@ -495,7 +505,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_backend_generates_non_empty_request_id_for_local_put() {
+    fn direct_backend_generates_non_empty_commit_id_for_local_put() {
         let temp_dir = tempdir().expect("create temp dir");
         let store = StoreConfig::LocalFs {
             root: temp_dir.path().display().to_string(),
@@ -526,6 +536,6 @@ mod tests {
         )
         .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
-        assert!(!changes.changes[0].request_id.trim().is_empty());
+        assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());
     }
 }

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -7,7 +7,7 @@ use loon_api::{
         CommitResponse as ApiCommitResponse, CompleteUploadRequest, CompleteUploadResponse,
         UploadContentResponse,
     },
-    ApiError, AuthoritativePathEntry, ChangeSeq, ContentRef, CreateNamespaceRequest,
+    ApiError, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, CreateNamespaceRequest,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
     FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, MutationResult,
     NamespaceId, NamespaceSummary,
@@ -62,6 +62,8 @@ pub enum ClientError {
     ConfigValidation { field: &'static str, reason: String },
     #[error("invalid namespace path `{0}`")]
     InvalidNamespacePath(String),
+    #[error("invalid commit_id `{0}`")]
+    InvalidCommitId(String),
     #[error("http error: {0}")]
     Http(String),
     #[error("server returned {status} {code}: {message}")]
@@ -296,21 +298,22 @@ impl Client {
         bytes: &[u8],
         force: bool,
     ) -> Result<MutationResult, ClientError> {
-        self.put_file_bytes_with_request_id(spec, bytes, force, &Uuid::new_v4().to_string())
+        self.put_file_bytes_with_commit_id(spec, bytes, force, &generated_commit_id())
     }
 
-    pub fn put_file_bytes_with_request_id(
+    pub fn put_file_bytes_with_commit_id(
         &self,
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-        request_id: &str,
+        commit_id: &str,
     ) -> Result<MutationResult, ClientError> {
+        let commit_id = parse_commit_id(commit_id)?;
         let content_ref = self.stage_bytes_as_content_ref(&spec.namespace, bytes)?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
             &FilesystemOperationRequest {
-                request_id: request_id.to_owned(),
+                commit_id,
                 operation: FilesystemOperation::PutFile {
                     path: spec.absolute_path.clone(),
                     content_ref,
@@ -330,31 +333,32 @@ impl Client {
         spec: &NamespacePath,
         bytes: &[u8],
     ) -> Result<MutationResult, ClientError> {
-        self.write_file_bytes_with_request_id(spec, bytes, &Uuid::new_v4().to_string())
+        self.write_file_bytes_with_commit_id(spec, bytes, &generated_commit_id())
     }
 
-    pub fn write_file_bytes_with_request_id(
+    pub fn write_file_bytes_with_commit_id(
         &self,
         spec: &NamespacePath,
         bytes: &[u8],
-        request_id: &str,
+        commit_id: &str,
     ) -> Result<MutationResult, ClientError> {
-        self.put_file_bytes_with_request_id(spec, bytes, true, request_id)
+        self.put_file_bytes_with_commit_id(spec, bytes, true, commit_id)
     }
 
     pub fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, ClientError> {
-        self.delete_path_with_request_id(spec, &Uuid::new_v4().to_string())
+        self.delete_path_with_commit_id(spec, &generated_commit_id())
     }
 
-    pub fn delete_path_with_request_id(
+    pub fn delete_path_with_commit_id(
         &self,
         spec: &NamespacePath,
-        request_id: &str,
+        commit_id: &str,
     ) -> Result<MutationResult, ClientError> {
+        let commit_id = parse_commit_id(commit_id)?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
             &FilesystemOperationRequest {
-                request_id: request_id.to_owned(),
+                commit_id,
                 operation: FilesystemOperation::DeletePath {
                     path: spec.absolute_path.clone(),
                 },
@@ -368,14 +372,14 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
     ) -> Result<MutationResult, ClientError> {
-        self.move_path_with_request_id(from, to, &Uuid::new_v4().to_string())
+        self.move_path_with_commit_id(from, to, &generated_commit_id())
     }
 
-    pub fn move_path_with_request_id(
+    pub fn move_path_with_commit_id(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        request_id: &str,
+        commit_id: &str,
     ) -> Result<MutationResult, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -383,10 +387,11 @@ impl Client {
                 from.namespace, to.namespace
             )));
         }
+        let commit_id = parse_commit_id(commit_id)?;
         let response = self.apply_filesystem_operation(
             &from.namespace,
             &FilesystemOperationRequest {
-                request_id: request_id.to_owned(),
+                commit_id,
                 operation: FilesystemOperation::MovePath {
                     from_path: from.absolute_path.clone(),
                     to_path: to.absolute_path.clone(),
@@ -401,14 +406,14 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
     ) -> Result<MutationResult, ClientError> {
-        self.copy_path_with_request_id(from, to, &Uuid::new_v4().to_string())
+        self.copy_path_with_commit_id(from, to, &generated_commit_id())
     }
 
-    pub fn copy_path_with_request_id(
+    pub fn copy_path_with_commit_id(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        request_id: &str,
+        commit_id: &str,
     ) -> Result<MutationResult, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -416,10 +421,11 @@ impl Client {
                 from.namespace, to.namespace
             )));
         }
+        let commit_id = parse_commit_id(commit_id)?;
         let response = self.apply_filesystem_operation(
             &from.namespace,
             &FilesystemOperationRequest {
-                request_id: request_id.to_owned(),
+                commit_id,
                 operation: FilesystemOperation::CopyPath {
                     from_path: from.absolute_path.clone(),
                     to_path: to.absolute_path.clone(),
@@ -608,6 +614,14 @@ fn namespace_url_segment(namespace: &str) -> Result<&str, ClientError> {
 
 fn invalid_namespace_id_error(error: loon_api::NamespaceIdValidationError) -> ClientError {
     ClientError::InvalidNamespacePath(error.to_string())
+}
+
+fn parse_commit_id(commit_id: &str) -> Result<CommitId, ClientError> {
+    CommitId::parse(commit_id).map_err(|error| ClientError::InvalidCommitId(error.to_string()))
+}
+
+fn generated_commit_id() -> String {
+    format!("c_{}", Uuid::new_v4().simple())
 }
 
 fn file_name_for_path(path: &str) -> Result<String, ClientError> {

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -4,7 +4,7 @@ use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::loading::read_head_object;
 use crate::metadata::{
-    DirentryRecord, InodeRecord, MetadataState, RequestReceiptRecord, RevisionRecord,
+    CommittedCommitRecord, DirentryRecord, InodeRecord, MetadataState, RevisionRecord,
     SubtreeTombstoneRecord,
 };
 use loon_api::{
@@ -33,7 +33,7 @@ const CHECKPOINT_TABLE_FAMILIES: [CheckpointTableFamily; 5] = [
     CheckpointTableFamily::Direntries,
     CheckpointTableFamily::Revisions,
     CheckpointTableFamily::Tombstones,
-    CheckpointTableFamily::RequestReceipts,
+    CheckpointTableFamily::CommittedCommits,
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -980,21 +980,21 @@ fn append_rows_to_metadata(
                     tombstone_op_index: *tombstone_op_index,
                 }),
             (
-                CheckpointTableFamily::RequestReceipts,
-                CheckpointRow::RequestReceipt {
-                    request_id,
-                    semantic_fingerprint_sha256,
-                    committed_seq,
+                CheckpointTableFamily::CommittedCommits,
+                CheckpointRow::CommittedCommit {
                     commit_id,
+                    request_fingerprint_sha256,
+                    committed_seq,
                     results,
                 },
-            ) => metadata_state.request_receipts.push(RequestReceiptRecord {
-                request_id: request_id.clone(),
-                semantic_fingerprint_sha256: semantic_fingerprint_sha256.clone(),
-                committed_seq: *committed_seq,
-                commit_id: commit_id.clone(),
-                results: results.clone(),
-            }),
+            ) => metadata_state
+                .committed_commits
+                .push(CommittedCommitRecord {
+                    commit_id: commit_id.clone(),
+                    request_fingerprint_sha256: request_fingerprint_sha256.clone(),
+                    committed_seq: *committed_seq,
+                    results: results.clone(),
+                }),
             _ => {
                 return Err(CheckpointLoadError::TableRowKindMismatch {
                     object_key: object_key.to_owned(),
@@ -1059,15 +1059,14 @@ fn checkpoint_rows_for_family(
                 tombstone_op_index: tombstone.tombstone_op_index,
             })
             .collect::<Vec<_>>(),
-        CheckpointTableFamily::RequestReceipts => metadata_state
-            .request_receipts
+        CheckpointTableFamily::CommittedCommits => metadata_state
+            .committed_commits
             .iter()
-            .map(|receipt| CheckpointRow::RequestReceipt {
-                request_id: receipt.request_id.clone(),
-                semantic_fingerprint_sha256: receipt.semantic_fingerprint_sha256.clone(),
-                committed_seq: receipt.committed_seq,
-                commit_id: receipt.commit_id.clone(),
-                results: receipt.results.clone(),
+            .map(|record| CheckpointRow::CommittedCommit {
+                commit_id: record.commit_id.clone(),
+                request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
+                committed_seq: record.committed_seq,
+                results: record.results.clone(),
             })
             .collect::<Vec<_>>(),
     };
@@ -1081,7 +1080,7 @@ fn snapshot_table_family(family: CheckpointTableFamily) -> SnapshotTableFamily {
         CheckpointTableFamily::Direntries => SnapshotTableFamily::Direntries,
         CheckpointTableFamily::Revisions => SnapshotTableFamily::Revisions,
         CheckpointTableFamily::Tombstones => SnapshotTableFamily::Tombstones,
-        CheckpointTableFamily::RequestReceipts => SnapshotTableFamily::RequestReceipts,
+        CheckpointTableFamily::CommittedCommits => SnapshotTableFamily::CommittedCommits,
     }
 }
 
@@ -1091,7 +1090,7 @@ fn checkpoint_row_kind(row: &CheckpointRow) -> &'static str {
         CheckpointRow::Direntry { .. } => "direntry",
         CheckpointRow::Revision { .. } => "revision",
         CheckpointRow::Tombstone { .. } => "tombstone",
-        CheckpointRow::RequestReceipt { .. } => "request_receipt",
+        CheckpointRow::CommittedCommit { .. } => "committed_commit",
     }
 }
 

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -4,7 +4,7 @@ use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::loading::read_head_object;
 use crate::metadata::{
-    CommittedCommitRecord, DirentryRecord, InodeRecord, MetadataState, RevisionRecord,
+    CommitReceiptRecord, DirentryRecord, InodeRecord, MetadataState, RevisionRecord,
     SubtreeTombstoneRecord,
 };
 use loon_api::{
@@ -33,7 +33,7 @@ const CHECKPOINT_TABLE_FAMILIES: [CheckpointTableFamily; 5] = [
     CheckpointTableFamily::Direntries,
     CheckpointTableFamily::Revisions,
     CheckpointTableFamily::Tombstones,
-    CheckpointTableFamily::CommittedCommits,
+    CheckpointTableFamily::CommitReceipts,
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -980,21 +980,19 @@ fn append_rows_to_metadata(
                     tombstone_op_index: *tombstone_op_index,
                 }),
             (
-                CheckpointTableFamily::CommittedCommits,
-                CheckpointRow::CommittedCommit {
+                CheckpointTableFamily::CommitReceipts,
+                CheckpointRow::CommitReceipt {
                     commit_id,
                     request_fingerprint_sha256,
                     committed_seq,
                     results,
                 },
-            ) => metadata_state
-                .committed_commits
-                .push(CommittedCommitRecord {
-                    commit_id: commit_id.clone(),
-                    request_fingerprint_sha256: request_fingerprint_sha256.clone(),
-                    committed_seq: *committed_seq,
-                    results: results.clone(),
-                }),
+            ) => metadata_state.commit_receipts.push(CommitReceiptRecord {
+                commit_id: commit_id.clone(),
+                request_fingerprint_sha256: request_fingerprint_sha256.clone(),
+                committed_seq: *committed_seq,
+                results: results.clone(),
+            }),
             _ => {
                 return Err(CheckpointLoadError::TableRowKindMismatch {
                     object_key: object_key.to_owned(),
@@ -1059,10 +1057,10 @@ fn checkpoint_rows_for_family(
                 tombstone_op_index: tombstone.tombstone_op_index,
             })
             .collect::<Vec<_>>(),
-        CheckpointTableFamily::CommittedCommits => metadata_state
-            .committed_commits
+        CheckpointTableFamily::CommitReceipts => metadata_state
+            .commit_receipts
             .iter()
-            .map(|record| CheckpointRow::CommittedCommit {
+            .map(|record| CheckpointRow::CommitReceipt {
                 commit_id: record.commit_id.clone(),
                 request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
                 committed_seq: record.committed_seq,
@@ -1080,7 +1078,7 @@ fn snapshot_table_family(family: CheckpointTableFamily) -> SnapshotTableFamily {
         CheckpointTableFamily::Direntries => SnapshotTableFamily::Direntries,
         CheckpointTableFamily::Revisions => SnapshotTableFamily::Revisions,
         CheckpointTableFamily::Tombstones => SnapshotTableFamily::Tombstones,
-        CheckpointTableFamily::CommittedCommits => SnapshotTableFamily::CommittedCommits,
+        CheckpointTableFamily::CommitReceipts => SnapshotTableFamily::CommitReceipts,
     }
 }
 
@@ -1090,7 +1088,7 @@ fn checkpoint_row_kind(row: &CheckpointRow) -> &'static str {
         CheckpointRow::Direntry { .. } => "direntry",
         CheckpointRow::Revision { .. } => "revision",
         CheckpointRow::Tombstone { .. } => "tombstone",
-        CheckpointRow::CommittedCommit { .. } => "committed_commit",
+        CheckpointRow::CommitReceipt { .. } => "commit_receipt",
     }
 }
 

--- a/crates/loon-core/src/commit.rs
+++ b/crates/loon-core/src/commit.rs
@@ -1,7 +1,7 @@
 use crate::metadata::MetadataState;
 use loon_api::{
-    v0::CommitAnnotations, ChangeSeq, ContentRef, FenceToken, HeadState, HeadStateEnvelope,
-    InodeId, InodeKind, LeaseState, NamespaceId, RevisionNo,
+    v0::CommitAnnotations, ChangeSeq, CommitId, ContentRef, FenceToken, HeadState,
+    HeadStateEnvelope, InodeId, InodeKind, LeaseState, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,12 +16,12 @@ pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRequest {
     pub namespace_id: NamespaceId,
-    pub request_id: String,
+    pub commit_id: CommitId,
     pub writer_id: String,
     pub writer_fence_token: FenceToken,
     pub planned_head_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_request_checksum_sha256: Option<String>,
+    pub request_fingerprint_sha256: Option<String>,
     pub ops: Vec<CommitOp>,
     pub preconditions: Vec<Precondition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -83,7 +83,7 @@ pub enum Precondition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitPlan {
     pub namespace_id: NamespaceId,
-    pub commit_id: String,
+    pub commit_id: CommitId,
     pub base_head_seq: ChangeSeq,
     pub next_seq: ChangeSeq,
     pub allocated_inode_ids: Vec<InodeId>,
@@ -298,35 +298,28 @@ pub(crate) fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
 }
 
 impl CommitRequest {
-    pub fn request_checksum_sha256(&self) -> Result<String, serde_json::Error> {
-        let bytes = serde_json::to_vec(self)?;
-        Ok(loon_api::sha256_digest(&bytes))
-    }
-
-    pub fn semantic_fingerprint_sha256(&self) -> Result<String, serde_json::Error> {
-        if let Some(source) = &self.source_request_checksum_sha256 {
-            return Ok(source.clone());
+    pub fn request_fingerprint_sha256(&self) -> Result<String, serde_json::Error> {
+        if let Some(fingerprint) = &self.request_fingerprint_sha256 {
+            return Ok(fingerprint.clone());
         }
         #[derive(Serialize)]
-        struct SemanticCommit<'a> {
+        struct CanonicalCommitRequest<'a> {
             namespace_id: &'a NamespaceId,
-            request_id: &'a str,
             planned_head_seq: ChangeSeq,
             ops: &'a [CommitOp],
             preconditions: &'a [Precondition],
             message: &'a Option<String>,
             annotations: &'a Option<CommitAnnotations>,
         }
-        let semantic = SemanticCommit {
+        let request = CanonicalCommitRequest {
             namespace_id: &self.namespace_id,
-            request_id: &self.request_id,
             planned_head_seq: self.planned_head_seq,
             ops: &self.ops,
             preconditions: &self.preconditions,
             message: &self.message,
             annotations: &self.annotations,
         };
-        let bytes = serde_json::to_vec(&semantic)?;
+        let bytes = serde_json::to_vec(&request)?;
         Ok(loon_api::sha256_digest(&bytes))
     }
 }

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -140,7 +140,7 @@ pub fn build_commit_plan(
 
     Ok(CommitPlan {
         namespace_id: request.namespace_id.clone(),
-        commit_id: request.request_id.clone(),
+        commit_id: request.commit_id.clone(),
         base_head_seq: context.head.seq,
         next_seq: shape.next_seq,
         allocated_inode_ids: shape.allocated_inode_ids,

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -6,13 +6,16 @@ use crate::loading::ControlObjectLoadError;
 use crate::metadata::{MetadataApplyError, VisiblePathError};
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::wal::WalBuildError;
-use loon_api::{ChangeSeq, InodeId, InodeKind, NamespaceId, NamespaceIdValidationError};
+use loon_api::{
+    ChangeSeq, CommitIdValidationError, InodeId, InodeKind, NamespaceId, NamespaceIdValidationError,
+};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoreErrorKind {
     InvalidPath,
     InvalidNamespaceId,
+    InvalidCommitId,
     NamespaceNotFound,
     NamespaceExists,
     NamespacePartial,
@@ -24,7 +27,7 @@ pub enum CoreErrorKind {
     TombstoneConflict,
     LeaseConflict,
     WouldCycle,
-    RequestIdConflict,
+    CommitIdReuseConflict,
     CommitQueueFull,
     CheckpointUnavailable,
     UploadNotFound,
@@ -60,6 +63,8 @@ pub enum CoreError {
     InvalidPath(String),
     #[error(transparent)]
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
+    #[error(transparent)]
+    InvalidCommitId(#[from] CommitIdValidationError),
     #[error("path not found `{0}`")]
     MissingPath(String),
     #[error("expected file at `{path}` but found `{kind:?}`")]
@@ -72,8 +77,8 @@ pub enum CoreError {
     RootMutationForbidden,
     #[error("destination already exists at `{0}`")]
     DestinationExists(String),
-    #[error("request id conflict for `{0}`")]
-    RequestIdConflict(String),
+    #[error("commit id conflict for `{0}`")]
+    CommitIdReuseConflict(String),
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
     #[error("{0}")]
@@ -164,10 +169,11 @@ impl CoreError {
                 CoreErrorKind::InvalidPath
             }
             CoreError::InvalidNamespaceId(_) => CoreErrorKind::InvalidNamespaceId,
+            CoreError::InvalidCommitId(_) => CoreErrorKind::InvalidCommitId,
             CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
             CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
             CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,
-            CoreError::RequestIdConflict(_) => CoreErrorKind::RequestIdConflict,
+            CoreError::CommitIdReuseConflict(_) => CoreErrorKind::CommitIdReuseConflict,
             CoreError::CommitQueueFull => CoreErrorKind::CommitQueueFull,
             CoreError::CheckpointUnavailable(_) => CoreErrorKind::CheckpointUnavailable,
             CoreError::UploadNotFound { .. } => CoreErrorKind::UploadNotFound,

--- a/crates/loon-core/src/genesis.rs
+++ b/crates/loon-core/src/genesis.rs
@@ -11,6 +11,6 @@ pub(crate) fn bootstrap_basis_metadata_state() -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        request_receipts: Vec::new(),
+        committed_commits: Vec::new(),
     }
 }

--- a/crates/loon-core/src/genesis.rs
+++ b/crates/loon-core/src/genesis.rs
@@ -11,6 +11,6 @@ pub(crate) fn bootstrap_basis_metadata_state() -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        committed_commits: Vec::new(),
+        commit_receipts: Vec::new(),
     }
 }

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -17,7 +17,7 @@ pub struct MetadataState {
     #[serde(default)]
     pub subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
-    pub committed_commits: Vec<CommittedCommitRecord>,
+    pub commit_receipts: Vec<CommitReceiptRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,7 +57,7 @@ pub struct SubtreeTombstoneRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CommittedCommitRecord {
+pub struct CommitReceiptRecord {
     pub commit_id: CommitId,
     pub request_fingerprint_sha256: String,
     pub committed_seq: ChangeSeq,
@@ -292,8 +292,8 @@ impl MetadataState {
         let mut applied = self.apply_committed_wal_ops(record.seq, &record.ops)?;
         applied
             .metadata_state
-            .committed_commits
-            .push(CommittedCommitRecord {
+            .commit_receipts
+            .push(CommitReceiptRecord {
                 commit_id: record.commit_id.clone(),
                 request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
                 committed_seq: record.seq,
@@ -301,7 +301,7 @@ impl MetadataState {
             });
         push_unique_invariant(
             &mut applied.checked_invariants,
-            "wal_replay_records_committed_commit",
+            "wal_replay_records_commit_receipt",
         );
         Ok(applied)
     }

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -1,6 +1,6 @@
 use loon_api::{
-    name_key_for_display_name, v0::CommitOpResult, ChangeSeq, ContentRef, InodeId, InodeKind,
-    NamePolicy, RevisionNo, WalCommitPayload, WalOp,
+    name_key_for_display_name, v0::CommitOpResult, ChangeSeq, CommitId, ContentRef, InodeId,
+    InodeKind, NamePolicy, RevisionNo, WalCommitPayload, WalOp,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -17,7 +17,7 @@ pub struct MetadataState {
     #[serde(default)]
     pub subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
-    pub request_receipts: Vec<RequestReceiptRecord>,
+    pub committed_commits: Vec<CommittedCommitRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,11 +57,10 @@ pub struct SubtreeTombstoneRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RequestReceiptRecord {
-    pub request_id: String,
-    pub semantic_fingerprint_sha256: String,
+pub struct CommittedCommitRecord {
+    pub commit_id: CommitId,
+    pub request_fingerprint_sha256: String,
     pub committed_seq: ChangeSeq,
-    pub commit_id: String,
     pub results: Vec<CommitOpResult>,
 }
 
@@ -293,17 +292,16 @@ impl MetadataState {
         let mut applied = self.apply_committed_wal_ops(record.seq, &record.ops)?;
         applied
             .metadata_state
-            .request_receipts
-            .push(RequestReceiptRecord {
-                request_id: record.request_id.clone(),
-                semantic_fingerprint_sha256: record.semantic_fingerprint_sha256.clone(),
-                committed_seq: record.seq,
+            .committed_commits
+            .push(CommittedCommitRecord {
                 commit_id: record.commit_id.clone(),
+                request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
+                committed_seq: record.seq,
                 results: record.results.clone(),
             });
         push_unique_invariant(
             &mut applied.checked_invariants,
-            "wal_replay_records_request_receipt",
+            "wal_replay_records_committed_commit",
         );
         Ok(applied)
     }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -7,11 +7,11 @@ use crate::commit::{
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
-use crate::metadata::{MetadataState, RequestReceiptRecord};
+use crate::metadata::{CommittedCommitRecord, MetadataState};
 use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
 use crate::wal::{
-    build_wal_commit_payload, prepare_wal_segment, PreparedWalRecord, StoredWalObject,
+    build_wal_record_payload, prepare_wal_segment, PreparedWalRecord, StoredWalObject,
 };
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitOp as ApiCommitOp, CommitOpResult,
@@ -20,8 +20,8 @@ use loon_api::v0::{
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
-    decode_wal_segment_envelope_zstd, ChangeSeq, CompletedUpload, ContentRef, ControlObjectKind,
-    HeadState, InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
+    decode_wal_segment_envelope_zstd, ChangeSeq, CommitId, CompletedUpload, ContentRef,
+    ControlObjectKind, HeadState, InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -40,7 +40,7 @@ struct LoadedUploadSessionObject {
 #[derive(Debug, Clone)]
 struct InBatchRequest {
     primary_index: usize,
-    semantic_fingerprint_sha256: String,
+    request_fingerprint_sha256: String,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -223,7 +223,7 @@ pub fn commit_operations<S: ObjectStore + ?Sized>(
     request: ApiCommitRequest,
     context: &MutationContext,
 ) -> Result<ApiCommitResponse, CoreError> {
-    commit_operations_with_source_checksum(store, namespace_id, request, None, context)
+    commit_operations_with_request_fingerprint(store, namespace_id, request, None, context)
 }
 
 pub fn commit_operations_batch<S: ObjectStore + ?Sized>(
@@ -252,11 +252,11 @@ pub(crate) fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     commit_namespace_mutations_batch(store, namespace_id, candidates, context)
 }
 
-fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
+fn commit_operations_with_request_fingerprint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     request: ApiCommitRequest,
-    source_request_checksum_sha256: Option<String>,
+    request_fingerprint_sha256: Option<String>,
     context: &MutationContext,
 ) -> Result<ApiCommitResponse, CoreError> {
     publish_namespace_mutations_batch(
@@ -265,7 +265,7 @@ fn commit_operations_with_source_checksum<S: ObjectStore + ?Sized>(
         vec![NamespaceMutationCandidate::Planned(
             PlannedNamespaceMutation {
                 commit_request: request,
-                source_request_checksum_sha256,
+                request_fingerprint_sha256,
             },
         )],
         context,
@@ -302,7 +302,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     let mut current_head = basis.head.clone();
     let mut current_metadata_state = basis.metadata_state.clone();
     let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
-    let mut in_batch_requests: HashMap<String, InBatchRequest> = HashMap::new();
+    let mut in_batch_requests: HashMap<CommitId, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
 
     for (index, candidate) in candidates.into_iter().enumerate() {
@@ -354,7 +354,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             plan: plan.clone(),
             results,
         };
-        let preview = match build_wal_commit_payload(namespace_id, &record) {
+        let preview = match build_wal_record_payload(namespace_id, &record) {
             Ok(payload) => payload,
             Err(error) => {
                 outcomes[index] = Some(Err(error.into()));
@@ -431,7 +431,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
             namespace_id: namespace_id.clone(),
-            commit_id: record.request.request_id,
+            commit_id: record.request.commit_id,
             committed_seq: wal.envelope.payload.records[accepted_index].seq,
             results: record.results,
         }));
@@ -450,13 +450,17 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     index: usize,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
-    in_batch_requests: &mut HashMap<String, InBatchRequest>,
+    in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
 ) -> Option<CoreCommitRequest> {
     match candidate {
         NamespaceMutationCandidate::Commit(request) => {
+            if let Err(error) = validate_commit_id(&request.commit_id) {
+                outcomes[index] = Some(Err(error));
+                return None;
+            }
             let request = map_commit_request(namespace_id, basis, request, None, context);
-            let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
+            let request_fingerprint = match request.request_fingerprint_sha256() {
                 Ok(value) => value,
                 Err(err) => {
                     outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
@@ -470,22 +474,26 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 in_batch_requests,
                 aliases,
                 index,
-                &request.request_id,
-                &semantic_fingerprint,
+                &request.commit_id,
+                &request_fingerprint,
             ) {
                 return None;
             }
             Some(request)
         }
         NamespaceMutationCandidate::Planned(planned) => {
+            if let Err(error) = validate_commit_id(&planned.commit_request.commit_id) {
+                outcomes[index] = Some(Err(error));
+                return None;
+            }
             let request = map_commit_request(
                 namespace_id,
                 basis,
                 planned.commit_request,
-                planned.source_request_checksum_sha256,
+                planned.request_fingerprint_sha256,
                 context,
             );
-            let semantic_fingerprint = match request.semantic_fingerprint_sha256() {
+            let request_fingerprint = match request.request_fingerprint_sha256() {
                 Ok(value) => value,
                 Err(err) => {
                     outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
@@ -499,22 +507,26 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 in_batch_requests,
                 aliases,
                 index,
-                &request.request_id,
-                &semantic_fingerprint,
+                &request.commit_id,
+                &request_fingerprint,
             ) {
                 return None;
             }
             Some(request)
         }
         NamespaceMutationCandidate::Path(intent) => {
-            let semantic_fingerprint = match intent.source_request_checksum_sha256(namespace_id) {
+            if let Err(error) = validate_commit_id(intent.commit_id()) {
+                outcomes[index] = Some(Err(error));
+                return None;
+            }
+            let request_fingerprint = match intent.request_fingerprint_sha256(namespace_id) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error));
                     return None;
                 }
             };
-            let request_id = intent.request_id().to_owned();
+            let commit_id = intent.commit_id().clone();
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
                 &basis.metadata_state,
@@ -522,8 +534,8 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 in_batch_requests,
                 aliases,
                 index,
-                &request_id,
-                &semantic_fingerprint,
+                &commit_id,
+                &request_fingerprint,
             ) {
                 return None;
             }
@@ -545,11 +557,17 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 namespace_id,
                 basis,
                 planned.commit_request,
-                Some(planned.source_request_checksum_sha256),
+                Some(planned.request_fingerprint_sha256),
                 context,
             ))
         }
     }
+}
+
+fn validate_commit_id(commit_id: &CommitId) -> Result<(), CoreError> {
+    CommitId::parse(commit_id.as_str())
+        .map(|_| ())
+        .map_err(CoreError::InvalidCommitId)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -557,35 +575,38 @@ fn record_primary_request_or_complete_idempotent(
     namespace_id: &NamespaceId,
     visible_metadata_state: &MetadataState,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
-    in_batch_requests: &mut HashMap<String, InBatchRequest>,
+    in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
     index: usize,
-    request_id: &str,
-    semantic_fingerprint: &str,
+    commit_id: &CommitId,
+    request_fingerprint: &str,
 ) -> bool {
-    if let Some(existing) = find_request_receipt(visible_metadata_state, request_id) {
+    if let Some(existing) = find_committed_commit(visible_metadata_state, commit_id) {
         outcomes[index] = Some(
-            if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
-                Err(CoreError::RequestIdConflict(request_id.to_owned()))
+            if existing.request_fingerprint_sha256 != request_fingerprint {
+                Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
             } else {
-                Ok(commit_response_from_receipt(namespace_id, existing))
+                Ok(commit_response_from_committed_commit(
+                    namespace_id,
+                    existing,
+                ))
             },
         );
         return false;
     }
-    if let Some(existing) = in_batch_requests.get(request_id) {
-        if existing.semantic_fingerprint_sha256 != semantic_fingerprint {
-            outcomes[index] = Some(Err(CoreError::RequestIdConflict(request_id.to_owned())));
+    if let Some(existing) = in_batch_requests.get(commit_id) {
+        if existing.request_fingerprint_sha256 != request_fingerprint {
+            outcomes[index] = Some(Err(CoreError::CommitIdReuseConflict(commit_id.to_string())));
         } else {
             aliases.push((index, existing.primary_index));
         }
         return false;
     }
     in_batch_requests.insert(
-        request_id.to_owned(),
+        commit_id.clone(),
         InBatchRequest {
             primary_index: index,
-            semantic_fingerprint_sha256: semantic_fingerprint.to_owned(),
+            request_fingerprint_sha256: request_fingerprint.to_owned(),
         },
     );
     true
@@ -622,7 +643,6 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
                 changes.push(CommittedChange {
                     seq: record.seq,
                     commit_id: record.commit_id,
-                    request_id: record.request_id,
                     message: record.message,
                     annotations: record.annotations,
                     ops: record.results,
@@ -719,16 +739,16 @@ fn map_commit_request(
     namespace_id: &NamespaceId,
     basis: &crate::VerifiedNamespaceBasis,
     request: ApiCommitRequest,
-    source_request_checksum_sha256: Option<String>,
+    request_fingerprint_sha256: Option<String>,
     context: &MutationContext,
 ) -> CoreCommitRequest {
     CoreCommitRequest {
         namespace_id: namespace_id.clone(),
-        request_id: request.request_id,
+        commit_id: request.commit_id,
         writer_id: context.writer_id.clone(),
         writer_fence_token: basis.head.active_fence_token,
         planned_head_seq: request.planned_head_seq,
-        source_request_checksum_sha256,
+        request_fingerprint_sha256,
         ops: request.ops.into_iter().map(map_commit_op).collect(),
         preconditions: request
             .preconditions
@@ -950,26 +970,26 @@ fn load_wal_range<S: ObjectStore + ?Sized>(
     Ok(out)
 }
 
-fn find_request_receipt<'a>(
+fn find_committed_commit<'a>(
     metadata_state: &'a crate::metadata::MetadataState,
-    request_id: &str,
-) -> Option<&'a RequestReceiptRecord> {
+    commit_id: &CommitId,
+) -> Option<&'a CommittedCommitRecord> {
     metadata_state
-        .request_receipts
+        .committed_commits
         .iter()
-        .filter(|receipt| receipt.request_id == request_id)
-        .max_by_key(|receipt| receipt.committed_seq)
+        .filter(|record| record.commit_id == *commit_id)
+        .max_by_key(|record| record.committed_seq)
 }
 
-fn commit_response_from_receipt(
+fn commit_response_from_committed_commit(
     namespace_id: &NamespaceId,
-    receipt: &RequestReceiptRecord,
+    record: &CommittedCommitRecord,
 ) -> ApiCommitResponse {
     ApiCommitResponse {
         namespace_id: namespace_id.clone(),
-        commit_id: receipt.commit_id.clone(),
-        committed_seq: receipt.committed_seq,
-        results: receipt.results.clone(),
+        commit_id: record.commit_id.clone(),
+        committed_seq: record.committed_seq,
+        results: record.results.clone(),
     }
 }
 

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -7,7 +7,7 @@ use crate::commit::{
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
-use crate::metadata::{CommittedCommitRecord, MetadataState};
+use crate::metadata::{CommitReceiptRecord, MetadataState};
 use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
 use crate::wal::{
@@ -581,15 +581,12 @@ fn record_primary_request_or_complete_idempotent(
     commit_id: &CommitId,
     request_fingerprint: &str,
 ) -> bool {
-    if let Some(existing) = find_committed_commit(visible_metadata_state, commit_id) {
+    if let Some(existing) = find_commit_receipt(visible_metadata_state, commit_id) {
         outcomes[index] = Some(
             if existing.request_fingerprint_sha256 != request_fingerprint {
                 Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
             } else {
-                Ok(commit_response_from_committed_commit(
-                    namespace_id,
-                    existing,
-                ))
+                Ok(commit_response_from_commit_receipt(namespace_id, existing))
             },
         );
         return false;
@@ -970,20 +967,20 @@ fn load_wal_range<S: ObjectStore + ?Sized>(
     Ok(out)
 }
 
-fn find_committed_commit<'a>(
+fn find_commit_receipt<'a>(
     metadata_state: &'a crate::metadata::MetadataState,
     commit_id: &CommitId,
-) -> Option<&'a CommittedCommitRecord> {
+) -> Option<&'a CommitReceiptRecord> {
     metadata_state
-        .committed_commits
+        .commit_receipts
         .iter()
         .filter(|record| record.commit_id == *commit_id)
         .max_by_key(|record| record.committed_seq)
 }
 
-fn commit_response_from_committed_commit(
+fn commit_response_from_commit_receipt(
     namespace_id: &NamespaceId,
-    record: &CommittedCommitRecord,
+    record: &CommitReceiptRecord,
 ) -> ApiCommitResponse {
     ApiCommitResponse {
         namespace_id: namespace_id.clone(),

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -2,7 +2,7 @@ use crate::context::MutationContext;
 use crate::error::{CoreError, CoreErrorKind};
 use crate::services::PutFileBehavior;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{ContentRef, MutationResult, NamespaceId};
+use loon_api::{CommitId, ContentRef, MutationResult, NamespaceId};
 use loon_objectstore::ObjectStore;
 
 const DEFAULT_STALE_HEAD_RETRY_LIMIT: usize = 8;
@@ -10,57 +10,57 @@ const DEFAULT_STALE_HEAD_RETRY_LIMIT: usize = 8;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathMutationIntent {
     PutFile {
-        request_id: String,
+        commit_id: CommitId,
         absolute_path: String,
         content_ref: ContentRef,
         behavior: PutFileBehavior,
     },
     DeletePath {
-        request_id: String,
+        commit_id: CommitId,
         absolute_path: String,
         recursive: bool,
     },
     MovePath {
-        request_id: String,
+        commit_id: CommitId,
         from_path: String,
         to_path: String,
     },
     CopyFilePath {
-        request_id: String,
+        commit_id: CommitId,
         from_path: String,
         to_path: String,
     },
 }
 
 impl PathMutationIntent {
-    pub fn request_id(&self) -> &str {
+    pub fn commit_id(&self) -> &CommitId {
         match self {
-            Self::PutFile { request_id, .. }
-            | Self::DeletePath { request_id, .. }
-            | Self::MovePath { request_id, .. }
-            | Self::CopyFilePath { request_id, .. } => request_id,
+            Self::PutFile { commit_id, .. }
+            | Self::DeletePath { commit_id, .. }
+            | Self::MovePath { commit_id, .. }
+            | Self::CopyFilePath { commit_id, .. } => commit_id,
         }
     }
 
-    pub fn source_request_checksum_sha256(
+    pub fn request_fingerprint_sha256(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<String, CoreError> {
-        crate::services::source_request_checksum_for_path_intent(namespace_id, self)
+        crate::services::request_fingerprint_for_path_intent(namespace_id, self)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedPathMutation {
-    pub request_id: String,
-    pub source_request_checksum_sha256: String,
+    pub commit_id: CommitId,
+    pub request_fingerprint_sha256: String,
     pub commit_request: ApiCommitRequest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedNamespaceMutation {
     pub commit_request: ApiCommitRequest,
-    pub source_request_checksum_sha256: Option<String>,
+    pub request_fingerprint_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -22,7 +22,7 @@ use loon_api::{
         CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
         CommitRequest as ApiCommitRequest,
     },
-    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
+    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef,
     ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
     FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind, LeaseState, LeaseStateEnvelope,
     MutationResult, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
@@ -515,7 +515,7 @@ pub fn store_bytes_as_content<S: ObjectStore + ?Sized>(
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum PathRequestIdentity {
+enum PathFingerprintInput {
     PutFile {
         namespace_id: NamespaceId,
         absolute_path: String,
@@ -539,18 +539,24 @@ enum PathRequestIdentity {
     },
 }
 
-fn normalized_request_id(request_id: Option<&str>) -> String {
-    request_id
-        .filter(|value| !value.trim().is_empty())
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| Uuid::new_v4().to_string())
+fn generated_commit_id() -> CommitId {
+    CommitId::from(format!("c_{}", Uuid::new_v4().simple()))
 }
 
-fn source_request_checksum_sha256(identity: &PathRequestIdentity) -> Result<String, CoreError> {
+fn normalized_commit_id(commit_id: Option<&str>) -> Result<CommitId, CoreError> {
+    let commit_id = commit_id
+        .filter(|value| !value.trim().is_empty())
+        .map(CommitId::parse)
+        .transpose()?
+        .unwrap_or_else(generated_commit_id);
+    Ok(commit_id)
+}
+
+fn request_fingerprint_sha256(identity: &PathFingerprintInput) -> Result<String, CoreError> {
     payload_checksum_sha256(identity).map_err(|err| CoreError::Store(err.to_string()))
 }
 
-pub(crate) fn source_request_checksum_for_path_intent(
+pub(crate) fn request_fingerprint_for_path_intent(
     namespace_id: &NamespaceId,
     intent: &PathMutationIntent,
 ) -> Result<String, CoreError> {
@@ -560,7 +566,7 @@ pub(crate) fn source_request_checksum_for_path_intent(
             behavior,
             content_ref,
             ..
-        } => PathRequestIdentity::PutFile {
+        } => PathFingerprintInput::PutFile {
             namespace_id: namespace_id.clone(),
             absolute_path: absolute_path.clone(),
             behavior: *behavior,
@@ -570,27 +576,27 @@ pub(crate) fn source_request_checksum_for_path_intent(
             absolute_path,
             recursive,
             ..
-        } => PathRequestIdentity::DeletePath {
+        } => PathFingerprintInput::DeletePath {
             namespace_id: namespace_id.clone(),
             absolute_path: absolute_path.clone(),
             recursive: *recursive,
         },
         PathMutationIntent::MovePath {
             from_path, to_path, ..
-        } => PathRequestIdentity::MovePath {
+        } => PathFingerprintInput::MovePath {
             namespace_id: namespace_id.clone(),
             from_path: from_path.clone(),
             to_path: to_path.clone(),
         },
         PathMutationIntent::CopyFilePath {
             from_path, to_path, ..
-        } => PathRequestIdentity::CopyFilePath {
+        } => PathFingerprintInput::CopyFilePath {
             namespace_id: namespace_id.clone(),
             from_path: from_path.clone(),
             to_path: to_path.clone(),
         },
     };
-    source_request_checksum_sha256(&identity)
+    request_fingerprint_sha256(&identity)
 }
 
 pub fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -600,7 +606,7 @@ pub fn put_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     behavior: PutFileBehavior,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
     validate_path_for_mutation(absolute_path)?;
     let stored = store_bytes_as_content(store, namespace_id, bytes)?;
@@ -611,7 +617,7 @@ pub fn put_file_bytes<S: ObjectStore + ?Sized>(
         stored.content_ref,
         behavior,
         context,
-        request_id,
+        commit_id,
     )
 }
 
@@ -621,7 +627,7 @@ pub fn write_file_bytes<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     bytes: &[u8],
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
     put_file_bytes(
         store,
@@ -630,7 +636,7 @@ pub fn write_file_bytes<S: ObjectStore + ?Sized>(
         bytes,
         PutFileBehavior::ReplaceExisting,
         context,
-        request_id,
+        commit_id,
     )
 }
 
@@ -641,11 +647,11 @@ pub fn put_file_content_ref<S: ObjectStore + ?Sized>(
     content_ref: ContentRef,
     behavior: PutFileBehavior,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let request_id = normalized_request_id(request_id);
+    let commit_id = normalized_commit_id(commit_id)?;
     let intent = PathMutationIntent::PutFile {
-        request_id,
+        commit_id,
         absolute_path: absolute_path.to_owned(),
         content_ref,
         behavior,
@@ -682,8 +688,8 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataState,
     content_store_id: &ContentStoreId,
 ) -> Result<PlannedPathMutation, CoreError> {
-    let request_id = intent.request_id().to_owned();
-    let source_request_checksum = source_request_checksum_for_path_intent(namespace_id, intent)?;
+    let commit_id = intent.commit_id().clone();
+    let request_fingerprint = request_fingerprint_for_path_intent(namespace_id, intent)?;
     let view = PathPlanningView {
         head,
         metadata_state,
@@ -700,24 +706,24 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
             absolute_path,
             content_ref.clone(),
             *behavior,
-            &request_id,
+            &commit_id,
             &view,
         )?,
         PathMutationIntent::DeletePath {
             absolute_path,
             recursive,
             ..
-        } => plan_delete_path(absolute_path, *recursive, &request_id, &view)?,
+        } => plan_delete_path(absolute_path, *recursive, &commit_id, &view)?,
         PathMutationIntent::MovePath {
             from_path, to_path, ..
-        } => plan_move_path(from_path, to_path, &request_id, &view)?,
+        } => plan_move_path(from_path, to_path, &commit_id, &view)?,
         PathMutationIntent::CopyFilePath {
             from_path, to_path, ..
-        } => plan_copy_file_path(store, from_path, to_path, &request_id, &view)?,
+        } => plan_copy_file_path(store, from_path, to_path, &commit_id, &view)?,
     };
     Ok(PlannedPathMutation {
-        request_id,
-        source_request_checksum_sha256: source_request_checksum,
+        commit_id,
+        request_fingerprint_sha256: request_fingerprint,
         commit_request,
     })
 }
@@ -733,7 +739,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     content_ref: ContentRef,
     behavior: PutFileBehavior,
-    request_id: &str,
+    commit_id: &CommitId,
     view: &PathPlanningView<'_>,
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(absolute_path)?;
@@ -805,7 +811,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
     }
 
     Ok(ApiCommitRequest {
-        request_id: request_id.to_owned(),
+        commit_id: commit_id.to_owned(),
         planned_head_seq: view.head.seq,
         ops,
         preconditions,
@@ -819,11 +825,11 @@ pub fn delete_path<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let request_id = normalized_request_id(request_id);
+    let commit_id = normalized_commit_id(commit_id)?;
     let intent = PathMutationIntent::DeletePath {
-        request_id,
+        commit_id,
         absolute_path: absolute_path.to_owned(),
         recursive: true,
     };
@@ -840,11 +846,11 @@ pub fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let request_id = normalized_request_id(request_id);
+    let commit_id = normalized_commit_id(commit_id)?;
     let intent = PathMutationIntent::DeletePath {
-        request_id,
+        commit_id,
         absolute_path: absolute_path.to_owned(),
         recursive: false,
     };
@@ -862,11 +868,11 @@ pub fn move_path<S: ObjectStore + ?Sized>(
     from_path: &str,
     to_path: &str,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let request_id = normalized_request_id(request_id);
+    let commit_id = normalized_commit_id(commit_id)?;
     let intent = PathMutationIntent::MovePath {
-        request_id,
+        commit_id,
         from_path: from_path.to_owned(),
         to_path: to_path.to_owned(),
     };
@@ -884,11 +890,11 @@ pub fn copy_file_path<S: ObjectStore + ?Sized>(
     from_path: &str,
     to_path: &str,
     context: &MutationContext,
-    request_id: Option<&str>,
+    commit_id: Option<&str>,
 ) -> Result<MutationResult, CoreError> {
-    let request_id = normalized_request_id(request_id);
+    let commit_id = normalized_commit_id(commit_id)?;
     let intent = PathMutationIntent::CopyFilePath {
-        request_id,
+        commit_id,
         from_path: from_path.to_owned(),
         to_path: to_path.to_owned(),
     };
@@ -903,7 +909,7 @@ pub fn copy_file_path<S: ObjectStore + ?Sized>(
 fn plan_delete_path(
     absolute_path: &str,
     recursive: bool,
-    request_id: &str,
+    commit_id: &CommitId,
     view: &PathPlanningView<'_>,
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(absolute_path)?;
@@ -936,7 +942,7 @@ fn plan_delete_path(
         }
     };
     Ok(ApiCommitRequest {
-        request_id: request_id.to_owned(),
+        commit_id: commit_id.to_owned(),
         planned_head_seq: view.head.seq,
         ops: vec![op],
         preconditions: vec![ApiCommitPrecondition::HeadSeqIs {
@@ -950,7 +956,7 @@ fn plan_delete_path(
 fn plan_move_path(
     from_path: &str,
     to_path: &str,
-    request_id: &str,
+    commit_id: &CommitId,
     view: &PathPlanningView<'_>,
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(from_path)?;
@@ -966,7 +972,7 @@ fn plan_move_path(
         return Err(CoreError::DestinationExists(to_path.to_owned()));
     }
     Ok(ApiCommitRequest {
-        request_id: request_id.to_owned(),
+        commit_id: commit_id.to_owned(),
         planned_head_seq: view.head.seq,
         ops: vec![ApiCommitOp::Rename {
             inode_id: source.inode_id,
@@ -985,7 +991,7 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
     store: &S,
     from_path: &str,
     to_path: &str,
-    request_id: &str,
+    commit_id: &CommitId,
     view: &PathPlanningView<'_>,
 ) -> Result<ApiCommitRequest, CoreError> {
     validate_path_for_mutation(from_path)?;
@@ -1018,7 +1024,7 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
     let target_name = final_component(to_path)?;
     let target_name_key = name_key_for_display_name(view.head.name_policy, &target_name);
     Ok(ApiCommitRequest {
-        request_id: request_id.to_owned(),
+        commit_id: commit_id.to_owned(),
         planned_head_seq: view.head.seq,
         ops: vec![ApiCommitOp::CreateFile {
             parent_inode: target_parent,

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -119,7 +119,7 @@ pub fn prepare_wal_segment(
 
     let mut payload_records: Vec<WalCommitPayload> = Vec::with_capacity(records.len());
     for record in records {
-        let payload_record = build_wal_commit_payload(&namespace_id, record)?;
+        let payload_record = build_wal_record_payload(&namespace_id, record)?;
         if let Some(previous) = payload_records.last() {
             let expected = previous
                 .seq
@@ -185,7 +185,7 @@ pub fn prepare_wal_segment(
     })
 }
 
-pub(crate) fn build_wal_commit_payload(
+pub(crate) fn build_wal_record_payload(
     namespace_id: &NamespaceId,
     record: &PreparedWalRecord,
 ) -> Result<WalCommitPayload, WalBuildError> {
@@ -210,16 +210,10 @@ pub(crate) fn build_wal_commit_payload(
         seq: record.plan.next_seq,
         base_head_seq: record.plan.base_head_seq,
         commit_id: record.plan.commit_id.clone(),
-        request_id: record.request.request_id.clone(),
-        request_checksum_sha256: record
+        request_fingerprint_sha256: record
             .request
-            .request_checksum_sha256()
+            .request_fingerprint_sha256()
             .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-        semantic_fingerprint_sha256: record
-            .request
-            .semantic_fingerprint_sha256()
-            .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-        source_request_checksum_sha256: record.request.source_request_checksum_sha256.clone(),
         writer_id: record.request.writer_id.clone(),
         writer_fence_token: record.request.writer_fence_token,
         message: record.request.message.clone(),
@@ -577,19 +571,19 @@ impl From<&Precondition> for WalPrecondition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loon_api::{v0::CommitOpResult, FenceToken};
+    use loon_api::{v0::CommitOpResult, CommitId, FenceToken};
 
     #[test]
-    fn build_wal_commit_payload_matches_segment_record_payload() {
+    fn build_wal_record_payload_matches_segment_record_payload() {
         let namespace_id = NamespaceId::from("demo");
         let record = PreparedWalRecord {
             request: CommitRequest {
                 namespace_id: namespace_id.clone(),
-                request_id: "req-wal-payload".to_owned(),
+                commit_id: CommitId::from("c_wal_payload"),
                 writer_id: "writer-a".to_owned(),
                 writer_fence_token: FenceToken(1),
                 planned_head_seq: ChangeSeq(0),
-                source_request_checksum_sha256: None,
+                request_fingerprint_sha256: None,
                 ops: vec![CommitOp::CreateDir {
                     parent_inode: InodeId(1),
                     display_name: "docs".to_owned(),
@@ -600,7 +594,7 @@ mod tests {
             },
             plan: CommitPlan {
                 namespace_id: namespace_id.clone(),
-                commit_id: "commit-wal-payload".to_owned(),
+                commit_id: CommitId::from("c_wal_payload"),
                 base_head_seq: ChangeSeq(0),
                 next_seq: ChangeSeq(1),
                 allocated_inode_ids: vec![InodeId(2)],
@@ -619,7 +613,7 @@ mod tests {
         };
 
         let payload =
-            build_wal_commit_payload(&namespace_id, &record).expect("build commit payload");
+            build_wal_record_payload(&namespace_id, &record).expect("build commit payload");
         let segment = prepare_wal_segment(namespace_id, None, &[record], "test-writer")
             .expect("prepare wal segment");
 

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -211,7 +211,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        committed_commits: Vec::new(),
+        commit_receipts: Vec::new(),
     }
 }
 

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -211,7 +211,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        request_receipts: Vec::new(),
+        committed_commits: Vec::new(),
     }
 }
 

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -556,7 +556,7 @@ fn restore_revision_overflow_is_rejected() {
             content_ref: content_ref("content-max"),
         }],
         subtree_tombstones: Vec::new(),
-        committed_commits: Vec::new(),
+        commit_receipts: Vec::new(),
     };
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
@@ -1079,7 +1079,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
 }
 
 #[test]
-fn direct_publisher_uses_durable_path_committed_commit_index() {
+fn direct_publisher_uses_durable_path_commit_receipt_index() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::from("demo");
@@ -2286,7 +2286,7 @@ fn metadata_state_after(sequences: &[Vec<loon_api::WalOp>]) -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        committed_commits: Vec::new(),
+        commit_receipts: Vec::new(),
     };
 
     for (index, ops) in sequences.iter().enumerate() {

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -4,9 +4,9 @@ use loon_api::{
         CommitOp as ApiCommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest,
         CompleteUploadRequest,
     },
-    ChangeSeq, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope, ControlObjectKind,
-    FenceToken, HeadState, InodeId, InodeKind, LeaseState, NamespaceDescriptorEnvelope,
-    NamespaceDescriptorState, NamespaceId, RevisionNo,
+    ChangeSeq, CommitId, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope,
+    ControlObjectKind, FenceToken, HeadState, InodeId, InodeKind, LeaseState,
+    NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId, RevisionNo,
 };
 use loon_core::commit::{
     build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
@@ -51,11 +51,11 @@ fn stale_head_precondition_is_rejected() {
     let context = validation_context(metadata_state, ChangeSeq(2), InodeId(4));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        request_id: "stale-head".to_owned(),
+        commit_id: CommitId::from("stale-head"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(2),
-        source_request_checksum_sha256: None,
+        request_fingerprint_sha256: None,
         ops: vec![CommitOp::DeleteFile {
             inode_id: InodeId(3),
         }],
@@ -100,11 +100,11 @@ fn stale_revision_precondition_is_rejected() {
     let context = validation_context(metadata_state, ChangeSeq(3), InodeId(4));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        request_id: "stale-revision".to_owned(),
+        commit_id: CommitId::from("stale-revision"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(3),
-        source_request_checksum_sha256: None,
+        request_fingerprint_sha256: None,
         ops: vec![CommitOp::ReplaceFile {
             inode_id: InodeId(3),
             base_revision: RevisionNo(1),
@@ -152,11 +152,11 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
     let create_error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "create-under-tombstone".to_owned(),
+            commit_id: CommitId::from("create-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(2),
                 display_name: "new.txt".to_owned(),
@@ -180,11 +180,11 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
     let replace_error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "replace-under-tombstone".to_owned(),
+            commit_id: CommitId::from("replace-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![CommitOp::ReplaceFile {
                 inode_id: InodeId(3),
                 base_revision: RevisionNo(1),
@@ -217,11 +217,11 @@ fn restore_revision_validation_rejects_missing_inode() {
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        request_id: "restore-missing-inode".to_owned(),
+        commit_id: CommitId::from("restore-missing-inode"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        source_request_checksum_sha256: None,
+        request_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(99),
             source_revision: RevisionNo(1),
@@ -252,11 +252,11 @@ fn restore_revision_validation_rejects_non_file_target() {
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        request_id: "restore-non-file".to_owned(),
+        commit_id: CommitId::from("restore-non-file"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        source_request_checksum_sha256: None,
+        request_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(1),
@@ -305,11 +305,11 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
     let stale_base = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "restore-stale-base".to_owned(),
+            commit_id: CommitId::from("restore-stale-base"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -334,11 +334,11 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
     let missing_source = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "restore-missing-source".to_owned(),
+            commit_id: CommitId::from("restore-missing-source"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(99),
@@ -382,11 +382,11 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
     let plan = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "restore-same-request-source".to_owned(),
+            commit_id: CommitId::from("restore-same-request-source"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(2),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::ReplaceFile {
                     inode_id: InodeId(3),
@@ -440,11 +440,11 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
     let plan = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "restore-after-restore-same-request".to_owned(),
+            commit_id: CommitId::from("restore-after-restore-same-request"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
@@ -499,11 +499,11 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
     let error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            request_id: "restore-under-tombstone".to_owned(),
+            commit_id: CommitId::from("restore-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            source_request_checksum_sha256: None,
+            request_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -556,16 +556,16 @@ fn restore_revision_overflow_is_rejected() {
             content_ref: content_ref("content-max"),
         }],
         subtree_tombstones: Vec::new(),
-        request_receipts: Vec::new(),
+        committed_commits: Vec::new(),
     };
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        request_id: "restore-overflow".to_owned(),
+        commit_id: CommitId::from("restore-overflow"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        source_request_checksum_sha256: None,
+        request_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(u64::MAX),
@@ -738,6 +738,39 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
 }
 
 #[test]
+fn commit_operations_reject_invalid_commit_id_before_wal_key_construction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let error = commit_operations(
+        &store,
+        &namespace_id,
+        ApiCommitRequest {
+            commit_id: CommitId::from("bad/commit"),
+            planned_head_seq: ChangeSeq(0),
+            preconditions: Vec::new(),
+            ops: vec![ApiCommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        },
+        &context,
+    )
+    .expect_err("invalid commit_id should be rejected");
+
+    assert_eq!(error.kind(), CoreErrorKind::InvalidCommitId);
+    assert_eq!(
+        store.list_prefix("namespaces/demo/wal/").expect("list wal"),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
 fn batch_commit_writes_one_segment_and_expands_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -750,7 +783,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                request_id: "req-batch-a".to_owned(),
+                commit_id: CommitId::from("req-batch-a"),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
@@ -761,7 +794,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
                 annotations: None,
             },
             ApiCommitRequest {
-                request_id: "req-batch-b".to_owned(),
+                commit_id: CommitId::from("req-batch-b"),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
@@ -798,8 +831,8 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 2);
-    assert_eq!(changes.changes[0].request_id, "req-batch-a");
-    assert_eq!(changes.changes[1].request_id, "req-batch-b");
+    assert_eq!(changes.changes[0].commit_id, CommitId::from("req-batch-a"));
+    assert_eq!(changes.changes[1].commit_id, CommitId::from("req-batch-b"));
 }
 
 #[test]
@@ -816,7 +849,7 @@ fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::PutFile {
-                request_id: "retry-after-orphan".to_owned(),
+                commit_id: CommitId::from("retry-after-orphan"),
                 absolute_path: "/retry.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -855,17 +888,20 @@ fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     assert_eq!(visible_segment.payload.end_seq, ChangeSeq(1));
     assert_eq!(visible_segment.payload.records.len(), 1);
     assert_eq!(
-        visible_segment.payload.records[0].request_id,
-        "retry-after-orphan"
+        visible_segment.payload.records[0].commit_id,
+        CommitId::from("retry-after-orphan")
     );
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
-    assert_eq!(changes.changes[0].request_id, "retry-after-orphan");
+    assert_eq!(
+        changes.changes[0].commit_id,
+        CommitId::from("retry-after-orphan")
+    );
 }
 
 #[test]
-fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
+fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::from("demo");
@@ -873,7 +909,7 @@ fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
     let request = ApiCommitRequest {
-        request_id: "req-duplicate".to_owned(),
+        commit_id: CommitId::from("req-duplicate"),
         planned_head_seq: ChangeSeq(0),
         preconditions: Vec::new(),
         ops: vec![ApiCommitOp::CreateDir {
@@ -905,11 +941,14 @@ fn batch_commit_aliases_duplicate_request_id_with_same_fingerprint() {
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
-    assert_eq!(changes.changes[0].request_id, "req-duplicate");
+    assert_eq!(
+        changes.changes[0].commit_id,
+        CommitId::from("req-duplicate")
+    );
 }
 
 #[test]
-fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
+fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::from("demo");
@@ -921,7 +960,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                request_id: "req-conflict".to_owned(),
+                commit_id: CommitId::from("req-conflict"),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
@@ -932,7 +971,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
                 annotations: None,
             },
             ApiCommitRequest {
-                request_id: "req-conflict".to_owned(),
+                commit_id: CommitId::from("req-conflict"),
                 planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
@@ -950,7 +989,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
     let error = responses[1].as_ref().expect_err("duplicate conflict");
     assert!(matches!(
         error,
-        CoreError::RequestIdConflict(request_id) if request_id == "req-conflict"
+        CoreError::CommitIdReuseConflict(commit_id) if commit_id == "req-conflict"
     ));
 
     let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
@@ -964,7 +1003,7 @@ fn batch_commit_rejects_duplicate_request_id_with_different_fingerprint() {
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
-    assert_eq!(changes.changes[0].request_id, "req-conflict");
+    assert_eq!(changes.changes[0].commit_id, CommitId::from("req-conflict"));
 }
 
 #[test]
@@ -981,7 +1020,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::PutFile {
-                request_id: "put-path".to_owned(),
+                commit_id: CommitId::from("put-path"),
                 absolute_path: "/docs/a.txt".to_owned(),
                 content_ref: content.content_ref.clone(),
                 behavior: PutFileBehavior::CreateOnly,
@@ -996,7 +1035,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::MovePath {
-                request_id: "move-path".to_owned(),
+                commit_id: CommitId::from("move-path"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/b.txt".to_owned(),
             },
@@ -1010,7 +1049,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::CopyFilePath {
-                request_id: "copy-path".to_owned(),
+                commit_id: CommitId::from("copy-path"),
                 from_path: "/docs/b.txt".to_owned(),
                 to_path: "/docs/c.txt".to_owned(),
             },
@@ -1024,7 +1063,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::DeletePath {
-                request_id: "delete-path".to_owned(),
+                commit_id: CommitId::from("delete-path"),
                 absolute_path: "/docs/b.txt".to_owned(),
                 recursive: false,
             },
@@ -1040,7 +1079,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
 }
 
 #[test]
-fn direct_publisher_uses_durable_path_request_id_receipts() {
+fn direct_publisher_uses_durable_path_committed_commit_index() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::from("demo");
@@ -1050,7 +1089,7 @@ fn direct_publisher_uses_durable_path_request_id_receipts() {
     let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
 
     let intent = PathMutationIntent::PutFile {
-        request_id: "same-path-request".to_owned(),
+        commit_id: CommitId::from("same-path-request"),
         absolute_path: "/same.txt".to_owned(),
         content_ref: content.content_ref.clone(),
         behavior: PutFileBehavior::CreateOnly,
@@ -1072,7 +1111,7 @@ fn direct_publisher_uses_durable_path_request_id_receipts() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::DeletePath {
-                request_id: "same-path-request".to_owned(),
+                commit_id: CommitId::from("same-path-request"),
                 absolute_path: "/same.txt".to_owned(),
                 recursive: false,
             },
@@ -1082,7 +1121,7 @@ fn direct_publisher_uses_durable_path_request_id_receipts() {
         .expect_err("conflicting retry");
     assert!(matches!(
         conflict,
-        CoreError::RequestIdConflict(request_id) if request_id == "same-path-request"
+        CoreError::CommitIdReuseConflict(commit_id) if commit_id == "same-path-request"
     ));
 
     let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
@@ -1103,13 +1142,13 @@ fn path_intents_in_one_batch_see_tentative_state() {
         &namespace_id,
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                request_id: "put-batched-path".to_owned(),
+                commit_id: CommitId::from("put-batched-path"),
                 absolute_path: "/docs/a.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
-                request_id: "move-batched-path".to_owned(),
+                commit_id: CommitId::from("move-batched-path"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/b.txt".to_owned(),
             }),
@@ -1483,7 +1522,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "restore-create".to_owned(),
+            commit_id: CommitId::from("restore-create"),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
@@ -1509,7 +1548,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "restore-replace".to_owned(),
+            commit_id: CommitId::from("restore-replace"),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
@@ -1537,7 +1576,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "restore-missing-content".to_owned(),
+            commit_id: CommitId::from("restore-missing-content"),
             planned_head_seq: ChangeSeq(2),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(2),
@@ -1585,7 +1624,7 @@ fn metadata_only_commit_does_not_validate_content_store_refs() {
         &guarded_store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "metadata-only-delete".to_owned(),
+            commit_id: CommitId::from("metadata-only-delete"),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
@@ -1617,7 +1656,7 @@ fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "create-missing-parent-missing-content".to_owned(),
+            commit_id: CommitId::from("create-missing-parent-missing-content"),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
@@ -1664,7 +1703,7 @@ fn replace_file_prioritizes_missing_durable_content_over_stale_revision() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "replace-stale-missing-content".to_owned(),
+            commit_id: CommitId::from("replace-stale-missing-content"),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
@@ -1711,7 +1750,7 @@ fn restore_revision_missing_source_is_revision_not_found() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "restore-missing-source".to_owned(),
+            commit_id: CommitId::from("restore-missing-source"),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
@@ -1742,7 +1781,7 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "resolve-before-durable-check-create".to_owned(),
+            commit_id: CommitId::from("resolve-before-durable-check-create"),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
@@ -1775,7 +1814,7 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            request_id: "resolve-before-durable-check-commit".to_owned(),
+            commit_id: CommitId::from("resolve-before-durable-check-commit"),
             planned_head_seq: ChangeSeq(1),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(1),
@@ -2247,7 +2286,7 @@ fn metadata_state_after(sequences: &[Vec<loon_api::WalOp>]) -> MetadataState {
         direntries: Vec::new(),
         revisions: Vec::new(),
         subtree_tombstones: Vec::new(),
-        request_receipts: Vec::new(),
+        committed_commits: Vec::new(),
     };
 
     for (index, ops) in sequences.iter().enumerate() {

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -6,7 +6,7 @@ pub enum SnapshotTableFamily {
     Direntries,
     Revisions,
     Tombstones,
-    RequestReceipts,
+    CommittedCommits,
 }
 
 impl SnapshotTableFamily {
@@ -16,7 +16,7 @@ impl SnapshotTableFamily {
             Self::Direntries => "direntries",
             Self::Revisions => "revisions",
             Self::Tombstones => "tombstones",
-            Self::RequestReceipts => "request-receipts",
+            Self::CommittedCommits => "committed-commits",
         }
     }
 }
@@ -31,10 +31,6 @@ pub fn namespace_descriptor(namespace: &str) -> String {
 
 pub fn namespace_lease(namespace: &str) -> String {
     format!("namespaces/{namespace}/lease.json")
-}
-
-pub fn wal_commit(namespace: &str, seq: u64, commit_id: &str) -> String {
-    format!("namespaces/{namespace}/wal/{seq:020}-{commit_id}.cbor.zst")
 }
 
 pub fn wal_segment(namespace: &str, start_seq: u64, end_seq: u64, segment_id: &str) -> String {
@@ -117,7 +113,7 @@ mod tests {
         conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
         derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
         sha256_hex_from_digest, snapshot_manifest, snapshot_table, upload_session,
-        upload_session_prefix, wal_commit, wal_segment, SnapshotTableFamily,
+        upload_session_prefix, wal_segment, SnapshotTableFamily,
     };
 
     #[test]
@@ -131,10 +127,6 @@ mod tests {
         assert_eq!(
             content_store_descriptor("cs-1"),
             "content-stores/cs-1/descriptor.json"
-        );
-        assert_eq!(
-            wal_commit("ns-1", 420, "commit-123"),
-            "namespaces/ns-1/wal/00000000000000000420-commit-123.cbor.zst"
         );
         assert_eq!(
             wal_segment("ns-1", 420, 425, "seg-123"),

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -6,7 +6,7 @@ pub enum SnapshotTableFamily {
     Direntries,
     Revisions,
     Tombstones,
-    CommittedCommits,
+    CommitReceipts,
 }
 
 impl SnapshotTableFamily {
@@ -16,7 +16,7 @@ impl SnapshotTableFamily {
             Self::Direntries => "direntries",
             Self::Revisions => "revisions",
             Self::Tombstones => "tombstones",
-            Self::CommittedCommits => "committed-commits",
+            Self::CommitReceipts => "commit-receipts",
         }
     }
 }
@@ -139,6 +139,10 @@ mod tests {
         assert_eq!(
             snapshot_table("ns-1", 400, SnapshotTableFamily::Direntries, 7),
             "namespaces/ns-1/snapshots/00000000000000000400/tables/direntries-00007.sst.zst"
+        );
+        assert_eq!(
+            snapshot_table("ns-1", 400, SnapshotTableFamily::CommitReceipts, 0),
+            "namespaces/ns-1/snapshots/00000000000000000400/tables/commit-receipts-00000.sst.zst"
         );
         assert_eq!(
             derived_progress("ns-1", "BuildSnapshot"),

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -158,6 +158,10 @@ fn key_builders_cover_locked_object_families() {
         "namespaces/ns-1/snapshots/00000000000000000420/tables/inodes-00003.sst.zst"
     );
     assert_eq!(
+        snapshot_table("ns-1", 420, SnapshotTableFamily::CommitReceipts, 0),
+        "namespaces/ns-1/snapshots/00000000000000000420/tables/commit-receipts-00000.sst.zst"
+    );
+    assert_eq!(
         derived_progress("ns-1", "BuildSnapshot"),
         "namespaces/ns-1/derived/BuildSnapshot/progress.json"
     );

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -3,7 +3,7 @@ mod provider_env;
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, derived_progress, namespace_descriptor, namespace_head,
-    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_commit,
+    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_segment,
     SnapshotTableFamily,
 };
 use loon_objectstore::probes::run_contract_probes;
@@ -146,8 +146,8 @@ fn key_builders_cover_locked_object_families() {
         "content-stores/cs-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
     );
     assert_eq!(
-        wal_commit("ns-1", 420, "commit-1"),
-        "namespaces/ns-1/wal/00000000000000000420-commit-1.cbor.zst"
+        wal_segment("ns-1", 420, 420, "seg-1"),
+        "namespaces/ns-1/wal/00000000000000000420-00000000000000000420-seg-1.cbor.zst"
     );
     assert_eq!(
         snapshot_manifest("ns-1", 420),
@@ -451,7 +451,7 @@ fn assert_sorted_list_prefix<S: ObjectStore>(store: &S) {
 }
 
 fn assert_supports_range_reads<S: ObjectStore>(store: &S) {
-    let key = wal_commit("ns-1", 420, "commit-1");
+    let key = wal_segment("ns-1", 420, 420, "seg-1");
     let _ = store.delete(&key);
 
     store

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -254,7 +254,7 @@ async fn filesystem_operation(
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let FilesystemOperationRequest {
-        request_id,
+        commit_id,
         operation,
     } = request;
     let intent = match operation {
@@ -263,23 +263,23 @@ async fn filesystem_operation(
             content_ref,
             behavior,
         } => PathMutationIntent::PutFile {
-            request_id,
+            commit_id,
             absolute_path: path,
             content_ref,
             behavior: map_filesystem_put_behavior(behavior),
         },
         FilesystemOperation::DeletePath { path } => PathMutationIntent::DeletePath {
-            request_id,
+            commit_id,
             absolute_path: path,
             recursive: false,
         },
         FilesystemOperation::MovePath { from_path, to_path } => PathMutationIntent::MovePath {
-            request_id,
+            commit_id,
             from_path,
             to_path,
         },
         FilesystemOperation::CopyPath { from_path, to_path } => PathMutationIntent::CopyFilePath {
-            request_id,
+            commit_id,
             from_path,
             to_path,
         },
@@ -540,6 +540,7 @@ impl ApiResponseError {
         let (status, code) = match error.kind() {
             CoreErrorKind::InvalidPath => (StatusCode::BAD_REQUEST, "invalid_path"),
             CoreErrorKind::InvalidNamespaceId => (StatusCode::BAD_REQUEST, "invalid_namespace_id"),
+            CoreErrorKind::InvalidCommitId => (StatusCode::BAD_REQUEST, "invalid_commit_id"),
             CoreErrorKind::NamespaceNotFound => (StatusCode::NOT_FOUND, "namespace_not_found"),
             CoreErrorKind::NamespaceExists => (StatusCode::CONFLICT, "namespace_exists"),
             CoreErrorKind::NamespacePartial => (StatusCode::CONFLICT, "namespace_partial"),
@@ -551,7 +552,9 @@ impl ApiResponseError {
             CoreErrorKind::TombstoneConflict => (StatusCode::CONFLICT, "tombstone_conflict"),
             CoreErrorKind::LeaseConflict => (StatusCode::CONFLICT, "lease_conflict"),
             CoreErrorKind::WouldCycle => (StatusCode::CONFLICT, "would_cycle"),
-            CoreErrorKind::RequestIdConflict => (StatusCode::CONFLICT, "idempotency_key_conflict"),
+            CoreErrorKind::CommitIdReuseConflict => {
+                (StatusCode::CONFLICT, "commit_id_reuse_conflict")
+            }
             CoreErrorKind::CommitQueueFull => {
                 (StatusCode::SERVICE_UNAVAILABLE, "commit_queue_full")
             }
@@ -918,7 +921,7 @@ mod tests {
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
             let request = CommitRequest {
-                request_id: "stale-explicit".to_owned(),
+                commit_id: loon_api::CommitId::from("stale-explicit"),
                 planned_head_seq: ChangeSeq(1),
                 preconditions: vec![CommitPrecondition::HeadSeqIs {
                     expected_seq: ChangeSeq(1),

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,6 +1,6 @@
 use crate::config::ServerConfig;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{payload_checksum_sha256, NamespaceId};
+use loon_api::{payload_checksum_sha256, CommitId, NamespaceId};
 use loon_core::{
     commit::CommitHeadPublishError, publish_namespace_mutations_batch, CoreError, MutationContext,
     NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation,
@@ -90,7 +90,7 @@ struct NamespacePublisher {
 
 struct NamespacePublisherState {
     batch: Option<OpenBatch>,
-    in_flight: HashMap<String, InFlightRequest>,
+    in_flight: HashMap<CommitId, InFlightRequest>,
     publishing: bool,
     next_allowed_cas_at: Instant,
 }
@@ -102,7 +102,7 @@ struct OpenBatch {
 
 #[derive(Clone)]
 struct BatchCandidate {
-    request_id: String,
+    commit_id: CommitId,
     candidate: NamespaceMutationCandidate,
 }
 
@@ -127,10 +127,10 @@ impl NamespacePublisher {
     }
 
     async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
-        let request_id = candidate_request_id(&candidate).to_owned();
+        let commit_id = candidate_commit_id(&candidate).clone();
         let fingerprint = candidate_fingerprint(&self.namespace_id, &candidate)?;
         let (sender, receiver) = oneshot::channel();
-        self.admit(request_id, candidate, fingerprint, sender)?;
+        self.admit(commit_id, candidate, fingerprint, sender)?;
         receiver
             .await
             .unwrap_or_else(|_| Err(CoreError::Store("publisher task stopped".to_owned())))
@@ -138,7 +138,7 @@ impl NamespacePublisher {
 
     fn admit(
         &self,
-        request_id: String,
+        commit_id: CommitId,
         candidate: NamespaceMutationCandidate,
         fingerprint: String,
         waiter: oneshot::Sender<CommitResult>,
@@ -150,9 +150,9 @@ impl NamespacePublisher {
                 .state
                 .lock()
                 .expect("namespace publisher mutex poisoned");
-            if let Some(existing) = state.in_flight.get_mut(&request_id) {
+            if let Some(existing) = state.in_flight.get_mut(&commit_id) {
                 if existing.fingerprint != fingerprint {
-                    return Err(CoreError::RequestIdConflict(request_id));
+                    return Err(CoreError::CommitIdReuseConflict(commit_id.to_string()));
                 }
                 existing.waiters.push(waiter);
                 return Ok(());
@@ -172,13 +172,13 @@ impl NamespacePublisher {
                     return Err(CoreError::CommitQueueFull);
                 }
                 batch.candidates.push(BatchCandidate {
-                    request_id: request_id.clone(),
+                    commit_id: commit_id.clone(),
                     candidate: candidate.clone(),
                 });
                 (batch.candidates.len(), batch.notify.clone())
             };
             state.in_flight.insert(
-                request_id,
+                commit_id,
                 InFlightRequest {
                     fingerprint,
                     waiters: vec![waiter],
@@ -324,7 +324,7 @@ impl NamespacePublisher {
                         "publisher returned too few batch results".to_owned(),
                     ))
                 });
-                if let Some(in_flight) = state.in_flight.remove(&candidate.request_id) {
+                if let Some(in_flight) = state.in_flight.remove(&candidate.commit_id) {
                     for waiter in in_flight.waiters {
                         deliveries.push((waiter, result.clone()));
                     }
@@ -353,13 +353,13 @@ fn is_head_publish_stale(result: &CommitResult) -> bool {
     )
 }
 
-fn candidate_request_id(candidate: &NamespaceMutationCandidate) -> &str {
+fn candidate_commit_id(candidate: &NamespaceMutationCandidate) -> &CommitId {
     match candidate {
-        NamespaceMutationCandidate::Commit(request) => &request.request_id,
+        NamespaceMutationCandidate::Commit(request) => &request.commit_id,
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
             commit_request, ..
-        }) => &commit_request.request_id,
-        NamespaceMutationCandidate::Path(intent) => intent.request_id(),
+        }) => &commit_request.commit_id,
+        NamespaceMutationCandidate::Path(intent) => intent.commit_id(),
     }
 }
 
@@ -368,27 +368,24 @@ fn candidate_fingerprint(
     candidate: &NamespaceMutationCandidate,
 ) -> Result<String, CoreError> {
     match candidate {
-        NamespaceMutationCandidate::Commit(request) => semantic_fingerprint(namespace_id, request)
+        NamespaceMutationCandidate::Commit(request) => request_fingerprint(namespace_id, request)
             .map_err(|err| CoreError::Store(err.to_string())),
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            source_request_checksum_sha256: Some(source),
+            request_fingerprint_sha256: Some(source),
             ..
         }) => Ok(source.clone()),
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
             commit_request,
-            source_request_checksum_sha256: None,
-        }) => semantic_fingerprint(namespace_id, commit_request)
+            request_fingerprint_sha256: None,
+        }) => request_fingerprint(namespace_id, commit_request)
             .map_err(|err| CoreError::Store(err.to_string())),
-        NamespaceMutationCandidate::Path(intent) => {
-            intent.source_request_checksum_sha256(namespace_id)
-        }
+        NamespaceMutationCandidate::Path(intent) => intent.request_fingerprint_sha256(namespace_id),
     }
 }
 
 #[derive(Serialize)]
-struct SemanticCommit<'a> {
+struct CanonicalCommitRequest<'a> {
     namespace_id: &'a NamespaceId,
-    request_id: &'a str,
     planned_head_seq: loon_api::ChangeSeq,
     preconditions: &'a [loon_api::v0::CommitPrecondition],
     ops: &'a [loon_api::v0::CommitOp],
@@ -396,13 +393,12 @@ struct SemanticCommit<'a> {
     annotations: &'a Option<loon_api::v0::CommitAnnotations>,
 }
 
-fn semantic_fingerprint(
+fn request_fingerprint(
     namespace_id: &NamespaceId,
     request: &ApiCommitRequest,
 ) -> Result<String, serde_json::Error> {
-    payload_checksum_sha256(&SemanticCommit {
+    payload_checksum_sha256(&CanonicalCommitRequest {
         namespace_id,
-        request_id: &request.request_id,
         planned_head_seq: request.planned_head_seq,
         preconditions: &request.preconditions,
         ops: &request.ops,
@@ -562,11 +558,11 @@ mod tests {
     }
 
     fn create_dir_request(
-        request_id: impl Into<String>,
+        commit_id: impl Into<String>,
         display_name: impl Into<String>,
     ) -> CommitRequest {
         CommitRequest {
-            request_id: request_id.into(),
+            commit_id: CommitId::from(commit_id.into()),
             planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
@@ -591,11 +587,11 @@ mod tests {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
-        let request_id = request.request_id.clone();
+        let commit_id = request.commit_id.clone();
         let candidate = NamespaceMutationCandidate::Commit(request);
         let fingerprint = candidate_fingerprint(namespace_id, &candidate)?;
         let (sender, receiver) = oneshot::channel();
-        publisher.admit(request_id, candidate, fingerprint, sender)?;
+        publisher.admit(commit_id, candidate, fingerprint, sender)?;
         Ok(receiver)
     }
 
@@ -703,7 +699,7 @@ mod tests {
         );
         assert!(matches!(
             conflict,
-            Err(CoreError::RequestIdConflict(request_id)) if request_id == "active"
+            Err(CoreError::CommitIdReuseConflict(commit_id)) if commit_id == "active"
         ));
 
         store.release_head_cas();
@@ -758,7 +754,7 @@ mod tests {
         );
         assert!(matches!(
             conflict,
-            Err(CoreError::RequestIdConflict(request_id)) if request_id == "pending-0"
+            Err(CoreError::CommitIdReuseConflict(commit_id)) if commit_id == "pending-0"
         ));
 
         let overflow = try_admit_commit(
@@ -855,7 +851,7 @@ mod tests {
         let registry = PublisherRegistry::new(store.clone(), config);
 
         let request_a = CommitRequest {
-            request_id: "req-a".to_owned(),
+            commit_id: CommitId::from("req-a"),
             planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
@@ -866,7 +862,7 @@ mod tests {
             annotations: None,
         };
         let request_b = CommitRequest {
-            request_id: "req-b".to_owned(),
+            commit_id: CommitId::from("req-b"),
             planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
@@ -916,7 +912,7 @@ mod tests {
         let registry = PublisherRegistry::new(store.clone(), config);
 
         let explicit = CommitRequest {
-            request_id: "explicit-commit".to_owned(),
+            commit_id: CommitId::from("explicit-commit"),
             planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
@@ -927,7 +923,7 @@ mod tests {
             annotations: None,
         };
         let path_intent = PathMutationIntent::PutFile {
-            request_id: "path-put".to_owned(),
+            commit_id: CommitId::from("path-put"),
             absolute_path: "/file.txt".to_owned(),
             content_ref: content.content_ref,
             behavior: PutFileBehavior::CreateOnly,

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -3,8 +3,8 @@ use loon_api::{
         CommitAnnotations, CommitOp, CommitOpResult, CommitPrecondition,
         CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
-    AdvanceRetentionResponse, ApiError, ChangeSeq, ContentRef, CreateCheckpointResponse, InodeId,
-    RevisionNo,
+    AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
+    InodeId, RevisionNo,
 };
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_objectstore::keys::snapshot_manifest;
@@ -297,7 +297,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         annotations.insert("source".to_owned(), json!("http-smoke"));
         annotations.insert("kind".to_owned(), json!("service-proxied"));
         let commit_request = ApiCommitRequest {
-            request_id: "req-phase-2a-create-file".to_owned(),
+            commit_id: CommitId::from("req-phase-2a-create-file"),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
@@ -314,7 +314,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             .client
             .commit_operations(namespace, &commit_request)
             .expect("commit uploaded file");
-        assert_eq!(commit.commit_id, "req-phase-2a-create-file");
+        assert_eq!(commit.commit_id, CommitId::from("req-phase-2a-create-file"));
         assert_eq!(commit.committed_seq, ChangeSeq(1));
         assert_eq!(
             commit.results,
@@ -355,7 +355,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         let change = &changes.changes[0];
         assert_eq!(change.seq, commit.committed_seq);
         assert_eq!(change.commit_id, commit.commit_id);
-        assert_eq!(change.request_id, commit_request.request_id);
+        assert_eq!(change.commit_id, commit_request.commit_id);
         assert_eq!(change.message.as_deref(), Some("upload over http"));
         assert_eq!(change.annotations, Some(annotations));
         assert_eq!(change.ops, commit.results);
@@ -398,7 +398,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    request_id: "req-restore-create".to_owned(),
+                    commit_id: CommitId::from("req-restore-create"),
                     planned_head_seq: ChangeSeq(0),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
                         expected_seq: ChangeSeq(0),
@@ -425,7 +425,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    request_id: "req-restore-replace".to_owned(),
+                    commit_id: CommitId::from("req-restore-replace"),
                     planned_head_seq: ChangeSeq(1),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
                         expected_seq: ChangeSeq(1),
@@ -447,7 +447,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    request_id: "req-restore-restore".to_owned(),
+                    commit_id: CommitId::from("req-restore-restore"),
                     planned_head_seq: ChangeSeq(2),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
                         expected_seq: ChangeSeq(2),
@@ -491,7 +491,10 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .list_changes(namespace, ChangeSeq(0))
             .expect("list changes");
         assert_eq!(changes.changes.len(), 3);
-        assert_eq!(changes.changes[2].request_id, "req-restore-restore");
+        assert_eq!(
+            changes.changes[2].commit_id,
+            CommitId::from("req-restore-restore")
+        );
         assert_eq!(changes.changes[2].ops, restore.results);
     })
     .await
@@ -525,7 +528,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    request_id: "req-restore-missing-source-create".to_owned(),
+                    commit_id: CommitId::from("req-restore-missing-source-create"),
                     planned_head_seq: ChangeSeq(0),
                     preconditions: vec![CommitPrecondition::HeadSeqIs {
                         expected_seq: ChangeSeq(0),
@@ -548,7 +551,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
         match harness.client.commit_operations(
             namespace,
             &ApiCommitRequest {
-                request_id: "req-restore-missing-source-restore".to_owned(),
+                commit_id: CommitId::from("req-restore-missing-source-restore"),
                 planned_head_seq: ChangeSeq(1),
                 preconditions: vec![CommitPrecondition::HeadSeqIs {
                     expected_seq: ChangeSeq(1),
@@ -576,7 +579,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_commit_rejects_same_request_id_with_different_payload() {
+async fn http_commit_rejects_same_commit_id_with_different_payload() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -596,7 +599,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
         let first_content_ref =
             stage_uploaded_content_ref(&harness.client, namespace, b"first payload\n");
         let first_request = ApiCommitRequest {
-            request_id: "req-phase-2a-conflict".to_owned(),
+            commit_id: CommitId::from("req-phase-2a-conflict"),
             planned_head_seq: ChangeSeq(0),
             preconditions: vec![CommitPrecondition::HeadSeqIs {
                 expected_seq: ChangeSeq(0),
@@ -619,7 +622,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
         let mut changed_annotations = BTreeMap::new();
         changed_annotations.insert("source".to_owned(), json!("changed"));
         let conflicting_request = ApiCommitRequest {
-            request_id: first_request.request_id.clone(),
+            commit_id: first_request.commit_id.clone(),
             planned_head_seq: ChangeSeq(0),
             preconditions: first_request.preconditions.clone(),
             ops: vec![CommitOp::CreateFile {
@@ -636,9 +639,9 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
             .commit_operations(namespace, &conflicting_request)
         {
             Err(ClientError::Api { code, .. }) => {
-                assert_eq!(code, "idempotency_key_conflict")
+                assert_eq!(code, "commit_id_reuse_conflict")
             }
-            other => panic!("expected idempotency_key_conflict, got {other:?}"),
+            other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
         }
     })
     .await
@@ -648,7 +651,7 @@ async fn http_commit_rejects_same_request_id_with_different_payload() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
+async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -664,17 +667,17 @@ async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
             .create_namespace("demo")
             .expect("create namespace");
         let target = NamespacePath::parse("demo:/docs/retry.txt").expect("target");
-        let request_id = "req-v1-put";
+        let commit_id = "req-v1-put";
 
         let first = harness
             .client
-            .put_file_bytes_with_request_id(&target, b"stable bytes\n", false, request_id)
+            .put_file_bytes_with_commit_id(&target, b"stable bytes\n", false, commit_id)
             .expect("first put");
         assert!(first.committed_seq.0 >= 1);
 
         let repeated = harness
             .client
-            .put_file_bytes_with_request_id(&target, b"stable bytes\n", false, request_id)
+            .put_file_bytes_with_commit_id(&target, b"stable bytes\n", false, commit_id)
             .expect("repeat put");
         assert_eq!(repeated, first);
 
@@ -683,16 +686,16 @@ async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
         let bytes = harness.client.read_file_bytes(&target).expect("read file");
         assert_eq!(bytes, b"stable bytes\n");
 
-        match harness.client.put_file_bytes_with_request_id(
+        match harness.client.put_file_bytes_with_commit_id(
             &target,
             b"different bytes\n",
             false,
-            request_id,
+            commit_id,
         ) {
             Err(ClientError::Api { code, .. }) => {
-                assert_eq!(code, "idempotency_key_conflict")
+                assert_eq!(code, "commit_id_reuse_conflict")
             }
-            other => panic!("expected idempotency_key_conflict, got {other:?}"),
+            other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
         }
     })
     .await
@@ -702,7 +705,7 @@ async fn http_put_request_id_is_idempotent_and_conflicts_on_different_bytes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_delete_move_and_copy_request_ids_are_idempotent() {
+async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -726,11 +729,11 @@ async fn http_delete_move_and_copy_request_ids_are_idempotent() {
         let copied = NamespacePath::parse("demo:/docs/copied.txt").expect("copied");
         let copy_first = harness
             .client
-            .copy_path_with_request_id(&source, &copied, "req-v1-copy")
+            .copy_path_with_commit_id(&source, &copied, "req-v1-copy")
             .expect("copy first");
         let copy_repeated = harness
             .client
-            .copy_path_with_request_id(&source, &copied, "req-v1-copy")
+            .copy_path_with_commit_id(&source, &copied, "req-v1-copy")
             .expect("copy repeat");
         assert_eq!(copy_repeated, copy_first);
         let source_entry = harness.client.stat_path(&source).expect("source stat");
@@ -741,11 +744,11 @@ async fn http_delete_move_and_copy_request_ids_are_idempotent() {
         let moved = NamespacePath::parse("demo:/docs/moved.txt").expect("moved");
         let move_first = harness
             .client
-            .move_path_with_request_id(&copied, &moved, "req-v1-move")
+            .move_path_with_commit_id(&copied, &moved, "req-v1-move")
             .expect("move first");
         let move_repeated = harness
             .client
-            .move_path_with_request_id(&copied, &moved, "req-v1-move")
+            .move_path_with_commit_id(&copied, &moved, "req-v1-move")
             .expect("move repeat");
         assert_eq!(move_repeated, move_first);
         match harness.client.stat_path(&copied) {
@@ -757,11 +760,11 @@ async fn http_delete_move_and_copy_request_ids_are_idempotent() {
 
         let delete_first = harness
             .client
-            .delete_path_with_request_id(&moved, "req-v1-delete")
+            .delete_path_with_commit_id(&moved, "req-v1-delete")
             .expect("delete first");
         let delete_repeated = harness
             .client
-            .delete_path_with_request_id(&moved, "req-v1-delete")
+            .delete_path_with_commit_id(&moved, "req-v1-delete")
             .expect("delete repeat");
         assert_eq!(delete_repeated, delete_first);
         match harness.client.stat_path(&moved) {

--- a/docs/specs/020-architecture-overview.md
+++ b/docs/specs/020-architecture-overview.md
@@ -36,7 +36,7 @@ LoonFS supports multiple client profiles. These profiles are defined by the prot
 | Client profile | Primary surface | Typical state |
 | --- | --- | --- |
 | **Path-oriented client** | Filesystem operations such as `ls`, `stat`, `get`, `put`, `mv`, and `cp` | Often little or no durable local state beyond transient request context. |
-| **Explicit-commit client** | Staged upload, request ids, explicit commit, and change cursors | Durable retry state for in-flight uploads and requests, but not necessarily a full local projection. |
+| **Explicit-commit client** | Staged upload, commit ids, explicit commit, and change cursors | Durable retry state for in-flight uploads and requests, but not necessarily a full local projection. |
 | **Sync client** | Change feed plus durable local projection, with optional writes | Durable local state, cursors, and restart-safe reconciliation state. |
 | **Operator or admin client** | Recovery, inspection, repair, and low-level operations | Implementation-specific. |
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -37,7 +37,7 @@ A commit request carries the following logical fields:
 
 | Field | Meaning |
 | --- | --- |
-| `request_id` | Client-generated stable idempotency key for this logical commit request. The same value must be reused for safe retries. |
+| `commit_id` | Client-generated stable idempotency key for this logical commit request. The same value must be reused for safe retries. |
 | `planned_head_seq` | The history point the client planned against. Preconditions are evaluated against authoritative state at this boundary. |
 | `preconditions` | Explicit checks such as `HeadSeqIs`, `InodeRevisionIs`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
 | `ops` | Ordered list of mutation operations. Operation order is preserved through validation, logical commit creation, and change-feed output. |
@@ -46,7 +46,7 @@ A commit request carries the following logical fields:
 
 The server validates each request against authoritative namespace state. A request may be rejected immediately. If it is tentatively accepted into a publication batch, the server may assign it a `seq`, but the request is not yet committed or successful at that point. It becomes one committed logical commit only after its WAL segment is durably written and the head update succeeds. If the WAL segment is written but the head update fails, the segment is orphaned and the request is not committed.
 
-The server may publish multiple committed logical commits in one WAL segment and one head update, but it must preserve per-request idempotency, ordering, and change-feed identity.
+The server may publish multiple committed logical commits in one WAL segment and one head update, but it must preserve per-commit idempotency, ordering, and change-feed identity.
 
 Annotations may be used to correlate multiple logical commits that belong to one higher-level workflow, for example with fields such as `operation_id`, `operation_kind`, or `operation_part`.
 
@@ -141,7 +141,7 @@ Representative request:
 
 ```json
 {
-  "request_id": "req_01J...",
+  "commit_id": "c_01j...",
   "message": "move report and publish new bytes",
   "annotations": {
     "source": "cli"
@@ -256,7 +256,7 @@ Representative request:
 
 ```json
 {
-  "request_id": "req_01J...",
+  "commit_id": "c_01j...",
   "planned_head_seq": 418,
   "message": "replace report bytes",
   "annotations": {
@@ -300,7 +300,7 @@ Representative response:
 ```json
 {
   "namespace_id": "demo",
-  "commit_id": "c_01J...",
+  "commit_id": "c_01j...",
   "committed_seq": 419,
   "results": [
     {
@@ -322,8 +322,7 @@ Representative response:
   "changes": [
     {
       "seq": 419,
-      "commit_id": "c_01J...",
-      "request_id": "req_01J...",
+      "commit_id": "c_01j...",
       "message": "replace report bytes",
       "ops": [
         {
@@ -394,7 +393,7 @@ This client uses the upload, commit, and change-feed surface more directly. It s
 Typical behavior:
 
 - content hashing and upload;
-- explicit commit with preconditions and request ids;
+- explicit commit with preconditions and commit ids;
 - change-feed reads or cursors where incremental observation is needed.
 
 ### 4.4 Operator or admin tool
@@ -420,6 +419,6 @@ The following table summarizes the core split. For more detailed command-oriente
 | --- | --- | --- |
 | Path resolution | Authoritative | Supplies user intent by path when using the filesystem surface. |
 | Content hashing and upload | May accept direct bytes, proxy uploads, or issue upload capabilities, but must verify that any content referenced by a commit is already durable. | Usually responsible for reading local bytes, computing content hashes, and uploading missing content when originating new data. |
-| Commit validation | Authoritative | Supplies preconditions and request ids where needed. |
+| Commit validation | Authoritative | Supplies preconditions and commit ids where needed. |
 | Namespace visibility | Authoritative | Observes committed results. |
 | Long-running transfer progress | Authoritative for sessions that affect correctness | Responsible for local temp files, local progress, retry behavior, and any higher-level orchestration outside the core model. |

--- a/docs/specs/090-versioning-conformance-and-extensions.md
+++ b/docs/specs/090-versioning-conformance-and-extensions.md
@@ -27,7 +27,7 @@ A conforming server must:
 7. serve replay from verified checkpoints plus the visible WAL segment chain, replayed as logical commits;
 8. honor the namespace's `NamePolicy`;
 9. keep control-plane sessions and any implementation-specific coordinators out of namespace history and the change feed; and
-10. preserve per-request idempotency, ordering, and change-feed identity even when physically batching logical commits in a WAL segment.
+10. preserve per-commit idempotency, ordering, and change-feed identity even when physically batching logical commits in a WAL segment.
 
 ## 3. Writer and client requirements
 
@@ -35,7 +35,7 @@ A conforming writer or client must:
 
 1. treat paths as selectors, not as durable identity;
 2. upload or otherwise stage content before asking the server to publish it;
-3. use request ids or equivalent idempotency keys for safe retry;
+3. use commit ids or equivalent idempotency keys for safe retry;
 4. tolerate commit rejection when preconditions no longer hold; and
 5. re-bootstrap if its cursor falls behind the retention floor.
 


### PR DESCRIPTION
Refactors namespace commit identity so **commit_id** is the client-supplied idempotency key (while seq remains the server-assigned namespace order and WAL segments keep their own segment_id). We had briefly introduced the concept of request_id as a separate concept, but that doesn't (yet) make sense and adds too much complexity too early. 

This updates the public HTTP/client/CLI/core surfaces, WAL payloads, checkpoint rows, metadata replay, change feed, and server publisher idempotency from request_id to commit_id. 