### PR TITLE
feat: cache namespace basis for reads

### DIFF
--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -5,7 +5,7 @@ use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs::{
     BootstrapNamespaceError, CopyOptions, CoreError, CoreErrorKind, CreateDirOptions,
     CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, MoveOptions, PutFileBehavior,
-    PutFileOptions, RuntimeError, SharedObjectStore,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::sync::Arc;
 
@@ -462,6 +462,7 @@ impl EmbeddedTarget {
                     .map(ToOwned::to_owned)
                     .unwrap_or_else(|| format!("loon/{}", env!("CARGO_PKG_VERSION"))),
                 lease_duration_ms: lease_duration_ms.unwrap_or(DEFAULT_LEASE_DURATION_MS),
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         )
         .map_err(map_runtime_error)?;

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -14,7 +14,10 @@ use loon_api::{
     decode_wal_segment_envelope_zstd, ChangeSeq, ContentStoreId, HeadState,
     NamespaceDescriptorState, NamespaceId, WalSegmentPointer,
 };
-use loon_objectstore::{keys::namespace_descriptor, ObjectStore};
+use loon_objectstore::{
+    keys::{namespace_descriptor, namespace_head},
+    ObjectStore,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -34,6 +37,12 @@ pub struct NamespaceHeadSummary {
     pub head_seq: ChangeSeq,
     pub checkpoint_hint_seq: Option<ChangeSeq>,
     pub retention_floor_seq: ChangeSeq,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceHeadIdentity {
+    pub namespace_id: NamespaceId,
+    pub head_etag: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
@@ -176,6 +185,37 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         head_seq: head.seq,
         checkpoint_hint_seq: head.checkpoint_hint_seq,
         retention_floor_seq: head.retention_floor_seq,
+    })
+}
+
+pub fn load_namespace_head_identity<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<NamespaceHeadIdentity, CoreError> {
+    NamespaceId::parse(expected_namespace.as_str())?;
+    let object_key = namespace_head(expected_namespace.as_str());
+    let metadata = store
+        .head(&object_key)
+        .map_err(|err| {
+            CoreError::Basis(BasisLoadError::LoadHead(ControlObjectLoadError::Store(
+                err.to_string(),
+            )))
+        })?
+        .ok_or_else(|| {
+            CoreError::Basis(BasisLoadError::LoadHead(
+                ControlObjectLoadError::MissingObject {
+                    object_key: object_key.clone(),
+                },
+            ))
+        })?;
+    let head_etag = metadata
+        .etag
+        .ok_or(CoreError::Basis(BasisLoadError::MissingHeadEtag {
+            object_key,
+        }))?;
+    Ok(NamespaceHeadIdentity {
+        namespace_id: expected_namespace.clone(),
+        head_etag,
     })
 }
 

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -41,7 +41,6 @@ pub struct NamespaceHeadSummary {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceHeadIdentity {
-    pub namespace_id: NamespaceId,
     pub head_etag: String,
 }
 
@@ -213,10 +212,7 @@ pub fn load_namespace_head_identity<S: ObjectStore + ?Sized>(
         .ok_or(CoreError::Basis(BasisLoadError::MissingHeadEtag {
             object_key,
         }))?;
-    Ok(NamespaceHeadIdentity {
-        namespace_id: expected_namespace.clone(),
-        head_etag,
-    })
+    Ok(NamespaceHeadIdentity { head_etag })
 }
 
 fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -18,8 +18,8 @@ pub mod services;
 pub mod wal;
 
 pub use basis::{
-    load_namespace_head_summary, load_verified_namespace_basis, BasisLoadError,
-    NamespaceHeadSummary, VerifiedNamespaceBasis,
+    load_namespace_head_identity, load_namespace_head_summary, load_verified_namespace_basis,
+    BasisLoadError, NamespaceHeadIdentity, NamespaceHeadSummary, VerifiedNamespaceBasis,
 };
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, CheckpointLoadError, CheckpointLoadErrorKind,
@@ -37,7 +37,8 @@ pub use publisher::{
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, create_dir_path, delete_path, delete_path_non_recursive,
-    fork_namespace, list_namespaces, list_path, move_path, put_file_bytes, put_file_content_ref,
-    read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
-    BootstrapNamespaceError, PutFileBehavior, StoredContent,
+    fork_namespace, list_namespaces, list_path, list_path_from_basis, move_path, put_file_bytes,
+    put_file_content_ref, read_file_bytes, read_file_bytes_from_basis, resolve_path,
+    resolve_path_from_basis, store_bytes_as_content, write_file_bytes, BootstrapNamespaceError,
+    PutFileBehavior, StoredContent,
 };

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -27,6 +27,12 @@ pub use checkpoint::{
 pub use context::MutationContext;
 pub use error::{CoreError, CoreErrorKind};
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
+pub use loading::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control, ControlObjectIdentity,
+    ControlObjectLoadError, LoadedContentStoreDescriptorControl, LoadedHeadControl,
+    LoadedLeaseControl, LoadedNamespaceDescriptorControl,
+};
 pub use protocol::{
     begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
     upload_content,

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,6 +1,7 @@
 use loon_api::{
-    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreId, ControlObjectKind,
-    HeadStateEnvelope, LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceId,
+    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
+    ContentStoreId, ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState,
+    LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
     CONTROL_OBJECT_FORMAT_VERSION,
 };
 use loon_objectstore::keys::{
@@ -38,6 +39,39 @@ pub(crate) struct LoadedLeaseObject {
     pub(crate) object_key: String,
     pub(crate) metadata: ObjectMetadata,
     pub(crate) envelope: LeaseStateEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct ControlObjectIdentity {
+    pub etag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedNamespaceDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: NamespaceDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedContentStoreDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: ContentStoreDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedHeadControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: HeadState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedLeaseControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: LeaseState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize, Error)]
@@ -214,6 +248,68 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+pub fn load_namespace_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedNamespaceDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_namespace_descriptor_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedNamespaceDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_content_store_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_content_store: &ContentStoreId,
+) -> Result<LoadedContentStoreDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_content_store_descriptor_object(store, expected_content_store)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedContentStoreDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_head_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedHeadControl, ControlObjectLoadError> {
+    let loaded = read_head_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedHeadControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_lease_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedLeaseControl, ControlObjectLoadError> {
+    let loaded = read_lease_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedLeaseControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+fn control_identity(
+    object_key: &str,
+    metadata: &ObjectMetadata,
+) -> Result<ControlObjectIdentity, ControlObjectLoadError> {
+    let etag = metadata.etag.clone().ok_or_else(|| {
+        ControlObjectLoadError::Store(format!("missing control object etag for `{object_key}`"))
+    })?;
+    Ok(ControlObjectIdentity { etag })
 }
 
 fn validate_namespace_id_for_control_key(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -10,9 +10,16 @@ use crate::content::{validate_durable_content_reference, write_immutable_object}
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
-use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::{
+    load_namespace_content_store_id, namespace_initialization_state, NamespaceInitializationError,
+    NamespaceInitializationState,
+};
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
+use crate::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control,
+};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitDelta, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
@@ -23,7 +30,7 @@ use loon_api::{
     CompletedUpload, ContentRef, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
     UploadSessionState, WalCommitDelta, WalDelta,
 };
-use loon_objectstore::keys::{content_blob, upload_session};
+use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
 
@@ -52,7 +59,15 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<BeginUploadResponse, CoreError> {
-    let _basis = load_verified_namespace_basis(store, namespace_id)?;
+    ensure_upload_namespace_available(store, namespace_id)?;
+    create_upload_session(store, namespace_id, context)
+}
+
+fn create_upload_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<BeginUploadResponse, CoreError> {
     let upload_id = generate_upload_id();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
@@ -78,6 +93,61 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
         upload_id,
         mode: UploadMode::ServiceProxied,
     })
+}
+
+fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<(), CoreError> {
+    match namespace_initialization_state(store, namespace_id) {
+        Ok(NamespaceInitializationState::Complete) => {
+            let descriptor =
+                load_namespace_descriptor_control(store, namespace_id).map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+                })?;
+            load_content_store_descriptor_control(store, &descriptor.state.content_store_id)
+                .map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+                })?;
+            load_namespace_head_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
+            load_namespace_lease_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadLease(error)))?;
+            Ok(())
+        }
+        Ok(NamespaceInitializationState::Absent) => {
+            Err(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
+                crate::loading::ControlObjectLoadError::MissingObject {
+                    object_key: namespace_descriptor(namespace_id.as_str()),
+                },
+            )))
+        }
+        Ok(NamespaceInitializationState::Partial) => {
+            Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            })
+        }
+        Err(error) => Err(map_upload_namespace_initialization_error(error)),
+    }
+}
+
+fn map_upload_namespace_initialization_error(error: NamespaceInitializationError) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+        }
+        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+        }
+        NamespaceInitializationError::InspectNamespaceDescriptor(_)
+        | NamespaceInitializationError::InspectNamespaceHead(_)
+        | NamespaceInitializationError::InspectNamespaceLease(_) => {
+            CoreError::Store(error.to_string())
+        }
+    }
 }
 
 pub fn upload_content<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -400,12 +400,20 @@ pub fn resolve_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<AuthoritativePathEntry, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
+    resolve_path_from_basis(store, &basis, absolute_path)
+}
+
+pub fn resolve_path_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<AuthoritativePathEntry, CoreError> {
     let resolved = basis
         .metadata_state
         .resolve_visible_path(absolute_path, basis.head.seq)?;
     build_authoritative_path_entry(
         store,
-        namespace_id,
+        &basis.head.namespace_id,
         &basis.content_store_id,
         basis.head.seq,
         &basis.metadata_state,
@@ -419,13 +427,21 @@ pub fn list_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
+    list_path_from_basis(store, &basis, absolute_path)
+}
+
+pub fn list_path_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
     let resolved = basis
         .metadata_state
         .resolve_visible_path(absolute_path, basis.head.seq)?;
     if resolved.inode_kind == InodeKind::File {
         return Ok(vec![build_authoritative_path_entry(
             store,
-            namespace_id,
+            &basis.head.namespace_id,
             &basis.content_store_id,
             basis.head.seq,
             &basis.metadata_state,
@@ -450,7 +466,7 @@ pub fn list_path<S: ObjectStore + ?Sized>(
                 .expect("visible child listing should resolve inode");
             build_authoritative_path_entry(
                 store,
-                namespace_id,
+                &basis.head.namespace_id,
                 &basis.content_store_id,
                 basis.head.seq,
                 &basis.metadata_state,
@@ -474,7 +490,16 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
 ) -> Result<AuthoritativeFileBytes, CoreError> {
-    let entry = resolve_path(store, namespace_id, absolute_path)?;
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    read_file_bytes_from_basis(store, &basis, absolute_path)
+}
+
+pub fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<AuthoritativeFileBytes, CoreError> {
+    let entry = resolve_path_from_basis(store, basis, absolute_path)?;
     if entry.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: entry.absolute_path,
@@ -485,8 +510,7 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
         .content_ref
         .clone()
         .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
-    let read = read_durable_content_bytes(store, &content_store_id, &content_ref)?;
+    let read = read_durable_content_bytes(store, &basis.content_store_id, &content_ref)?;
     Ok(AuthoritativeFileBytes {
         entry,
         bytes: read.bytes,

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -13,9 +13,9 @@ use loon_core::commit::{
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
-    bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
-    copy_file_path, create_dir_path, delete_path, delete_path_non_recursive, fork_namespace,
-    list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
+    begin_upload, bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
+    copy_file_path, create_checkpoint, create_dir_path, delete_path, delete_path_non_recursive,
+    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
     publish_namespace_mutations_batch, put_file_bytes, read_file_bytes, resolve_path,
     store_bytes_as_content, upload_content, write_file_bytes, CoreError, CoreErrorKind,
     DirectObjectStorePublisher, MutationContext, NamespaceMutationCandidate, PathMutationIntent,
@@ -672,6 +672,10 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
         .expect_err("invalid namespace_id should be rejected before lookup");
     assert_eq!(read_error.kind(), CoreErrorKind::InvalidNamespaceId);
 
+    let begin_upload_error = begin_upload(&store, &invalid_namespace, &context)
+        .expect_err("invalid namespace_id should be rejected before upload session creation");
+    assert_eq!(begin_upload_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
     let delete_error = delete_path_non_recursive(
         &store,
         &invalid_namespace,
@@ -700,6 +704,63 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
             .expect("list namespace objects"),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    let missing_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("missing namespace");
+    assert_eq!(missing_error.kind(), CoreErrorKind::NamespaceNotFound);
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete descriptor");
+
+    let partial_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("partial namespace");
+    assert_eq!(partial_error.kind(), CoreErrorKind::NamespacePartial);
+}
+
+#[test]
+fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false).expect("bootstrap");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileBehavior::CreateOnly,
+        &context,
+        Some("upload-guard-create"),
+    )
+    .expect("create file");
+    create_checkpoint(&setup_store, &namespace_id, &context).expect("checkpoint");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileBehavior::ReplaceExisting,
+        &context,
+        Some("upload-guard-replace"),
+    )
+    .expect("replace file");
+
+    let guarded_store = ReplayReadGuardStore::new(temp_dir.path(), namespace_id.as_str());
+    let begin = begin_upload(&guarded_store, &namespace_id, &context).expect("begin upload");
+    assert_eq!(begin.namespace_id, namespace_id);
+    assert_eq!(guarded_store.guarded_get_count(), 0);
 }
 
 #[test]
@@ -2660,6 +2721,75 @@ fn content_ref(seed: &str) -> ContentRef {
         kind: ContentRefKind::WholeFileV0,
         digest: sha256_digest(seed.as_bytes()),
         size_bytes: seed.len() as u64,
+    }
+}
+
+struct ReplayReadGuardStore {
+    inner: LocalFsStore,
+    guarded_prefixes: Vec<String>,
+    guarded_gets: AtomicUsize,
+}
+
+impl ReplayReadGuardStore {
+    fn new(root: impl AsRef<Path>, namespace: &str) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            guarded_prefixes: vec![
+                format!("namespaces/{namespace}/wal/"),
+                format!("namespaces/{namespace}/checkpoints/"),
+            ],
+            guarded_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn guarded_get_count(&self) -> usize {
+        self.guarded_gets.load(Ordering::SeqCst)
+    }
+
+    fn reject_replay_read(&self, key: &str) -> Result<(), ObjectStoreError> {
+        if self
+            .guarded_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
+            self.guarded_gets.fetch_add(1, Ordering::SeqCst);
+            return Err(ObjectStoreError::Transport(format!(
+                "begin_upload unexpectedly read replay object `{key}`"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl ObjectStore for ReplayReadGuardStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.reject_replay_read(key)?;
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
     }
 }
 

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -19,7 +19,7 @@ use loon_api::{
 };
 use loonfs::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, CreateNamespaceOptions, Fs, FsConfig,
-    PathMutationIntent, PutFileBehavior, RuntimeError, SharedObjectStore,
+    PathMutationIntent, PutFileBehavior, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -123,6 +123,7 @@ fn build_fs(config: &ServerConfig, store: SharedStore) -> Result<Fs, ServerConfi
             writer_id: config.writer_id.clone(),
             writer_version: config.writer_version.clone(),
             lease_duration_ms: config.lease_duration_ms,
+            runtime_cache: RuntimeCacheConfig::default(),
         },
     )
     .map_err(|error| ServerConfigError::InvalidField {
@@ -616,7 +617,9 @@ mod tests {
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::namespace_head;
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
-    use loonfs::{CreateNamespaceOptions, Fs, FsConfig, PutFileBehavior, PutFileOptions};
+    use loonfs::{
+        CreateNamespaceOptions, Fs, FsConfig, PutFileBehavior, PutFileOptions, RuntimeCacheConfig,
+    };
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -1036,6 +1039,7 @@ mod tests {
                 writer_id: writer_id.to_owned(),
                 writer_version: format!("{writer_id}/0.1.0"),
                 lease_duration_ms: 60_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         )
         .expect("open runtime")

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -375,7 +375,9 @@ mod tests {
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::namespace_head;
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
-    use loonfs::{CreateNamespaceOptions, Fs, FsConfig, SharedObjectStore as SharedStore};
+    use loonfs::{
+        CreateNamespaceOptions, Fs, FsConfig, RuntimeCacheConfig, SharedObjectStore as SharedStore,
+    };
     use std::path::Path;
     use std::sync::Condvar;
     use tempfile::tempdir;
@@ -509,6 +511,7 @@ mod tests {
                     writer_id: config.writer_id.clone(),
                     writer_version: config.writer_version.clone(),
                     lease_duration_ms: config.lease_duration_ms,
+                    runtime_cache: RuntimeCacheConfig::default(),
                 },
             )
             .expect("open runtime"),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub use loon_api::v0::{
@@ -13,11 +14,11 @@ pub use loon_api::{
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
-use loon_core::MutationContext;
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
+use loon_core::{MutationContext, VerifiedNamespaceBasis};
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -42,6 +43,7 @@ pub struct FsConfig {
     pub writer_id: String,
     pub writer_version: String,
     pub lease_duration_ms: u64,
+    pub runtime_cache: RuntimeCacheConfig,
 }
 
 impl FsConfig {
@@ -50,6 +52,31 @@ impl FsConfig {
             writer_id: writer_id.into(),
             writer_version: default_writer_version(),
             lease_duration_ms: DEFAULT_LEASE_DURATION_MS,
+            runtime_cache: RuntimeCacheConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCacheConfig {
+    pub basis_cache_enabled: bool,
+    pub max_cached_namespaces: usize,
+}
+
+impl RuntimeCacheConfig {
+    pub fn disabled() -> Self {
+        Self {
+            basis_cache_enabled: false,
+            max_cached_namespaces: 0,
+        }
+    }
+}
+
+impl Default for RuntimeCacheConfig {
+    fn default() -> Self {
+        Self {
+            basis_cache_enabled: true,
+            max_cached_namespaces: 64,
         }
     }
 }
@@ -62,6 +89,7 @@ pub struct Fs {
 struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
+    basis_cache: Mutex<BasisCache>,
 }
 
 pub struct FsBuilder {
@@ -69,6 +97,46 @@ pub struct FsBuilder {
     writer_id: Option<String>,
     writer_version: String,
     lease_duration_ms: u64,
+    runtime_cache: RuntimeCacheConfig,
+}
+
+#[derive(Debug, Default)]
+struct BasisCache {
+    entries: HashMap<NamespaceId, VerifiedNamespaceBasis>,
+    order: VecDeque<NamespaceId>,
+}
+
+impl BasisCache {
+    fn get(&mut self, namespace_id: &NamespaceId) -> Option<VerifiedNamespaceBasis> {
+        let basis = self.entries.get(namespace_id).cloned()?;
+        self.touch(namespace_id);
+        Some(basis)
+    }
+
+    fn insert(&mut self, basis: VerifiedNamespaceBasis, max_cached_namespaces: usize) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        let namespace_id = basis.head.namespace_id.clone();
+        self.entries.insert(namespace_id.clone(), basis);
+        self.touch(&namespace_id);
+        while self.entries.len() > max_cached_namespaces {
+            let Some(evicted) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&evicted);
+        }
+    }
+
+    fn invalidate(&mut self, namespace_id: &NamespaceId) {
+        self.entries.remove(namespace_id);
+        self.order.retain(|candidate| candidate != namespace_id);
+    }
+
+    fn touch(&mut self, namespace_id: &NamespaceId) {
+        self.order.retain(|candidate| candidate != namespace_id);
+        self.order.push_back(namespace_id.clone());
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -163,6 +231,7 @@ impl FsBuilder {
             writer_id: None,
             writer_version: default_writer_version(),
             lease_duration_ms: DEFAULT_LEASE_DURATION_MS,
+            runtime_cache: RuntimeCacheConfig::default(),
         }
     }
 
@@ -181,6 +250,11 @@ impl FsBuilder {
         self
     }
 
+    pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
+        self.runtime_cache = runtime_cache;
+        self
+    }
+
     pub fn build(self) -> Result<Fs> {
         let writer_id = self
             .writer_id
@@ -191,6 +265,7 @@ impl FsBuilder {
                 writer_id,
                 writer_version: self.writer_version,
                 lease_duration_ms: self.lease_duration_ms,
+                runtime_cache: self.runtime_cache,
             },
         )
     }
@@ -200,7 +275,11 @@ impl Fs {
     pub fn open(store: SharedObjectStore, config: FsConfig) -> Result<Self> {
         validate_config(&config)?;
         Ok(Self {
-            inner: Arc::new(FsInner { store, config }),
+            inner: Arc::new(FsInner {
+                store,
+                config,
+                basis_cache: Mutex::new(BasisCache::default()),
+            }),
         })
     }
 
@@ -217,12 +296,14 @@ impl Fs {
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> Result<NamespaceSummary> {
-        Ok(loon_core::bootstrap_namespace(
+        let result = loon_core::bootstrap_namespace(
             self.store(),
             namespace_id,
             &self.mutation_context(),
             options.allow_existing,
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn fork_namespace(
@@ -230,12 +311,16 @@ impl Fs {
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> Result<NamespaceSummary> {
-        Ok(loon_core::fork_namespace(
-            self.store(),
-            source,
-            target,
-            &self.mutation_context(),
-        )?)
+        let result =
+            loon_core::fork_namespace(self.store(), source, target, &self.mutation_context())
+                .map_err(RuntimeError::from);
+        if should_invalidate_after_result(&result) {
+            self.invalidate_namespace_cache(source);
+        }
+        if result.is_ok() {
+            self.invalidate_namespace_cache(target);
+        }
+        result
     }
 
     pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
@@ -320,9 +405,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativePathEntry> {
-        Ok(loon_core::resolve_path(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::resolve_path_from_basis(
             self.store(),
-            namespace_id,
+            &basis,
             absolute_path,
         )?)
     }
@@ -332,9 +418,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<Vec<AuthoritativePathEntry>> {
-        Ok(loon_core::list_path(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::list_path_from_basis(
             self.store(),
-            namespace_id,
+            &basis,
             absolute_path,
         )?)
     }
@@ -344,9 +431,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
-        Ok(loon_core::read_file_bytes(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::read_file_bytes_from_basis(
             self.store(),
-            namespace_id,
+            &basis,
             absolute_path,
         )?)
     }
@@ -358,7 +446,7 @@ impl Fs {
         bytes: &[u8],
         options: PutFileOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::put_file_bytes(
+        let result = loon_core::put_file_bytes(
             self.store(),
             namespace_id,
             absolute_path,
@@ -366,7 +454,9 @@ impl Fs {
             options.behavior,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn put_file_content_ref(
@@ -376,7 +466,7 @@ impl Fs {
         content_ref: ContentRef,
         options: PutFileOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::put_file_content_ref(
+        let result = loon_core::put_file_content_ref(
             self.store(),
             namespace_id,
             absolute_path,
@@ -384,7 +474,9 @@ impl Fs {
             options.behavior,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn create_dir(
@@ -393,13 +485,15 @@ impl Fs {
         absolute_path: &str,
         options: CreateDirOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::create_dir_path(
+        let result = loon_core::create_dir_path(
             self.store(),
             namespace_id,
             absolute_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn delete_path(
@@ -409,23 +503,25 @@ impl Fs {
         options: DeleteOptions,
     ) -> Result<MutationResult> {
         let commit_id = options.commit_id.as_ref().map(CommitId::as_str);
-        if options.recursive {
-            Ok(loon_core::delete_path(
+        let result = if options.recursive {
+            loon_core::delete_path(
                 self.store(),
                 namespace_id,
                 absolute_path,
                 &self.mutation_context(),
                 commit_id,
-            )?)
+            )
         } else {
-            Ok(loon_core::delete_path_non_recursive(
+            loon_core::delete_path_non_recursive(
                 self.store(),
                 namespace_id,
                 absolute_path,
                 &self.mutation_context(),
                 commit_id,
-            )?)
+            )
         }
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn move_path(
@@ -435,14 +531,16 @@ impl Fs {
         to_path: &str,
         options: MoveOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::move_path(
+        let result = loon_core::move_path(
             self.store(),
             namespace_id,
             from_path,
             to_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn copy_path(
@@ -452,14 +550,16 @@ impl Fs {
         to_path: &str,
         options: CopyOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::copy_file_path(
+        let result = loon_core::copy_file_path(
             self.store(),
             namespace_id,
             from_path,
             to_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
@@ -505,12 +605,14 @@ impl Fs {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        Ok(loon_core::commit_operations(
+        let result = loon_core::commit_operations(
             self.store(),
             namespace_id,
             request,
             &self.mutation_context(),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn commit_operations_batch(
@@ -518,7 +620,7 @@ impl Fs {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        loon_core::commit_operations_batch(
+        let results: Vec<_> = loon_core::commit_operations_batch(
             self.store(),
             namespace_id,
             requests,
@@ -526,7 +628,9 @@ impl Fs {
         )
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
-        .collect()
+        .collect();
+        self.invalidate_namespace_cache_after_batch(namespace_id, &results);
+        results
     }
 
     pub fn publish_namespace_mutations_batch(
@@ -534,7 +638,7 @@ impl Fs {
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<Result<CommitResponse>> {
-        loon_core::publish_namespace_mutations_batch(
+        let results: Vec<_> = loon_core::publish_namespace_mutations_batch(
             self.store(),
             namespace_id,
             candidates,
@@ -542,7 +646,9 @@ impl Fs {
         )
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
-        .collect()
+        .collect();
+        self.invalidate_namespace_cache_after_batch(namespace_id, &results);
+        results
     }
 
     pub fn list_changes_after(
@@ -561,22 +667,99 @@ impl Fs {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
-        Ok(loon_core::create_checkpoint(
-            self.store(),
-            namespace_id,
-            &self.mutation_context(),
-        )?)
+        let result =
+            loon_core::create_checkpoint(self.store(), namespace_id, &self.mutation_context())
+                .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn advance_retention_floor(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
-        Ok(loon_core::advance_retention_floor(
+        let result = loon_core::advance_retention_floor(
             self.store(),
             namespace_id,
             &self.mutation_context(),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+
+    fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<VerifiedNamespaceBasis> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
+            return Ok(
+                loon_core::load_verified_namespace_basis(self.store(), namespace_id)
+                    .map_err(CoreError::from)?,
+            );
+        }
+
+        let cached = self
+            .inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .get(namespace_id);
+        if let Some(basis) = cached {
+            match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
+                Ok(identity)
+                    if identity.namespace_id == *namespace_id
+                        && identity.head_etag == basis.head_etag =>
+                {
+                    return Ok(basis);
+                }
+                Ok(_) | Err(_) => {
+                    self.invalidate_namespace_cache(namespace_id);
+                }
+            }
+        }
+
+        let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
+            .map_err(CoreError::from)?;
+        self.cache_basis(basis.clone());
+        Ok(basis)
+    }
+
+    fn cache_basis(&self, basis: VerifiedNamespaceBasis) {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
+            return;
+        }
+        self.inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .insert(basis, cache_config.max_cached_namespaces);
+    }
+
+    fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
+        self.inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .invalidate(namespace_id);
+    }
+
+    fn finish_namespace_mutation<T>(
+        &self,
+        namespace_id: &NamespaceId,
+        result: Result<T>,
+    ) -> Result<T> {
+        if should_invalidate_after_result(&result) {
+            self.invalidate_namespace_cache(namespace_id);
+        }
+        result
+    }
+
+    fn invalidate_namespace_cache_after_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        results: &[Result<CommitResponse>],
+    ) {
+        if results.iter().any(should_invalidate_after_result) {
+            self.invalidate_namespace_cache(namespace_id);
+        }
     }
 
     fn store(&self) -> &(dyn ObjectStore + Send + Sync) {
@@ -614,6 +797,14 @@ fn validate_config(config: &FsConfig) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn should_invalidate_after_result<T>(result: &Result<T>) -> bool {
+    match result {
+        Ok(_) => true,
+        Err(RuntimeError::Core(error)) if error.kind() == CoreErrorKind::StaleHead => true,
+        _ => false,
+    }
 }
 
 fn current_time_ms() -> u64 {

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -9,6 +9,7 @@ pub use loon_api::v0::{
     CommitRequest, CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
     UploadContentResponse,
 };
+use loon_api::HeadState;
 pub use loon_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CommitId,
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
@@ -18,7 +19,11 @@ pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
-use loon_core::{MutationContext, VerifiedNamespaceBasis};
+use loon_core::{
+    ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
+    VerifiedNamespaceBasis,
+};
+use loon_objectstore::keys::namespace_head;
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -60,6 +65,7 @@ impl FsConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
     pub basis_cache_enabled: bool,
+    pub control_cache_enabled: bool,
     pub max_cached_namespaces: usize,
 }
 
@@ -67,6 +73,7 @@ impl RuntimeCacheConfig {
     pub fn disabled() -> Self {
         Self {
             basis_cache_enabled: false,
+            control_cache_enabled: false,
             max_cached_namespaces: 0,
         }
     }
@@ -76,6 +83,7 @@ impl Default for RuntimeCacheConfig {
     fn default() -> Self {
         Self {
             basis_cache_enabled: true,
+            control_cache_enabled: true,
             max_cached_namespaces: 64,
         }
     }
@@ -90,6 +98,7 @@ struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
     basis_cache: Mutex<BasisCache>,
+    control_cache: Mutex<RuntimeControlCache>,
 }
 
 pub struct FsBuilder {
@@ -136,6 +145,80 @@ impl BasisCache {
     fn touch(&mut self, namespace_id: &NamespaceId) {
         self.order.retain(|candidate| candidate != namespace_id);
         self.order.push_back(namespace_id.clone());
+    }
+}
+
+#[derive(Debug, Default)]
+struct RuntimeControlCache {
+    namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespace_order: VecDeque<NamespaceId>,
+}
+
+#[derive(Debug, Default)]
+struct NamespaceControlCacheEntry {
+    head: Option<CachedControl<HeadState>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedControl<T> {
+    identity: ControlObjectIdentity,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl RuntimeControlCache {
+    fn namespace_head(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<HeadState>> {
+        let head = self.namespaces.get(namespace_id)?.head.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(head)
+    }
+
+    fn insert_namespace_head(
+        &mut self,
+        namespace_id: &NamespaceId,
+        head: CachedControl<HeadState>,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        self.namespace_entry(namespace_id, max_cached_namespaces)
+            .head = Some(head);
+    }
+
+    fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespaces.remove(namespace_id);
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+    }
+
+    fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.head = None;
+        }
+    }
+
+    fn namespace_entry(
+        &mut self,
+        namespace_id: &NamespaceId,
+        max_cached_namespaces: usize,
+    ) -> &mut NamespaceControlCacheEntry {
+        self.namespaces.entry(namespace_id.clone()).or_default();
+        self.touch_namespace(namespace_id);
+        while self.namespaces.len() > max_cached_namespaces {
+            let Some(evicted) = self.namespace_order.pop_front() else {
+                break;
+            };
+            self.namespaces.remove(&evicted);
+        }
+        self.namespaces
+            .get_mut(namespace_id)
+            .expect("namespace cache entry should exist")
+    }
+
+    fn touch_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+        self.namespace_order.push_back(namespace_id.clone());
     }
 }
 
@@ -279,6 +362,7 @@ impl Fs {
                 store,
                 config,
                 basis_cache: Mutex::new(BasisCache::default()),
+                control_cache: Mutex::new(RuntimeControlCache::default()),
             }),
         })
     }
@@ -686,6 +770,94 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
+    fn load_namespace_head_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<CachedControl<HeadState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !self.control_cache_enabled() {
+            return loon_core::load_namespace_head_control(self.store(), namespace_id)
+                .map(cached_head);
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .namespace_head(namespace_id);
+        if let Some(head) = cached {
+            match self.cached_control_identity_matches(
+                &namespace_head(namespace_id.as_str()),
+                &head.identity,
+            ) {
+                Ok(true) => return Ok(head),
+                Ok(false) => self
+                    .inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id),
+                Err(error) => {
+                    self.inner
+                        .control_cache
+                        .lock()
+                        .expect("control cache lock poisoned")
+                        .invalidate_namespace_head(namespace_id);
+                    return Err(error);
+                }
+            }
+        }
+
+        let loaded = match loon_core::load_namespace_head_control(self.store(), namespace_id) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id);
+                return Err(error);
+            }
+        };
+        let head = cached_head(loaded);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_namespace_head(
+                namespace_id,
+                head.clone(),
+                cache_config.max_cached_namespaces,
+            );
+        Ok(head)
+    }
+
+    fn cached_control_identity_matches(
+        &self,
+        object_key: &str,
+        identity: &ControlObjectIdentity,
+    ) -> std::result::Result<bool, ControlObjectLoadError> {
+        let metadata = self
+            .store()
+            .head(object_key)
+            .map_err(|error| ControlObjectLoadError::Store(error.to_string()))?
+            .ok_or_else(|| ControlObjectLoadError::MissingObject {
+                object_key: object_key.to_owned(),
+            })?;
+        let Some(etag) = metadata.etag else {
+            return Err(ControlObjectLoadError::Store(format!(
+                "missing control object etag for `{object_key}`"
+            )));
+        };
+        Ok(etag == identity.etag)
+    }
+
+    fn control_cache_enabled(&self) -> bool {
+        let cache_config = &self.inner.config.runtime_cache;
+        cache_config.control_cache_enabled && cache_config.max_cached_namespaces > 0
+    }
+
     fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
         let cache_config = &self.inner.config.runtime_cache;
         if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
@@ -702,12 +874,23 @@ impl Fs {
             .expect("basis cache lock poisoned")
             .get(namespace_id);
         if let Some(basis) = cached {
-            match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
-                Ok(identity) if identity.head_etag == basis.head_etag => {
-                    return Ok(basis);
+            if self.control_cache_enabled() {
+                match self.load_namespace_head_cached(namespace_id) {
+                    Ok(head) if head.identity.etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
                 }
-                Ok(_) | Err(_) => {
-                    self.invalidate_namespace_cache(namespace_id);
+            } else {
+                match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
+                    Ok(identity) if identity.head_etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
                 }
             }
         }
@@ -737,6 +920,11 @@ impl Fs {
             .lock()
             .expect("basis cache lock poisoned")
             .invalidate(namespace_id);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .invalidate_namespace(namespace_id);
     }
 
     fn finish_namespace_mutation<T>(
@@ -771,6 +959,13 @@ impl Fs {
             now_ms: current_time_ms(),
             lease_duration_ms: self.inner.config.lease_duration_ms,
         }
+    }
+}
+
+fn cached_head(loaded: LoadedHeadControl) -> CachedControl<HeadState> {
+    CachedControl {
+        identity: loaded.identity,
+        _marker: std::marker::PhantomData,
     }
 }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -102,18 +102,18 @@ pub struct FsBuilder {
 
 #[derive(Debug, Default)]
 struct BasisCache {
-    entries: HashMap<NamespaceId, VerifiedNamespaceBasis>,
+    entries: HashMap<NamespaceId, Arc<VerifiedNamespaceBasis>>,
     order: VecDeque<NamespaceId>,
 }
 
 impl BasisCache {
-    fn get(&mut self, namespace_id: &NamespaceId) -> Option<VerifiedNamespaceBasis> {
+    fn get(&mut self, namespace_id: &NamespaceId) -> Option<Arc<VerifiedNamespaceBasis>> {
         let basis = self.entries.get(namespace_id).cloned()?;
         self.touch(namespace_id);
         Some(basis)
     }
 
-    fn insert(&mut self, basis: VerifiedNamespaceBasis, max_cached_namespaces: usize) {
+    fn insert(&mut self, basis: Arc<VerifiedNamespaceBasis>, max_cached_namespaces: usize) {
         if max_cached_namespaces == 0 {
             return;
         }
@@ -408,7 +408,7 @@ impl Fs {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(loon_core::resolve_path_from_basis(
             self.store(),
-            &basis,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -421,7 +421,7 @@ impl Fs {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(loon_core::list_path_from_basis(
             self.store(),
-            &basis,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -434,7 +434,7 @@ impl Fs {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(loon_core::read_file_bytes_from_basis(
             self.store(),
-            &basis,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -686,13 +686,13 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<VerifiedNamespaceBasis> {
+    fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
         let cache_config = &self.inner.config.runtime_cache;
         if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
-            return Ok(
+            return Ok(Arc::new(
                 loon_core::load_verified_namespace_basis(self.store(), namespace_id)
                     .map_err(CoreError::from)?,
-            );
+            ));
         }
 
         let cached = self
@@ -703,10 +703,7 @@ impl Fs {
             .get(namespace_id);
         if let Some(basis) = cached {
             match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
-                Ok(identity)
-                    if identity.namespace_id == *namespace_id
-                        && identity.head_etag == basis.head_etag =>
-                {
+                Ok(identity) if identity.head_etag == basis.head_etag => {
                     return Ok(basis);
                 }
                 Ok(_) | Err(_) => {
@@ -717,11 +714,12 @@ impl Fs {
 
         let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
             .map_err(CoreError::from)?;
-        self.cache_basis(basis.clone());
+        let basis = Arc::new(basis);
+        self.cache_basis(Arc::clone(&basis));
         Ok(basis)
     }
 
-    fn cache_basis(&self, basis: VerifiedNamespaceBasis) {
+    fn cache_basis(&self, basis: Arc<VerifiedNamespaceBasis>) {
         let cache_config = &self.inner.config.runtime_cache;
         if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
             return;

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1,5 +1,5 @@
 use loon_objectstore::fs::LocalFsStore;
-use loon_objectstore::keys::{namespace_descriptor, namespace_head};
+use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
@@ -421,6 +421,271 @@ fn upload_flow_is_available_from_runtime() {
 }
 
 #[test]
+fn begin_upload_validates_controls_without_replay_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-cache-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileOptions {
+            behavior: PutFileBehavior::ReplaceExisting,
+            commit_id: None,
+        },
+    )
+    .expect("replace file");
+
+    raw_store.reset_control_get_counts();
+    fs.begin_upload(&namespace_id).expect("first begin upload");
+    fs.begin_upload(&namespace_id).expect("second begin upload");
+
+    assert_eq!(raw_store.wal_get_count(), 0);
+    assert_eq!(raw_store.checkpoint_get_count(), 0);
+}
+
+#[test]
+fn runtime_control_cache_reuses_head_for_basis_validation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("control-cache-head-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+
+    raw_store.reset_control_get_counts();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first cached basis validation loads head body");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second cached basis validation reuses head body");
+
+    assert_eq!(raw_store.head_get_count(), 1);
+}
+
+#[test]
+fn control_cache_eviction_reloads_head_for_basis_validation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("control-cache-eviction-test")
+        .runtime_cache(RuntimeCacheConfig {
+            basis_cache_enabled: true,
+            control_cache_enabled: true,
+            max_cached_namespaces: 1,
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
+        .expect("create other namespace");
+    fs.create_dir(&other_namespace, "/docs", CreateDirOptions::default())
+        .expect("create other docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace basis");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace head cache");
+
+    raw_store.reset_control_get_counts();
+    fs.stat_path(&other_namespace, "/docs")
+        .expect("load other namespace basis and evict first head cache");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("reload first namespace basis and head cache");
+
+    assert_eq!(raw_store.head_get_count(), 1);
+}
+
+#[test]
+fn runtime_control_cache_reloads_head_after_external_change() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let reader = Fs::builder(object_store.clone())
+        .writer_id("control-cache-reader")
+        .build()
+        .expect("build reader runtime");
+    let writer = Fs::builder(object_store)
+        .writer_id("control-cache-writer")
+        .build()
+        .expect("build writer runtime");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+    raw_store.reset_control_get_counts();
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime control cache");
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("reuse unchanged control cache");
+    assert_eq!(raw_store.head_get_count(), 1);
+
+    writer
+        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .expect("advance head");
+    raw_store.reset_control_get_counts();
+    reader
+        .stat_path(&namespace_id, "/docs/new")
+        .expect("reload changed head");
+    assert!(raw_store.head_get_count() > 0);
+}
+
+#[test]
+fn begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-missing-partial-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceNotFound,
+    );
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete namespace descriptor");
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespacePartial,
+    );
+}
+
+#[test]
+fn begin_upload_rejects_malformed_descriptors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_descriptor(namespace_id.as_str()),
+            br#"{"not":"a namespace descriptor"}"#,
+        )
+        .expect("corrupt namespace descriptor");
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+
+    let content_bad = NamespaceId::parse("content-bad").expect("valid namespace id");
+    fs.create_namespace(&content_bad, CreateNamespaceOptions::default())
+        .expect("create content-bad namespace");
+    for key in raw_store
+        .list_prefix("content-stores/")
+        .expect("list content stores")
+        .into_iter()
+        .filter(|key| key.ends_with("/descriptor.json"))
+    {
+        raw_store
+            .put_overwrite(&key, br#"{"not":"a content store descriptor"}"#)
+            .expect("corrupt content store descriptor");
+    }
+    assert_core_error_kind(
+        fs.begin_upload(&content_bad),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+}
+
+#[test]
+fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-control-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
+    fs.create_namespace(&head_bad, CreateNamespaceOptions::default())
+        .expect("create head-bad namespace");
+    raw_store
+        .put_overwrite(&namespace_head(head_bad.as_str()), br#"{"not":"a head"}"#)
+        .expect("corrupt head");
+    assert_core_error_kind(fs.begin_upload(&head_bad), CoreErrorKind::NamespaceCorrupt);
+
+    let lease_bad = NamespaceId::parse("lease-bad").expect("valid namespace id");
+    fs.create_namespace(&lease_bad, CreateNamespaceOptions::default())
+        .expect("create lease-bad namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_lease(lease_bad.as_str()),
+            br#"{"not":"a lease"}"#,
+        )
+        .expect("corrupt lease");
+    assert_core_error_kind(fs.begin_upload(&lease_bad), CoreErrorKind::NamespaceCorrupt);
+}
+
+#[test]
 fn explicit_commit_appears_in_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "commit-test");
@@ -725,8 +990,11 @@ struct HeadCasFailureStore {
     inner: LocalFsStore,
     head_key: String,
     wal_prefix: String,
+    checkpoint_prefix: String,
     fail_head_cas: AtomicBool,
     wal_get_count: AtomicUsize,
+    checkpoint_get_count: AtomicUsize,
+    head_get_count: AtomicUsize,
 }
 
 impl HeadCasFailureStore {
@@ -735,8 +1003,11 @@ impl HeadCasFailureStore {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
             wal_prefix: format!("namespaces/{namespace}/wal/"),
+            checkpoint_prefix: format!("namespaces/{namespace}/checkpoints/"),
             fail_head_cas: AtomicBool::new(false),
             wal_get_count: AtomicUsize::new(0),
+            checkpoint_get_count: AtomicUsize::new(0),
+            head_get_count: AtomicUsize::new(0),
         }
     }
 
@@ -752,8 +1023,22 @@ impl HeadCasFailureStore {
         self.wal_get_count.store(0, Ordering::SeqCst);
     }
 
+    fn reset_control_get_counts(&self) {
+        self.checkpoint_get_count.store(0, Ordering::SeqCst);
+        self.head_get_count.store(0, Ordering::SeqCst);
+        self.reset_wal_get_count();
+    }
+
     fn wal_get_count(&self) -> usize {
         self.wal_get_count.load(Ordering::SeqCst)
+    }
+
+    fn checkpoint_get_count(&self) -> usize {
+        self.checkpoint_get_count.load(Ordering::SeqCst)
+    }
+
+    fn head_get_count(&self) -> usize {
+        self.head_get_count.load(Ordering::SeqCst)
     }
 }
 
@@ -769,6 +1054,12 @@ impl ObjectStore for HeadCasFailureStore {
     ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
         if key.starts_with(&self.wal_prefix) {
             self.wal_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key.starts_with(&self.checkpoint_prefix) {
+            self.checkpoint_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key == self.head_key {
+            self.head_get_count.fetch_add(1, Ordering::SeqCst);
         }
         self.inner.get(key, range)
     }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -195,6 +195,48 @@ fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
 }
 
 #[test]
+fn runtime_cache_observes_head_advanced_by_another_runtime() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let reader = Fs::builder(object_store.clone())
+        .writer_id("basis-cache-reader")
+        .build()
+        .expect("build reader runtime");
+    let writer = Fs::builder(object_store)
+        .writer_id("basis-cache-writer")
+        .build()
+        .expect("build writer runtime");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime reader cache");
+
+    writer
+        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .expect("advance head from another runtime");
+
+    raw_store.reset_wal_get_count();
+    let stat = reader
+        .stat_path(&namespace_id, "/docs/new")
+        .expect("reader should observe external head advance");
+    assert_eq!(stat.absolute_path, "/docs/new");
+    assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
+    assert!(raw_store.wal_get_count() > 0);
+}
+
+#[test]
 fn runtime_cache_can_be_disabled() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -3,12 +3,12 @@ use loon_objectstore::keys::{namespace_descriptor, namespace_head};
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
-    CoreErrorKind, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
+    CoreErrorKind, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
     MaintenanceTickOptions, MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior,
-    PutFileOptions, RuntimeError, SharedObjectStore,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -59,6 +59,7 @@ fn open_validates_runtime_config() {
                 writer_id: "   ".to_owned(),
                 writer_version: "runtime-test/0.1.0".to_owned(),
                 lease_duration_ms: 5_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "writer_id",
@@ -70,6 +71,7 @@ fn open_validates_runtime_config() {
                 writer_id: "runtime-test".to_owned(),
                 writer_version: "   ".to_owned(),
                 lease_duration_ms: 5_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "writer_version",
@@ -81,6 +83,7 @@ fn open_validates_runtime_config() {
                 writer_id: "runtime-test".to_owned(),
                 writer_version: "runtime-test/0.1.0".to_owned(),
                 lease_duration_ms: 0,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "lease_duration_ms",
@@ -153,6 +156,104 @@ fn filesystem_operations_match_core_semantics() {
             .bytes,
         b"updated"
     );
+}
+
+#[test]
+fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first stat should load basis");
+    assert_eq!(raw_store.wal_get_count(), 1);
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second stat should reuse cached basis");
+    assert_eq!(raw_store.wal_get_count(), 1);
+
+    fs.create_dir(&namespace_id, "/other", CreateDirOptions::default())
+        .expect("create other");
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("stat after mutation should reload basis");
+    assert!(raw_store.wal_get_count() > 0);
+}
+
+#[test]
+fn runtime_cache_can_be_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-disabled-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first stat should load basis");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second stat should load basis again");
+    assert_eq!(raw_store.wal_get_count(), 2);
+}
+
+#[test]
+fn stale_head_write_error_invalidates_runtime_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-stale-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+
+    raw_store.fail_head_cas();
+    assert_core_error_kind(
+        fs.create_dir(&namespace_id, "/stale", CreateDirOptions::default()),
+        CoreErrorKind::StaleHead,
+    );
+
+    raw_store.allow_head_cas();
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("read after stale head should reload basis");
+    assert!(raw_store.wal_get_count() > 0);
 }
 
 #[test]
@@ -581,7 +682,9 @@ fn separate_runtime_instances_share_object_store_state() {
 struct HeadCasFailureStore {
     inner: LocalFsStore,
     head_key: String,
+    wal_prefix: String,
     fail_head_cas: AtomicBool,
+    wal_get_count: AtomicUsize,
 }
 
 impl HeadCasFailureStore {
@@ -589,12 +692,26 @@ impl HeadCasFailureStore {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
+            wal_prefix: format!("namespaces/{namespace}/wal/"),
             fail_head_cas: AtomicBool::new(false),
+            wal_get_count: AtomicUsize::new(0),
         }
     }
 
     fn fail_head_cas(&self) {
         self.fail_head_cas.store(true, Ordering::SeqCst);
+    }
+
+    fn allow_head_cas(&self) {
+        self.fail_head_cas.store(false, Ordering::SeqCst);
+    }
+
+    fn reset_wal_get_count(&self) {
+        self.wal_get_count.store(0, Ordering::SeqCst);
+    }
+
+    fn wal_get_count(&self) -> usize {
+        self.wal_get_count.load(Ordering::SeqCst)
     }
 }
 
@@ -608,6 +725,9 @@ impl ObjectStore for HeadCasFailureStore {
         key: &str,
         range: Option<ByteRange>,
     ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        if key.starts_with(&self.wal_prefix) {
+            self.wal_get_count.fetch_add(1, Ordering::SeqCst);
+        }
         self.inner.get(key, range)
     }
 


### PR DESCRIPTION
This PR adds a small cache inside `loonfs::Fs`. Repeated embedded or server reads can reuse the verified namespace basis after checking the current object storage head identity allowing the runtime to avoid checkpoint/WAL replay when the namespace head has not advanced.

As of this PR, LoonFS is now faster than Dropbox overall, mostly because Dropbox metadata moves are extremely slow. LoonFS is ~2.7x slower than Box overall and ~12x slower than Google Drive overall. (The custom benchmark does 6,000 operations, split over writes, updates, and reads.)

Future improvements should get LoonFS closer to Box and Google Drive. 