### PR TITLE
refactor(loon-core): remove public head sequence commit semantics

### DIFF
--- a/crates/loon-api/src/v0.rs
+++ b/crates/loon-api/src/v0.rs
@@ -40,7 +40,6 @@ pub struct CompleteUploadResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRequest {
     pub commit_id: CommitId,
-    pub planned_head_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preconditions: Vec<CommitPrecondition>,
     pub ops: Vec<CommitOp>,
@@ -96,9 +95,6 @@ pub enum CommitOp {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CommitPrecondition {
-    HeadSeqIs {
-        expected_seq: ChangeSeq,
-    },
     InodeRevisionIs {
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -109,6 +105,14 @@ pub enum CommitPrecondition {
     ChildNameAbsent {
         parent_inode: InodeId,
         name_key: String,
+    },
+    ChildNameIs {
+        parent_inode: InodeId,
+        name_key: String,
+        child_inode: InodeId,
+    },
+    DirectoryEmpty {
+        inode_id: InodeId,
     },
 }
 

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -66,7 +66,6 @@ pub enum WalOp {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WalPrecondition {
-    HeadSeqIs(ChangeSeq),
     InodeRevisionIs {
         inode_id: InodeId,
         revision: RevisionNo,
@@ -78,13 +77,21 @@ pub enum WalPrecondition {
         parent_inode: InodeId,
         name_key: String,
     },
+    ChildNameIs {
+        parent_inode: InodeId,
+        name_key: String,
+        child_inode: InodeId,
+    },
+    DirectoryEmpty {
+        inode_id: InodeId,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WalCommitPayload {
     pub namespace_id: NamespaceId,
     pub seq: ChangeSeq,
-    pub base_head_seq: ChangeSeq,
+    pub apply_after_seq: ChangeSeq,
     pub commit_id: CommitId,
     pub semantic_commit_fingerprint_sha256: String,
     pub writer_id: String,

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -307,6 +307,7 @@ fn map_core_error(error: CoreError) -> CliError {
         CoreErrorKind::PathNotFound => "path_not_found",
         CoreErrorKind::RevisionNotFound => "revision_not_found",
         CoreErrorKind::PathConflict => "path_conflict",
+        CoreErrorKind::DirectoryNotEmpty => "directory_not_empty",
         CoreErrorKind::StaleHead => "stale_head",
         CoreErrorKind::StaleRevision => "stale_revision",
         CoreErrorKind::TombstoneConflict => "tombstone_conflict",

--- a/crates/loon-cli/tests/cli.rs
+++ b/crates/loon-cli/tests/cli.rs
@@ -156,7 +156,7 @@ fn local_profile_filesystem_flow_works_end_to_end() {
 
     let rm_dir = harness.run(&["--json", "rm", "/docs"]);
     assert_failure(&rm_dir);
-    assert_eq!(json_error(&rm_dir)["code"], "path_conflict");
+    assert_eq!(json_error(&rm_dir)["code"], "directory_not_empty");
 
     let rm = harness.run(&["--json", "rm", "/docs/final.txt"]);
     assert_success(&rm);

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -18,7 +18,6 @@ pub fn commit_request_from_v0(
         commit_id: request.commit_id,
         writer_id: ctx.writer_id,
         writer_fence_token: ctx.writer_fence_token,
-        planned_head_seq: request.planned_head_seq,
         ops: request.ops.into_iter().map(commit_op_from_v0).collect(),
         preconditions: request
             .preconditions
@@ -84,9 +83,6 @@ pub(super) fn commit_precondition_from_v0(
     precondition: api_v0::CommitPrecondition,
 ) -> Precondition {
     match precondition {
-        api_v0::CommitPrecondition::HeadSeqIs { expected_seq } => {
-            Precondition::HeadSeqIs(expected_seq)
-        }
         api_v0::CommitPrecondition::InodeRevisionIs {
             inode_id,
             revision_no,
@@ -104,6 +100,18 @@ pub(super) fn commit_precondition_from_v0(
             parent_inode,
             name_key,
         },
+        api_v0::CommitPrecondition::ChildNameIs {
+            parent_inode,
+            name_key,
+            child_inode,
+        } => Precondition::ChildNameIs {
+            parent_inode,
+            name_key,
+            child_inode,
+        },
+        api_v0::CommitPrecondition::DirectoryEmpty { inode_id } => {
+            Precondition::DirectoryEmpty { inode_id }
+        }
     }
 }
 
@@ -112,7 +120,7 @@ mod tests {
     use super::*;
     use loon_api::{
         v0::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition},
-        ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo,
+        CommitId, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo,
     };
 
     #[test]
@@ -120,11 +128,7 @@ mod tests {
         let content_ref = ContentRef::whole_file_v0(b"hello");
         let request = api_v0::CommitRequest {
             commit_id: CommitId::from("commit-a"),
-            planned_head_seq: ChangeSeq(10),
             preconditions: vec![
-                ApiCommitPrecondition::HeadSeqIs {
-                    expected_seq: ChangeSeq(10),
-                },
                 ApiCommitPrecondition::InodeRevisionIs {
                     inode_id: InodeId(2),
                     revision_no: RevisionNo(3),
@@ -135,6 +139,14 @@ mod tests {
                 ApiCommitPrecondition::ChildNameAbsent {
                     parent_inode: InodeId(1),
                     name_key: "docs".to_owned(),
+                },
+                ApiCommitPrecondition::ChildNameIs {
+                    parent_inode: InodeId(1),
+                    name_key: "file.txt".to_owned(),
+                    child_inode: InodeId(2),
+                },
+                ApiCommitPrecondition::DirectoryEmpty {
+                    inode_id: InodeId(3),
                 },
             ],
             ops: vec![
@@ -184,7 +196,7 @@ mod tests {
         .expect("convert request");
 
         assert_eq!(core.ops.len(), 7);
-        assert_eq!(core.preconditions.len(), 4);
+        assert_eq!(core.preconditions.len(), 5);
         assert_eq!(core.writer_fence_token, FenceToken(9));
     }
 }

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -15,8 +15,8 @@ pub fn wal_payload_from_materialized_commit(
 
     Ok(WalCommitPayload {
         namespace_id: prepared.plan.namespace_id.clone(),
-        seq: prepared.plan.next_seq,
-        base_head_seq: prepared.plan.base_head_seq,
+        seq: prepared.plan.assigned_seq,
+        apply_after_seq: prepared.plan.apply_after_seq,
         commit_id: prepared.plan.commit_id.clone(),
         semantic_commit_fingerprint_sha256: prepared
             .semantic_commit_fingerprint
@@ -40,7 +40,6 @@ pub fn wal_payload_from_materialized_commit(
 impl From<&Precondition> for WalPrecondition {
     fn from(value: &Precondition) -> Self {
         match value {
-            Precondition::HeadSeqIs(seq) => Self::HeadSeqIs(*seq),
             Precondition::InodeRevisionIs { inode_id, revision } => Self::InodeRevisionIs {
                 inode_id: *inode_id,
                 revision: *revision,
@@ -56,6 +55,18 @@ impl From<&Precondition> for WalPrecondition {
             } => Self::ChildNameAbsent {
                 parent_inode: *parent_inode,
                 name_key: name_key.clone(),
+            },
+            Precondition::ChildNameIs {
+                parent_inode,
+                name_key,
+                child_inode,
+            } => Self::ChildNameIs {
+                parent_inode: *parent_inode,
+                name_key: name_key.clone(),
+                child_inode: *child_inode,
+            },
+            Precondition::DirectoryEmpty { inode_id } => Self::DirectoryEmpty {
+                inode_id: *inode_id,
             },
         }
     }
@@ -75,24 +86,23 @@ mod tests {
             commit_id: CommitId::from("c_wal_payload"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(0),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            preconditions: Vec::new(),
             message: Some("create docs".to_owned()),
             annotations: None,
         };
         let plan = CommitPlan {
             namespace_id: namespace_id.clone(),
             commit_id: CommitId::from("c_wal_payload"),
-            base_head_seq: ChangeSeq(0),
-            next_seq: ChangeSeq(1),
+            apply_after_seq: ChangeSeq(0),
+            assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");

--- a/crates/loon-core/src/commit/frame.rs
+++ b/crates/loon-core/src/commit/frame.rs
@@ -1,6 +1,5 @@
-use super::{CommitRequest, CommitValidationContext, CommitValidationError, Precondition};
+use super::{CommitRequest, CommitValidationContext, CommitValidationError};
 use crate::namespace::head_and_lease_fence_tokens_agree;
-use loon_api::ChangeSeq;
 
 pub(super) fn validate_commit_request_frame(
     request: &CommitRequest,
@@ -27,8 +26,6 @@ pub(super) fn validate_commit_request_frame(
         });
     }
 
-    validate_head_seq_preconditions(&request.preconditions, context.head.seq)?;
-
     if request.writer_fence_token != context.head.active_fence_token {
         return Err(CommitValidationError::StaleWriterFenceToken {
             active: context.head.active_fence_token,
@@ -48,24 +45,6 @@ pub(super) fn validate_commit_request_frame(
             lease_expires_at_ms: context.lease.lease_expires_at_ms,
             now_ms: context.now_ms,
         });
-    }
-
-    Ok(())
-}
-
-fn validate_head_seq_preconditions(
-    preconditions: &[Precondition],
-    current_head_seq: ChangeSeq,
-) -> Result<(), CommitValidationError> {
-    for precondition in preconditions {
-        if let Precondition::HeadSeqIs(actual) = precondition {
-            if *actual != current_head_seq {
-                return Err(CommitValidationError::ConflictingHeadSeqPrecondition {
-                    expected: current_head_seq,
-                    actual: *actual,
-                });
-            }
-        }
     }
 
     Ok(())

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -1,6 +1,6 @@
 use super::api_adapter::{commit_op_from_v0, commit_precondition_from_v0};
 use super::{CommitOp, CommitRequest, Precondition};
-use loon_api::{payload_checksum_sha256, v0 as api_v0, ChangeSeq, NamespaceId};
+use loon_api::{payload_checksum_sha256, v0 as api_v0, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -30,7 +30,6 @@ pub fn semantic_commit_fingerprint(
 ) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
     semantic_commit_fingerprint_from_parts(
         &request.namespace_id,
-        request.planned_head_seq,
         &request.preconditions,
         &request.ops,
         &request.message,
@@ -56,7 +55,6 @@ pub fn semantic_commit_fingerprint_for_v0_request(
         .collect::<Vec<_>>();
     semantic_commit_fingerprint_from_parts(
         namespace_id,
-        request.planned_head_seq,
         &preconditions,
         &ops,
         &request.message,
@@ -66,7 +64,6 @@ pub fn semantic_commit_fingerprint_for_v0_request(
 
 fn semantic_commit_fingerprint_from_parts(
     namespace_id: &NamespaceId,
-    planned_head_seq: ChangeSeq,
     preconditions: &[Precondition],
     ops: &[CommitOp],
     message: &Option<String>,
@@ -76,7 +73,6 @@ fn semantic_commit_fingerprint_from_parts(
     struct CanonicalSemanticCommit<'a> {
         domain: &'static str,
         namespace_id: &'a NamespaceId,
-        planned_head_seq: ChangeSeq,
         preconditions: &'a [Precondition],
         ops: &'a [CommitOp],
         message: &'a Option<String>,
@@ -86,7 +82,6 @@ fn semantic_commit_fingerprint_from_parts(
     payload_checksum_sha256(&CanonicalSemanticCommit {
         domain: SEMANTIC_CORE_COMMIT_DOMAIN,
         namespace_id,
-        planned_head_seq,
         preconditions,
         ops,
         message,
@@ -99,8 +94,8 @@ fn semantic_commit_fingerprint_from_parts(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{CommitOp, CommitRequest, Precondition};
-    use loon_api::{ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
+    use crate::commit::{CommitOp, CommitRequest};
+    use loon_api::{CommitId, FenceToken, InodeId, NamespaceId};
 
     fn core_request(writer_fence_token: FenceToken) -> CommitRequest {
         CommitRequest {
@@ -108,12 +103,11 @@ mod tests {
             commit_id: CommitId::from("commit-a"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token,
-            planned_head_seq: ChangeSeq(7),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(7))],
+            preconditions: Vec::new(),
             message: Some("create docs".to_owned()),
             annotations: None,
         }
@@ -169,10 +163,7 @@ mod tests {
         let namespace_id = NamespaceId::from("demo");
         let api_request = api_v0::CommitRequest {
             commit_id: CommitId::from("commit-a"),
-            planned_head_seq: ChangeSeq(7),
-            preconditions: vec![api_v0::CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(7),
-            }],
+            preconditions: Vec::new(),
             ops: vec![api_v0::CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -310,14 +310,24 @@ pub enum CommitHeadPublishError {
         head: NamespaceId,
         plan: NamespaceId,
     },
-    PlanApplyAfterSeqBeforeHead {
-        head: ChangeSeq,
-        plan: ChangeSeq,
+    WalSegmentNamespaceMismatch {
+        head: NamespaceId,
+        wal: NamespaceId,
     },
-    PlanAssignedSeqNotAfterHead {
-        head: ChangeSeq,
-        plan: ChangeSeq,
+    WalSegmentBaseHeadSeqMismatch {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
     },
+    WalSegmentStartSeqMismatch {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
+    WalSegmentEndSeqMismatch {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
+    EmptyWalSegment,
+    SeqOverflow,
     StaleHead,
     Codec(String),
     Store(String),

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -34,7 +34,6 @@ pub struct CommitRequest {
     pub commit_id: CommitId,
     pub writer_id: String,
     pub writer_fence_token: FenceToken,
-    pub planned_head_seq: ChangeSeq,
     pub ops: Vec<CommitOp>,
     pub preconditions: Vec<Precondition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -79,7 +78,6 @@ pub enum CommitOp {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Precondition {
-    HeadSeqIs(ChangeSeq),
     InodeRevisionIs {
         inode_id: InodeId,
         revision: RevisionNo,
@@ -91,14 +89,22 @@ pub enum Precondition {
         parent_inode: InodeId,
         name_key: String,
     },
+    ChildNameIs {
+        parent_inode: InodeId,
+        name_key: String,
+        child_inode: InodeId,
+    },
+    DirectoryEmpty {
+        inode_id: InodeId,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitPlan {
     pub namespace_id: NamespaceId,
     pub commit_id: CommitId,
-    pub base_head_seq: ChangeSeq,
-    pub next_seq: ChangeSeq,
+    pub apply_after_seq: ChangeSeq,
+    pub assigned_seq: ChangeSeq,
     pub allocated_inode_ids: Vec<InodeId>,
     pub resolved_restore_content_refs: Vec<Option<ContentRef>>,
     pub resulting_next_inode_id: InodeId,
@@ -133,16 +139,32 @@ pub enum CommitValidationError {
         head: FenceToken,
         lease: FenceToken,
     },
-    PlannedHeadSeqMismatch {
-        expected: ChangeSeq,
-        actual: ChangeSeq,
+    ChildNamePreconditionParentMissing {
+        parent_inode: InodeId,
     },
-    MissingHeadSeqPrecondition {
-        expected: ChangeSeq,
+    ChildNamePreconditionParentNotDirectory {
+        parent_inode: InodeId,
+        actual_kind: InodeKind,
     },
-    ConflictingHeadSeqPrecondition {
-        expected: ChangeSeq,
-        actual: ChangeSeq,
+    ChildNamePreconditionMissing {
+        parent_inode: InodeId,
+        name_key: String,
+    },
+    ChildNamePreconditionMismatch {
+        parent_inode: InodeId,
+        name_key: String,
+        expected_child_inode: InodeId,
+        actual_child_inode: InodeId,
+    },
+    DirectoryEmptyPreconditionInodeMissing {
+        inode_id: InodeId,
+    },
+    DirectoryEmptyPreconditionInodeNotDirectory {
+        inode_id: InodeId,
+        actual_kind: InodeKind,
+    },
+    DirectoryEmptyPreconditionNotEmpty {
+        inode_id: InodeId,
     },
     CreateParentMissing {
         parent_inode: InodeId,
@@ -288,11 +310,11 @@ pub enum CommitHeadPublishError {
         head: NamespaceId,
         plan: NamespaceId,
     },
-    PlanBaseHeadSeqMismatch {
+    PlanApplyAfterSeqBeforeHead {
         head: ChangeSeq,
         plan: ChangeSeq,
     },
-    PlanNextSeqMismatch {
+    PlanAssignedSeqNotAfterHead {
         head: ChangeSeq,
         plan: ChangeSeq,
     },

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -2,7 +2,7 @@ use super::frame::validate_commit_request_frame;
 use super::prepared::materialize_commit_op;
 use super::{
     push_unique_invariant, CommitMaterializationError, CommitOp, CommitPlan, CommitRequest,
-    CommitValidationContext, CommitValidationError,
+    CommitValidationContext, CommitValidationError, Precondition,
 };
 use crate::invariants::INVARIANTS;
 use crate::metadata::MetadataState;
@@ -12,7 +12,7 @@ use loon_api::{
 use std::collections::BTreeMap;
 
 struct CommitShape {
-    next_seq: ChangeSeq,
+    assigned_seq: ChangeSeq,
     allocated_inode_ids: Vec<InodeId>,
     resulting_next_inode_id: InodeId,
 }
@@ -88,7 +88,7 @@ pub fn build_commit_plan(
     let resolved_restore_content_refs = validate_metadata_preconditions(
         request,
         &context.metadata_state,
-        shape.next_seq,
+        shape.assigned_seq,
         &shape.allocated_inode_ids,
         &mut checked_invariants,
     )?;
@@ -133,8 +133,8 @@ pub fn build_commit_plan(
     Ok(CommitPlan {
         namespace_id: request.namespace_id.clone(),
         commit_id: request.commit_id.clone(),
-        base_head_seq: context.head.seq,
-        next_seq: shape.next_seq,
+        apply_after_seq: context.head.seq,
+        assigned_seq: shape.assigned_seq,
         allocated_inode_ids: shape.allocated_inode_ids,
         resolved_restore_content_refs,
         resulting_next_inode_id: shape.resulting_next_inode_id,
@@ -147,7 +147,7 @@ fn compute_commit_shape(
     request: &CommitRequest,
     context: &CommitValidationContext,
 ) -> Result<CommitShape, CommitValidationError> {
-    let next_seq = context
+    let assigned_seq = context
         .head
         .seq
         .0
@@ -183,7 +183,7 @@ fn compute_commit_shape(
         .ok_or(CommitValidationError::NextInodeOverflow)?;
 
     Ok(CommitShape {
-        next_seq,
+        assigned_seq,
         allocated_inode_ids,
         resulting_next_inode_id,
     })
@@ -199,6 +199,13 @@ fn validate_metadata_preconditions(
     let mut ephemeral_metadata_state = metadata_state.clone();
     let mut allocated_inode_ids = allocated_inode_ids.iter().copied();
     let mut resolved_restore_content_refs = Vec::with_capacity(request.ops.len());
+
+    validate_explicit_preconditions(
+        &request.preconditions,
+        &ephemeral_metadata_state,
+        committed_seq,
+        checked_invariants,
+    )?;
 
     for (op_index, op) in request.ops.iter().enumerate() {
         let op_index =
@@ -403,6 +410,152 @@ fn materialization_error_to_validation_error(
         (CommitMaterializationError::OpIndexOverflow, _) => CommitValidationError::OpIndexOverflow,
         _ => CommitValidationError::NextInodeOverflow,
     }
+}
+
+fn validate_explicit_preconditions(
+    preconditions: &[Precondition],
+    metadata_state: &MetadataState,
+    base_seq: ChangeSeq,
+    checked_invariants: &mut Vec<String>,
+) -> Result<(), CommitValidationError> {
+    for precondition in preconditions {
+        match precondition {
+            Precondition::InodeRevisionIs { inode_id, revision } => {
+                validate_inode_revision_is(metadata_state, *inode_id, *revision, base_seq)?;
+            }
+            Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
+                validate_ancestors_not_subtree_deleted(
+                    metadata_state,
+                    *inode_id,
+                    base_seq,
+                    checked_invariants,
+                    false,
+                )?;
+            }
+            Precondition::ChildNameAbsent {
+                parent_inode,
+                name_key,
+            } => {
+                validate_child_name_absent_precondition(
+                    metadata_state,
+                    *parent_inode,
+                    name_key,
+                    base_seq,
+                )?;
+            }
+            Precondition::ChildNameIs {
+                parent_inode,
+                name_key,
+                child_inode,
+            } => {
+                validate_child_name_is_precondition(
+                    metadata_state,
+                    *parent_inode,
+                    name_key,
+                    *child_inode,
+                    base_seq,
+                )?;
+            }
+            Precondition::DirectoryEmpty { inode_id } => {
+                validate_directory_empty_precondition(metadata_state, *inode_id, base_seq)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_child_name_absent_precondition(
+    metadata_state: &MetadataState,
+    parent_inode: InodeId,
+    name_key: &str,
+    base_seq: ChangeSeq,
+) -> Result<(), CommitValidationError> {
+    let parent = metadata_state
+        .inode_at_seq(parent_inode, base_seq)
+        .ok_or(CommitValidationError::ChildNamePreconditionParentMissing { parent_inode })?;
+    if parent.inode_kind != InodeKind::Dir {
+        return Err(
+            CommitValidationError::ChildNamePreconditionParentNotDirectory {
+                parent_inode,
+                actual_kind: parent.inode_kind,
+            },
+        );
+    }
+
+    if let Some(existing) = metadata_state.visible_child(parent_inode, name_key, base_seq) {
+        return Err(CommitValidationError::CreateChildNameCollision {
+            parent_inode,
+            name_key: name_key.to_owned(),
+            child_inode: existing.child_inode_id,
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_child_name_is_precondition(
+    metadata_state: &MetadataState,
+    parent_inode: InodeId,
+    name_key: &str,
+    child_inode: InodeId,
+    base_seq: ChangeSeq,
+) -> Result<(), CommitValidationError> {
+    let parent = metadata_state
+        .inode_at_seq(parent_inode, base_seq)
+        .ok_or(CommitValidationError::ChildNamePreconditionParentMissing { parent_inode })?;
+    if parent.inode_kind != InodeKind::Dir {
+        return Err(
+            CommitValidationError::ChildNamePreconditionParentNotDirectory {
+                parent_inode,
+                actual_kind: parent.inode_kind,
+            },
+        );
+    }
+
+    let Some(existing) = metadata_state.visible_child(parent_inode, name_key, base_seq) else {
+        return Err(CommitValidationError::ChildNamePreconditionMissing {
+            parent_inode,
+            name_key: name_key.to_owned(),
+        });
+    };
+    if existing.child_inode_id != child_inode {
+        return Err(CommitValidationError::ChildNamePreconditionMismatch {
+            parent_inode,
+            name_key: name_key.to_owned(),
+            expected_child_inode: child_inode,
+            actual_child_inode: existing.child_inode_id,
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_directory_empty_precondition(
+    metadata_state: &MetadataState,
+    inode_id: InodeId,
+    base_seq: ChangeSeq,
+) -> Result<(), CommitValidationError> {
+    let inode = metadata_state
+        .visible_inode(inode_id, base_seq)
+        .ok_or(CommitValidationError::DirectoryEmptyPreconditionInodeMissing { inode_id })?;
+    if inode.inode_kind != InodeKind::Dir {
+        return Err(
+            CommitValidationError::DirectoryEmptyPreconditionInodeNotDirectory {
+                inode_id,
+                actual_kind: inode.inode_kind,
+            },
+        );
+    }
+
+    if !metadata_state
+        .visible_children(inode_id, base_seq)
+        .is_empty()
+    {
+        return Err(CommitValidationError::DirectoryEmptyPreconditionNotEmpty { inode_id });
+    }
+
+    Ok(())
 }
 
 fn validate_child_name_absent(

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -306,7 +306,7 @@ pub(super) fn materialize_commit_op(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{CommitOp, Precondition};
+    use crate::commit::CommitOp;
     use loon_api::{ChangeSeq, CommitId};
 
     fn request() -> CommitRequest {
@@ -315,12 +315,11 @@ mod tests {
             commit_id: CommitId::from("commit-a"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(0),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         }
@@ -330,12 +329,12 @@ mod tests {
         CommitPlan {
             namespace_id: NamespaceId::from("demo"),
             commit_id: CommitId::from("commit-a"),
-            base_head_seq: ChangeSeq(0),
-            next_seq: ChangeSeq(1),
+            apply_after_seq: ChangeSeq(0),
+            assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         }
     }
@@ -363,9 +362,9 @@ mod tests {
     }
 
     #[test]
-    fn prepared_commit_allows_ephemeral_batch_base_seq() {
+    fn prepared_commit_allows_ephemeral_batch_apply_after_seq() {
         let mut plan = plan();
-        plan.base_head_seq = ChangeSeq(9);
+        plan.apply_after_seq = ChangeSeq(9);
 
         PreparedCommit::new(request(), plan).expect("prepare commit");
     }

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -1,5 +1,6 @@
 use super::{push_unique_invariant, CommitHeadPublishError, CommitPlan, PreparedCommitHeadPublish};
-use loon_api::{ControlObjectKind, HeadState, HeadStateEnvelope, WalSegmentPointer};
+use crate::wal::PreparedWalSegment;
+use loon_api::{ChangeSeq, ControlObjectKind, HeadState, HeadStateEnvelope};
 use loon_objectstore::keys::namespace_head;
 use loon_objectstore::ObjectStoreError;
 use loon_objectstore::{ObjectMetadata, ObjectStore};
@@ -7,7 +8,7 @@ use loon_objectstore::{ObjectMetadata, ObjectStore};
 pub fn prepare_commit_head_publish(
     current_head: &HeadState,
     plan: &CommitPlan,
-    visible_wal_tip: WalSegmentPointer,
+    wal: &PreparedWalSegment,
     writer_version: &str,
 ) -> Result<PreparedCommitHeadPublish, CommitHeadPublishError> {
     if writer_version.trim().is_empty() {
@@ -21,17 +22,43 @@ pub fn prepare_commit_head_publish(
         });
     }
 
-    if plan.apply_after_seq < current_head.seq {
-        return Err(CommitHeadPublishError::PlanApplyAfterSeqBeforeHead {
-            head: current_head.seq,
-            plan: plan.apply_after_seq,
+    let wal_payload = &wal.envelope.payload;
+    if wal_payload.namespace_id != current_head.namespace_id {
+        return Err(CommitHeadPublishError::WalSegmentNamespaceMismatch {
+            head: current_head.namespace_id.clone(),
+            wal: wal_payload.namespace_id.clone(),
         });
     }
 
-    if plan.assigned_seq <= current_head.seq {
-        return Err(CommitHeadPublishError::PlanAssignedSeqNotAfterHead {
-            head: current_head.seq,
-            plan: plan.assigned_seq,
+    if wal_payload.records.is_empty() {
+        return Err(CommitHeadPublishError::EmptyWalSegment);
+    }
+
+    if wal_payload.base_head_seq != current_head.seq {
+        return Err(CommitHeadPublishError::WalSegmentBaseHeadSeqMismatch {
+            expected: current_head.seq,
+            actual: wal_payload.base_head_seq,
+        });
+    }
+
+    let expected_start_seq = ChangeSeq(
+        current_head
+            .seq
+            .0
+            .checked_add(1)
+            .ok_or(CommitHeadPublishError::SeqOverflow)?,
+    );
+    if wal_payload.start_seq != expected_start_seq {
+        return Err(CommitHeadPublishError::WalSegmentStartSeqMismatch {
+            expected: expected_start_seq,
+            actual: wal_payload.start_seq,
+        });
+    }
+
+    if wal_payload.end_seq != plan.assigned_seq {
+        return Err(CommitHeadPublishError::WalSegmentEndSeqMismatch {
+            expected: plan.assigned_seq,
+            actual: wal_payload.end_seq,
         });
     }
 
@@ -43,7 +70,7 @@ pub fn prepare_commit_head_publish(
         name_policy: current_head.name_policy,
         snapshot_hint_seq: current_head.snapshot_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
-        visible_wal_tip: Some(visible_wal_tip),
+        visible_wal_tip: Some(wal.envelope.pointer(wal.object_key.clone())),
     };
     let envelope = HeadStateEnvelope::from_state(
         ControlObjectKind::NamespaceHead,
@@ -90,5 +117,206 @@ fn map_object_store_error(err: ObjectStoreError) -> CommitHeadPublishError {
             CommitHeadPublishError::StaleHead
         }
         other => CommitHeadPublishError::Store(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loon_api::{
+        CommitId, FenceToken, InodeId, NamespaceId, WalCommitPayload, WalSegmentEnvelope,
+        WalSegmentPayload,
+    };
+
+    fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
+        HeadState {
+            namespace_id,
+            seq,
+            active_fence_token: FenceToken(1),
+            next_inode_id: InodeId(10),
+            name_policy: loon_api::NamePolicy::default(),
+            snapshot_hint_seq: Some(ChangeSeq(0)),
+            retention_floor_seq: ChangeSeq(0),
+            visible_wal_tip: None,
+        }
+    }
+
+    fn plan(namespace_id: NamespaceId, assigned_seq: ChangeSeq) -> CommitPlan {
+        CommitPlan {
+            namespace_id,
+            commit_id: CommitId::from("publish-plan"),
+            apply_after_seq: ChangeSeq(assigned_seq.0.saturating_sub(1)),
+            assigned_seq,
+            allocated_inode_ids: Vec::new(),
+            resolved_restore_content_refs: Vec::new(),
+            resulting_next_inode_id: InodeId(10),
+            metadata_preconditions: Vec::new(),
+            checked_invariants: Vec::new(),
+        }
+    }
+
+    fn wal_segment(
+        namespace_id: NamespaceId,
+        base_head_seq: ChangeSeq,
+        start_seq: ChangeSeq,
+        end_seq: ChangeSeq,
+        record_count: usize,
+    ) -> PreparedWalSegment {
+        let records = (0..record_count)
+            .map(|index| {
+                let offset = u64::try_from(index).expect("test index");
+                let seq = ChangeSeq(start_seq.0 + offset);
+                WalCommitPayload {
+                    namespace_id: namespace_id.clone(),
+                    seq,
+                    apply_after_seq: ChangeSeq(seq.0.saturating_sub(1)),
+                    commit_id: CommitId::from(format!("publish-record-{index}")),
+                    semantic_commit_fingerprint_sha256: format!("fingerprint-{index}"),
+                    writer_id: "writer-a".to_owned(),
+                    writer_fence_token: FenceToken(1),
+                    message: None,
+                    annotations: None,
+                    ops: Vec::new(),
+                    preconditions: Vec::new(),
+                    results: Vec::new(),
+                }
+            })
+            .collect();
+        let segment_id = "seg_publish_test".to_owned();
+        let payload = WalSegmentPayload {
+            namespace_id: namespace_id.clone(),
+            segment_id: segment_id.clone(),
+            prev_visible_segment: None,
+            base_head_seq,
+            start_seq,
+            end_seq,
+            records,
+        };
+        let envelope = WalSegmentEnvelope::from_payload("test", payload).expect("wal envelope");
+        PreparedWalSegment {
+            object_key: format!(
+                "namespaces/{}/wal/{}-{}-{segment_id}.cbor.zst",
+                namespace_id.as_str(),
+                start_seq.0,
+                end_seq.0
+            ),
+            segment_id,
+            envelope,
+            encoded_bytes: Vec::new(),
+            checked_invariants: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn head_publish_accepts_segment_connecting_current_head_to_plan() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(9), 2);
+
+        let prepared = prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer")
+            .expect("prepare head publish");
+
+        assert_eq!(prepared.resulting_head.seq, ChangeSeq(9));
+        assert_eq!(
+            prepared.resulting_head.visible_wal_tip,
+            Some(wal.envelope.pointer(wal.object_key.clone()))
+        );
+    }
+
+    #[test]
+    fn head_publish_rejects_segment_base_after_current_head() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(8), ChangeSeq(9), ChangeSeq(9), 1);
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::WalSegmentBaseHeadSeqMismatch {
+                expected: ChangeSeq(7),
+                actual: ChangeSeq(8),
+            })
+        ));
+    }
+
+    #[test]
+    fn head_publish_rejects_segment_base_before_current_head() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(6), ChangeSeq(7), ChangeSeq(9), 3);
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::WalSegmentBaseHeadSeqMismatch {
+                expected: ChangeSeq(7),
+                actual: ChangeSeq(6),
+            })
+        ));
+    }
+
+    #[test]
+    fn head_publish_rejects_empty_segment() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(9), 0);
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::EmptyWalSegment)
+        ));
+    }
+
+    #[test]
+    fn head_publish_rejects_segment_start_that_skips_current_head() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(9), ChangeSeq(9), 1);
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::WalSegmentStartSeqMismatch {
+                expected: ChangeSeq(8),
+                actual: ChangeSeq(9),
+            })
+        ));
+    }
+
+    #[test]
+    fn head_publish_rejects_segment_end_that_differs_from_plan() {
+        let namespace_id = NamespaceId::from("demo");
+        let current_head = head(namespace_id.clone(), ChangeSeq(7));
+        let plan = plan(namespace_id.clone(), ChangeSeq(9));
+        let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(10), 3);
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::WalSegmentEndSeqMismatch {
+                expected: ChangeSeq(9),
+                actual: ChangeSeq(10),
+            })
+        ));
+    }
+
+    #[test]
+    fn head_publish_rejects_segment_namespace_mismatch() {
+        let current_head = head(NamespaceId::from("demo"), ChangeSeq(7));
+        let plan = plan(NamespaceId::from("demo"), ChangeSeq(9));
+        let wal = wal_segment(
+            NamespaceId::from("other"),
+            ChangeSeq(7),
+            ChangeSeq(8),
+            ChangeSeq(9),
+            2,
+        );
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
+            Err(CommitHeadPublishError::WalSegmentNamespaceMismatch { head, wal })
+                if head == NamespaceId::from("demo") && wal == NamespaceId::from("other")
+        ));
     }
 }

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -21,23 +21,23 @@ pub fn prepare_commit_head_publish(
         });
     }
 
-    if plan.base_head_seq < current_head.seq {
-        return Err(CommitHeadPublishError::PlanBaseHeadSeqMismatch {
+    if plan.apply_after_seq < current_head.seq {
+        return Err(CommitHeadPublishError::PlanApplyAfterSeqBeforeHead {
             head: current_head.seq,
-            plan: plan.base_head_seq,
+            plan: plan.apply_after_seq,
         });
     }
 
-    if plan.next_seq <= current_head.seq {
-        return Err(CommitHeadPublishError::PlanNextSeqMismatch {
+    if plan.assigned_seq <= current_head.seq {
+        return Err(CommitHeadPublishError::PlanAssignedSeqNotAfterHead {
             head: current_head.seq,
-            plan: plan.next_seq,
+            plan: plan.assigned_seq,
         });
     }
 
     let resulting_head = HeadState {
         namespace_id: current_head.namespace_id.clone(),
-        seq: plan.next_seq,
+        seq: plan.assigned_seq,
         active_fence_token: current_head.active_fence_token,
         next_inode_id: plan.resulting_next_inode_id,
         name_policy: current_head.name_policy,

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -24,6 +24,7 @@ pub enum CoreErrorKind {
     PathNotFound,
     RevisionNotFound,
     PathConflict,
+    DirectoryNotEmpty,
     StaleHead,
     StaleRevision,
     TombstoneConflict,
@@ -196,8 +197,8 @@ impl CoreError {
             CoreError::RebootstrapRequired { .. } => CoreErrorKind::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
             | CoreError::ExpectedDirectory { .. }
-            | CoreError::DirectoryNotEmpty(_)
             | CoreError::DestinationExists(_) => CoreErrorKind::PathConflict,
+            CoreError::DirectoryNotEmpty(_) => CoreErrorKind::DirectoryNotEmpty,
             CoreError::TombstoneConflict { .. } => CoreErrorKind::TombstoneConflict,
             CoreError::NonDirectoryPathComponent(_) => CoreErrorKind::InvalidPath,
         }
@@ -291,9 +292,6 @@ fn classify_lease_acquire_error(error: &LeaseAcquireError) -> CoreErrorKind {
 
 fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorKind {
     match error {
-        CommitValidationError::PlannedHeadSeqMismatch { .. }
-        | CommitValidationError::MissingHeadSeqPrecondition { .. }
-        | CommitValidationError::ConflictingHeadSeqPrecondition { .. } => CoreErrorKind::StaleHead,
         CommitValidationError::ReplaceFileBaseRevisionMismatch { .. }
         | CommitValidationError::RestoreRevisionBaseRevisionMismatch { .. } => {
             CoreErrorKind::StaleRevision
@@ -311,23 +309,34 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
             CoreErrorKind::TombstoneConflict
         }
         CommitValidationError::CreateChildNameCollision { .. }
+        | CommitValidationError::ChildNamePreconditionParentNotDirectory { .. }
+        | CommitValidationError::ChildNamePreconditionMismatch { .. }
         | CommitValidationError::CreateParentNotDirectory { .. }
         | CommitValidationError::ReplaceFileInodeNotFile { .. }
         | CommitValidationError::RestoreRevisionInodeNotFile { .. }
         | CommitValidationError::DeleteFileInodeNotFile { .. }
         | CommitValidationError::RenameTargetParentNotDirectory { .. }
         | CommitValidationError::RenameTargetNameCollision { .. }
-        | CommitValidationError::DeleteSubtreeRootNotDirectory { .. } => {
+        | CommitValidationError::DeleteSubtreeRootNotDirectory { .. }
+        | CommitValidationError::DirectoryEmptyPreconditionInodeNotDirectory { .. } => {
             CoreErrorKind::PathConflict
         }
+        CommitValidationError::DirectoryEmptyPreconditionNotEmpty { .. } => {
+            CoreErrorKind::DirectoryNotEmpty
+        }
         CommitValidationError::CreateParentMissing { .. }
+        | CommitValidationError::ChildNamePreconditionParentMissing { .. }
+        | CommitValidationError::ChildNamePreconditionMissing { .. }
         | CommitValidationError::ReplaceFileInodeMissing { .. }
         | CommitValidationError::RestoreRevisionInodeMissing { .. }
         | CommitValidationError::DeleteFileInodeMissing { .. }
         | CommitValidationError::RenameInodeMissing { .. }
         | CommitValidationError::RenameSourceBindingMissing { .. }
         | CommitValidationError::RenameTargetParentMissing { .. }
-        | CommitValidationError::DeleteSubtreeRootMissing { .. } => CoreErrorKind::PathNotFound,
+        | CommitValidationError::DeleteSubtreeRootMissing { .. }
+        | CommitValidationError::DirectoryEmptyPreconditionInodeMissing { .. } => {
+            CoreErrorKind::PathNotFound
+        }
         CommitValidationError::RenameWouldCycleDirectory { .. } => CoreErrorKind::WouldCycle,
         CommitValidationError::StaleWriterFenceToken { .. }
         | CommitValidationError::LeaseHolderMismatch { .. }
@@ -350,8 +359,8 @@ fn classify_head_publish_error(error: &CommitHeadPublishError) -> CoreErrorKind 
         CommitHeadPublishError::EmptyWriterVersion
         | CommitHeadPublishError::EmptyExpectedHeadEtag
         | CommitHeadPublishError::NamespaceMismatch { .. }
-        | CommitHeadPublishError::PlanBaseHeadSeqMismatch { .. }
-        | CommitHeadPublishError::PlanNextSeqMismatch { .. }
+        | CommitHeadPublishError::PlanApplyAfterSeqBeforeHead { .. }
+        | CommitHeadPublishError::PlanAssignedSeqNotAfterHead { .. }
         | CommitHeadPublishError::Codec(_)
         | CommitHeadPublishError::Store(_) => CoreErrorKind::ServerError,
     }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -359,8 +359,12 @@ fn classify_head_publish_error(error: &CommitHeadPublishError) -> CoreErrorKind 
         CommitHeadPublishError::EmptyWriterVersion
         | CommitHeadPublishError::EmptyExpectedHeadEtag
         | CommitHeadPublishError::NamespaceMismatch { .. }
-        | CommitHeadPublishError::PlanApplyAfterSeqBeforeHead { .. }
-        | CommitHeadPublishError::PlanAssignedSeqNotAfterHead { .. }
+        | CommitHeadPublishError::WalSegmentNamespaceMismatch { .. }
+        | CommitHeadPublishError::WalSegmentBaseHeadSeqMismatch { .. }
+        | CommitHeadPublishError::WalSegmentStartSeqMismatch { .. }
+        | CommitHeadPublishError::WalSegmentEndSeqMismatch { .. }
+        | CommitHeadPublishError::EmptyWalSegment
+        | CommitHeadPublishError::SeqOverflow
         | CommitHeadPublishError::Codec(_)
         | CommitHeadPublishError::Store(_) => CoreErrorKind::ServerError,
     }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -411,12 +411,8 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         .expect("non-empty accepted records")
         .prepared
         .plan;
-    let head_publish = prepare_commit_head_publish(
-        &basis.head,
-        last_plan,
-        wal.envelope.pointer(wal.object_key.clone()),
-        &context.writer_version,
-    );
+    let head_publish =
+        prepare_commit_head_publish(&basis.head, last_plan, &wal, &context.writer_version);
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -366,7 +366,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         match current_metadata_state.apply_committed_wal_record(&preview) {
             Ok(applied) => {
                 current_metadata_state = applied.metadata_state;
-                current_head.seq = plan.next_seq;
+                current_head.seq = plan.assigned_seq;
                 current_head.next_inode_id = plan.resulting_next_inode_id;
                 accepted.push((index, materialized));
             }

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -738,6 +738,31 @@ struct PathPlanningView<'a> {
     content_store_id: &'a ContentStoreId,
 }
 
+fn child_name_is_precondition(
+    view: &PathPlanningView<'_>,
+    resolved: &ResolvedVisiblePath,
+) -> Result<ApiCommitPrecondition, CoreError> {
+    let parent_inode = resolved
+        .parent_inode_id
+        .ok_or(CoreError::RootMutationForbidden)?;
+    Ok(ApiCommitPrecondition::ChildNameIs {
+        parent_inode,
+        name_key: name_key_for_display_name(view.head.name_policy, &resolved.display_name),
+        child_inode: resolved.inode_id,
+    })
+}
+
+fn child_name_absent_precondition(
+    view: &PathPlanningView<'_>,
+    parent_inode: InodeId,
+    display_name: &str,
+) -> ApiCommitPrecondition {
+    ApiCommitPrecondition::ChildNameAbsent {
+        parent_inode,
+        name_key: name_key_for_display_name(view.head.name_policy, display_name),
+    }
+}
+
 fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
     absolute_path: &str,
@@ -765,9 +790,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
         &mut op_index,
     )?;
     let final_name = final_component(absolute_path)?;
-    let mut preconditions = vec![ApiCommitPrecondition::HeadSeqIs {
-        expected_seq: view.head.seq,
-    }];
+    let mut preconditions = Vec::new();
 
     match target {
         Ok(existing) => {
@@ -784,6 +807,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
                 .metadata_state
                 .latest_revision_head_at_seq(existing.inode_id, view.head.seq)
                 .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
+            preconditions.push(child_name_is_precondition(view, &existing)?);
             ops.push(ApiCommitOp::ReplaceFile {
                 inode_id: existing.inode_id,
                 base_revision_no: revision.revision_no,
@@ -803,20 +827,26 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
                 display_name: final_name.clone(),
                 content_ref,
             });
-            preconditions.push(ApiCommitPrecondition::ChildNameAbsent {
-                parent_inode: final_parent_inode,
-                name_key: name_key_for_display_name(view.head.name_policy, &final_name),
-            });
-            preconditions.push(ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
-                inode_id: final_parent_inode,
-            });
+            if view
+                .metadata_state
+                .visible_inode(final_parent_inode, view.head.seq)
+                .is_some()
+            {
+                preconditions.push(child_name_absent_precondition(
+                    view,
+                    final_parent_inode,
+                    &final_name,
+                ));
+                preconditions.push(ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                    inode_id: final_parent_inode,
+                });
+            }
         }
         Err(other) => return Err(other.into()),
     }
 
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
-        planned_head_seq: view.head.seq,
         ops,
         preconditions,
         message: None,
@@ -945,13 +975,16 @@ fn plan_delete_path(
             });
         }
     };
+    let mut preconditions = vec![child_name_is_precondition(view, &resolved)?];
+    if !recursive && resolved.inode_kind == InodeKind::Dir {
+        preconditions.push(ApiCommitPrecondition::DirectoryEmpty {
+            inode_id: resolved.inode_id,
+        });
+    }
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
-        planned_head_seq: view.head.seq,
         ops: vec![op],
-        preconditions: vec![ApiCommitPrecondition::HeadSeqIs {
-            expected_seq: view.head.seq,
-        }],
+        preconditions,
         message: None,
         annotations: None,
     })
@@ -977,15 +1010,21 @@ fn plan_move_path(
     }
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
-        planned_head_seq: view.head.seq,
         ops: vec![ApiCommitOp::Rename {
             inode_id: source.inode_id,
             new_parent_inode: target_parent,
-            new_display_name: target_name,
+            new_display_name: target_name.clone(),
         }],
-        preconditions: vec![ApiCommitPrecondition::HeadSeqIs {
-            expected_seq: view.head.seq,
-        }],
+        preconditions: vec![
+            child_name_is_precondition(view, &source)?,
+            child_name_absent_precondition(view, target_parent, &target_name),
+            ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                inode_id: source.inode_id,
+            },
+            ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                inode_id: target_parent,
+            },
+        ],
         message: None,
         annotations: None,
     })
@@ -1026,23 +1065,23 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
 
     let target_parent = resolve_parent_directory(view.metadata_state, to_path, view.head.seq)?;
     let target_name = final_component(to_path)?;
-    let target_name_key = name_key_for_display_name(view.head.name_policy, &target_name);
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
-        planned_head_seq: view.head.seq,
         ops: vec![ApiCommitOp::CreateFile {
             parent_inode: target_parent,
             display_name: target_name.clone(),
             content_ref: revision.content_ref,
         }],
         preconditions: vec![
-            ApiCommitPrecondition::HeadSeqIs {
-                expected_seq: view.head.seq,
+            child_name_is_precondition(view, &source)?,
+            ApiCommitPrecondition::InodeRevisionIs {
+                inode_id: source.inode_id,
+                revision_no: revision.revision_no,
             },
-            ApiCommitPrecondition::ChildNameAbsent {
-                parent_inode: target_parent,
-                name_key: target_name_key,
+            ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
+                inode_id: source.inode_id,
             },
+            child_name_absent_precondition(view, target_parent, &target_name),
             ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
                 inode_id: target_parent,
             },

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -126,9 +126,9 @@ pub fn prepare_wal_segment(
                     actual: payload_record.seq,
                 });
             }
-            if payload_record.base_head_seq != previous.seq {
+            if payload_record.apply_after_seq != previous.seq {
                 return Err(WalBuildError::BaseHeadSeqMismatch {
-                    request: payload_record.base_head_seq,
+                    request: payload_record.apply_after_seq,
                     plan: previous.seq,
                 });
             }
@@ -149,7 +149,7 @@ pub fn prepare_wal_segment(
         namespace_id,
         segment_id: segment_id.clone(),
         prev_visible_segment,
-        base_head_seq: payload_records[0].base_head_seq,
+        base_head_seq: payload_records[0].apply_after_seq,
         start_seq,
         end_seq,
         records: payload_records,
@@ -392,9 +392,7 @@ fn push_invariant(checked_invariants: &mut Vec<String>, invariant: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{
-        materialize_commit, CommitOp, CommitPlan, CommitRequest, Precondition, PreparedCommit,
-    };
+    use crate::commit::{materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit};
     use loon_api::{CommitId, FenceToken};
 
     #[test]
@@ -405,24 +403,23 @@ mod tests {
             commit_id: CommitId::from("c_wal_payload"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(0),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
                 display_name: "docs".to_owned(),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            preconditions: Vec::new(),
             message: Some("create docs".to_owned()),
             annotations: None,
         };
         let plan = CommitPlan {
             namespace_id: namespace_id.clone(),
             commit_id: CommitId::from("c_wal_payload"),
-            base_head_seq: ChangeSeq(0),
-            next_seq: ChangeSeq(1),
+            apply_after_seq: ChangeSeq(0),
+            assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],
             resolved_restore_content_refs: vec![None],
             resulting_next_inode_id: InodeId(3),
-            metadata_preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(0))],
+            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -10,7 +10,6 @@ use loon_api::{
 };
 use loon_core::commit::{
     build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
-    Precondition,
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
@@ -31,48 +30,6 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use tempfile::tempdir;
-
-#[test]
-fn stale_head_precondition_is_rejected() {
-    let metadata_state = metadata_state_after(&[
-        vec![loon_api::WalOp::CreateDir {
-            op_index: 0,
-            inode_id: InodeId(2),
-            parent_inode: InodeId(1),
-            display_name: "docs".to_owned(),
-        }],
-        vec![loon_api::WalOp::CreateFile {
-            op_index: 0,
-            inode_id: InodeId(3),
-            parent_inode: InodeId(2),
-            display_name: "readme.txt".to_owned(),
-            content_ref: content_ref("content-1"),
-        }],
-    ]);
-    let context = validation_context(metadata_state, ChangeSeq(2), InodeId(4));
-    let request = CommitRequest {
-        namespace_id: namespace_id(),
-        commit_id: CommitId::from("stale-head"),
-        writer_id: "writer-a".to_owned(),
-        writer_fence_token: FenceToken(1),
-        planned_head_seq: ChangeSeq(2),
-        ops: vec![CommitOp::DeleteFile {
-            inode_id: InodeId(3),
-        }],
-        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(1))],
-        message: None,
-        annotations: None,
-    };
-
-    let error = build_commit_plan(&request, &context).expect_err("stale head");
-    assert!(matches!(
-        error,
-        CommitValidationError::ConflictingHeadSeqPrecondition {
-            expected: ChangeSeq(2),
-            actual: ChangeSeq(1),
-        }
-    ));
-}
 
 #[test]
 fn stale_revision_precondition_is_rejected() {
@@ -103,13 +60,12 @@ fn stale_revision_precondition_is_rejected() {
         commit_id: CommitId::from("stale-revision"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
-        planned_head_seq: ChangeSeq(3),
         ops: vec![CommitOp::ReplaceFile {
             inode_id: InodeId(3),
             base_revision: RevisionNo(1),
             content_ref: content_ref("content-3"),
         }],
-        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+        preconditions: Vec::new(),
         message: None,
         annotations: None,
     };
@@ -154,13 +110,12 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             commit_id: CommitId::from("create-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(2),
                 display_name: "new.txt".to_owned(),
                 content_ref: content_ref("content-2"),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -181,13 +136,12 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             commit_id: CommitId::from("replace-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![CommitOp::ReplaceFile {
                 inode_id: InodeId(3),
                 base_revision: RevisionNo(1),
                 content_ref: content_ref("content-2"),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -217,13 +171,12 @@ fn restore_revision_validation_rejects_missing_inode() {
         commit_id: CommitId::from("restore-missing-inode"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
-        planned_head_seq: ChangeSeq(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(99),
             source_revision: RevisionNo(1),
             base_revision: RevisionNo(1),
         }],
-        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(1))],
+        preconditions: Vec::new(),
         message: None,
         annotations: None,
     };
@@ -251,13 +204,12 @@ fn restore_revision_validation_rejects_non_file_target() {
         commit_id: CommitId::from("restore-non-file"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
-        planned_head_seq: ChangeSeq(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(1),
             base_revision: RevisionNo(1),
         }],
-        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(1))],
+        preconditions: Vec::new(),
         message: None,
         annotations: None,
     };
@@ -303,13 +255,12 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             commit_id: CommitId::from("restore-stale-base"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
                 base_revision: RevisionNo(1),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -331,13 +282,12 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             commit_id: CommitId::from("restore-missing-source"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(99),
                 base_revision: RevisionNo(2),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -378,7 +328,6 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
             commit_id: CommitId::from("restore-same-request-source"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(2),
             ops: vec![
                 CommitOp::ReplaceFile {
                     inode_id: InodeId(3),
@@ -391,7 +340,7 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
                     base_revision: RevisionNo(2),
                 },
             ],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(2))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -435,7 +384,6 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
             commit_id: CommitId::from("restore-after-restore-same-request"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
@@ -448,7 +396,7 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
                     base_revision: RevisionNo(3),
                 },
             ],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -493,13 +441,12 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
             commit_id: CommitId::from("restore-under-tombstone"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
-            planned_head_seq: ChangeSeq(3),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
                 source_revision: RevisionNo(1),
                 base_revision: RevisionNo(1),
             }],
-            preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(3))],
+            preconditions: Vec::new(),
             message: None,
             annotations: None,
         },
@@ -554,13 +501,12 @@ fn restore_revision_overflow_is_rejected() {
         commit_id: CommitId::from("restore-overflow"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
-        planned_head_seq: ChangeSeq(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
             source_revision: RevisionNo(u64::MAX),
             base_revision: RevisionNo(u64::MAX),
         }],
-        preconditions: vec![Precondition::HeadSeqIs(ChangeSeq(1))],
+        preconditions: Vec::new(),
         message: None,
         annotations: None,
     };
@@ -739,7 +685,6 @@ fn commit_operations_reject_invalid_commit_id_before_wal_key_construction() {
         &namespace_id,
         ApiCommitRequest {
             commit_id: CommitId::from("bad/commit"),
-            planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -800,7 +745,6 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
         vec![
             ApiCommitRequest {
                 commit_id: CommitId::from("req-batch-a"),
-                planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -811,7 +755,6 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
             },
             ApiCommitRequest {
                 commit_id: CommitId::from("req-batch-b"),
-                planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -849,6 +792,143 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
     assert_eq!(changes.changes.len(), 2);
     assert_eq!(changes.changes[0].commit_id, CommitId::from("req-batch-a"));
     assert_eq!(changes.changes[1].commit_id, CommitId::from("req-batch-b"));
+}
+
+#[test]
+fn child_name_is_precondition_observes_earlier_batch_candidate() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/readme.txt",
+        b"hello",
+        &context,
+        Some("seed-child-name-is"),
+    )
+    .expect("seed file");
+    let docs_inode = resolve_path(&store, &namespace_id, "/docs")
+        .expect("resolve docs")
+        .inode_id;
+    let file_inode = resolve_path(&store, &namespace_id, "/docs/readme.txt")
+        .expect("resolve file")
+        .inode_id;
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            ApiCommitRequest {
+                commit_id: CommitId::from("move-before-child-name-check"),
+                preconditions: Vec::new(),
+                ops: vec![ApiCommitOp::Rename {
+                    inode_id: file_inode,
+                    new_parent_inode: docs_inode,
+                    new_display_name: "moved.txt".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+            ApiCommitRequest {
+                commit_id: CommitId::from("delete-with-stale-child-name"),
+                preconditions: vec![CommitPrecondition::ChildNameIs {
+                    parent_inode: docs_inode,
+                    name_key: loon_api::name_key_for_display_name(
+                        loon_api::NamePolicy::default(),
+                        "readme.txt",
+                    ),
+                    child_inode: file_inode,
+                }],
+                ops: vec![ApiCommitOp::DeleteFile {
+                    inode_id: file_inode,
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+        &context,
+    );
+
+    assert_eq!(
+        responses[0].as_ref().expect("rename").committed_seq,
+        ChangeSeq(2)
+    );
+    let error = responses[1]
+        .as_ref()
+        .expect_err("stale child-name precondition");
+    assert_eq!(error.kind(), CoreErrorKind::PathNotFound);
+}
+
+#[test]
+fn directory_empty_precondition_observes_earlier_batch_candidate() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let seed = commit_operations(
+        &store,
+        &namespace_id,
+        ApiCommitRequest {
+            commit_id: CommitId::from("seed-empty-dir"),
+            preconditions: Vec::new(),
+            ops: vec![ApiCommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        },
+        &context,
+    )
+    .expect("seed docs");
+    let docs_inode = match seed.results[0] {
+        loon_api::v0::CommitOpResult::CreateDir { inode_id, .. } => inode_id,
+        ref other => panic!("unexpected seed result: {other:?}"),
+    };
+    let content = store_bytes_as_content(&store, &namespace_id, b"child").expect("stage content");
+
+    let responses = commit_operations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            ApiCommitRequest {
+                commit_id: CommitId::from("create-child-before-empty-check"),
+                preconditions: Vec::new(),
+                ops: vec![ApiCommitOp::CreateFile {
+                    parent_inode: docs_inode,
+                    display_name: "child.txt".to_owned(),
+                    content_ref: content.content_ref,
+                }],
+                message: None,
+                annotations: None,
+            },
+            ApiCommitRequest {
+                commit_id: CommitId::from("delete-dir-with-stale-empty-check"),
+                preconditions: vec![CommitPrecondition::DirectoryEmpty {
+                    inode_id: docs_inode,
+                }],
+                ops: vec![ApiCommitOp::DeleteSubtree {
+                    root_inode: docs_inode,
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+        &context,
+    );
+
+    assert_eq!(
+        responses[0].as_ref().expect("create child").committed_seq,
+        ChangeSeq(2)
+    );
+    let error = responses[1]
+        .as_ref()
+        .expect_err("directory empty precondition");
+    assert_eq!(error.kind(), CoreErrorKind::DirectoryNotEmpty);
 }
 
 #[test]
@@ -926,7 +1006,6 @@ fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
 
     let request = ApiCommitRequest {
         commit_id: CommitId::from("req-duplicate"),
-        planned_head_seq: ChangeSeq(0),
         preconditions: Vec::new(),
         ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
@@ -973,7 +1052,6 @@ fn visible_commit_id_retry_aliases_across_writer_takeover() {
 
     let request = ApiCommitRequest {
         commit_id: CommitId::from("retry-across-writer"),
-        planned_head_seq: ChangeSeq(0),
         preconditions: Vec::new(),
         ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
@@ -1015,7 +1093,6 @@ fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
         vec![
             ApiCommitRequest {
                 commit_id: CommitId::from("req-conflict"),
-                planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1026,7 +1103,6 @@ fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
             },
             ApiCommitRequest {
                 commit_id: CommitId::from("req-conflict"),
-                planned_head_seq: ChangeSeq(0),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1577,10 +1653,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("restore-create"),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(0),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "restore.txt".to_owned(),
@@ -1603,10 +1676,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("restore-replace"),
-            planned_head_seq: ChangeSeq(1),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(1),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no: RevisionNo(1),
@@ -1631,10 +1701,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("restore-missing-content"),
-            planned_head_seq: ChangeSeq(2),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(2),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
                 source_revision_no: RevisionNo(1),
@@ -1679,10 +1746,7 @@ fn metadata_only_commit_does_not_validate_content_store_refs() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("metadata-only-delete"),
-            planned_head_seq: ChangeSeq(1),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(1),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::DeleteFile { inode_id }],
             message: None,
             annotations: None,
@@ -1711,10 +1775,7 @@ fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("create-missing-parent-missing-content"),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(0),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(99),
                 display_name: "missing.txt".to_owned(),
@@ -1758,10 +1819,7 @@ fn replace_file_prioritizes_missing_durable_content_over_stale_revision() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("replace-stale-missing-content"),
-            planned_head_seq: ChangeSeq(1),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(1),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no: RevisionNo(99),
@@ -1805,10 +1863,7 @@ fn restore_revision_missing_source_is_revision_not_found() {
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("restore-missing-source"),
-            planned_head_seq: ChangeSeq(1),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(1),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
                 source_revision_no: RevisionNo(99),
@@ -1836,10 +1891,7 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("resolve-before-durable-check-create"),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(0),
-            }],
+            preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "restore.txt".to_owned(),
@@ -1869,10 +1921,7 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &namespace_id(),
         ApiCommitRequest {
             commit_id: CommitId::from("resolve-before-durable-check-commit"),
-            planned_head_seq: ChangeSeq(1),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(1),
-            }],
+            preconditions: Vec::new(),
             ops: vec![
                 ApiCommitOp::ReplaceFile {
                     inode_id,

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -548,6 +548,7 @@ impl ApiResponseError {
             CoreErrorKind::PathNotFound => (StatusCode::NOT_FOUND, "path_not_found"),
             CoreErrorKind::RevisionNotFound => (StatusCode::CONFLICT, "revision_not_found"),
             CoreErrorKind::PathConflict => (StatusCode::CONFLICT, "path_conflict"),
+            CoreErrorKind::DirectoryNotEmpty => (StatusCode::CONFLICT, "directory_not_empty"),
             CoreErrorKind::StaleHead => (StatusCode::CONFLICT, "stale_head"),
             CoreErrorKind::StaleRevision => (StatusCode::CONFLICT, "stale_revision"),
             CoreErrorKind::TombstoneConflict => (StatusCode::CONFLICT, "tombstone_conflict"),
@@ -604,8 +605,7 @@ impl IntoResponse for ApiResponseError {
 mod tests {
     use super::{app_with_store, SharedStore};
     use crate::{ServerConfig, StoreConfig};
-    use loon_api::v0::{CommitOp, CommitPrecondition, CommitRequest};
-    use loon_api::{ChangeSeq, InodeId};
+    use loon_api::ChangeSeq;
     use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
     use loon_core::{bootstrap_namespace, delete_path, write_file_bytes, MutationContext};
     use loon_objectstore::fs::LocalFsStore;
@@ -899,47 +899,6 @@ mod tests {
                 .write_file_bytes(&target, b"race")
                 .expect("path write retries stale head");
             assert_eq!(result.committed_seq, ChangeSeq(1));
-        })
-        .await
-        .expect("join blocking task");
-
-        harness.server.abort();
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn http_explicit_stale_head_precondition_surfaces_as_409() {
-        let temp_dir = tempdir().expect("tempdir");
-        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-        let now_ms = now_ms();
-        bootstrap_namespace(
-            store.as_ref(),
-            &"demo".into(),
-            &context("server-writer", now_ms),
-            false,
-        )
-        .expect("bootstrap namespace");
-
-        let harness = start_server(store, temp_dir.path(), "server-writer").await;
-        tokio::task::spawn_blocking(move || {
-            let request = CommitRequest {
-                commit_id: loon_api::CommitId::from("stale-explicit"),
-                planned_head_seq: ChangeSeq(1),
-                preconditions: vec![CommitPrecondition::HeadSeqIs {
-                    expected_seq: ChangeSeq(1),
-                }],
-                ops: vec![CommitOp::CreateDir {
-                    parent_inode: InodeId(1),
-                    display_name: "late".to_owned(),
-                }],
-                message: None,
-                annotations: None,
-            };
-            assert_api_error(
-                harness.client.commit_operations("demo", &request),
-                409,
-                "stale_head",
-                None,
-            );
         })
         .await
         .expect("join blocking task");

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -534,7 +534,6 @@ mod tests {
     ) -> CommitRequest {
         CommitRequest {
             commit_id: CommitId::from(commit_id.into()),
-            planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -823,7 +822,6 @@ mod tests {
 
         let request_a = CommitRequest {
             commit_id: CommitId::from("req-a"),
-            planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -834,7 +832,6 @@ mod tests {
         };
         let request_b = CommitRequest {
             commit_id: CommitId::from("req-b"),
-            planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -884,7 +881,6 @@ mod tests {
 
         let explicit = CommitRequest {
             commit_id: CommitId::from("explicit-commit"),
-            planned_head_seq: ChangeSeq(0),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -1,7 +1,7 @@
 use loon_api::{
     v0::{
-        CommitAnnotations, CommitOp, CommitOpResult, CommitPrecondition,
-        CommitRequest as ApiCommitRequest, CompleteUploadRequest,
+        CommitAnnotations, CommitOp, CommitOpResult, CommitRequest as ApiCommitRequest,
+        CompleteUploadRequest,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, ControlObjectKind,
     CreateCheckpointResponse, InodeId, LeaseStateEnvelope, RevisionNo,
@@ -333,10 +333,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         annotations.insert("kind".to_owned(), json!("service-proxied"));
         let commit_request = ApiCommitRequest {
             commit_id: CommitId::from("req-phase-2a-create-file"),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(0),
-            }],
+            preconditions: Vec::new(),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "uploaded.txt".to_owned(),
@@ -434,10 +431,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
                 namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::from("req-restore-create"),
-                    planned_head_seq: ChangeSeq(0),
-                    preconditions: vec![CommitPrecondition::HeadSeqIs {
-                        expected_seq: ChangeSeq(0),
-                    }],
+                    preconditions: Vec::new(),
                     ops: vec![CommitOp::CreateFile {
                         parent_inode: InodeId(1),
                         display_name: "restore.txt".to_owned(),
@@ -461,10 +455,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
                 namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::from("req-restore-replace"),
-                    planned_head_seq: ChangeSeq(1),
-                    preconditions: vec![CommitPrecondition::HeadSeqIs {
-                        expected_seq: ChangeSeq(1),
-                    }],
+                    preconditions: Vec::new(),
                     ops: vec![CommitOp::ReplaceFile {
                         inode_id,
                         base_revision_no: RevisionNo(1),
@@ -483,10 +474,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
                 namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::from("req-restore-restore"),
-                    planned_head_seq: ChangeSeq(2),
-                    preconditions: vec![CommitPrecondition::HeadSeqIs {
-                        expected_seq: ChangeSeq(2),
-                    }],
+                    preconditions: Vec::new(),
                     ops: vec![CommitOp::RestoreRevision {
                         inode_id,
                         source_revision_no: RevisionNo(1),
@@ -564,10 +552,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
                 namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::from("req-restore-missing-source-create"),
-                    planned_head_seq: ChangeSeq(0),
-                    preconditions: vec![CommitPrecondition::HeadSeqIs {
-                        expected_seq: ChangeSeq(0),
-                    }],
+                    preconditions: Vec::new(),
                     ops: vec![CommitOp::CreateFile {
                         parent_inode: InodeId(1),
                         display_name: "restore.txt".to_owned(),
@@ -587,10 +572,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             namespace,
             &ApiCommitRequest {
                 commit_id: CommitId::from("req-restore-missing-source-restore"),
-                planned_head_seq: ChangeSeq(1),
-                preconditions: vec![CommitPrecondition::HeadSeqIs {
-                    expected_seq: ChangeSeq(1),
-                }],
+                preconditions: Vec::new(),
                 ops: vec![CommitOp::RestoreRevision {
                     inode_id,
                     source_revision_no: RevisionNo(99),
@@ -635,10 +617,7 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
             stage_uploaded_content_ref(&harness.client, namespace, b"first payload\n");
         let first_request = ApiCommitRequest {
             commit_id: CommitId::from("req-phase-2a-conflict"),
-            planned_head_seq: ChangeSeq(0),
-            preconditions: vec![CommitPrecondition::HeadSeqIs {
-                expected_seq: ChangeSeq(0),
-            }],
+            preconditions: Vec::new(),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(1),
                 display_name: "first.txt".to_owned(),
@@ -658,7 +637,6 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
         changed_annotations.insert("source".to_owned(), json!("changed"));
         let conflicting_request = ApiCommitRequest {
             commit_id: first_request.commit_id.clone(),
-            planned_head_seq: ChangeSeq(0),
             preconditions: first_request.preconditions.clone(),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(1),

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -177,10 +177,11 @@ The core kinds of precondition are:
 
 | Kind of check | Example use |
 | --- | --- |
-| **Head-based** | "Apply this only if I planned against the current head." |
 | **Name-slot based** | "Create this child only if that name slot is still empty." |
+| **Name-binding based** | "Move or delete this item only if this name still points at the inode I saw." |
 | **Revision-based** | "Replace this file only if it is still at the revision I saw." |
 | **Ancestor-visibility based** | "Apply this only if no ancestor was tombstoned." |
+| **Directory-contents based** | "Delete this directory non-recursively only if it is still empty." |
 
 The exact wire shape of preconditions may vary by transport binding, but the semantics must match these checks.
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -38,8 +38,7 @@ A commit request carries the following logical fields:
 | Field | Meaning |
 | --- | --- |
 | `commit_id` | Client-generated stable idempotency key for this logical commit request. The same value must be reused for safe retries. |
-| `planned_head_seq` | The history point the client planned against. Preconditions are evaluated against authoritative state at this boundary. |
-| `preconditions` | Explicit checks such as `HeadSeqIs`, `InodeRevisionIs`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
+| `preconditions` | Explicit semantic checks such as `inode_revision_is`, `child_name_is`, `child_name_absent`, `directory_empty`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
 | `ops` | Ordered list of mutation operations. Operation order is preserved through validation, logical commit creation, and change-feed output. |
 | `message` | Optional human-readable description of the mutation event. |
 | `annotations` | Optional structured metadata attached to the logical commit request. |
@@ -257,7 +256,6 @@ Representative request:
 ```json
 {
   "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
-  "planned_head_seq": 418,
   "message": "replace report bytes",
   "annotations": {
     "source": "sync",
@@ -265,16 +263,12 @@ Representative request:
   },
   "preconditions": [
     {
-      "type": "HeadSeqIs",
-      "expected_seq": 418
-    },
-    {
-      "type": "InodeRevisionIs",
+      "type": "inode_revision_is",
       "inode_id": 42,
       "revision_no": 7
     },
     {
-      "type": "AncestorsNotSubtreeDeleted",
+      "type": "ancestors_not_subtree_deleted",
       "inode_id": 42
     }
   ],


### PR DESCRIPTION
In this PR we remove the client-provided precondition that allowed clients to specify "head sequence". It no longer makes sense that a client can say "this should be accepted only for sequence # 100" because when we moved to a batch WAL, the client will be randomly sorted into that batch (where the head sequence shifts for every batch member), and we shouldn't encourage a pattern that it likely to fail, especially at the expense of simplicity. Instead, clients can use semantic preconditions that are evaluated at the request's batch application point. This removes `planned_head_seq` and `HeadSeqIs` from the public commit path while keeping WAL/head sequencing internal to publication. (E.g., instead of "only accept this if the current state is still snapshot X" the client can provide the semantic check they actually require, such as "only accept this commit if the name of the file doesn't exist yet")