### PR TITLE
refactor(loon-core): simplify commit adapters

### DIFF
--- a/crates/loon-api/src/checkpoint.rs
+++ b/crates/loon-api/src/checkpoint.rs
@@ -93,7 +93,7 @@ pub enum CheckpointRow {
     },
     CommitReceipt {
         commit_id: CommitId,
-        request_fingerprint_sha256: String,
+        semantic_commit_fingerprint_sha256: String,
         committed_seq: ChangeSeq,
         results: Vec<CommitOpResult>,
     },

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -86,7 +86,7 @@ pub struct WalCommitPayload {
     pub seq: ChangeSeq,
     pub base_head_seq: ChangeSeq,
     pub commit_id: CommitId,
-    pub request_fingerprint_sha256: String,
+    pub semantic_commit_fingerprint_sha256: String,
     pub writer_id: String,
     pub writer_fence_token: FenceToken,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -984,13 +984,13 @@ fn append_rows_to_metadata(
                 CheckpointTableFamily::CommitReceipts,
                 CheckpointRow::CommitReceipt {
                     commit_id,
-                    request_fingerprint_sha256,
+                    semantic_commit_fingerprint_sha256,
                     committed_seq,
                     results,
                 },
             ) => metadata_state.commit_receipts.push(CommitReceiptRecord {
                 commit_id: commit_id.clone(),
-                request_fingerprint_sha256: request_fingerprint_sha256.clone(),
+                semantic_commit_fingerprint_sha256: semantic_commit_fingerprint_sha256.clone(),
                 committed_seq: *committed_seq,
                 results: results.clone(),
             }),
@@ -1063,7 +1063,9 @@ fn checkpoint_rows_for_family(
             .iter()
             .map(|record| CheckpointRow::CommitReceipt {
                 commit_id: record.commit_id.clone(),
-                request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
+                semantic_commit_fingerprint_sha256: record
+                    .semantic_commit_fingerprint_sha256
+                    .clone(),
                 committed_seq: record.committed_seq,
                 results: record.results.clone(),
             })

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -12,14 +12,6 @@ pub fn commit_request_from_v0(
     ctx: CommitExecutionContext,
     request: api_v0::CommitRequest,
 ) -> Result<CommitRequest, CommitConversionError> {
-    commit_request_from_v0_with_semantic_fingerprint(ctx, request, None)
-}
-
-pub fn commit_request_from_v0_with_semantic_fingerprint(
-    ctx: CommitExecutionContext,
-    request: api_v0::CommitRequest,
-    semantic_commit_fingerprint_sha256: Option<String>,
-) -> Result<CommitRequest, CommitConversionError> {
     loon_api::CommitId::parse(request.commit_id.as_str())?;
     Ok(CommitRequest {
         namespace_id: ctx.namespace_id,
@@ -27,7 +19,6 @@ pub fn commit_request_from_v0_with_semantic_fingerprint(
         writer_id: ctx.writer_id,
         writer_fence_token: ctx.writer_fence_token,
         planned_head_seq: request.planned_head_seq,
-        semantic_commit_fingerprint_sha256,
         ops: request.ops.into_iter().map(commit_op_from_v0).collect(),
         preconditions: request
             .preconditions
@@ -39,7 +30,7 @@ pub fn commit_request_from_v0_with_semantic_fingerprint(
     })
 }
 
-fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
+pub(super) fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
     match op {
         api_v0::CommitOp::CreateDir {
             parent_inode,
@@ -89,7 +80,9 @@ fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
     }
 }
 
-fn commit_precondition_from_v0(precondition: api_v0::CommitPrecondition) -> Precondition {
+pub(super) fn commit_precondition_from_v0(
+    precondition: api_v0::CommitPrecondition,
+) -> Precondition {
     match precondition {
         api_v0::CommitPrecondition::HeadSeqIs { expected_seq } => {
             Precondition::HeadSeqIs(expected_seq)

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -1,0 +1,197 @@
+use super::{CommitExecutionContext, CommitOp, CommitRequest, Precondition};
+use loon_api::{v0 as api_v0, CommitIdValidationError};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CommitConversionError {
+    #[error(transparent)]
+    InvalidCommitId(#[from] CommitIdValidationError),
+}
+
+pub fn commit_request_from_v0(
+    ctx: CommitExecutionContext,
+    request: api_v0::CommitRequest,
+) -> Result<CommitRequest, CommitConversionError> {
+    commit_request_from_v0_with_semantic_fingerprint(ctx, request, None)
+}
+
+pub fn commit_request_from_v0_with_semantic_fingerprint(
+    ctx: CommitExecutionContext,
+    request: api_v0::CommitRequest,
+    semantic_commit_fingerprint_sha256: Option<String>,
+) -> Result<CommitRequest, CommitConversionError> {
+    loon_api::CommitId::parse(request.commit_id.as_str())?;
+    Ok(CommitRequest {
+        namespace_id: ctx.namespace_id,
+        commit_id: request.commit_id,
+        writer_id: ctx.writer_id,
+        writer_fence_token: ctx.writer_fence_token,
+        planned_head_seq: request.planned_head_seq,
+        semantic_commit_fingerprint_sha256,
+        ops: request.ops.into_iter().map(commit_op_from_v0).collect(),
+        preconditions: request
+            .preconditions
+            .into_iter()
+            .map(commit_precondition_from_v0)
+            .collect(),
+        message: request.message,
+        annotations: request.annotations,
+    })
+}
+
+fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
+    match op {
+        api_v0::CommitOp::CreateDir {
+            parent_inode,
+            display_name,
+        } => CommitOp::CreateDir {
+            parent_inode,
+            display_name,
+        },
+        api_v0::CommitOp::CreateFile {
+            parent_inode,
+            display_name,
+            content_ref,
+        } => CommitOp::CreateFile {
+            parent_inode,
+            display_name,
+            content_ref,
+        },
+        api_v0::CommitOp::ReplaceFile {
+            inode_id,
+            base_revision_no,
+            content_ref,
+        } => CommitOp::ReplaceFile {
+            inode_id,
+            base_revision: base_revision_no,
+            content_ref,
+        },
+        api_v0::CommitOp::RestoreRevision {
+            inode_id,
+            source_revision_no,
+            base_revision_no,
+        } => CommitOp::RestoreRevision {
+            inode_id,
+            source_revision: source_revision_no,
+            base_revision: base_revision_no,
+        },
+        api_v0::CommitOp::DeleteFile { inode_id } => CommitOp::DeleteFile { inode_id },
+        api_v0::CommitOp::Rename {
+            inode_id,
+            new_parent_inode,
+            new_display_name,
+        } => CommitOp::Rename {
+            inode_id,
+            new_parent_inode,
+            new_display_name,
+        },
+        api_v0::CommitOp::DeleteSubtree { root_inode } => CommitOp::DeleteSubtree { root_inode },
+    }
+}
+
+fn commit_precondition_from_v0(precondition: api_v0::CommitPrecondition) -> Precondition {
+    match precondition {
+        api_v0::CommitPrecondition::HeadSeqIs { expected_seq } => {
+            Precondition::HeadSeqIs(expected_seq)
+        }
+        api_v0::CommitPrecondition::InodeRevisionIs {
+            inode_id,
+            revision_no,
+        } => Precondition::InodeRevisionIs {
+            inode_id,
+            revision: revision_no,
+        },
+        api_v0::CommitPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
+            Precondition::AncestorsNotSubtreeDeleted { inode_id }
+        }
+        api_v0::CommitPrecondition::ChildNameAbsent {
+            parent_inode,
+            name_key,
+        } => Precondition::ChildNameAbsent {
+            parent_inode,
+            name_key,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loon_api::{
+        v0::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition},
+        ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo,
+    };
+
+    #[test]
+    fn api_adapter_maps_all_v0_ops_and_preconditions() {
+        let content_ref = ContentRef::whole_file_v0(b"hello");
+        let request = api_v0::CommitRequest {
+            commit_id: CommitId::from("commit-a"),
+            planned_head_seq: ChangeSeq(10),
+            preconditions: vec![
+                ApiCommitPrecondition::HeadSeqIs {
+                    expected_seq: ChangeSeq(10),
+                },
+                ApiCommitPrecondition::InodeRevisionIs {
+                    inode_id: InodeId(2),
+                    revision_no: RevisionNo(3),
+                },
+                ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                    inode_id: InodeId(2),
+                },
+                ApiCommitPrecondition::ChildNameAbsent {
+                    parent_inode: InodeId(1),
+                    name_key: "docs".to_owned(),
+                },
+            ],
+            ops: vec![
+                ApiCommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "docs".to_owned(),
+                },
+                ApiCommitOp::CreateFile {
+                    parent_inode: InodeId(1),
+                    display_name: "a.txt".to_owned(),
+                    content_ref: content_ref.clone(),
+                },
+                ApiCommitOp::ReplaceFile {
+                    inode_id: InodeId(2),
+                    base_revision_no: RevisionNo(1),
+                    content_ref: content_ref.clone(),
+                },
+                ApiCommitOp::RestoreRevision {
+                    inode_id: InodeId(2),
+                    source_revision_no: RevisionNo(1),
+                    base_revision_no: RevisionNo(2),
+                },
+                ApiCommitOp::DeleteFile {
+                    inode_id: InodeId(2),
+                },
+                ApiCommitOp::Rename {
+                    inode_id: InodeId(2),
+                    new_parent_inode: InodeId(1),
+                    new_display_name: "b.txt".to_owned(),
+                },
+                ApiCommitOp::DeleteSubtree {
+                    root_inode: InodeId(3),
+                },
+            ],
+            message: Some("all ops".to_owned()),
+            annotations: None,
+        };
+
+        let core = commit_request_from_v0(
+            CommitExecutionContext {
+                namespace_id: NamespaceId::from("demo"),
+                writer_id: "writer-a".to_owned(),
+                writer_fence_token: FenceToken(9),
+            },
+            request,
+        )
+        .expect("convert request");
+
+        assert_eq!(core.ops.len(), 7);
+        assert_eq!(core.preconditions.len(), 4);
+        assert_eq!(core.writer_fence_token, FenceToken(9));
+    }
+}

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -1,0 +1,230 @@
+use super::{CommitOp, MaterializedCommit, Precondition};
+use crate::wal::WalBuildError;
+use loon_api::{WalCommitPayload, WalOp, WalPrecondition};
+
+pub fn wal_payload_from_materialized_commit(
+    commit: &MaterializedCommit,
+) -> Result<WalCommitPayload, WalBuildError> {
+    let prepared = &commit.prepared;
+    if !prepared.plan.wal_object_must_be_written {
+        return Err(WalBuildError::WalWriteNotRequired);
+    }
+    if prepared.request.namespace_id != prepared.plan.namespace_id {
+        return Err(WalBuildError::NamespaceMismatch {
+            request: prepared.request.namespace_id.clone(),
+            plan: prepared.plan.namespace_id.clone(),
+        });
+    }
+
+    Ok(WalCommitPayload {
+        namespace_id: prepared.plan.namespace_id.clone(),
+        seq: prepared.plan.next_seq,
+        base_head_seq: prepared.plan.base_head_seq,
+        commit_id: prepared.plan.commit_id.clone(),
+        semantic_commit_fingerprint_sha256: prepared
+            .identity
+            .semantic_commit_fingerprint_sha256
+            .clone(),
+        writer_id: prepared.request.writer_id.clone(),
+        writer_fence_token: prepared.request.writer_fence_token,
+        message: prepared.request.message.clone(),
+        annotations: prepared.request.annotations.clone(),
+        ops: build_wal_ops(prepared)?,
+        preconditions: prepared
+            .request
+            .preconditions
+            .iter()
+            .map(WalPrecondition::from)
+            .collect(),
+        results: commit.results.clone(),
+    })
+}
+
+fn build_wal_ops(prepared: &super::PreparedCommit) -> Result<Vec<WalOp>, WalBuildError> {
+    let request_create_ops = prepared
+        .request
+        .ops
+        .iter()
+        .filter(|op| matches!(op, CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. }))
+        .count();
+    if request_create_ops != prepared.plan.allocated_inode_ids.len() {
+        return Err(WalBuildError::AllocatedInodeCountMismatch {
+            request_create_ops,
+            plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
+        });
+    }
+
+    let mut allocated_inode_ids = prepared.plan.allocated_inode_ids.iter().copied();
+    let mut wal_ops = Vec::with_capacity(prepared.request.ops.len());
+
+    for (op_index, op) in prepared.request.ops.iter().enumerate() {
+        let op_index = u32::try_from(op_index)
+            .map_err(|_| WalBuildError::Codec("op index overflow".to_owned()))?;
+        let resolved_restore_content_ref = prepared
+            .plan
+            .resolved_restore_content_refs
+            .get(op_index as usize)
+            .and_then(|content_ref| content_ref.as_ref());
+        let wal_op = match op {
+            CommitOp::CreateDir {
+                parent_inode,
+                display_name,
+            } => WalOp::CreateDir {
+                op_index,
+                inode_id: allocated_inode_ids.next().ok_or(
+                    WalBuildError::AllocatedInodeCountMismatch {
+                        request_create_ops,
+                        plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
+                    },
+                )?,
+                parent_inode: *parent_inode,
+                display_name: display_name.clone(),
+            },
+            CommitOp::CreateFile {
+                parent_inode,
+                display_name,
+                content_ref,
+            } => WalOp::CreateFile {
+                op_index,
+                inode_id: allocated_inode_ids.next().ok_or(
+                    WalBuildError::AllocatedInodeCountMismatch {
+                        request_create_ops,
+                        plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
+                    },
+                )?,
+                parent_inode: *parent_inode,
+                display_name: display_name.clone(),
+                content_ref: content_ref.clone(),
+            },
+            CommitOp::ReplaceFile {
+                inode_id,
+                base_revision,
+                content_ref,
+            } => WalOp::ReplaceFile {
+                op_index,
+                inode_id: *inode_id,
+                base_revision: *base_revision,
+                content_ref: content_ref.clone(),
+            },
+            CommitOp::RestoreRevision {
+                inode_id,
+                source_revision,
+                base_revision,
+            } => WalOp::RestoreRevision {
+                op_index,
+                inode_id: *inode_id,
+                source_revision_no: *source_revision,
+                base_revision: *base_revision,
+                content_ref: resolved_restore_content_ref
+                    .ok_or_else(|| {
+                        WalBuildError::Codec(format!(
+                            "missing resolved restore content ref for op index {op_index}"
+                        ))
+                    })?
+                    .clone(),
+            },
+            CommitOp::DeleteFile { inode_id } => WalOp::DeleteFile {
+                op_index,
+                inode_id: *inode_id,
+            },
+            CommitOp::Rename {
+                inode_id,
+                new_parent_inode,
+                new_display_name,
+            } => WalOp::Rename {
+                op_index,
+                inode_id: *inode_id,
+                new_parent_inode: *new_parent_inode,
+                new_display_name: new_display_name.clone(),
+            },
+            CommitOp::DeleteSubtree { root_inode } => WalOp::DeleteSubtree {
+                op_index,
+                root_inode: *root_inode,
+            },
+        };
+        wal_ops.push(wal_op);
+    }
+
+    Ok(wal_ops)
+}
+
+impl From<&Precondition> for WalPrecondition {
+    fn from(value: &Precondition) -> Self {
+        match value {
+            Precondition::HeadSeqIs(seq) => Self::HeadSeqIs(*seq),
+            Precondition::InodeRevisionIs { inode_id, revision } => Self::InodeRevisionIs {
+                inode_id: *inode_id,
+                revision: *revision,
+            },
+            Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
+                Self::AncestorsNotSubtreeDeleted {
+                    inode_id: *inode_id,
+                }
+            }
+            Precondition::ChildNameAbsent {
+                parent_inode,
+                name_key,
+            } => Self::ChildNameAbsent {
+                parent_inode: *parent_inode,
+                name_key: name_key.clone(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::{CommitPlan, CommitRequest, PreparedCommit};
+    use loon_api::{v0::CommitOpResult, ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
+
+    #[test]
+    fn durable_adapter_builds_expected_wal_payload() {
+        let namespace_id = NamespaceId::from("demo");
+        let request = CommitRequest {
+            namespace_id: namespace_id.clone(),
+            commit_id: CommitId::from("c_wal_payload"),
+            writer_id: "writer-a".to_owned(),
+            writer_fence_token: FenceToken(1),
+            planned_head_seq: ChangeSeq(0),
+            semantic_commit_fingerprint_sha256: None,
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            message: Some("create docs".to_owned()),
+            annotations: None,
+        };
+        let plan = CommitPlan {
+            namespace_id: namespace_id.clone(),
+            commit_id: CommitId::from("c_wal_payload"),
+            base_head_seq: ChangeSeq(0),
+            next_seq: ChangeSeq(1),
+            allocated_inode_ids: vec![InodeId(2)],
+            resolved_restore_content_refs: vec![None],
+            resulting_next_inode_id: InodeId(3),
+            durable_content_required: false,
+            wal_object_must_be_written: true,
+            head_cas_must_succeed: true,
+            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            checked_invariants: Vec::new(),
+        };
+        let prepared = PreparedCommit::new(request, plan, None).expect("prepare commit");
+        let materialized = MaterializedCommit {
+            prepared,
+            results: vec![CommitOpResult::CreateDir {
+                op_index: 0,
+                inode_id: InodeId(2),
+            }],
+        };
+
+        let payload =
+            wal_payload_from_materialized_commit(&materialized).expect("build wal payload");
+
+        assert_eq!(payload.namespace_id, namespace_id);
+        assert_eq!(payload.seq, ChangeSeq(1));
+        assert_eq!(payload.ops.len(), 1);
+        assert_eq!(payload.results.len(), 1);
+    }
+}

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -1,14 +1,11 @@
-use super::{CommitOp, MaterializedCommit, Precondition};
+use super::{MaterializedCommit, Precondition};
 use crate::wal::WalBuildError;
-use loon_api::{WalCommitPayload, WalOp, WalPrecondition};
+use loon_api::{WalCommitPayload, WalPrecondition};
 
 pub fn wal_payload_from_materialized_commit(
     commit: &MaterializedCommit,
 ) -> Result<WalCommitPayload, WalBuildError> {
     let prepared = &commit.prepared;
-    if !prepared.plan.wal_object_must_be_written {
-        return Err(WalBuildError::WalWriteNotRequired);
-    }
     if prepared.request.namespace_id != prepared.plan.namespace_id {
         return Err(WalBuildError::NamespaceMismatch {
             request: prepared.request.namespace_id.clone(),
@@ -21,128 +18,23 @@ pub fn wal_payload_from_materialized_commit(
         seq: prepared.plan.next_seq,
         base_head_seq: prepared.plan.base_head_seq,
         commit_id: prepared.plan.commit_id.clone(),
-        semantic_commit_fingerprint_sha256: prepared.semantic_commit_fingerprint_sha256.clone(),
+        semantic_commit_fingerprint_sha256: prepared
+            .semantic_commit_fingerprint
+            .as_str()
+            .to_owned(),
         writer_id: prepared.request.writer_id.clone(),
         writer_fence_token: prepared.request.writer_fence_token,
         message: prepared.request.message.clone(),
         annotations: prepared.request.annotations.clone(),
-        ops: build_wal_ops(prepared)?,
+        ops: commit.ops.iter().map(|op| op.wal_op.clone()).collect(),
         preconditions: prepared
             .request
             .preconditions
             .iter()
             .map(WalPrecondition::from)
             .collect(),
-        results: commit.results.clone(),
+        results: commit.ops.iter().map(|op| op.result.clone()).collect(),
     })
-}
-
-fn build_wal_ops(prepared: &super::PreparedCommit) -> Result<Vec<WalOp>, WalBuildError> {
-    let request_create_ops = prepared
-        .request
-        .ops
-        .iter()
-        .filter(|op| matches!(op, CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. }))
-        .count();
-    if request_create_ops != prepared.plan.allocated_inode_ids.len() {
-        return Err(WalBuildError::AllocatedInodeCountMismatch {
-            request_create_ops,
-            plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
-        });
-    }
-
-    let mut allocated_inode_ids = prepared.plan.allocated_inode_ids.iter().copied();
-    let mut wal_ops = Vec::with_capacity(prepared.request.ops.len());
-
-    for (op_index, op) in prepared.request.ops.iter().enumerate() {
-        let op_index = u32::try_from(op_index)
-            .map_err(|_| WalBuildError::Codec("op index overflow".to_owned()))?;
-        let resolved_restore_content_ref = prepared
-            .plan
-            .resolved_restore_content_refs
-            .get(op_index as usize)
-            .and_then(|content_ref| content_ref.as_ref());
-        let wal_op = match op {
-            CommitOp::CreateDir {
-                parent_inode,
-                display_name,
-            } => WalOp::CreateDir {
-                op_index,
-                inode_id: allocated_inode_ids.next().ok_or(
-                    WalBuildError::AllocatedInodeCountMismatch {
-                        request_create_ops,
-                        plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
-                    },
-                )?,
-                parent_inode: *parent_inode,
-                display_name: display_name.clone(),
-            },
-            CommitOp::CreateFile {
-                parent_inode,
-                display_name,
-                content_ref,
-            } => WalOp::CreateFile {
-                op_index,
-                inode_id: allocated_inode_ids.next().ok_or(
-                    WalBuildError::AllocatedInodeCountMismatch {
-                        request_create_ops,
-                        plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
-                    },
-                )?,
-                parent_inode: *parent_inode,
-                display_name: display_name.clone(),
-                content_ref: content_ref.clone(),
-            },
-            CommitOp::ReplaceFile {
-                inode_id,
-                base_revision,
-                content_ref,
-            } => WalOp::ReplaceFile {
-                op_index,
-                inode_id: *inode_id,
-                base_revision: *base_revision,
-                content_ref: content_ref.clone(),
-            },
-            CommitOp::RestoreRevision {
-                inode_id,
-                source_revision,
-                base_revision,
-            } => WalOp::RestoreRevision {
-                op_index,
-                inode_id: *inode_id,
-                source_revision_no: *source_revision,
-                base_revision: *base_revision,
-                content_ref: resolved_restore_content_ref
-                    .ok_or_else(|| {
-                        WalBuildError::Codec(format!(
-                            "missing resolved restore content ref for op index {op_index}"
-                        ))
-                    })?
-                    .clone(),
-            },
-            CommitOp::DeleteFile { inode_id } => WalOp::DeleteFile {
-                op_index,
-                inode_id: *inode_id,
-            },
-            CommitOp::Rename {
-                inode_id,
-                new_parent_inode,
-                new_display_name,
-            } => WalOp::Rename {
-                op_index,
-                inode_id: *inode_id,
-                new_parent_inode: *new_parent_inode,
-                new_display_name: new_display_name.clone(),
-            },
-            CommitOp::DeleteSubtree { root_inode } => WalOp::DeleteSubtree {
-                op_index,
-                root_inode: *root_inode,
-            },
-        };
-        wal_ops.push(wal_op);
-    }
-
-    Ok(wal_ops)
 }
 
 impl From<&Precondition> for WalPrecondition {
@@ -172,8 +64,8 @@ impl From<&Precondition> for WalPrecondition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{CommitPlan, CommitRequest, PreparedCommit};
-    use loon_api::{v0::CommitOpResult, ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
+    use crate::commit::{materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit};
+    use loon_api::{ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
 
     #[test]
     fn durable_adapter_builds_expected_wal_payload() {
@@ -184,7 +76,6 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(0),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
@@ -201,20 +92,11 @@ mod tests {
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            durable_content_required: false,
-            wal_object_must_be_written: true,
-            head_cas_must_succeed: true,
             metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
-        let materialized = MaterializedCommit {
-            prepared,
-            results: vec![CommitOpResult::CreateDir {
-                op_index: 0,
-                inode_id: InodeId(2),
-            }],
-        };
+        let materialized = materialize_commit(prepared).expect("materialize commit");
 
         let payload =
             wal_payload_from_materialized_commit(&materialized).expect("build wal payload");

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -21,10 +21,7 @@ pub fn wal_payload_from_materialized_commit(
         seq: prepared.plan.next_seq,
         base_head_seq: prepared.plan.base_head_seq,
         commit_id: prepared.plan.commit_id.clone(),
-        semantic_commit_fingerprint_sha256: prepared
-            .identity
-            .semantic_commit_fingerprint_sha256
-            .clone(),
+        semantic_commit_fingerprint_sha256: prepared.semantic_commit_fingerprint_sha256.clone(),
         writer_id: prepared.request.writer_id.clone(),
         writer_fence_token: prepared.request.writer_fence_token,
         message: prepared.request.message.clone(),
@@ -210,7 +207,7 @@ mod tests {
             metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
             checked_invariants: Vec::new(),
         };
-        let prepared = PreparedCommit::new(request, plan, None).expect("prepare commit");
+        let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
         let materialized = MaterializedCommit {
             prepared,
             results: vec![CommitOpResult::CreateDir {

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -56,8 +56,6 @@ pub fn semantic_commit_fingerprint_sha256(
     struct CanonicalSemanticCommit<'a> {
         domain: &'static str,
         namespace_id: &'a loon_api::NamespaceId,
-        commit_id: &'a loon_api::CommitId,
-        writer_id: &'a str,
         planned_head_seq: loon_api::ChangeSeq,
         preconditions: &'a [super::Precondition],
         ops: &'a [super::CommitOp],
@@ -68,8 +66,6 @@ pub fn semantic_commit_fingerprint_sha256(
     payload_checksum_sha256(&CanonicalSemanticCommit {
         domain: SEMANTIC_CORE_COMMIT_DOMAIN,
         namespace_id: &request.namespace_id,
-        commit_id: &request.commit_id,
-        writer_id: &request.writer_id,
         planned_head_seq: request.planned_head_seq,
         preconditions: &request.preconditions,
         ops: &request.ops,
@@ -127,13 +123,23 @@ mod tests {
     }
 
     #[test]
-    fn semantic_fingerprint_excludes_writer_fence_token() {
+    fn semantic_fingerprint_excludes_writer_context_and_commit_id() {
         let left = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
             .expect("left fingerprint");
-        let right = semantic_commit_fingerprint_sha256(&core_request(FenceToken(2)))
-            .expect("right fingerprint");
+        let different_fence = semantic_commit_fingerprint_sha256(&core_request(FenceToken(2)))
+            .expect("different fence fingerprint");
+        let mut different_writer = core_request(FenceToken(1));
+        different_writer.writer_id = "writer-b".to_owned();
+        let different_writer = semantic_commit_fingerprint_sha256(&different_writer)
+            .expect("different writer fingerprint");
+        let mut different_commit_id = core_request(FenceToken(1));
+        different_commit_id.commit_id = CommitId::from("commit-b");
+        let different_commit_id = semantic_commit_fingerprint_sha256(&different_commit_id)
+            .expect("different commit id fingerprint");
 
-        assert_eq!(left, right);
+        assert_eq!(left, different_fence);
+        assert_eq!(left, different_writer);
+        assert_eq!(left, different_commit_id);
     }
 
     #[test]

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -10,7 +10,7 @@ const SEMANTIC_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
 pub struct SemanticCommitFingerprint(String);
 
 impl SemanticCommitFingerprint {
-    pub fn new_unchecked(value: String) -> Self {
+    pub(crate) fn new_unchecked(value: String) -> Self {
         Self(value)
     }
 
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn v0_request_fingerprint_matches_core_request_fingerprint() {
+    fn v0_semantic_fingerprint_matches_core_semantic_fingerprint() {
         let namespace_id = NamespaceId::from("demo");
         let api_request = api_v0::CommitRequest {
             commit_id: CommitId::from("commit-a"),

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -1,0 +1,172 @@
+use super::CommitRequest;
+use loon_api::{payload_checksum_sha256, v0 as api_v0};
+use serde::Serialize;
+use thiserror::Error;
+
+const SOURCE_API_COMMIT_DOMAIN: &str = "loonfs.api.v0.commit";
+const DURABLE_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.durable.v0";
+const SEMANTIC_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CommitIdentityError {
+    #[error("commit identity codec error: {0}")]
+    Codec(String),
+}
+
+pub fn source_api_commit_checksum_sha256(
+    request: &api_v0::CommitRequest,
+) -> Result<String, CommitIdentityError> {
+    #[derive(Serialize)]
+    struct CanonicalSourceApiCommit<'a> {
+        domain: &'static str,
+        request: &'a api_v0::CommitRequest,
+    }
+
+    payload_checksum_sha256(&CanonicalSourceApiCommit {
+        domain: SOURCE_API_COMMIT_DOMAIN,
+        request,
+    })
+    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
+}
+
+pub fn durable_commit_checksum_sha256(
+    request: &CommitRequest,
+) -> Result<String, CommitIdentityError> {
+    #[derive(Serialize)]
+    struct CanonicalDurableCommit<'a> {
+        domain: &'static str,
+        request: &'a CommitRequest,
+    }
+
+    payload_checksum_sha256(&CanonicalDurableCommit {
+        domain: DURABLE_CORE_COMMIT_DOMAIN,
+        request,
+    })
+    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
+}
+
+pub fn semantic_commit_fingerprint_sha256(
+    request: &CommitRequest,
+) -> Result<String, CommitIdentityError> {
+    if let Some(fingerprint) = &request.semantic_commit_fingerprint_sha256 {
+        return Ok(fingerprint.clone());
+    }
+
+    #[derive(Serialize)]
+    struct CanonicalSemanticCommit<'a> {
+        domain: &'static str,
+        namespace_id: &'a loon_api::NamespaceId,
+        commit_id: &'a loon_api::CommitId,
+        writer_id: &'a str,
+        planned_head_seq: loon_api::ChangeSeq,
+        preconditions: &'a [super::Precondition],
+        ops: &'a [super::CommitOp],
+        message: &'a Option<String>,
+        annotations: &'a Option<api_v0::CommitAnnotations>,
+    }
+
+    payload_checksum_sha256(&CanonicalSemanticCommit {
+        domain: SEMANTIC_CORE_COMMIT_DOMAIN,
+        namespace_id: &request.namespace_id,
+        commit_id: &request.commit_id,
+        writer_id: &request.writer_id,
+        planned_head_seq: request.planned_head_seq,
+        preconditions: &request.preconditions,
+        ops: &request.ops,
+        message: &request.message,
+        annotations: &request.annotations,
+    })
+    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
+}
+
+pub fn commit_identity(
+    source_api_commit_checksum_sha256: Option<String>,
+    request: &CommitRequest,
+) -> Result<super::CommitIdentity, CommitIdentityError> {
+    Ok(super::CommitIdentity {
+        source_api_commit_checksum_sha256,
+        durable_commit_checksum_sha256: durable_commit_checksum_sha256(request)?,
+        semantic_commit_fingerprint_sha256: semantic_commit_fingerprint_sha256(request)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::{CommitOp, CommitRequest, Precondition};
+    use loon_api::{
+        v0::CommitOp as ApiCommitOp, ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId,
+    };
+
+    fn core_request(writer_fence_token: FenceToken) -> CommitRequest {
+        CommitRequest {
+            namespace_id: NamespaceId::from("demo"),
+            commit_id: CommitId::from("commit-a"),
+            writer_id: "writer-a".to_owned(),
+            writer_fence_token,
+            planned_head_seq: ChangeSeq(7),
+            semantic_commit_fingerprint_sha256: None,
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(7))],
+            message: Some("create docs".to_owned()),
+            annotations: None,
+        }
+    }
+
+    #[test]
+    fn semantic_fingerprint_is_stable_for_same_logical_commit() {
+        let left = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
+            .expect("left fingerprint");
+        let right = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
+            .expect("right fingerprint");
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn semantic_fingerprint_excludes_writer_fence_token() {
+        let left = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
+            .expect("left fingerprint");
+        let right = semantic_commit_fingerprint_sha256(&core_request(FenceToken(2)))
+            .expect("right fingerprint");
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn semantic_fingerprint_changes_when_logical_inputs_change() {
+        let baseline = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
+            .expect("baseline fingerprint");
+        let mut changed = core_request(FenceToken(1));
+        changed.ops = vec![CommitOp::CreateDir {
+            parent_inode: InodeId(1),
+            display_name: "drafts".to_owned(),
+        }];
+
+        let changed = semantic_commit_fingerprint_sha256(&changed).expect("changed fingerprint");
+
+        assert_ne!(baseline, changed);
+    }
+
+    #[test]
+    fn source_api_checksum_uses_public_request_shape() {
+        let request = api_v0::CommitRequest {
+            commit_id: CommitId::from("commit-a"),
+            planned_head_seq: ChangeSeq(7),
+            preconditions: Vec::new(),
+            ops: vec![ApiCommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        };
+
+        let checksum = source_api_commit_checksum_sha256(&request).expect("source checksum");
+
+        assert!(!checksum.is_empty());
+    }
+}

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -17,10 +17,6 @@ impl SemanticCommitFingerprint {
     pub fn as_str(&self) -> &str {
         &self.0
     }
-
-    pub fn into_string(self) -> String {
-        self.0
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -1,53 +1,18 @@
-use super::CommitRequest;
 use loon_api::{payload_checksum_sha256, v0 as api_v0};
 use serde::Serialize;
 use thiserror::Error;
 
-const SOURCE_API_COMMIT_DOMAIN: &str = "loonfs.api.v0.commit";
-const DURABLE_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.durable.v0";
 const SEMANTIC_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum CommitIdentityError {
-    #[error("commit identity codec error: {0}")]
+pub enum CommitFingerprintError {
+    #[error("commit fingerprint codec error: {0}")]
     Codec(String),
 }
 
-pub fn source_api_commit_checksum_sha256(
-    request: &api_v0::CommitRequest,
-) -> Result<String, CommitIdentityError> {
-    #[derive(Serialize)]
-    struct CanonicalSourceApiCommit<'a> {
-        domain: &'static str,
-        request: &'a api_v0::CommitRequest,
-    }
-
-    payload_checksum_sha256(&CanonicalSourceApiCommit {
-        domain: SOURCE_API_COMMIT_DOMAIN,
-        request,
-    })
-    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
-}
-
-pub fn durable_commit_checksum_sha256(
-    request: &CommitRequest,
-) -> Result<String, CommitIdentityError> {
-    #[derive(Serialize)]
-    struct CanonicalDurableCommit<'a> {
-        domain: &'static str,
-        request: &'a CommitRequest,
-    }
-
-    payload_checksum_sha256(&CanonicalDurableCommit {
-        domain: DURABLE_CORE_COMMIT_DOMAIN,
-        request,
-    })
-    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
-}
-
 pub fn semantic_commit_fingerprint_sha256(
-    request: &CommitRequest,
-) -> Result<String, CommitIdentityError> {
+    request: &super::CommitRequest,
+) -> Result<String, CommitFingerprintError> {
     if let Some(fingerprint) = &request.semantic_commit_fingerprint_sha256 {
         return Ok(fingerprint.clone());
     }
@@ -72,27 +37,14 @@ pub fn semantic_commit_fingerprint_sha256(
         message: &request.message,
         annotations: &request.annotations,
     })
-    .map_err(|err| CommitIdentityError::Codec(err.to_string()))
-}
-
-pub fn commit_identity(
-    source_api_commit_checksum_sha256: Option<String>,
-    request: &CommitRequest,
-) -> Result<super::CommitIdentity, CommitIdentityError> {
-    Ok(super::CommitIdentity {
-        source_api_commit_checksum_sha256,
-        durable_commit_checksum_sha256: durable_commit_checksum_sha256(request)?,
-        semantic_commit_fingerprint_sha256: semantic_commit_fingerprint_sha256(request)?,
-    })
+    .map_err(|err| CommitFingerprintError::Codec(err.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commit::{CommitOp, CommitRequest, Precondition};
-    use loon_api::{
-        v0::CommitOp as ApiCommitOp, ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId,
-    };
+    use loon_api::{ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
 
     fn core_request(writer_fence_token: FenceToken) -> CommitRequest {
         CommitRequest {
@@ -155,24 +107,5 @@ mod tests {
         let changed = semantic_commit_fingerprint_sha256(&changed).expect("changed fingerprint");
 
         assert_ne!(baseline, changed);
-    }
-
-    #[test]
-    fn source_api_checksum_uses_public_request_shape() {
-        let request = api_v0::CommitRequest {
-            commit_id: CommitId::from("commit-a"),
-            planned_head_seq: ChangeSeq(7),
-            preconditions: Vec::new(),
-            ops: vec![ApiCommitOp::CreateDir {
-                parent_inode: InodeId(1),
-                display_name: "docs".to_owned(),
-            }],
-            message: None,
-            annotations: None,
-        };
-
-        let checksum = source_api_commit_checksum_sha256(&request).expect("source checksum");
-
-        assert!(!checksum.is_empty());
     }
 }

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -1,8 +1,27 @@
-use loon_api::{payload_checksum_sha256, v0 as api_v0};
-use serde::Serialize;
+use super::api_adapter::{commit_op_from_v0, commit_precondition_from_v0};
+use super::{CommitOp, CommitRequest, Precondition};
+use loon_api::{payload_checksum_sha256, v0 as api_v0, ChangeSeq, NamespaceId};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const SEMANTIC_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SemanticCommitFingerprint(String);
+
+impl SemanticCommitFingerprint {
+    pub fn new_unchecked(value: String) -> Self {
+        Self(value)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommitFingerprintError {
@@ -10,33 +29,74 @@ pub enum CommitFingerprintError {
     Codec(String),
 }
 
-pub fn semantic_commit_fingerprint_sha256(
-    request: &super::CommitRequest,
-) -> Result<String, CommitFingerprintError> {
-    if let Some(fingerprint) = &request.semantic_commit_fingerprint_sha256 {
-        return Ok(fingerprint.clone());
-    }
+pub fn semantic_commit_fingerprint(
+    request: &CommitRequest,
+) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
+    semantic_commit_fingerprint_from_parts(
+        &request.namespace_id,
+        request.planned_head_seq,
+        &request.preconditions,
+        &request.ops,
+        &request.message,
+        &request.annotations,
+    )
+}
 
+pub fn semantic_commit_fingerprint_for_v0_request(
+    namespace_id: &NamespaceId,
+    request: &api_v0::CommitRequest,
+) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
+    let preconditions = request
+        .preconditions
+        .iter()
+        .cloned()
+        .map(commit_precondition_from_v0)
+        .collect::<Vec<_>>();
+    let ops = request
+        .ops
+        .iter()
+        .cloned()
+        .map(commit_op_from_v0)
+        .collect::<Vec<_>>();
+    semantic_commit_fingerprint_from_parts(
+        namespace_id,
+        request.planned_head_seq,
+        &preconditions,
+        &ops,
+        &request.message,
+        &request.annotations,
+    )
+}
+
+fn semantic_commit_fingerprint_from_parts(
+    namespace_id: &NamespaceId,
+    planned_head_seq: ChangeSeq,
+    preconditions: &[Precondition],
+    ops: &[CommitOp],
+    message: &Option<String>,
+    annotations: &Option<api_v0::CommitAnnotations>,
+) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
     #[derive(Serialize)]
     struct CanonicalSemanticCommit<'a> {
         domain: &'static str,
-        namespace_id: &'a loon_api::NamespaceId,
-        planned_head_seq: loon_api::ChangeSeq,
-        preconditions: &'a [super::Precondition],
-        ops: &'a [super::CommitOp],
+        namespace_id: &'a NamespaceId,
+        planned_head_seq: ChangeSeq,
+        preconditions: &'a [Precondition],
+        ops: &'a [CommitOp],
         message: &'a Option<String>,
         annotations: &'a Option<api_v0::CommitAnnotations>,
     }
 
     payload_checksum_sha256(&CanonicalSemanticCommit {
         domain: SEMANTIC_CORE_COMMIT_DOMAIN,
-        namespace_id: &request.namespace_id,
-        planned_head_seq: request.planned_head_seq,
-        preconditions: &request.preconditions,
-        ops: &request.ops,
-        message: &request.message,
-        annotations: &request.annotations,
+        namespace_id,
+        planned_head_seq,
+        preconditions,
+        ops,
+        message,
+        annotations,
     })
+    .map(SemanticCommitFingerprint::new_unchecked)
     .map_err(|err| CommitFingerprintError::Codec(err.to_string()))
 }
 
@@ -53,7 +113,6 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_fence_token,
             planned_head_seq: ChangeSeq(7),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
@@ -66,27 +125,27 @@ mod tests {
 
     #[test]
     fn semantic_fingerprint_is_stable_for_same_logical_commit() {
-        let left = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
-            .expect("left fingerprint");
-        let right = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
-            .expect("right fingerprint");
+        let left =
+            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
+        let right =
+            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("right fingerprint");
 
         assert_eq!(left, right);
     }
 
     #[test]
     fn semantic_fingerprint_excludes_writer_context_and_commit_id() {
-        let left = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
-            .expect("left fingerprint");
-        let different_fence = semantic_commit_fingerprint_sha256(&core_request(FenceToken(2)))
+        let left =
+            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
+        let different_fence = semantic_commit_fingerprint(&core_request(FenceToken(2)))
             .expect("different fence fingerprint");
         let mut different_writer = core_request(FenceToken(1));
         different_writer.writer_id = "writer-b".to_owned();
-        let different_writer = semantic_commit_fingerprint_sha256(&different_writer)
-            .expect("different writer fingerprint");
+        let different_writer =
+            semantic_commit_fingerprint(&different_writer).expect("different writer fingerprint");
         let mut different_commit_id = core_request(FenceToken(1));
         different_commit_id.commit_id = CommitId::from("commit-b");
-        let different_commit_id = semantic_commit_fingerprint_sha256(&different_commit_id)
+        let different_commit_id = semantic_commit_fingerprint(&different_commit_id)
             .expect("different commit id fingerprint");
 
         assert_eq!(left, different_fence);
@@ -96,7 +155,7 @@ mod tests {
 
     #[test]
     fn semantic_fingerprint_changes_when_logical_inputs_change() {
-        let baseline = semantic_commit_fingerprint_sha256(&core_request(FenceToken(1)))
+        let baseline = semantic_commit_fingerprint(&core_request(FenceToken(1)))
             .expect("baseline fingerprint");
         let mut changed = core_request(FenceToken(1));
         changed.ops = vec![CommitOp::CreateDir {
@@ -104,8 +163,41 @@ mod tests {
             display_name: "drafts".to_owned(),
         }];
 
-        let changed = semantic_commit_fingerprint_sha256(&changed).expect("changed fingerprint");
+        let changed = semantic_commit_fingerprint(&changed).expect("changed fingerprint");
 
         assert_ne!(baseline, changed);
+    }
+
+    #[test]
+    fn v0_request_fingerprint_matches_core_request_fingerprint() {
+        let namespace_id = NamespaceId::from("demo");
+        let api_request = api_v0::CommitRequest {
+            commit_id: CommitId::from("commit-a"),
+            planned_head_seq: ChangeSeq(7),
+            preconditions: vec![api_v0::CommitPrecondition::HeadSeqIs {
+                expected_seq: ChangeSeq(7),
+            }],
+            ops: vec![api_v0::CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            message: Some("create docs".to_owned()),
+            annotations: None,
+        };
+        let core = super::super::commit_request_from_v0(
+            super::super::CommitExecutionContext {
+                namespace_id: namespace_id.clone(),
+                writer_id: "writer-a".to_owned(),
+                writer_fence_token: FenceToken(1),
+            },
+            api_request.clone(),
+        )
+        .expect("core request");
+
+        assert_eq!(
+            semantic_commit_fingerprint_for_v0_request(&namespace_id, &api_request)
+                .expect("api fingerprint"),
+            semantic_commit_fingerprint(&core).expect("core fingerprint")
+        );
     }
 }

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -13,15 +13,18 @@ mod ordered;
 mod prepared;
 mod publish;
 
-pub use self::api_adapter::{
-    commit_request_from_v0, commit_request_from_v0_with_semantic_fingerprint, CommitConversionError,
-};
+pub use self::api_adapter::{commit_request_from_v0, CommitConversionError};
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
-pub use self::identity::{semantic_commit_fingerprint_sha256, CommitFingerprintError};
+pub use self::identity::{
+    semantic_commit_fingerprint, semantic_commit_fingerprint_for_v0_request,
+    CommitFingerprintError, SemanticCommitFingerprint,
+};
 pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
 pub use self::prepared::{
-    CommitExecutionContext, CommitPrepareError, MaterializedCommit, PreparedCommit,
+    materialize_commit, CommitExecutionContext, CommitFingerprintSource,
+    CommitMaterializationError, CommitPrepareError, MaterializedCommit, MaterializedCommitOp,
+    PreparedCommit,
 };
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 
@@ -32,8 +35,6 @@ pub struct CommitRequest {
     pub writer_id: String,
     pub writer_fence_token: FenceToken,
     pub planned_head_seq: ChangeSeq,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub semantic_commit_fingerprint_sha256: Option<String>,
     pub ops: Vec<CommitOp>,
     pub preconditions: Vec<Precondition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -101,9 +102,6 @@ pub struct CommitPlan {
     pub allocated_inode_ids: Vec<InodeId>,
     pub resolved_restore_content_refs: Vec<Option<ContentRef>>,
     pub resulting_next_inode_id: InodeId,
-    pub durable_content_required: bool,
-    pub wal_object_must_be_written: bool,
-    pub head_cas_must_succeed: bool,
     pub metadata_preconditions: Vec<Precondition>,
     pub checked_invariants: Vec<String>,
 }

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -21,10 +21,10 @@ pub use self::identity::{
 };
 pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
+pub(crate) use self::prepared::CommitFingerprintSource;
 pub use self::prepared::{
-    materialize_commit, CommitExecutionContext, CommitFingerprintSource,
-    CommitMaterializationError, CommitPrepareError, MaterializedCommit, MaterializedCommitOp,
-    PreparedCommit,
+    materialize_commit, CommitExecutionContext, CommitMaterializationError, CommitPrepareError,
+    MaterializedCommit, MaterializedCommitOp, PreparedCommit,
 };
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -17,14 +17,11 @@ pub use self::api_adapter::{
     commit_request_from_v0, commit_request_from_v0_with_semantic_fingerprint, CommitConversionError,
 };
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
-pub use self::identity::{
-    commit_identity, durable_commit_checksum_sha256, semantic_commit_fingerprint_sha256,
-    source_api_commit_checksum_sha256, CommitIdentityError,
-};
+pub use self::identity::{semantic_commit_fingerprint_sha256, CommitFingerprintError};
 pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
 pub use self::prepared::{
-    CommitExecutionContext, CommitIdentity, CommitPrepareError, MaterializedCommit, PreparedCommit,
+    CommitExecutionContext, CommitPrepareError, MaterializedCommit, PreparedCommit,
 };
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -5,12 +5,27 @@ use loon_api::{
 };
 use serde::{Deserialize, Serialize};
 
+mod api_adapter;
+mod durable_adapter;
 mod frame;
+mod identity;
 mod ordered;
+mod prepared;
 mod publish;
 
+pub use self::api_adapter::{
+    commit_request_from_v0, commit_request_from_v0_with_semantic_fingerprint, CommitConversionError,
+};
+pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
+pub use self::identity::{
+    commit_identity, durable_commit_checksum_sha256, semantic_commit_fingerprint_sha256,
+    source_api_commit_checksum_sha256, CommitIdentityError,
+};
 pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
+pub use self::prepared::{
+    CommitExecutionContext, CommitIdentity, CommitPrepareError, MaterializedCommit, PreparedCommit,
+};
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,7 +36,7 @@ pub struct CommitRequest {
     pub writer_fence_token: FenceToken,
     pub planned_head_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub request_fingerprint_sha256: Option<String>,
+    pub semantic_commit_fingerprint_sha256: Option<String>,
     pub ops: Vec<CommitOp>,
     pub preconditions: Vec<Precondition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,32 +309,5 @@ pub enum CommitHeadPublishError {
 pub(crate) fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
     if !invariants.iter().any(|existing| existing == name) {
         invariants.push(name.to_owned());
-    }
-}
-
-impl CommitRequest {
-    pub fn request_fingerprint_sha256(&self) -> Result<String, serde_json::Error> {
-        if let Some(fingerprint) = &self.request_fingerprint_sha256 {
-            return Ok(fingerprint.clone());
-        }
-        #[derive(Serialize)]
-        struct CanonicalCommitRequest<'a> {
-            namespace_id: &'a NamespaceId,
-            planned_head_seq: ChangeSeq,
-            ops: &'a [CommitOp],
-            preconditions: &'a [Precondition],
-            message: &'a Option<String>,
-            annotations: &'a Option<CommitAnnotations>,
-        }
-        let request = CanonicalCommitRequest {
-            namespace_id: &self.namespace_id,
-            planned_head_seq: self.planned_head_seq,
-            ops: &self.ops,
-            preconditions: &self.preconditions,
-            message: &self.message,
-            annotations: &self.annotations,
-        };
-        let bytes = serde_json::to_vec(&request)?;
-        Ok(loon_api::sha256_digest(&bytes))
     }
 }

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -1,13 +1,13 @@
 use super::frame::validate_commit_request_frame;
+use super::prepared::materialize_commit_op;
 use super::{
-    push_unique_invariant, CommitOp, CommitPlan, CommitRequest, CommitValidationContext,
-    CommitValidationError,
+    push_unique_invariant, CommitMaterializationError, CommitOp, CommitPlan, CommitRequest,
+    CommitValidationContext, CommitValidationError,
 };
 use crate::invariants::INVARIANTS;
 use crate::metadata::MetadataState;
 use loon_api::{
     name_key_for_display_name, ChangeSeq, ContentRef, InodeId, InodeKind, NamePolicy, RevisionNo,
-    WalOp,
 };
 use std::collections::BTreeMap;
 
@@ -93,14 +93,6 @@ pub fn build_commit_plan(
         &mut checked_invariants,
     )?;
 
-    let durable_content_required = request.ops.iter().any(|op| {
-        matches!(
-            op,
-            CommitOp::CreateFile { .. }
-                | CommitOp::ReplaceFile { .. }
-                | CommitOp::RestoreRevision { .. }
-        )
-    });
     if !shape.allocated_inode_ids.is_empty() {
         push_unique_invariant(
             &mut checked_invariants,
@@ -146,9 +138,6 @@ pub fn build_commit_plan(
         allocated_inode_ids: shape.allocated_inode_ids,
         resolved_restore_content_refs,
         resulting_next_inode_id: shape.resulting_next_inode_id,
-        durable_content_required,
-        wal_object_must_be_written: true,
-        head_cas_must_succeed: true,
         metadata_preconditions: request.preconditions.clone(),
         checked_invariants,
     })
@@ -357,12 +346,14 @@ fn validate_metadata_preconditions(
         let applied_metadata = ephemeral_metadata_state
             .apply_committed_wal_ops(
                 committed_seq,
-                &[materialize_simulated_wal_op(
+                &[materialize_commit_op(
                     op,
                     op_index,
                     resolved_restore_content_ref.as_ref(),
                     &mut allocated_inode_ids,
-                )?],
+                )
+                .map_err(|err| materialization_error_to_validation_error(err, op))?
+                .wal_op],
             )
             .expect("validated commit ops should always apply into ephemeral metadata state");
         ephemeral_metadata_state = applied_metadata.metadata_state;
@@ -371,84 +362,47 @@ fn validate_metadata_preconditions(
     Ok(resolved_restore_content_refs)
 }
 
-fn materialize_simulated_wal_op(
+fn materialization_error_to_validation_error(
+    error: CommitMaterializationError,
     op: &CommitOp,
-    op_index: u32,
-    resolved_restore_content_ref: Option<&ContentRef>,
-    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
-) -> Result<WalOp, CommitValidationError> {
-    Ok(match op {
-        CommitOp::CreateDir {
-            parent_inode,
-            display_name,
-        } => WalOp::CreateDir {
-            op_index,
-            inode_id: allocated_inode_ids
-                .next()
-                .ok_or(CommitValidationError::NextInodeOverflow)?,
-            parent_inode: *parent_inode,
-            display_name: display_name.clone(),
+) -> CommitValidationError {
+    match (error, op) {
+        (
+            CommitMaterializationError::MissingResolvedRestoreContentRef { .. },
+            CommitOp::RestoreRevision {
+                inode_id,
+                source_revision,
+                ..
+            },
+        ) => CommitValidationError::RestoreRevisionSourceRevisionMissing {
+            inode_id: *inode_id,
+            source_revision: *source_revision,
         },
-        CommitOp::CreateFile {
-            parent_inode,
-            display_name,
-            content_ref,
-        } => WalOp::CreateFile {
-            op_index,
-            inode_id: allocated_inode_ids
-                .next()
-                .ok_or(CommitValidationError::NextInodeOverflow)?,
-            parent_inode: *parent_inode,
-            display_name: display_name.clone(),
-            content_ref: content_ref.clone(),
-        },
-        CommitOp::ReplaceFile {
-            inode_id,
-            base_revision,
-            content_ref,
-        } => WalOp::ReplaceFile {
-            op_index,
+        (
+            CommitMaterializationError::ReplaceRevisionOverflow { .. },
+            CommitOp::ReplaceFile {
+                inode_id,
+                base_revision,
+                ..
+            },
+        ) => CommitValidationError::ReplaceFileRevisionOverflow {
             inode_id: *inode_id,
             base_revision: *base_revision,
-            content_ref: content_ref.clone(),
         },
-        CommitOp::RestoreRevision {
-            inode_id,
-            source_revision,
-            base_revision,
-        } => WalOp::RestoreRevision {
-            op_index,
+        (
+            CommitMaterializationError::RestoreRevisionOverflow { .. },
+            CommitOp::RestoreRevision {
+                inode_id,
+                base_revision,
+                ..
+            },
+        ) => CommitValidationError::RestoreRevisionOverflow {
             inode_id: *inode_id,
-            source_revision_no: *source_revision,
             base_revision: *base_revision,
-            content_ref: resolved_restore_content_ref
-                .ok_or(
-                    CommitValidationError::RestoreRevisionSourceRevisionMissing {
-                        inode_id: *inode_id,
-                        source_revision: *source_revision,
-                    },
-                )?
-                .clone(),
         },
-        CommitOp::DeleteFile { inode_id } => WalOp::DeleteFile {
-            op_index,
-            inode_id: *inode_id,
-        },
-        CommitOp::Rename {
-            inode_id,
-            new_parent_inode,
-            new_display_name,
-        } => WalOp::Rename {
-            op_index,
-            inode_id: *inode_id,
-            new_parent_inode: *new_parent_inode,
-            new_display_name: new_display_name.clone(),
-        },
-        CommitOp::DeleteSubtree { root_inode } => WalOp::DeleteSubtree {
-            op_index,
-            root_inode: *root_inode,
-        },
-    })
+        (CommitMaterializationError::OpIndexOverflow, _) => CommitValidationError::OpIndexOverflow,
+        _ => CommitValidationError::NextInodeOverflow,
+    }
 }
 
 fn validate_child_name_absent(

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -16,7 +16,7 @@ pub struct CommitExecutionContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CommitFingerprintSource {
+pub(crate) enum CommitFingerprintSource {
     ComputeFromRequest,
     TrustedPrecomputed(SemanticCommitFingerprint),
 }
@@ -86,19 +86,7 @@ impl PreparedCommit {
         Self::prepare(request, plan, CommitFingerprintSource::ComputeFromRequest)
     }
 
-    pub fn new_with_fingerprint(
-        request: CommitRequest,
-        plan: CommitPlan,
-        fingerprint: SemanticCommitFingerprint,
-    ) -> Result<Self, CommitPrepareError> {
-        Self::prepare(
-            request,
-            plan,
-            CommitFingerprintSource::TrustedPrecomputed(fingerprint),
-        )
-    }
-
-    pub fn prepare(
+    pub(crate) fn prepare(
         request: CommitRequest,
         plan: CommitPlan,
         fingerprint_source: CommitFingerprintSource,
@@ -385,8 +373,12 @@ mod tests {
     #[test]
     fn prepared_commit_uses_trusted_precomputed_fingerprint() {
         let fingerprint = SemanticCommitFingerprint::new_unchecked("trusted".to_owned());
-        let prepared = PreparedCommit::new_with_fingerprint(request(), plan(), fingerprint.clone())
-            .expect("prepare commit");
+        let prepared = PreparedCommit::prepare(
+            request(),
+            plan(),
+            CommitFingerprintSource::TrustedPrecomputed(fingerprint.clone()),
+        )
+        .expect("prepare commit");
 
         assert_eq!(prepared.semantic_commit_fingerprint, fingerprint);
     }

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -1,7 +1,10 @@
 use super::{
-    semantic_commit_fingerprint_sha256, CommitFingerprintError, CommitPlan, CommitRequest,
+    semantic_commit_fingerprint, CommitFingerprintError, CommitOp, CommitPlan, CommitRequest,
+    SemanticCommitFingerprint,
 };
-use loon_api::{FenceToken, NamespaceId};
+use loon_api::{
+    v0::CommitOpResult, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo, WalOp,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -12,17 +15,30 @@ pub struct CommitExecutionContext {
     pub writer_fence_token: FenceToken,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommitFingerprintSource {
+    ComputeFromRequest,
+    TrustedPrecomputed(SemanticCommitFingerprint),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedCommit {
     pub request: CommitRequest,
     pub plan: CommitPlan,
-    pub semantic_commit_fingerprint_sha256: String,
+    pub semantic_commit_fingerprint: SemanticCommitFingerprint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializedCommitOp {
+    pub op_index: u32,
+    pub wal_op: WalOp,
+    pub result: CommitOpResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MaterializedCommit {
     pub prepared: PreparedCommit,
-    pub results: Vec<loon_api::v0::CommitOpResult>,
+    pub ops: Vec<MaterializedCommitOp>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -38,8 +54,55 @@ pub enum CommitPrepareError {
     Fingerprint(#[from] CommitFingerprintError),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CommitMaterializationError {
+    #[error("commit op index overflow")]
+    OpIndexOverflow,
+    #[error(
+        "allocated inode count mismatch: request_create_ops={request_create_ops}, plan_allocated_count={plan_allocated_count}"
+    )]
+    AllocatedInodeCountMismatch {
+        request_create_ops: usize,
+        plan_allocated_count: usize,
+    },
+    #[error("missing allocated inode for op index {op_index}")]
+    MissingAllocatedInode { op_index: u32 },
+    #[error("missing resolved restore content ref for op index {op_index}")]
+    MissingResolvedRestoreContentRef { op_index: u32 },
+    #[error("replace_file revision overflow for inode {inode_id:?} at base {base_revision:?}")]
+    ReplaceRevisionOverflow {
+        inode_id: InodeId,
+        base_revision: RevisionNo,
+    },
+    #[error("restore_revision overflow for inode {inode_id:?} at base {base_revision:?}")]
+    RestoreRevisionOverflow {
+        inode_id: InodeId,
+        base_revision: RevisionNo,
+    },
+}
+
 impl PreparedCommit {
     pub fn new(request: CommitRequest, plan: CommitPlan) -> Result<Self, CommitPrepareError> {
+        Self::prepare(request, plan, CommitFingerprintSource::ComputeFromRequest)
+    }
+
+    pub fn new_with_fingerprint(
+        request: CommitRequest,
+        plan: CommitPlan,
+        fingerprint: SemanticCommitFingerprint,
+    ) -> Result<Self, CommitPrepareError> {
+        Self::prepare(
+            request,
+            plan,
+            CommitFingerprintSource::TrustedPrecomputed(fingerprint),
+        )
+    }
+
+    pub fn prepare(
+        request: CommitRequest,
+        plan: CommitPlan,
+        fingerprint_source: CommitFingerprintSource,
+    ) -> Result<Self, CommitPrepareError> {
         if request.namespace_id != plan.namespace_id {
             return Err(CommitPrepareError::NamespaceMismatch {
                 request: request.namespace_id.clone(),
@@ -49,21 +112,214 @@ impl PreparedCommit {
         if request.commit_id != plan.commit_id {
             return Err(CommitPrepareError::CommitIdMismatch);
         }
-        let semantic_commit_fingerprint_sha256 = semantic_commit_fingerprint_sha256(&request)?;
+        let semantic_commit_fingerprint = match fingerprint_source {
+            CommitFingerprintSource::ComputeFromRequest => semantic_commit_fingerprint(&request)?,
+            CommitFingerprintSource::TrustedPrecomputed(fingerprint) => fingerprint,
+        };
 
         Ok(Self {
             request,
             plan,
-            semantic_commit_fingerprint_sha256,
+            semantic_commit_fingerprint,
         })
     }
+}
+
+pub fn materialize_commit(
+    prepared: PreparedCommit,
+) -> Result<MaterializedCommit, CommitMaterializationError> {
+    let request_create_ops = prepared
+        .request
+        .ops
+        .iter()
+        .filter(|op| matches!(op, CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. }))
+        .count();
+    if request_create_ops != prepared.plan.allocated_inode_ids.len() {
+        return Err(CommitMaterializationError::AllocatedInodeCountMismatch {
+            request_create_ops,
+            plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
+        });
+    }
+
+    let mut allocated_inode_ids = prepared.plan.allocated_inode_ids.iter().copied();
+    let mut ops = Vec::with_capacity(prepared.request.ops.len());
+    for (op_index, op) in prepared.request.ops.iter().enumerate() {
+        let op_index =
+            u32::try_from(op_index).map_err(|_| CommitMaterializationError::OpIndexOverflow)?;
+        let resolved_restore_content_ref = prepared
+            .plan
+            .resolved_restore_content_refs
+            .get(op_index as usize)
+            .and_then(|content_ref| content_ref.as_ref());
+        ops.push(materialize_commit_op(
+            op,
+            op_index,
+            resolved_restore_content_ref,
+            &mut allocated_inode_ids,
+        )?);
+    }
+
+    Ok(MaterializedCommit { prepared, ops })
+}
+
+pub(super) fn materialize_commit_op(
+    op: &CommitOp,
+    op_index: u32,
+    resolved_restore_content_ref: Option<&ContentRef>,
+    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
+) -> Result<MaterializedCommitOp, CommitMaterializationError> {
+    let materialized = match op {
+        CommitOp::CreateDir {
+            parent_inode,
+            display_name,
+        } => {
+            let inode_id = allocated_inode_ids
+                .next()
+                .ok_or(CommitMaterializationError::MissingAllocatedInode { op_index })?;
+            MaterializedCommitOp {
+                op_index,
+                wal_op: WalOp::CreateDir {
+                    op_index,
+                    inode_id,
+                    parent_inode: *parent_inode,
+                    display_name: display_name.clone(),
+                },
+                result: CommitOpResult::CreateDir { op_index, inode_id },
+            }
+        }
+        CommitOp::CreateFile {
+            parent_inode,
+            display_name,
+            content_ref,
+        } => {
+            let inode_id = allocated_inode_ids
+                .next()
+                .ok_or(CommitMaterializationError::MissingAllocatedInode { op_index })?;
+            MaterializedCommitOp {
+                op_index,
+                wal_op: WalOp::CreateFile {
+                    op_index,
+                    inode_id,
+                    parent_inode: *parent_inode,
+                    display_name: display_name.clone(),
+                    content_ref: content_ref.clone(),
+                },
+                result: CommitOpResult::CreateFile {
+                    op_index,
+                    inode_id,
+                    revision_no: RevisionNo(1),
+                    content_ref: content_ref.clone(),
+                },
+            }
+        }
+        CommitOp::ReplaceFile {
+            inode_id,
+            base_revision,
+            content_ref,
+        } => {
+            let revision_no = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                CommitMaterializationError::ReplaceRevisionOverflow {
+                    inode_id: *inode_id,
+                    base_revision: *base_revision,
+                },
+            )?;
+            MaterializedCommitOp {
+                op_index,
+                wal_op: WalOp::ReplaceFile {
+                    op_index,
+                    inode_id: *inode_id,
+                    base_revision: *base_revision,
+                    content_ref: content_ref.clone(),
+                },
+                result: CommitOpResult::ReplaceFile {
+                    op_index,
+                    inode_id: *inode_id,
+                    revision_no,
+                    content_ref: content_ref.clone(),
+                },
+            }
+        }
+        CommitOp::RestoreRevision {
+            inode_id,
+            source_revision,
+            base_revision,
+        } => {
+            let content_ref = resolved_restore_content_ref
+                .ok_or(CommitMaterializationError::MissingResolvedRestoreContentRef { op_index })?
+                .clone();
+            let revision_no = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                CommitMaterializationError::RestoreRevisionOverflow {
+                    inode_id: *inode_id,
+                    base_revision: *base_revision,
+                },
+            )?;
+            MaterializedCommitOp {
+                op_index,
+                wal_op: WalOp::RestoreRevision {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_revision_no: *source_revision,
+                    base_revision: *base_revision,
+                    content_ref: content_ref.clone(),
+                },
+                result: CommitOpResult::RestoreRevision {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_revision_no: *source_revision,
+                    revision_no,
+                    content_ref,
+                },
+            }
+        }
+        CommitOp::DeleteFile { inode_id } => MaterializedCommitOp {
+            op_index,
+            wal_op: WalOp::DeleteFile {
+                op_index,
+                inode_id: *inode_id,
+            },
+            result: CommitOpResult::DeleteFile {
+                op_index,
+                inode_id: *inode_id,
+            },
+        },
+        CommitOp::Rename {
+            inode_id,
+            new_parent_inode,
+            new_display_name,
+        } => MaterializedCommitOp {
+            op_index,
+            wal_op: WalOp::Rename {
+                op_index,
+                inode_id: *inode_id,
+                new_parent_inode: *new_parent_inode,
+                new_display_name: new_display_name.clone(),
+            },
+            result: CommitOpResult::Rename {
+                op_index,
+                inode_id: *inode_id,
+            },
+        },
+        CommitOp::DeleteSubtree { root_inode } => MaterializedCommitOp {
+            op_index,
+            wal_op: WalOp::DeleteSubtree {
+                op_index,
+                root_inode: *root_inode,
+            },
+            result: CommitOpResult::DeleteSubtree {
+                op_index,
+                root_inode: *root_inode,
+            },
+        },
+    };
+
+    Ok(materialized)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commit::{CommitOp, Precondition};
-    use loon_api::{ChangeSeq, CommitId, InodeId};
+    use loon_api::{ChangeSeq, CommitId};
 
     fn request() -> CommitRequest {
         CommitRequest {
@@ -72,7 +328,6 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(0),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
@@ -92,9 +347,6 @@ mod tests {
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            durable_content_required: false,
-            wal_object_must_be_written: true,
-            head_cas_must_succeed: true,
             metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
             checked_invariants: Vec::new(),
         }
@@ -128,5 +380,31 @@ mod tests {
         plan.base_head_seq = ChangeSeq(9);
 
         PreparedCommit::new(request(), plan).expect("prepare commit");
+    }
+
+    #[test]
+    fn prepared_commit_uses_trusted_precomputed_fingerprint() {
+        let fingerprint = SemanticCommitFingerprint::new_unchecked("trusted".to_owned());
+        let prepared = PreparedCommit::new_with_fingerprint(request(), plan(), fingerprint.clone())
+            .expect("prepare commit");
+
+        assert_eq!(prepared.semantic_commit_fingerprint, fingerprint);
+    }
+
+    #[test]
+    fn materialize_commit_outputs_wal_ops_and_results_once() {
+        let materialized =
+            materialize_commit(PreparedCommit::new(request(), plan()).expect("prepare commit"))
+                .expect("materialize commit");
+
+        assert_eq!(materialized.ops.len(), 1);
+        assert!(matches!(
+            materialized.ops[0].wal_op,
+            WalOp::CreateDir { .. }
+        ));
+        assert!(matches!(
+            materialized.ops[0].result,
+            CommitOpResult::CreateDir { .. }
+        ));
     }
 }

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -1,4 +1,6 @@
-use super::{commit_identity, CommitIdentityError, CommitPlan, CommitRequest};
+use super::{
+    semantic_commit_fingerprint_sha256, CommitFingerprintError, CommitPlan, CommitRequest,
+};
 use loon_api::{FenceToken, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -11,17 +13,10 @@ pub struct CommitExecutionContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CommitIdentity {
-    pub source_api_commit_checksum_sha256: Option<String>,
-    pub durable_commit_checksum_sha256: String,
-    pub semantic_commit_fingerprint_sha256: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedCommit {
     pub request: CommitRequest,
     pub plan: CommitPlan,
-    pub identity: CommitIdentity,
+    pub semantic_commit_fingerprint_sha256: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,15 +35,11 @@ pub enum CommitPrepareError {
     #[error("prepared commit id mismatch")]
     CommitIdMismatch,
     #[error(transparent)]
-    Identity(#[from] CommitIdentityError),
+    Fingerprint(#[from] CommitFingerprintError),
 }
 
 impl PreparedCommit {
-    pub fn new(
-        request: CommitRequest,
-        plan: CommitPlan,
-        source_api_commit_checksum_sha256: Option<String>,
-    ) -> Result<Self, CommitPrepareError> {
+    pub fn new(request: CommitRequest, plan: CommitPlan) -> Result<Self, CommitPrepareError> {
         if request.namespace_id != plan.namespace_id {
             return Err(CommitPrepareError::NamespaceMismatch {
                 request: request.namespace_id.clone(),
@@ -58,12 +49,12 @@ impl PreparedCommit {
         if request.commit_id != plan.commit_id {
             return Err(CommitPrepareError::CommitIdMismatch);
         }
-        let identity = commit_identity(source_api_commit_checksum_sha256, &request)?;
+        let semantic_commit_fingerprint_sha256 = semantic_commit_fingerprint_sha256(&request)?;
 
         Ok(Self {
             request,
             plan,
-            identity,
+            semantic_commit_fingerprint_sha256,
         })
     }
 }
@@ -115,7 +106,7 @@ mod tests {
         plan.namespace_id = NamespaceId::from("other");
 
         assert!(matches!(
-            PreparedCommit::new(request(), plan, None),
+            PreparedCommit::new(request(), plan),
             Err(CommitPrepareError::NamespaceMismatch { .. })
         ));
     }
@@ -126,7 +117,7 @@ mod tests {
         plan.commit_id = CommitId::from("commit-b");
 
         assert!(matches!(
-            PreparedCommit::new(request(), plan, None),
+            PreparedCommit::new(request(), plan),
             Err(CommitPrepareError::CommitIdMismatch)
         ));
     }
@@ -136,6 +127,6 @@ mod tests {
         let mut plan = plan();
         plan.base_head_seq = ChangeSeq(9);
 
-        PreparedCommit::new(request(), plan, None).expect("prepare commit");
+        PreparedCommit::new(request(), plan).expect("prepare commit");
     }
 }

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -1,0 +1,141 @@
+use super::{commit_identity, CommitIdentityError, CommitPlan, CommitRequest};
+use loon_api::{FenceToken, NamespaceId};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitExecutionContext {
+    pub namespace_id: NamespaceId,
+    pub writer_id: String,
+    pub writer_fence_token: FenceToken,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitIdentity {
+    pub source_api_commit_checksum_sha256: Option<String>,
+    pub durable_commit_checksum_sha256: String,
+    pub semantic_commit_fingerprint_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedCommit {
+    pub request: CommitRequest,
+    pub plan: CommitPlan,
+    pub identity: CommitIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializedCommit {
+    pub prepared: PreparedCommit,
+    pub results: Vec<loon_api::v0::CommitOpResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CommitPrepareError {
+    #[error("prepared commit namespace mismatch: request={request:?}, plan={plan:?}")]
+    NamespaceMismatch {
+        request: NamespaceId,
+        plan: NamespaceId,
+    },
+    #[error("prepared commit id mismatch")]
+    CommitIdMismatch,
+    #[error(transparent)]
+    Identity(#[from] CommitIdentityError),
+}
+
+impl PreparedCommit {
+    pub fn new(
+        request: CommitRequest,
+        plan: CommitPlan,
+        source_api_commit_checksum_sha256: Option<String>,
+    ) -> Result<Self, CommitPrepareError> {
+        if request.namespace_id != plan.namespace_id {
+            return Err(CommitPrepareError::NamespaceMismatch {
+                request: request.namespace_id.clone(),
+                plan: plan.namespace_id.clone(),
+            });
+        }
+        if request.commit_id != plan.commit_id {
+            return Err(CommitPrepareError::CommitIdMismatch);
+        }
+        let identity = commit_identity(source_api_commit_checksum_sha256, &request)?;
+
+        Ok(Self {
+            request,
+            plan,
+            identity,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::{CommitOp, Precondition};
+    use loon_api::{ChangeSeq, CommitId, InodeId};
+
+    fn request() -> CommitRequest {
+        CommitRequest {
+            namespace_id: NamespaceId::from("demo"),
+            commit_id: CommitId::from("commit-a"),
+            writer_id: "writer-a".to_owned(),
+            writer_fence_token: FenceToken(1),
+            planned_head_seq: ChangeSeq(0),
+            semantic_commit_fingerprint_sha256: None,
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            message: None,
+            annotations: None,
+        }
+    }
+
+    fn plan() -> CommitPlan {
+        CommitPlan {
+            namespace_id: NamespaceId::from("demo"),
+            commit_id: CommitId::from("commit-a"),
+            base_head_seq: ChangeSeq(0),
+            next_seq: ChangeSeq(1),
+            allocated_inode_ids: vec![InodeId(2)],
+            resolved_restore_content_refs: vec![None],
+            resulting_next_inode_id: InodeId(3),
+            durable_content_required: false,
+            wal_object_must_be_written: true,
+            head_cas_must_succeed: true,
+            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            checked_invariants: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn prepared_commit_rejects_namespace_mismatch() {
+        let mut plan = plan();
+        plan.namespace_id = NamespaceId::from("other");
+
+        assert!(matches!(
+            PreparedCommit::new(request(), plan, None),
+            Err(CommitPrepareError::NamespaceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn prepared_commit_rejects_commit_id_mismatch() {
+        let mut plan = plan();
+        plan.commit_id = CommitId::from("commit-b");
+
+        assert!(matches!(
+            PreparedCommit::new(request(), plan, None),
+            Err(CommitPrepareError::CommitIdMismatch)
+        ));
+    }
+
+    #[test]
+    fn prepared_commit_allows_ephemeral_batch_base_seq() {
+        let mut plan = plan();
+        plan.base_head_seq = ChangeSeq(9);
+
+        PreparedCommit::new(request(), plan, None).expect("prepare commit");
+    }
+}

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -1,5 +1,5 @@
 use crate::basis::BasisLoadError;
-use crate::commit::{CommitHeadPublishError, CommitValidationError};
+use crate::commit::{CommitConversionError, CommitHeadPublishError, CommitValidationError};
 use crate::content::{DurableContentValidationError, ImmutableObjectWriteError};
 use crate::lease::LeaseAcquireError;
 use crate::loading::ControlObjectLoadError;
@@ -141,6 +141,14 @@ impl From<MetadataApplyError> for CoreError {
 impl From<CommitHeadPublishError> for CoreError {
     fn from(value: CommitHeadPublishError) -> Self {
         Self::HeadPublish(value)
+    }
+}
+
+impl From<CommitConversionError> for CoreError {
+    fn from(value: CommitConversionError) -> Self {
+        match value {
+            CommitConversionError::InvalidCommitId(error) => Self::InvalidCommitId(error),
+        }
     }
 }
 

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -30,8 +30,7 @@ pub use protocol::{
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
-    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation, PlannedPathMutation,
-    PublishOptions,
+    NamespaceMutationCandidate, PathMutationIntent, PlannedPathMutation, PublishOptions,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, delete_path, delete_path_non_recursive, fork_namespace,

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -59,7 +59,7 @@ pub struct SubtreeTombstoneRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitReceiptRecord {
     pub commit_id: CommitId,
-    pub request_fingerprint_sha256: String,
+    pub semantic_commit_fingerprint_sha256: String,
     pub committed_seq: ChangeSeq,
     pub results: Vec<CommitOpResult>,
 }
@@ -295,7 +295,9 @@ impl MetadataState {
             .commit_receipts
             .push(CommitReceiptRecord {
                 commit_id: record.commit_id.clone(),
-                request_fingerprint_sha256: record.request_fingerprint_sha256.clone(),
+                semantic_commit_fingerprint_sha256: record
+                    .semantic_commit_fingerprint_sha256
+                    .clone(),
                 committed_seq: record.seq,
                 results: record.results.clone(),
             });

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -501,52 +501,6 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 fingerprint_source: CommitFingerprintSource::ComputeFromRequest,
             })
         }
-        NamespaceMutationCandidate::Planned(planned) => {
-            if let Err(error) = validate_commit_id(&planned.commit_request.commit_id) {
-                outcomes[index] = Some(Err(error));
-                return None;
-            }
-            let trusted_fingerprint = planned.semantic_commit_fingerprint;
-            let request = match commit_request_from_v0(conversion_context, planned.commit_request) {
-                Ok(value) => value,
-                Err(error) => {
-                    outcomes[index] = Some(Err(error.into()));
-                    return None;
-                }
-            };
-            let (semantic_fingerprint, fingerprint_source) = match trusted_fingerprint {
-                Some(fingerprint) => (
-                    fingerprint.clone(),
-                    CommitFingerprintSource::TrustedPrecomputed(fingerprint),
-                ),
-                None => {
-                    let fingerprint = match semantic_commit_fingerprint(&request) {
-                        Ok(value) => value,
-                        Err(error) => {
-                            outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
-                            return None;
-                        }
-                    };
-                    (fingerprint, CommitFingerprintSource::ComputeFromRequest)
-                }
-            };
-            if !record_primary_request_or_complete_idempotent(
-                namespace_id,
-                &basis.metadata_state,
-                outcomes,
-                in_batch_requests,
-                aliases,
-                index,
-                &request.commit_id,
-                &semantic_fingerprint,
-            ) {
-                return None;
-            }
-            Some(CandidateCoreRequest {
-                request,
-                fingerprint_source,
-            })
-        }
         NamespaceMutationCandidate::Path(intent) => {
             if let Err(error) = validate_commit_id(intent.commit_id()) {
                 outcomes[index] = Some(Err(error));

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -2,10 +2,9 @@ use crate::basis::{load_verified_namespace_basis, BasisLoadError};
 use crate::commit::{
     build_commit_plan, commit_request_from_v0_with_semantic_fingerprint,
     prepare_commit_head_publish, publish_commit_head, resolve_restore_content_refs,
-    semantic_commit_fingerprint_sha256, source_api_commit_checksum_sha256,
-    wal_payload_from_materialized_commit, CommitExecutionContext, CommitOp,
-    CommitRequest as CoreCommitRequest, CommitValidationContext, MaterializedCommit,
-    PreparedCommit,
+    semantic_commit_fingerprint_sha256, wal_payload_from_materialized_commit,
+    CommitExecutionContext, CommitOp, CommitRequest as CoreCommitRequest, CommitValidationContext,
+    MaterializedCommit, PreparedCommit,
 };
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
@@ -45,7 +44,6 @@ struct InBatchRequest {
 
 struct CandidateCoreRequest {
     request: CoreCommitRequest,
-    source_api_commit_checksum_sha256: Option<String>,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -340,11 +338,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             &plan.allocated_inode_ids,
             &plan.resolved_restore_content_refs,
         );
-        let prepared = match PreparedCommit::new(
-            request,
-            plan.clone(),
-            candidate_request.source_api_commit_checksum_sha256,
-        ) {
+        let prepared = match PreparedCommit::new(request, plan.clone()) {
             Ok(value) => value,
             Err(error) => {
                 outcomes[index] = Some(Err(CoreError::Store(format!(
@@ -468,13 +462,6 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let source_api_checksum = match source_api_commit_checksum_sha256(&request) {
-                Ok(value) => Some(value),
-                Err(error) => {
-                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
-                    return None;
-                }
-            };
             let request = match commit_request_from_v0_with_semantic_fingerprint(
                 conversion_context,
                 request,
@@ -505,10 +492,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            Some(CandidateCoreRequest {
-                request,
-                source_api_commit_checksum_sha256: source_api_checksum,
-            })
+            Some(CandidateCoreRequest { request })
         }
         NamespaceMutationCandidate::Planned(planned) => {
             if let Err(error) = validate_commit_id(&planned.commit_request.commit_id) {
@@ -545,10 +529,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            Some(CandidateCoreRequest {
-                request,
-                source_api_commit_checksum_sha256: None,
-            })
+            Some(CandidateCoreRequest { request })
         }
         NamespaceMutationCandidate::Path(intent) => {
             if let Err(error) = validate_commit_id(intent.commit_id()) {
@@ -601,10 +582,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                     return None;
                 }
             };
-            Some(CandidateCoreRequest {
-                request,
-                source_api_commit_checksum_sha256: None,
-            })
+            Some(CandidateCoreRequest { request })
         }
     }
 }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,10 +1,10 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
 use crate::commit::{
-    build_commit_plan, commit_request_from_v0_with_semantic_fingerprint,
-    prepare_commit_head_publish, publish_commit_head, resolve_restore_content_refs,
-    semantic_commit_fingerprint_sha256, wal_payload_from_materialized_commit,
-    CommitExecutionContext, CommitOp, CommitRequest as CoreCommitRequest, CommitValidationContext,
-    MaterializedCommit, PreparedCommit,
+    build_commit_plan, commit_request_from_v0, materialize_commit, prepare_commit_head_publish,
+    publish_commit_head, resolve_restore_content_refs, semantic_commit_fingerprint,
+    wal_payload_from_materialized_commit, CommitExecutionContext, CommitFingerprintSource,
+    CommitOp, CommitRequest as CoreCommitRequest, CommitValidationContext, MaterializedCommit,
+    PreparedCommit, SemanticCommitFingerprint,
 };
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
@@ -14,14 +14,14 @@ use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
 use loon_api::v0::{
-    BeginUploadResponse, ChangesResponse, CommitOpResult, CommitRequest as ApiCommitRequest,
+    BeginUploadResponse, ChangesResponse, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
     decode_wal_segment_envelope_zstd, generate_upload_id, validate_upload_id, ChangeSeq, CommitId,
-    CompletedUpload, ContentRef, ControlObjectKind, HeadState, InodeId, NamespaceId,
-    UploadSessionEnvelope, UploadSessionState,
+    CompletedUpload, ContentRef, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
+    UploadSessionState,
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -39,11 +39,12 @@ struct LoadedUploadSessionObject {
 #[derive(Debug, Clone)]
 struct InBatchRequest {
     primary_index: usize,
-    semantic_commit_fingerprint_sha256: String,
+    semantic_commit_fingerprint: SemanticCommitFingerprint,
 }
 
 struct CandidateCoreRequest {
     request: CoreCommitRequest,
+    fingerprint_source: CommitFingerprintSource,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -333,12 +334,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
                 continue;
             }
         };
-        let results = derive_commit_results(
-            &request.ops,
-            &plan.allocated_inode_ids,
-            &plan.resolved_restore_content_refs,
-        );
-        let prepared = match PreparedCommit::new(request, plan.clone()) {
+        let prepared = match PreparedCommit::prepare(
+            request,
+            plan.clone(),
+            candidate_request.fingerprint_source,
+        ) {
             Ok(value) => value,
             Err(error) => {
                 outcomes[index] = Some(Err(CoreError::Store(format!(
@@ -347,7 +347,15 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
                 continue;
             }
         };
-        let materialized = MaterializedCommit { prepared, results };
+        let materialized = match materialize_commit(prepared) {
+            Ok(value) => value,
+            Err(error) => {
+                outcomes[index] = Some(Err(CoreError::Store(format!(
+                    "commit materialization failed: {error}"
+                ))));
+                continue;
+            }
+        };
         let preview = match wal_payload_from_materialized_commit(&materialized) {
             Ok(payload) => payload,
             Err(error) => {
@@ -431,7 +439,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             namespace_id: namespace_id.clone(),
             commit_id: record.prepared.request.commit_id,
             committed_seq: wal.envelope.payload.records[accepted_index].seq,
-            results: record.results,
+            results: record.ops.into_iter().map(|op| op.result).collect(),
         }));
     }
     finish_batch_outcomes_with_aliases(outcomes, &aliases)
@@ -462,18 +470,14 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request = match commit_request_from_v0_with_semantic_fingerprint(
-                conversion_context,
-                request,
-                None,
-            ) {
+            let request = match commit_request_from_v0(conversion_context, request) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error.into()));
                     return None;
                 }
             };
-            let semantic_fingerprint = match semantic_commit_fingerprint_sha256(&request) {
+            let semantic_fingerprint = match semantic_commit_fingerprint(&request) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
@@ -492,29 +496,38 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            Some(CandidateCoreRequest { request })
+            Some(CandidateCoreRequest {
+                request,
+                fingerprint_source: CommitFingerprintSource::ComputeFromRequest,
+            })
         }
         NamespaceMutationCandidate::Planned(planned) => {
             if let Err(error) = validate_commit_id(&planned.commit_request.commit_id) {
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request = match commit_request_from_v0_with_semantic_fingerprint(
-                conversion_context,
-                planned.commit_request,
-                planned.semantic_commit_fingerprint_sha256,
-            ) {
+            let trusted_fingerprint = planned.semantic_commit_fingerprint;
+            let request = match commit_request_from_v0(conversion_context, planned.commit_request) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error.into()));
                     return None;
                 }
             };
-            let semantic_fingerprint = match semantic_commit_fingerprint_sha256(&request) {
-                Ok(value) => value,
-                Err(error) => {
-                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
-                    return None;
+            let (semantic_fingerprint, fingerprint_source) = match trusted_fingerprint {
+                Some(fingerprint) => (
+                    fingerprint.clone(),
+                    CommitFingerprintSource::TrustedPrecomputed(fingerprint),
+                ),
+                None => {
+                    let fingerprint = match semantic_commit_fingerprint(&request) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
+                            return None;
+                        }
+                    };
+                    (fingerprint, CommitFingerprintSource::ComputeFromRequest)
                 }
             };
             if !record_primary_request_or_complete_idempotent(
@@ -529,15 +542,17 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            Some(CandidateCoreRequest { request })
+            Some(CandidateCoreRequest {
+                request,
+                fingerprint_source,
+            })
         }
         NamespaceMutationCandidate::Path(intent) => {
             if let Err(error) = validate_commit_id(intent.commit_id()) {
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let semantic_fingerprint = match intent.semantic_commit_fingerprint_sha256(namespace_id)
-            {
+            let semantic_fingerprint = match intent.semantic_commit_fingerprint(namespace_id) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error));
@@ -571,18 +586,19 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                     return None;
                 }
             };
-            let request = match commit_request_from_v0_with_semantic_fingerprint(
-                conversion_context,
-                planned.commit_request,
-                Some(planned.semantic_commit_fingerprint_sha256),
-            ) {
+            let request = match commit_request_from_v0(conversion_context, planned.commit_request) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error.into()));
                     return None;
                 }
             };
-            Some(CandidateCoreRequest { request })
+            Some(CandidateCoreRequest {
+                request,
+                fingerprint_source: CommitFingerprintSource::TrustedPrecomputed(
+                    planned.semantic_commit_fingerprint,
+                ),
+            })
         }
     }
 }
@@ -602,11 +618,11 @@ fn record_primary_request_or_complete_idempotent(
     aliases: &mut Vec<(usize, usize)>,
     index: usize,
     commit_id: &CommitId,
-    semantic_commit_fingerprint: &str,
+    semantic_commit_fingerprint: &SemanticCommitFingerprint,
 ) -> bool {
     if let Some(existing) = find_commit_receipt(visible_metadata_state, commit_id) {
         outcomes[index] = Some(
-            if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint {
+            if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint.as_str() {
                 Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
             } else {
                 Ok(commit_response_from_commit_receipt(namespace_id, existing))
@@ -615,7 +631,7 @@ fn record_primary_request_or_complete_idempotent(
         return false;
     }
     if let Some(existing) = in_batch_requests.get(commit_id) {
-        if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint {
+        if existing.semantic_commit_fingerprint != *semantic_commit_fingerprint {
             outcomes[index] = Some(Err(CoreError::CommitIdReuseConflict(commit_id.to_string())));
         } else {
             aliases.push((index, existing.primary_index));
@@ -626,7 +642,7 @@ fn record_primary_request_or_complete_idempotent(
         commit_id.clone(),
         InBatchRequest {
             primary_index: index,
-            semantic_commit_fingerprint_sha256: semantic_commit_fingerprint.to_owned(),
+            semantic_commit_fingerprint: semantic_commit_fingerprint.clone(),
         },
     );
     true
@@ -677,82 +693,6 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         through_seq: basis.head.seq,
         changes,
     })
-}
-
-fn derive_commit_results(
-    ops: &[CommitOp],
-    allocated_inode_ids: &[InodeId],
-    resolved_restore_content_refs: &[Option<ContentRef>],
-) -> Vec<CommitOpResult> {
-    let mut allocated = allocated_inode_ids.iter().copied();
-    ops.iter()
-        .enumerate()
-        .map(|(index, op)| {
-            let op_index = u32::try_from(index).expect("commit op index should fit in u32");
-            match op {
-                CommitOp::CreateDir { .. } => CommitOpResult::CreateDir {
-                    op_index,
-                    inode_id: allocated
-                        .next()
-                        .expect("allocated inode ids should cover create ops"),
-                },
-                CommitOp::CreateFile { content_ref, .. } => CommitOpResult::CreateFile {
-                    op_index,
-                    inode_id: allocated
-                        .next()
-                        .expect("allocated inode ids should cover create ops"),
-                    revision_no: loon_api::RevisionNo(1),
-                    content_ref: content_ref.clone(),
-                },
-                CommitOp::ReplaceFile {
-                    inode_id,
-                    base_revision,
-                    content_ref,
-                } => CommitOpResult::ReplaceFile {
-                    op_index,
-                    inode_id: *inode_id,
-                    revision_no: loon_api::RevisionNo(
-                        base_revision
-                            .0
-                            .checked_add(1)
-                            .expect("replace_file revision increment validated"),
-                    ),
-                    content_ref: content_ref.clone(),
-                },
-                CommitOp::RestoreRevision {
-                    inode_id,
-                    source_revision,
-                    base_revision,
-                } => CommitOpResult::RestoreRevision {
-                    op_index,
-                    inode_id: *inode_id,
-                    source_revision_no: *source_revision,
-                    revision_no: loon_api::RevisionNo(
-                        base_revision
-                            .0
-                            .checked_add(1)
-                            .expect("restore_revision increment validated"),
-                    ),
-                    content_ref: resolved_restore_content_refs[index]
-                        .as_ref()
-                        .expect("resolved restore content ref should be present")
-                        .clone(),
-                },
-                CommitOp::DeleteFile { inode_id } => CommitOpResult::DeleteFile {
-                    op_index,
-                    inode_id: *inode_id,
-                },
-                CommitOp::Rename { inode_id, .. } => CommitOpResult::Rename {
-                    op_index,
-                    inode_id: *inode_id,
-                },
-                CommitOp::DeleteSubtree { root_inode } => CommitOpResult::DeleteSubtree {
-                    op_index,
-                    root_inode: *root_inode,
-                },
-            }
-        })
-        .collect()
 }
 
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,21 +1,21 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
 use crate::commit::{
-    build_commit_plan, prepare_commit_head_publish, publish_commit_head,
-    resolve_restore_content_refs, CommitOp, CommitRequest as CoreCommitRequest,
-    CommitValidationContext, Precondition,
+    build_commit_plan, commit_request_from_v0_with_semantic_fingerprint,
+    prepare_commit_head_publish, publish_commit_head, resolve_restore_content_refs,
+    semantic_commit_fingerprint_sha256, source_api_commit_checksum_sha256,
+    wal_payload_from_materialized_commit, CommitExecutionContext, CommitOp,
+    CommitRequest as CoreCommitRequest, CommitValidationContext, MaterializedCommit,
+    PreparedCommit,
 };
 use crate::content::{validate_durable_content_reference, write_immutable_object};
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
 use crate::namespace::catalog::load_namespace_content_store_id;
-use crate::publisher::{NamespaceMutationCandidate, PlannedNamespaceMutation};
-use crate::wal::{
-    build_wal_record_payload, prepare_wal_segment, PreparedWalRecord, StoredWalObject,
-};
+use crate::publisher::NamespaceMutationCandidate;
+use crate::wal::{prepare_wal_segment, StoredWalObject};
 use loon_api::v0::{
-    BeginUploadResponse, ChangesResponse, CommitOp as ApiCommitOp, CommitOpResult,
-    CommitPrecondition as ApiCommitPrecondition, CommitRequest as ApiCommitRequest,
+    BeginUploadResponse, ChangesResponse, CommitOpResult, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
@@ -40,7 +40,12 @@ struct LoadedUploadSessionObject {
 #[derive(Debug, Clone)]
 struct InBatchRequest {
     primary_index: usize,
-    request_fingerprint_sha256: String,
+    semantic_commit_fingerprint_sha256: String,
+}
+
+struct CandidateCoreRequest {
+    request: CoreCommitRequest,
+    source_api_commit_checksum_sha256: Option<String>,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -223,7 +228,14 @@ pub fn commit_operations<S: ObjectStore + ?Sized>(
     request: ApiCommitRequest,
     context: &MutationContext,
 ) -> Result<ApiCommitResponse, CoreError> {
-    commit_operations_with_request_fingerprint(store, namespace_id, request, None, context)
+    publish_namespace_mutations_batch(
+        store,
+        namespace_id,
+        vec![NamespaceMutationCandidate::Commit(request)],
+        context,
+    )
+    .pop()
+    .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
 }
 
 pub fn commit_operations_batch<S: ObjectStore + ?Sized>(
@@ -250,28 +262,6 @@ pub(crate) fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse, CoreError>> {
     commit_namespace_mutations_batch(store, namespace_id, candidates, context)
-}
-
-fn commit_operations_with_request_fingerprint<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    request: ApiCommitRequest,
-    request_fingerprint_sha256: Option<String>,
-    context: &MutationContext,
-) -> Result<ApiCommitResponse, CoreError> {
-    publish_namespace_mutations_batch(
-        store,
-        namespace_id,
-        vec![NamespaceMutationCandidate::Planned(
-            PlannedNamespaceMutation {
-                commit_request: request,
-                request_fingerprint_sha256,
-            },
-        )],
-        context,
-    )
-    .pop()
-    .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
 }
 
 fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
@@ -301,12 +291,12 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         (0..candidates.len()).map(|_| None).collect();
     let mut current_head = basis.head.clone();
     let mut current_metadata_state = basis.metadata_state.clone();
-    let mut accepted: Vec<(usize, PreparedWalRecord)> = Vec::new();
+    let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
     let mut in_batch_requests: HashMap<CommitId, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
 
     for (index, candidate) in candidates.into_iter().enumerate() {
-        let Some(request) = prepare_candidate_request(
+        let Some(candidate_request) = prepare_candidate_request(
             store,
             namespace_id,
             &basis,
@@ -327,6 +317,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             now_ms: context.now_ms,
             metadata_state: current_metadata_state.clone(),
         };
+        let request = candidate_request.request;
         let resolved_restore_content_refs = resolve_restore_content_refs(&request, &validation);
         if let Err(error) = validate_commit_content_references(
             store,
@@ -349,12 +340,21 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             &plan.allocated_inode_ids,
             &plan.resolved_restore_content_refs,
         );
-        let record = PreparedWalRecord {
+        let prepared = match PreparedCommit::new(
             request,
-            plan: plan.clone(),
-            results,
+            plan.clone(),
+            candidate_request.source_api_commit_checksum_sha256,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                outcomes[index] = Some(Err(CoreError::Store(format!(
+                    "commit preparation failed: {error}"
+                ))));
+                continue;
+            }
         };
-        let preview = match build_wal_record_payload(namespace_id, &record) {
+        let materialized = MaterializedCommit { prepared, results };
+        let preview = match wal_payload_from_materialized_commit(&materialized) {
             Ok(payload) => payload,
             Err(error) => {
                 outcomes[index] = Some(Err(error.into()));
@@ -366,7 +366,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
                 current_metadata_state = applied.metadata_state;
                 current_head.seq = plan.next_seq;
                 current_head.next_inode_id = plan.resulting_next_inode_id;
-                accepted.push((index, record));
+                accepted.push((index, materialized));
             }
             Err(error) => outcomes[index] = Some(Err(error.into())),
         }
@@ -404,7 +404,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         }
     }
 
-    let last_plan = &records.last().expect("non-empty accepted records").plan;
+    let last_plan = &records
+        .last()
+        .expect("non-empty accepted records")
+        .prepared
+        .plan;
     let head_publish = prepare_commit_head_publish(
         &basis.head,
         last_plan,
@@ -431,7 +435,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
             namespace_id: namespace_id.clone(),
-            commit_id: record.request.commit_id,
+            commit_id: record.prepared.request.commit_id,
             committed_seq: wal.envelope.payload.records[accepted_index].seq,
             results: record.results,
         }));
@@ -452,18 +456,40 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
     in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
-) -> Option<CoreCommitRequest> {
+) -> Option<CandidateCoreRequest> {
+    let conversion_context = CommitExecutionContext {
+        namespace_id: namespace_id.clone(),
+        writer_id: context.writer_id.clone(),
+        writer_fence_token: basis.head.active_fence_token,
+    };
     match candidate {
         NamespaceMutationCandidate::Commit(request) => {
             if let Err(error) = validate_commit_id(&request.commit_id) {
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request = map_commit_request(namespace_id, basis, request, None, context);
-            let request_fingerprint = match request.request_fingerprint_sha256() {
+            let source_api_checksum = match source_api_commit_checksum_sha256(&request) {
+                Ok(value) => Some(value),
+                Err(error) => {
+                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
+                    return None;
+                }
+            };
+            let request = match commit_request_from_v0_with_semantic_fingerprint(
+                conversion_context,
+                request,
+                None,
+            ) {
                 Ok(value) => value,
-                Err(err) => {
-                    outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
+                Err(error) => {
+                    outcomes[index] = Some(Err(error.into()));
+                    return None;
+                }
+            };
+            let semantic_fingerprint = match semantic_commit_fingerprint_sha256(&request) {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
                     return None;
                 }
             };
@@ -475,28 +501,35 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 aliases,
                 index,
                 &request.commit_id,
-                &request_fingerprint,
+                &semantic_fingerprint,
             ) {
                 return None;
             }
-            Some(request)
+            Some(CandidateCoreRequest {
+                request,
+                source_api_commit_checksum_sha256: source_api_checksum,
+            })
         }
         NamespaceMutationCandidate::Planned(planned) => {
             if let Err(error) = validate_commit_id(&planned.commit_request.commit_id) {
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request = map_commit_request(
-                namespace_id,
-                basis,
+            let request = match commit_request_from_v0_with_semantic_fingerprint(
+                conversion_context,
                 planned.commit_request,
-                planned.request_fingerprint_sha256,
-                context,
-            );
-            let request_fingerprint = match request.request_fingerprint_sha256() {
+                planned.semantic_commit_fingerprint_sha256,
+            ) {
                 Ok(value) => value,
-                Err(err) => {
-                    outcomes[index] = Some(Err(CoreError::Store(err.to_string())));
+                Err(error) => {
+                    outcomes[index] = Some(Err(error.into()));
+                    return None;
+                }
+            };
+            let semantic_fingerprint = match semantic_commit_fingerprint_sha256(&request) {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
                     return None;
                 }
             };
@@ -508,18 +541,22 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 aliases,
                 index,
                 &request.commit_id,
-                &request_fingerprint,
+                &semantic_fingerprint,
             ) {
                 return None;
             }
-            Some(request)
+            Some(CandidateCoreRequest {
+                request,
+                source_api_commit_checksum_sha256: None,
+            })
         }
         NamespaceMutationCandidate::Path(intent) => {
             if let Err(error) = validate_commit_id(intent.commit_id()) {
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request_fingerprint = match intent.request_fingerprint_sha256(namespace_id) {
+            let semantic_fingerprint = match intent.semantic_commit_fingerprint_sha256(namespace_id)
+            {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error));
@@ -535,7 +572,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 aliases,
                 index,
                 &commit_id,
-                &request_fingerprint,
+                &semantic_fingerprint,
             ) {
                 return None;
             }
@@ -553,13 +590,21 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                     return None;
                 }
             };
-            Some(map_commit_request(
-                namespace_id,
-                basis,
+            let request = match commit_request_from_v0_with_semantic_fingerprint(
+                conversion_context,
                 planned.commit_request,
-                Some(planned.request_fingerprint_sha256),
-                context,
-            ))
+                Some(planned.semantic_commit_fingerprint_sha256),
+            ) {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(error.into()));
+                    return None;
+                }
+            };
+            Some(CandidateCoreRequest {
+                request,
+                source_api_commit_checksum_sha256: None,
+            })
         }
     }
 }
@@ -579,11 +624,11 @@ fn record_primary_request_or_complete_idempotent(
     aliases: &mut Vec<(usize, usize)>,
     index: usize,
     commit_id: &CommitId,
-    request_fingerprint: &str,
+    semantic_commit_fingerprint: &str,
 ) -> bool {
     if let Some(existing) = find_commit_receipt(visible_metadata_state, commit_id) {
         outcomes[index] = Some(
-            if existing.request_fingerprint_sha256 != request_fingerprint {
+            if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint {
                 Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
             } else {
                 Ok(commit_response_from_commit_receipt(namespace_id, existing))
@@ -592,7 +637,7 @@ fn record_primary_request_or_complete_idempotent(
         return false;
     }
     if let Some(existing) = in_batch_requests.get(commit_id) {
-        if existing.request_fingerprint_sha256 != request_fingerprint {
+        if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint {
             outcomes[index] = Some(Err(CoreError::CommitIdReuseConflict(commit_id.to_string())));
         } else {
             aliases.push((index, existing.primary_index));
@@ -603,7 +648,7 @@ fn record_primary_request_or_complete_idempotent(
         commit_id.clone(),
         InBatchRequest {
             primary_index: index,
-            request_fingerprint_sha256: request_fingerprint.to_owned(),
+            semantic_commit_fingerprint_sha256: semantic_commit_fingerprint.to_owned(),
         },
     );
     true
@@ -730,104 +775,6 @@ fn derive_commit_results(
             }
         })
         .collect()
-}
-
-fn map_commit_request(
-    namespace_id: &NamespaceId,
-    basis: &crate::VerifiedNamespaceBasis,
-    request: ApiCommitRequest,
-    request_fingerprint_sha256: Option<String>,
-    context: &MutationContext,
-) -> CoreCommitRequest {
-    CoreCommitRequest {
-        namespace_id: namespace_id.clone(),
-        commit_id: request.commit_id,
-        writer_id: context.writer_id.clone(),
-        writer_fence_token: basis.head.active_fence_token,
-        planned_head_seq: request.planned_head_seq,
-        request_fingerprint_sha256,
-        ops: request.ops.into_iter().map(map_commit_op).collect(),
-        preconditions: request
-            .preconditions
-            .into_iter()
-            .map(map_commit_precondition)
-            .collect(),
-        message: request.message,
-        annotations: request.annotations,
-    }
-}
-
-fn map_commit_op(op: ApiCommitOp) -> CommitOp {
-    match op {
-        ApiCommitOp::CreateDir {
-            parent_inode,
-            display_name,
-        } => CommitOp::CreateDir {
-            parent_inode,
-            display_name,
-        },
-        ApiCommitOp::CreateFile {
-            parent_inode,
-            display_name,
-            content_ref,
-        } => CommitOp::CreateFile {
-            parent_inode,
-            display_name,
-            content_ref,
-        },
-        ApiCommitOp::ReplaceFile {
-            inode_id,
-            base_revision_no,
-            content_ref,
-        } => CommitOp::ReplaceFile {
-            inode_id,
-            base_revision: base_revision_no,
-            content_ref,
-        },
-        ApiCommitOp::RestoreRevision {
-            inode_id,
-            source_revision_no,
-            base_revision_no,
-        } => CommitOp::RestoreRevision {
-            inode_id,
-            source_revision: source_revision_no,
-            base_revision: base_revision_no,
-        },
-        ApiCommitOp::DeleteFile { inode_id } => CommitOp::DeleteFile { inode_id },
-        ApiCommitOp::Rename {
-            inode_id,
-            new_parent_inode,
-            new_display_name,
-        } => CommitOp::Rename {
-            inode_id,
-            new_parent_inode,
-            new_display_name,
-        },
-        ApiCommitOp::DeleteSubtree { root_inode } => CommitOp::DeleteSubtree { root_inode },
-    }
-}
-
-fn map_commit_precondition(precondition: ApiCommitPrecondition) -> Precondition {
-    match precondition {
-        ApiCommitPrecondition::HeadSeqIs { expected_seq } => Precondition::HeadSeqIs(expected_seq),
-        ApiCommitPrecondition::InodeRevisionIs {
-            inode_id,
-            revision_no,
-        } => Precondition::InodeRevisionIs {
-            inode_id,
-            revision: revision_no,
-        },
-        ApiCommitPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
-            Precondition::AncestorsNotSubtreeDeleted { inode_id }
-        }
-        ApiCommitPrecondition::ChildNameAbsent {
-            parent_inode,
-            name_key,
-        } => Precondition::ChildNameAbsent {
-            parent_inode,
-            name_key,
-        },
-    }
 }
 
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -1,3 +1,4 @@
+use crate::commit::SemanticCommitFingerprint;
 use crate::context::MutationContext;
 use crate::error::{CoreError, CoreErrorKind};
 use crate::services::PutFileBehavior;
@@ -42,10 +43,10 @@ impl PathMutationIntent {
         }
     }
 
-    pub fn semantic_commit_fingerprint_sha256(
+    pub fn semantic_commit_fingerprint(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<String, CoreError> {
+    ) -> Result<SemanticCommitFingerprint, CoreError> {
         crate::services::semantic_commit_fingerprint_for_path_intent(namespace_id, self)
     }
 }
@@ -53,14 +54,14 @@ impl PathMutationIntent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedPathMutation {
     pub commit_id: CommitId,
-    pub semantic_commit_fingerprint_sha256: String,
+    pub semantic_commit_fingerprint: SemanticCommitFingerprint,
     pub commit_request: ApiCommitRequest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedNamespaceMutation {
     pub commit_request: ApiCommitRequest,
-    pub semantic_commit_fingerprint_sha256: Option<String>,
+    pub semantic_commit_fingerprint: Option<SemanticCommitFingerprint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -42,25 +42,25 @@ impl PathMutationIntent {
         }
     }
 
-    pub fn request_fingerprint_sha256(
+    pub fn semantic_commit_fingerprint_sha256(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<String, CoreError> {
-        crate::services::request_fingerprint_for_path_intent(namespace_id, self)
+        crate::services::semantic_commit_fingerprint_for_path_intent(namespace_id, self)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedPathMutation {
     pub commit_id: CommitId,
-    pub request_fingerprint_sha256: String,
+    pub semantic_commit_fingerprint_sha256: String,
     pub commit_request: ApiCommitRequest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedNamespaceMutation {
     pub commit_request: ApiCommitRequest,
-    pub request_fingerprint_sha256: Option<String>,
+    pub semantic_commit_fingerprint_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -59,15 +59,8 @@ pub struct PlannedPathMutation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlannedNamespaceMutation {
-    pub commit_request: ApiCommitRequest,
-    pub semantic_commit_fingerprint: Option<SemanticCommitFingerprint>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NamespaceMutationCandidate {
     Commit(ApiCommitRequest),
-    Planned(PlannedNamespaceMutation),
     Path(PathMutationIntent),
 }
 

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -3,6 +3,7 @@ use crate::checkpoint::{
     create_checkpoint, load_verified_checkpoint_materialization,
     write_verified_checkpoint_from_metadata, CheckpointMetadataWriteRequest,
 };
+use crate::commit::SemanticCommitFingerprint;
 use crate::content::{
     read_durable_content_bytes, validate_durable_content_reference, write_immutable_object,
 };
@@ -551,16 +552,18 @@ fn normalized_commit_id(commit_id: Option<&str>) -> Result<CommitId, CoreError> 
     Ok(commit_id)
 }
 
-fn semantic_commit_fingerprint_sha256(
+fn path_semantic_commit_fingerprint(
     identity: &PathFingerprintInput,
-) -> Result<String, CoreError> {
-    payload_checksum_sha256(identity).map_err(|err| CoreError::Store(err.to_string()))
+) -> Result<SemanticCommitFingerprint, CoreError> {
+    payload_checksum_sha256(identity)
+        .map(SemanticCommitFingerprint::new_unchecked)
+        .map_err(|err| CoreError::Store(err.to_string()))
 }
 
 pub(crate) fn semantic_commit_fingerprint_for_path_intent(
     namespace_id: &NamespaceId,
     intent: &PathMutationIntent,
-) -> Result<String, CoreError> {
+) -> Result<SemanticCommitFingerprint, CoreError> {
     let identity = match intent {
         PathMutationIntent::PutFile {
             absolute_path,
@@ -597,7 +600,7 @@ pub(crate) fn semantic_commit_fingerprint_for_path_intent(
             to_path: to_path.clone(),
         },
     };
-    semantic_commit_fingerprint_sha256(&identity)
+    path_semantic_commit_fingerprint(&identity)
 }
 
 pub fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -724,7 +727,7 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
     };
     Ok(PlannedPathMutation {
         commit_id,
-        semantic_commit_fingerprint_sha256: semantic_fingerprint,
+        semantic_commit_fingerprint: semantic_fingerprint,
         commit_request,
     })
 }

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -551,11 +551,13 @@ fn normalized_commit_id(commit_id: Option<&str>) -> Result<CommitId, CoreError> 
     Ok(commit_id)
 }
 
-fn request_fingerprint_sha256(identity: &PathFingerprintInput) -> Result<String, CoreError> {
+fn semantic_commit_fingerprint_sha256(
+    identity: &PathFingerprintInput,
+) -> Result<String, CoreError> {
     payload_checksum_sha256(identity).map_err(|err| CoreError::Store(err.to_string()))
 }
 
-pub(crate) fn request_fingerprint_for_path_intent(
+pub(crate) fn semantic_commit_fingerprint_for_path_intent(
     namespace_id: &NamespaceId,
     intent: &PathMutationIntent,
 ) -> Result<String, CoreError> {
@@ -595,7 +597,7 @@ pub(crate) fn request_fingerprint_for_path_intent(
             to_path: to_path.clone(),
         },
     };
-    request_fingerprint_sha256(&identity)
+    semantic_commit_fingerprint_sha256(&identity)
 }
 
 pub fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -688,7 +690,7 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
 ) -> Result<PlannedPathMutation, CoreError> {
     let commit_id = intent.commit_id().clone();
-    let request_fingerprint = request_fingerprint_for_path_intent(namespace_id, intent)?;
+    let semantic_fingerprint = semantic_commit_fingerprint_for_path_intent(namespace_id, intent)?;
     let view = PathPlanningView {
         head,
         metadata_state,
@@ -722,7 +724,7 @@ pub(crate) fn plan_path_mutation_against_state<S: ObjectStore + ?Sized>(
     };
     Ok(PlannedPathMutation {
         commit_id,
-        request_fingerprint_sha256: request_fingerprint,
+        semantic_commit_fingerprint_sha256: semantic_fingerprint,
         commit_request,
     })
 }

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -432,7 +432,7 @@ mod tests {
             metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
             checked_invariants: Vec::new(),
         };
-        let prepared = PreparedCommit::new(request, plan, None).expect("prepare commit");
+        let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
         let record = MaterializedCommit {
             prepared,
             results: vec![CommitOpResult::CreateDir {

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -1,20 +1,12 @@
-use crate::commit::{CommitOp, CommitPlan, CommitRequest, Precondition};
+use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
 use crate::metadata::{MetadataApplyError, MetadataState};
 use loon_api::{
     decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, generate_wal_segment_id,
-    v0::CommitOpResult, validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId,
-    WalCommitPayload, WalOp, WalPrecondition, WalSegmentEnvelope, WalSegmentPayload,
-    WalSegmentPointer,
+    validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitPayload, WalOp,
+    WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
 };
 use loon_objectstore::keys::wal_segment;
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedWalRecord {
-    pub request: CommitRequest,
-    pub plan: CommitPlan,
-    pub results: Vec<CommitOpResult>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedWalSegment {
@@ -107,7 +99,7 @@ pub enum WalReplayError {
 pub fn prepare_wal_segment(
     namespace_id: NamespaceId,
     prev_visible_segment: Option<WalSegmentPointer>,
-    records: &[PreparedWalRecord],
+    records: &[MaterializedCommit],
     writer_version: &str,
 ) -> Result<PreparedWalSegment, WalBuildError> {
     if writer_version.trim().is_empty() {
@@ -119,7 +111,13 @@ pub fn prepare_wal_segment(
 
     let mut payload_records: Vec<WalCommitPayload> = Vec::with_capacity(records.len());
     for record in records {
-        let payload_record = build_wal_record_payload(&namespace_id, record)?;
+        let payload_record = wal_payload_from_materialized_commit(record)?;
+        if payload_record.namespace_id != namespace_id {
+            return Err(WalBuildError::NamespaceMismatch {
+                request: payload_record.namespace_id.clone(),
+                plan: namespace_id.clone(),
+            });
+        }
         if let Some(previous) = payload_records.last() {
             let expected = previous
                 .seq
@@ -182,50 +180,6 @@ pub fn prepare_wal_segment(
             "wal_key_matches_segment_seq_range".to_owned(),
             "head_publish_requires_durable_wal".to_owned(),
         ],
-    })
-}
-
-pub(crate) fn build_wal_record_payload(
-    namespace_id: &NamespaceId,
-    record: &PreparedWalRecord,
-) -> Result<WalCommitPayload, WalBuildError> {
-    if !record.plan.wal_object_must_be_written {
-        return Err(WalBuildError::WalWriteNotRequired);
-    }
-    if record.request.namespace_id != record.plan.namespace_id {
-        return Err(WalBuildError::NamespaceMismatch {
-            request: record.request.namespace_id.clone(),
-            plan: record.plan.namespace_id.clone(),
-        });
-    }
-    if record.plan.namespace_id != *namespace_id {
-        return Err(WalBuildError::NamespaceMismatch {
-            request: record.plan.namespace_id.clone(),
-            plan: namespace_id.clone(),
-        });
-    }
-
-    Ok(WalCommitPayload {
-        namespace_id: record.plan.namespace_id.clone(),
-        seq: record.plan.next_seq,
-        base_head_seq: record.plan.base_head_seq,
-        commit_id: record.plan.commit_id.clone(),
-        request_fingerprint_sha256: record
-            .request
-            .request_fingerprint_sha256()
-            .map_err(|err| WalBuildError::Codec(err.to_string()))?,
-        writer_id: record.request.writer_id.clone(),
-        writer_fence_token: record.request.writer_fence_token,
-        message: record.request.message.clone(),
-        annotations: record.request.annotations.clone(),
-        ops: build_wal_ops(&record.request, &record.plan)?,
-        preconditions: record
-            .request
-            .preconditions
-            .iter()
-            .map(WalPrecondition::from)
-            .collect(),
-        results: record.results.clone(),
     })
 }
 
@@ -326,112 +280,6 @@ impl From<&PreparedWalSegment> for StoredWalObject {
             encoded_bytes: value.encoded_bytes.clone(),
         }
     }
-}
-
-fn build_wal_ops(request: &CommitRequest, plan: &CommitPlan) -> Result<Vec<WalOp>, WalBuildError> {
-    let request_create_ops = request
-        .ops
-        .iter()
-        .filter(|op| matches!(op, CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. }))
-        .count();
-    if request_create_ops != plan.allocated_inode_ids.len() {
-        return Err(WalBuildError::AllocatedInodeCountMismatch {
-            request_create_ops,
-            plan_allocated_count: plan.allocated_inode_ids.len(),
-        });
-    }
-
-    let mut allocated_inode_ids = plan.allocated_inode_ids.iter().copied();
-    let mut wal_ops = Vec::with_capacity(request.ops.len());
-
-    for (op_index, op) in request.ops.iter().enumerate() {
-        let op_index = u32::try_from(op_index)
-            .map_err(|_| WalBuildError::Codec("op index overflow".to_owned()))?;
-        let resolved_restore_content_ref = plan
-            .resolved_restore_content_refs
-            .get(op_index as usize)
-            .and_then(|content_ref| content_ref.as_ref());
-        let wal_op = match op {
-            CommitOp::CreateDir {
-                parent_inode,
-                display_name,
-            } => WalOp::CreateDir {
-                op_index,
-                inode_id: allocated_inode_ids.next().ok_or(
-                    WalBuildError::AllocatedInodeCountMismatch {
-                        request_create_ops,
-                        plan_allocated_count: plan.allocated_inode_ids.len(),
-                    },
-                )?,
-                parent_inode: *parent_inode,
-                display_name: display_name.clone(),
-            },
-            CommitOp::CreateFile {
-                parent_inode,
-                display_name,
-                content_ref,
-            } => WalOp::CreateFile {
-                op_index,
-                inode_id: allocated_inode_ids.next().ok_or(
-                    WalBuildError::AllocatedInodeCountMismatch {
-                        request_create_ops,
-                        plan_allocated_count: plan.allocated_inode_ids.len(),
-                    },
-                )?,
-                parent_inode: *parent_inode,
-                display_name: display_name.clone(),
-                content_ref: content_ref.clone(),
-            },
-            CommitOp::ReplaceFile {
-                inode_id,
-                base_revision,
-                content_ref,
-            } => WalOp::ReplaceFile {
-                op_index,
-                inode_id: *inode_id,
-                base_revision: *base_revision,
-                content_ref: content_ref.clone(),
-            },
-            CommitOp::RestoreRevision {
-                inode_id,
-                source_revision,
-                base_revision,
-            } => WalOp::RestoreRevision {
-                op_index,
-                inode_id: *inode_id,
-                source_revision_no: *source_revision,
-                base_revision: *base_revision,
-                content_ref: resolved_restore_content_ref
-                    .ok_or_else(|| {
-                        WalBuildError::Codec(format!(
-                            "missing resolved restore content ref for op index {op_index}"
-                        ))
-                    })?
-                    .clone(),
-            },
-            CommitOp::DeleteFile { inode_id } => WalOp::DeleteFile {
-                op_index,
-                inode_id: *inode_id,
-            },
-            CommitOp::Rename {
-                inode_id,
-                new_parent_inode,
-                new_display_name,
-            } => WalOp::Rename {
-                op_index,
-                inode_id: *inode_id,
-                new_parent_inode: *new_parent_inode,
-                new_display_name: new_display_name.clone(),
-            },
-            CommitOp::DeleteSubtree { root_inode } => WalOp::DeleteSubtree {
-                op_index,
-                root_inode: *root_inode,
-            },
-        };
-        wal_ops.push(wal_op);
-    }
-
-    Ok(wal_ops)
 }
 
 fn decode_and_validate_replayed_wal(
@@ -546,78 +394,61 @@ fn push_invariant(checked_invariants: &mut Vec<String>, invariant: &str) {
     }
 }
 
-impl From<&Precondition> for WalPrecondition {
-    fn from(value: &Precondition) -> Self {
-        match value {
-            Precondition::HeadSeqIs(seq) => Self::HeadSeqIs(*seq),
-            Precondition::InodeRevisionIs { inode_id, revision } => Self::InodeRevisionIs {
-                inode_id: *inode_id,
-                revision: *revision,
-            },
-            Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
-                Self::AncestorsNotSubtreeDeleted {
-                    inode_id: *inode_id,
-                }
-            }
-            Precondition::ChildNameAbsent {
-                parent_inode,
-                name_key,
-            } => Self::ChildNameAbsent {
-                parent_inode: *parent_inode,
-                name_key: name_key.clone(),
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commit::{CommitOp, CommitPlan, CommitRequest, Precondition, PreparedCommit};
     use loon_api::{v0::CommitOpResult, CommitId, FenceToken};
 
     #[test]
     fn build_wal_record_payload_matches_segment_record_payload() {
         let namespace_id = NamespaceId::from("demo");
-        let record = PreparedWalRecord {
-            request: CommitRequest {
-                namespace_id: namespace_id.clone(),
-                commit_id: CommitId::from("c_wal_payload"),
-                writer_id: "writer-a".to_owned(),
-                writer_fence_token: FenceToken(1),
-                planned_head_seq: ChangeSeq(0),
-                request_fingerprint_sha256: None,
-                ops: vec![CommitOp::CreateDir {
-                    parent_inode: InodeId(1),
-                    display_name: "docs".to_owned(),
-                }],
-                preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
-                message: Some("create docs".to_owned()),
-                annotations: None,
-            },
-            plan: CommitPlan {
-                namespace_id: namespace_id.clone(),
-                commit_id: CommitId::from("c_wal_payload"),
-                base_head_seq: ChangeSeq(0),
-                next_seq: ChangeSeq(1),
-                allocated_inode_ids: vec![InodeId(2)],
-                resolved_restore_content_refs: vec![None],
-                resulting_next_inode_id: InodeId(3),
-                durable_content_required: false,
-                wal_object_must_be_written: true,
-                head_cas_must_succeed: true,
-                metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
-                checked_invariants: Vec::new(),
-            },
+        let request = CommitRequest {
+            namespace_id: namespace_id.clone(),
+            commit_id: CommitId::from("c_wal_payload"),
+            writer_id: "writer-a".to_owned(),
+            writer_fence_token: FenceToken(1),
+            planned_head_seq: ChangeSeq(0),
+            semantic_commit_fingerprint_sha256: None,
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            message: Some("create docs".to_owned()),
+            annotations: None,
+        };
+        let plan = CommitPlan {
+            namespace_id: namespace_id.clone(),
+            commit_id: CommitId::from("c_wal_payload"),
+            base_head_seq: ChangeSeq(0),
+            next_seq: ChangeSeq(1),
+            allocated_inode_ids: vec![InodeId(2)],
+            resolved_restore_content_refs: vec![None],
+            resulting_next_inode_id: InodeId(3),
+            durable_content_required: false,
+            wal_object_must_be_written: true,
+            head_cas_must_succeed: true,
+            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            checked_invariants: Vec::new(),
+        };
+        let prepared = PreparedCommit::new(request, plan, None).expect("prepare commit");
+        let record = MaterializedCommit {
+            prepared,
             results: vec![CommitOpResult::CreateDir {
                 op_index: 0,
                 inode_id: InodeId(2),
             }],
         };
 
-        let payload =
-            build_wal_record_payload(&namespace_id, &record).expect("build commit payload");
-        let segment = prepare_wal_segment(namespace_id, None, &[record], "test-writer")
-            .expect("prepare wal segment");
+        let segment = prepare_wal_segment(
+            namespace_id,
+            None,
+            std::slice::from_ref(&record),
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        let payload = wal_payload_from_materialized_commit(&record).expect("build commit payload");
 
         assert_eq!(payload, segment.envelope.payload.records[0]);
     }

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -20,7 +20,6 @@ pub struct PreparedWalSegment {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WalBuildError {
     EmptyWriterVersion,
-    WalWriteNotRequired,
     EmptySegment,
     NamespaceMismatch {
         request: NamespaceId,
@@ -29,10 +28,6 @@ pub enum WalBuildError {
     BaseHeadSeqMismatch {
         request: ChangeSeq,
         plan: ChangeSeq,
-    },
-    AllocatedInodeCountMismatch {
-        request_create_ops: usize,
-        plan_allocated_count: usize,
     },
     NonContiguousSeq {
         expected: ChangeSeq,
@@ -397,8 +392,10 @@ fn push_invariant(checked_invariants: &mut Vec<String>, invariant: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{CommitOp, CommitPlan, CommitRequest, Precondition, PreparedCommit};
-    use loon_api::{v0::CommitOpResult, CommitId, FenceToken};
+    use crate::commit::{
+        materialize_commit, CommitOp, CommitPlan, CommitRequest, Precondition, PreparedCommit,
+    };
+    use loon_api::{CommitId, FenceToken};
 
     #[test]
     fn build_wal_record_payload_matches_segment_record_payload() {
@@ -409,7 +406,6 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(0),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
@@ -426,20 +422,11 @@ mod tests {
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            durable_content_required: false,
-            wal_object_must_be_written: true,
-            head_cas_must_succeed: true,
             metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
-        let record = MaterializedCommit {
-            prepared,
-            results: vec![CommitOpResult::CreateDir {
-                op_index: 0,
-                inode_id: InodeId(2),
-            }],
-        };
+        let record = materialize_commit(prepared).expect("materialize commit");
 
         let segment = prepare_wal_segment(
             namespace_id,

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -976,6 +976,44 @@ fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
 }
 
 #[test]
+fn visible_commit_id_retry_aliases_across_writer_takeover() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let writer_a = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &writer_a, false).expect("bootstrap");
+
+    let request = ApiCommitRequest {
+        commit_id: CommitId::from("retry-across-writer"),
+        planned_head_seq: ChangeSeq(0),
+        preconditions: Vec::new(),
+        ops: vec![ApiCommitOp::CreateDir {
+            parent_inode: InodeId(1),
+            display_name: "alpha".to_owned(),
+        }],
+        message: None,
+        annotations: None,
+    };
+
+    let first = commit_operations(&store, &namespace_id, request.clone(), &writer_a)
+        .expect("writer a commit");
+    let writer_b = MutationContext {
+        writer_id: "writer-b".to_owned(),
+        writer_version: "writer-b/0.1.0".to_owned(),
+        now_ms: writer_a
+            .now_ms
+            .saturating_add(writer_a.lease_duration_ms)
+            .saturating_add(1),
+        lease_duration_ms: writer_a.lease_duration_ms,
+    };
+
+    let retry =
+        commit_operations(&store, &namespace_id, request, &writer_b).expect("writer b retry");
+
+    assert_eq!(first, retry);
+}
+
+#[test]
 fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -56,7 +56,7 @@ fn stale_head_precondition_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(2),
-        request_fingerprint_sha256: None,
+        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::DeleteFile {
             inode_id: InodeId(3),
         }],
@@ -105,7 +105,7 @@ fn stale_revision_precondition_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(3),
-        request_fingerprint_sha256: None,
+        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::ReplaceFile {
             inode_id: InodeId(3),
             base_revision: RevisionNo(1),
@@ -157,7 +157,7 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(2),
                 display_name: "new.txt".to_owned(),
@@ -185,7 +185,7 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::ReplaceFile {
                 inode_id: InodeId(3),
                 base_revision: RevisionNo(1),
@@ -222,7 +222,7 @@ fn restore_revision_validation_rejects_missing_inode() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        request_fingerprint_sha256: None,
+        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(99),
             source_revision: RevisionNo(1),
@@ -257,7 +257,7 @@ fn restore_revision_validation_rejects_non_file_target() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        request_fingerprint_sha256: None,
+        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(1),
@@ -310,7 +310,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -339,7 +339,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(99),
@@ -387,7 +387,7 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(2),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::ReplaceFile {
                     inode_id: InodeId(3),
@@ -445,7 +445,7 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
@@ -504,7 +504,7 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            request_fingerprint_sha256: None,
+            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -566,7 +566,7 @@ fn restore_revision_overflow_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        request_fingerprint_sha256: None,
+        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(u64::MAX),

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -56,7 +56,6 @@ fn stale_head_precondition_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(2),
-        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::DeleteFile {
             inode_id: InodeId(3),
         }],
@@ -105,7 +104,6 @@ fn stale_revision_precondition_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(3),
-        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::ReplaceFile {
             inode_id: InodeId(3),
             base_revision: RevisionNo(1),
@@ -157,7 +155,6 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(2),
                 display_name: "new.txt".to_owned(),
@@ -185,7 +182,6 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::ReplaceFile {
                 inode_id: InodeId(3),
                 base_revision: RevisionNo(1),
@@ -222,7 +218,6 @@ fn restore_revision_validation_rejects_missing_inode() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(99),
             source_revision: RevisionNo(1),
@@ -257,7 +252,6 @@ fn restore_revision_validation_rejects_non_file_target() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(1),
@@ -310,7 +304,6 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -339,7 +332,6 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(99),
@@ -387,7 +379,6 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(2),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::ReplaceFile {
                     inode_id: InodeId(3),
@@ -445,7 +436,6 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
@@ -504,7 +494,6 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             planned_head_seq: ChangeSeq(3),
-            semantic_commit_fingerprint_sha256: None,
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
@@ -566,7 +555,6 @@ fn restore_revision_overflow_is_rejected() {
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         planned_head_seq: ChangeSeq(1),
-        semantic_commit_fingerprint_sha256: None,
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(u64::MAX),

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,10 +1,10 @@
 use crate::config::ServerConfig;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{CommitId, FenceToken, NamespaceId};
+use loon_api::{CommitId, NamespaceId};
 use loon_core::{
     commit::{
-        commit_request_from_v0, commit_request_from_v0_with_semantic_fingerprint,
-        semantic_commit_fingerprint_sha256, CommitExecutionContext, CommitHeadPublishError,
+        semantic_commit_fingerprint_for_v0_request, CommitHeadPublishError,
+        SemanticCommitFingerprint,
     },
     publish_namespace_mutations_batch, CoreError, MutationContext, NamespaceMutationCandidate,
     PathMutationIntent, PlannedNamespaceMutation,
@@ -110,7 +110,7 @@ struct BatchCandidate {
 }
 
 struct InFlightRequest {
-    fingerprint: String,
+    fingerprint: SemanticCommitFingerprint,
     waiters: Vec<oneshot::Sender<CommitResult>>,
 }
 
@@ -131,11 +131,7 @@ impl NamespacePublisher {
 
     async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
         let commit_id = candidate_commit_id(&candidate).clone();
-        let fingerprint = candidate_semantic_commit_fingerprint(
-            &self.namespace_id,
-            &self.config.writer_id,
-            &candidate,
-        )?;
+        let fingerprint = candidate_semantic_commit_fingerprint(&self.namespace_id, &candidate)?;
         let (sender, receiver) = oneshot::channel();
         self.admit(commit_id, candidate, fingerprint, sender)?;
         receiver
@@ -147,7 +143,7 @@ impl NamespacePublisher {
         &self,
         commit_id: CommitId,
         candidate: NamespaceMutationCandidate,
-        fingerprint: String,
+        fingerprint: SemanticCommitFingerprint,
         waiter: oneshot::Sender<CommitResult>,
     ) -> Result<(), CoreError> {
         let mut should_spawn = false;
@@ -372,44 +368,24 @@ fn candidate_commit_id(candidate: &NamespaceMutationCandidate) -> &CommitId {
 
 fn candidate_semantic_commit_fingerprint(
     namespace_id: &NamespaceId,
-    writer_id: &str,
     candidate: &NamespaceMutationCandidate,
-) -> Result<String, CoreError> {
+) -> Result<SemanticCommitFingerprint, CoreError> {
     match candidate {
         NamespaceMutationCandidate::Commit(request) => {
-            let request = commit_request_from_v0(
-                CommitExecutionContext {
-                    namespace_id: namespace_id.clone(),
-                    writer_id: writer_id.to_owned(),
-                    writer_fence_token: FenceToken(0),
-                },
-                request.clone(),
-            )?;
-            semantic_commit_fingerprint_sha256(&request)
+            semantic_commit_fingerprint_for_v0_request(namespace_id, request)
                 .map_err(|err| CoreError::Store(err.to_string()))
         }
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            semantic_commit_fingerprint_sha256: Some(source),
+            semantic_commit_fingerprint: Some(source),
             ..
         }) => Ok(source.clone()),
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
             commit_request,
-            semantic_commit_fingerprint_sha256: None,
-        }) => {
-            let request = commit_request_from_v0_with_semantic_fingerprint(
-                CommitExecutionContext {
-                    namespace_id: namespace_id.clone(),
-                    writer_id: writer_id.to_owned(),
-                    writer_fence_token: FenceToken(0),
-                },
-                commit_request.clone(),
-                None,
-            )?;
-            semantic_commit_fingerprint_sha256(&request)
-                .map_err(|err| CoreError::Store(err.to_string()))
-        }
+            semantic_commit_fingerprint: None,
+        }) => semantic_commit_fingerprint_for_v0_request(namespace_id, commit_request)
+            .map_err(|err| CoreError::Store(err.to_string())),
         NamespaceMutationCandidate::Path(intent) => {
-            intent.semantic_commit_fingerprint_sha256(namespace_id)
+            intent.semantic_commit_fingerprint(namespace_id)
         }
     }
 }
@@ -596,11 +572,7 @@ mod tests {
     ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
         let commit_id = request.commit_id.clone();
         let candidate = NamespaceMutationCandidate::Commit(request);
-        let fingerprint = candidate_semantic_commit_fingerprint(
-            namespace_id,
-            &publisher.config.writer_id,
-            &candidate,
-        )?;
+        let fingerprint = candidate_semantic_commit_fingerprint(namespace_id, &candidate)?;
         let (sender, receiver) = oneshot::channel();
         publisher.admit(commit_id, candidate, fingerprint, sender)?;
         Ok(receiver)

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,12 +1,15 @@
 use crate::config::ServerConfig;
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{payload_checksum_sha256, CommitId, NamespaceId};
+use loon_api::{CommitId, FenceToken, NamespaceId};
 use loon_core::{
-    commit::CommitHeadPublishError, publish_namespace_mutations_batch, CoreError, MutationContext,
-    NamespaceMutationCandidate, PathMutationIntent, PlannedNamespaceMutation,
+    commit::{
+        commit_request_from_v0, commit_request_from_v0_with_semantic_fingerprint,
+        semantic_commit_fingerprint_sha256, CommitExecutionContext, CommitHeadPublishError,
+    },
+    publish_namespace_mutations_batch, CoreError, MutationContext, NamespaceMutationCandidate,
+    PathMutationIntent, PlannedNamespaceMutation,
 };
 use loon_objectstore::ObjectStore;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -128,7 +131,11 @@ impl NamespacePublisher {
 
     async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
         let commit_id = candidate_commit_id(&candidate).clone();
-        let fingerprint = candidate_fingerprint(&self.namespace_id, &candidate)?;
+        let fingerprint = candidate_semantic_commit_fingerprint(
+            &self.namespace_id,
+            &self.config.writer_id,
+            &candidate,
+        )?;
         let (sender, receiver) = oneshot::channel();
         self.admit(commit_id, candidate, fingerprint, sender)?;
         receiver
@@ -363,48 +370,48 @@ fn candidate_commit_id(candidate: &NamespaceMutationCandidate) -> &CommitId {
     }
 }
 
-fn candidate_fingerprint(
+fn candidate_semantic_commit_fingerprint(
     namespace_id: &NamespaceId,
+    writer_id: &str,
     candidate: &NamespaceMutationCandidate,
 ) -> Result<String, CoreError> {
     match candidate {
-        NamespaceMutationCandidate::Commit(request) => request_fingerprint(namespace_id, request)
-            .map_err(|err| CoreError::Store(err.to_string())),
+        NamespaceMutationCandidate::Commit(request) => {
+            let request = commit_request_from_v0(
+                CommitExecutionContext {
+                    namespace_id: namespace_id.clone(),
+                    writer_id: writer_id.to_owned(),
+                    writer_fence_token: FenceToken(0),
+                },
+                request.clone(),
+            )?;
+            semantic_commit_fingerprint_sha256(&request)
+                .map_err(|err| CoreError::Store(err.to_string()))
+        }
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            request_fingerprint_sha256: Some(source),
+            semantic_commit_fingerprint_sha256: Some(source),
             ..
         }) => Ok(source.clone()),
         NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
             commit_request,
-            request_fingerprint_sha256: None,
-        }) => request_fingerprint(namespace_id, commit_request)
-            .map_err(|err| CoreError::Store(err.to_string())),
-        NamespaceMutationCandidate::Path(intent) => intent.request_fingerprint_sha256(namespace_id),
+            semantic_commit_fingerprint_sha256: None,
+        }) => {
+            let request = commit_request_from_v0_with_semantic_fingerprint(
+                CommitExecutionContext {
+                    namespace_id: namespace_id.clone(),
+                    writer_id: writer_id.to_owned(),
+                    writer_fence_token: FenceToken(0),
+                },
+                commit_request.clone(),
+                None,
+            )?;
+            semantic_commit_fingerprint_sha256(&request)
+                .map_err(|err| CoreError::Store(err.to_string()))
+        }
+        NamespaceMutationCandidate::Path(intent) => {
+            intent.semantic_commit_fingerprint_sha256(namespace_id)
+        }
     }
-}
-
-#[derive(Serialize)]
-struct CanonicalCommitRequest<'a> {
-    namespace_id: &'a NamespaceId,
-    planned_head_seq: loon_api::ChangeSeq,
-    preconditions: &'a [loon_api::v0::CommitPrecondition],
-    ops: &'a [loon_api::v0::CommitOp],
-    message: &'a Option<String>,
-    annotations: &'a Option<loon_api::v0::CommitAnnotations>,
-}
-
-fn request_fingerprint(
-    namespace_id: &NamespaceId,
-    request: &ApiCommitRequest,
-) -> Result<String, serde_json::Error> {
-    payload_checksum_sha256(&CanonicalCommitRequest {
-        namespace_id,
-        planned_head_seq: request.planned_head_seq,
-        preconditions: &request.preconditions,
-        ops: &request.ops,
-        message: &request.message,
-        annotations: &request.annotations,
-    })
 }
 
 fn mutation_context(config: &ServerConfig) -> MutationContext {
@@ -589,7 +596,11 @@ mod tests {
     ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
         let commit_id = request.commit_id.clone();
         let candidate = NamespaceMutationCandidate::Commit(request);
-        let fingerprint = candidate_fingerprint(namespace_id, &candidate)?;
+        let fingerprint = candidate_semantic_commit_fingerprint(
+            namespace_id,
+            &publisher.config.writer_id,
+            &candidate,
+        )?;
         let (sender, receiver) = oneshot::channel();
         publisher.admit(commit_id, candidate, fingerprint, sender)?;
         Ok(receiver)

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -7,7 +7,7 @@ use loon_core::{
         SemanticCommitFingerprint,
     },
     publish_namespace_mutations_batch, CoreError, MutationContext, NamespaceMutationCandidate,
-    PathMutationIntent, PlannedNamespaceMutation,
+    PathMutationIntent,
 };
 use loon_objectstore::ObjectStore;
 use std::collections::HashMap;
@@ -359,9 +359,6 @@ fn is_head_publish_stale(result: &CommitResult) -> bool {
 fn candidate_commit_id(candidate: &NamespaceMutationCandidate) -> &CommitId {
     match candidate {
         NamespaceMutationCandidate::Commit(request) => &request.commit_id,
-        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            commit_request, ..
-        }) => &commit_request.commit_id,
         NamespaceMutationCandidate::Path(intent) => intent.commit_id(),
     }
 }
@@ -375,15 +372,6 @@ fn candidate_semantic_commit_fingerprint(
             semantic_commit_fingerprint_for_v0_request(namespace_id, request)
                 .map_err(|err| CoreError::Store(err.to_string()))
         }
-        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            semantic_commit_fingerprint: Some(source),
-            ..
-        }) => Ok(source.clone()),
-        NamespaceMutationCandidate::Planned(PlannedNamespaceMutation {
-            commit_request,
-            semantic_commit_fingerprint: None,
-        }) => semantic_commit_fingerprint_for_v0_request(namespace_id, commit_request)
-            .map_err(|err| CoreError::Store(err.to_string())),
         NamespaceMutationCandidate::Path(intent) => {
             intent.semantic_commit_fingerprint(namespace_id)
         }

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -3,11 +3,11 @@ use loon_api::{
         CommitAnnotations, CommitOp, CommitOpResult, CommitPrecondition,
         CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
-    AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
-    InodeId, RevisionNo,
+    AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, ControlObjectKind,
+    CreateCheckpointResponse, InodeId, LeaseStateEnvelope, RevisionNo,
 };
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loon_objectstore::keys::snapshot_manifest;
+use loon_objectstore::keys::{namespace_lease, snapshot_manifest};
 use loon_objectstore::{ConfiguredObjectStore, ObjectStore};
 use loon_server::{app, ServerConfig, StoreConfig};
 use serde_json::json;
@@ -951,18 +951,20 @@ async fn two_servers_share_one_store_and_handoff_the_lease() {
         store_root.clone(),
         "loon-server-a",
         "two-server-smoke",
-        200,
+        60_000,
     ))
     .await;
     let server_b = start_server(test_config(
         store_root,
         "loon-server-b",
         "two-server-smoke",
-        200,
+        60_000,
     ))
     .await;
     let client_a = server_a.client.clone();
     let client_b = server_b.client.clone();
+    let store_root = server_a.store_root.clone();
+    let store_key_prefix = server_a.store_key_prefix.clone();
 
     tokio::task::spawn_blocking(move || {
         client_a.create_namespace("demo").expect("create namespace");
@@ -976,6 +978,7 @@ async fn two_servers_share_one_store_and_handoff_the_lease() {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "lease_conflict"),
             other => panic!("expected lease_conflict, got {other:?}"),
         }
+        force_expire_namespace_lease(&store_root, store_key_prefix.as_deref(), "demo");
 
         let committed_seq = retry_until_lease_handoff(&client_b, &host_a_target, &host_b_target);
         assert!(
@@ -1121,6 +1124,34 @@ fn retry_until_lease_handoff(client: &Client, from: &NamespacePath, to: &Namespa
     }
 
     panic!("timed out waiting for lease handoff");
+}
+
+fn force_expire_namespace_lease(
+    store_root: &std::path::Path,
+    key_prefix: Option<&str>,
+    namespace: &str,
+) {
+    let store =
+        ConfiguredObjectStore::local_fs(store_root, key_prefix).expect("construct test store");
+    let lease_key = namespace_lease(namespace);
+    let bytes = store
+        .get(&lease_key, None)
+        .expect("read namespace lease")
+        .expect("namespace lease exists");
+    let mut envelope: LeaseStateEnvelope =
+        serde_json::from_slice(&bytes).expect("decode namespace lease");
+    envelope.state.lease_expires_at_ms = 0;
+    let writer_version = envelope.writer_version;
+    let envelope = LeaseStateEnvelope::from_state(
+        ControlObjectKind::NamespaceLease,
+        writer_version,
+        envelope.state,
+    )
+    .expect("encode expired namespace lease");
+    let bytes = serde_json::to_vec(&envelope).expect("serialize expired namespace lease");
+    store
+        .put_overwrite(&lease_key, &bytes)
+        .expect("write expired namespace lease");
 }
 
 fn stage_uploaded_content_ref(client: &Client, namespace: &str, file_bytes: &[u8]) -> ContentRef {


### PR DESCRIPTION
This PR cleans up the commit flow in `loon-core` (previously had some confusing code flow).

Before this, `protocol.rs` and `wal.rs` were doing too much: mapping API commit requests into core requests, computing fingerprints, preparing commits, and building WAL payloads. This PR moves those pieces into small commit-specific adapters so the flow is easier to follow.

A few other helpers/unused functions were cleaned up as well.

The main split is now:
- `api_adapter.rs` maps v0 API commit requests into core commit requests
- `identity.rs` computes the semantic commit fingerprint (needed for idempotency checks)
- `prepared.rs` ties together the request, plan, and fingerprint
- `durable_adapter.rs` turns a materialized commit into a WAL payload