### PR TITLE
refactor(metadata): create metadata state utility

### DIFF
--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -6,7 +6,7 @@ use crate::error::CoreError;
 use crate::loading::read_head_object;
 use crate::metadata::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
-    RevisionRecord, SubtreeTombstoneRecord,
+    MetadataStateBuilder, RevisionRecord, SubtreeTombstoneRecord,
 };
 use loon_api::{
     checkpoint_page_checksum_sha256, checkpoint_segment_payload_checksum_sha256,
@@ -666,7 +666,7 @@ fn load_checkpoint_materialization_from_tables<S: ObjectStore + ?Sized>(
     tables: &[CheckpointTableManifest],
 ) -> Result<MetadataState, CheckpointLoadError> {
     let ordered_tables = ordered_checkpoint_tables(manifest_object_key, tables)?;
-    let mut metadata_state = MetadataState::default();
+    let mut metadata_state = MetadataStateBuilder::default();
 
     for table in ordered_tables {
         for descriptor in &table.segments {
@@ -715,7 +715,7 @@ fn load_checkpoint_materialization_from_tables<S: ObjectStore + ?Sized>(
         }
     }
 
-    Ok(metadata_state)
+    Ok(metadata_state.finish())
 }
 
 fn ordered_checkpoint_tables<'a>(
@@ -914,7 +914,7 @@ fn validate_checkpoint_page(
 }
 
 fn append_rows_to_metadata(
-    metadata_state: &mut MetadataState,
+    metadata_state: &mut MetadataStateBuilder,
     family: CheckpointTableFamily,
     object_key: &str,
     rows: &[CheckpointRow],
@@ -928,7 +928,7 @@ fn append_rows_to_metadata(
                     inode_kind,
                     created_seq,
                 },
-            ) => metadata_state.inodes.push(InodeRecord {
+            ) => metadata_state.push_inode(InodeRecord {
                 inode_id: *inode_id,
                 inode_kind: inode_kind.clone(),
                 created_seq: *created_seq,
@@ -943,7 +943,7 @@ fn append_rows_to_metadata(
                     bind_seq,
                     bind_delta_index,
                 },
-            ) => metadata_state.direntry_binds.push(DirentryBindRecord {
+            ) => metadata_state.push_direntry_bind(DirentryBindRecord {
                 parent_inode_id: *parent_inode_id,
                 name_key: name_key.clone(),
                 display_name: display_name.clone(),
@@ -962,7 +962,7 @@ fn append_rows_to_metadata(
                     unbind_seq,
                     unbind_delta_index,
                 },
-            ) => metadata_state.direntry_unbinds.push(DirentryUnbindRecord {
+            ) => metadata_state.push_direntry_unbind(DirentryUnbindRecord {
                 parent_inode_id: *parent_inode_id,
                 name_key: name_key.clone(),
                 child_inode_id: *child_inode_id,
@@ -980,7 +980,7 @@ fn append_rows_to_metadata(
                     revision_delta_index,
                     content_ref,
                 },
-            ) => metadata_state.revisions.push(RevisionRecord {
+            ) => metadata_state.push_revision(RevisionRecord {
                 inode_id: *inode_id,
                 revision_no: *revision_no,
                 committed_seq: *committed_seq,
@@ -994,13 +994,11 @@ fn append_rows_to_metadata(
                     tombstone_seq,
                     tombstone_delta_index,
                 },
-            ) => metadata_state
-                .subtree_tombstones
-                .push(SubtreeTombstoneRecord {
-                    root_inode_id: *root_inode_id,
-                    tombstone_seq: *tombstone_seq,
-                    tombstone_delta_index: *tombstone_delta_index,
-                }),
+            ) => metadata_state.push_subtree_tombstone(SubtreeTombstoneRecord {
+                root_inode_id: *root_inode_id,
+                tombstone_seq: *tombstone_seq,
+                tombstone_delta_index: *tombstone_delta_index,
+            }),
             (
                 CheckpointTableFamily::CommitReceipts,
                 CheckpointRow::CommitReceipt {
@@ -1009,7 +1007,7 @@ fn append_rows_to_metadata(
                     committed_seq,
                     results,
                 },
-            ) => metadata_state.commit_receipts.push(CommitReceiptRecord {
+            ) => metadata_state.push_commit_receipt(CommitReceiptRecord {
                 commit_id: commit_id.clone(),
                 semantic_commit_fingerprint_sha256: semantic_commit_fingerprint_sha256.clone(),
                 committed_seq: *committed_seq,
@@ -1039,7 +1037,7 @@ fn checkpoint_rows_for_family(
 ) -> Vec<CheckpointRow> {
     let mut rows = match family {
         CheckpointTableFamily::Inodes => metadata_state
-            .inodes
+            .inodes()
             .iter()
             .map(|inode| CheckpointRow::Inode {
                 inode_id: inode.inode_id,
@@ -1048,7 +1046,7 @@ fn checkpoint_rows_for_family(
             })
             .collect::<Vec<_>>(),
         CheckpointTableFamily::DirentryBinds => metadata_state
-            .direntry_binds
+            .direntry_binds()
             .iter()
             .map(|direntry| CheckpointRow::DirentryBind {
                 parent_inode_id: direntry.parent_inode_id,
@@ -1060,7 +1058,7 @@ fn checkpoint_rows_for_family(
             })
             .collect::<Vec<_>>(),
         CheckpointTableFamily::DirentryUnbinds => metadata_state
-            .direntry_unbinds
+            .direntry_unbinds()
             .iter()
             .map(|unbind| CheckpointRow::DirentryUnbind {
                 parent_inode_id: unbind.parent_inode_id,
@@ -1073,7 +1071,7 @@ fn checkpoint_rows_for_family(
             })
             .collect::<Vec<_>>(),
         CheckpointTableFamily::Revisions => metadata_state
-            .revisions
+            .revisions()
             .iter()
             .map(|revision| CheckpointRow::Revision {
                 inode_id: revision.inode_id,
@@ -1084,7 +1082,7 @@ fn checkpoint_rows_for_family(
             })
             .collect::<Vec<_>>(),
         CheckpointTableFamily::Tombstones => metadata_state
-            .subtree_tombstones
+            .subtree_tombstones()
             .iter()
             .map(|tombstone| CheckpointRow::Tombstone {
                 root_inode_id: tombstone.root_inode_id,
@@ -1093,7 +1091,7 @@ fn checkpoint_rows_for_family(
             })
             .collect::<Vec<_>>(),
         CheckpointTableFamily::CommitReceipts => metadata_state
-            .commit_receipts
+            .commit_receipts()
             .iter()
             .map(|record| CheckpointRow::CommitReceipt {
                 commit_id: record.commit_id.clone(),
@@ -1227,13 +1225,13 @@ mod tests {
         .expect("move hello");
 
         let before = load_verified_namespace_basis(&store, &namespace_id).expect("basis before");
-        assert_eq!(before.metadata_state.direntry_unbinds.len(), 1);
+        assert_eq!(before.metadata_state.direntry_unbinds().len(), 1);
         create_checkpoint(&store, &namespace_id, &context).expect("create checkpoint");
         let after = load_verified_namespace_basis(&store, &namespace_id).expect("basis after");
 
         assert_eq!(
-            after.metadata_state.direntry_unbinds,
-            before.metadata_state.direntry_unbinds
+            after.metadata_state.direntry_unbinds(),
+            before.metadata_state.direntry_unbinds()
         );
         assert!(metadata_states_equivalent(
             &before.metadata_state,

--- a/crates/loon-core/src/genesis.rs
+++ b/crates/loon-core/src/genesis.rs
@@ -2,16 +2,16 @@ use crate::metadata::{InodeRecord, MetadataState};
 use loon_api::{ChangeSeq, InodeId, InodeKind};
 
 pub(crate) fn bootstrap_basis_metadata_state() -> MetadataState {
-    MetadataState {
-        inodes: vec![InodeRecord {
+    MetadataState::from_rows(
+        vec![InodeRecord {
             inode_id: InodeId(1),
             inode_kind: InodeKind::Dir,
             created_seq: ChangeSeq(0),
         }],
-        direntry_binds: Vec::new(),
-        direntry_unbinds: Vec::new(),
-        revisions: Vec::new(),
-        subtree_tombstones: Vec::new(),
-        commit_receipts: Vec::new(),
-    }
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
 }

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -9,17 +9,17 @@ use thiserror::Error;
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct MetadataState {
     #[serde(default)]
-    pub inodes: Vec<InodeRecord>,
+    inodes: Vec<InodeRecord>,
     #[serde(default)]
-    pub direntry_binds: Vec<DirentryBindRecord>,
+    direntry_binds: Vec<DirentryBindRecord>,
     #[serde(default)]
-    pub direntry_unbinds: Vec<DirentryUnbindRecord>,
+    direntry_unbinds: Vec<DirentryUnbindRecord>,
     #[serde(default)]
-    pub revisions: Vec<RevisionRecord>,
+    revisions: Vec<RevisionRecord>,
     #[serde(default)]
-    pub subtree_tombstones: Vec<SubtreeTombstoneRecord>,
+    subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
-    pub commit_receipts: Vec<CommitReceiptRecord>,
+    commit_receipts: Vec<CommitReceiptRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -116,6 +116,55 @@ pub enum MetadataApplyError {
 }
 
 impl MetadataState {
+    pub(crate) fn from_rows(
+        inodes: Vec<InodeRecord>,
+        direntry_binds: Vec<DirentryBindRecord>,
+        direntry_unbinds: Vec<DirentryUnbindRecord>,
+        revisions: Vec<RevisionRecord>,
+        subtree_tombstones: Vec<SubtreeTombstoneRecord>,
+        commit_receipts: Vec<CommitReceiptRecord>,
+    ) -> Self {
+        Self {
+            inodes,
+            direntry_binds,
+            direntry_unbinds,
+            revisions,
+            subtree_tombstones,
+            commit_receipts,
+        }
+    }
+
+    pub fn inodes(&self) -> &[InodeRecord] {
+        &self.inodes
+    }
+
+    pub fn direntry_binds(&self) -> &[DirentryBindRecord] {
+        &self.direntry_binds
+    }
+
+    pub fn direntry_unbinds(&self) -> &[DirentryUnbindRecord] {
+        &self.direntry_unbinds
+    }
+
+    pub fn revisions(&self) -> &[RevisionRecord] {
+        &self.revisions
+    }
+
+    pub fn subtree_tombstones(&self) -> &[SubtreeTombstoneRecord] {
+        &self.subtree_tombstones
+    }
+
+    pub fn commit_receipts(&self) -> &[CommitReceiptRecord] {
+        &self.commit_receipts
+    }
+
+    pub fn find_commit_receipt(&self, commit_id: &CommitId) -> Option<&CommitReceiptRecord> {
+        self.commit_receipts
+            .iter()
+            .filter(|record| record.commit_id == *commit_id)
+            .max_by_key(|record| record.committed_seq)
+    }
+
     pub fn apply_committed_wal_deltas(
         &self,
         committed_seq: ChangeSeq,
@@ -586,6 +635,41 @@ impl MetadataState {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct MetadataStateBuilder {
+    state: MetadataState,
+}
+
+impl MetadataStateBuilder {
+    pub(crate) fn push_inode(&mut self, record: InodeRecord) {
+        self.state.inodes.push(record);
+    }
+
+    pub(crate) fn push_direntry_bind(&mut self, record: DirentryBindRecord) {
+        self.state.direntry_binds.push(record);
+    }
+
+    pub(crate) fn push_direntry_unbind(&mut self, record: DirentryUnbindRecord) {
+        self.state.direntry_unbinds.push(record);
+    }
+
+    pub(crate) fn push_revision(&mut self, record: RevisionRecord) {
+        self.state.revisions.push(record);
+    }
+
+    pub(crate) fn push_subtree_tombstone(&mut self, record: SubtreeTombstoneRecord) {
+        self.state.subtree_tombstones.push(record);
+    }
+
+    pub(crate) fn push_commit_receipt(&mut self, record: CommitReceiptRecord) {
+        self.state.commit_receipts.push(record);
+    }
+
+    pub(crate) fn finish(self) -> MetadataState {
+        self.state
+    }
+}
+
 fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
     if !invariants.iter().any(|existing| existing == name) {
         invariants.push(name.to_owned());
@@ -619,8 +703,8 @@ mod tests {
             )
             .expect("apply bind delta");
 
-        assert_eq!(applied.metadata_state.direntry_binds.len(), 1);
-        let bind = &applied.metadata_state.direntry_binds[0];
+        assert_eq!(applied.metadata_state.direntry_binds().len(), 1);
+        let bind = &applied.metadata_state.direntry_binds()[0];
         assert_eq!(bind.name_key, "persisted-key");
         assert_eq!(bind.display_name, "Report.TXT");
         assert_eq!(bind.bind_delta_index, 7);
@@ -628,8 +712,8 @@ mod tests {
 
     #[test]
     fn child_lookup_uses_persisted_name_key_without_recanonicalizing() {
-        let metadata_state = MetadataState {
-            inodes: vec![
+        let metadata_state = MetadataState::from_rows(
+            vec![
                 InodeRecord {
                     inode_id: InodeId(1),
                     inode_kind: InodeKind::Dir,
@@ -641,7 +725,7 @@ mod tests {
                     created_seq: ChangeSeq(1),
                 },
             ],
-            direntry_binds: vec![DirentryBindRecord {
+            vec![DirentryBindRecord {
                 parent_inode_id: InodeId(1),
                 name_key: "persisted-key".to_owned(),
                 display_name: "Report.TXT".to_owned(),
@@ -649,8 +733,11 @@ mod tests {
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 0,
             }],
-            ..MetadataState::default()
-        };
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
 
         assert!(metadata_state
             .visible_child(InodeId(1), "persisted-key", ChangeSeq(1))
@@ -662,8 +749,8 @@ mod tests {
 
     #[test]
     fn resolve_visible_path_uses_explicit_name_policy_and_stored_display_name() {
-        let metadata_state = MetadataState {
-            inodes: vec![
+        let metadata_state = MetadataState::from_rows(
+            vec![
                 InodeRecord {
                     inode_id: InodeId(1),
                     inode_kind: InodeKind::Dir,
@@ -675,7 +762,7 @@ mod tests {
                     created_seq: ChangeSeq(1),
                 },
             ],
-            direntry_binds: vec![DirentryBindRecord {
+            vec![DirentryBindRecord {
                 parent_inode_id: InodeId(1),
                 name_key: "report.txt".to_owned(),
                 display_name: "Report.TXT".to_owned(),
@@ -683,8 +770,11 @@ mod tests {
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 0,
             }],
-            ..MetadataState::default()
-        };
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
 
         let resolved = metadata_state
             .resolve_visible_path(
@@ -697,5 +787,99 @@ mod tests {
         assert_eq!(resolved.inode_id, InodeId(2));
         assert_eq!(resolved.absolute_path, "/Report.TXT");
         assert_eq!(resolved.display_name, "Report.TXT");
+    }
+
+    #[test]
+    fn metadata_state_serialized_shape_preserves_row_field_names() {
+        let metadata_state = MetadataState::from_rows(
+            vec![InodeRecord {
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Dir,
+                created_seq: ChangeSeq(0),
+            }],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let encoded = serde_json::to_value(&metadata_state).expect("encode metadata state");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "inodes": [{
+                    "inode_id": 1,
+                    "inode_kind": "dir",
+                    "created_seq": 0
+                }],
+                "direntry_binds": [],
+                "direntry_unbinds": [],
+                "revisions": [],
+                "subtree_tombstones": [],
+                "commit_receipts": []
+            })
+        );
+    }
+
+    #[test]
+    fn metadata_state_accessors_expose_rows_read_only() {
+        let metadata_state = MetadataState::from_rows(
+            vec![InodeRecord {
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Dir,
+                created_seq: ChangeSeq(0),
+            }],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(metadata_state.inodes().len(), 1);
+        assert!(metadata_state.direntry_binds().is_empty());
+        assert!(metadata_state.direntry_unbinds().is_empty());
+        assert!(metadata_state.revisions().is_empty());
+        assert!(metadata_state.subtree_tombstones().is_empty());
+        assert!(metadata_state.commit_receipts().is_empty());
+    }
+
+    #[test]
+    fn find_commit_receipt_returns_latest_matching_receipt() {
+        let commit_id = CommitId::from("same-commit");
+        let metadata_state = MetadataState::from_rows(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![
+                CommitReceiptRecord {
+                    commit_id: commit_id.clone(),
+                    semantic_commit_fingerprint_sha256: "old".to_owned(),
+                    committed_seq: ChangeSeq(1),
+                    results: Vec::new(),
+                },
+                CommitReceiptRecord {
+                    commit_id: CommitId::from("other-commit"),
+                    semantic_commit_fingerprint_sha256: "other".to_owned(),
+                    committed_seq: ChangeSeq(3),
+                    results: Vec::new(),
+                },
+                CommitReceiptRecord {
+                    commit_id: commit_id.clone(),
+                    semantic_commit_fingerprint_sha256: "new".to_owned(),
+                    committed_seq: ChangeSeq(2),
+                    results: Vec::new(),
+                },
+            ],
+        );
+
+        let receipt = metadata_state
+            .find_commit_receipt(&commit_id)
+            .expect("receipt");
+        assert_eq!(receipt.committed_seq, ChangeSeq(2));
+        assert_eq!(receipt.semantic_commit_fingerprint_sha256, "new");
     }
 }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -925,11 +925,7 @@ fn find_commit_receipt<'a>(
     metadata_state: &'a crate::metadata::MetadataState,
     commit_id: &CommitId,
 ) -> Option<&'a CommitReceiptRecord> {
-    metadata_state
-        .commit_receipts
-        .iter()
-        .filter(|record| record.commit_id == *commit_id)
-        .max_by_key(|record| record.committed_seq)
+    metadata_state.find_commit_receipt(commit_id)
 }
 
 fn commit_response_from_commit_receipt(

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -1,7 +1,7 @@
 use loon_api::{
     sha256_digest, ChangeSeq, ContentRef, ContentRefKind, InodeId, InodeKind, RevisionNo, WalDelta,
 };
-use loon_core::metadata::{InodeRecord, MetadataState as CoreMetadataState};
+use loon_core::metadata::MetadataState as CoreMetadataState;
 use loon_model::metadata::MetadataState as ModelMetadataState;
 
 type NormalizedInodes = Vec<(u64, &'static str, u64)>;
@@ -230,18 +230,17 @@ fn metadata_apply_matches_model_for_delete_subtree() {
 }
 
 fn core_bootstrap_state() -> CoreMetadataState {
-    CoreMetadataState {
-        inodes: vec![InodeRecord {
-            inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
-            created_seq: ChangeSeq(0),
-        }],
-        direntry_binds: Vec::new(),
-        direntry_unbinds: Vec::new(),
-        revisions: Vec::new(),
-        subtree_tombstones: Vec::new(),
-        commit_receipts: Vec::new(),
-    }
+    CoreMetadataState::default()
+        .apply_committed_wal_deltas(
+            ChangeSeq(0),
+            &[WalDelta::CreateInode {
+                delta_index: 0,
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Dir,
+            }],
+        )
+        .expect("bootstrap core root")
+        .metadata_state
 }
 
 fn model_bootstrap_state() -> ModelMetadataState {
@@ -270,7 +269,7 @@ fn assert_states_match(sequences: &[Vec<WalDelta>]) {
 fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
     (
         state
-            .inodes
+            .inodes()
             .iter()
             .map(|inode| {
                 normalize_inode(
@@ -281,7 +280,7 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
             })
             .collect(),
         state
-            .direntry_binds
+            .direntry_binds()
             .iter()
             .map(|direntry| {
                 (
@@ -294,7 +293,7 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
             })
             .collect(),
         state
-            .revisions
+            .revisions()
             .iter()
             .map(|revision| {
                 (
@@ -307,7 +306,7 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
             })
             .collect(),
         state
-            .subtree_tombstones
+            .subtree_tombstones()
             .iter()
             .map(|tombstone| {
                 (
@@ -321,9 +320,15 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
 }
 
 fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
+    let ModelMetadataState {
+        inodes,
+        direntry_binds,
+        revisions,
+        subtree_tombstones,
+        ..
+    } = state;
     (
-        state
-            .inodes
+        inodes
             .iter()
             .map(|inode| {
                 normalize_inode(
@@ -333,8 +338,7 @@ fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
                 )
             })
             .collect(),
-        state
-            .direntry_binds
+        direntry_binds
             .iter()
             .map(|direntry| {
                 (
@@ -346,8 +350,7 @@ fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
                 )
             })
             .collect(),
-        state
-            .revisions
+        revisions
             .iter()
             .map(|revision| {
                 (
@@ -359,8 +362,7 @@ fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
                 )
             })
             .collect(),
-        state
-            .subtree_tombstones
+        subtree_tombstones
             .iter()
             .map(|tombstone| {
                 (

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -11,7 +11,7 @@ use loon_api::{
 use loon_core::commit::{
     build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
 };
-use loon_core::metadata::{InodeRecord, MetadataState};
+use loon_core::metadata::MetadataState;
 use loon_core::{
     begin_upload, bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
     copy_file_path, create_checkpoint, create_dir_path, delete_path, delete_path_non_recursive,
@@ -484,38 +484,33 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
 
 #[test]
 fn restore_revision_overflow_is_rejected() {
-    let metadata_state = MetadataState {
-        inodes: vec![
-            InodeRecord {
+    let mut deltas = wal_create_file(
+        0,
+        InodeId(2),
+        InodeId(1),
+        "overflow.txt".to_owned(),
+        content_ref("content-max"),
+    );
+    deltas[2] = loon_api::WalDelta::AppendFileRevision {
+        delta_index: 2,
+        inode_id: InodeId(2),
+        revision_no: RevisionNo(u64::MAX),
+        content_ref: content_ref("content-max"),
+    };
+    let metadata_state = MetadataState::default()
+        .apply_committed_wal_deltas(
+            ChangeSeq(0),
+            &[loon_api::WalDelta::CreateInode {
+                delta_index: 0,
                 inode_id: InodeId(1),
                 inode_kind: InodeKind::Dir,
-                created_seq: ChangeSeq(0),
-            },
-            InodeRecord {
-                inode_id: InodeId(2),
-                inode_kind: InodeKind::File,
-                created_seq: ChangeSeq(1),
-            },
-        ],
-        direntry_binds: vec![loon_core::metadata::DirentryBindRecord {
-            parent_inode_id: InodeId(1),
-            name_key: "overflow.txt".to_owned(),
-            display_name: "overflow.txt".to_owned(),
-            child_inode_id: InodeId(2),
-            bind_seq: ChangeSeq(1),
-            bind_delta_index: 0,
-        }],
-        direntry_unbinds: Vec::new(),
-        revisions: vec![loon_core::metadata::RevisionRecord {
-            inode_id: InodeId(2),
-            revision_no: RevisionNo(u64::MAX),
-            committed_seq: ChangeSeq(1),
-            revision_delta_index: 0,
-            content_ref: content_ref("content-max"),
-        }],
-        subtree_tombstones: Vec::new(),
-        commit_receipts: Vec::new(),
-    };
+            }],
+        )
+        .expect("bootstrap root")
+        .metadata_state
+        .apply_committed_wal_deltas(ChangeSeq(1), &deltas)
+        .expect("create max revision")
+        .metadata_state;
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
@@ -2360,7 +2355,7 @@ fn path_move_writes_unbind_and_stale_binding_is_fails() {
     )
     .expect("move file");
     let moved_basis = load_verified_namespace_basis(&store, &namespace_id()).expect("load basis");
-    assert_eq!(moved_basis.metadata_state.direntry_unbinds.len(), 1);
+    assert_eq!(moved_basis.metadata_state.direntry_unbinds().len(), 1);
     assert!(resolve_path(&store, &namespace_id(), "/docs/a.txt").is_err());
     resolve_path(&store, &namespace_id(), "/docs/b.txt").expect("new path visible");
 
@@ -2745,18 +2740,17 @@ impl ObjectStore for InjectCreateFailureStore {
 }
 
 fn metadata_state_after(sequences: &[Vec<loon_api::WalDelta>]) -> MetadataState {
-    let mut state = MetadataState {
-        inodes: vec![InodeRecord {
-            inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
-            created_seq: ChangeSeq(0),
-        }],
-        direntry_binds: Vec::new(),
-        direntry_unbinds: Vec::new(),
-        revisions: Vec::new(),
-        subtree_tombstones: Vec::new(),
-        commit_receipts: Vec::new(),
-    };
+    let mut state = MetadataState::default()
+        .apply_committed_wal_deltas(
+            ChangeSeq(0),
+            &[loon_api::WalDelta::CreateInode {
+                delta_index: 0,
+                inode_id: InodeId(1),
+                inode_kind: InodeKind::Dir,
+            }],
+        )
+        .expect("bootstrap root")
+        .metadata_state;
 
     for (index, deltas) in sequences.iter().enumerate() {
         state = state


### PR DESCRIPTION
This is another refactor PR that creates a standalone `MetadataState` so callers can no longer treat it as a public mutable collection of row vectors. The row shape and serialized field names are unchanged, but row access now goes through read-only functions and helper APIs.

This is intended to make upcoming metadata indexes easier to add without littering logic throughout the codebase.