### PR TITLE
fix: minor checkpoint and revision vocabulary update

### DIFF
--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -44,7 +44,7 @@ pub struct HeadState {
     pub next_inode_id: InodeId,
     #[serde(default)]
     pub name_policy: NamePolicy,
-    pub snapshot_hint_seq: Option<ChangeSeq>,
+    pub checkpoint_hint_seq: Option<ChangeSeq>,
     pub retention_floor_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_wal_tip: Option<WalSegmentPointer>,
@@ -58,7 +58,7 @@ impl HeadState {
             active_fence_token: FenceToken(0),
             next_inode_id: InodeId(2),
             name_policy: NamePolicy::default(),
-            snapshot_hint_seq: None,
+            checkpoint_hint_seq: None,
             retention_floor_seq: ChangeSeq(0),
             visible_wal_tip: None,
         }

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -77,8 +77,8 @@ pub struct FilesystemOperationResponse {
 pub struct CreateCheckpointResponse {
     pub namespace_id: NamespaceId,
     pub checkpoint_seq: ChangeSeq,
-    pub snapshot_hint_seq: Option<ChangeSeq>,
-    pub snapshot_hint_points_at_checkpoint: bool,
+    pub checkpoint_hint_seq: Option<ChangeSeq>,
+    pub checkpoint_hint_points_at_checkpoint: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -34,7 +34,7 @@ pub enum WalOp {
         #[serde(default)]
         op_index: u32,
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
         content_ref: ContentRef,
     },
     RestoreRevision {
@@ -42,7 +42,7 @@ pub enum WalOp {
         op_index: u32,
         inode_id: InodeId,
         source_revision_no: RevisionNo,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
         content_ref: ContentRef,
     },
     DeleteFile {
@@ -68,7 +68,7 @@ pub enum WalOp {
 pub enum WalPrecondition {
     InodeRevisionIs {
         inode_id: InodeId,
-        revision: RevisionNo,
+        revision_no: RevisionNo,
     },
     AncestorsNotSubtreeDeleted {
         inode_id: InodeId,

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -472,7 +472,7 @@ mod tests {
         let error = map_core_error(CoreError::CommitValidation(
             CommitValidationError::RestoreRevisionSourceRevisionMissing {
                 inode_id: InodeId(42),
-                source_revision: RevisionNo(7),
+                source_revision_no: RevisionNo(7),
             },
         ));
 

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -100,7 +100,7 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
             })?;
 
     let (initial_head, initial_metadata_state) = if let Some(checkpoint_seq) =
-        loaded_head.envelope.state.snapshot_hint_seq
+        loaded_head.envelope.state.checkpoint_hint_seq
     {
         let materialized =
             load_verified_checkpoint_materialization(store, expected_namespace, checkpoint_seq)?;
@@ -145,7 +145,7 @@ fn ensure_reconstructed_head_matches(
         || current_head.seq != reconstructed.seq
         || current_head.next_inode_id != reconstructed.next_inode_id
         || current_head.name_policy != reconstructed.name_policy
-        || current_head.snapshot_hint_seq != reconstructed.snapshot_hint_seq
+        || current_head.checkpoint_hint_seq != reconstructed.checkpoint_hint_seq
         || current_head.retention_floor_seq != reconstructed.retention_floor_seq
         || (reconstructed.visible_wal_tip.is_some()
             && current_head.visible_wal_tip != reconstructed.visible_wal_tip)

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -17,7 +17,8 @@ use loon_api::{
     CreateCheckpointResponse, FenceToken, HeadState, HeadStateEnvelope, InodeId, NamespaceId,
 };
 use loon_objectstore::keys::{
-    derived_progress, snapshot_manifest, snapshot_table, DerivedWorkClass, SnapshotTableFamily,
+    checkpoint_manifest, checkpoint_table, derived_progress,
+    CheckpointTableFamily as ObjectStoreCheckpointTableFamily, DerivedWorkClass,
 };
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 use serde::{Deserialize, Serialize};
@@ -197,7 +198,7 @@ pub fn create_checkpoint<S: ObjectStore + ?Sized>(
                 store,
                 namespace_id,
                 checkpoint_seq,
-                &snapshot_manifest(namespace_id.as_str(), checkpoint_seq.0),
+                &checkpoint_manifest(namespace_id.as_str(), checkpoint_seq.0),
                 &tables,
             )
             .map_err(|error| CoreError::Basis(BasisLoadError::CheckpointLoad(error)))?;
@@ -228,13 +229,13 @@ pub fn create_checkpoint<S: ObjectStore + ?Sized>(
     }
 
     let resulting_head =
-        publish_snapshot_hint_seq(store, namespace_id, checkpoint_seq, &context.writer_version)?;
+        publish_checkpoint_hint_seq(store, namespace_id, checkpoint_seq, &context.writer_version)?;
 
     Ok(CreateCheckpointResponse {
         namespace_id: namespace_id.clone(),
         checkpoint_seq,
-        snapshot_hint_seq: resulting_head.snapshot_hint_seq,
-        snapshot_hint_points_at_checkpoint: resulting_head.snapshot_hint_seq
+        checkpoint_hint_seq: resulting_head.checkpoint_hint_seq,
+        checkpoint_hint_points_at_checkpoint: resulting_head.checkpoint_hint_seq
             == Some(checkpoint_seq),
     })
 }
@@ -264,7 +265,7 @@ pub(crate) fn write_verified_checkpoint_from_metadata<S: ObjectStore + ?Sized>(
         store,
         request.namespace_id,
         request.checkpoint_seq,
-        &snapshot_manifest(request.namespace_id.as_str(), request.checkpoint_seq.0),
+        &checkpoint_manifest(request.namespace_id.as_str(), request.checkpoint_seq.0),
         &tables,
     )
     .map_err(|error| CoreError::Basis(BasisLoadError::CheckpointLoad(error)))?;
@@ -300,7 +301,7 @@ pub fn advance_retention_floor<S: ObjectStore + ?Sized>(
         let loaded_head = read_head_object(store, namespace_id)
             .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
         let head = loaded_head.envelope.state;
-        let Some(target_floor) = head.snapshot_hint_seq else {
+        let Some(target_floor) = head.checkpoint_hint_seq else {
             return Err(CoreError::CheckpointUnavailable(format!(
                 "namespace `{}` has no published checkpoint",
                 namespace_id.as_str()
@@ -323,7 +324,7 @@ pub fn advance_retention_floor<S: ObjectStore + ?Sized>(
             active_fence_token: head.active_fence_token,
             next_inode_id: head.next_inode_id,
             name_policy: head.name_policy,
-            snapshot_hint_seq: head.snapshot_hint_seq,
+            checkpoint_hint_seq: head.checkpoint_hint_seq,
             retention_floor_seq: target_floor,
             visible_wal_tip: head.visible_wal_tip.clone(),
         };
@@ -357,7 +358,7 @@ pub(crate) fn load_verified_checkpoint_materialization<S: ObjectStore + ?Sized>(
 ) -> Result<LoadedCheckpointMaterialization, CheckpointLoadError> {
     load_verified_checkpoint_materialization_if_present(store, namespace_id, checkpoint_seq)?
         .ok_or_else(|| CheckpointLoadError::MissingManifest {
-            object_key: snapshot_manifest(namespace_id.as_str(), checkpoint_seq.0),
+            object_key: checkpoint_manifest(namespace_id.as_str(), checkpoint_seq.0),
         })
 }
 
@@ -373,7 +374,7 @@ pub(crate) fn checkpoint_basis_head(
         active_fence_token: manifest.payload.active_fence_token,
         next_inode_id: manifest.payload.next_inode_id,
         name_policy: current_head.name_policy,
-        snapshot_hint_seq: current_head.snapshot_hint_seq,
+        checkpoint_hint_seq: current_head.checkpoint_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
         visible_wal_tip: None,
     }
@@ -384,7 +385,7 @@ fn load_verified_checkpoint_materialization_if_present<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     checkpoint_seq: ChangeSeq,
 ) -> Result<Option<LoadedCheckpointMaterialization>, CheckpointLoadError> {
-    let manifest_key = snapshot_manifest(namespace_id.as_str(), checkpoint_seq.0);
+    let manifest_key = checkpoint_manifest(namespace_id.as_str(), checkpoint_seq.0);
     let Some(manifest_bytes) =
         store
             .get(&manifest_key, None)
@@ -455,10 +456,10 @@ fn build_checkpoint_tables<S: ObjectStore + ?Sized>(
             .map_err(|err| CoreError::Store(err.to_string()))?;
         let encoded = encode_checkpoint_segment_envelope_zstd(&envelope)
             .map_err(|err| CoreError::Store(err.to_string()))?;
-        let object_key = snapshot_table(
+        let object_key = checkpoint_table(
             namespace_id.as_str(),
             checkpoint_seq.0,
-            snapshot_table_family(family),
+            checkpoint_table_family(family),
             0,
         );
         write_immutable_object(store, &object_key, &encoded)?;
@@ -487,7 +488,7 @@ fn write_checkpoint_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     manifest: &CheckpointManifestEnvelope,
 ) -> Result<(), BasisLoadError> {
-    let manifest_key = snapshot_manifest(
+    let manifest_key = checkpoint_manifest(
         manifest.payload.namespace_id.as_str(),
         manifest.payload.checkpoint_seq.0,
     );
@@ -534,7 +535,7 @@ fn write_checkpoint_manifest<S: ObjectStore + ?Sized>(
     }
 }
 
-fn publish_snapshot_hint_seq<S: ObjectStore + ?Sized>(
+fn publish_checkpoint_hint_seq<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     checkpoint_seq: ChangeSeq,
@@ -544,7 +545,7 @@ fn publish_snapshot_hint_seq<S: ObjectStore + ?Sized>(
         let loaded_head = read_head_object(store, namespace_id)
             .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
         let current_head = loaded_head.envelope.state;
-        if current_head.snapshot_hint_seq >= Some(checkpoint_seq) {
+        if current_head.checkpoint_hint_seq >= Some(checkpoint_seq) {
             return Ok(current_head);
         }
 
@@ -554,7 +555,7 @@ fn publish_snapshot_hint_seq<S: ObjectStore + ?Sized>(
             active_fence_token: current_head.active_fence_token,
             next_inode_id: current_head.next_inode_id,
             name_policy: current_head.name_policy,
-            snapshot_hint_seq: Some(checkpoint_seq),
+            checkpoint_hint_seq: Some(checkpoint_seq),
             retention_floor_seq: current_head.retention_floor_seq,
             visible_wal_tip: current_head.visible_wal_tip.clone(),
         };
@@ -669,10 +670,10 @@ fn load_checkpoint_materialization_from_tables<S: ObjectStore + ?Sized>(
 
     for table in ordered_tables {
         for descriptor in &table.segments {
-            let expected_key = snapshot_table(
+            let expected_key = checkpoint_table(
                 namespace_id.as_str(),
                 checkpoint_seq.0,
-                snapshot_table_family(table.family),
+                checkpoint_table_family(table.family),
                 descriptor.segment_index,
             );
             if descriptor.object_key != expected_key {
@@ -1075,13 +1076,13 @@ fn checkpoint_rows_for_family(
     rows
 }
 
-fn snapshot_table_family(family: CheckpointTableFamily) -> SnapshotTableFamily {
+fn checkpoint_table_family(family: CheckpointTableFamily) -> ObjectStoreCheckpointTableFamily {
     match family {
-        CheckpointTableFamily::Inodes => SnapshotTableFamily::Inodes,
-        CheckpointTableFamily::Direntries => SnapshotTableFamily::Direntries,
-        CheckpointTableFamily::Revisions => SnapshotTableFamily::Revisions,
-        CheckpointTableFamily::Tombstones => SnapshotTableFamily::Tombstones,
-        CheckpointTableFamily::CommitReceipts => SnapshotTableFamily::CommitReceipts,
+        CheckpointTableFamily::Inodes => ObjectStoreCheckpointTableFamily::Inodes,
+        CheckpointTableFamily::Direntries => ObjectStoreCheckpointTableFamily::Direntries,
+        CheckpointTableFamily::Revisions => ObjectStoreCheckpointTableFamily::Revisions,
+        CheckpointTableFamily::Tombstones => ObjectStoreCheckpointTableFamily::Tombstones,
+        CheckpointTableFamily::CommitReceipts => ObjectStoreCheckpointTableFamily::CommitReceipts,
     }
 }
 
@@ -1100,7 +1101,7 @@ mod tests {
     use super::{
         advance_retention_floor, build_checkpoint_tables, checkpoint_basis_head, create_checkpoint,
         load_verified_checkpoint_materialization, metadata_states_equivalent,
-        publish_snapshot_hint_seq, write_checkpoint_manifest, CheckpointLoadError,
+        publish_checkpoint_hint_seq, write_checkpoint_manifest, CheckpointLoadError,
     };
     use crate::{
         bootstrap_namespace, load_verified_namespace_basis, put_file_bytes, write_file_bytes,
@@ -1108,7 +1109,7 @@ mod tests {
     };
     use loon_api::{ChangeSeq, CheckpointManifestEnvelope, CheckpointManifestPayload, NamespaceId};
     use loon_objectstore::fs::LocalFsStore;
-    use loon_objectstore::keys::{snapshot_manifest, snapshot_table, SnapshotTableFamily};
+    use loon_objectstore::keys::{checkpoint_manifest, checkpoint_table, CheckpointTableFamily};
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -1153,7 +1154,7 @@ mod tests {
         create_checkpoint(&store, &namespace_id, &context).expect("create checkpoint");
         let after = load_verified_namespace_basis(&store, &namespace_id).expect("basis after");
 
-        assert_eq!(after.head.snapshot_hint_seq, Some(before.head.seq));
+        assert_eq!(after.head.checkpoint_hint_seq, Some(before.head.seq));
         assert_eq!(before.head.seq, after.head.seq);
         assert!(metadata_states_equivalent(
             &before.metadata_state,
@@ -1171,7 +1172,7 @@ mod tests {
 
         create_checkpoint(&store, &namespace_id, &context).expect("create checkpoint");
         let basis = load_verified_namespace_basis(&store, &namespace_id).expect("basis");
-        assert_eq!(basis.head.snapshot_hint_seq, Some(ChangeSeq(0)));
+        assert_eq!(basis.head.checkpoint_hint_seq, Some(ChangeSeq(0)));
     }
 
     #[test]
@@ -1192,7 +1193,7 @@ mod tests {
         .expect("write hello");
         create_checkpoint(&store, &namespace_id, &context).expect("create checkpoint");
 
-        let manifest_key = snapshot_manifest(namespace_id.as_str(), 1);
+        let manifest_key = checkpoint_manifest(namespace_id.as_str(), 1);
         store
             .put_overwrite(&manifest_key, br#"{"bad":"json"}"#)
             .expect("corrupt manifest");
@@ -1208,7 +1209,7 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::from("demo");
         let context = test_context();
-        let manifest_key = snapshot_manifest(namespace_id.as_str(), 1);
+        let manifest_key = checkpoint_manifest(namespace_id.as_str(), 1);
         let store = ConflictOnManifestCreateStore::new(
             LocalFsStore::new(temp_dir.path()).expect("store"),
             manifest_key,
@@ -1233,7 +1234,7 @@ mod tests {
         }
 
         let basis = load_verified_namespace_basis(&store, &namespace_id).expect("basis");
-        assert_eq!(basis.head.snapshot_hint_seq, None);
+        assert_eq!(basis.head.checkpoint_hint_seq, None);
     }
 
     #[test]
@@ -1273,7 +1274,7 @@ mod tests {
             1
         );
         assert!(store
-            .head(&snapshot_manifest(namespace_id.as_str(), 1))
+            .head(&checkpoint_manifest(namespace_id.as_str(), 1))
             .expect("manifest head")
             .is_some());
     }
@@ -1307,8 +1308,12 @@ mod tests {
             &current.metadata_state
         ));
 
-        let segment_key =
-            snapshot_table(namespace_id.as_str(), 1, SnapshotTableFamily::Revisions, 0);
+        let segment_key = checkpoint_table(
+            namespace_id.as_str(),
+            1,
+            CheckpointTableFamily::Revisions,
+            0,
+        );
         assert!(store.head(&segment_key).expect("head segment").is_some());
     }
 
@@ -1362,7 +1367,7 @@ mod tests {
             None,
         )
         .expect("write second");
-        let published = publish_snapshot_hint_seq(
+        let published = publish_checkpoint_hint_seq(
             &store,
             &namespace_id,
             basis_before.head.seq,
@@ -1371,11 +1376,11 @@ mod tests {
         .expect("publish snapshot hint");
 
         assert_eq!(published.seq, ChangeSeq(2));
-        assert_eq!(published.snapshot_hint_seq, Some(ChangeSeq(1)));
+        assert_eq!(published.checkpoint_hint_seq, Some(ChangeSeq(1)));
 
         let after = load_verified_namespace_basis(&store, &namespace_id).expect("basis after");
         assert_eq!(after.head.seq, ChangeSeq(2));
-        assert_eq!(after.head.snapshot_hint_seq, Some(ChangeSeq(1)));
+        assert_eq!(after.head.checkpoint_hint_seq, Some(ChangeSeq(1)));
     }
 
     fn test_context() -> MutationContext {

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -53,7 +53,7 @@ pub(super) fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
             content_ref,
         } => CommitOp::ReplaceFile {
             inode_id,
-            base_revision: base_revision_no,
+            base_revision_no,
             content_ref,
         },
         api_v0::CommitOp::RestoreRevision {
@@ -62,8 +62,8 @@ pub(super) fn commit_op_from_v0(op: api_v0::CommitOp) -> CommitOp {
             base_revision_no,
         } => CommitOp::RestoreRevision {
             inode_id,
-            source_revision: source_revision_no,
-            base_revision: base_revision_no,
+            source_revision_no,
+            base_revision_no,
         },
         api_v0::CommitOp::DeleteFile { inode_id } => CommitOp::DeleteFile { inode_id },
         api_v0::CommitOp::Rename {
@@ -88,7 +88,7 @@ pub(super) fn commit_precondition_from_v0(
             revision_no,
         } => Precondition::InodeRevisionIs {
             inode_id,
-            revision: revision_no,
+            revision_no,
         },
         api_v0::CommitPrecondition::AncestorsNotSubtreeDeleted { inode_id } => {
             Precondition::AncestorsNotSubtreeDeleted { inode_id }

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -40,9 +40,12 @@ pub fn wal_payload_from_materialized_commit(
 impl From<&Precondition> for WalPrecondition {
     fn from(value: &Precondition) -> Self {
         match value {
-            Precondition::InodeRevisionIs { inode_id, revision } => Self::InodeRevisionIs {
+            Precondition::InodeRevisionIs {
+                inode_id,
+                revision_no,
+            } => Self::InodeRevisionIs {
                 inode_id: *inode_id,
-                revision: *revision,
+                revision_no: *revision_no,
             },
             Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
                 Self::AncestorsNotSubtreeDeleted {

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -55,13 +55,13 @@ pub enum CommitOp {
     },
     ReplaceFile {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
         content_ref: ContentRef,
     },
     RestoreRevision {
         inode_id: InodeId,
-        source_revision: RevisionNo,
-        base_revision: RevisionNo,
+        source_revision_no: RevisionNo,
+        base_revision_no: RevisionNo,
     },
     DeleteFile {
         inode_id: InodeId,
@@ -80,7 +80,7 @@ pub enum CommitOp {
 pub enum Precondition {
     InodeRevisionIs {
         inode_id: InodeId,
-        revision: RevisionNo,
+        revision_no: RevisionNo,
     },
     AncestorsNotSubtreeDeleted {
         inode_id: InodeId,
@@ -209,7 +209,7 @@ pub enum CommitValidationError {
     },
     RestoreRevisionSourceRevisionMissing {
         inode_id: InodeId,
-        source_revision: RevisionNo,
+        source_revision_no: RevisionNo,
     },
     RestoreRevisionUnderSubtreeTombstone {
         inode_id: InodeId,
@@ -279,11 +279,11 @@ pub enum CommitValidationError {
     },
     RestoreRevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
     ReplaceFileRevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
     StaleWriterFenceToken {
         active: FenceToken,

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -29,10 +29,10 @@ pub(crate) fn resolve_restore_content_refs(
         .map(|op| match op {
             CommitOp::ReplaceFile {
                 inode_id,
-                base_revision,
+                base_revision_no,
                 content_ref,
             } => {
-                if let Some(next_revision) = base_revision.0.checked_add(1).map(RevisionNo) {
+                if let Some(next_revision) = base_revision_no.0.checked_add(1).map(RevisionNo) {
                     resolved_request_revisions
                         .insert((*inode_id, next_revision), content_ref.clone());
                 }
@@ -40,20 +40,20 @@ pub(crate) fn resolve_restore_content_refs(
             }
             CommitOp::RestoreRevision {
                 inode_id,
-                source_revision,
-                base_revision,
+                source_revision_no,
+                base_revision_no,
             } => {
                 let resolved = resolved_request_revisions
-                    .get(&(*inode_id, *source_revision))
+                    .get(&(*inode_id, *source_revision_no))
                     .cloned()
                     .or_else(|| {
                         context
                             .metadata_state
-                            .revision_at_seq(*inode_id, *source_revision, context.head.seq)
+                            .revision_at_seq(*inode_id, *source_revision_no, context.head.seq)
                             .map(|revision| revision.content_ref)
                     });
                 if let (Some(next_revision), Some(content_ref)) = (
-                    base_revision.0.checked_add(1).map(RevisionNo),
+                    base_revision_no.0.checked_add(1).map(RevisionNo),
                     resolved.clone(),
                 ) {
                     resolved_request_revisions.insert((*inode_id, next_revision), content_ref);
@@ -213,25 +213,25 @@ fn validate_metadata_preconditions(
         let resolved_restore_content_ref = match op {
             CommitOp::RestoreRevision {
                 inode_id,
-                source_revision,
-                base_revision,
+                source_revision_no,
+                base_revision_no,
             } => {
                 validate_restore_target(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    *base_revision,
+                    *base_revision_no,
                     committed_seq,
                 )?;
-                let source_revision = validate_restore_source_revision(
+                let source_revision_no = validate_restore_source_revision(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    *source_revision,
+                    *source_revision_no,
                     committed_seq,
                 )?;
-                if base_revision.0.checked_add(1).is_none() {
+                if base_revision_no.0.checked_add(1).is_none() {
                     return Err(CommitValidationError::RestoreRevisionOverflow {
                         inode_id: *inode_id,
-                        base_revision: *base_revision,
+                        base_revision_no: *base_revision_no,
                     });
                 }
                 validate_restore_not_covered(
@@ -240,7 +240,7 @@ fn validate_metadata_preconditions(
                     committed_seq,
                     checked_invariants,
                 )?;
-                Some(source_revision.content_ref)
+                Some(source_revision_no.content_ref)
             }
             _ => None,
         };
@@ -270,19 +270,19 @@ fn validate_metadata_preconditions(
             }
             CommitOp::ReplaceFile {
                 inode_id,
-                base_revision,
+                base_revision_no,
                 ..
             } => {
                 validate_inode_revision_is(
                     &ephemeral_metadata_state,
                     *inode_id,
-                    *base_revision,
+                    *base_revision_no,
                     committed_seq,
                 )?;
-                if base_revision.0.checked_add(1).is_none() {
+                if base_revision_no.0.checked_add(1).is_none() {
                     return Err(CommitValidationError::ReplaceFileRevisionOverflow {
                         inode_id: *inode_id,
-                        base_revision: *base_revision,
+                        base_revision_no: *base_revision_no,
                     });
                 }
                 validate_ancestors_not_subtree_deleted(
@@ -378,34 +378,34 @@ fn materialization_error_to_validation_error(
             CommitMaterializationError::MissingResolvedRestoreContentRef { .. },
             CommitOp::RestoreRevision {
                 inode_id,
-                source_revision,
+                source_revision_no,
                 ..
             },
         ) => CommitValidationError::RestoreRevisionSourceRevisionMissing {
             inode_id: *inode_id,
-            source_revision: *source_revision,
+            source_revision_no: *source_revision_no,
         },
         (
             CommitMaterializationError::ReplaceRevisionOverflow { .. },
             CommitOp::ReplaceFile {
                 inode_id,
-                base_revision,
+                base_revision_no,
                 ..
             },
         ) => CommitValidationError::ReplaceFileRevisionOverflow {
             inode_id: *inode_id,
-            base_revision: *base_revision,
+            base_revision_no: *base_revision_no,
         },
         (
             CommitMaterializationError::RestoreRevisionOverflow { .. },
             CommitOp::RestoreRevision {
                 inode_id,
-                base_revision,
+                base_revision_no,
                 ..
             },
         ) => CommitValidationError::RestoreRevisionOverflow {
             inode_id: *inode_id,
-            base_revision: *base_revision,
+            base_revision_no: *base_revision_no,
         },
         (CommitMaterializationError::OpIndexOverflow, _) => CommitValidationError::OpIndexOverflow,
         _ => CommitValidationError::NextInodeOverflow,
@@ -420,8 +420,11 @@ fn validate_explicit_preconditions(
 ) -> Result<(), CommitValidationError> {
     for precondition in preconditions {
         match precondition {
-            Precondition::InodeRevisionIs { inode_id, revision } => {
-                validate_inode_revision_is(metadata_state, *inode_id, *revision, base_seq)?;
+            Precondition::InodeRevisionIs {
+                inode_id,
+                revision_no,
+            } => {
+                validate_inode_revision_is(metadata_state, *inode_id, *revision_no, base_seq)?;
             }
             Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
                 validate_ancestors_not_subtree_deleted(
@@ -588,7 +591,7 @@ fn validate_child_name_absent(
 fn validate_inode_revision_is(
     metadata_state: &MetadataState,
     inode_id: InodeId,
-    expected_revision: RevisionNo,
+    expected_revision_no: RevisionNo,
     base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
@@ -601,14 +604,14 @@ fn validate_inode_revision_is(
         });
     }
 
-    let actual_revision = metadata_state
+    let actual_revision_no = metadata_state
         .latest_revision_head_at_seq(inode_id, base_seq)
         .map(|revision| revision.revision_no);
-    if actual_revision != Some(expected_revision) {
+    if actual_revision_no != Some(expected_revision_no) {
         return Err(CommitValidationError::ReplaceFileBaseRevisionMismatch {
             inode_id,
-            expected: expected_revision,
-            actual: actual_revision,
+            expected: expected_revision_no,
+            actual: actual_revision_no,
         });
     }
 
@@ -618,7 +621,7 @@ fn validate_inode_revision_is(
 fn validate_restore_target(
     metadata_state: &MetadataState,
     inode_id: InodeId,
-    expected_revision: RevisionNo,
+    expected_revision_no: RevisionNo,
     base_seq: ChangeSeq,
 ) -> Result<(), CommitValidationError> {
     let inode = metadata_state
@@ -631,14 +634,14 @@ fn validate_restore_target(
         });
     }
 
-    let actual_revision = metadata_state
+    let actual_revision_no = metadata_state
         .latest_revision_head_at_seq(inode_id, base_seq)
         .map(|revision| revision.revision_no);
-    if actual_revision != Some(expected_revision) {
+    if actual_revision_no != Some(expected_revision_no) {
         return Err(CommitValidationError::RestoreRevisionBaseRevisionMismatch {
             inode_id,
-            expected: expected_revision,
-            actual: actual_revision,
+            expected: expected_revision_no,
+            actual: actual_revision_no,
         });
     }
 
@@ -648,15 +651,15 @@ fn validate_restore_target(
 fn validate_restore_source_revision(
     metadata_state: &MetadataState,
     inode_id: InodeId,
-    source_revision: RevisionNo,
+    source_revision_no: RevisionNo,
     base_seq: ChangeSeq,
 ) -> Result<crate::metadata::RevisionRecord, CommitValidationError> {
     metadata_state
-        .revision_at_seq(inode_id, source_revision, base_seq)
+        .revision_at_seq(inode_id, source_revision_no, base_seq)
         .ok_or(
             CommitValidationError::RestoreRevisionSourceRevisionMissing {
                 inode_id,
-                source_revision,
+                source_revision_no,
             },
         )
 }

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -69,15 +69,15 @@ pub enum CommitMaterializationError {
     MissingAllocatedInode { op_index: u32 },
     #[error("missing resolved restore content ref for op index {op_index}")]
     MissingResolvedRestoreContentRef { op_index: u32 },
-    #[error("replace_file revision overflow for inode {inode_id:?} at base {base_revision:?}")]
+    #[error("replace_file revision overflow for inode {inode_id:?} at base {base_revision_no:?}")]
     ReplaceRevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
-    #[error("restore_revision overflow for inode {inode_id:?} at base {base_revision:?}")]
+    #[error("restore_revision overflow for inode {inode_id:?} at base {base_revision_no:?}")]
     RestoreRevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
 }
 
@@ -202,13 +202,13 @@ pub(super) fn materialize_commit_op(
         }
         CommitOp::ReplaceFile {
             inode_id,
-            base_revision,
+            base_revision_no,
             content_ref,
         } => {
-            let revision_no = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+            let revision_no = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                 CommitMaterializationError::ReplaceRevisionOverflow {
                     inode_id: *inode_id,
-                    base_revision: *base_revision,
+                    base_revision_no: *base_revision_no,
                 },
             )?;
             MaterializedCommitOp {
@@ -216,7 +216,7 @@ pub(super) fn materialize_commit_op(
                 wal_op: WalOp::ReplaceFile {
                     op_index,
                     inode_id: *inode_id,
-                    base_revision: *base_revision,
+                    base_revision_no: *base_revision_no,
                     content_ref: content_ref.clone(),
                 },
                 result: CommitOpResult::ReplaceFile {
@@ -229,16 +229,16 @@ pub(super) fn materialize_commit_op(
         }
         CommitOp::RestoreRevision {
             inode_id,
-            source_revision,
-            base_revision,
+            source_revision_no,
+            base_revision_no,
         } => {
             let content_ref = resolved_restore_content_ref
                 .ok_or(CommitMaterializationError::MissingResolvedRestoreContentRef { op_index })?
                 .clone();
-            let revision_no = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+            let revision_no = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                 CommitMaterializationError::RestoreRevisionOverflow {
                     inode_id: *inode_id,
-                    base_revision: *base_revision,
+                    base_revision_no: *base_revision_no,
                 },
             )?;
             MaterializedCommitOp {
@@ -246,14 +246,14 @@ pub(super) fn materialize_commit_op(
                 wal_op: WalOp::RestoreRevision {
                     op_index,
                     inode_id: *inode_id,
-                    source_revision_no: *source_revision,
-                    base_revision: *base_revision,
+                    source_revision_no: *source_revision_no,
+                    base_revision_no: *base_revision_no,
                     content_ref: content_ref.clone(),
                 },
                 result: CommitOpResult::RestoreRevision {
                     op_index,
                     inode_id: *inode_id,
-                    source_revision_no: *source_revision,
+                    source_revision_no: *source_revision_no,
                     revision_no,
                     content_ref,
                 },

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -68,7 +68,7 @@ pub fn prepare_commit_head_publish(
         active_fence_token: current_head.active_fence_token,
         next_inode_id: plan.resulting_next_inode_id,
         name_policy: current_head.name_policy,
-        snapshot_hint_seq: current_head.snapshot_hint_seq,
+        checkpoint_hint_seq: current_head.checkpoint_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
         visible_wal_tip: Some(wal.envelope.pointer(wal.object_key.clone())),
     };
@@ -135,7 +135,7 @@ mod tests {
             active_fence_token: FenceToken(1),
             next_inode_id: InodeId(10),
             name_policy: loon_api::NamePolicy::default(),
-            snapshot_hint_seq: Some(ChangeSeq(0)),
+            checkpoint_hint_seq: Some(ChangeSeq(0)),
             retention_floor_seq: ChangeSeq(0),
             visible_wal_tip: None,
         }

--- a/crates/loon-core/src/invariants.rs
+++ b/crates/loon-core/src/invariants.rs
@@ -54,8 +54,8 @@ pub const BACKGROUND_WORK_QUEUE_SHARD_OBJECT_INVARIANTS: &[&str] = &[
 
 pub const BACKGROUND_WORK_QUEUE_MUTATION_INVARIANTS: &[&str] = &[
     "lost_enqueue_repair_enqueues_when_head_outpaces_progress",
-    "snapshot_repair_dedupe_key_is_namespace_scoped",
-    "snapshot_repair_claimed_job_gets_follow_up",
+    "checkpoint_repair_dedupe_key_is_namespace_scoped",
+    "checkpoint_repair_claimed_job_gets_follow_up",
     "broker_lease_takeover_increments_epoch",
     "active_broker_lease_required_for_shard_mutation",
     "claim_timeout_allows_steal",
@@ -66,7 +66,7 @@ pub const BACKGROUND_WORK_QUEUE_MUTATION_INVARIANTS: &[&str] = &[
 
 pub const BACKGROUND_WORK_CHECKPOINT_HEAD_PUBLISH_INVARIANTS: &[&str] = &[
     "checkpoint_publish_requires_verified_checkpoint",
-    "snapshot_hint_seq_advances_monotonically",
+    "checkpoint_hint_seq_advances_monotonically",
     "retention_floor_seq_advances_monotonically",
     "retention_floor_seq_requires_checkpoint_coverage",
     "retention_floor_seq_requires_derived_progress",
@@ -255,14 +255,14 @@ pub const INVARIANTS: &[&str] = &[
     "queue_shard_key_matches_shard_id",
     "queue_shard_cas_protects_updates",
     "checkpoint_publish_requires_verified_checkpoint",
-    "snapshot_hint_seq_advances_monotonically",
+    "checkpoint_hint_seq_advances_monotonically",
     "retention_floor_seq_advances_monotonically",
     "retention_floor_seq_requires_checkpoint_coverage",
     "retention_floor_seq_requires_derived_progress",
     "retention_floor_seq_respects_policy_gate",
     "lost_enqueue_repair_enqueues_when_head_outpaces_progress",
-    "snapshot_repair_dedupe_key_is_namespace_scoped",
-    "snapshot_repair_claimed_job_gets_follow_up",
+    "checkpoint_repair_dedupe_key_is_namespace_scoped",
+    "checkpoint_repair_claimed_job_gets_follow_up",
     "broker_lease_takeover_increments_epoch",
     "active_broker_lease_required_for_shard_mutation",
     "claim_timeout_allows_steal",

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -101,7 +101,7 @@ pub enum VisiblePathError {
 pub enum MetadataApplyError {
     RevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
 }
 
@@ -175,13 +175,13 @@ impl MetadataState {
                 WalOp::ReplaceFile {
                     op_index,
                     inode_id,
-                    base_revision,
+                    base_revision_no,
                     content_ref,
                 } => {
-                    let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    let next_revision = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                         MetadataApplyError::RevisionOverflow {
                             inode_id: *inode_id,
-                            base_revision: *base_revision,
+                            base_revision_no: *base_revision_no,
                         },
                     )?;
                     metadata_state.revisions.push(RevisionRecord {
@@ -199,14 +199,14 @@ impl MetadataState {
                 WalOp::RestoreRevision {
                     op_index,
                     inode_id,
-                    base_revision,
+                    base_revision_no,
                     content_ref,
                     ..
                 } => {
-                    let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    let next_revision = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                         MetadataApplyError::RevisionOverflow {
                             inode_id: *inode_id,
-                            base_revision: *base_revision,
+                            base_revision_no: *base_revision_no,
                         },
                     )?;
                     metadata_state.revisions.push(RevisionRecord {

--- a/crates/loon-core/src/namespace.rs
+++ b/crates/loon-core/src/namespace.rs
@@ -27,7 +27,7 @@ pub fn next_takeover_head(current_head: &HeadState) -> Result<HeadState, HeadFen
         active_fence_token: FenceToken(next_fence),
         next_inode_id: current_head.next_inode_id,
         name_policy: current_head.name_policy,
-        snapshot_hint_seq: current_head.snapshot_hint_seq,
+        checkpoint_hint_seq: current_head.checkpoint_hint_seq,
         retention_floor_seq: current_head.retention_floor_seq,
         visible_wal_tip: current_head.visible_wal_tip.clone(),
     })

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -257,7 +257,7 @@ pub fn fork_namespace<S: ObjectStore + ?Sized>(
         active_fence_token: FenceToken(0),
         next_inode_id: source_checkpoint.manifest.payload.next_inode_id,
         name_policy: source_basis.head.name_policy,
-        snapshot_hint_seq: Some(fork_seq),
+        checkpoint_hint_seq: Some(fork_seq),
         retention_floor_seq: fork_seq,
         visible_wal_tip: None,
     };

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -44,7 +44,7 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
     let replace_file = vec![WalOp::ReplaceFile {
         op_index: 0,
         inode_id: InodeId(3),
-        base_revision: RevisionNo(1),
+        base_revision_no: RevisionNo(1),
         content_ref: content_ref("content-2"),
     }];
 
@@ -117,14 +117,14 @@ fn metadata_apply_matches_model_for_restore_revision() {
         vec![WalOp::ReplaceFile {
             op_index: 0,
             inode_id: InodeId(3),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-2"),
         }],
         vec![WalOp::RestoreRevision {
             op_index: 0,
             inode_id: InodeId(3),
             source_revision_no: RevisionNo(1),
-            base_revision: RevisionNo(2),
+            base_revision_no: RevisionNo(2),
             content_ref: content_ref("content-1"),
         }],
     ]);
@@ -150,7 +150,7 @@ fn metadata_apply_matches_model_for_restore_revision_of_current_head() {
             op_index: 0,
             inode_id: InodeId(3),
             source_revision_no: RevisionNo(1),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-1"),
         }],
     ]);

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -50,7 +50,7 @@ fn stale_revision_precondition_is_rejected() {
         vec![loon_api::WalOp::ReplaceFile {
             op_index: 0,
             inode_id: InodeId(3),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-2"),
         }],
     ]);
@@ -62,7 +62,7 @@ fn stale_revision_precondition_is_rejected() {
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::ReplaceFile {
             inode_id: InodeId(3),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-3"),
         }],
         preconditions: Vec::new(),
@@ -138,7 +138,7 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::ReplaceFile {
                 inode_id: InodeId(3),
-                base_revision: RevisionNo(1),
+                base_revision_no: RevisionNo(1),
                 content_ref: content_ref("content-2"),
             }],
             preconditions: Vec::new(),
@@ -173,8 +173,8 @@ fn restore_revision_validation_rejects_missing_inode() {
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(99),
-            source_revision: RevisionNo(1),
-            base_revision: RevisionNo(1),
+            source_revision_no: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
         }],
         preconditions: Vec::new(),
         message: None,
@@ -206,8 +206,8 @@ fn restore_revision_validation_rejects_non_file_target() {
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
-            source_revision: RevisionNo(1),
-            base_revision: RevisionNo(1),
+            source_revision_no: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
         }],
         preconditions: Vec::new(),
         message: None,
@@ -243,7 +243,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
         vec![loon_api::WalOp::ReplaceFile {
             op_index: 0,
             inode_id: InodeId(3),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-2"),
         }],
     ]);
@@ -257,8 +257,8 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
-                source_revision: RevisionNo(1),
-                base_revision: RevisionNo(1),
+                source_revision_no: RevisionNo(1),
+                base_revision_no: RevisionNo(1),
             }],
             preconditions: Vec::new(),
             message: None,
@@ -284,8 +284,8 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
-                source_revision: RevisionNo(99),
-                base_revision: RevisionNo(2),
+                source_revision_no: RevisionNo(99),
+                base_revision_no: RevisionNo(2),
             }],
             preconditions: Vec::new(),
             message: None,
@@ -298,7 +298,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
         missing_source,
         CommitValidationError::RestoreRevisionSourceRevisionMissing {
             inode_id: InodeId(3),
-            source_revision: RevisionNo(99),
+            source_revision_no: RevisionNo(99),
         }
     ));
 }
@@ -331,13 +331,13 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
             ops: vec![
                 CommitOp::ReplaceFile {
                     inode_id: InodeId(3),
-                    base_revision: RevisionNo(1),
+                    base_revision_no: RevisionNo(1),
                     content_ref: content_ref("content-2"),
                 },
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
-                    source_revision: RevisionNo(2),
-                    base_revision: RevisionNo(2),
+                    source_revision_no: RevisionNo(2),
+                    base_revision_no: RevisionNo(2),
                 },
             ],
             preconditions: Vec::new(),
@@ -372,7 +372,7 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
         vec![loon_api::WalOp::ReplaceFile {
             op_index: 0,
             inode_id: InodeId(3),
-            base_revision: RevisionNo(1),
+            base_revision_no: RevisionNo(1),
             content_ref: content_ref("content-2"),
         }],
     ]);
@@ -387,13 +387,13 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
             ops: vec![
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
-                    source_revision: RevisionNo(1),
-                    base_revision: RevisionNo(2),
+                    source_revision_no: RevisionNo(1),
+                    base_revision_no: RevisionNo(2),
                 },
                 CommitOp::RestoreRevision {
                     inode_id: InodeId(3),
-                    source_revision: RevisionNo(3),
-                    base_revision: RevisionNo(3),
+                    source_revision_no: RevisionNo(3),
+                    base_revision_no: RevisionNo(3),
                 },
             ],
             preconditions: Vec::new(),
@@ -443,8 +443,8 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
                 inode_id: InodeId(3),
-                source_revision: RevisionNo(1),
-                base_revision: RevisionNo(1),
+                source_revision_no: RevisionNo(1),
+                base_revision_no: RevisionNo(1),
             }],
             preconditions: Vec::new(),
             message: None,
@@ -503,8 +503,8 @@ fn restore_revision_overflow_is_rejected() {
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
-            source_revision: RevisionNo(u64::MAX),
-            base_revision: RevisionNo(u64::MAX),
+            source_revision_no: RevisionNo(u64::MAX),
+            base_revision_no: RevisionNo(u64::MAX),
         }],
         preconditions: Vec::new(),
         message: None,
@@ -516,7 +516,7 @@ fn restore_revision_overflow_is_rejected() {
         error,
         CommitValidationError::RestoreRevisionOverflow {
             inode_id: InodeId(2),
-            base_revision: RevisionNo(u64::MAX),
+            base_revision_no: RevisionNo(u64::MAX),
         }
     ));
 }
@@ -1384,7 +1384,7 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
         load_verified_namespace_basis(&store, &clone_namespace_id).expect("clone basis");
     assert_eq!(clone_basis.content_store_id, content_store_id);
     assert_eq!(clone_basis.head.seq, ChangeSeq(1));
-    assert_eq!(clone_basis.head.snapshot_hint_seq, Some(ChangeSeq(1)));
+    assert_eq!(clone_basis.head.checkpoint_hint_seq, Some(ChangeSeq(1)));
     assert_eq!(clone_basis.head.retention_floor_seq, ChangeSeq(1));
 
     let duplicate_error =
@@ -1496,7 +1496,7 @@ fn fork_target_head_reservation_failure_writes_no_checkpoint_artifacts() {
     assert!(
         store
             .list_prefix(&format!(
-                "namespaces/{}/snapshots/",
+                "namespaces/{}/checkpoints/",
                 clone_namespace_id.as_str()
             ))
             .expect("list target snapshots")
@@ -1515,7 +1515,7 @@ fn fork_failure_after_target_head_reserves_partial_namespace() {
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         KeyMatcher::Prefix(format!(
-            "namespaces/{}/snapshots/",
+            "namespaces/{}/checkpoints/",
             clone_namespace_id.as_str()
         )),
         InjectedCreateFailure::Transport {
@@ -1578,7 +1578,7 @@ fn fork_failure_after_target_checkpoint_artifacts_remains_partial() {
     );
     let target_snapshot_keys = store
         .list_prefix(&format!(
-            "namespaces/{}/snapshots/",
+            "namespaces/{}/checkpoints/",
             clone_namespace_id.as_str()
         ))
         .expect("list target snapshots");
@@ -2414,7 +2414,7 @@ fn validation_context(
         active_fence_token: FenceToken(1),
         next_inode_id,
         name_policy: loon_api::NamePolicy::default(),
-        snapshot_hint_seq: Some(ChangeSeq(0)),
+        checkpoint_hint_seq: Some(ChangeSeq(0)),
         retention_floor_seq: ChangeSeq(0),
         visible_wal_tip: None,
     };

--- a/crates/loon-model/src/metadata.rs
+++ b/crates/loon-model/src/metadata.rs
@@ -91,7 +91,7 @@ pub enum VisiblePathError {
 pub enum MetadataApplyError {
     RevisionOverflow {
         inode_id: InodeId,
-        base_revision: RevisionNo,
+        base_revision_no: RevisionNo,
     },
 }
 
@@ -165,13 +165,13 @@ impl MetadataState {
                 WalOp::ReplaceFile {
                     op_index,
                     inode_id,
-                    base_revision,
+                    base_revision_no,
                     content_ref,
                 } => {
-                    let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    let next_revision = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                         MetadataApplyError::RevisionOverflow {
                             inode_id: *inode_id,
-                            base_revision: *base_revision,
+                            base_revision_no: *base_revision_no,
                         },
                     )?;
                     metadata_state.revisions.push(RevisionRecord {
@@ -189,14 +189,14 @@ impl MetadataState {
                 WalOp::RestoreRevision {
                     op_index,
                     inode_id,
-                    base_revision,
+                    base_revision_no,
                     content_ref,
                     ..
                 } => {
-                    let next_revision = base_revision.0.checked_add(1).map(RevisionNo).ok_or(
+                    let next_revision = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
                         MetadataApplyError::RevisionOverflow {
                             inode_id: *inode_id,
-                            base_revision: *base_revision,
+                            base_revision_no: *base_revision_no,
                         },
                     )?;
                     metadata_state.revisions.push(RevisionRecord {

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -1,7 +1,7 @@
 use crate::ObjectStoreError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SnapshotTableFamily {
+pub enum CheckpointTableFamily {
     Inodes,
     Direntries,
     Revisions,
@@ -9,7 +9,7 @@ pub enum SnapshotTableFamily {
     CommitReceipts,
 }
 
-impl SnapshotTableFamily {
+impl CheckpointTableFamily {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Inodes => "inodes",
@@ -23,13 +23,13 @@ impl SnapshotTableFamily {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DerivedWorkClass {
-    SnapshotBuilder,
+    CheckpointBuilder,
 }
 
 impl DerivedWorkClass {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::SnapshotBuilder => "snapshot-builder",
+            Self::CheckpointBuilder => "checkpoint-builder",
         }
     }
 }
@@ -80,18 +80,18 @@ pub fn upload_session_prefix(namespace: &str) -> String {
     format!("namespaces/{namespace}/control/uploads/")
 }
 
-pub fn snapshot_manifest(namespace: &str, seq: u64) -> String {
-    format!("namespaces/{namespace}/snapshots/{seq:020}/manifest.json")
+pub fn checkpoint_manifest(namespace: &str, seq: u64) -> String {
+    format!("namespaces/{namespace}/checkpoints/{seq:020}/manifest.json")
 }
 
-pub fn snapshot_table(
+pub fn checkpoint_table(
     namespace: &str,
     seq: u64,
-    family: SnapshotTableFamily,
+    family: CheckpointTableFamily,
     segment_index: u32,
 ) -> String {
     format!(
-        "namespaces/{namespace}/snapshots/{seq:020}/tables/{}-{segment_index:05}.sst.zst",
+        "namespaces/{namespace}/checkpoints/{seq:020}/tables/{}-{segment_index:05}.sst.zst",
         family.as_str()
     )
 }
@@ -124,10 +124,10 @@ pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
-        derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
-        sha256_hex_from_digest, snapshot_manifest, snapshot_table, upload_session,
-        upload_session_prefix, wal_segment, DerivedWorkClass, SnapshotTableFamily,
+        checkpoint_manifest, checkpoint_table, conflict_artifact, conflict_artifact_prefix,
+        content_blob, content_store_descriptor, derived_progress, namespace_descriptor,
+        namespace_head, namespace_lease, queue_shard, sha256_hex_from_digest, upload_session,
+        upload_session_prefix, wal_segment, CheckpointTableFamily, DerivedWorkClass,
     };
 
     #[test]
@@ -147,20 +147,20 @@ mod tests {
             "namespaces/ns-1/wal/00000000000000000420-00000000000000000425-seg_00000000000000000000000000000001.cbor.zst"
         );
         assert_eq!(
-            snapshot_manifest("ns-1", 400),
-            "namespaces/ns-1/snapshots/00000000000000000400/manifest.json"
+            checkpoint_manifest("ns-1", 400),
+            "namespaces/ns-1/checkpoints/00000000000000000400/manifest.json"
         );
         assert_eq!(
-            snapshot_table("ns-1", 400, SnapshotTableFamily::Direntries, 7),
-            "namespaces/ns-1/snapshots/00000000000000000400/tables/direntries-00007.sst.zst"
+            checkpoint_table("ns-1", 400, CheckpointTableFamily::Direntries, 7),
+            "namespaces/ns-1/checkpoints/00000000000000000400/tables/direntries-00007.sst.zst"
         );
         assert_eq!(
-            snapshot_table("ns-1", 400, SnapshotTableFamily::CommitReceipts, 0),
-            "namespaces/ns-1/snapshots/00000000000000000400/tables/commit-receipts-00000.sst.zst"
+            checkpoint_table("ns-1", 400, CheckpointTableFamily::CommitReceipts, 0),
+            "namespaces/ns-1/checkpoints/00000000000000000400/tables/commit-receipts-00000.sst.zst"
         );
         assert_eq!(
-            derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder),
-            "namespaces/ns-1/derived/snapshot-builder/progress.json"
+            derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder),
+            "namespaces/ns-1/derived/checkpoint-builder/progress.json"
         );
         assert_eq!(queue_shard(17), "queue/shards/00017.json");
         assert_eq!(

--- a/crates/loon-objectstore/src/probes.rs
+++ b/crates/loon-objectstore/src/probes.rs
@@ -134,7 +134,7 @@ fn probe_visibility_after_write<S: ObjectStore + ?Sized>(
 ) -> Result<(), ContractProbeError> {
     let key = derived_progress(
         &probe_namespace(run_id, "visibility"),
-        DerivedWorkClass::SnapshotBuilder,
+        DerivedWorkClass::CheckpointBuilder,
     );
     let _ = store.delete(&key);
 
@@ -163,7 +163,7 @@ fn probe_visibility_after_delete<S: ObjectStore + ?Sized>(
     run_id: &str,
 ) -> Result<(), ContractProbeError> {
     let namespace = probe_namespace(run_id, "delete");
-    let key = derived_progress(&namespace, DerivedWorkClass::SnapshotBuilder);
+    let key = derived_progress(&namespace, DerivedWorkClass::CheckpointBuilder);
     let _ = store.delete(&key);
 
     store
@@ -191,7 +191,7 @@ fn probe_sorted_listing<S: ObjectStore + ?Sized>(
 ) -> Result<(), ContractProbeError> {
     let namespace = probe_namespace(run_id, "sorted");
     let keys = vec![
-        derived_progress(&namespace, DerivedWorkClass::SnapshotBuilder),
+        derived_progress(&namespace, DerivedWorkClass::CheckpointBuilder),
         namespace_head(&namespace),
         namespace_lease(&namespace),
     ];

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -2,9 +2,9 @@ mod provider_env;
 
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
-    content_blob, content_store_descriptor, derived_progress, namespace_descriptor, namespace_head,
-    namespace_lease, queue_shard, snapshot_manifest, snapshot_table, wal_segment, DerivedWorkClass,
-    SnapshotTableFamily,
+    checkpoint_manifest, checkpoint_table, content_blob, content_store_descriptor,
+    derived_progress, namespace_descriptor, namespace_head, namespace_lease, queue_shard,
+    wal_segment, CheckpointTableFamily, DerivedWorkClass,
 };
 use loon_objectstore::probes::run_contract_probes;
 use loon_objectstore::provider::{Expectation, AWS_S3, CLOUDFLARE_R2, LOCAL_FS};
@@ -150,20 +150,20 @@ fn key_builders_cover_locked_object_families() {
         "namespaces/ns-1/wal/00000000000000000420-00000000000000000420-seg_00000000000000000000000000000001.cbor.zst"
     );
     assert_eq!(
-        snapshot_manifest("ns-1", 420),
-        "namespaces/ns-1/snapshots/00000000000000000420/manifest.json"
+        checkpoint_manifest("ns-1", 420),
+        "namespaces/ns-1/checkpoints/00000000000000000420/manifest.json"
     );
     assert_eq!(
-        snapshot_table("ns-1", 420, SnapshotTableFamily::Inodes, 3),
-        "namespaces/ns-1/snapshots/00000000000000000420/tables/inodes-00003.sst.zst"
+        checkpoint_table("ns-1", 420, CheckpointTableFamily::Inodes, 3),
+        "namespaces/ns-1/checkpoints/00000000000000000420/tables/inodes-00003.sst.zst"
     );
     assert_eq!(
-        snapshot_table("ns-1", 420, SnapshotTableFamily::CommitReceipts, 0),
-        "namespaces/ns-1/snapshots/00000000000000000420/tables/commit-receipts-00000.sst.zst"
+        checkpoint_table("ns-1", 420, CheckpointTableFamily::CommitReceipts, 0),
+        "namespaces/ns-1/checkpoints/00000000000000000420/tables/commit-receipts-00000.sst.zst"
     );
     assert_eq!(
-        derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder),
-        "namespaces/ns-1/derived/snapshot-builder/progress.json"
+        derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder),
+        "namespaces/ns-1/derived/checkpoint-builder/progress.json"
     );
     assert_eq!(queue_shard(12), "queue/shards/00012.json");
 }
@@ -402,7 +402,7 @@ fn assert_delete_missing_is_idempotent<S: ObjectStore>(store: &S) {
 }
 
 fn assert_lists_immediately_after_write_and_delete<S: ObjectStore>(store: &S) {
-    let key = derived_progress("ns-1", DerivedWorkClass::SnapshotBuilder);
+    let key = derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder);
     let _ = store.delete(&key);
 
     store
@@ -424,7 +424,7 @@ fn assert_lists_immediately_after_write_and_delete<S: ObjectStore>(store: &S) {
 
 fn assert_sorted_list_prefix<S: ObjectStore>(store: &S) {
     let keys = vec![
-        derived_progress("ns-sort", DerivedWorkClass::SnapshotBuilder),
+        derived_progress("ns-sort", DerivedWorkClass::CheckpointBuilder),
         namespace_head("ns-sort"),
         namespace_lease("ns-sort"),
     ];

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -7,7 +7,7 @@ use loon_api::{
     CreateCheckpointResponse, InodeId, LeaseStateEnvelope, RevisionNo,
 };
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loon_objectstore::keys::{namespace_lease, snapshot_manifest};
+use loon_objectstore::keys::{checkpoint_manifest, namespace_lease};
 use loon_objectstore::{ConfiguredObjectStore, ObjectStore};
 use loon_server::{app, ServerConfig, StoreConfig};
 use serde_json::json;
@@ -816,8 +816,8 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
 
         let first = post_checkpoint(&server_url, namespace).expect("first checkpoint");
         assert_eq!(first.checkpoint_seq, ChangeSeq(1));
-        assert_eq!(first.snapshot_hint_seq, Some(ChangeSeq(1)));
-        assert!(first.snapshot_hint_points_at_checkpoint);
+        assert_eq!(first.checkpoint_hint_seq, Some(ChangeSeq(1)));
+        assert!(first.checkpoint_hint_points_at_checkpoint);
 
         let repeated = post_checkpoint(&server_url, namespace).expect("repeat checkpoint");
         assert_eq!(repeated, first);
@@ -907,7 +907,7 @@ async fn http_checkpoint_consumption_is_strict_when_manifest_is_corrupted() {
         let store = ConfiguredObjectStore::local_fs(&store_root, store_key_prefix.as_deref())
             .expect("construct store");
         store
-            .put_overwrite(&snapshot_manifest(namespace, 1), br#"{"bad":"json"}"#)
+            .put_overwrite(&checkpoint_manifest(namespace, 1), br#"{"bad":"json"}"#)
             .expect("corrupt manifest");
 
         match client.stat_path(&target) {

--- a/docs/specs/010-glossary.md
+++ b/docs/specs/010-glossary.md
@@ -12,7 +12,7 @@
 | **Direntry** | A directory binding that places one inode under one parent directory and one name. |
 | **Path** | A human-friendly name built by walking visible directory bindings. Paths can change; inode identity does not. |
 | **Revision** | One immutable committed version of a file's content. Revisions are ordered by `revision_no` within an inode. |
-| **Checkpoint** | A verified snapshot of namespace metadata at one chosen `seq`. It lets readers avoid replaying the entire WAL history. |
+| **Checkpoint** | A verified materialization of namespace metadata at one chosen `seq`. It lets readers avoid replaying the entire WAL history. |
 | **Content object** | One immutable object containing file bytes. In v0, each file revision stores the whole file as one object. |
 | **Content ref** | The metadata pointer for a file revision. In v0 it has `kind: "whole_file_v0"`, a `sha256:<hex>` digest, and `size_bytes`. |
 | **NamePolicy** | The versioned rule that decides how sibling names are compared for collisions. |

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -31,8 +31,8 @@ The required durable object families and standard key patterns are:
 | **Content-store descriptor** | Immutable | Record content-store identity. | `content-stores/{content_store_id}/descriptor.json` |
 | **Content objects** | Immutable | Store whole-file v0 bytes. | `content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` |
 | **WAL segments** | Immutable | Record one or more logical commits with a contiguous sequence range. | `namespaces/{namespace_id}/wal/{start_seq}-{end_seq}-{segment_id}.cbor.zst` |
-| **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/manifest.json` |
-| **Checkpoint segments** | Immutable | Store verified checkpoint data. | `namespaces/{namespace_id}/snapshots/{checkpoint_seq}/tables/{family}-{segment_index}.sst.zst` |
+| **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced checkpoint data. | `namespaces/{namespace_id}/checkpoints/{checkpoint_seq}/manifest.json` |
+| **Checkpoint segments** | Immutable | Store verified checkpoint data. | `namespaces/{namespace_id}/checkpoints/{checkpoint_seq}/tables/{family}-{segment_index}.sst.zst` |
 
 These key shapes are part of the interoperable storage contract. Implementations may add other control-plane objects.
 
@@ -42,7 +42,7 @@ LoonFS uses distinct naming conventions for distinct surfaces:
 
 - Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `commit-receipts`, and `control/uploads`.
 - Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41`, `upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c`, and `seg_b7c14a0d9e6f42a38c5d21f0e8a739bc`.
-- Durable work-class names use lowercase-kebab, e.g. `snapshot-builder`.
+- Durable work-class names use lowercase-kebab, e.g. `checkpoint-builder`.
 - JSON enum values use snake_case.
 - Namespace IDs are human/operator slugs; prefer lowercase kebab-case while preserving the namespace grammar.
 

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -213,7 +213,7 @@ The head summarizes the current visible boundary and replay hints, including at 
 
 - `seq`
 - `next_inode_id`
-- `snapshot_hint_seq`
+- `checkpoint_hint_seq`
 - `retention_floor_seq`
 - `wal_tip_segment_id` or an equivalent visible tail pointer
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -82,8 +82,8 @@ A read reconstructs the visible filesystem state from durable artifacts on objec
 The reader builds an in-memory metadata state from two kinds of durable object:
 
 1. Read the namespace descriptor and content-store descriptor to learn the namespace's immutable content-store relationship.
-2. Read the namespace **head** object to learn the current `seq`, `snapshot_hint_seq`, and visible WAL tip.
-3. If `snapshot_hint_seq` is set, load the **verified checkpoint** at that `seq`. The checkpoint materializes metadata state through that `seq` across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
+2. Read the namespace **head** object to learn the current `seq`, `checkpoint_hint_seq`, and visible WAL tip.
+3. If `checkpoint_hint_seq` is set, load the **verified checkpoint** at that `seq`. The checkpoint materializes metadata state through that `seq` across four append-only tables: inodes, direntries, revisions, and subtree tombstones.
 4. Use the visible WAL tip named by the head to identify the visible segment chain after the checkpoint `seq` (or from genesis, if no checkpoint exists), then replay the logical commit records in ascending `seq` order through `head.seq`. Each logical commit appends rows to the same four tables.
 
 The result is a complete metadata state pinned to one `seq`.
@@ -201,7 +201,7 @@ A namespace may advance a retention floor to say:
 
 > Incremental replay older than this point is no longer promised.
 
-Clients older than the retention floor must re-bootstrap from a fresh snapshot instead of replaying from an obsolete cursor.
+Clients older than the retention floor must re-bootstrap from a fresh checkpoint instead of replaying from an obsolete cursor.
 
 The retention floor may advance only after the system has enough verified material to keep replay safe at or after that point.
 

--- a/docs/specs/080-background-jobs.md
+++ b/docs/specs/080-background-jobs.md
@@ -10,7 +10,7 @@ Background work reduces read cost, supports safe retention, and cleans up durabl
 
 A checkpoint summarizes namespace metadata at one chosen `seq`.
 
-A checkpoint is useful only after it is verified. Readers must prefer verified checkpoints plus the visible WAL segment chain over unverified or partial snapshots.
+A checkpoint is useful only after it is verified. Readers must prefer verified checkpoints plus the visible WAL segment chain over unverified or partial checkpoints.
 
 ### 2.2 Retention management
 


### PR DESCRIPTION
This PR makes ~2 small changes to vocab. The "checkpoint" naming convention is written to storage so hard to reverse later. Getting ahead of that here. 