### PR TITLE
fix(loon-core): improve WAL API

### DIFF
--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -377,7 +377,6 @@ pub struct NameKey(pub String);
 pub enum InodeKind {
     File,
     Dir,
-    Mount,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -352,7 +352,7 @@ impl<'de> Deserialize<'de> for ContentStoreId {
     }
 }
 
-/// Numeric identity of a file, directory, or mount within a namespace.
+/// Numeric identity of a file or directory within a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InodeId(pub u64);
 

--- a/crates/loon-api/src/v0.rs
+++ b/crates/loon-api/src/v0.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, CommitId, ContentRef, InodeId, NamespaceId, RevisionNo};
+use crate::{ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -120,11 +120,6 @@ pub enum CommitPrecondition {
         parent_inode: InodeId,
         name_key: String,
     },
-    ChildNameIs {
-        parent_inode: InodeId,
-        name_key: String,
-        child_inode: InodeId,
-    },
     BindingIs {
         parent_inode: InodeId,
         name_key: String,
@@ -178,6 +173,46 @@ pub enum CommitOpResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "delta", rename_all = "snake_case")]
+pub enum CommitDelta {
+    CreateInode {
+        semantic_op_index: u32,
+        delta_index: u32,
+        inode_id: InodeId,
+        inode_kind: InodeKind,
+    },
+    BindDirentry {
+        semantic_op_index: u32,
+        delta_index: u32,
+        parent_inode: InodeId,
+        name_key: String,
+        display_name: String,
+        child_inode: InodeId,
+    },
+    UnbindDirentry {
+        semantic_op_index: u32,
+        delta_index: u32,
+        parent_inode: InodeId,
+        name_key: String,
+        child_inode: InodeId,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    },
+    AppendFileRevision {
+        semantic_op_index: u32,
+        delta_index: u32,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        content_ref: ContentRef,
+    },
+    TombstoneSubtree {
+        semantic_op_index: u32,
+        delta_index: u32,
+        root_inode: InodeId,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommittedChange {
     pub seq: ChangeSeq,
     pub commit_id: CommitId,
@@ -186,6 +221,7 @@ pub struct CommittedChange {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<CommitAnnotations>,
     pub ops: Vec<CommitOpResult>,
+    pub deltas: Vec<CommitDelta>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -25,6 +25,7 @@ pub enum WalDelta {
     BindDirentry {
         delta_index: u32,
         parent_inode: InodeId,
+        name_key: String,
         display_name: String,
         child_inode: InodeId,
     },
@@ -61,11 +62,6 @@ pub enum WalPrecondition {
         parent_inode: InodeId,
         name_key: String,
     },
-    ChildNameIs {
-        parent_inode: InodeId,
-        name_key: String,
-        child_inode: InodeId,
-    },
     BindingIs {
         parent_inode: InodeId,
         name_key: String,
@@ -76,6 +72,12 @@ pub enum WalPrecondition {
     DirectoryEmpty {
         inode_id: InodeId,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalCommitDelta {
+    pub semantic_op_index: u32,
+    pub delta: WalDelta,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,7 +93,7 @@ pub struct WalCommitPayload {
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<CommitAnnotations>,
-    pub deltas: Vec<WalDelta>,
+    pub deltas: Vec<WalCommitDelta>,
     pub preconditions: Vec<WalPrecondition>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub results: Vec<CommitOpResult>,

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -5,7 +5,7 @@ use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs::{
     BootstrapNamespaceError, CopyOptions, CoreError, CoreErrorKind, CreateDirOptions,
     CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, MoveOptions, PutFileBehavior,
-    PutFileOptions, RuntimeError, SharedObjectStore,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::sync::Arc;
 
@@ -462,6 +462,7 @@ impl EmbeddedTarget {
                     .map(ToOwned::to_owned)
                     .unwrap_or_else(|| format!("loon/{}", env!("CARGO_PKG_VERSION"))),
                 lease_duration_ms: lease_duration_ms.unwrap_or(DEFAULT_LEASE_DURATION_MS),
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         )
         .map_err(map_runtime_error)?;

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -486,9 +486,6 @@ impl Client {
                     bytes_written,
                 })
             }
-            kind => Err(ClientError::InvalidNamespacePath(format!(
-                "unsupported inode kind for get: {kind:?}"
-            ))),
         }
     }
 
@@ -563,7 +560,6 @@ impl Client {
                     let bytes = self.read_file_bytes(&child_spec)?;
                     bytes_written += write_local_file(&child_dest, &bytes)?;
                 }
-                _ => {}
             }
         }
         Ok(bytes_written)

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -14,7 +14,10 @@ use loon_api::{
     decode_wal_segment_envelope_zstd, ChangeSeq, ContentStoreId, HeadState,
     NamespaceDescriptorState, NamespaceId, WalSegmentPointer,
 };
-use loon_objectstore::{keys::namespace_descriptor, ObjectStore};
+use loon_objectstore::{
+    keys::{namespace_descriptor, namespace_head},
+    ObjectStore,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -34,6 +37,11 @@ pub struct NamespaceHeadSummary {
     pub head_seq: ChangeSeq,
     pub checkpoint_hint_seq: Option<ChangeSeq>,
     pub retention_floor_seq: ChangeSeq,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceHeadIdentity {
+    pub head_etag: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
@@ -177,6 +185,34 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         checkpoint_hint_seq: head.checkpoint_hint_seq,
         retention_floor_seq: head.retention_floor_seq,
     })
+}
+
+pub fn load_namespace_head_identity<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<NamespaceHeadIdentity, CoreError> {
+    NamespaceId::parse(expected_namespace.as_str())?;
+    let object_key = namespace_head(expected_namespace.as_str());
+    let metadata = store
+        .head(&object_key)
+        .map_err(|err| {
+            CoreError::Basis(BasisLoadError::LoadHead(ControlObjectLoadError::Store(
+                err.to_string(),
+            )))
+        })?
+        .ok_or_else(|| {
+            CoreError::Basis(BasisLoadError::LoadHead(
+                ControlObjectLoadError::MissingObject {
+                    object_key: object_key.clone(),
+                },
+            ))
+        })?;
+    let head_etag = metadata
+        .etag
+        .ok_or(CoreError::Basis(BasisLoadError::MissingHeadEtag {
+            object_key,
+        }))?;
+    Ok(NamespaceHeadIdentity { head_etag })
 }
 
 fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -102,15 +102,6 @@ pub(super) fn commit_precondition_from_v0(
             parent_inode,
             name_key,
         },
-        api_v0::CommitPrecondition::ChildNameIs {
-            parent_inode,
-            name_key,
-            child_inode,
-        } => Precondition::ChildNameIs {
-            parent_inode,
-            name_key,
-            child_inode,
-        },
         api_v0::CommitPrecondition::BindingIs {
             parent_inode,
             name_key,
@@ -155,10 +146,12 @@ mod tests {
                     parent_inode: InodeId(1),
                     name_key: "docs".to_owned(),
                 },
-                ApiCommitPrecondition::ChildNameIs {
+                ApiCommitPrecondition::BindingIs {
                     parent_inode: InodeId(1),
                     name_key: "file.txt".to_owned(),
                     child_inode: InodeId(2),
+                    bind_seq: loon_api::ChangeSeq(4),
+                    bind_delta_index: 1,
                 },
                 ApiCommitPrecondition::DirectoryEmpty {
                     inode_id: InodeId(3),

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -1,6 +1,6 @@
 use super::{MaterializedCommit, Precondition};
 use crate::wal::WalBuildError;
-use loon_api::{WalCommitPayload, WalPrecondition};
+use loon_api::{WalCommitDelta, WalCommitPayload, WalPrecondition};
 
 pub fn wal_payload_from_materialized_commit(
     commit: &MaterializedCommit,
@@ -29,7 +29,10 @@ pub fn wal_payload_from_materialized_commit(
         deltas: commit
             .deltas
             .iter()
-            .map(|delta| delta.wal_delta.clone())
+            .map(|delta| WalCommitDelta {
+                semantic_op_index: delta.semantic_op_index,
+                delta: delta.wal_delta.clone(),
+            })
             .collect(),
         preconditions: prepared
             .request
@@ -62,15 +65,6 @@ impl From<&Precondition> for WalPrecondition {
             } => Self::ChildNameAbsent {
                 parent_inode: *parent_inode,
                 name_key: name_key.clone(),
-            },
-            Precondition::ChildNameIs {
-                parent_inode,
-                name_key,
-                child_inode,
-            } => Self::ChildNameIs {
-                parent_inode: *parent_inode,
-                name_key: name_key.clone(),
-                child_inode: *child_inode,
             },
             Precondition::BindingIs {
                 parent_inode,
@@ -123,6 +117,7 @@ mod tests {
             resolved_restore_content_refs: vec![None],
             resolved_source_bindings: vec![None],
             resulting_next_inode_id: InodeId(3),
+            name_policy: loon_api::NamePolicy::default(),
             metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -155,10 +155,10 @@ pub enum CommitValidationError {
         head: FenceToken,
         lease: FenceToken,
     },
-    ChildNamePreconditionParentMissing {
+    NamePreconditionParentMissing {
         parent_inode: InodeId,
     },
-    ChildNamePreconditionParentNotDirectory {
+    NamePreconditionParentNotDirectory {
         parent_inode: InodeId,
         actual_kind: InodeKind,
     },

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -2,7 +2,7 @@ use crate::metadata::MetadataState;
 use loon_api::{
     v0::{CommitAnnotations, RenameMode},
     ChangeSeq, CommitId, ContentRef, FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind,
-    LeaseState, NamespaceId, RevisionNo,
+    LeaseState, NamePolicy, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -91,11 +91,6 @@ pub enum Precondition {
         parent_inode: InodeId,
         name_key: String,
     },
-    ChildNameIs {
-        parent_inode: InodeId,
-        name_key: String,
-        child_inode: InodeId,
-    },
     BindingIs {
         parent_inode: InodeId,
         name_key: String,
@@ -128,6 +123,7 @@ pub struct CommitPlan {
     pub resolved_restore_content_refs: Vec<Option<ContentRef>>,
     pub resolved_source_bindings: Vec<Option<ResolvedBinding>>,
     pub resulting_next_inode_id: InodeId,
+    pub name_policy: NamePolicy,
     pub metadata_preconditions: Vec<Precondition>,
     pub checked_invariants: Vec<String>,
 }
@@ -165,16 +161,6 @@ pub enum CommitValidationError {
     ChildNamePreconditionParentNotDirectory {
         parent_inode: InodeId,
         actual_kind: InodeKind,
-    },
-    ChildNamePreconditionMissing {
-        parent_inode: InodeId,
-        name_key: String,
-    },
-    ChildNamePreconditionMismatch {
-        parent_inode: InodeId,
-        name_key: String,
-        expected_child_inode: InodeId,
-        actual_child_inode: InodeId,
     },
     BindingPreconditionMissing {
         parent_inode: InodeId,

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -95,6 +95,7 @@ pub fn build_commit_plan(
         &context.metadata_state,
         shape.assigned_seq,
         &shape.allocated_inode_ids,
+        context.head.name_policy,
         &mut checked_invariants,
     )?;
 
@@ -144,6 +145,7 @@ pub fn build_commit_plan(
         resolved_restore_content_refs: resolved_metadata.resolved_restore_content_refs,
         resolved_source_bindings: resolved_metadata.resolved_source_bindings,
         resulting_next_inode_id: shape.resulting_next_inode_id,
+        name_policy: context.head.name_policy,
         metadata_preconditions: request.preconditions.clone(),
         checked_invariants,
     })
@@ -200,6 +202,7 @@ fn validate_metadata_preconditions(
     metadata_state: &MetadataState,
     committed_seq: ChangeSeq,
     allocated_inode_ids: &[InodeId],
+    name_policy: NamePolicy,
     checked_invariants: &mut Vec<String>,
 ) -> Result<ResolvedMetadataPreconditions, CommitValidationError> {
     let mut ephemeral_metadata_state = metadata_state.clone();
@@ -291,6 +294,7 @@ fn validate_metadata_preconditions(
                     *parent_inode,
                     display_name,
                     committed_seq,
+                    name_policy,
                 )?;
                 validate_ancestors_not_subtree_deleted(
                     &ephemeral_metadata_state,
@@ -347,6 +351,7 @@ fn validate_metadata_preconditions(
                     *new_parent_inode,
                     new_display_name,
                     committed_seq,
+                    name_policy,
                 )?;
                 validate_rename_does_not_cycle(
                     &ephemeral_metadata_state,
@@ -387,6 +392,7 @@ fn validate_metadata_preconditions(
         let (deltas, _result) = materialize_commit_op(
             op,
             op_index,
+            name_policy,
             resolved_restore_content_ref.as_ref(),
             resolved_source_binding.as_ref(),
             &mut allocated_inode_ids,
@@ -507,19 +513,6 @@ fn validate_explicit_preconditions(
                     base_seq,
                 )?;
             }
-            Precondition::ChildNameIs {
-                parent_inode,
-                name_key,
-                child_inode,
-            } => {
-                validate_child_name_is_precondition(
-                    metadata_state,
-                    *parent_inode,
-                    name_key,
-                    *child_inode,
-                    base_seq,
-                )?;
-            }
             Precondition::BindingIs {
                 parent_inode,
                 name_key,
@@ -569,43 +562,6 @@ fn validate_child_name_absent_precondition(
             parent_inode,
             name_key: name_key.to_owned(),
             child_inode: existing.child_inode_id,
-        });
-    }
-
-    Ok(())
-}
-
-fn validate_child_name_is_precondition(
-    metadata_state: &MetadataState,
-    parent_inode: InodeId,
-    name_key: &str,
-    child_inode: InodeId,
-    base_seq: ChangeSeq,
-) -> Result<(), CommitValidationError> {
-    let parent = metadata_state
-        .inode_at_seq(parent_inode, base_seq)
-        .ok_or(CommitValidationError::ChildNamePreconditionParentMissing { parent_inode })?;
-    if parent.inode_kind != InodeKind::Dir {
-        return Err(
-            CommitValidationError::ChildNamePreconditionParentNotDirectory {
-                parent_inode,
-                actual_kind: parent.inode_kind,
-            },
-        );
-    }
-
-    let Some(existing) = metadata_state.visible_child(parent_inode, name_key, base_seq) else {
-        return Err(CommitValidationError::ChildNamePreconditionMissing {
-            parent_inode,
-            name_key: name_key.to_owned(),
-        });
-    };
-    if existing.child_inode_id != child_inode {
-        return Err(CommitValidationError::ChildNamePreconditionMismatch {
-            parent_inode,
-            name_key: name_key.to_owned(),
-            expected_child_inode: child_inode,
-            actual_child_inode: existing.child_inode_id,
         });
     }
 
@@ -704,6 +660,7 @@ fn validate_child_name_absent(
     parent_inode: InodeId,
     display_name: &str,
     base_seq: ChangeSeq,
+    name_policy: NamePolicy,
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
@@ -718,7 +675,7 @@ fn validate_child_name_absent(
     if let Some(existing) = metadata_state.visible_child(parent_inode, display_name, base_seq) {
         return Err(CommitValidationError::CreateChildNameCollision {
             parent_inode,
-            name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+            name_key: name_key_for_display_name(name_policy, display_name),
             child_inode: existing.child_inode_id,
         });
     }
@@ -956,6 +913,7 @@ fn validate_rename_target_name_absent(
     parent_inode: InodeId,
     display_name: &str,
     base_seq: ChangeSeq,
+    name_policy: NamePolicy,
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
@@ -970,7 +928,7 @@ fn validate_rename_target_name_absent(
     if let Some(existing) = metadata_state.visible_child(parent_inode, display_name, base_seq) {
         return Err(CommitValidationError::RenameTargetNameCollision {
             parent_inode,
-            name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+            name_key: name_key_for_display_name(name_policy, display_name),
             child_inode: existing.child_inode_id,
         });
     }

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -547,14 +547,12 @@ fn validate_child_name_absent_precondition(
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
-        .ok_or(CommitValidationError::ChildNamePreconditionParentMissing { parent_inode })?;
+        .ok_or(CommitValidationError::NamePreconditionParentMissing { parent_inode })?;
     if parent.inode_kind != InodeKind::Dir {
-        return Err(
-            CommitValidationError::ChildNamePreconditionParentNotDirectory {
-                parent_inode,
-                actual_kind: parent.inode_kind,
-            },
-        );
+        return Err(CommitValidationError::NamePreconditionParentNotDirectory {
+            parent_inode,
+            actual_kind: parent.inode_kind,
+        });
     }
 
     if let Some(existing) = metadata_state.visible_child(parent_inode, name_key, base_seq) {
@@ -597,14 +595,12 @@ fn validate_binding_is_precondition(
 ) -> Result<(), CommitValidationError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
-        .ok_or(CommitValidationError::ChildNamePreconditionParentMissing { parent_inode })?;
+        .ok_or(CommitValidationError::NamePreconditionParentMissing { parent_inode })?;
     if parent.inode_kind != InodeKind::Dir {
-        return Err(
-            CommitValidationError::ChildNamePreconditionParentNotDirectory {
-                parent_inode,
-                actual_kind: parent.inode_kind,
-            },
-        );
+        return Err(CommitValidationError::NamePreconditionParentNotDirectory {
+            parent_inode,
+            actual_kind: parent.inode_kind,
+        });
     }
 
     let Some(existing) = metadata_state.visible_child(parent_inode, name_key, base_seq) else {

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -3,8 +3,8 @@ use super::{
     ResolvedBinding, SemanticCommitFingerprint,
 };
 use loon_api::{
-    v0::CommitOpResult, ContentRef, FenceToken, InodeId, InodeKind, NamespaceId, RevisionNo,
-    WalDelta,
+    name_key_for_display_name, v0::CommitOpResult, ContentRef, FenceToken, InodeId, InodeKind,
+    NamePolicy, NamespaceId, RevisionNo, WalDelta,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -155,6 +155,7 @@ pub fn materialize_commit(
         let (mut op_deltas, result) = materialize_commit_op(
             op,
             op_index,
+            prepared.plan.name_policy,
             resolved_restore_content_ref,
             resolved_source_binding,
             &mut allocated_inode_ids,
@@ -174,6 +175,7 @@ pub fn materialize_commit(
 pub(super) fn materialize_commit_op(
     op: &CommitOp,
     op_index: u32,
+    name_policy: NamePolicy,
     resolved_restore_content_ref: Option<&ContentRef>,
     resolved_source_binding: Option<&ResolvedBinding>,
     allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
@@ -205,6 +207,7 @@ pub(super) fn materialize_commit_op(
                 WalDelta::BindDirentry {
                     delta_index: 0,
                     parent_inode: *parent_inode,
+                    name_key: name_key_for_display_name(name_policy, display_name),
                     display_name: display_name.clone(),
                     child_inode: inode_id,
                 },
@@ -236,6 +239,7 @@ pub(super) fn materialize_commit_op(
                 WalDelta::BindDirentry {
                     delta_index: 0,
                     parent_inode: *parent_inode,
+                    name_key: name_key_for_display_name(name_policy, display_name),
                     display_name: display_name.clone(),
                     child_inode: inode_id,
                 },
@@ -354,6 +358,7 @@ pub(super) fn materialize_commit_op(
                 WalDelta::BindDirentry {
                     delta_index: 0,
                     parent_inode: *new_parent_inode,
+                    name_key: name_key_for_display_name(name_policy, new_display_name),
                     display_name: new_display_name.clone(),
                     child_inode: *inode_id,
                 },
@@ -478,6 +483,7 @@ mod tests {
             resolved_restore_content_refs: vec![None],
             resolved_source_bindings: vec![None],
             resulting_next_inode_id: InodeId(3),
+            name_policy: loon_api::NamePolicy::default(),
             metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         }

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -151,6 +151,7 @@ mod tests {
             resolved_restore_content_refs: Vec::new(),
             resolved_source_bindings: Vec::new(),
             resulting_next_inode_id: InodeId(10),
+            name_policy: loon_api::NamePolicy::default(),
             metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -311,7 +311,6 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
         }
         CommitValidationError::CreateChildNameCollision { .. }
         | CommitValidationError::ChildNamePreconditionParentNotDirectory { .. }
-        | CommitValidationError::ChildNamePreconditionMismatch { .. }
         | CommitValidationError::BindingPreconditionMissing { .. }
         | CommitValidationError::BindingPreconditionMismatch { .. }
         | CommitValidationError::CreateParentNotDirectory { .. }
@@ -329,7 +328,6 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
         }
         CommitValidationError::CreateParentMissing { .. }
         | CommitValidationError::ChildNamePreconditionParentMissing { .. }
-        | CommitValidationError::ChildNamePreconditionMissing { .. }
         | CommitValidationError::ReplaceFileInodeMissing { .. }
         | CommitValidationError::RestoreRevisionInodeMissing { .. }
         | CommitValidationError::DeleteFileInodeMissing { .. }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -310,7 +310,7 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
             CoreErrorKind::TombstoneConflict
         }
         CommitValidationError::CreateChildNameCollision { .. }
-        | CommitValidationError::ChildNamePreconditionParentNotDirectory { .. }
+        | CommitValidationError::NamePreconditionParentNotDirectory { .. }
         | CommitValidationError::BindingPreconditionMissing { .. }
         | CommitValidationError::BindingPreconditionMismatch { .. }
         | CommitValidationError::CreateParentNotDirectory { .. }
@@ -327,7 +327,7 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
             CoreErrorKind::DirectoryNotEmpty
         }
         CommitValidationError::CreateParentMissing { .. }
-        | CommitValidationError::ChildNamePreconditionParentMissing { .. }
+        | CommitValidationError::NamePreconditionParentMissing { .. }
         | CommitValidationError::ReplaceFileInodeMissing { .. }
         | CommitValidationError::RestoreRevisionInodeMissing { .. }
         | CommitValidationError::DeleteFileInodeMissing { .. }

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -18,8 +18,8 @@ pub mod services;
 pub mod wal;
 
 pub use basis::{
-    load_namespace_head_summary, load_verified_namespace_basis, BasisLoadError,
-    NamespaceHeadSummary, VerifiedNamespaceBasis,
+    load_namespace_head_identity, load_namespace_head_summary, load_verified_namespace_basis,
+    BasisLoadError, NamespaceHeadIdentity, NamespaceHeadSummary, VerifiedNamespaceBasis,
 };
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, CheckpointLoadError, CheckpointLoadErrorKind,
@@ -27,6 +27,12 @@ pub use checkpoint::{
 pub use context::MutationContext;
 pub use error::{CoreError, CoreErrorKind};
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
+pub use loading::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control, ControlObjectIdentity,
+    ControlObjectLoadError, LoadedContentStoreDescriptorControl, LoadedHeadControl,
+    LoadedLeaseControl, LoadedNamespaceDescriptorControl,
+};
 pub use protocol::{
     begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
     upload_content,
@@ -37,7 +43,8 @@ pub use publisher::{
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, create_dir_path, delete_path, delete_path_non_recursive,
-    fork_namespace, list_namespaces, list_path, move_path, put_file_bytes, put_file_content_ref,
-    read_file_bytes, resolve_path, store_bytes_as_content, write_file_bytes,
-    BootstrapNamespaceError, PutFileBehavior, StoredContent,
+    fork_namespace, list_namespaces, list_path, list_path_from_basis, move_path, put_file_bytes,
+    put_file_content_ref, read_file_bytes, read_file_bytes_from_basis, resolve_path,
+    resolve_path_from_basis, store_bytes_as_content, write_file_bytes, BootstrapNamespaceError,
+    PutFileBehavior, StoredContent,
 };

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,6 +1,7 @@
 use loon_api::{
-    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreId, ControlObjectKind,
-    HeadStateEnvelope, LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceId,
+    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
+    ContentStoreId, ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState,
+    LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
     CONTROL_OBJECT_FORMAT_VERSION,
 };
 use loon_objectstore::keys::{
@@ -38,6 +39,39 @@ pub(crate) struct LoadedLeaseObject {
     pub(crate) object_key: String,
     pub(crate) metadata: ObjectMetadata,
     pub(crate) envelope: LeaseStateEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct ControlObjectIdentity {
+    pub etag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedNamespaceDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: NamespaceDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedContentStoreDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: ContentStoreDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedHeadControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: HeadState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedLeaseControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: LeaseState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize, Error)]
@@ -214,6 +248,68 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+pub fn load_namespace_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedNamespaceDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_namespace_descriptor_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedNamespaceDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_content_store_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_content_store: &ContentStoreId,
+) -> Result<LoadedContentStoreDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_content_store_descriptor_object(store, expected_content_store)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedContentStoreDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_head_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedHeadControl, ControlObjectLoadError> {
+    let loaded = read_head_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedHeadControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_lease_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedLeaseControl, ControlObjectLoadError> {
+    let loaded = read_lease_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedLeaseControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+fn control_identity(
+    object_key: &str,
+    metadata: &ObjectMetadata,
+) -> Result<ControlObjectIdentity, ControlObjectLoadError> {
+    let etag = metadata.etag.clone().ok_or_else(|| {
+        ControlObjectLoadError::Store(format!("missing control object etag for `{object_key}`"))
+    })?;
+    Ok(ControlObjectIdentity { etag })
 }
 
 fn validate_namespace_id_for_control_key(

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -141,12 +141,13 @@ impl MetadataState {
                 WalDelta::BindDirentry {
                     delta_index,
                     parent_inode,
+                    name_key,
                     display_name,
                     child_inode,
                 } => {
                     metadata_state.direntry_binds.push(DirentryBindRecord {
                         parent_inode_id: *parent_inode,
-                        name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+                        name_key: name_key.clone(),
                         display_name: display_name.clone(),
                         child_inode_id: *child_inode,
                         bind_seq: committed_seq,
@@ -226,7 +227,12 @@ impl MetadataState {
         &self,
         record: &WalCommitPayload,
     ) -> Result<AppliedMetadataState, MetadataApplyError> {
-        let mut applied = self.apply_committed_wal_deltas(record.seq, &record.deltas)?;
+        let deltas = record
+            .deltas
+            .iter()
+            .map(|delta| delta.delta.clone())
+            .collect::<Vec<_>>();
+        let mut applied = self.apply_committed_wal_deltas(record.seq, &deltas)?;
         applied
             .metadata_state
             .commit_receipts
@@ -611,5 +617,32 @@ fn join_absolute_path(base: &str, component: &str) -> String {
         format!("/{component}")
     } else {
         format!("{base}/{component}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_direntry_replay_uses_persisted_name_key() {
+        let applied = MetadataState::default()
+            .apply_committed_wal_deltas(
+                ChangeSeq(1),
+                &[WalDelta::BindDirentry {
+                    delta_index: 7,
+                    parent_inode: InodeId(1),
+                    name_key: "persisted-key".to_owned(),
+                    display_name: "Report.TXT".to_owned(),
+                    child_inode: InodeId(2),
+                }],
+            )
+            .expect("apply bind delta");
+
+        assert_eq!(applied.metadata_state.direntry_binds.len(), 1);
+        let bind = &applied.metadata_state.direntry_binds[0];
+        assert_eq!(bind.name_key, "persisted-key");
+        assert_eq!(bind.display_name, "Report.TXT");
+        assert_eq!(bind.bind_delta_index, 7);
     }
 }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -14,14 +14,14 @@ use crate::namespace::catalog::load_namespace_content_store_id;
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
 use loon_api::v0::{
-    BeginUploadResponse, ChangesResponse, CommitRequest as ApiCommitRequest,
+    BeginUploadResponse, ChangesResponse, CommitDelta, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
     decode_wal_segment_envelope_zstd, generate_upload_id, validate_upload_id, ChangeSeq, CommitId,
     CompletedUpload, ContentRef, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
-    UploadSessionState,
+    UploadSessionState, WalCommitDelta, WalDelta,
 };
 use loon_objectstore::keys::{content_blob, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -632,6 +632,7 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
                     message: record.message,
                     annotations: record.annotations,
                     ops: record.results,
+                    deltas: record.deltas.iter().map(commit_delta_from_wal).collect(),
                 });
             }
         }
@@ -643,6 +644,72 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         through_seq: basis.head.seq,
         changes,
     })
+}
+
+fn commit_delta_from_wal(delta: &WalCommitDelta) -> CommitDelta {
+    let semantic_op_index = delta.semantic_op_index;
+    match &delta.delta {
+        WalDelta::CreateInode {
+            delta_index,
+            inode_id,
+            inode_kind,
+        } => CommitDelta::CreateInode {
+            semantic_op_index,
+            delta_index: *delta_index,
+            inode_id: *inode_id,
+            inode_kind: inode_kind.clone(),
+        },
+        WalDelta::BindDirentry {
+            delta_index,
+            parent_inode,
+            name_key,
+            display_name,
+            child_inode,
+        } => CommitDelta::BindDirentry {
+            semantic_op_index,
+            delta_index: *delta_index,
+            parent_inode: *parent_inode,
+            name_key: name_key.clone(),
+            display_name: display_name.clone(),
+            child_inode: *child_inode,
+        },
+        WalDelta::UnbindDirentry {
+            delta_index,
+            parent_inode,
+            name_key,
+            child_inode,
+            bind_seq,
+            bind_delta_index,
+        } => CommitDelta::UnbindDirentry {
+            semantic_op_index,
+            delta_index: *delta_index,
+            parent_inode: *parent_inode,
+            name_key: name_key.clone(),
+            child_inode: *child_inode,
+            bind_seq: *bind_seq,
+            bind_delta_index: *bind_delta_index,
+        },
+        WalDelta::AppendFileRevision {
+            delta_index,
+            inode_id,
+            revision_no,
+            content_ref,
+        } => CommitDelta::AppendFileRevision {
+            semantic_op_index,
+            delta_index: *delta_index,
+            inode_id: *inode_id,
+            revision_no: *revision_no,
+            content_ref: content_ref.clone(),
+        },
+        WalDelta::TombstoneSubtree {
+            delta_index,
+            root_inode,
+        } => CommitDelta::TombstoneSubtree {
+            semantic_op_index,
+            delta_index: *delta_index,
+            root_inode: *root_inode,
+        },
+    }
 }
 
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -10,9 +10,16 @@ use crate::content::{validate_durable_content_reference, write_immutable_object}
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
-use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::{
+    load_namespace_content_store_id, namespace_initialization_state, NamespaceInitializationError,
+    NamespaceInitializationState,
+};
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
+use crate::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control,
+};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitDelta, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
@@ -23,7 +30,7 @@ use loon_api::{
     CompletedUpload, ContentRef, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
     UploadSessionState, WalCommitDelta, WalDelta,
 };
-use loon_objectstore::keys::{content_blob, upload_session};
+use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
 
@@ -52,7 +59,15 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<BeginUploadResponse, CoreError> {
-    let _basis = load_verified_namespace_basis(store, namespace_id)?;
+    ensure_upload_namespace_available(store, namespace_id)?;
+    create_upload_session(store, namespace_id, context)
+}
+
+fn create_upload_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<BeginUploadResponse, CoreError> {
     let upload_id = generate_upload_id();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
@@ -78,6 +93,61 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
         upload_id,
         mode: UploadMode::ServiceProxied,
     })
+}
+
+fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<(), CoreError> {
+    match namespace_initialization_state(store, namespace_id) {
+        Ok(NamespaceInitializationState::Complete) => {
+            let descriptor =
+                load_namespace_descriptor_control(store, namespace_id).map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+                })?;
+            load_content_store_descriptor_control(store, &descriptor.state.content_store_id)
+                .map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+                })?;
+            load_namespace_head_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
+            load_namespace_lease_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadLease(error)))?;
+            Ok(())
+        }
+        Ok(NamespaceInitializationState::Absent) => {
+            Err(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
+                crate::loading::ControlObjectLoadError::MissingObject {
+                    object_key: namespace_descriptor(namespace_id.as_str()),
+                },
+            )))
+        }
+        Ok(NamespaceInitializationState::Partial) => {
+            Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            })
+        }
+        Err(error) => Err(map_upload_namespace_initialization_error(error)),
+    }
+}
+
+fn map_upload_namespace_initialization_error(error: NamespaceInitializationError) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+        }
+        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+        }
+        NamespaceInitializationError::InspectNamespaceDescriptor(_)
+        | NamespaceInitializationError::InspectNamespaceHead(_)
+        | NamespaceInitializationError::InspectNamespaceLease(_) => {
+            CoreError::Store(error.to_string())
+        }
+    }
 }
 
 pub fn upload_content<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -400,12 +400,20 @@ pub fn resolve_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<AuthoritativePathEntry, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
+    resolve_path_from_basis(store, &basis, absolute_path)
+}
+
+pub fn resolve_path_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<AuthoritativePathEntry, CoreError> {
     let resolved = basis
         .metadata_state
         .resolve_visible_path(absolute_path, basis.head.seq)?;
     build_authoritative_path_entry(
         store,
-        namespace_id,
+        &basis.head.namespace_id,
         &basis.content_store_id,
         basis.head.seq,
         &basis.metadata_state,
@@ -419,13 +427,21 @@ pub fn list_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
+    list_path_from_basis(store, &basis, absolute_path)
+}
+
+pub fn list_path_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
     let resolved = basis
         .metadata_state
         .resolve_visible_path(absolute_path, basis.head.seq)?;
     if resolved.inode_kind == InodeKind::File {
         return Ok(vec![build_authoritative_path_entry(
             store,
-            namespace_id,
+            &basis.head.namespace_id,
             &basis.content_store_id,
             basis.head.seq,
             &basis.metadata_state,
@@ -450,7 +466,7 @@ pub fn list_path<S: ObjectStore + ?Sized>(
                 .expect("visible child listing should resolve inode");
             build_authoritative_path_entry(
                 store,
-                namespace_id,
+                &basis.head.namespace_id,
                 &basis.content_store_id,
                 basis.head.seq,
                 &basis.metadata_state,
@@ -474,7 +490,16 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
 ) -> Result<AuthoritativeFileBytes, CoreError> {
-    let entry = resolve_path(store, namespace_id, absolute_path)?;
+    let basis = load_verified_namespace_basis(store, namespace_id)?;
+    read_file_bytes_from_basis(store, &basis, absolute_path)
+}
+
+pub fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    basis: &crate::VerifiedNamespaceBasis,
+    absolute_path: &str,
+) -> Result<AuthoritativeFileBytes, CoreError> {
+    let entry = resolve_path_from_basis(store, basis, absolute_path)?;
     if entry.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: entry.absolute_path,
@@ -485,8 +510,7 @@ pub fn read_file_bytes<S: ObjectStore + ?Sized>(
         .content_ref
         .clone()
         .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
-    let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
-    let read = read_durable_content_bytes(store, &content_store_id, &content_ref)?;
+    let read = read_durable_content_bytes(store, &basis.content_store_id, &content_ref)?;
     Ok(AuthoritativeFileBytes {
         entry,
         bytes: read.bytes,

--- a/crates/loon-core/src/services.rs
+++ b/crates/loon-core/src/services.rs
@@ -777,7 +777,7 @@ struct PathPlanningView<'a> {
     content_store_id: &'a ContentStoreId,
 }
 
-fn child_name_is_precondition(
+fn binding_is_precondition(
     view: &PathPlanningView<'_>,
     resolved: &ResolvedVisiblePath,
 ) -> Result<ApiCommitPrecondition, CoreError> {
@@ -861,6 +861,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
     let final_parent_inode = ensure_parent_directories(
         absolute_path,
         view.head.seq,
+        view.head.name_policy,
         &mut working,
         &mut ops,
         &mut next_inode_id,
@@ -884,7 +885,7 @@ fn plan_put_file_content_ref<S: ObjectStore + ?Sized>(
                 .metadata_state
                 .latest_revision_head_at_seq(existing.inode_id, view.head.seq)
                 .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
-            preconditions.push(child_name_is_precondition(view, &existing)?);
+            preconditions.push(binding_is_precondition(view, &existing)?);
             ops.push(ApiCommitOp::ReplaceFile {
                 inode_id: existing.inode_id,
                 base_revision_no: revision.revision_no,
@@ -1046,14 +1047,8 @@ fn plan_delete_path(
                 root_inode: resolved.inode_id,
             }
         }
-        kind => {
-            return Err(CoreError::ExpectedFile {
-                path: absolute_path.to_owned(),
-                kind,
-            });
-        }
     };
-    let mut preconditions = vec![child_name_is_precondition(view, &resolved)?];
+    let mut preconditions = vec![binding_is_precondition(view, &resolved)?];
     if !recursive && resolved.inode_kind == InodeKind::Dir {
         preconditions.push(ApiCommitPrecondition::DirectoryEmpty {
             inode_id: resolved.inode_id,
@@ -1101,7 +1096,7 @@ fn plan_move_path(
             mode,
         }],
         preconditions: vec![
-            child_name_is_precondition(view, &source)?,
+            binding_is_precondition(view, &source)?,
             child_name_absent_precondition(view, target_parent, &target_name),
             ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
                 inode_id: source.inode_id,
@@ -1158,7 +1153,7 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
             content_ref: revision.content_ref,
         }],
         preconditions: vec![
-            child_name_is_precondition(view, &source)?,
+            binding_is_precondition(view, &source)?,
             ApiCommitPrecondition::InodeRevisionIs {
                 inode_id: source.inode_id,
                 revision_no: revision.revision_no,
@@ -1179,6 +1174,7 @@ fn plan_copy_file_path<S: ObjectStore + ?Sized>(
 fn ensure_parent_directories(
     absolute_path: &str,
     committed_seq: ChangeSeq,
+    name_policy: loon_api::NamePolicy,
     working: &mut MetadataState,
     ops: &mut Vec<ApiCommitOp>,
     next_inode_id: &mut InodeId,
@@ -1220,6 +1216,7 @@ fn ensure_parent_directories(
                 loon_api::WalDelta::BindDirentry {
                     delta_index: delta_index.saturating_add(1),
                     parent_inode: current_inode,
+                    name_key: name_key_for_display_name(name_policy, component),
                     display_name: component.clone(),
                     child_inode: allocated,
                 },

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -2,8 +2,8 @@ use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
 use crate::metadata::{MetadataApplyError, MetadataState};
 use loon_api::{
     decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, generate_wal_segment_id,
-    validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitPayload,
-    WalDelta, WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
+    validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitDelta,
+    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
 };
 use loon_objectstore::keys::wal_segment;
 use serde::{Deserialize, Serialize};
@@ -190,7 +190,7 @@ pub fn replay_wal_segment(
     for record in &envelope.payload.records {
         resulting_head.seq = record.seq;
         resulting_head.next_inode_id =
-            replay_next_inode_id(resulting_head.next_inode_id, &record.deltas);
+            replay_next_inode_id_from_commit_deltas(resulting_head.next_inode_id, &record.deltas);
     }
     resulting_head.visible_wal_tip = Some(envelope.pointer(wal_object.object_key.clone()));
 
@@ -377,6 +377,15 @@ fn replay_next_inode_id(current_next_inode_id: InodeId, deltas: &[WalDelta]) -> 
         })
 }
 
+fn replay_next_inode_id_from_commit_deltas(
+    current_next_inode_id: InodeId,
+    deltas: &[WalCommitDelta],
+) -> InodeId {
+    deltas.iter().fold(current_next_inode_id, |next, delta| {
+        replay_next_inode_id(next, std::slice::from_ref(&delta.delta))
+    })
+}
+
 fn extend_invariants(checked_invariants: &mut Vec<String>, new_invariants: &[String]) {
     for invariant in new_invariants {
         push_invariant(checked_invariants, invariant);
@@ -423,6 +432,7 @@ mod tests {
             resolved_restore_content_refs: vec![None],
             resolved_source_bindings: vec![None],
             resulting_next_inode_id: InodeId(3),
+            name_policy: loon_api::NamePolicy::default(),
             metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
@@ -502,6 +512,7 @@ mod tests {
             resolved_restore_content_refs: vec![None],
             resolved_source_bindings: vec![None],
             resulting_next_inode_id: InodeId(3),
+            name_policy: loon_api::NamePolicy::default(),
             metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -38,6 +38,10 @@ fn create_dir(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
+            name_key: loon_api::name_key_for_display_name(
+                loon_api::NamePolicy::default(),
+                display_name,
+            ),
             display_name: display_name.to_owned(),
             child_inode: inode_id,
         },
@@ -60,6 +64,10 @@ fn create_file(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
+            name_key: loon_api::name_key_for_display_name(
+                loon_api::NamePolicy::default(),
+                display_name,
+            ),
             display_name: display_name.to_owned(),
             child_inode: inode_id,
         },
@@ -95,6 +103,10 @@ fn bind(
     vec![WalDelta::BindDirentry {
         delta_index,
         parent_inode,
+        name_key: loon_api::name_key_for_display_name(
+            loon_api::NamePolicy::default(),
+            display_name,
+        ),
         display_name: display_name.to_owned(),
         child_inode: inode_id,
     }]
@@ -371,7 +383,6 @@ fn normalize_inode(
         match inode_kind {
             InodeKind::Dir => "dir",
             InodeKind::File => "file",
-            InodeKind::Mount => "mount",
         },
         created_seq,
     )

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,8 +1,8 @@
 use loon_api::{
     decode_wal_segment_envelope_zstd, sha256_digest,
     v0::{
-        CommitOp as ApiCommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest,
-        CompleteUploadRequest,
+        CommitDelta, CommitOp as ApiCommitOp, CommitPrecondition,
+        CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
     ChangeSeq, CommitId, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope,
     ControlObjectKind, FenceToken, HeadState, InodeId, InodeKind, LeaseState,
@@ -47,6 +47,10 @@ fn wal_create_dir(
         loon_api::WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
+            name_key: loon_api::name_key_for_display_name(
+                loon_api::NamePolicy::default(),
+                &display_name,
+            ),
             display_name,
             child_inode: inode_id,
         },
@@ -69,6 +73,10 @@ fn wal_create_file(
         loon_api::WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
+            name_key: loon_api::name_key_for_display_name(
+                loon_api::NamePolicy::default(),
+                &display_name,
+            ),
             display_name,
             child_inode: inode_id,
         },
@@ -803,6 +811,20 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
     assert_eq!(segment.payload.start_seq, ChangeSeq(1));
     assert_eq!(segment.payload.end_seq, ChangeSeq(2));
     assert_eq!(segment.payload.records.len(), 2);
+    assert_eq!(segment.payload.records[0].deltas.len(), 2);
+    assert_eq!(segment.payload.records[0].deltas[0].semantic_op_index, 0);
+    assert_eq!(segment.payload.records[0].deltas[1].semantic_op_index, 0);
+    match &segment.payload.records[0].deltas[1].delta {
+        loon_api::WalDelta::BindDirentry {
+            name_key,
+            display_name,
+            ..
+        } => {
+            assert_eq!(name_key, "alpha");
+            assert_eq!(display_name, "alpha");
+        }
+        delta => panic!("expected bind delta, got {delta:?}"),
+    }
     store
         .put_if_absent(
             "namespaces/demo/wal/00000000000000000999-00000000000000000999-orphan.cbor.zst",
@@ -814,10 +836,31 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
     assert_eq!(changes.changes.len(), 2);
     assert_eq!(changes.changes[0].commit_id, CommitId::from("req-batch-a"));
     assert_eq!(changes.changes[1].commit_id, CommitId::from("req-batch-b"));
+    assert_eq!(changes.changes[0].ops, first.results);
+    assert_eq!(changes.changes[0].deltas.len(), 2);
+    assert!(matches!(
+        &changes.changes[0].deltas[0],
+        CommitDelta::CreateInode {
+            semantic_op_index: 0,
+            delta_index: 0,
+            inode_kind: InodeKind::Dir,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &changes.changes[0].deltas[1],
+        CommitDelta::BindDirentry {
+            semantic_op_index: 0,
+            delta_index: 1,
+            name_key,
+            display_name,
+            ..
+        } if name_key == "alpha" && display_name == "alpha"
+    ));
 }
 
 #[test]
-fn child_name_is_precondition_observes_earlier_batch_candidate() {
+fn binding_is_precondition_observes_earlier_batch_candidate() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::from("demo");
@@ -838,6 +881,11 @@ fn child_name_is_precondition_observes_earlier_batch_candidate() {
     let file_inode = resolve_path(&store, &namespace_id, "/docs/readme.txt")
         .expect("resolve file")
         .inode_id;
+    let basis = load_verified_namespace_basis(&store, &namespace_id).expect("load basis");
+    let original_binding = basis
+        .metadata_state
+        .current_parent_binding_for_child(file_inode, basis.head.seq)
+        .expect("source binding");
 
     let responses = commit_operations_batch(
         &store,
@@ -856,14 +904,13 @@ fn child_name_is_precondition_observes_earlier_batch_candidate() {
                 annotations: None,
             },
             ApiCommitRequest {
-                commit_id: CommitId::from("delete-with-stale-child-name"),
-                preconditions: vec![CommitPrecondition::ChildNameIs {
+                commit_id: CommitId::from("delete-with-stale-binding"),
+                preconditions: vec![CommitPrecondition::BindingIs {
                     parent_inode: docs_inode,
-                    name_key: loon_api::name_key_for_display_name(
-                        loon_api::NamePolicy::default(),
-                        "readme.txt",
-                    ),
+                    name_key: original_binding.name_key,
                     child_inode: file_inode,
+                    bind_seq: original_binding.bind_seq,
+                    bind_delta_index: original_binding.bind_delta_index,
                 }],
                 ops: vec![ApiCommitOp::DeleteFile {
                     inode_id: file_inode,
@@ -881,8 +928,8 @@ fn child_name_is_precondition_observes_earlier_batch_candidate() {
     );
     let error = responses[1]
         .as_ref()
-        .expect_err("stale child-name precondition");
-    assert_eq!(error.kind(), CoreErrorKind::PathNotFound);
+        .expect_err("stale binding precondition");
+    assert_eq!(error.kind(), CoreErrorKind::PathConflict);
 }
 
 #[test]

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -13,9 +13,9 @@ use loon_core::commit::{
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
-    bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
-    copy_file_path, create_dir_path, delete_path, delete_path_non_recursive, fork_namespace,
-    list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
+    begin_upload, bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
+    copy_file_path, create_checkpoint, create_dir_path, delete_path, delete_path_non_recursive,
+    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
     publish_namespace_mutations_batch, put_file_bytes, read_file_bytes, resolve_path,
     store_bytes_as_content, upload_content, write_file_bytes, CoreError, CoreErrorKind,
     DirectObjectStorePublisher, MutationContext, NamespaceMutationCandidate, PathMutationIntent,
@@ -672,6 +672,10 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
         .expect_err("invalid namespace_id should be rejected before lookup");
     assert_eq!(read_error.kind(), CoreErrorKind::InvalidNamespaceId);
 
+    let begin_upload_error = begin_upload(&store, &invalid_namespace, &context)
+        .expect_err("invalid namespace_id should be rejected before upload session creation");
+    assert_eq!(begin_upload_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
     let delete_error = delete_path_non_recursive(
         &store,
         &invalid_namespace,
@@ -700,6 +704,63 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
             .expect("list namespace objects"),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    let missing_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("missing namespace");
+    assert_eq!(missing_error.kind(), CoreErrorKind::NamespaceNotFound);
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete descriptor");
+
+    let partial_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("partial namespace");
+    assert_eq!(partial_error.kind(), CoreErrorKind::NamespacePartial);
+}
+
+#[test]
+fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false).expect("bootstrap");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileBehavior::CreateOnly,
+        &context,
+        Some("upload-guard-create"),
+    )
+    .expect("create file");
+    create_checkpoint(&setup_store, &namespace_id, &context).expect("checkpoint");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileBehavior::ReplaceExisting,
+        &context,
+        Some("upload-guard-replace"),
+    )
+    .expect("replace file");
+
+    let guarded_store = ReplayReadGuardStore::new(temp_dir.path(), namespace_id.as_str());
+    let begin = begin_upload(&guarded_store, &namespace_id, &context).expect("begin upload");
+    assert_eq!(begin.namespace_id, namespace_id);
+    assert_eq!(guarded_store.guarded_get_count(), 0);
 }
 
 #[test]
@@ -2660,6 +2721,75 @@ fn content_ref(seed: &str) -> ContentRef {
         kind: ContentRefKind::WholeFileV0,
         digest: sha256_digest(seed.as_bytes()),
         size_bytes: seed.len() as u64,
+    }
+}
+
+struct ReplayReadGuardStore {
+    inner: LocalFsStore,
+    guarded_prefixes: Vec<String>,
+    guarded_gets: AtomicUsize,
+}
+
+impl ReplayReadGuardStore {
+    fn new(root: impl AsRef<Path>, namespace: &str) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            guarded_prefixes: vec![
+                format!("namespaces/{namespace}/wal/"),
+                format!("namespaces/{namespace}/checkpoints/"),
+            ],
+            guarded_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn guarded_get_count(&self) -> usize {
+        self.guarded_gets.load(Ordering::SeqCst)
+    }
+
+    fn reject_replay_read(&self, key: &str) -> Result<(), ObjectStoreError> {
+        if self
+            .guarded_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
+            self.guarded_gets.fetch_add(1, Ordering::SeqCst);
+            return Err(ObjectStoreError::Transport(format!(
+                "begin_upload unexpectedly read replay object `{key}`"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl ObjectStore for ReplayReadGuardStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.reject_replay_read(key)?;
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
     }
 }
 

--- a/crates/loon-model/src/metadata.rs
+++ b/crates/loon-model/src/metadata.rs
@@ -131,12 +131,13 @@ impl MetadataState {
                 WalDelta::BindDirentry {
                     delta_index,
                     parent_inode,
+                    name_key,
                     display_name,
                     child_inode,
                 } => {
                     metadata_state.direntry_binds.push(DirentryBindRecord {
                         parent_inode_id: *parent_inode,
-                        name_key: name_key_for_display_name(NamePolicy::default(), display_name),
+                        name_key: name_key.clone(),
                         display_name: display_name.clone(),
                         child_inode_id: *child_inode,
                         bind_seq: committed_seq,
@@ -578,5 +579,32 @@ fn join_absolute_path(base: &str, component: &str) -> String {
         format!("/{component}")
     } else {
         format!("{base}/{component}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_direntry_replay_uses_persisted_name_key() {
+        let applied = MetadataState::default()
+            .apply_committed_wal_deltas(
+                ChangeSeq(1),
+                &[WalDelta::BindDirentry {
+                    delta_index: 7,
+                    parent_inode: InodeId(1),
+                    name_key: "persisted-key".to_owned(),
+                    display_name: "Report.TXT".to_owned(),
+                    child_inode: InodeId(2),
+                }],
+            )
+            .expect("apply bind delta");
+
+        assert_eq!(applied.metadata_state.direntry_binds.len(), 1);
+        assert_eq!(
+            applied.metadata_state.direntry_binds[0].name_key,
+            "persisted-key"
+        );
     }
 }

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -19,7 +19,7 @@ use loon_api::{
 };
 use loonfs::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, CreateNamespaceOptions, Fs, FsConfig,
-    PathMutationIntent, PutFileBehavior, RuntimeError, SharedObjectStore,
+    PathMutationIntent, PutFileBehavior, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -123,6 +123,7 @@ fn build_fs(config: &ServerConfig, store: SharedStore) -> Result<Fs, ServerConfi
             writer_id: config.writer_id.clone(),
             writer_version: config.writer_version.clone(),
             lease_duration_ms: config.lease_duration_ms,
+            runtime_cache: RuntimeCacheConfig::default(),
         },
     )
     .map_err(|error| ServerConfigError::InvalidField {
@@ -616,7 +617,9 @@ mod tests {
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::namespace_head;
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
-    use loonfs::{CreateNamespaceOptions, Fs, FsConfig, PutFileBehavior, PutFileOptions};
+    use loonfs::{
+        CreateNamespaceOptions, Fs, FsConfig, PutFileBehavior, PutFileOptions, RuntimeCacheConfig,
+    };
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -1036,6 +1039,7 @@ mod tests {
                 writer_id: writer_id.to_owned(),
                 writer_version: format!("{writer_id}/0.1.0"),
                 lease_duration_ms: 60_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         )
         .expect("open runtime")

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -375,7 +375,9 @@ mod tests {
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::namespace_head;
     use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
-    use loonfs::{CreateNamespaceOptions, Fs, FsConfig, SharedObjectStore as SharedStore};
+    use loonfs::{
+        CreateNamespaceOptions, Fs, FsConfig, RuntimeCacheConfig, SharedObjectStore as SharedStore,
+    };
     use std::path::Path;
     use std::sync::Condvar;
     use tempfile::tempdir;
@@ -509,6 +511,7 @@ mod tests {
                     writer_id: config.writer_id.clone(),
                     writer_version: config.writer_version.clone(),
                     lease_duration_ms: config.lease_duration_ms,
+                    runtime_cache: RuntimeCacheConfig::default(),
                 },
             )
             .expect("open runtime"),

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -1,7 +1,7 @@
 use loon_api::{
     v0::{
-        CommitAnnotations, CommitOp, CommitOpResult, CommitRequest as ApiCommitRequest,
-        CompleteUploadRequest,
+        CommitAnnotations, CommitDelta, CommitOp, CommitOpResult,
+        CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, ControlObjectKind,
     CreateCheckpointResponse, InodeId, InodeKind, LeaseStateEnvelope, RevisionNo,
@@ -402,6 +402,17 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         assert_eq!(change.message.as_deref(), Some("upload over http"));
         assert_eq!(change.annotations, Some(annotations));
         assert_eq!(change.ops, commit.results);
+        assert_eq!(change.deltas.len(), 3);
+        assert!(matches!(
+            &change.deltas[1],
+            CommitDelta::BindDirentry {
+                semantic_op_index: 0,
+                delta_index: 1,
+                name_key,
+                display_name,
+                ..
+            } if name_key == "uploaded.txt" && display_name == "uploaded.txt"
+        ));
 
         let empty = harness
             .client

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub use loon_api::v0::{
@@ -8,16 +9,21 @@ pub use loon_api::v0::{
     CommitRequest, CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
     UploadContentResponse,
 };
+use loon_api::HeadState;
 pub use loon_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CommitId,
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
-use loon_core::MutationContext;
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
+use loon_core::{
+    ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
+    VerifiedNamespaceBasis,
+};
+use loon_objectstore::keys::namespace_head;
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -42,6 +48,7 @@ pub struct FsConfig {
     pub writer_id: String,
     pub writer_version: String,
     pub lease_duration_ms: u64,
+    pub runtime_cache: RuntimeCacheConfig,
 }
 
 impl FsConfig {
@@ -50,6 +57,34 @@ impl FsConfig {
             writer_id: writer_id.into(),
             writer_version: default_writer_version(),
             lease_duration_ms: DEFAULT_LEASE_DURATION_MS,
+            runtime_cache: RuntimeCacheConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCacheConfig {
+    pub basis_cache_enabled: bool,
+    pub control_cache_enabled: bool,
+    pub max_cached_namespaces: usize,
+}
+
+impl RuntimeCacheConfig {
+    pub fn disabled() -> Self {
+        Self {
+            basis_cache_enabled: false,
+            control_cache_enabled: false,
+            max_cached_namespaces: 0,
+        }
+    }
+}
+
+impl Default for RuntimeCacheConfig {
+    fn default() -> Self {
+        Self {
+            basis_cache_enabled: true,
+            control_cache_enabled: true,
+            max_cached_namespaces: 64,
         }
     }
 }
@@ -62,6 +97,8 @@ pub struct Fs {
 struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
+    basis_cache: Mutex<BasisCache>,
+    control_cache: Mutex<RuntimeControlCache>,
 }
 
 pub struct FsBuilder {
@@ -69,6 +106,120 @@ pub struct FsBuilder {
     writer_id: Option<String>,
     writer_version: String,
     lease_duration_ms: u64,
+    runtime_cache: RuntimeCacheConfig,
+}
+
+#[derive(Debug, Default)]
+struct BasisCache {
+    entries: HashMap<NamespaceId, Arc<VerifiedNamespaceBasis>>,
+    order: VecDeque<NamespaceId>,
+}
+
+impl BasisCache {
+    fn get(&mut self, namespace_id: &NamespaceId) -> Option<Arc<VerifiedNamespaceBasis>> {
+        let basis = self.entries.get(namespace_id).cloned()?;
+        self.touch(namespace_id);
+        Some(basis)
+    }
+
+    fn insert(&mut self, basis: Arc<VerifiedNamespaceBasis>, max_cached_namespaces: usize) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        let namespace_id = basis.head.namespace_id.clone();
+        self.entries.insert(namespace_id.clone(), basis);
+        self.touch(&namespace_id);
+        while self.entries.len() > max_cached_namespaces {
+            let Some(evicted) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&evicted);
+        }
+    }
+
+    fn invalidate(&mut self, namespace_id: &NamespaceId) {
+        self.entries.remove(namespace_id);
+        self.order.retain(|candidate| candidate != namespace_id);
+    }
+
+    fn touch(&mut self, namespace_id: &NamespaceId) {
+        self.order.retain(|candidate| candidate != namespace_id);
+        self.order.push_back(namespace_id.clone());
+    }
+}
+
+#[derive(Debug, Default)]
+struct RuntimeControlCache {
+    namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespace_order: VecDeque<NamespaceId>,
+}
+
+#[derive(Debug, Default)]
+struct NamespaceControlCacheEntry {
+    head: Option<CachedControl<HeadState>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedControl<T> {
+    identity: ControlObjectIdentity,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl RuntimeControlCache {
+    fn namespace_head(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<HeadState>> {
+        let head = self.namespaces.get(namespace_id)?.head.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(head)
+    }
+
+    fn insert_namespace_head(
+        &mut self,
+        namespace_id: &NamespaceId,
+        head: CachedControl<HeadState>,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        self.namespace_entry(namespace_id, max_cached_namespaces)
+            .head = Some(head);
+    }
+
+    fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespaces.remove(namespace_id);
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+    }
+
+    fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.head = None;
+        }
+    }
+
+    fn namespace_entry(
+        &mut self,
+        namespace_id: &NamespaceId,
+        max_cached_namespaces: usize,
+    ) -> &mut NamespaceControlCacheEntry {
+        self.namespaces.entry(namespace_id.clone()).or_default();
+        self.touch_namespace(namespace_id);
+        while self.namespaces.len() > max_cached_namespaces {
+            let Some(evicted) = self.namespace_order.pop_front() else {
+                break;
+            };
+            self.namespaces.remove(&evicted);
+        }
+        self.namespaces
+            .get_mut(namespace_id)
+            .expect("namespace cache entry should exist")
+    }
+
+    fn touch_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+        self.namespace_order.push_back(namespace_id.clone());
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -163,6 +314,7 @@ impl FsBuilder {
             writer_id: None,
             writer_version: default_writer_version(),
             lease_duration_ms: DEFAULT_LEASE_DURATION_MS,
+            runtime_cache: RuntimeCacheConfig::default(),
         }
     }
 
@@ -181,6 +333,11 @@ impl FsBuilder {
         self
     }
 
+    pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
+        self.runtime_cache = runtime_cache;
+        self
+    }
+
     pub fn build(self) -> Result<Fs> {
         let writer_id = self
             .writer_id
@@ -191,6 +348,7 @@ impl FsBuilder {
                 writer_id,
                 writer_version: self.writer_version,
                 lease_duration_ms: self.lease_duration_ms,
+                runtime_cache: self.runtime_cache,
             },
         )
     }
@@ -200,7 +358,12 @@ impl Fs {
     pub fn open(store: SharedObjectStore, config: FsConfig) -> Result<Self> {
         validate_config(&config)?;
         Ok(Self {
-            inner: Arc::new(FsInner { store, config }),
+            inner: Arc::new(FsInner {
+                store,
+                config,
+                basis_cache: Mutex::new(BasisCache::default()),
+                control_cache: Mutex::new(RuntimeControlCache::default()),
+            }),
         })
     }
 
@@ -217,12 +380,14 @@ impl Fs {
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> Result<NamespaceSummary> {
-        Ok(loon_core::bootstrap_namespace(
+        let result = loon_core::bootstrap_namespace(
             self.store(),
             namespace_id,
             &self.mutation_context(),
             options.allow_existing,
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn fork_namespace(
@@ -230,12 +395,16 @@ impl Fs {
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> Result<NamespaceSummary> {
-        Ok(loon_core::fork_namespace(
-            self.store(),
-            source,
-            target,
-            &self.mutation_context(),
-        )?)
+        let result =
+            loon_core::fork_namespace(self.store(), source, target, &self.mutation_context())
+                .map_err(RuntimeError::from);
+        if should_invalidate_after_result(&result) {
+            self.invalidate_namespace_cache(source);
+        }
+        if result.is_ok() {
+            self.invalidate_namespace_cache(target);
+        }
+        result
     }
 
     pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
@@ -320,9 +489,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativePathEntry> {
-        Ok(loon_core::resolve_path(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::resolve_path_from_basis(
             self.store(),
-            namespace_id,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -332,9 +502,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<Vec<AuthoritativePathEntry>> {
-        Ok(loon_core::list_path(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::list_path_from_basis(
             self.store(),
-            namespace_id,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -344,9 +515,10 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
-        Ok(loon_core::read_file_bytes(
+        let basis = self.basis_for_read(namespace_id)?;
+        Ok(loon_core::read_file_bytes_from_basis(
             self.store(),
-            namespace_id,
+            basis.as_ref(),
             absolute_path,
         )?)
     }
@@ -358,7 +530,7 @@ impl Fs {
         bytes: &[u8],
         options: PutFileOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::put_file_bytes(
+        let result = loon_core::put_file_bytes(
             self.store(),
             namespace_id,
             absolute_path,
@@ -366,7 +538,9 @@ impl Fs {
             options.behavior,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn put_file_content_ref(
@@ -376,7 +550,7 @@ impl Fs {
         content_ref: ContentRef,
         options: PutFileOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::put_file_content_ref(
+        let result = loon_core::put_file_content_ref(
             self.store(),
             namespace_id,
             absolute_path,
@@ -384,7 +558,9 @@ impl Fs {
             options.behavior,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn create_dir(
@@ -393,13 +569,15 @@ impl Fs {
         absolute_path: &str,
         options: CreateDirOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::create_dir_path(
+        let result = loon_core::create_dir_path(
             self.store(),
             namespace_id,
             absolute_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn delete_path(
@@ -409,23 +587,25 @@ impl Fs {
         options: DeleteOptions,
     ) -> Result<MutationResult> {
         let commit_id = options.commit_id.as_ref().map(CommitId::as_str);
-        if options.recursive {
-            Ok(loon_core::delete_path(
+        let result = if options.recursive {
+            loon_core::delete_path(
                 self.store(),
                 namespace_id,
                 absolute_path,
                 &self.mutation_context(),
                 commit_id,
-            )?)
+            )
         } else {
-            Ok(loon_core::delete_path_non_recursive(
+            loon_core::delete_path_non_recursive(
                 self.store(),
                 namespace_id,
                 absolute_path,
                 &self.mutation_context(),
                 commit_id,
-            )?)
+            )
         }
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn move_path(
@@ -435,14 +615,16 @@ impl Fs {
         to_path: &str,
         options: MoveOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::move_path(
+        let result = loon_core::move_path(
             self.store(),
             namespace_id,
             from_path,
             to_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn copy_path(
@@ -452,14 +634,16 @@ impl Fs {
         to_path: &str,
         options: CopyOptions,
     ) -> Result<MutationResult> {
-        Ok(loon_core::copy_file_path(
+        let result = loon_core::copy_file_path(
             self.store(),
             namespace_id,
             from_path,
             to_path,
             &self.mutation_context(),
             options.commit_id.as_ref().map(CommitId::as_str),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
@@ -505,12 +689,14 @@ impl Fs {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        Ok(loon_core::commit_operations(
+        let result = loon_core::commit_operations(
             self.store(),
             namespace_id,
             request,
             &self.mutation_context(),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn commit_operations_batch(
@@ -518,7 +704,7 @@ impl Fs {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        loon_core::commit_operations_batch(
+        let results: Vec<_> = loon_core::commit_operations_batch(
             self.store(),
             namespace_id,
             requests,
@@ -526,7 +712,9 @@ impl Fs {
         )
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
-        .collect()
+        .collect();
+        self.invalidate_namespace_cache_after_batch(namespace_id, &results);
+        results
     }
 
     pub fn publish_namespace_mutations_batch(
@@ -534,7 +722,7 @@ impl Fs {
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<Result<CommitResponse>> {
-        loon_core::publish_namespace_mutations_batch(
+        let results: Vec<_> = loon_core::publish_namespace_mutations_batch(
             self.store(),
             namespace_id,
             candidates,
@@ -542,7 +730,9 @@ impl Fs {
         )
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
-        .collect()
+        .collect();
+        self.invalidate_namespace_cache_after_batch(namespace_id, &results);
+        results
     }
 
     pub fn list_changes_after(
@@ -561,22 +751,201 @@ impl Fs {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
-        Ok(loon_core::create_checkpoint(
-            self.store(),
-            namespace_id,
-            &self.mutation_context(),
-        )?)
+        let result =
+            loon_core::create_checkpoint(self.store(), namespace_id, &self.mutation_context())
+                .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     pub fn advance_retention_floor(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
-        Ok(loon_core::advance_retention_floor(
+        let result = loon_core::advance_retention_floor(
             self.store(),
             namespace_id,
             &self.mutation_context(),
-        )?)
+        )
+        .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+
+    fn load_namespace_head_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<CachedControl<HeadState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !self.control_cache_enabled() {
+            return loon_core::load_namespace_head_control(self.store(), namespace_id)
+                .map(cached_head);
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .namespace_head(namespace_id);
+        if let Some(head) = cached {
+            match self.cached_control_identity_matches(
+                &namespace_head(namespace_id.as_str()),
+                &head.identity,
+            ) {
+                Ok(true) => return Ok(head),
+                Ok(false) => self
+                    .inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id),
+                Err(error) => {
+                    self.inner
+                        .control_cache
+                        .lock()
+                        .expect("control cache lock poisoned")
+                        .invalidate_namespace_head(namespace_id);
+                    return Err(error);
+                }
+            }
+        }
+
+        let loaded = match loon_core::load_namespace_head_control(self.store(), namespace_id) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id);
+                return Err(error);
+            }
+        };
+        let head = cached_head(loaded);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_namespace_head(
+                namespace_id,
+                head.clone(),
+                cache_config.max_cached_namespaces,
+            );
+        Ok(head)
+    }
+
+    fn cached_control_identity_matches(
+        &self,
+        object_key: &str,
+        identity: &ControlObjectIdentity,
+    ) -> std::result::Result<bool, ControlObjectLoadError> {
+        let metadata = self
+            .store()
+            .head(object_key)
+            .map_err(|error| ControlObjectLoadError::Store(error.to_string()))?
+            .ok_or_else(|| ControlObjectLoadError::MissingObject {
+                object_key: object_key.to_owned(),
+            })?;
+        let Some(etag) = metadata.etag else {
+            return Err(ControlObjectLoadError::Store(format!(
+                "missing control object etag for `{object_key}`"
+            )));
+        };
+        Ok(etag == identity.etag)
+    }
+
+    fn control_cache_enabled(&self) -> bool {
+        let cache_config = &self.inner.config.runtime_cache;
+        cache_config.control_cache_enabled && cache_config.max_cached_namespaces > 0
+    }
+
+    fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
+            return Ok(Arc::new(
+                loon_core::load_verified_namespace_basis(self.store(), namespace_id)
+                    .map_err(CoreError::from)?,
+            ));
+        }
+
+        let cached = self
+            .inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .get(namespace_id);
+        if let Some(basis) = cached {
+            if self.control_cache_enabled() {
+                match self.load_namespace_head_cached(namespace_id) {
+                    Ok(head) if head.identity.etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
+                }
+            } else {
+                match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
+                    Ok(identity) if identity.head_etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
+                }
+            }
+        }
+
+        let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
+            .map_err(CoreError::from)?;
+        let basis = Arc::new(basis);
+        self.cache_basis(Arc::clone(&basis));
+        Ok(basis)
+    }
+
+    fn cache_basis(&self, basis: Arc<VerifiedNamespaceBasis>) {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
+            return;
+        }
+        self.inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .insert(basis, cache_config.max_cached_namespaces);
+    }
+
+    fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
+        self.inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned")
+            .invalidate(namespace_id);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .invalidate_namespace(namespace_id);
+    }
+
+    fn finish_namespace_mutation<T>(
+        &self,
+        namespace_id: &NamespaceId,
+        result: Result<T>,
+    ) -> Result<T> {
+        if should_invalidate_after_result(&result) {
+            self.invalidate_namespace_cache(namespace_id);
+        }
+        result
+    }
+
+    fn invalidate_namespace_cache_after_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        results: &[Result<CommitResponse>],
+    ) {
+        if results.iter().any(should_invalidate_after_result) {
+            self.invalidate_namespace_cache(namespace_id);
+        }
     }
 
     fn store(&self) -> &(dyn ObjectStore + Send + Sync) {
@@ -590,6 +959,13 @@ impl Fs {
             now_ms: current_time_ms(),
             lease_duration_ms: self.inner.config.lease_duration_ms,
         }
+    }
+}
+
+fn cached_head(loaded: LoadedHeadControl) -> CachedControl<HeadState> {
+    CachedControl {
+        identity: loaded.identity,
+        _marker: std::marker::PhantomData,
     }
 }
 
@@ -614,6 +990,14 @@ fn validate_config(config: &FsConfig) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn should_invalidate_after_result<T>(result: &Result<T>) -> bool {
+    match result {
+        Ok(_) => true,
+        Err(RuntimeError::Core(error)) if error.kind() == CoreErrorKind::StaleHead => true,
+        _ => false,
+    }
 }
 
 fn current_time_ms() -> u64 {

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1,14 +1,14 @@
 use loon_objectstore::fs::LocalFsStore;
-use loon_objectstore::keys::{namespace_descriptor, namespace_head};
+use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
-    CoreErrorKind, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
+    CoreErrorKind, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
     MaintenanceTickOptions, MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior,
-    PutFileOptions, RuntimeError, SharedObjectStore,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -59,6 +59,7 @@ fn open_validates_runtime_config() {
                 writer_id: "   ".to_owned(),
                 writer_version: "runtime-test/0.1.0".to_owned(),
                 lease_duration_ms: 5_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "writer_id",
@@ -70,6 +71,7 @@ fn open_validates_runtime_config() {
                 writer_id: "runtime-test".to_owned(),
                 writer_version: "   ".to_owned(),
                 lease_duration_ms: 5_000,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "writer_version",
@@ -81,6 +83,7 @@ fn open_validates_runtime_config() {
                 writer_id: "runtime-test".to_owned(),
                 writer_version: "runtime-test/0.1.0".to_owned(),
                 lease_duration_ms: 0,
+                runtime_cache: RuntimeCacheConfig::default(),
             },
         ),
         "lease_duration_ms",
@@ -153,6 +156,146 @@ fn filesystem_operations_match_core_semantics() {
             .bytes,
         b"updated"
     );
+}
+
+#[test]
+fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first stat should load basis");
+    assert_eq!(raw_store.wal_get_count(), 1);
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second stat should reuse cached basis");
+    assert_eq!(raw_store.wal_get_count(), 1);
+
+    fs.create_dir(&namespace_id, "/other", CreateDirOptions::default())
+        .expect("create other");
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("stat after mutation should reload basis");
+    assert!(raw_store.wal_get_count() > 0);
+}
+
+#[test]
+fn runtime_cache_observes_head_advanced_by_another_runtime() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let reader = Fs::builder(object_store.clone())
+        .writer_id("basis-cache-reader")
+        .build()
+        .expect("build reader runtime");
+    let writer = Fs::builder(object_store)
+        .writer_id("basis-cache-writer")
+        .build()
+        .expect("build writer runtime");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime reader cache");
+
+    writer
+        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .expect("advance head from another runtime");
+
+    raw_store.reset_wal_get_count();
+    let stat = reader
+        .stat_path(&namespace_id, "/docs/new")
+        .expect("reader should observe external head advance");
+    assert_eq!(stat.absolute_path, "/docs/new");
+    assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
+    assert!(raw_store.wal_get_count() > 0);
+}
+
+#[test]
+fn runtime_cache_can_be_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-disabled-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first stat should load basis");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second stat should load basis again");
+    assert_eq!(raw_store.wal_get_count(), 2);
+}
+
+#[test]
+fn stale_head_write_error_invalidates_runtime_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("basis-cache-stale-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+
+    raw_store.fail_head_cas();
+    assert_core_error_kind(
+        fs.create_dir(&namespace_id, "/stale", CreateDirOptions::default()),
+        CoreErrorKind::StaleHead,
+    );
+
+    raw_store.allow_head_cas();
+    raw_store.reset_wal_get_count();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("read after stale head should reload basis");
+    assert!(raw_store.wal_get_count() > 0);
 }
 
 #[test]
@@ -275,6 +418,271 @@ fn upload_flow_is_available_from_runtime() {
         .complete_upload(&namespace_id, &begin.upload_id, &request)
         .expect("repeat complete upload");
     assert_eq!(completed.content_ref, completed_again.content_ref);
+}
+
+#[test]
+fn begin_upload_validates_controls_without_replay_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-cache-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileOptions {
+            behavior: PutFileBehavior::ReplaceExisting,
+            commit_id: None,
+        },
+    )
+    .expect("replace file");
+
+    raw_store.reset_control_get_counts();
+    fs.begin_upload(&namespace_id).expect("first begin upload");
+    fs.begin_upload(&namespace_id).expect("second begin upload");
+
+    assert_eq!(raw_store.wal_get_count(), 0);
+    assert_eq!(raw_store.checkpoint_get_count(), 0);
+}
+
+#[test]
+fn runtime_control_cache_reuses_head_for_basis_validation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("control-cache-head-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+
+    raw_store.reset_control_get_counts();
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first cached basis validation loads head body");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second cached basis validation reuses head body");
+
+    assert_eq!(raw_store.head_get_count(), 1);
+}
+
+#[test]
+fn control_cache_eviction_reloads_head_for_basis_validation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("control-cache-eviction-test")
+        .runtime_cache(RuntimeCacheConfig {
+            basis_cache_enabled: true,
+            control_cache_enabled: true,
+            max_cached_namespaces: 1,
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
+        .expect("create other namespace");
+    fs.create_dir(&other_namespace, "/docs", CreateDirOptions::default())
+        .expect("create other docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace basis");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace head cache");
+
+    raw_store.reset_control_get_counts();
+    fs.stat_path(&other_namespace, "/docs")
+        .expect("load other namespace basis and evict first head cache");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("reload first namespace basis and head cache");
+
+    assert_eq!(raw_store.head_get_count(), 1);
+}
+
+#[test]
+fn runtime_control_cache_reloads_head_after_external_change() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let reader = Fs::builder(object_store.clone())
+        .writer_id("control-cache-reader")
+        .build()
+        .expect("build reader runtime");
+    let writer = Fs::builder(object_store)
+        .writer_id("control-cache-writer")
+        .build()
+        .expect("build writer runtime");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
+    raw_store.reset_control_get_counts();
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime control cache");
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("reuse unchanged control cache");
+    assert_eq!(raw_store.head_get_count(), 1);
+
+    writer
+        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .expect("advance head");
+    raw_store.reset_control_get_counts();
+    reader
+        .stat_path(&namespace_id, "/docs/new")
+        .expect("reload changed head");
+    assert!(raw_store.head_get_count() > 0);
+}
+
+#[test]
+fn begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-missing-partial-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceNotFound,
+    );
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete namespace descriptor");
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespacePartial,
+    );
+}
+
+#[test]
+fn begin_upload_rejects_malformed_descriptors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_descriptor(namespace_id.as_str()),
+            br#"{"not":"a namespace descriptor"}"#,
+        )
+        .expect("corrupt namespace descriptor");
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+
+    let content_bad = NamespaceId::parse("content-bad").expect("valid namespace id");
+    fs.create_namespace(&content_bad, CreateNamespaceOptions::default())
+        .expect("create content-bad namespace");
+    for key in raw_store
+        .list_prefix("content-stores/")
+        .expect("list content stores")
+        .into_iter()
+        .filter(|key| key.ends_with("/descriptor.json"))
+    {
+        raw_store
+            .put_overwrite(&key, br#"{"not":"a content store descriptor"}"#)
+            .expect("corrupt content store descriptor");
+    }
+    assert_core_error_kind(
+        fs.begin_upload(&content_bad),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+}
+
+#[test]
+fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-control-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
+    fs.create_namespace(&head_bad, CreateNamespaceOptions::default())
+        .expect("create head-bad namespace");
+    raw_store
+        .put_overwrite(&namespace_head(head_bad.as_str()), br#"{"not":"a head"}"#)
+        .expect("corrupt head");
+    assert_core_error_kind(fs.begin_upload(&head_bad), CoreErrorKind::NamespaceCorrupt);
+
+    let lease_bad = NamespaceId::parse("lease-bad").expect("valid namespace id");
+    fs.create_namespace(&lease_bad, CreateNamespaceOptions::default())
+        .expect("create lease-bad namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_lease(lease_bad.as_str()),
+            br#"{"not":"a lease"}"#,
+        )
+        .expect("corrupt lease");
+    assert_core_error_kind(fs.begin_upload(&lease_bad), CoreErrorKind::NamespaceCorrupt);
 }
 
 #[test]
@@ -581,7 +989,12 @@ fn separate_runtime_instances_share_object_store_state() {
 struct HeadCasFailureStore {
     inner: LocalFsStore,
     head_key: String,
+    wal_prefix: String,
+    checkpoint_prefix: String,
     fail_head_cas: AtomicBool,
+    wal_get_count: AtomicUsize,
+    checkpoint_get_count: AtomicUsize,
+    head_get_count: AtomicUsize,
 }
 
 impl HeadCasFailureStore {
@@ -589,12 +1002,43 @@ impl HeadCasFailureStore {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
+            wal_prefix: format!("namespaces/{namespace}/wal/"),
+            checkpoint_prefix: format!("namespaces/{namespace}/checkpoints/"),
             fail_head_cas: AtomicBool::new(false),
+            wal_get_count: AtomicUsize::new(0),
+            checkpoint_get_count: AtomicUsize::new(0),
+            head_get_count: AtomicUsize::new(0),
         }
     }
 
     fn fail_head_cas(&self) {
         self.fail_head_cas.store(true, Ordering::SeqCst);
+    }
+
+    fn allow_head_cas(&self) {
+        self.fail_head_cas.store(false, Ordering::SeqCst);
+    }
+
+    fn reset_wal_get_count(&self) {
+        self.wal_get_count.store(0, Ordering::SeqCst);
+    }
+
+    fn reset_control_get_counts(&self) {
+        self.checkpoint_get_count.store(0, Ordering::SeqCst);
+        self.head_get_count.store(0, Ordering::SeqCst);
+        self.reset_wal_get_count();
+    }
+
+    fn wal_get_count(&self) -> usize {
+        self.wal_get_count.load(Ordering::SeqCst)
+    }
+
+    fn checkpoint_get_count(&self) -> usize {
+        self.checkpoint_get_count.load(Ordering::SeqCst)
+    }
+
+    fn head_get_count(&self) -> usize {
+        self.head_get_count.load(Ordering::SeqCst)
     }
 }
 
@@ -608,6 +1052,15 @@ impl ObjectStore for HeadCasFailureStore {
         key: &str,
         range: Option<ByteRange>,
     ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        if key.starts_with(&self.wal_prefix) {
+            self.wal_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key.starts_with(&self.checkpoint_prefix) {
+            self.checkpoint_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key == self.head_key {
+            self.head_get_count.fetch_add(1, Ordering::SeqCst);
+        }
         self.inner.get(key, range)
     }
 

--- a/docs/specs/010-glossary.md
+++ b/docs/specs/010-glossary.md
@@ -20,7 +20,7 @@
 | **Retention floor** | The oldest sequence number from which the system still promises incremental replay. Older clients must re-bootstrap. |
 | **Change feed** | The ordered stream of committed metadata changes after a chosen `seq`. |
 | **Cursor** | A bookmark such as `after_seq` used to resume incremental reads. |
-| **Mount** | A special inode that exposes another namespace, or a subtree of another namespace, inside the current tree. |
+| **mount** | Reserved future presentation concept for exposing another namespace, or a subtree of another namespace, inside a visible tree; not a v0 inode kind. |
 | **ACL** | An access-control rule granting a principal a role over a namespace or subtree. ACLs are not part of namespace metadata history. |
 | **Share** | An access grant to a namespace or subtree. A share may later be presented through a mount in another tree. |
 | **Precondition** | A rule that must still hold at an explicit namespace history point before a commit is accepted. |

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -120,7 +120,6 @@ The core inode kinds are:
 | --- | --- |
 | **DIR** | A directory that can own child bindings. |
 | **FILE** | A file whose history is an ordered set of revisions. |
-| **MOUNT** | Reserved for a future presentation point for another namespace or subtree. |
 
 The spec does not require a larger type taxonomy in the core model. New resource types should normally be represented through file content or resource properties rather than by introducing new inode kinds.
 
@@ -195,9 +194,9 @@ No durable parent/child relationship is part of v0 namespace state. After fork, 
 
 ## 7. Mounts
 
-A mount will present another namespace, or a subtree of another namespace, inside the current tree. Mount creation, mount metadata, and mount traversal are reserved future work in v0; no standard mutation operation creates a mount today.
+A mount may later present another namespace, or a subtree of another namespace, inside the current tree; mount creation, mount metadata, mount inode kinds, and mount traversal are reserved future work. The v0 model has no mount inode kind and no standard mutation operation creates a mount.
 
-A mount carries:
+A future mount would carry:
 
 - a target namespace id
 - a target root inode id within that namespace

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -102,7 +102,7 @@ To resolve an absolute path at seq N:
 
 1. Start at the root inode (inode id 1).
 2. For each path component, find the active directory binding whose normalized `name_key` matches the component under the namespace's `NamePolicy`.
-3. Follow the binding to its `child_inode_id`. Mount traversal is reserved future work; v0 path resolution does not cross mounts.
+3. Follow the binding to its `child_inode_id`; v0 path resolution does not cross mounts, and mount traversal is reserved future work.
 4. If any component has no matching visible binding, the path does not exist.
 
 ### 2.4 File content retrieval
@@ -170,6 +170,8 @@ The first standard lower-level mutation set includes:
 
 The path-oriented filesystem surface may compile higher-level operations into these lower-level mutations.
 
+`rename` accepts the explicit mode shape for forward compatibility, but v0 implements only `no_replace`. Reserved modes such as `replace_existing` and `exchange` must fail with `unsupported_rename_mode`.
+
 These are semantic commit operations. Durable WAL payloads store normalized metadata deltas derived from the semantic operations: `create_inode`, `bind_direntry`, `unbind_direntry`, `append_file_revision`, and `tombstone_subtree`. Raw bind/unbind/create-inode deltas are not standard client-facing commit operations.
 
 ## 6. Preconditions
@@ -199,6 +201,11 @@ A namespace exposes an ordered change feed. The feed answers the question:
 This feed is the basis for sync engines, replication, and other incremental consumers.
 
 The change feed is ordered by logical commit, not by physical WAL segment. A segment containing N logical commits produces N ordered change events.
+
+Each change event exposes both layers of the committed mutation:
+
+- semantic operation results, keyed by `op_index`, describe the client-facing operation outcome; and
+- materialized WAL deltas, keyed by `semantic_op_index` and `delta_index`, describe the authoritative metadata facts that replay/projectors should apply.
 
 ## 8. Retention floor
 

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -309,7 +309,12 @@ Representative response:
           "op_index": 0,
           "op": "replace_file",
           "inode_id": 42,
-          "revision_no": 8
+          "revision_no": 8,
+          "content_ref": {
+            "kind": "whole_file_v0",
+            "digest": "sha256:7ab...",
+            "size_bytes": 20591
+          }
         }
       ],
       "deltas": [

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -38,7 +38,7 @@ A commit request carries the following logical fields:
 | Field | Meaning |
 | --- | --- |
 | `commit_id` | Client-generated stable idempotency key for this logical commit request. The same value must be reused for safe retries. |
-| `preconditions` | Explicit semantic checks such as `inode_revision_is`, `child_name_is`, `child_name_absent`, `directory_empty`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
+| `preconditions` | Explicit semantic checks such as `inode_revision_is`, `binding_is`, `child_name_absent`, `directory_empty`, or ancestor-visibility checks that make races fail explicitly rather than silently merge. |
 | `ops` | Ordered list of mutation operations. Operation order is preserved through validation, logical commit creation, and change-feed output. |
 | `message` | Optional human-readable description of the mutation event. |
 | `annotations` | Optional structured metadata attached to the logical commit request. |
@@ -310,6 +310,20 @@ Representative response:
           "op": "replace_file",
           "inode_id": 42,
           "revision_no": 8
+        }
+      ],
+      "deltas": [
+        {
+          "semantic_op_index": 0,
+          "delta_index": 0,
+          "delta": "append_file_revision",
+          "inode_id": 42,
+          "revision_no": 8,
+          "content_ref": {
+            "kind": "whole_file_v0",
+            "digest": "sha256:7ab...",
+            "size_bytes": 20591
+          }
         }
       ]
     }

--- a/docs/specs/070-access-control-and-shares.md
+++ b/docs/specs/070-access-control-and-shares.md
@@ -45,17 +45,17 @@ A share object includes at least:
 - role
 - optional presentation metadata such as display name or description
 
-A mount presents that accessible subtree somewhere in a visible tree.
+A future mount feature may present that accessible subtree somewhere in a visible tree; this is not part of the v0 namespace mutation model.
 
 Example:
 
 - a project subtree is shared with a user;
-- that subtree is then mounted at `/Shared/ProjectA` inside another namespace.
+- a future presentation layer may mount that subtree at `/Shared/ProjectA` inside another namespace.
 
 This separates access and presentation:
 
 - the share answers "who may access this subtree?";
-- the mount answers "where is that subtree shown in a tree?".
+- a future mount would answer "where is that subtree shown in a tree?".
 
 ## 5. Download and upload capabilities
 


### PR DESCRIPTION
The main goal of this PR is to make the WAL replay shape explicit: semantic commit results stay client-facing, while WAL deltas carry the authoritative metadata facts that replay/projectors should apply. Both can be used depending on the use case of the replay. 
