### PR TITLE
feat(loonfs): add basic maintenance tool

### DIFF
--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -1,6 +1,7 @@
 use crate::checkpoint::{
     checkpoint_basis_head, load_verified_checkpoint_materialization, CheckpointLoadError,
 };
+use crate::error::CoreError;
 use crate::genesis::bootstrap_basis_metadata_state;
 use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
 use crate::metadata::MetadataState;
@@ -22,6 +23,14 @@ pub struct VerifiedNamespaceBasis {
     pub head_etag: String,
     pub lease: loon_api::LeaseState,
     pub metadata_state: MetadataState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceHeadSummary {
+    pub namespace_id: NamespaceId,
+    pub head_seq: ChangeSeq,
+    pub checkpoint_hint_seq: Option<ChangeSeq>,
+    pub retention_floor_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
@@ -132,6 +141,21 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
         head_etag,
         lease: loaded_lease.envelope.state,
         metadata_state: replayed.resulting_metadata_state,
+    })
+}
+
+pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<NamespaceHeadSummary, CoreError> {
+    let loaded_head = read_head_object(store, expected_namespace)
+        .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
+    let head = loaded_head.envelope.state;
+    Ok(NamespaceHeadSummary {
+        namespace_id: head.namespace_id,
+        head_seq: head.seq,
+        checkpoint_hint_seq: head.checkpoint_hint_seq,
+        retention_floor_seq: head.retention_floor_seq,
     })
 }
 

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -5,13 +5,16 @@ use crate::error::CoreError;
 use crate::genesis::bootstrap_basis_metadata_state;
 use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
 use crate::metadata::MetadataState;
-use crate::namespace::catalog::{load_namespace_catalog_entry, NamespaceCatalogLoadError};
+use crate::namespace::catalog::{
+    load_namespace_catalog_entry, namespace_initialization_state, NamespaceCatalogLoadError,
+    NamespaceInitializationError, NamespaceInitializationState,
+};
 use crate::wal::{replay_wal_tail_with_metadata, StoredWalObject, WalReplayError};
 use loon_api::{
     decode_wal_segment_envelope_zstd, ChangeSeq, ContentStoreId, HeadState,
     NamespaceDescriptorState, NamespaceId, WalSegmentPointer,
 };
-use loon_objectstore::ObjectStore;
+use loon_objectstore::{keys::namespace_descriptor, ObjectStore};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -148,6 +151,23 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
 ) -> Result<NamespaceHeadSummary, CoreError> {
+    match namespace_initialization_state(store, expected_namespace) {
+        Ok(NamespaceInitializationState::Complete) => {}
+        Ok(NamespaceInitializationState::Absent) => {
+            return Err(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
+                ControlObjectLoadError::MissingObject {
+                    object_key: namespace_descriptor(expected_namespace.as_str()),
+                },
+            )));
+        }
+        Ok(NamespaceInitializationState::Partial) => {
+            return Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: expected_namespace.clone(),
+            });
+        }
+        Err(error) => return Err(map_namespace_initialization_error_to_core(error)),
+    }
+
     let loaded_head = read_head_object(store, expected_namespace)
         .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
     let head = loaded_head.envelope.state;
@@ -157,6 +177,25 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         checkpoint_hint_seq: head.checkpoint_hint_seq,
         retention_floor_seq: head.retention_floor_seq,
     })
+}
+
+fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+        }
+        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+        }
+        NamespaceInitializationError::InspectNamespaceDescriptor(_)
+        | NamespaceInitializationError::InspectNamespaceHead(_)
+        | NamespaceInitializationError::InspectNamespaceLease(_) => {
+            CoreError::Store(error.to_string())
+        }
+    }
 }
 
 fn ensure_reconstructed_head_matches(

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -1,4 +1,5 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError};
+use crate::commit::CommitHeadPublishError;
 use crate::content::write_immutable_object;
 use crate::context::MutationContext;
 use crate::error::CoreError;
@@ -572,9 +573,7 @@ fn publish_checkpoint_hint_seq<S: ObjectStore + ?Sized>(
         }
     }
 
-    Err(CoreError::Store(
-        "snapshot hint compare-and-swap retry exhausted".to_owned(),
-    ))
+    Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
 }
 
 fn compare_and_swap_head<S: ObjectStore + ?Sized>(
@@ -1105,11 +1104,13 @@ mod tests {
     };
     use crate::{
         bootstrap_namespace, load_verified_namespace_basis, put_file_bytes, write_file_bytes,
-        BasisLoadError, CoreError, MutationContext, PutFileBehavior,
+        BasisLoadError, CoreError, CoreErrorKind, MutationContext, PutFileBehavior,
     };
     use loon_api::{ChangeSeq, CheckpointManifestEnvelope, CheckpointManifestPayload, NamespaceId};
     use loon_objectstore::fs::LocalFsStore;
-    use loon_objectstore::keys::{checkpoint_manifest, checkpoint_table, CheckpointTableFamily};
+    use loon_objectstore::keys::{
+        checkpoint_manifest, checkpoint_table, namespace_head, CheckpointTableFamily,
+    };
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -1383,12 +1384,98 @@ mod tests {
         assert_eq!(after.head.checkpoint_hint_seq, Some(ChangeSeq(1)));
     }
 
+    #[test]
+    fn checkpoint_hint_cas_retry_exhaustion_is_stale_head() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::from("demo");
+        let context = test_context();
+        let store = HeadCasFailureStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("store"),
+            namespace_head(namespace_id.as_str()),
+        );
+        bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+        store.fail_head_cas();
+        let error = publish_checkpoint_hint_seq(
+            &store,
+            &namespace_id,
+            ChangeSeq(0),
+            &context.writer_version,
+        )
+        .expect_err("checkpoint hint publication should exhaust CAS retries");
+
+        assert_eq!(error.kind(), CoreErrorKind::StaleHead);
+    }
+
     fn test_context() -> MutationContext {
         MutationContext {
             writer_id: "test-writer".to_owned(),
             writer_version: "test-writer/0.1.0".to_owned(),
             now_ms: 1_000,
             lease_duration_ms: 60_000,
+        }
+    }
+
+    struct HeadCasFailureStore {
+        inner: LocalFsStore,
+        head_key: String,
+        fail_head_cas: Mutex<bool>,
+    }
+
+    impl HeadCasFailureStore {
+        fn new(inner: LocalFsStore, head_key: String) -> Self {
+            Self {
+                inner,
+                head_key,
+                fail_head_cas: Mutex::new(false),
+            }
+        }
+
+        fn fail_head_cas(&self) {
+            *self
+                .fail_head_cas
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+        }
+    }
+
+    impl ObjectStore for HeadCasFailureStore {
+        fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key)
+        }
+
+        fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+            self.inner.get(key, range)
+        }
+
+        fn put(
+            &self,
+            key: &str,
+            bytes: &[u8],
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            if key == self.head_key
+                && matches!(&mode, PutMode::CompareAndSwap { .. })
+                && *self
+                    .fail_head_cas
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+            {
+                return Err(ObjectStoreError::PreconditionFailed);
+            }
+            self.inner.put(key, bytes, mode)
+        }
+
+        fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key)
+        }
+
+        fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+            self.inner.list_prefix(prefix)
         }
     }
 

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -17,7 +17,10 @@ pub mod publisher;
 pub mod services;
 pub mod wal;
 
-pub use basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
+pub use basis::{
+    load_namespace_head_summary, load_verified_namespace_basis, BasisLoadError,
+    NamespaceHeadSummary, VerifiedNamespaceBasis,
+};
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, CheckpointLoadError, CheckpointLoadErrorKind,
 };

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -22,6 +22,7 @@ pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
 pub const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
+pub const DEFAULT_MAX_UNCHECKPOINTED_COMMITS: u64 = 1_000;
 
 pub type SharedObjectStore = Arc<dyn ObjectStore + Send + Sync>;
 pub type Result<T> = std::result::Result<T, RuntimeError>;
@@ -68,6 +69,50 @@ pub struct FsBuilder {
     writer_id: Option<String>,
     writer_version: String,
     lease_duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceStatus {
+    pub namespace_id: NamespaceId,
+    pub head_seq: ChangeSeq,
+    pub checkpoint_hint_seq: Option<ChangeSeq>,
+    pub uncheckpointed_commits: u64,
+    pub retention_floor_seq: ChangeSeq,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaintenanceTickOptions {
+    pub max_uncheckpointed_commits: u64,
+}
+
+impl Default for MaintenanceTickOptions {
+    fn default() -> Self {
+        Self {
+            max_uncheckpointed_commits: DEFAULT_MAX_UNCHECKPOINTED_COMMITS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaintenanceTickOutcome {
+    NotNeeded,
+    CheckpointPublished {
+        checkpoint_seq: ChangeSeq,
+    },
+    CheckpointSuperseded {
+        attempted_seq: ChangeSeq,
+        checkpoint_hint_seq: ChangeSeq,
+    },
+    CheckpointPublishRaceLost {
+        attempted_seq: ChangeSeq,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaintenanceTickResult {
+    pub namespace_id: NamespaceId,
+    pub status_before: NamespaceStatus,
+    pub outcome: MaintenanceTickOutcome,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -190,6 +235,77 @@ impl Fs {
 
     pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
         Ok(loon_core::list_namespaces(self.store())?)
+    }
+
+    pub fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
+        let summary = loon_core::load_namespace_head_summary(self.store(), namespace_id)?;
+        let checkpoint_seq = summary
+            .checkpoint_hint_seq
+            .map(|seq| seq.0)
+            .unwrap_or_default();
+        Ok(NamespaceStatus {
+            namespace_id: summary.namespace_id,
+            head_seq: summary.head_seq,
+            checkpoint_hint_seq: summary.checkpoint_hint_seq,
+            uncheckpointed_commits: summary.head_seq.0.saturating_sub(checkpoint_seq),
+            retention_floor_seq: summary.retention_floor_seq,
+        })
+    }
+
+    pub fn maintenance_tick_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> Result<MaintenanceTickResult> {
+        if options.max_uncheckpointed_commits == 0 {
+            return Err(RuntimeError::Config(
+                "max_uncheckpointed_commits must be greater than zero".to_owned(),
+            ));
+        }
+
+        let status_before = self.namespace_status(namespace_id)?;
+        let attempted_seq = status_before.head_seq;
+        if status_before.uncheckpointed_commits < options.max_uncheckpointed_commits {
+            return Ok(MaintenanceTickResult {
+                namespace_id: namespace_id.clone(),
+                status_before,
+                outcome: MaintenanceTickOutcome::NotNeeded,
+            });
+        }
+
+        let checkpoint = match self.create_checkpoint(namespace_id) {
+            Ok(checkpoint) => checkpoint,
+            Err(RuntimeError::Core(error)) if error.kind() == CoreErrorKind::StaleHead => {
+                return Ok(MaintenanceTickResult {
+                    namespace_id: namespace_id.clone(),
+                    status_before,
+                    outcome: MaintenanceTickOutcome::CheckpointPublishRaceLost { attempted_seq },
+                });
+            }
+            Err(error) => return Err(error),
+        };
+
+        let outcome = if checkpoint.checkpoint_hint_points_at_checkpoint {
+            MaintenanceTickOutcome::CheckpointPublished {
+                checkpoint_seq: checkpoint.checkpoint_seq,
+            }
+        } else {
+            let Some(checkpoint_hint_seq) = checkpoint.checkpoint_hint_seq else {
+                return Err(RuntimeError::Core(CoreError::Store(
+                    "checkpoint hint publication returned no checkpoint hint".to_owned(),
+                )));
+            };
+            MaintenanceTickOutcome::CheckpointSuperseded {
+                attempted_seq,
+                checkpoint_hint_seq,
+            }
+        };
+
+        Ok(MaintenanceTickResult {
+            namespace_id: namespace_id.clone(),
+            status_before,
+            outcome,
+        })
     }
 
     pub fn stat_path(

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -104,7 +104,7 @@ pub enum MaintenanceTickOutcome {
         checkpoint_hint_seq: ChangeSeq,
     },
     CheckpointPublishRaceLost {
-        attempted_seq: ChangeSeq,
+        observed_head_seq: ChangeSeq,
     },
 }
 
@@ -264,7 +264,7 @@ impl Fs {
         }
 
         let status_before = self.namespace_status(namespace_id)?;
-        let attempted_seq = status_before.head_seq;
+        let observed_head_seq = status_before.head_seq;
         if status_before.uncheckpointed_commits < options.max_uncheckpointed_commits {
             return Ok(MaintenanceTickResult {
                 namespace_id: namespace_id.clone(),
@@ -279,7 +279,9 @@ impl Fs {
                 return Ok(MaintenanceTickResult {
                     namespace_id: namespace_id.clone(),
                     status_before,
-                    outcome: MaintenanceTickOutcome::CheckpointPublishRaceLost { attempted_seq },
+                    outcome: MaintenanceTickOutcome::CheckpointPublishRaceLost {
+                        observed_head_seq,
+                    },
                 });
             }
             Err(error) => return Err(error),
@@ -296,7 +298,7 @@ impl Fs {
                 )));
             };
             MaintenanceTickOutcome::CheckpointSuperseded {
-                attempted_seq,
+                attempted_seq: checkpoint.checkpoint_seq,
                 checkpoint_hint_seq,
             }
         };

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1,10 +1,14 @@
 use loon_objectstore::fs::LocalFsStore;
+use loon_objectstore::keys::namespace_head;
+use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
-    CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId, MoveOptions, NamespaceId,
-    PutFileBehavior, PutFileOptions, RuntimeError, SharedObjectStore,
+    CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId, MaintenanceTickOptions,
+    MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior, PutFileOptions,
+    RuntimeError, SharedObjectStore,
 };
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -299,6 +303,177 @@ fn explicit_commit_appears_in_change_feed() {
 }
 
 #[test]
+fn namespace_status_reports_checkpoint_lag_from_head() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "status-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let status = fs
+        .namespace_status(&namespace_id)
+        .expect("status for new namespace");
+    assert_eq!(status.namespace_id, namespace_id);
+    assert_eq!(status.head_seq, ChangeSeq(0));
+    assert_eq!(status.checkpoint_hint_seq, None);
+    assert_eq!(status.uncheckpointed_commits, 0);
+    assert_eq!(status.retention_floor_seq, ChangeSeq(0));
+
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+
+    let status = fs
+        .namespace_status(&namespace_id)
+        .expect("status after commit");
+    assert_eq!(status.head_seq, ChangeSeq(1));
+    assert_eq!(status.checkpoint_hint_seq, None);
+    assert_eq!(status.uncheckpointed_commits, 1);
+    assert_eq!(status.retention_floor_seq, ChangeSeq(0));
+}
+
+#[test]
+fn maintenance_tick_below_threshold_is_not_needed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "tick-not-needed-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+
+    let tick = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_uncheckpointed_commits: 2,
+            },
+        )
+        .expect("maintenance tick");
+    assert_eq!(tick.namespace_id, namespace_id);
+    assert_eq!(tick.status_before.uncheckpointed_commits, 1);
+    assert_eq!(tick.outcome, MaintenanceTickOutcome::NotNeeded);
+}
+
+#[test]
+fn maintenance_tick_at_threshold_publishes_checkpoint() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "tick-publish-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+
+    let tick = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_uncheckpointed_commits: 1,
+            },
+        )
+        .expect("maintenance tick");
+    assert_eq!(tick.status_before.head_seq, ChangeSeq(1));
+    assert_eq!(
+        tick.outcome,
+        MaintenanceTickOutcome::CheckpointPublished {
+            checkpoint_seq: ChangeSeq(1)
+        }
+    );
+
+    let status = fs
+        .namespace_status(&namespace_id)
+        .expect("status after checkpoint");
+    assert_eq!(status.checkpoint_hint_seq, Some(ChangeSeq(1)));
+    assert_eq!(status.uncheckpointed_commits, 0);
+}
+
+#[test]
+fn maintenance_tick_rejects_zero_threshold() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "tick-config-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let error = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_uncheckpointed_commits: 0,
+            },
+        )
+        .expect_err("zero threshold should fail");
+    match error {
+        RuntimeError::Config(message) => assert!(message.contains("max_uncheckpointed_commits")),
+        other => panic!("expected config error, got {other:?}"),
+    }
+}
+
+#[test]
+fn maintenance_tick_treats_checkpoint_hint_cas_loss_as_benign_race() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("tick-race-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+
+    raw_store.fail_head_cas();
+    let tick = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_uncheckpointed_commits: 1,
+            },
+        )
+        .expect("maintenance tick should not fail on checkpoint hint race");
+
+    assert_eq!(
+        tick.outcome,
+        MaintenanceTickOutcome::CheckpointPublishRaceLost {
+            attempted_seq: ChangeSeq(1)
+        }
+    );
+    let status = fs
+        .namespace_status(&namespace_id)
+        .expect("status after lost race");
+    assert_eq!(status.checkpoint_hint_seq, None);
+    assert_eq!(status.uncheckpointed_commits, 1);
+}
+
+#[test]
 fn checkpoint_and_retention_hooks_are_available() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "maintenance-test");
@@ -349,4 +524,62 @@ fn separate_runtime_instances_share_object_store_state() {
         .read_file_bytes(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");
     assert_eq!(file.bytes, b"shared");
+}
+
+#[derive(Debug)]
+struct HeadCasFailureStore {
+    inner: LocalFsStore,
+    head_key: String,
+    fail_head_cas: AtomicBool,
+}
+
+impl HeadCasFailureStore {
+    fn new(root: &Path, namespace: &str) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            head_key: namespace_head(namespace),
+            fail_head_cas: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_head_cas(&self) {
+        self.fail_head_cas.store(true, Ordering::SeqCst);
+    }
+}
+
+impl ObjectStore for HeadCasFailureStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key == self.head_key
+            && matches!(&mode, PutMode::CompareAndSwap { .. })
+            && self.fail_head_cas.load(Ordering::SeqCst)
+        {
+            return Err(ObjectStoreError::PreconditionFailed);
+        }
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
+    }
 }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1,11 +1,11 @@
 use loon_objectstore::fs::LocalFsStore;
-use loon_objectstore::keys::namespace_head;
+use loon_objectstore::keys::{namespace_descriptor, namespace_head};
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
-    CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior, PutFileOptions,
-    RuntimeError, SharedObjectStore,
+    CoreErrorKind, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior,
+    PutFileOptions, RuntimeError, SharedObjectStore,
 };
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -35,6 +35,14 @@ fn assert_config_error(result: loonfs::Result<Fs>, expected: &str) {
         ),
         Err(error) => panic!("expected config error, got {error:?}"),
         Ok(_) => panic!("expected config error"),
+    }
+}
+
+fn assert_core_error_kind<T>(result: loonfs::Result<T>, expected: CoreErrorKind) {
+    match result {
+        Err(RuntimeError::Core(error)) => assert_eq!(error.kind(), expected),
+        Err(error) => panic!("expected core error {expected:?}, got {error:?}"),
+        Ok(_) => panic!("expected core error {expected:?}"),
     }
 }
 
@@ -337,6 +345,49 @@ fn namespace_status_reports_checkpoint_lag_from_head() {
 }
 
 #[test]
+fn namespace_status_and_tick_reject_missing_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "missing-status-test");
+    let namespace_id = namespace();
+
+    assert_core_error_kind(
+        fs.namespace_status(&namespace_id),
+        CoreErrorKind::NamespaceNotFound,
+    );
+    assert_core_error_kind(
+        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        CoreErrorKind::NamespaceNotFound,
+    );
+}
+
+#[test]
+fn namespace_status_and_tick_reject_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("partial-status-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete namespace descriptor");
+
+    assert_core_error_kind(
+        fs.namespace_status(&namespace_id),
+        CoreErrorKind::NamespacePartial,
+    );
+    assert_core_error_kind(
+        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        CoreErrorKind::NamespacePartial,
+    );
+}
+
+#[test]
 fn maintenance_tick_below_threshold_is_not_needed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-not-needed-test");
@@ -463,7 +514,7 @@ fn maintenance_tick_treats_checkpoint_hint_cas_loss_as_benign_race() {
     assert_eq!(
         tick.outcome,
         MaintenanceTickOutcome::CheckpointPublishRaceLost {
-            attempted_seq: ChangeSeq(1)
+            observed_head_seq: ChangeSeq(1)
         }
     );
     let status = fs


### PR DESCRIPTION
Adds a small maintenance tool to `loonfs`: `namespace_status` reads checkpoint lag from the namespace head, and `maintenance_tick_namespace` opportunistically publishes a checkpoint once lag crosses `max_uncheckpointed_commits`. for example, if the lag is set to 1000 commits, at 1001 commits, it will trigger a maintenance job to "compact" the tail and rebuild a checkpoint. 