### PR TITLE
fix: naming cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-casefold",
  "unicode-normalization",
+ "uuid",
  "zstd",
 ]
 
@@ -1346,7 +1347,6 @@ dependencies = [
  "tempfile",
  "toml",
  "ureq",
- "uuid",
 ]
 
 [[package]]
@@ -1362,7 +1362,6 @@ dependencies = [
  "toml",
  "ureq",
  "urlencoding",
- "uuid",
  "walkdir",
 ]
 
@@ -1378,7 +1377,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
- "uuid",
 ]
 
 [[package]]

--- a/crates/loon-api/Cargo.toml
+++ b/crates/loon-api/Cargo.toml
@@ -13,4 +13,5 @@ sha2.workspace = true
 thiserror.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true
+uuid.workspace = true
 zstd.workspace = true

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use thiserror::Error;
+use uuid::Uuid;
+
+const SERVER_GENERATED_ID_BODY_LEN: usize = 32;
 
 /// Unique identifier for a namespace (a logical sync boundary).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -28,6 +31,13 @@ pub struct CommitIdValidationError {
     reason: &'static str,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid generated id {value:?}: {reason}")]
+pub struct GeneratedIdValidationError {
+    value: String,
+    reason: String,
+}
+
 impl NamespaceIdValidationError {
     pub fn value(&self) -> &str {
         &self.value
@@ -45,6 +55,16 @@ impl CommitIdValidationError {
 
     pub fn reason(&self) -> &'static str {
         self.reason
+    }
+}
+
+impl GeneratedIdValidationError {
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
     }
 }
 
@@ -94,6 +114,63 @@ impl CommitId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    pub fn generate() -> Self {
+        Self(generated_id("c"))
+    }
+}
+
+/// Generates a project-standard opaque durable identifier.
+///
+/// Generated server-side IDs use an underscore prefix plus a 32-character
+/// lowercase UUID-simple body, such as `cs_<32hex>` or `seg_<32hex>`.
+pub fn generated_id(prefix: &'static str) -> String {
+    format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+pub fn generate_upload_id() -> String {
+    generated_id("upl")
+}
+
+pub fn generate_wal_segment_id() -> String {
+    generated_id("seg")
+}
+
+pub fn validate_upload_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValidationError> {
+    validate_generated_id("upl", value.as_ref())
+}
+
+pub fn validate_wal_segment_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValidationError> {
+    validate_generated_id("seg", value.as_ref())
+}
+
+pub fn validate_generated_id(
+    prefix: &'static str,
+    value: &str,
+) -> Result<(), GeneratedIdValidationError> {
+    let expected_prefix = format!("{prefix}_");
+    let Some(body) = value.strip_prefix(&expected_prefix) else {
+        return Err(generated_id_error(
+            value,
+            format!("must start with `{expected_prefix}`"),
+        ));
+    };
+    if body.len() != SERVER_GENERATED_ID_BODY_LEN {
+        return Err(generated_id_error(
+            value,
+            format!("body must be {SERVER_GENERATED_ID_BODY_LEN} lowercase hex characters"),
+        ));
+    }
+    if !body
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(generated_id_error(
+            value,
+            "body must contain only lowercase hex characters".to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_namespace_id(value: &str) -> Result<(), NamespaceIdValidationError> {
@@ -150,9 +227,32 @@ fn commit_id_error(value: &str, reason: &'static str) -> CommitIdValidationError
     }
 }
 
+fn generated_id_error(value: &str, reason: String) -> GeneratedIdValidationError {
+    GeneratedIdValidationError {
+        value: value.to_owned(),
+        reason,
+    }
+}
+
 impl ContentStoreId {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
+    }
+
+    pub fn generate() -> Self {
+        Self(generated_id("cs"))
+    }
+
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, GeneratedIdValidationError> {
+        let value = value.as_ref();
+        validate_generated_id("cs", value)?;
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn try_new(value: impl Into<String>) -> Result<Self, GeneratedIdValidationError> {
+        let value = value.into();
+        validate_generated_id("cs", &value)?;
+        Ok(Self(value))
     }
 
     pub fn as_str(&self) -> &str {
@@ -247,7 +347,8 @@ impl<'de> Deserialize<'de> for ContentStoreId {
     where
         D: Deserializer<'de>,
     {
-        Ok(Self(String::deserialize(deserializer)?))
+        let value = String::deserialize(deserializer)?;
+        ContentStoreId::try_new(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -318,7 +419,9 @@ impl fmt::Display for InodeId {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommitId, NamespaceId};
+    use super::{
+        validate_upload_id, validate_wal_segment_id, CommitId, ContentStoreId, NamespaceId,
+    };
 
     #[test]
     fn namespace_id_parse_accepts_allowed_grammar() {
@@ -357,5 +460,40 @@ mod tests {
         assert_eq!(parsed.as_str(), "c_demo-1");
         assert!(CommitId::parse("c/demo").is_err());
         assert!(CommitId::parse("C_demo").is_err());
+    }
+
+    #[test]
+    fn generated_content_store_id_parse_requires_prefix_and_lower_hex_body() {
+        let parsed = ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id");
+
+        assert_eq!(parsed.as_str(), "cs_00000000000000000000000000000001");
+        let hyphenated_content_store_id = ["cs", "1"].join("-");
+        for value in [
+            hyphenated_content_store_id.as_str(),
+            "upl_00000000000000000000000000000001",
+            "content-stores/foo",
+            "cs_",
+            "cs_abcdef",
+            "cs_0000000000000000000000000000000",
+            "cs_000000000000000000000000000000001",
+            "cs_ABCDEF00000000000000000000000000",
+            "cs_0000000000000000000000000000000g",
+            " cs_00000000000000000000000000000001",
+            "cs_00000000000000000000000000000001 ",
+        ] {
+            assert!(
+                ContentStoreId::parse(value).is_err(),
+                "expected invalid content store id {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_upload_and_wal_segment_validators_reject_hyphenated_ids() {
+        assert!(validate_upload_id("upl_00000000000000000000000000000001").is_ok());
+        assert!(validate_wal_segment_id("seg_00000000000000000000000000000001").is_ok());
+        assert!(validate_upload_id(["upl", "123"].join("-")).is_err());
+        assert!(validate_wal_segment_id(["seg", "123"].join("-")).is_err());
     }
 }

--- a/crates/loon-cli/Cargo.toml
+++ b/crates/loon-cli/Cargo.toml
@@ -22,7 +22,6 @@ loon-objectstore = { path = "../loon-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.39", features = ["json"] }

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -1,6 +1,6 @@
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
-use loon_api::{AuthoritativePathEntry, MutationResult, NamespaceId, NamespaceSummary};
+use loon_api::{AuthoritativePathEntry, CommitId, MutationResult, NamespaceId, NamespaceSummary};
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_core::{
     bootstrap_namespace, copy_file_path, delete_path_non_recursive, fork_namespace,
@@ -9,7 +9,6 @@ use loon_core::{
 };
 use loon_objectstore::ConfiguredObjectStore;
 use std::time::{SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
@@ -284,13 +283,15 @@ fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
 }
 
 fn generated_commit_id() -> String {
-    format!("c_{}", Uuid::new_v4().simple())
+    CommitId::generate().to_string()
 }
 
 fn map_core_error(error: CoreError) -> CliError {
     if matches!(
         error.kind(),
-        CoreErrorKind::InvalidNamespaceId | CoreErrorKind::InvalidCommitId
+        CoreErrorKind::InvalidNamespaceId
+            | CoreErrorKind::InvalidCommitId
+            | CoreErrorKind::InvalidUploadId
     ) {
         return CliError::invalid_input(error.to_string());
     }
@@ -299,6 +300,7 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::InvalidPath => "invalid_path",
         CoreErrorKind::InvalidNamespaceId => unreachable!("handled before code mapping"),
         CoreErrorKind::InvalidCommitId => unreachable!("handled before code mapping"),
+        CoreErrorKind::InvalidUploadId => unreachable!("handled before code mapping"),
         CoreErrorKind::NamespaceNotFound => "namespace_not_found",
         CoreErrorKind::NamespaceExists => "namespace_exists",
         CoreErrorKind::NamespacePartial => "namespace_partial",

--- a/crates/loon-client/Cargo.toml
+++ b/crates/loon-client/Cargo.toml
@@ -14,7 +14,6 @@ thiserror.workspace = true
 toml.workspace = true
 ureq.workspace = true
 urlencoding.workspace = true
-uuid.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -17,7 +17,6 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
-use uuid::Uuid;
 use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -621,7 +620,7 @@ fn parse_commit_id(commit_id: &str) -> Result<CommitId, ClientError> {
 }
 
 fn generated_commit_id() -> String {
-    format!("c_{}", Uuid::new_v4().simple())
+    CommitId::generate().to_string()
 }
 
 fn file_name_for_path(path: &str) -> Result<String, ClientError> {

--- a/crates/loon-core/Cargo.toml
+++ b/crates/loon-core/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
 loon-model = { path = "../loon-model" }

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -17,7 +17,7 @@ use loon_api::{
     CreateCheckpointResponse, FenceToken, HeadState, HeadStateEnvelope, InodeId, NamespaceId,
 };
 use loon_objectstore::keys::{
-    derived_progress, snapshot_manifest, snapshot_table, SnapshotTableFamily,
+    derived_progress, snapshot_manifest, snapshot_table, DerivedWorkClass, SnapshotTableFamily,
 };
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ const HEAD_UPDATE_RETRY_LIMIT: usize = 8;
 // V1 does not require any derived work classes to be caught up before the
 // retention floor advances. This hook stays in place so future retention gates
 // can add progress requirements without restructuring the flow.
-const REQUIRED_RETENTION_PROGRESS_CLASSES: &[&str] = &[];
+const REQUIRED_RETENTION_PROGRESS_CLASSES: &[DerivedWorkClass] = &[];
 const CHECKPOINT_TABLE_FAMILIES: [CheckpointTableFamily; 5] = [
     CheckpointTableFamily::Inodes,
     CheckpointTableFamily::Direntries,
@@ -605,13 +605,14 @@ fn ensure_required_retention_progress<S: ObjectStore + ?Sized>(
     target_floor: ChangeSeq,
 ) -> Result<(), CoreError> {
     for work_class in REQUIRED_RETENTION_PROGRESS_CLASSES {
-        let object_key = derived_progress(namespace_id.as_str(), work_class);
+        let object_key = derived_progress(namespace_id.as_str(), *work_class);
+        let work_class_name = work_class.as_str();
         let Some(bytes) = store
             .get(&object_key, None)
             .map_err(|err| CoreError::Store(err.to_string()))?
         else {
             return Err(CoreError::CheckpointUnavailable(format!(
-                "required derived progress `{work_class}` is missing for namespace `{}`",
+                "required derived progress `{work_class_name}` is missing for namespace `{}`",
                 namespace_id.as_str()
             )));
         };
@@ -619,7 +620,7 @@ fn ensure_required_retention_progress<S: ObjectStore + ?Sized>(
             serde_json::from_slice(&bytes).map_err(|err| CoreError::Store(err.to_string()))?;
         if progress.state.through_seq < target_floor {
             return Err(CoreError::CheckpointUnavailable(format!(
-                "required derived progress `{work_class}` only covers {:?} for namespace `{}`",
+                "required derived progress `{work_class_name}` only covers {:?} for namespace `{}`",
                 progress.state.through_seq,
                 namespace_id.as_str()
             )));

--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -258,7 +258,7 @@ mod tests {
     fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let content_store_id = ContentStoreId::from("content-tests");
+        let content_store_id = ContentStoreId::from("cs_00000000000000000000000000000001");
         (temp_dir, store, content_store_id)
     }
 

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -7,7 +7,8 @@ use crate::metadata::{MetadataApplyError, VisiblePathError};
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::wal::WalBuildError;
 use loon_api::{
-    ChangeSeq, CommitIdValidationError, InodeId, InodeKind, NamespaceId, NamespaceIdValidationError,
+    ChangeSeq, CommitIdValidationError, GeneratedIdValidationError, InodeId, InodeKind,
+    NamespaceId, NamespaceIdValidationError,
 };
 use thiserror::Error;
 
@@ -16,6 +17,7 @@ pub enum CoreErrorKind {
     InvalidPath,
     InvalidNamespaceId,
     InvalidCommitId,
+    InvalidUploadId,
     NamespaceNotFound,
     NamespaceExists,
     NamespacePartial,
@@ -65,6 +67,8 @@ pub enum CoreError {
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error(transparent)]
     InvalidCommitId(#[from] CommitIdValidationError),
+    #[error(transparent)]
+    InvalidUploadId(GeneratedIdValidationError),
     #[error("path not found `{0}`")]
     MissingPath(String),
     #[error("expected file at `{path}` but found `{kind:?}`")]
@@ -170,6 +174,7 @@ impl CoreError {
             }
             CoreError::InvalidNamespaceId(_) => CoreErrorKind::InvalidNamespaceId,
             CoreError::InvalidCommitId(_) => CoreErrorKind::InvalidCommitId,
+            CoreError::InvalidUploadId(_) => CoreErrorKind::InvalidUploadId,
             CoreError::MissingPath(_) => CoreErrorKind::PathNotFound,
             CoreError::NamespaceAlreadyExists { .. } => CoreErrorKind::NamespaceExists,
             CoreError::NamespacePartiallyInitialized { .. } => CoreErrorKind::NamespacePartial,

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -20,13 +20,13 @@ use loon_api::v0::{
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
-    decode_wal_segment_envelope_zstd, ChangeSeq, CommitId, CompletedUpload, ContentRef,
-    ControlObjectKind, HeadState, InodeId, NamespaceId, UploadSessionEnvelope, UploadSessionState,
+    decode_wal_segment_envelope_zstd, generate_upload_id, validate_upload_id, ChangeSeq, CommitId,
+    CompletedUpload, ContentRef, ControlObjectKind, HeadState, InodeId, NamespaceId,
+    UploadSessionEnvelope, UploadSessionState,
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
-use uuid::Uuid;
 
 const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
 
@@ -49,7 +49,7 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<BeginUploadResponse, CoreError> {
     let _basis = load_verified_namespace_basis(store, namespace_id)?;
-    let upload_id = format!("upl_{}", Uuid::new_v4().simple());
+    let upload_id = generate_upload_id();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
         upload_id: upload_id.clone(),
@@ -873,6 +873,7 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
     upload_id: &str,
 ) -> Result<LoadedUploadSessionObject, CoreError> {
     NamespaceId::parse(namespace_id.as_str()).map_err(CoreError::from)?;
+    validate_upload_id(upload_id).map_err(CoreError::InvalidUploadId)?;
     let object_key = upload_session(namespace_id.as_str(), upload_id);
     let metadata = store
         .head(&object_key)

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -34,7 +34,6 @@ use loon_objectstore::keys::{
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use uuid::Uuid;
 
 pub use crate::context::MutationContext;
 pub use crate::error::{CoreError, CoreErrorKind};
@@ -198,7 +197,7 @@ fn create_new_content_store<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<ContentStoreId, BootstrapNamespaceError> {
     for _attempt in 0..CONTENT_STORE_ID_RETRY_LIMIT {
-        let content_store_id = ContentStoreId::from(format!("cs_{}", Uuid::new_v4().simple()));
+        let content_store_id = ContentStoreId::generate();
         let descriptor = ContentStoreDescriptorEnvelope::from_state(
             ControlObjectKind::ContentStoreDescriptor,
             &context.writer_version,
@@ -540,7 +539,7 @@ enum PathFingerprintInput {
 }
 
 fn generated_commit_id() -> CommitId {
-    CommitId::from(format!("c_{}", Uuid::new_v4().simple()))
+    CommitId::generate()
 }
 
 fn normalized_commit_id(commit_id: Option<&str>) -> Result<CommitId, CoreError> {

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -1,13 +1,13 @@
 use crate::commit::{CommitOp, CommitPlan, CommitRequest, Precondition};
 use crate::metadata::{MetadataApplyError, MetadataState};
 use loon_api::{
-    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, v0::CommitOpResult,
-    ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitPayload, WalOp, WalPrecondition,
-    WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
+    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, generate_wal_segment_id,
+    v0::CommitOpResult, validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId,
+    WalCommitPayload, WalOp, WalPrecondition, WalSegmentEnvelope, WalSegmentPayload,
+    WalSegmentPointer,
 };
 use loon_objectstore::keys::wal_segment;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedWalRecord {
@@ -151,7 +151,7 @@ pub fn prepare_wal_segment(
         .last()
         .map(|record| record.seq)
         .ok_or(WalBuildError::EmptySegment)?;
-    let segment_id = format!("seg_{}", Uuid::new_v4().simple());
+    let segment_id = generate_wal_segment_id();
     let payload = WalSegmentPayload {
         namespace_id,
         segment_id: segment_id.clone(),
@@ -439,6 +439,8 @@ fn decode_and_validate_replayed_wal(
     wal_object: &StoredWalObject,
 ) -> Result<WalSegmentEnvelope, WalReplayError> {
     let envelope = decode_wal_segment_envelope_zstd(&wal_object.encoded_bytes)
+        .map_err(|err| WalReplayError::Codec(err.to_string()))?;
+    validate_wal_segment_id(&envelope.payload.segment_id)
         .map_err(|err| WalReplayError::Codec(err.to_string()))?;
     let expected_object_key = wal_segment(
         envelope.payload.namespace_id.as_str(),

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -17,13 +17,14 @@ use loon_core::{
     bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
     copy_file_path, delete_path, delete_path_non_recursive, fork_namespace, list_changes_after,
     list_namespaces, load_verified_namespace_basis, move_path, publish_namespace_mutations_batch,
-    put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
-    CoreError, CoreErrorKind, DirectObjectStorePublisher, MutationContext,
+    put_file_bytes, read_file_bytes, resolve_path, store_bytes_as_content, upload_content,
+    write_file_bytes, CoreError, CoreErrorKind, DirectObjectStorePublisher, MutationContext,
     NamespaceMutationCandidate, PathMutationIntent, PublishOptions, PutFileBehavior,
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
+    upload_session_prefix,
 };
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use std::path::Path;
@@ -766,6 +767,33 @@ fn commit_operations_reject_invalid_commit_id_before_wal_key_construction() {
     assert_eq!(error.kind(), CoreErrorKind::InvalidCommitId);
     assert_eq!(
         store.list_prefix("namespaces/demo/wal/").expect("list wal"),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn upload_content_rejects_invalid_upload_id_before_key_construction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let invalid_upload_id = ["upl", "123"].join("-");
+    let error = upload_content(
+        &store,
+        &namespace_id,
+        &invalid_upload_id,
+        b"hello",
+        &context,
+    )
+    .expect_err("invalid upload_id should be rejected");
+
+    assert_eq!(error.kind(), CoreErrorKind::InvalidUploadId);
+    assert_eq!(
+        store
+            .list_prefix(&upload_session_prefix(namespace_id.as_str()))
+            .expect("list upload sessions"),
         Vec::<String>::new()
     );
 }
@@ -1855,7 +1883,7 @@ fn move_path_into_occupied_target_is_path_conflict() {
         &store,
         &namespace_id(),
         "/docs/a.txt",
-        b"docs-a",
+        b"alpha",
         &context,
         Some("seed-docs"),
     )

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -21,6 +21,19 @@ impl SnapshotTableFamily {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DerivedWorkClass {
+    SnapshotBuilder,
+}
+
+impl DerivedWorkClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SnapshotBuilder => "snapshot-builder",
+        }
+    }
+}
+
 pub fn namespace_head(namespace: &str) -> String {
     format!("namespaces/{namespace}/head.json")
 }
@@ -83,7 +96,8 @@ pub fn snapshot_table(
     )
 }
 
-pub fn derived_progress(namespace: &str, work_class: &str) -> String {
+pub fn derived_progress(namespace: &str, work_class: DerivedWorkClass) -> String {
+    let work_class = work_class.as_str();
     format!("namespaces/{namespace}/derived/{work_class}/progress.json")
 }
 
@@ -113,7 +127,7 @@ mod tests {
         conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
         derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
         sha256_hex_from_digest, snapshot_manifest, snapshot_table, upload_session,
-        upload_session_prefix, wal_segment, SnapshotTableFamily,
+        upload_session_prefix, wal_segment, DerivedWorkClass, SnapshotTableFamily,
     };
 
     #[test]
@@ -125,12 +139,12 @@ mod tests {
         );
         assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
         assert_eq!(
-            content_store_descriptor("cs-1"),
-            "content-stores/cs-1/descriptor.json"
+            content_store_descriptor("cs_00000000000000000000000000000001"),
+            "content-stores/cs_00000000000000000000000000000001/descriptor.json"
         );
         assert_eq!(
-            wal_segment("ns-1", 420, 425, "seg-123"),
-            "namespaces/ns-1/wal/00000000000000000420-00000000000000000425-seg-123.cbor.zst"
+            wal_segment("ns-1", 420, 425, "seg_00000000000000000000000000000001"),
+            "namespaces/ns-1/wal/00000000000000000420-00000000000000000425-seg_00000000000000000000000000000001.cbor.zst"
         );
         assert_eq!(
             snapshot_manifest("ns-1", 400),
@@ -145,17 +159,17 @@ mod tests {
             "namespaces/ns-1/snapshots/00000000000000000400/tables/commit-receipts-00000.sst.zst"
         );
         assert_eq!(
-            derived_progress("ns-1", "BuildSnapshot"),
-            "namespaces/ns-1/derived/BuildSnapshot/progress.json"
+            derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder),
+            "namespaces/ns-1/derived/snapshot-builder/progress.json"
         );
         assert_eq!(queue_shard(17), "queue/shards/00017.json");
         assert_eq!(
             content_blob(
-                "cs-1",
+                "cs_00000000000000000000000000000001",
                 "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
             )
             .expect("content key"),
-            "content-stores/cs-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            "content-stores/cs_00000000000000000000000000000001/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         );
         assert_eq!(
             conflict_artifact("ns-1", "conflict-deadbeef"),
@@ -166,8 +180,8 @@ mod tests {
             "namespaces/ns-1/conflicts/"
         );
         assert_eq!(
-            upload_session("ns-1", "upl-123"),
-            "namespaces/ns-1/control/uploads/upl-123.json"
+            upload_session("ns-1", "upl_00000000000000000000000000000001"),
+            "namespaces/ns-1/control/uploads/upl_00000000000000000000000000000001.json"
         );
         assert_eq!(
             upload_session_prefix("ns-1"),

--- a/crates/loon-objectstore/src/probes.rs
+++ b/crates/loon-objectstore/src/probes.rs
@@ -1,4 +1,4 @@
-use crate::keys::{derived_progress, namespace_head, namespace_lease};
+use crate::keys::{derived_progress, namespace_head, namespace_lease, DerivedWorkClass};
 use crate::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -132,7 +132,10 @@ fn probe_visibility_after_write<S: ObjectStore + ?Sized>(
     store: &S,
     run_id: &str,
 ) -> Result<(), ContractProbeError> {
-    let key = derived_progress(&probe_namespace(run_id, "visibility"), "BuildSnapshot");
+    let key = derived_progress(
+        &probe_namespace(run_id, "visibility"),
+        DerivedWorkClass::SnapshotBuilder,
+    );
     let _ = store.delete(&key);
 
     store
@@ -160,7 +163,7 @@ fn probe_visibility_after_delete<S: ObjectStore + ?Sized>(
     run_id: &str,
 ) -> Result<(), ContractProbeError> {
     let namespace = probe_namespace(run_id, "delete");
-    let key = derived_progress(&namespace, "BuildSnapshot");
+    let key = derived_progress(&namespace, DerivedWorkClass::SnapshotBuilder);
     let _ = store.delete(&key);
 
     store
@@ -188,7 +191,7 @@ fn probe_sorted_listing<S: ObjectStore + ?Sized>(
 ) -> Result<(), ContractProbeError> {
     let namespace = probe_namespace(run_id, "sorted");
     let keys = vec![
-        derived_progress(&namespace, "BuildSnapshot"),
+        derived_progress(&namespace, DerivedWorkClass::SnapshotBuilder),
         namespace_head(&namespace),
         namespace_lease(&namespace),
     ];

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -3,7 +3,7 @@ mod provider_env;
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
     content_blob, content_store_descriptor, derived_progress, namespace_descriptor, namespace_head,
-    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_segment,
+    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_segment, DerivedWorkClass,
     SnapshotTableFamily,
 };
 use loon_objectstore::probes::run_contract_probes;
@@ -134,20 +134,20 @@ fn key_builders_cover_locked_object_families() {
     assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/head.json");
     assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
     assert_eq!(
-        content_store_descriptor("cs-1"),
-        "content-stores/cs-1/descriptor.json"
+        content_store_descriptor("cs_00000000000000000000000000000001"),
+        "content-stores/cs_00000000000000000000000000000001/descriptor.json"
     );
     assert_eq!(
         content_blob(
-            "cs-1",
+            "cs_00000000000000000000000000000001",
             "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         )
         .expect("content blob key"),
-        "content-stores/cs-1/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        "content-stores/cs_00000000000000000000000000000001/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
     );
     assert_eq!(
-        wal_segment("ns-1", 420, 420, "seg-1"),
-        "namespaces/ns-1/wal/00000000000000000420-00000000000000000420-seg-1.cbor.zst"
+        wal_segment("ns-1", 420, 420, "seg_00000000000000000000000000000001"),
+        "namespaces/ns-1/wal/00000000000000000420-00000000000000000420-seg_00000000000000000000000000000001.cbor.zst"
     );
     assert_eq!(
         snapshot_manifest("ns-1", 420),
@@ -162,8 +162,8 @@ fn key_builders_cover_locked_object_families() {
         "namespaces/ns-1/snapshots/00000000000000000420/tables/commit-receipts-00000.sst.zst"
     );
     assert_eq!(
-        derived_progress("ns-1", "BuildSnapshot"),
-        "namespaces/ns-1/derived/BuildSnapshot/progress.json"
+        derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder),
+        "namespaces/ns-1/derived/snapshot-builder/progress.json"
     );
     assert_eq!(queue_shard(12), "queue/shards/00012.json");
 }
@@ -402,7 +402,7 @@ fn assert_delete_missing_is_idempotent<S: ObjectStore>(store: &S) {
 }
 
 fn assert_lists_immediately_after_write_and_delete<S: ObjectStore>(store: &S) {
-    let key = derived_progress("ns-1", "BuildSnapshot");
+    let key = derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder);
     let _ = store.delete(&key);
 
     store
@@ -424,7 +424,7 @@ fn assert_lists_immediately_after_write_and_delete<S: ObjectStore>(store: &S) {
 
 fn assert_sorted_list_prefix<S: ObjectStore>(store: &S) {
     let keys = vec![
-        derived_progress("ns-sort", "BuildSnapshot"),
+        derived_progress("ns-sort", DerivedWorkClass::SnapshotBuilder),
         namespace_head("ns-sort"),
         namespace_lease("ns-sort"),
     ];
@@ -455,7 +455,7 @@ fn assert_sorted_list_prefix<S: ObjectStore>(store: &S) {
 }
 
 fn assert_supports_range_reads<S: ObjectStore>(store: &S) {
-    let key = wal_segment("ns-1", 420, 420, "seg-1");
+    let key = wal_segment("ns-1", 420, 420, "seg_00000000000000000000000000000001");
     let _ = store.delete(&key);
 
     store

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -541,6 +541,7 @@ impl ApiResponseError {
             CoreErrorKind::InvalidPath => (StatusCode::BAD_REQUEST, "invalid_path"),
             CoreErrorKind::InvalidNamespaceId => (StatusCode::BAD_REQUEST, "invalid_namespace_id"),
             CoreErrorKind::InvalidCommitId => (StatusCode::BAD_REQUEST, "invalid_commit_id"),
+            CoreErrorKind::InvalidUploadId => (StatusCode::BAD_REQUEST, "invalid_upload_id"),
             CoreErrorKind::NamespaceNotFound => (StatusCode::NOT_FOUND, "namespace_not_found"),
             CoreErrorKind::NamespaceExists => (StatusCode::CONFLICT, "namespace_exists"),
             CoreErrorKind::NamespacePartial => (StatusCode::CONFLICT, "namespace_partial"),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -85,6 +85,41 @@ async fn http_rejects_invalid_namespace_ids_in_body_and_path() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_upload_content_rejects_invalid_upload_id() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loon-server-test",
+        "http-invalid-upload-id",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create namespace");
+
+        let invalid_upload_id = ["upl", "123"].join("-");
+        match harness
+            .client
+            .upload_content("demo", &invalid_upload_id, b"hello")
+        {
+            Err(ClientError::Api { status, code, .. }) => {
+                assert_eq!(status, 400);
+                assert_eq!(code, "invalid_upload_id");
+            }
+            other => panic!("expected invalid_upload_id, got {other:?}"),
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_create_only_and_copy_preserve_cli_semantics() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(

--- a/docs/specs/010-glossary.md
+++ b/docs/specs/010-glossary.md
@@ -24,6 +24,6 @@
 | **ACL** | An access-control rule granting a principal a role over a namespace or subtree. ACLs are not part of namespace metadata history. |
 | **Share** | An access grant to a namespace or subtree. A share may later be presented through a mount in another tree. |
 | **Precondition** | A rule that must still hold at an explicit namespace history point before a commit is accepted. |
-| **Request id** | A stable client-generated id used for idempotent retries of one commit request. |
+| **Commit id** | A stable client-generated id used for idempotent retries of one commit request. |
 | **Operation id** | Optional commit metadata used to correlate multiple commits that belong to one higher-level workflow. |
 | **Control object** | A server-side control-plane object used to preserve authoritative state across multiple requests, such as a pinned read snapshot, a resumable upload, or a stable destination binding. |

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -41,7 +41,7 @@ These key shapes are part of the interoperable storage contract. Implementations
 LoonFS uses distinct naming conventions for distinct surfaces:
 
 - Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `committed-commits`, and `control/uploads`.
-- Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_00000000000000000000000000000001`, `upl_00000000000000000000000000000001`, and `seg_00000000000000000000000000000001`.
+- Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41`, `upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c`, and `seg_b7c14a0d9e6f42a38c5d21f0e8a739bc`.
 - Durable work-class names use lowercase-kebab, e.g. `snapshot-builder`.
 - JSON enum values use snake_case.
 - Namespace IDs are human/operator slugs; prefer lowercase kebab-case while preserving the namespace grammar.

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -36,7 +36,19 @@ The required durable object families and standard key patterns are:
 
 These key shapes are part of the interoperable storage contract. Implementations may add other control-plane objects.
 
-## 4. WAL segment rules
+## 4. Durable naming conventions
+
+LoonFS uses distinct naming conventions for distinct surfaces:
+
+- Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `committed-commits`, and `control/uploads`.
+- Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_00000000000000000000000000000001`, `upl_00000000000000000000000000000001`, and `seg_00000000000000000000000000000001`.
+- Durable work-class names use lowercase-kebab, e.g. `snapshot-builder`.
+- JSON enum values use snake_case.
+- Namespace IDs are human/operator slugs; prefer lowercase kebab-case while preserving the namespace grammar.
+
+Underscores are reserved for generated opaque ID prefixes and JSON snake_case values. Fixed object-store path-family names should not use underscores.
+
+## 5. WAL segment rules
 
 The metadata log has five important rules.
 
@@ -46,7 +58,7 @@ The metadata log has five important rules.
 4. The visible WAL chain must be deterministically recoverable from the head plus referenced segment metadata. A head field such as `wal_tip_segment_id`, together with segment metadata such as `segment_id`, `start_seq`, `end_seq`, `base_head_seq`, and `prev_visible_segment_id`, is one conforming shape. Equivalent semantics are acceptable.
 5. Orphan WAL segments are permitted and harmless when a writer loses the head compare-and-swap.
 
-## 5. Immutable content rules
+## 6. Immutable content rules
 
 The content model has four rules.
 
@@ -59,13 +71,13 @@ In v0, file content is stored as one whole-file object whose `content_ref.kind` 
 
 A reader or writer resolves content through the namespace descriptor: `namespace_id -> content_store_id -> content-stores/{content_store_id}/...`. File revisions and change-feed payloads store only `content_ref`; they do not store content-store ids or object-store paths.
 
-## 6. Mutable control-object rules
+## 7. Mutable control-object rules
 
 Small mutable objects such as the namespace head or a lease must use compare-and-swap semantics. These objects must remain small enough that guarded rewrite is practical.
 
 Large immutable file data may use multipart upload or another provider-specific optimization. Small mutable control objects should not depend on those mechanisms.
 
-## 7. Provider conformance
+## 8. Provider conformance
 
 The spec standardizes the required behaviors, not a brand name such as "S3 compatible." A provider is conforming only when those behaviors are verified by conformance tests.
 

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -40,7 +40,7 @@ These key shapes are part of the interoperable storage contract. Implementations
 
 LoonFS uses distinct naming conventions for distinct surfaces:
 
-- Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `committed-commits`, and `control/uploads`.
+- Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `commit-receipts`, and `control/uploads`.
 - Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41`, `upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c`, and `seg_b7c14a0d9e6f42a38c5d21f0e8a739bc`.
 - Durable work-class names use lowercase-kebab, e.g. `snapshot-builder`.
 - JSON enum values use snake_case.

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -141,7 +141,7 @@ Representative request:
 
 ```json
 {
-  "commit_id": "c_01j...",
+  "commit_id": "c_00000000000000000000000000000001",
   "message": "move report and publish new bytes",
   "annotations": {
     "source": "cli"
@@ -205,7 +205,7 @@ Representative begin-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_01J...",
+  "upload_id": "upl_00000000000000000000000000000001",
   "mode": "service_proxied"
 }
 ```
@@ -215,7 +215,7 @@ Representative content-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_01J...",
+  "upload_id": "upl_00000000000000000000000000000001",
   "content_ref": {
     "kind": "whole_file_v0",
     "digest": "sha256:7ab...",
@@ -241,7 +241,7 @@ Representative complete-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_01J...",
+  "upload_id": "upl_00000000000000000000000000000001",
   "content_ref": {
     "kind": "whole_file_v0",
     "digest": "sha256:7ab...",
@@ -256,7 +256,7 @@ Representative request:
 
 ```json
 {
-  "commit_id": "c_01j...",
+  "commit_id": "c_00000000000000000000000000000001",
   "planned_head_seq": 418,
   "message": "replace report bytes",
   "annotations": {
@@ -300,7 +300,7 @@ Representative response:
 ```json
 {
   "namespace_id": "demo",
-  "commit_id": "c_01j...",
+  "commit_id": "c_00000000000000000000000000000001",
   "committed_seq": 419,
   "results": [
     {
@@ -322,7 +322,7 @@ Representative response:
   "changes": [
     {
       "seq": 419,
-      "commit_id": "c_01j...",
+      "commit_id": "c_00000000000000000000000000000001",
       "message": "replace report bytes",
       "ops": [
         {

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -141,7 +141,7 @@ Representative request:
 
 ```json
 {
-  "commit_id": "c_00000000000000000000000000000001",
+  "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
   "message": "move report and publish new bytes",
   "annotations": {
     "source": "cli"
@@ -205,7 +205,7 @@ Representative begin-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_00000000000000000000000000000001",
+  "upload_id": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
   "mode": "service_proxied"
 }
 ```
@@ -215,7 +215,7 @@ Representative content-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_00000000000000000000000000000001",
+  "upload_id": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
   "content_ref": {
     "kind": "whole_file_v0",
     "digest": "sha256:7ab...",
@@ -241,7 +241,7 @@ Representative complete-upload response:
 ```json
 {
   "namespace_id": "demo",
-  "upload_id": "upl_00000000000000000000000000000001",
+  "upload_id": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
   "content_ref": {
     "kind": "whole_file_v0",
     "digest": "sha256:7ab...",
@@ -256,7 +256,7 @@ Representative request:
 
 ```json
 {
-  "commit_id": "c_00000000000000000000000000000001",
+  "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
   "planned_head_seq": 418,
   "message": "replace report bytes",
   "annotations": {
@@ -300,7 +300,7 @@ Representative response:
 ```json
 {
   "namespace_id": "demo",
-  "commit_id": "c_00000000000000000000000000000001",
+  "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
   "committed_seq": 419,
   "results": [
     {
@@ -322,7 +322,7 @@ Representative response:
   "changes": [
     {
       "seq": 419,
-      "commit_id": "c_00000000000000000000000000000001",
+      "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
       "message": "replace report bytes",
       "ops": [
         {


### PR DESCRIPTION
This PR tightens the naming model around generated IDs and object-store keys (we had a few conflicting patterns in use).

Generated internal IDs now come from shared loon-api helpers and use prefix + UUID-simple lowercase hex forms like cs_<32hex>, upl_<32hex>, seg_<32hex>, and generated c_<32hex> commit IDs. 

This also validates ContentStoreIds, CommitIds and validates upload IDs as they can be generated outside of core and need validation.

Docs and examples were updated accordingly.