### PR TITLE
perf(loonfs): add control cache for upload setup

### DIFF
--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -27,9 +27,15 @@ pub use checkpoint::{
 pub use context::MutationContext;
 pub use error::{CoreError, CoreErrorKind};
 pub use lease::{acquire_or_renew_namespace_lease, LeaseAcquireError};
+pub use loading::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control, ControlObjectIdentity,
+    ControlObjectLoadError, LoadedContentStoreDescriptorControl, LoadedHeadControl,
+    LoadedLeaseControl, LoadedNamespaceDescriptorControl,
+};
 pub use protocol::{
-    begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
-    upload_content,
+    begin_upload, commit_operations, commit_operations_batch, complete_upload,
+    create_upload_session, list_changes_after, upload_content,
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -34,8 +34,8 @@ pub use loading::{
     LoadedLeaseControl, LoadedNamespaceDescriptorControl,
 };
 pub use protocol::{
-    begin_upload, commit_operations, commit_operations_batch, complete_upload,
-    create_upload_session, list_changes_after, upload_content,
+    begin_upload, commit_operations, commit_operations_batch, complete_upload, list_changes_after,
+    upload_content,
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,6 +1,7 @@
 use loon_api::{
-    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreId, ControlObjectKind,
-    HeadStateEnvelope, LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceId,
+    payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
+    ContentStoreId, ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState,
+    LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
     CONTROL_OBJECT_FORMAT_VERSION,
 };
 use loon_objectstore::keys::{
@@ -38,6 +39,39 @@ pub(crate) struct LoadedLeaseObject {
     pub(crate) object_key: String,
     pub(crate) metadata: ObjectMetadata,
     pub(crate) envelope: LeaseStateEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct ControlObjectIdentity {
+    pub etag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedNamespaceDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: NamespaceDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedContentStoreDescriptorControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: ContentStoreDescriptorState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedHeadControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: HeadState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize)]
+pub struct LoadedLeaseControl {
+    pub object_key: String,
+    pub identity: ControlObjectIdentity,
+    pub state: LeaseState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, DeriveSerialize, Deserialize, Error)]
@@ -214,6 +248,68 @@ pub(crate) fn read_lease_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
+}
+
+pub fn load_namespace_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedNamespaceDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_namespace_descriptor_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedNamespaceDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_content_store_descriptor_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_content_store: &ContentStoreId,
+) -> Result<LoadedContentStoreDescriptorControl, ControlObjectLoadError> {
+    let loaded = read_content_store_descriptor_object(store, expected_content_store)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedContentStoreDescriptorControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_head_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedHeadControl, ControlObjectLoadError> {
+    let loaded = read_head_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedHeadControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+pub fn load_namespace_lease_control<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+) -> Result<LoadedLeaseControl, ControlObjectLoadError> {
+    let loaded = read_lease_object(store, expected_namespace)?;
+    let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
+    Ok(LoadedLeaseControl {
+        object_key: loaded.object_key,
+        identity,
+        state: loaded.envelope.state,
+    })
+}
+
+fn control_identity(
+    object_key: &str,
+    metadata: &ObjectMetadata,
+) -> Result<ControlObjectIdentity, ControlObjectLoadError> {
+    let etag = metadata.etag.clone().ok_or_else(|| {
+        ControlObjectLoadError::Store(format!("missing control object etag for `{object_key}`"))
+    })?;
+    Ok(ControlObjectIdentity { etag })
 }
 
 fn validate_namespace_id_for_control_key(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -16,6 +16,10 @@ use crate::namespace::catalog::{
 };
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
+use crate::{
+    load_content_store_descriptor_control, load_namespace_descriptor_control,
+    load_namespace_head_control, load_namespace_lease_control,
+};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitDelta, CommitRequest as ApiCommitRequest,
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
@@ -59,7 +63,7 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     create_upload_session(store, namespace_id, context)
 }
 
-pub fn create_upload_session<S: ObjectStore + ?Sized>(
+fn create_upload_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
@@ -96,7 +100,21 @@ fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
 ) -> Result<(), CoreError> {
     match namespace_initialization_state(store, namespace_id) {
-        Ok(NamespaceInitializationState::Complete) => Ok(()),
+        Ok(NamespaceInitializationState::Complete) => {
+            let descriptor =
+                load_namespace_descriptor_control(store, namespace_id).map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+                })?;
+            load_content_store_descriptor_control(store, &descriptor.state.content_store_id)
+                .map_err(|error| {
+                    CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+                })?;
+            load_namespace_head_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
+            load_namespace_lease_control(store, namespace_id)
+                .map_err(|error| CoreError::Basis(BasisLoadError::LoadLease(error)))?;
+            Ok(())
+        }
         Ok(NamespaceInitializationState::Absent) => {
             Err(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
                 crate::loading::ControlObjectLoadError::MissingObject {

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -10,7 +10,10 @@ use crate::content::{validate_durable_content_reference, write_immutable_object}
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::metadata::{CommitReceiptRecord, MetadataState};
-use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::{
+    load_namespace_content_store_id, namespace_initialization_state, NamespaceInitializationError,
+    NamespaceInitializationState,
+};
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
 use loon_api::v0::{
@@ -23,7 +26,7 @@ use loon_api::{
     CompletedUpload, ContentRef, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
     UploadSessionState, WalCommitDelta, WalDelta,
 };
-use loon_objectstore::keys::{content_blob, upload_session};
+use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
 
@@ -52,7 +55,7 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<BeginUploadResponse, CoreError> {
-    let _basis = load_verified_namespace_basis(store, namespace_id)?;
+    ensure_upload_namespace_available(store, namespace_id)?;
     let upload_id = generate_upload_id();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
@@ -78,6 +81,47 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
         upload_id,
         mode: UploadMode::ServiceProxied,
     })
+}
+
+fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<(), CoreError> {
+    match namespace_initialization_state(store, namespace_id) {
+        Ok(NamespaceInitializationState::Complete) => Ok(()),
+        Ok(NamespaceInitializationState::Absent) => {
+            Err(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
+                crate::loading::ControlObjectLoadError::MissingObject {
+                    object_key: namespace_descriptor(namespace_id.as_str()),
+                },
+            )))
+        }
+        Ok(NamespaceInitializationState::Partial) => {
+            Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            })
+        }
+        Err(error) => Err(map_upload_namespace_initialization_error(error)),
+    }
+}
+
+fn map_upload_namespace_initialization_error(error: NamespaceInitializationError) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(error))
+        }
+        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+            CoreError::Basis(BasisLoadError::LoadContentStoreDescriptor(error))
+        }
+        NamespaceInitializationError::InspectNamespaceDescriptor(_)
+        | NamespaceInitializationError::InspectNamespaceHead(_)
+        | NamespaceInitializationError::InspectNamespaceLease(_) => {
+            CoreError::Store(error.to_string())
+        }
+    }
 }
 
 pub fn upload_content<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -56,6 +56,14 @@ pub fn begin_upload<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<BeginUploadResponse, CoreError> {
     ensure_upload_namespace_available(store, namespace_id)?;
+    create_upload_session(store, namespace_id, context)
+}
+
+pub fn create_upload_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<BeginUploadResponse, CoreError> {
     let upload_id = generate_upload_id();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -13,9 +13,9 @@ use loon_core::commit::{
 };
 use loon_core::metadata::{InodeRecord, MetadataState};
 use loon_core::{
-    bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
-    copy_file_path, create_dir_path, delete_path, delete_path_non_recursive, fork_namespace,
-    list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
+    begin_upload, bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
+    copy_file_path, create_checkpoint, create_dir_path, delete_path, delete_path_non_recursive,
+    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
     publish_namespace_mutations_batch, put_file_bytes, read_file_bytes, resolve_path,
     store_bytes_as_content, upload_content, write_file_bytes, CoreError, CoreErrorKind,
     DirectObjectStorePublisher, MutationContext, NamespaceMutationCandidate, PathMutationIntent,
@@ -672,6 +672,10 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
         .expect_err("invalid namespace_id should be rejected before lookup");
     assert_eq!(read_error.kind(), CoreErrorKind::InvalidNamespaceId);
 
+    let begin_upload_error = begin_upload(&store, &invalid_namespace, &context)
+        .expect_err("invalid namespace_id should be rejected before upload session creation");
+    assert_eq!(begin_upload_error.kind(), CoreErrorKind::InvalidNamespaceId);
+
     let delete_error = delete_path_non_recursive(
         &store,
         &invalid_namespace,
@@ -700,6 +704,63 @@ fn public_namespace_operations_reject_invalid_namespace_id_before_key_constructi
             .expect("list namespace objects"),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    let missing_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("missing namespace");
+    assert_eq!(missing_error.kind(), CoreErrorKind::NamespaceNotFound);
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete descriptor");
+
+    let partial_error =
+        begin_upload(&store, &namespace_id, &context).expect_err("partial namespace");
+    assert_eq!(partial_error.kind(), CoreErrorKind::NamespacePartial);
+}
+
+#[test]
+fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false).expect("bootstrap");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileBehavior::CreateOnly,
+        &context,
+        Some("upload-guard-create"),
+    )
+    .expect("create file");
+    create_checkpoint(&setup_store, &namespace_id, &context).expect("checkpoint");
+    put_file_bytes(
+        &setup_store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileBehavior::ReplaceExisting,
+        &context,
+        Some("upload-guard-replace"),
+    )
+    .expect("replace file");
+
+    let guarded_store = ReplayReadGuardStore::new(temp_dir.path(), namespace_id.as_str());
+    let begin = begin_upload(&guarded_store, &namespace_id, &context).expect("begin upload");
+    assert_eq!(begin.namespace_id, namespace_id);
+    assert_eq!(guarded_store.guarded_get_count(), 0);
 }
 
 #[test]
@@ -2660,6 +2721,75 @@ fn content_ref(seed: &str) -> ContentRef {
         kind: ContentRefKind::WholeFileV0,
         digest: sha256_digest(seed.as_bytes()),
         size_bytes: seed.len() as u64,
+    }
+}
+
+struct ReplayReadGuardStore {
+    inner: LocalFsStore,
+    guarded_prefixes: Vec<String>,
+    guarded_gets: AtomicUsize,
+}
+
+impl ReplayReadGuardStore {
+    fn new(root: impl AsRef<Path>, namespace: &str) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            guarded_prefixes: vec![
+                format!("namespaces/{namespace}/wal/"),
+                format!("namespaces/{namespace}/checkpoints/"),
+            ],
+            guarded_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn guarded_get_count(&self) -> usize {
+        self.guarded_gets.load(Ordering::SeqCst)
+    }
+
+    fn reject_replay_read(&self, key: &str) -> Result<(), ObjectStoreError> {
+        if self
+            .guarded_prefixes
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        {
+            self.guarded_gets.fetch_add(1, Ordering::SeqCst);
+            return Err(ObjectStoreError::Transport(format!(
+                "begin_upload unexpectedly read replay object `{key}`"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl ObjectStore for ReplayReadGuardStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.reject_replay_read(key)?;
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
     }
 }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -9,23 +9,21 @@ pub use loon_api::v0::{
     CommitRequest, CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
     UploadContentResponse,
 };
+use loon_api::HeadState;
 pub use loon_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CommitId,
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
-use loon_api::{
-    ContentStoreDescriptorState, ContentStoreId, HeadState, LeaseState, NamespaceDescriptorState,
-};
-use loon_core::{
-    BasisLoadError, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
-    LoadedLeaseControl, MutationContext, VerifiedNamespaceBasis,
-};
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
-use loon_objectstore::keys::{namespace_head, namespace_lease};
+use loon_core::{
+    ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
+    VerifiedNamespaceBasis,
+};
+use loon_objectstore::keys::namespace_head;
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -69,7 +67,6 @@ pub struct RuntimeCacheConfig {
     pub basis_cache_enabled: bool,
     pub control_cache_enabled: bool,
     pub max_cached_namespaces: usize,
-    pub max_cached_content_stores: usize,
 }
 
 impl RuntimeCacheConfig {
@@ -78,7 +75,6 @@ impl RuntimeCacheConfig {
             basis_cache_enabled: false,
             control_cache_enabled: false,
             max_cached_namespaces: 0,
-            max_cached_content_stores: 0,
         }
     }
 }
@@ -89,7 +85,6 @@ impl Default for RuntimeCacheConfig {
             basis_cache_enabled: true,
             control_cache_enabled: true,
             max_cached_namespaces: 64,
-            max_cached_content_stores: 64,
         }
     }
 }
@@ -157,46 +152,20 @@ impl BasisCache {
 struct RuntimeControlCache {
     namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
     namespace_order: VecDeque<NamespaceId>,
-    content_stores: HashMap<ContentStoreId, Arc<ContentStoreDescriptorState>>,
-    content_store_order: VecDeque<ContentStoreId>,
 }
 
 #[derive(Debug, Default)]
 struct NamespaceControlCacheEntry {
-    descriptor: Option<Arc<NamespaceDescriptorState>>,
     head: Option<CachedControl<HeadState>>,
-    lease: Option<CachedControl<LeaseState>>,
 }
 
 #[derive(Debug, Clone)]
 struct CachedControl<T> {
     identity: ControlObjectIdentity,
-    state: Arc<T>,
+    _marker: std::marker::PhantomData<T>,
 }
 
 impl RuntimeControlCache {
-    fn namespace_descriptor(
-        &mut self,
-        namespace_id: &NamespaceId,
-    ) -> Option<Arc<NamespaceDescriptorState>> {
-        let descriptor = self.namespaces.get(namespace_id)?.descriptor.clone()?;
-        self.touch_namespace(namespace_id);
-        Some(descriptor)
-    }
-
-    fn insert_namespace_descriptor(
-        &mut self,
-        descriptor: Arc<NamespaceDescriptorState>,
-        max_cached_namespaces: usize,
-    ) {
-        if max_cached_namespaces == 0 {
-            return;
-        }
-        let namespace_id = descriptor.namespace_id.clone();
-        self.namespace_entry(&namespace_id, max_cached_namespaces)
-            .descriptor = Some(descriptor);
-    }
-
     fn namespace_head(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<HeadState>> {
         let head = self.namespaces.get(namespace_id)?.head.clone()?;
         self.touch_namespace(namespace_id);
@@ -216,60 +185,6 @@ impl RuntimeControlCache {
             .head = Some(head);
     }
 
-    fn namespace_lease(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<LeaseState>> {
-        let lease = self.namespaces.get(namespace_id)?.lease.clone()?;
-        self.touch_namespace(namespace_id);
-        Some(lease)
-    }
-
-    fn insert_namespace_lease(
-        &mut self,
-        namespace_id: &NamespaceId,
-        lease: CachedControl<LeaseState>,
-        max_cached_namespaces: usize,
-    ) {
-        if max_cached_namespaces == 0 {
-            return;
-        }
-        self.namespace_entry(namespace_id, max_cached_namespaces)
-            .lease = Some(lease);
-    }
-
-    fn content_store_descriptor(
-        &mut self,
-        content_store_id: &ContentStoreId,
-    ) -> Option<Arc<ContentStoreDescriptorState>> {
-        let descriptor = self.content_stores.get(content_store_id).cloned()?;
-        self.touch_content_store(content_store_id);
-        Some(descriptor)
-    }
-
-    fn insert_content_store_descriptor(
-        &mut self,
-        descriptor: Arc<ContentStoreDescriptorState>,
-        max_cached_content_stores: usize,
-    ) {
-        if max_cached_content_stores == 0 {
-            return;
-        }
-        let content_store_id = descriptor.content_store_id.clone();
-        self.content_stores
-            .insert(content_store_id.clone(), descriptor);
-        self.touch_content_store(&content_store_id);
-        while self.content_stores.len() > max_cached_content_stores {
-            let Some(evicted) = self.content_store_order.pop_front() else {
-                break;
-            };
-            self.content_stores.remove(&evicted);
-        }
-    }
-
-    fn invalidate_content_store(&mut self, content_store_id: &ContentStoreId) {
-        self.content_stores.remove(content_store_id);
-        self.content_store_order
-            .retain(|candidate| candidate != content_store_id);
-    }
-
     fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
         self.namespaces.remove(namespace_id);
         self.namespace_order
@@ -279,12 +194,6 @@ impl RuntimeControlCache {
     fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
         if let Some(entry) = self.namespaces.get_mut(namespace_id) {
             entry.head = None;
-        }
-    }
-
-    fn invalidate_namespace_lease(&mut self, namespace_id: &NamespaceId) {
-        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
-            entry.lease = None;
         }
     }
 
@@ -310,12 +219,6 @@ impl RuntimeControlCache {
         self.namespace_order
             .retain(|candidate| candidate != namespace_id);
         self.namespace_order.push_back(namespace_id.clone());
-    }
-
-    fn touch_content_store(&mut self, content_store_id: &ContentStoreId) {
-        self.content_store_order
-            .retain(|candidate| candidate != content_store_id);
-        self.content_store_order.push_back(content_store_id.clone());
     }
 }
 
@@ -744,20 +647,11 @@ impl Fs {
     }
 
     pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
-        if self.control_cache_enabled() {
-            self.ensure_upload_namespace_available_cached(namespace_id)?;
-            Ok(loon_core::create_upload_session(
-                self.store(),
-                namespace_id,
-                &self.mutation_context(),
-            )?)
-        } else {
-            Ok(loon_core::begin_upload(
-                self.store(),
-                namespace_id,
-                &self.mutation_context(),
-            )?)
-        }
+        Ok(loon_core::begin_upload(
+            self.store(),
+            namespace_id,
+            &self.mutation_context(),
+        )?)
     }
 
     pub fn upload_content(
@@ -876,149 +770,6 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    fn ensure_upload_namespace_available_cached(&self, namespace_id: &NamespaceId) -> Result<()> {
-        let descriptor = match self.load_namespace_descriptor_cached(namespace_id) {
-            Ok(descriptor) => descriptor,
-            Err(error) => {
-                return Err(self.namespace_descriptor_error_for_upload(namespace_id, error))
-            }
-        };
-        let head = self
-            .load_namespace_head_cached(namespace_id)
-            .map_err(|error| head_error_for_upload(namespace_id, error))?;
-        let lease = self
-            .load_namespace_lease_cached(namespace_id)
-            .map_err(|error| lease_error_for_upload(namespace_id, error))?;
-        debug_assert_eq!(head.state.namespace_id, *namespace_id);
-        debug_assert_eq!(lease.state.namespace_id, *namespace_id);
-        self.load_content_store_descriptor_cached(&descriptor.content_store_id)
-            .map_err(content_store_descriptor_error)?;
-        Ok(())
-    }
-
-    fn namespace_descriptor_error_for_upload(
-        &self,
-        namespace_id: &NamespaceId,
-        error: ControlObjectLoadError,
-    ) -> RuntimeError {
-        match error {
-            ControlObjectLoadError::MissingObject { .. }
-            | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
-                match self.namespace_head_or_lease_exists(namespace_id) {
-                    Ok(true) => RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
-                        namespace_id: namespace_id.clone(),
-                    }),
-                    Ok(false) => namespace_descriptor_error(error),
-                    Err(error) => error,
-                }
-            }
-            error => namespace_descriptor_error(error),
-        }
-    }
-
-    fn namespace_head_or_lease_exists(&self, namespace_id: &NamespaceId) -> Result<bool> {
-        let head_exists = self
-            .store()
-            .head(&namespace_head(namespace_id.as_str()))
-            .map_err(|error| RuntimeError::Core(CoreError::Store(error.to_string())))?
-            .is_some();
-        let lease_exists = self
-            .store()
-            .head(&namespace_lease(namespace_id.as_str()))
-            .map_err(|error| RuntimeError::Core(CoreError::Store(error.to_string())))?
-            .is_some();
-        Ok(head_exists || lease_exists)
-    }
-
-    fn load_namespace_descriptor_cached(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> std::result::Result<Arc<NamespaceDescriptorState>, ControlObjectLoadError> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if !self.control_cache_enabled() {
-            return loon_core::load_namespace_descriptor_control(self.store(), namespace_id)
-                .map(|loaded| Arc::new(loaded.state));
-        }
-
-        let cached = self
-            .inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .namespace_descriptor(namespace_id);
-        if let Some(descriptor) = cached {
-            return Ok(descriptor);
-        }
-
-        let loaded = match loon_core::load_namespace_descriptor_control(self.store(), namespace_id)
-        {
-            Ok(loaded) => loaded,
-            Err(error) => {
-                self.invalidate_namespace_cache(namespace_id);
-                return Err(error);
-            }
-        };
-        let descriptor = Arc::new(loaded.state);
-        self.inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .insert_namespace_descriptor(
-                Arc::clone(&descriptor),
-                cache_config.max_cached_namespaces,
-            );
-        Ok(descriptor)
-    }
-
-    fn load_content_store_descriptor_cached(
-        &self,
-        content_store_id: &ContentStoreId,
-    ) -> std::result::Result<Arc<ContentStoreDescriptorState>, ControlObjectLoadError> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if !cache_config.control_cache_enabled || cache_config.max_cached_content_stores == 0 {
-            return loon_core::load_content_store_descriptor_control(
-                self.store(),
-                content_store_id,
-            )
-            .map(|loaded| Arc::new(loaded.state));
-        }
-
-        let cached = self
-            .inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .content_store_descriptor(content_store_id);
-        if let Some(descriptor) = cached {
-            return Ok(descriptor);
-        }
-
-        let loaded = match loon_core::load_content_store_descriptor_control(
-            self.store(),
-            content_store_id,
-        ) {
-            Ok(loaded) => loaded,
-            Err(error) => {
-                self.inner
-                    .control_cache
-                    .lock()
-                    .expect("control cache lock poisoned")
-                    .invalidate_content_store(content_store_id);
-                return Err(error);
-            }
-        };
-        let descriptor = Arc::new(loaded.state);
-        self.inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .insert_content_store_descriptor(
-                Arc::clone(&descriptor),
-                cache_config.max_cached_content_stores,
-            );
-        Ok(descriptor)
-    }
-
     fn load_namespace_head_cached(
         &self,
         namespace_id: &NamespaceId,
@@ -1080,69 +831,6 @@ impl Fs {
                 cache_config.max_cached_namespaces,
             );
         Ok(head)
-    }
-
-    fn load_namespace_lease_cached(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> std::result::Result<CachedControl<LeaseState>, ControlObjectLoadError> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if !self.control_cache_enabled() {
-            return loon_core::load_namespace_lease_control(self.store(), namespace_id)
-                .map(cached_lease);
-        }
-
-        let cached = self
-            .inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .namespace_lease(namespace_id);
-        if let Some(lease) = cached {
-            match self.cached_control_identity_matches(
-                &namespace_lease(namespace_id.as_str()),
-                &lease.identity,
-            ) {
-                Ok(true) => return Ok(lease),
-                Ok(false) => self
-                    .inner
-                    .control_cache
-                    .lock()
-                    .expect("control cache lock poisoned")
-                    .invalidate_namespace_lease(namespace_id),
-                Err(error) => {
-                    self.inner
-                        .control_cache
-                        .lock()
-                        .expect("control cache lock poisoned")
-                        .invalidate_namespace_lease(namespace_id);
-                    return Err(error);
-                }
-            }
-        }
-
-        let loaded = match loon_core::load_namespace_lease_control(self.store(), namespace_id) {
-            Ok(loaded) => loaded,
-            Err(error) => {
-                self.inner
-                    .control_cache
-                    .lock()
-                    .expect("control cache lock poisoned")
-                    .invalidate_namespace_lease(namespace_id);
-                return Err(error);
-            }
-        };
-        let lease = cached_lease(loaded);
-        self.inner
-            .control_cache
-            .lock()
-            .expect("control cache lock poisoned")
-            .insert_namespace_lease(
-                namespace_id,
-                lease.clone(),
-                cache_config.max_cached_namespaces,
-            );
-        Ok(lease)
     }
 
     fn cached_control_identity_matches(
@@ -1277,56 +965,7 @@ impl Fs {
 fn cached_head(loaded: LoadedHeadControl) -> CachedControl<HeadState> {
     CachedControl {
         identity: loaded.identity,
-        state: Arc::new(loaded.state),
-    }
-}
-
-fn cached_lease(loaded: LoadedLeaseControl) -> CachedControl<LeaseState> {
-    CachedControl {
-        identity: loaded.identity,
-        state: Arc::new(loaded.state),
-    }
-}
-
-fn namespace_descriptor_error(error: ControlObjectLoadError) -> RuntimeError {
-    RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
-        error,
-    )))
-}
-
-fn content_store_descriptor_error(error: ControlObjectLoadError) -> RuntimeError {
-    RuntimeError::Core(CoreError::Basis(
-        BasisLoadError::LoadContentStoreDescriptor(error),
-    ))
-}
-
-fn head_error_for_upload(
-    namespace_id: &NamespaceId,
-    error: ControlObjectLoadError,
-) -> RuntimeError {
-    match error {
-        ControlObjectLoadError::MissingObject { .. }
-        | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
-            RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
-                namespace_id: namespace_id.clone(),
-            })
-        }
-        error => RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadHead(error))),
-    }
-}
-
-fn lease_error_for_upload(
-    namespace_id: &NamespaceId,
-    error: ControlObjectLoadError,
-) -> RuntimeError {
-    match error {
-        ControlObjectLoadError::MissingObject { .. }
-        | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
-            RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
-                namespace_id: namespace_id.clone(),
-            })
-        }
-        error => RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadLease(error))),
+        _marker: std::marker::PhantomData,
     }
 }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -14,11 +14,18 @@ pub use loon_api::{
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
+use loon_api::{
+    ContentStoreDescriptorState, ContentStoreId, HeadState, LeaseState, NamespaceDescriptorState,
+};
+use loon_core::{
+    BasisLoadError, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
+    LoadedLeaseControl, MutationContext, VerifiedNamespaceBasis,
+};
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
-use loon_core::{MutationContext, VerifiedNamespaceBasis};
+use loon_objectstore::keys::{namespace_head, namespace_lease};
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
@@ -60,14 +67,18 @@ impl FsConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
     pub basis_cache_enabled: bool,
+    pub control_cache_enabled: bool,
     pub max_cached_namespaces: usize,
+    pub max_cached_content_stores: usize,
 }
 
 impl RuntimeCacheConfig {
     pub fn disabled() -> Self {
         Self {
             basis_cache_enabled: false,
+            control_cache_enabled: false,
             max_cached_namespaces: 0,
+            max_cached_content_stores: 0,
         }
     }
 }
@@ -76,7 +87,9 @@ impl Default for RuntimeCacheConfig {
     fn default() -> Self {
         Self {
             basis_cache_enabled: true,
+            control_cache_enabled: true,
             max_cached_namespaces: 64,
+            max_cached_content_stores: 64,
         }
     }
 }
@@ -90,6 +103,7 @@ struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
     basis_cache: Mutex<BasisCache>,
+    control_cache: Mutex<RuntimeControlCache>,
 }
 
 pub struct FsBuilder {
@@ -136,6 +150,172 @@ impl BasisCache {
     fn touch(&mut self, namespace_id: &NamespaceId) {
         self.order.retain(|candidate| candidate != namespace_id);
         self.order.push_back(namespace_id.clone());
+    }
+}
+
+#[derive(Debug, Default)]
+struct RuntimeControlCache {
+    namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespace_order: VecDeque<NamespaceId>,
+    content_stores: HashMap<ContentStoreId, Arc<ContentStoreDescriptorState>>,
+    content_store_order: VecDeque<ContentStoreId>,
+}
+
+#[derive(Debug, Default)]
+struct NamespaceControlCacheEntry {
+    descriptor: Option<Arc<NamespaceDescriptorState>>,
+    head: Option<CachedControl<HeadState>>,
+    lease: Option<CachedControl<LeaseState>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedControl<T> {
+    identity: ControlObjectIdentity,
+    state: Arc<T>,
+}
+
+impl RuntimeControlCache {
+    fn namespace_descriptor(
+        &mut self,
+        namespace_id: &NamespaceId,
+    ) -> Option<Arc<NamespaceDescriptorState>> {
+        let descriptor = self.namespaces.get(namespace_id)?.descriptor.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(descriptor)
+    }
+
+    fn insert_namespace_descriptor(
+        &mut self,
+        descriptor: Arc<NamespaceDescriptorState>,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        let namespace_id = descriptor.namespace_id.clone();
+        self.namespace_entry(&namespace_id, max_cached_namespaces)
+            .descriptor = Some(descriptor);
+    }
+
+    fn namespace_head(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<HeadState>> {
+        let head = self.namespaces.get(namespace_id)?.head.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(head)
+    }
+
+    fn insert_namespace_head(
+        &mut self,
+        namespace_id: &NamespaceId,
+        head: CachedControl<HeadState>,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        self.namespace_entry(namespace_id, max_cached_namespaces)
+            .head = Some(head);
+    }
+
+    fn namespace_lease(&mut self, namespace_id: &NamespaceId) -> Option<CachedControl<LeaseState>> {
+        let lease = self.namespaces.get(namespace_id)?.lease.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(lease)
+    }
+
+    fn insert_namespace_lease(
+        &mut self,
+        namespace_id: &NamespaceId,
+        lease: CachedControl<LeaseState>,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        self.namespace_entry(namespace_id, max_cached_namespaces)
+            .lease = Some(lease);
+    }
+
+    fn content_store_descriptor(
+        &mut self,
+        content_store_id: &ContentStoreId,
+    ) -> Option<Arc<ContentStoreDescriptorState>> {
+        let descriptor = self.content_stores.get(content_store_id).cloned()?;
+        self.touch_content_store(content_store_id);
+        Some(descriptor)
+    }
+
+    fn insert_content_store_descriptor(
+        &mut self,
+        descriptor: Arc<ContentStoreDescriptorState>,
+        max_cached_content_stores: usize,
+    ) {
+        if max_cached_content_stores == 0 {
+            return;
+        }
+        let content_store_id = descriptor.content_store_id.clone();
+        self.content_stores
+            .insert(content_store_id.clone(), descriptor);
+        self.touch_content_store(&content_store_id);
+        while self.content_stores.len() > max_cached_content_stores {
+            let Some(evicted) = self.content_store_order.pop_front() else {
+                break;
+            };
+            self.content_stores.remove(&evicted);
+        }
+    }
+
+    fn invalidate_content_store(&mut self, content_store_id: &ContentStoreId) {
+        self.content_stores.remove(content_store_id);
+        self.content_store_order
+            .retain(|candidate| candidate != content_store_id);
+    }
+
+    fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespaces.remove(namespace_id);
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+    }
+
+    fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.head = None;
+        }
+    }
+
+    fn invalidate_namespace_lease(&mut self, namespace_id: &NamespaceId) {
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.lease = None;
+        }
+    }
+
+    fn namespace_entry(
+        &mut self,
+        namespace_id: &NamespaceId,
+        max_cached_namespaces: usize,
+    ) -> &mut NamespaceControlCacheEntry {
+        self.namespaces.entry(namespace_id.clone()).or_default();
+        self.touch_namespace(namespace_id);
+        while self.namespaces.len() > max_cached_namespaces {
+            let Some(evicted) = self.namespace_order.pop_front() else {
+                break;
+            };
+            self.namespaces.remove(&evicted);
+        }
+        self.namespaces
+            .get_mut(namespace_id)
+            .expect("namespace cache entry should exist")
+    }
+
+    fn touch_namespace(&mut self, namespace_id: &NamespaceId) {
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+        self.namespace_order.push_back(namespace_id.clone());
+    }
+
+    fn touch_content_store(&mut self, content_store_id: &ContentStoreId) {
+        self.content_store_order
+            .retain(|candidate| candidate != content_store_id);
+        self.content_store_order.push_back(content_store_id.clone());
     }
 }
 
@@ -279,6 +459,7 @@ impl Fs {
                 store,
                 config,
                 basis_cache: Mutex::new(BasisCache::default()),
+                control_cache: Mutex::new(RuntimeControlCache::default()),
             }),
         })
     }
@@ -563,11 +744,20 @@ impl Fs {
     }
 
     pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
-        Ok(loon_core::begin_upload(
-            self.store(),
-            namespace_id,
-            &self.mutation_context(),
-        )?)
+        if self.control_cache_enabled() {
+            self.ensure_upload_namespace_available_cached(namespace_id)?;
+            Ok(loon_core::create_upload_session(
+                self.store(),
+                namespace_id,
+                &self.mutation_context(),
+            )?)
+        } else {
+            Ok(loon_core::begin_upload(
+                self.store(),
+                namespace_id,
+                &self.mutation_context(),
+            )?)
+        }
     }
 
     pub fn upload_content(
@@ -686,6 +876,300 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
+    fn ensure_upload_namespace_available_cached(&self, namespace_id: &NamespaceId) -> Result<()> {
+        let descriptor = match self.load_namespace_descriptor_cached(namespace_id) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                return Err(self.namespace_descriptor_error_for_upload(namespace_id, error))
+            }
+        };
+        let head = self
+            .load_namespace_head_cached(namespace_id)
+            .map_err(|error| head_error_for_upload(namespace_id, error))?;
+        let lease = self
+            .load_namespace_lease_cached(namespace_id)
+            .map_err(|error| lease_error_for_upload(namespace_id, error))?;
+        debug_assert_eq!(head.state.namespace_id, *namespace_id);
+        debug_assert_eq!(lease.state.namespace_id, *namespace_id);
+        self.load_content_store_descriptor_cached(&descriptor.content_store_id)
+            .map_err(content_store_descriptor_error)?;
+        Ok(())
+    }
+
+    fn namespace_descriptor_error_for_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        error: ControlObjectLoadError,
+    ) -> RuntimeError {
+        match error {
+            ControlObjectLoadError::MissingObject { .. }
+            | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
+                match self.namespace_head_or_lease_exists(namespace_id) {
+                    Ok(true) => RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
+                        namespace_id: namespace_id.clone(),
+                    }),
+                    Ok(false) => namespace_descriptor_error(error),
+                    Err(error) => error,
+                }
+            }
+            error => namespace_descriptor_error(error),
+        }
+    }
+
+    fn namespace_head_or_lease_exists(&self, namespace_id: &NamespaceId) -> Result<bool> {
+        let head_exists = self
+            .store()
+            .head(&namespace_head(namespace_id.as_str()))
+            .map_err(|error| RuntimeError::Core(CoreError::Store(error.to_string())))?
+            .is_some();
+        let lease_exists = self
+            .store()
+            .head(&namespace_lease(namespace_id.as_str()))
+            .map_err(|error| RuntimeError::Core(CoreError::Store(error.to_string())))?
+            .is_some();
+        Ok(head_exists || lease_exists)
+    }
+
+    fn load_namespace_descriptor_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<Arc<NamespaceDescriptorState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !self.control_cache_enabled() {
+            return loon_core::load_namespace_descriptor_control(self.store(), namespace_id)
+                .map(|loaded| Arc::new(loaded.state));
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .namespace_descriptor(namespace_id);
+        if let Some(descriptor) = cached {
+            return Ok(descriptor);
+        }
+
+        let loaded = match loon_core::load_namespace_descriptor_control(self.store(), namespace_id)
+        {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.invalidate_namespace_cache(namespace_id);
+                return Err(error);
+            }
+        };
+        let descriptor = Arc::new(loaded.state);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_namespace_descriptor(
+                Arc::clone(&descriptor),
+                cache_config.max_cached_namespaces,
+            );
+        Ok(descriptor)
+    }
+
+    fn load_content_store_descriptor_cached(
+        &self,
+        content_store_id: &ContentStoreId,
+    ) -> std::result::Result<Arc<ContentStoreDescriptorState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !cache_config.control_cache_enabled || cache_config.max_cached_content_stores == 0 {
+            return loon_core::load_content_store_descriptor_control(
+                self.store(),
+                content_store_id,
+            )
+            .map(|loaded| Arc::new(loaded.state));
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .content_store_descriptor(content_store_id);
+        if let Some(descriptor) = cached {
+            return Ok(descriptor);
+        }
+
+        let loaded = match loon_core::load_content_store_descriptor_control(
+            self.store(),
+            content_store_id,
+        ) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_content_store(content_store_id);
+                return Err(error);
+            }
+        };
+        let descriptor = Arc::new(loaded.state);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_content_store_descriptor(
+                Arc::clone(&descriptor),
+                cache_config.max_cached_content_stores,
+            );
+        Ok(descriptor)
+    }
+
+    fn load_namespace_head_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<CachedControl<HeadState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !self.control_cache_enabled() {
+            return loon_core::load_namespace_head_control(self.store(), namespace_id)
+                .map(cached_head);
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .namespace_head(namespace_id);
+        if let Some(head) = cached {
+            match self.cached_control_identity_matches(
+                &namespace_head(namespace_id.as_str()),
+                &head.identity,
+            ) {
+                Ok(true) => return Ok(head),
+                Ok(false) => self
+                    .inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id),
+                Err(error) => {
+                    self.inner
+                        .control_cache
+                        .lock()
+                        .expect("control cache lock poisoned")
+                        .invalidate_namespace_head(namespace_id);
+                    return Err(error);
+                }
+            }
+        }
+
+        let loaded = match loon_core::load_namespace_head_control(self.store(), namespace_id) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_head(namespace_id);
+                return Err(error);
+            }
+        };
+        let head = cached_head(loaded);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_namespace_head(
+                namespace_id,
+                head.clone(),
+                cache_config.max_cached_namespaces,
+            );
+        Ok(head)
+    }
+
+    fn load_namespace_lease_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> std::result::Result<CachedControl<LeaseState>, ControlObjectLoadError> {
+        let cache_config = &self.inner.config.runtime_cache;
+        if !self.control_cache_enabled() {
+            return loon_core::load_namespace_lease_control(self.store(), namespace_id)
+                .map(cached_lease);
+        }
+
+        let cached = self
+            .inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .namespace_lease(namespace_id);
+        if let Some(lease) = cached {
+            match self.cached_control_identity_matches(
+                &namespace_lease(namespace_id.as_str()),
+                &lease.identity,
+            ) {
+                Ok(true) => return Ok(lease),
+                Ok(false) => self
+                    .inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_lease(namespace_id),
+                Err(error) => {
+                    self.inner
+                        .control_cache
+                        .lock()
+                        .expect("control cache lock poisoned")
+                        .invalidate_namespace_lease(namespace_id);
+                    return Err(error);
+                }
+            }
+        }
+
+        let loaded = match loon_core::load_namespace_lease_control(self.store(), namespace_id) {
+            Ok(loaded) => loaded,
+            Err(error) => {
+                self.inner
+                    .control_cache
+                    .lock()
+                    .expect("control cache lock poisoned")
+                    .invalidate_namespace_lease(namespace_id);
+                return Err(error);
+            }
+        };
+        let lease = cached_lease(loaded);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .insert_namespace_lease(
+                namespace_id,
+                lease.clone(),
+                cache_config.max_cached_namespaces,
+            );
+        Ok(lease)
+    }
+
+    fn cached_control_identity_matches(
+        &self,
+        object_key: &str,
+        identity: &ControlObjectIdentity,
+    ) -> std::result::Result<bool, ControlObjectLoadError> {
+        let metadata = self
+            .store()
+            .head(object_key)
+            .map_err(|error| ControlObjectLoadError::Store(error.to_string()))?
+            .ok_or_else(|| ControlObjectLoadError::MissingObject {
+                object_key: object_key.to_owned(),
+            })?;
+        let Some(etag) = metadata.etag else {
+            return Err(ControlObjectLoadError::Store(format!(
+                "missing control object etag for `{object_key}`"
+            )));
+        };
+        Ok(etag == identity.etag)
+    }
+
+    fn control_cache_enabled(&self) -> bool {
+        let cache_config = &self.inner.config.runtime_cache;
+        cache_config.control_cache_enabled && cache_config.max_cached_namespaces > 0
+    }
+
     fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
         let cache_config = &self.inner.config.runtime_cache;
         if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
@@ -702,12 +1186,23 @@ impl Fs {
             .expect("basis cache lock poisoned")
             .get(namespace_id);
         if let Some(basis) = cached {
-            match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
-                Ok(identity) if identity.head_etag == basis.head_etag => {
-                    return Ok(basis);
+            if self.control_cache_enabled() {
+                match self.load_namespace_head_cached(namespace_id) {
+                    Ok(head) if head.identity.etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
                 }
-                Ok(_) | Err(_) => {
-                    self.invalidate_namespace_cache(namespace_id);
+            } else {
+                match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
+                    Ok(identity) if identity.head_etag == basis.head_etag => {
+                        return Ok(basis);
+                    }
+                    Ok(_) | Err(_) => {
+                        self.invalidate_namespace_cache(namespace_id);
+                    }
                 }
             }
         }
@@ -737,6 +1232,11 @@ impl Fs {
             .lock()
             .expect("basis cache lock poisoned")
             .invalidate(namespace_id);
+        self.inner
+            .control_cache
+            .lock()
+            .expect("control cache lock poisoned")
+            .invalidate_namespace(namespace_id);
     }
 
     fn finish_namespace_mutation<T>(
@@ -771,6 +1271,62 @@ impl Fs {
             now_ms: current_time_ms(),
             lease_duration_ms: self.inner.config.lease_duration_ms,
         }
+    }
+}
+
+fn cached_head(loaded: LoadedHeadControl) -> CachedControl<HeadState> {
+    CachedControl {
+        identity: loaded.identity,
+        state: Arc::new(loaded.state),
+    }
+}
+
+fn cached_lease(loaded: LoadedLeaseControl) -> CachedControl<LeaseState> {
+    CachedControl {
+        identity: loaded.identity,
+        state: Arc::new(loaded.state),
+    }
+}
+
+fn namespace_descriptor_error(error: ControlObjectLoadError) -> RuntimeError {
+    RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadNamespaceDescriptor(
+        error,
+    )))
+}
+
+fn content_store_descriptor_error(error: ControlObjectLoadError) -> RuntimeError {
+    RuntimeError::Core(CoreError::Basis(
+        BasisLoadError::LoadContentStoreDescriptor(error),
+    ))
+}
+
+fn head_error_for_upload(
+    namespace_id: &NamespaceId,
+    error: ControlObjectLoadError,
+) -> RuntimeError {
+    match error {
+        ControlObjectLoadError::MissingObject { .. }
+        | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
+            RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            })
+        }
+        error => RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadHead(error))),
+    }
+}
+
+fn lease_error_for_upload(
+    namespace_id: &NamespaceId,
+    error: ControlObjectLoadError,
+) -> RuntimeError {
+    match error {
+        ControlObjectLoadError::MissingObject { .. }
+        | ControlObjectLoadError::MissingObjectAfterHead { .. } => {
+            RuntimeError::Core(CoreError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            })
+        }
+        error => RuntimeError::Core(CoreError::Basis(BasisLoadError::LoadLease(error))),
     }
 }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1,5 +1,5 @@
 use loon_objectstore::fs::LocalFsStore;
-use loon_objectstore::keys::{namespace_descriptor, namespace_head};
+use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
@@ -421,6 +421,227 @@ fn upload_flow_is_available_from_runtime() {
 }
 
 #[test]
+fn begin_upload_uses_control_cache_without_replay_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-cache-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"updated",
+        PutFileOptions {
+            behavior: PutFileBehavior::ReplaceExisting,
+            commit_id: None,
+        },
+    )
+    .expect("replace file");
+
+    raw_store.reset_control_get_counts();
+    fs.begin_upload(&namespace_id).expect("first begin upload");
+    fs.begin_upload(&namespace_id).expect("second begin upload");
+
+    assert_eq!(raw_store.wal_get_count(), 0);
+    assert_eq!(raw_store.checkpoint_get_count(), 0);
+    assert_eq!(raw_store.namespace_descriptor_get_count(), 1);
+    assert_eq!(raw_store.content_store_descriptor_get_count(), 1);
+    assert_eq!(raw_store.head_get_count(), 1);
+    assert_eq!(raw_store.lease_get_count(), 1);
+}
+
+#[test]
+fn disabled_control_cache_reloads_begin_upload_descriptors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-cache-disabled-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    raw_store.reset_control_get_counts();
+    fs.begin_upload(&namespace_id).expect("first begin upload");
+    fs.begin_upload(&namespace_id).expect("second begin upload");
+
+    assert_eq!(raw_store.namespace_descriptor_get_count(), 2);
+    assert_eq!(raw_store.content_store_descriptor_get_count(), 2);
+}
+
+#[test]
+fn control_cache_eviction_reloads_descriptors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("control-cache-eviction-test")
+        .runtime_cache(RuntimeCacheConfig {
+            basis_cache_enabled: false,
+            control_cache_enabled: true,
+            max_cached_namespaces: 1,
+            max_cached_content_stores: 1,
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
+        .expect("create other namespace");
+
+    raw_store.reset_control_get_counts();
+    fs.begin_upload(&namespace_id).expect("begin upload demo");
+    fs.begin_upload(&other_namespace)
+        .expect("begin upload other");
+    fs.begin_upload(&namespace_id)
+        .expect("begin upload demo after eviction");
+
+    assert_eq!(raw_store.namespace_descriptor_get_count(), 3);
+    assert_eq!(raw_store.content_store_descriptor_get_count(), 3);
+}
+
+#[test]
+fn control_cache_reloads_head_after_external_change() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let reader = Fs::builder(object_store.clone())
+        .writer_id("control-cache-reader")
+        .build()
+        .expect("build reader runtime");
+    let writer = Fs::builder(object_store)
+        .writer_id("control-cache-writer")
+        .build()
+        .expect("build writer runtime");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store.reset_control_get_counts();
+    reader
+        .begin_upload(&namespace_id)
+        .expect("prime control cache");
+    reader
+        .begin_upload(&namespace_id)
+        .expect("reuse unchanged control cache");
+    assert_eq!(raw_store.head_get_count(), 1);
+
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("advance head");
+    raw_store.reset_control_get_counts();
+    reader
+        .begin_upload(&namespace_id)
+        .expect("reload changed head");
+    assert_eq!(raw_store.head_get_count(), 1);
+}
+
+#[test]
+fn cached_begin_upload_rejects_missing_and_partial_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-missing-partial-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceNotFound,
+    );
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .delete(&namespace_descriptor(namespace_id.as_str()))
+        .expect("delete namespace descriptor");
+
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespacePartial,
+    );
+}
+
+#[test]
+fn cached_begin_upload_rejects_malformed_descriptors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-test")
+        .build()
+        .expect("build runtime");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_descriptor(namespace_id.as_str()),
+            br#"{"not":"a namespace descriptor"}"#,
+        )
+        .expect("corrupt namespace descriptor");
+    assert_core_error_kind(
+        fs.begin_upload(&namespace_id),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+
+    let content_bad = NamespaceId::parse("content-bad").expect("valid namespace id");
+    fs.create_namespace(&content_bad, CreateNamespaceOptions::default())
+        .expect("create content-bad namespace");
+    for key in raw_store
+        .list_prefix("content-stores/")
+        .expect("list content stores")
+        .into_iter()
+        .filter(|key| key.ends_with("/descriptor.json"))
+    {
+        raw_store
+            .put_overwrite(&key, br#"{"not":"a content store descriptor"}"#)
+            .expect("corrupt content store descriptor");
+    }
+    assert_core_error_kind(
+        fs.begin_upload(&content_bad),
+        CoreErrorKind::NamespaceCorrupt,
+    );
+}
+
+#[test]
 fn explicit_commit_appears_in_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "commit-test");
@@ -724,9 +945,16 @@ fn separate_runtime_instances_share_object_store_state() {
 struct HeadCasFailureStore {
     inner: LocalFsStore,
     head_key: String,
+    lease_key: String,
     wal_prefix: String,
+    checkpoint_prefix: String,
     fail_head_cas: AtomicBool,
     wal_get_count: AtomicUsize,
+    checkpoint_get_count: AtomicUsize,
+    namespace_descriptor_get_count: AtomicUsize,
+    content_store_descriptor_get_count: AtomicUsize,
+    head_get_count: AtomicUsize,
+    lease_get_count: AtomicUsize,
 }
 
 impl HeadCasFailureStore {
@@ -734,9 +962,16 @@ impl HeadCasFailureStore {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
+            lease_key: namespace_lease(namespace),
             wal_prefix: format!("namespaces/{namespace}/wal/"),
+            checkpoint_prefix: format!("namespaces/{namespace}/checkpoints/"),
             fail_head_cas: AtomicBool::new(false),
             wal_get_count: AtomicUsize::new(0),
+            checkpoint_get_count: AtomicUsize::new(0),
+            namespace_descriptor_get_count: AtomicUsize::new(0),
+            content_store_descriptor_get_count: AtomicUsize::new(0),
+            head_get_count: AtomicUsize::new(0),
+            lease_get_count: AtomicUsize::new(0),
         }
     }
 
@@ -752,8 +987,40 @@ impl HeadCasFailureStore {
         self.wal_get_count.store(0, Ordering::SeqCst);
     }
 
+    fn reset_control_get_counts(&self) {
+        self.checkpoint_get_count.store(0, Ordering::SeqCst);
+        self.namespace_descriptor_get_count
+            .store(0, Ordering::SeqCst);
+        self.content_store_descriptor_get_count
+            .store(0, Ordering::SeqCst);
+        self.head_get_count.store(0, Ordering::SeqCst);
+        self.lease_get_count.store(0, Ordering::SeqCst);
+        self.reset_wal_get_count();
+    }
+
     fn wal_get_count(&self) -> usize {
         self.wal_get_count.load(Ordering::SeqCst)
+    }
+
+    fn checkpoint_get_count(&self) -> usize {
+        self.checkpoint_get_count.load(Ordering::SeqCst)
+    }
+
+    fn namespace_descriptor_get_count(&self) -> usize {
+        self.namespace_descriptor_get_count.load(Ordering::SeqCst)
+    }
+
+    fn content_store_descriptor_get_count(&self) -> usize {
+        self.content_store_descriptor_get_count
+            .load(Ordering::SeqCst)
+    }
+
+    fn head_get_count(&self) -> usize {
+        self.head_get_count.load(Ordering::SeqCst)
+    }
+
+    fn lease_get_count(&self) -> usize {
+        self.lease_get_count.load(Ordering::SeqCst)
     }
 }
 
@@ -769,6 +1036,23 @@ impl ObjectStore for HeadCasFailureStore {
     ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
         if key.starts_with(&self.wal_prefix) {
             self.wal_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key.starts_with(&self.checkpoint_prefix) {
+            self.checkpoint_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key.starts_with("namespaces/") && key.ends_with("/descriptor.json") {
+            self.namespace_descriptor_get_count
+                .fetch_add(1, Ordering::SeqCst);
+        }
+        if key.starts_with("content-stores/") && key.ends_with("/descriptor.json") {
+            self.content_store_descriptor_get_count
+                .fetch_add(1, Ordering::SeqCst);
+        }
+        if key == self.head_key {
+            self.head_get_count.fetch_add(1, Ordering::SeqCst);
+        }
+        if key == self.lease_key {
+            self.lease_get_count.fetch_add(1, Ordering::SeqCst);
         }
         self.inner.get(key, range)
     }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -421,7 +421,7 @@ fn upload_flow_is_available_from_runtime() {
 }
 
 #[test]
-fn begin_upload_uses_control_cache_without_replay_reads() {
+fn begin_upload_validates_controls_without_replay_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let raw_store = Arc::new(HeadCasFailureStore::new(
@@ -461,14 +461,10 @@ fn begin_upload_uses_control_cache_without_replay_reads() {
 
     assert_eq!(raw_store.wal_get_count(), 0);
     assert_eq!(raw_store.checkpoint_get_count(), 0);
-    assert_eq!(raw_store.namespace_descriptor_get_count(), 1);
-    assert_eq!(raw_store.content_store_descriptor_get_count(), 1);
-    assert_eq!(raw_store.head_get_count(), 1);
-    assert_eq!(raw_store.lease_get_count(), 1);
 }
 
 #[test]
-fn disabled_control_cache_reloads_begin_upload_descriptors() {
+fn runtime_control_cache_reuses_head_for_basis_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let raw_store = Arc::new(HeadCasFailureStore::new(
@@ -477,24 +473,29 @@ fn disabled_control_cache_reloads_begin_upload_descriptors() {
     ));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = Fs::builder(object_store)
-        .writer_id("begin-upload-cache-disabled-test")
-        .runtime_cache(RuntimeCacheConfig::disabled())
+        .writer_id("control-cache-head-test")
         .build()
         .expect("build runtime");
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
 
     raw_store.reset_control_get_counts();
-    fs.begin_upload(&namespace_id).expect("first begin upload");
-    fs.begin_upload(&namespace_id).expect("second begin upload");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("first cached basis validation loads head body");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("second cached basis validation reuses head body");
 
-    assert_eq!(raw_store.namespace_descriptor_get_count(), 2);
-    assert_eq!(raw_store.content_store_descriptor_get_count(), 2);
+    assert_eq!(raw_store.head_get_count(), 1);
 }
 
 #[test]
-fn control_cache_eviction_reloads_descriptors() {
+fn control_cache_eviction_reloads_head_for_basis_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
@@ -506,32 +507,38 @@ fn control_cache_eviction_reloads_descriptors() {
     let fs = Fs::builder(object_store)
         .writer_id("control-cache-eviction-test")
         .runtime_cache(RuntimeCacheConfig {
-            basis_cache_enabled: false,
+            basis_cache_enabled: true,
             control_cache_enabled: true,
             max_cached_namespaces: 1,
-            max_cached_content_stores: 1,
         })
         .build()
         .expect("build runtime");
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
+    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
     fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
         .expect("create other namespace");
+    fs.create_dir(&other_namespace, "/docs", CreateDirOptions::default())
+        .expect("create other docs");
+
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace basis");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("prime first namespace head cache");
 
     raw_store.reset_control_get_counts();
-    fs.begin_upload(&namespace_id).expect("begin upload demo");
-    fs.begin_upload(&other_namespace)
-        .expect("begin upload other");
-    fs.begin_upload(&namespace_id)
-        .expect("begin upload demo after eviction");
+    fs.stat_path(&other_namespace, "/docs")
+        .expect("load other namespace basis and evict first head cache");
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("reload first namespace basis and head cache");
 
-    assert_eq!(raw_store.namespace_descriptor_get_count(), 3);
-    assert_eq!(raw_store.content_store_descriptor_get_count(), 3);
+    assert_eq!(raw_store.head_get_count(), 1);
 }
 
 #[test]
-fn control_cache_reloads_head_after_external_change() {
+fn runtime_control_cache_reloads_head_after_external_change() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let raw_store = Arc::new(HeadCasFailureStore::new(
@@ -551,27 +558,33 @@ fn control_cache_reloads_head_after_external_change() {
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
+    writer
+        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .expect("create docs");
+    reader
+        .stat_path(&namespace_id, "/docs")
+        .expect("prime basis cache");
     raw_store.reset_control_get_counts();
     reader
-        .begin_upload(&namespace_id)
+        .stat_path(&namespace_id, "/docs")
         .expect("prime control cache");
     reader
-        .begin_upload(&namespace_id)
+        .stat_path(&namespace_id, "/docs")
         .expect("reuse unchanged control cache");
     assert_eq!(raw_store.head_get_count(), 1);
 
     writer
-        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
         .expect("advance head");
     raw_store.reset_control_get_counts();
     reader
-        .begin_upload(&namespace_id)
+        .stat_path(&namespace_id, "/docs/new")
         .expect("reload changed head");
-    assert_eq!(raw_store.head_get_count(), 1);
+    assert!(raw_store.head_get_count() > 0);
 }
 
 #[test]
-fn cached_begin_upload_rejects_missing_and_partial_namespace() {
+fn begin_upload_rejects_missing_and_partial_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
@@ -599,7 +612,7 @@ fn cached_begin_upload_rejects_missing_and_partial_namespace() {
 }
 
 #[test]
-fn cached_begin_upload_rejects_malformed_descriptors() {
+fn begin_upload_rejects_malformed_descriptors() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
@@ -639,6 +652,37 @@ fn cached_begin_upload_rejects_malformed_descriptors() {
         fs.begin_upload(&content_bad),
         CoreErrorKind::NamespaceCorrupt,
     );
+}
+
+#[test]
+fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("begin-upload-malformed-control-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
+    fs.create_namespace(&head_bad, CreateNamespaceOptions::default())
+        .expect("create head-bad namespace");
+    raw_store
+        .put_overwrite(&namespace_head(head_bad.as_str()), br#"{"not":"a head"}"#)
+        .expect("corrupt head");
+    assert_core_error_kind(fs.begin_upload(&head_bad), CoreErrorKind::NamespaceCorrupt);
+
+    let lease_bad = NamespaceId::parse("lease-bad").expect("valid namespace id");
+    fs.create_namespace(&lease_bad, CreateNamespaceOptions::default())
+        .expect("create lease-bad namespace");
+    raw_store
+        .put_overwrite(
+            &namespace_lease(lease_bad.as_str()),
+            br#"{"not":"a lease"}"#,
+        )
+        .expect("corrupt lease");
+    assert_core_error_kind(fs.begin_upload(&lease_bad), CoreErrorKind::NamespaceCorrupt);
 }
 
 #[test]
@@ -945,16 +989,12 @@ fn separate_runtime_instances_share_object_store_state() {
 struct HeadCasFailureStore {
     inner: LocalFsStore,
     head_key: String,
-    lease_key: String,
     wal_prefix: String,
     checkpoint_prefix: String,
     fail_head_cas: AtomicBool,
     wal_get_count: AtomicUsize,
     checkpoint_get_count: AtomicUsize,
-    namespace_descriptor_get_count: AtomicUsize,
-    content_store_descriptor_get_count: AtomicUsize,
     head_get_count: AtomicUsize,
-    lease_get_count: AtomicUsize,
 }
 
 impl HeadCasFailureStore {
@@ -962,16 +1002,12 @@ impl HeadCasFailureStore {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
-            lease_key: namespace_lease(namespace),
             wal_prefix: format!("namespaces/{namespace}/wal/"),
             checkpoint_prefix: format!("namespaces/{namespace}/checkpoints/"),
             fail_head_cas: AtomicBool::new(false),
             wal_get_count: AtomicUsize::new(0),
             checkpoint_get_count: AtomicUsize::new(0),
-            namespace_descriptor_get_count: AtomicUsize::new(0),
-            content_store_descriptor_get_count: AtomicUsize::new(0),
             head_get_count: AtomicUsize::new(0),
-            lease_get_count: AtomicUsize::new(0),
         }
     }
 
@@ -989,12 +1025,7 @@ impl HeadCasFailureStore {
 
     fn reset_control_get_counts(&self) {
         self.checkpoint_get_count.store(0, Ordering::SeqCst);
-        self.namespace_descriptor_get_count
-            .store(0, Ordering::SeqCst);
-        self.content_store_descriptor_get_count
-            .store(0, Ordering::SeqCst);
         self.head_get_count.store(0, Ordering::SeqCst);
-        self.lease_get_count.store(0, Ordering::SeqCst);
         self.reset_wal_get_count();
     }
 
@@ -1006,21 +1037,8 @@ impl HeadCasFailureStore {
         self.checkpoint_get_count.load(Ordering::SeqCst)
     }
 
-    fn namespace_descriptor_get_count(&self) -> usize {
-        self.namespace_descriptor_get_count.load(Ordering::SeqCst)
-    }
-
-    fn content_store_descriptor_get_count(&self) -> usize {
-        self.content_store_descriptor_get_count
-            .load(Ordering::SeqCst)
-    }
-
     fn head_get_count(&self) -> usize {
         self.head_get_count.load(Ordering::SeqCst)
-    }
-
-    fn lease_get_count(&self) -> usize {
-        self.lease_get_count.load(Ordering::SeqCst)
     }
 }
 
@@ -1040,19 +1058,8 @@ impl ObjectStore for HeadCasFailureStore {
         if key.starts_with(&self.checkpoint_prefix) {
             self.checkpoint_get_count.fetch_add(1, Ordering::SeqCst);
         }
-        if key.starts_with("namespaces/") && key.ends_with("/descriptor.json") {
-            self.namespace_descriptor_get_count
-                .fetch_add(1, Ordering::SeqCst);
-        }
-        if key.starts_with("content-stores/") && key.ends_with("/descriptor.json") {
-            self.content_store_descriptor_get_count
-                .fetch_add(1, Ordering::SeqCst);
-        }
         if key == self.head_key {
             self.head_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        if key == self.lease_key {
-            self.lease_get_count.fetch_add(1, Ordering::SeqCst);
         }
         self.inner.get(key, range)
     }


### PR DESCRIPTION
This stacks on top of PR 56 and keeps the cache work focused on the runtime/control-plane path before review.

The main change in this PR is a lightweight control-object loading layer in `loon-core` plus a runtime-owned head-control cache in `loonfs`. 