### PR TITLE
perf(publisher): reuse warm namespace basis

### DIFF
--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -42,8 +42,7 @@ pub use protocol::{
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
-    NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
-    PublishOptions, WarmBasisEvent,
+    NamespaceCommitEngine, NamespaceMutationCandidate, PublishOptions,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, create_dir_path, delete_path, delete_path_non_recursive,

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -42,7 +42,8 @@ pub use protocol::{
 };
 pub use publisher::{
     publish_namespace_mutations_batch, DirectObjectStorePublisher, FlushPolicy,
-    NamespaceMutationCandidate, PublishOptions,
+    NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
+    PublishOptions, WarmBasisEvent,
 };
 pub use services::{
     bootstrap_namespace, copy_file_path, create_dir_path, delete_path, delete_path_non_recursive,

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -40,8 +40,43 @@ const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
 #[derive(Debug, Clone)]
 pub(crate) struct PublishBatchAgainstBasisResult {
     pub(crate) results: Vec<Result<ApiCommitResponse, CoreError>>,
-    pub(crate) post_commit_basis: Option<VerifiedNamespaceBasis>,
-    pub(crate) basis_advanced: bool,
+    pub(crate) basis_promotion: BasisPromotion,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum BasisPromotion {
+    Unchanged(VerifiedNamespaceBasis),
+    Advanced(VerifiedNamespaceBasis),
+    NotCacheable,
+}
+
+impl PublishBatchAgainstBasisResult {
+    fn unchanged(
+        results: Vec<Result<ApiCommitResponse, CoreError>>,
+        basis: &VerifiedNamespaceBasis,
+    ) -> Self {
+        Self {
+            results,
+            basis_promotion: BasisPromotion::Unchanged(basis.clone()),
+        }
+    }
+
+    fn advanced(
+        results: Vec<Result<ApiCommitResponse, CoreError>>,
+        basis: VerifiedNamespaceBasis,
+    ) -> Self {
+        Self {
+            results,
+            basis_promotion: BasisPromotion::Advanced(basis),
+        }
+    }
+
+    fn not_cacheable(results: Vec<Result<ApiCommitResponse, CoreError>>) -> Self {
+        Self {
+            results,
+            basis_promotion: BasisPromotion::NotCacheable,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -366,7 +401,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     publish_namespace_mutations_batch_against_basis(
         store,
         namespace_id,
-        candidates,
+        &candidates,
         context,
         &basis,
     )
@@ -376,29 +411,23 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
 pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    candidates: Vec<NamespaceMutationCandidate>,
+    candidates: &[NamespaceMutationCandidate],
     context: &MutationContext,
     basis: &VerifiedNamespaceBasis,
 ) -> PublishBatchAgainstBasisResult {
     if candidates.is_empty() {
-        return PublishBatchAgainstBasisResult {
-            results: Vec::new(),
-            post_commit_basis: Some(basis.clone()),
-            basis_advanced: false,
-        };
+        return PublishBatchAgainstBasisResult::unchanged(Vec::new(), basis);
     }
     if basis.head.namespace_id != *namespace_id {
-        return PublishBatchAgainstBasisResult {
-            results: (0..candidates.len())
+        return PublishBatchAgainstBasisResult::not_cacheable(
+            (0..candidates.len())
                 .map(|_| {
                     Err(CoreError::Store(
                         "publish basis namespace mismatch".to_owned(),
                     ))
                 })
                 .collect(),
-            post_commit_basis: None,
-            basis_advanced: false,
-        };
+        );
     }
     let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
         (0..candidates.len()).map(|_| None).collect();
@@ -408,7 +437,7 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
     let mut in_batch_requests: HashMap<CommitId, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
 
-    for (index, candidate) in candidates.into_iter().enumerate() {
+    for (index, candidate) in candidates.iter().enumerate() {
         let Some(candidate_request) = prepare_candidate_request(
             store,
             namespace_id,
@@ -489,11 +518,10 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
     }
 
     if accepted.is_empty() {
-        return PublishBatchAgainstBasisResult {
-            results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-            post_commit_basis: Some(basis.clone()),
-            basis_advanced: false,
-        };
+        return PublishBatchAgainstBasisResult::unchanged(
+            finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            basis,
+        );
     }
     let records = accepted
         .iter()
@@ -511,11 +539,9 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return PublishBatchAgainstBasisResult {
-                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-                post_commit_basis: None,
-                basis_advanced: false,
-            };
+            return PublishBatchAgainstBasisResult::not_cacheable(
+                finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            );
         }
     };
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
@@ -524,11 +550,9 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
             }
-            return PublishBatchAgainstBasisResult {
-                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-                post_commit_basis: None,
-                basis_advanced: false,
-            };
+            return PublishBatchAgainstBasisResult::not_cacheable(
+                finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            );
         }
     }
 
@@ -546,11 +570,9 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return PublishBatchAgainstBasisResult {
-                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-                post_commit_basis: None,
-                basis_advanced: false,
-            };
+            return PublishBatchAgainstBasisResult::not_cacheable(
+                finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            );
         }
     };
     let head_metadata = match publish_commit_head(store, &basis.head_etag, &head_publish) {
@@ -559,15 +581,13 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(error.clone().into()));
             }
-            return PublishBatchAgainstBasisResult {
-                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-                post_commit_basis: None,
-                basis_advanced: false,
-            };
+            return PublishBatchAgainstBasisResult::not_cacheable(
+                finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            );
         }
     };
 
-    let post_commit_basis = head_metadata.etag.map(|head_etag| VerifiedNamespaceBasis {
+    let promoted_basis = head_metadata.etag.map(|head_etag| VerifiedNamespaceBasis {
         namespace_descriptor: basis.namespace_descriptor.clone(),
         content_store_id: basis.content_store_id.clone(),
         head: head_publish.resulting_head.clone(),
@@ -584,10 +604,10 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
             results: record.results,
         }));
     }
-    PublishBatchAgainstBasisResult {
-        results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
-        post_commit_basis,
-        basis_advanced: true,
+    let results = finish_batch_outcomes_with_aliases(outcomes, &aliases);
+    match promoted_basis {
+        Some(basis) => PublishBatchAgainstBasisResult::advanced(results, basis),
+        None => PublishBatchAgainstBasisResult::not_cacheable(results),
     }
 }
 
@@ -598,7 +618,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     basis: &crate::VerifiedNamespaceBasis,
     current_head: &HeadState,
     current_metadata_state: &MetadataState,
-    candidate: NamespaceMutationCandidate,
+    candidate: &NamespaceMutationCandidate,
     context: &MutationContext,
     index: usize,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
@@ -616,7 +636,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let request = match commit_request_from_v0(conversion_context, request) {
+            let request = match commit_request_from_v0(conversion_context, request.clone()) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error.into()));
@@ -653,7 +673,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 return None;
             }
             let semantic_fingerprint =
-                match semantic_commit_fingerprint_for_path_intent(namespace_id, &intent) {
+                match semantic_commit_fingerprint_for_path_intent(namespace_id, intent) {
                     Ok(value) => value,
                     Err(error) => {
                         outcomes[index] = Some(Err(error));
@@ -675,7 +695,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             }
             let planned = match PathPlanner::new(store).plan_against_state(
                 namespace_id,
-                &intent,
+                intent,
                 current_head,
                 current_metadata_state,
                 &basis.content_store_id,

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,4 +1,4 @@
-use crate::basis::{load_verified_namespace_basis, BasisLoadError};
+use crate::basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
 use crate::commit::{
     build_commit_plan, commit_request_from_v0, materialize_commit, prepare_commit_head_publish,
     publish_commit_head, resolve_restore_content_refs, semantic_commit_fingerprint,
@@ -36,6 +36,13 @@ use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
 
 const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
+
+#[derive(Debug, Clone)]
+pub(crate) struct PublishBatchAgainstBasisResult {
+    pub(crate) results: Vec<Result<ApiCommitResponse, CoreError>>,
+    pub(crate) post_commit_basis: Option<VerifiedNamespaceBasis>,
+    pub(crate) basis_advanced: bool,
+}
 
 #[derive(Debug, Clone)]
 struct LoadedUploadSessionObject {
@@ -356,7 +363,43 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
                 .collect()
         }
     };
+    publish_namespace_mutations_batch_against_basis(
+        store,
+        namespace_id,
+        candidates,
+        context,
+        &basis,
+    )
+    .results
+}
 
+pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+    basis: &VerifiedNamespaceBasis,
+) -> PublishBatchAgainstBasisResult {
+    if candidates.is_empty() {
+        return PublishBatchAgainstBasisResult {
+            results: Vec::new(),
+            post_commit_basis: Some(basis.clone()),
+            basis_advanced: false,
+        };
+    }
+    if basis.head.namespace_id != *namespace_id {
+        return PublishBatchAgainstBasisResult {
+            results: (0..candidates.len())
+                .map(|_| {
+                    Err(CoreError::Store(
+                        "publish basis namespace mismatch".to_owned(),
+                    ))
+                })
+                .collect(),
+            post_commit_basis: None,
+            basis_advanced: false,
+        };
+    }
     let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
         (0..candidates.len()).map(|_| None).collect();
     let mut current_head = basis.head.clone();
@@ -369,7 +412,7 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         let Some(candidate_request) = prepare_candidate_request(
             store,
             namespace_id,
-            &basis,
+            basis,
             &current_head,
             &current_metadata_state,
             candidate,
@@ -446,7 +489,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     }
 
     if accepted.is_empty() {
-        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+        return PublishBatchAgainstBasisResult {
+            results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+            post_commit_basis: Some(basis.clone()),
+            basis_advanced: false,
+        };
     }
     let records = accepted
         .iter()
@@ -464,7 +511,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return PublishBatchAgainstBasisResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                post_commit_basis: None,
+                basis_advanced: false,
+            };
         }
     };
     match store.put_if_absent(&wal.object_key, &wal.encoded_bytes) {
@@ -473,7 +524,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::WalWrite(err.to_string())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return PublishBatchAgainstBasisResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                post_commit_basis: None,
+                basis_advanced: false,
+            };
         }
     }
 
@@ -491,15 +546,35 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             for (index, _) in accepted {
                 outcomes[index] = Some(Err(CoreError::Store(message.clone())));
             }
-            return finish_batch_outcomes_with_aliases(outcomes, &aliases);
+            return PublishBatchAgainstBasisResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                post_commit_basis: None,
+                basis_advanced: false,
+            };
         }
     };
-    if let Err(error) = publish_commit_head(store, &basis.head_etag, &head_publish) {
-        for (index, _) in accepted {
-            outcomes[index] = Some(Err(error.clone().into()));
+    let head_metadata = match publish_commit_head(store, &basis.head_etag, &head_publish) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            for (index, _) in accepted {
+                outcomes[index] = Some(Err(error.clone().into()));
+            }
+            return PublishBatchAgainstBasisResult {
+                results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+                post_commit_basis: None,
+                basis_advanced: false,
+            };
         }
-        return finish_batch_outcomes_with_aliases(outcomes, &aliases);
-    }
+    };
+
+    let post_commit_basis = head_metadata.etag.map(|head_etag| VerifiedNamespaceBasis {
+        namespace_descriptor: basis.namespace_descriptor.clone(),
+        content_store_id: basis.content_store_id.clone(),
+        head: head_publish.resulting_head.clone(),
+        head_etag,
+        lease: basis.lease.clone(),
+        metadata_state: current_metadata_state,
+    });
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
@@ -509,7 +584,11 @@ fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
             results: record.results,
         }));
     }
-    finish_batch_outcomes_with_aliases(outcomes, &aliases)
+    PublishBatchAgainstBasisResult {
+        results: finish_batch_outcomes_with_aliases(outcomes, &aliases),
+        post_commit_basis,
+        basis_advanced: true,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -5,9 +5,14 @@ use crate::path::intent::PathMutationIntent;
 use crate::path::planner::{
     semantic_commit_fingerprint_for_path_intent, PathPlanner, PlannedPathMutation,
 };
+use crate::{
+    load_namespace_head_identity, load_namespace_lease_control, load_verified_namespace_basis,
+    BasisLoadError, VerifiedNamespaceBasis,
+};
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::{CommitId, MutationResult, NamespaceId};
 use loon_objectstore::ObjectStore;
+use std::sync::Arc;
 
 const DEFAULT_STALE_HEAD_RETRY_LIMIT: usize = 8;
 
@@ -57,6 +62,151 @@ impl Default for PublishOptions {
             flush: FlushPolicy::Immediate,
             stale_head_retry_limit: DEFAULT_STALE_HEAD_RETRY_LIMIT,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarmBasisEvent {
+    Disabled,
+    ColdLoaded,
+    Reused,
+    InvalidatedThenColdLoaded,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamespaceCommitEnginePublishResult {
+    pub results: Vec<Result<ApiCommitResponse, CoreError>>,
+    pub post_commit_basis: Option<VerifiedNamespaceBasis>,
+    pub warm_basis_event: WarmBasisEvent,
+    pub warm_basis_advanced: bool,
+    pub warm_basis_invalidated: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamespaceCommitEngine {
+    namespace_id: NamespaceId,
+    basis: Option<Arc<VerifiedNamespaceBasis>>,
+}
+
+impl NamespaceCommitEngine {
+    pub fn new(namespace_id: NamespaceId) -> Self {
+        Self {
+            namespace_id,
+            basis: None,
+        }
+    }
+
+    pub fn invalidate(&mut self) {
+        self.basis = None;
+    }
+
+    pub fn publish_batch<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        candidates: Vec<NamespaceMutationCandidate>,
+        context: &MutationContext,
+    ) -> NamespaceCommitEnginePublishResult {
+        if candidates.is_empty() {
+            return NamespaceCommitEnginePublishResult {
+                results: Vec::new(),
+                post_commit_basis: self.basis.as_deref().cloned(),
+                warm_basis_event: WarmBasisEvent::Disabled,
+                warm_basis_advanced: false,
+                warm_basis_invalidated: false,
+            };
+        }
+
+        let candidate_count = candidates.len();
+        if let Err(error) =
+            crate::acquire_or_renew_namespace_lease(store, &self.namespace_id, context)
+        {
+            self.invalidate();
+            return NamespaceCommitEnginePublishResult {
+                results: (0..candidate_count)
+                    .map(|_| Err(CoreError::Lease(error.clone())))
+                    .collect(),
+                post_commit_basis: None,
+                warm_basis_event: WarmBasisEvent::Disabled,
+                warm_basis_advanced: false,
+                warm_basis_invalidated: true,
+            };
+        }
+
+        let (basis, warm_basis_event, invalidated_before_load) = match self.basis_for_publish(store)
+        {
+            Ok(value) => value,
+            Err(error) => {
+                self.invalidate();
+                return NamespaceCommitEnginePublishResult {
+                    results: (0..candidate_count)
+                        .map(|_| Err(CoreError::Basis(error.clone())))
+                        .collect(),
+                    post_commit_basis: None,
+                    warm_basis_event: WarmBasisEvent::Disabled,
+                    warm_basis_advanced: false,
+                    warm_basis_invalidated: true,
+                };
+            }
+        };
+
+        let published = crate::protocol::publish_namespace_mutations_batch_against_basis(
+            store,
+            &self.namespace_id,
+            candidates,
+            context,
+            &basis,
+        );
+        let mut warm_basis_invalidated = invalidated_before_load;
+        if let Some(post_commit_basis) = published.post_commit_basis.clone() {
+            self.basis = Some(Arc::new(post_commit_basis.clone()));
+        } else {
+            self.invalidate();
+            warm_basis_invalidated = true;
+        }
+
+        NamespaceCommitEnginePublishResult {
+            results: published.results,
+            post_commit_basis: published.post_commit_basis,
+            warm_basis_event,
+            warm_basis_advanced: published.basis_advanced && self.basis.is_some(),
+            warm_basis_invalidated,
+        }
+    }
+
+    fn basis_for_publish<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+    ) -> Result<(VerifiedNamespaceBasis, WarmBasisEvent, bool), BasisLoadError> {
+        let mut invalidated = false;
+        if let Some(cached) = self.basis.clone() {
+            match load_namespace_head_identity(store, &self.namespace_id) {
+                Ok(identity) if identity.head_etag == cached.head_etag => {
+                    match load_namespace_lease_control(store, &self.namespace_id) {
+                        Ok(lease) => {
+                            let mut basis = cached.as_ref().clone();
+                            basis.lease = lease.state;
+                            return Ok((basis, WarmBasisEvent::Reused, false));
+                        }
+                        Err(_) => {
+                            self.invalidate();
+                            invalidated = true;
+                        }
+                    }
+                }
+                Ok(_) | Err(_) => {
+                    self.invalidate();
+                    invalidated = true;
+                }
+            }
+        }
+
+        let basis = load_verified_namespace_basis(store, &self.namespace_id)?;
+        let event = if invalidated {
+            WarmBasisEvent::InvalidatedThenColdLoaded
+        } else {
+            WarmBasisEvent::ColdLoaded
+        };
+        Ok((basis, event, invalidated))
     }
 }
 
@@ -143,5 +293,6 @@ pub fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse, CoreError>> {
-    crate::protocol::publish_namespace_mutations_batch(store, namespace_id, candidates, context)
+    let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
+    engine.publish_batch(store, candidates, context).results
 }

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -152,10 +152,48 @@ impl NamespaceCommitEngine {
         let published = crate::protocol::publish_namespace_mutations_batch_against_basis(
             store,
             &self.namespace_id,
-            candidates,
+            candidates.clone(),
             context,
             &basis,
         );
+        if should_retry_reused_warm_rejection(warm_basis_event, &published) {
+            self.invalidate();
+            let cold_basis = match load_verified_namespace_basis(store, &self.namespace_id) {
+                Ok(value) => value,
+                Err(error) => {
+                    return NamespaceCommitEnginePublishResult {
+                        results: (0..candidate_count)
+                            .map(|_| Err(CoreError::Basis(error.clone())))
+                            .collect(),
+                        post_commit_basis: None,
+                        warm_basis_event: WarmBasisEvent::InvalidatedThenColdLoaded,
+                        warm_basis_advanced: false,
+                        warm_basis_invalidated: true,
+                    };
+                }
+            };
+            let retried = crate::protocol::publish_namespace_mutations_batch_against_basis(
+                store,
+                &self.namespace_id,
+                candidates,
+                context,
+                &cold_basis,
+            );
+            return self.finish_publish_result(
+                retried,
+                WarmBasisEvent::InvalidatedThenColdLoaded,
+                true,
+            );
+        }
+        self.finish_publish_result(published, warm_basis_event, invalidated_before_load)
+    }
+
+    fn finish_publish_result(
+        &mut self,
+        published: crate::protocol::PublishBatchAgainstBasisResult,
+        warm_basis_event: WarmBasisEvent,
+        invalidated_before_load: bool,
+    ) -> NamespaceCommitEnginePublishResult {
         let mut warm_basis_invalidated = invalidated_before_load;
         if let Some(post_commit_basis) = published.post_commit_basis.clone() {
             self.basis = Some(Arc::new(post_commit_basis.clone()));
@@ -208,6 +246,16 @@ impl NamespaceCommitEngine {
         };
         Ok((basis, event, invalidated))
     }
+}
+
+fn should_retry_reused_warm_rejection(
+    warm_basis_event: WarmBasisEvent,
+    published: &crate::protocol::PublishBatchAgainstBasisResult,
+) -> bool {
+    warm_basis_event == WarmBasisEvent::Reused
+        && !published.basis_advanced
+        && published.post_commit_basis.is_some()
+        && published.results.iter().any(Result::is_err)
 }
 
 pub struct DirectObjectStorePublisher<'a, S: ObjectStore + ?Sized> {

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -76,10 +76,33 @@ pub enum WarmBasisEvent {
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
     pub results: Vec<Result<ApiCommitResponse, CoreError>>,
-    pub post_commit_basis: Option<VerifiedNamespaceBasis>,
     pub warm_basis_event: WarmBasisEvent,
-    pub warm_basis_advanced: bool,
-    pub warm_basis_invalidated: bool,
+    pub warm_basis_update: WarmBasisUpdate,
+}
+
+#[derive(Debug, Clone)]
+pub enum WarmBasisUpdate {
+    NoChange,
+    Retained(VerifiedNamespaceBasis),
+    Advanced(VerifiedNamespaceBasis),
+    Invalidated,
+}
+
+impl WarmBasisUpdate {
+    pub fn basis(&self) -> Option<&VerifiedNamespaceBasis> {
+        match self {
+            Self::Retained(basis) | Self::Advanced(basis) => Some(basis),
+            Self::NoChange | Self::Invalidated => None,
+        }
+    }
+
+    pub fn is_advanced(&self) -> bool {
+        matches!(self, Self::Advanced(_))
+    }
+
+    pub fn is_invalidated(&self) -> bool {
+        matches!(self, Self::Invalidated)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -109,10 +132,13 @@ impl NamespaceCommitEngine {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
-                post_commit_basis: self.basis.as_deref().cloned(),
                 warm_basis_event: WarmBasisEvent::Disabled,
-                warm_basis_advanced: false,
-                warm_basis_invalidated: false,
+                warm_basis_update: self
+                    .basis
+                    .as_deref()
+                    .cloned()
+                    .map(WarmBasisUpdate::Retained)
+                    .unwrap_or(WarmBasisUpdate::NoChange),
             };
         }
 
@@ -122,29 +148,20 @@ impl NamespaceCommitEngine {
         {
             self.invalidate();
             return NamespaceCommitEnginePublishResult {
-                results: (0..candidate_count)
-                    .map(|_| Err(CoreError::Lease(error.clone())))
-                    .collect(),
-                post_commit_basis: None,
+                results: repeated_error(candidate_count, CoreError::Lease(error)),
                 warm_basis_event: WarmBasisEvent::Disabled,
-                warm_basis_advanced: false,
-                warm_basis_invalidated: true,
+                warm_basis_update: WarmBasisUpdate::Invalidated,
             };
         }
 
-        let (basis, warm_basis_event, invalidated_before_load) = match self.basis_for_publish(store)
-        {
+        let (basis, warm_basis_event) = match self.basis_for_publish(store) {
             Ok(value) => value,
             Err(error) => {
                 self.invalidate();
                 return NamespaceCommitEnginePublishResult {
-                    results: (0..candidate_count)
-                        .map(|_| Err(CoreError::Basis(error.clone())))
-                        .collect(),
-                    post_commit_basis: None,
+                    results: repeated_error(candidate_count, CoreError::Basis(error)),
                     warm_basis_event: WarmBasisEvent::Disabled,
-                    warm_basis_advanced: false,
-                    warm_basis_invalidated: true,
+                    warm_basis_update: WarmBasisUpdate::Invalidated,
                 };
             }
         };
@@ -152,7 +169,7 @@ impl NamespaceCommitEngine {
         let published = crate::protocol::publish_namespace_mutations_batch_against_basis(
             store,
             &self.namespace_id,
-            candidates.clone(),
+            &candidates,
             context,
             &basis,
         );
@@ -162,59 +179,55 @@ impl NamespaceCommitEngine {
                 Ok(value) => value,
                 Err(error) => {
                     return NamespaceCommitEnginePublishResult {
-                        results: (0..candidate_count)
-                            .map(|_| Err(CoreError::Basis(error.clone())))
-                            .collect(),
-                        post_commit_basis: None,
+                        results: repeated_error(candidate_count, CoreError::Basis(error)),
                         warm_basis_event: WarmBasisEvent::InvalidatedThenColdLoaded,
-                        warm_basis_advanced: false,
-                        warm_basis_invalidated: true,
+                        warm_basis_update: WarmBasisUpdate::Invalidated,
                     };
                 }
             };
             let retried = crate::protocol::publish_namespace_mutations_batch_against_basis(
                 store,
                 &self.namespace_id,
-                candidates,
+                &candidates,
                 context,
                 &cold_basis,
             );
-            return self.finish_publish_result(
-                retried,
-                WarmBasisEvent::InvalidatedThenColdLoaded,
-                true,
-            );
+            return self.finish_publish_result(retried, WarmBasisEvent::InvalidatedThenColdLoaded);
         }
-        self.finish_publish_result(published, warm_basis_event, invalidated_before_load)
+        self.finish_publish_result(published, warm_basis_event)
     }
 
     fn finish_publish_result(
         &mut self,
         published: crate::protocol::PublishBatchAgainstBasisResult,
         warm_basis_event: WarmBasisEvent,
-        invalidated_before_load: bool,
     ) -> NamespaceCommitEnginePublishResult {
-        let mut warm_basis_invalidated = invalidated_before_load;
-        if let Some(post_commit_basis) = published.post_commit_basis.clone() {
-            self.basis = Some(Arc::new(post_commit_basis.clone()));
-        } else {
-            self.invalidate();
-            warm_basis_invalidated = true;
-        }
+        let warm_basis_update = match published.basis_promotion {
+            crate::protocol::BasisPromotion::Unchanged(basis) => {
+                self.basis = Some(Arc::new(basis.clone()));
+                WarmBasisUpdate::Retained(basis)
+            }
+            crate::protocol::BasisPromotion::Advanced(basis) => {
+                self.basis = Some(Arc::new(basis.clone()));
+                WarmBasisUpdate::Advanced(basis)
+            }
+            crate::protocol::BasisPromotion::NotCacheable => {
+                self.invalidate();
+                WarmBasisUpdate::Invalidated
+            }
+        };
 
         NamespaceCommitEnginePublishResult {
             results: published.results,
-            post_commit_basis: published.post_commit_basis,
             warm_basis_event,
-            warm_basis_advanced: published.basis_advanced && self.basis.is_some(),
-            warm_basis_invalidated,
+            warm_basis_update,
         }
     }
 
     fn basis_for_publish<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
-    ) -> Result<(VerifiedNamespaceBasis, WarmBasisEvent, bool), BasisLoadError> {
+    ) -> Result<(VerifiedNamespaceBasis, WarmBasisEvent), BasisLoadError> {
         let mut invalidated = false;
         if let Some(cached) = self.basis.clone() {
             match load_namespace_head_identity(store, &self.namespace_id) {
@@ -223,7 +236,7 @@ impl NamespaceCommitEngine {
                         Ok(lease) => {
                             let mut basis = cached.as_ref().clone();
                             basis.lease = lease.state;
-                            return Ok((basis, WarmBasisEvent::Reused, false));
+                            return Ok((basis, WarmBasisEvent::Reused));
                         }
                         Err(_) => {
                             self.invalidate();
@@ -244,7 +257,7 @@ impl NamespaceCommitEngine {
         } else {
             WarmBasisEvent::ColdLoaded
         };
-        Ok((basis, event, invalidated))
+        Ok((basis, event))
     }
 }
 
@@ -253,9 +266,15 @@ fn should_retry_reused_warm_rejection(
     published: &crate::protocol::PublishBatchAgainstBasisResult,
 ) -> bool {
     warm_basis_event == WarmBasisEvent::Reused
-        && !published.basis_advanced
-        && published.post_commit_basis.is_some()
+        && matches!(
+            published.basis_promotion,
+            crate::protocol::BasisPromotion::Unchanged(_)
+        )
         && published.results.iter().any(Result::is_err)
+}
+
+fn repeated_error(count: usize, error: CoreError) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    (0..count).map(|_| Err(error.clone())).collect()
 }
 
 pub struct DirectObjectStorePublisher<'a, S: ObjectStore + ?Sized> {

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -21,7 +22,8 @@ pub use loon_core::{
 };
 use loon_core::{
     ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
-    VerifiedNamespaceBasis,
+    NamespaceCommitEngine, NamespaceCommitEnginePublishResult, VerifiedNamespaceBasis,
+    WarmBasisEvent,
 };
 use loon_objectstore::keys::namespace_head;
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};
@@ -98,7 +100,9 @@ struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
     basis_cache: Mutex<BasisCache>,
+    commit_engines: Mutex<CommitEngineCache>,
     control_cache: Mutex<RuntimeControlCache>,
+    cache_stats: RuntimeCacheStatsInner,
 }
 
 pub struct FsBuilder {
@@ -149,6 +153,50 @@ impl BasisCache {
 }
 
 #[derive(Debug, Default)]
+struct CommitEngineCache {
+    entries: HashMap<NamespaceId, Arc<Mutex<NamespaceCommitEngine>>>,
+    order: VecDeque<NamespaceId>,
+}
+
+impl CommitEngineCache {
+    fn get_or_insert(
+        &mut self,
+        namespace_id: &NamespaceId,
+        max_cached_namespaces: usize,
+    ) -> Arc<Mutex<NamespaceCommitEngine>> {
+        if let Some(engine) = self.entries.get(namespace_id).cloned() {
+            self.touch(namespace_id);
+            return engine;
+        }
+        let engine = Arc::new(Mutex::new(NamespaceCommitEngine::new(namespace_id.clone())));
+        self.entries.insert(namespace_id.clone(), engine.clone());
+        self.touch(namespace_id);
+        while self.entries.len() > max_cached_namespaces {
+            let Some(evicted) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&evicted);
+        }
+        engine
+    }
+
+    fn invalidate(&mut self, namespace_id: &NamespaceId) {
+        if let Some(engine) = self.entries.remove(namespace_id) {
+            engine
+                .lock()
+                .expect("commit engine lock poisoned")
+                .invalidate();
+        }
+        self.order.retain(|candidate| candidate != namespace_id);
+    }
+
+    fn touch(&mut self, namespace_id: &NamespaceId) {
+        self.order.retain(|candidate| candidate != namespace_id);
+        self.order.push_back(namespace_id.clone());
+    }
+}
+
+#[derive(Debug, Default)]
 struct RuntimeControlCache {
     namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
     namespace_order: VecDeque<NamespaceId>,
@@ -163,6 +211,56 @@ struct NamespaceControlCacheEntry {
 struct CachedControl<T> {
     identity: ControlObjectIdentity,
     _marker: std::marker::PhantomData<T>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeCacheStats {
+    pub publish_warm_basis_hits: usize,
+    pub publish_warm_basis_misses: usize,
+    pub publish_warm_basis_invalidations: usize,
+    pub publish_warm_basis_advances: usize,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeCacheStatsInner {
+    publish_warm_basis_hits: AtomicUsize,
+    publish_warm_basis_misses: AtomicUsize,
+    publish_warm_basis_invalidations: AtomicUsize,
+    publish_warm_basis_advances: AtomicUsize,
+}
+
+impl RuntimeCacheStatsInner {
+    fn snapshot(&self) -> RuntimeCacheStats {
+        RuntimeCacheStats {
+            publish_warm_basis_hits: self.publish_warm_basis_hits.load(Ordering::SeqCst),
+            publish_warm_basis_misses: self.publish_warm_basis_misses.load(Ordering::SeqCst),
+            publish_warm_basis_invalidations: self
+                .publish_warm_basis_invalidations
+                .load(Ordering::SeqCst),
+            publish_warm_basis_advances: self.publish_warm_basis_advances.load(Ordering::SeqCst),
+        }
+    }
+
+    fn record_publish_result(&self, result: &NamespaceCommitEnginePublishResult) {
+        match result.warm_basis_event {
+            WarmBasisEvent::Reused => {
+                self.publish_warm_basis_hits.fetch_add(1, Ordering::SeqCst);
+            }
+            WarmBasisEvent::ColdLoaded | WarmBasisEvent::InvalidatedThenColdLoaded => {
+                self.publish_warm_basis_misses
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+            WarmBasisEvent::Disabled => {}
+        }
+        if result.warm_basis_invalidated {
+            self.publish_warm_basis_invalidations
+                .fetch_add(1, Ordering::SeqCst);
+        }
+        if result.warm_basis_advanced {
+            self.publish_warm_basis_advances
+                .fetch_add(1, Ordering::SeqCst);
+        }
+    }
 }
 
 impl RuntimeControlCache {
@@ -362,7 +460,9 @@ impl Fs {
                 store,
                 config,
                 basis_cache: Mutex::new(BasisCache::default()),
+                commit_engines: Mutex::new(CommitEngineCache::default()),
                 control_cache: Mutex::new(RuntimeControlCache::default()),
+                cache_stats: RuntimeCacheStatsInner::default(),
             }),
         })
     }
@@ -689,14 +789,17 @@ impl Fs {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        let result = loon_core::commit_operations(
-            self.store(),
+        self.publish_namespace_mutations_batch(
             namespace_id,
-            request,
-            &self.mutation_context(),
+            vec![NamespaceMutationCandidate::Commit(request)],
         )
-        .map_err(RuntimeError::from);
-        self.finish_namespace_mutation(namespace_id, result)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| {
+            Err(RuntimeError::Core(CoreError::Store(
+                "empty commit batch".to_owned(),
+            )))
+        })
     }
 
     pub fn commit_operations_batch(
@@ -704,17 +807,13 @@ impl Fs {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        let results: Vec<_> = loon_core::commit_operations_batch(
-            self.store(),
+        self.publish_namespace_mutations_batch(
             namespace_id,
-            requests,
-            &self.mutation_context(),
+            requests
+                .into_iter()
+                .map(NamespaceMutationCandidate::Commit)
+                .collect(),
         )
-        .into_iter()
-        .map(|result| result.map_err(RuntimeError::Core))
-        .collect();
-        self.invalidate_namespace_cache_after_batch(namespace_id, &results);
-        results
     }
 
     pub fn publish_namespace_mutations_batch(
@@ -722,6 +821,25 @@ impl Fs {
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<Result<CommitResponse>> {
+        if self.commit_engine_cache_enabled() {
+            let engine = self.commit_engine(namespace_id);
+            let publish = {
+                let mut engine = engine.lock().expect("commit engine lock poisoned");
+                engine.publish_batch(self.store(), candidates, &self.mutation_context())
+            };
+            self.inner.cache_stats.record_publish_result(&publish);
+            if let Some(basis) = publish.post_commit_basis.clone() {
+                self.cache_basis(Arc::new(basis));
+            } else if publish.warm_basis_invalidated {
+                self.invalidate_namespace_cache(namespace_id);
+            }
+            return publish
+                .results
+                .into_iter()
+                .map(|result| result.map_err(RuntimeError::Core))
+                .collect();
+        }
+
         let results: Vec<_> = loon_core::publish_namespace_mutations_batch(
             self.store(),
             namespace_id,
@@ -733,6 +851,10 @@ impl Fs {
         .collect();
         self.invalidate_namespace_cache_after_batch(namespace_id, &results);
         results
+    }
+
+    pub fn runtime_cache_stats(&self) -> RuntimeCacheStats {
+        self.inner.cache_stats.snapshot()
     }
 
     pub fn list_changes_after(
@@ -858,6 +980,20 @@ impl Fs {
         cache_config.control_cache_enabled && cache_config.max_cached_namespaces > 0
     }
 
+    fn commit_engine_cache_enabled(&self) -> bool {
+        let cache_config = &self.inner.config.runtime_cache;
+        cache_config.basis_cache_enabled && cache_config.max_cached_namespaces > 0
+    }
+
+    fn commit_engine(&self, namespace_id: &NamespaceId) -> Arc<Mutex<NamespaceCommitEngine>> {
+        let cache_config = &self.inner.config.runtime_cache;
+        self.inner
+            .commit_engines
+            .lock()
+            .expect("commit engine cache lock poisoned")
+            .get_or_insert(namespace_id, cache_config.max_cached_namespaces)
+    }
+
     fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
         let cache_config = &self.inner.config.runtime_cache;
         if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
@@ -925,6 +1061,11 @@ impl Fs {
             .lock()
             .expect("control cache lock poisoned")
             .invalidate_namespace(namespace_id);
+        self.inner
+            .commit_engines
+            .lock()
+            .expect("commit engine cache lock poisoned")
+            .invalidate(namespace_id);
     }
 
     fn finish_namespace_mutation<T>(

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -252,11 +252,13 @@ impl RuntimeCacheStatsInner {
             }
             WarmBasisEvent::Disabled => {}
         }
-        if result.warm_basis_invalidated {
+        if result.warm_basis_event == WarmBasisEvent::InvalidatedThenColdLoaded
+            || result.warm_basis_update.is_invalidated()
+        {
             self.publish_warm_basis_invalidations
                 .fetch_add(1, Ordering::SeqCst);
         }
-        if result.warm_basis_advanced {
+        if result.warm_basis_update.is_advanced() {
             self.publish_warm_basis_advances
                 .fetch_add(1, Ordering::SeqCst);
         }
@@ -828,9 +830,9 @@ impl Fs {
                 engine.publish_batch(self.store(), candidates, &self.mutation_context())
             };
             self.inner.cache_stats.record_publish_result(&publish);
-            if let Some(basis) = publish.post_commit_basis.clone() {
-                self.cache_basis(Arc::new(basis));
-            } else if publish.warm_basis_invalidated {
+            if let Some(basis) = publish.warm_basis_update.basis() {
+                self.cache_basis(Arc::new(basis.clone()));
+            } else if publish.warm_basis_update.is_invalidated() {
                 self.invalidate_namespace_cache(namespace_id);
             }
             return publish

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -16,14 +16,14 @@ pub use loon_api::{
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
+use loon_core::publisher::{NamespaceCommitEnginePublishResult, WarmBasisEvent};
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
 };
 use loon_core::{
     ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
-    NamespaceCommitEngine, NamespaceCommitEnginePublishResult, VerifiedNamespaceBasis,
-    WarmBasisEvent,
+    NamespaceCommitEngine, VerifiedNamespaceBasis,
 };
 use loon_objectstore::keys::namespace_head;
 pub use loon_objectstore::{ObjectStore, ObjectStoreError};

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -54,6 +54,14 @@ fn create_dir_candidate(commit_id: &str, absolute_path: &str) -> NamespaceMutati
     })
 }
 
+fn delete_candidate(commit_id: &str, absolute_path: &str) -> NamespaceMutationCandidate {
+    NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+        commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+        absolute_path: absolute_path.to_owned(),
+        recursive: true,
+    })
+}
+
 fn assert_single_publish_ok(results: Vec<loonfs::Result<loonfs::CommitResponse>>) {
     let result = results
         .into_iter()
@@ -364,6 +372,56 @@ fn runtime_publish_cold_loads_after_external_head_advance() {
         "stale warm basis should be discarded and replaced by a cold replay"
     );
 
+    let stats = first.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_hits, 0);
+    assert_eq!(stats.publish_warm_basis_misses, 2);
+    assert_eq!(stats.publish_warm_basis_invalidations, 1);
+    assert_eq!(stats.publish_warm_basis_advances, 2);
+}
+
+#[test]
+fn runtime_publish_retries_warm_rejection_after_external_head_race() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let first = Fs::builder(object_store.clone())
+        .writer_id("shared-race-writer")
+        .build()
+        .expect("build first runtime");
+    let second = Fs::builder(object_store)
+        .writer_id("shared-race-writer")
+        .build()
+        .expect("build second runtime");
+
+    first
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("race-prime", "/docs")],
+    ));
+    second
+        .create_dir(&namespace_id, "/a", CreateDirOptions::default())
+        .expect("external runtime creates /a");
+
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![delete_candidate("race-delete-a", "/a")],
+    ));
+    assert!(
+        raw_store.wal_get_count() > 0,
+        "warm rejection should be retried from a cold basis"
+    );
+
+    assert_core_error_kind(
+        first.stat_path(&namespace_id, "/a"),
+        CoreErrorKind::PathNotFound,
+    );
     let stats = first.runtime_cache_stats();
     assert_eq!(stats.publish_warm_basis_hits, 0);
     assert_eq!(stats.publish_warm_basis_misses, 2);

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -4,8 +4,9 @@ use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError,
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
     CoreErrorKind, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, InodeId,
-    MaintenanceTickOptions, MaintenanceTickOutcome, MoveOptions, NamespaceId, PutFileBehavior,
-    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MoveOptions, NamespaceId,
+    NamespaceMutationCandidate, PathMutationIntent, PutFileBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore,
 };
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -44,6 +45,22 @@ fn assert_core_error_kind<T>(result: loonfs::Result<T>, expected: CoreErrorKind)
         Err(error) => panic!("expected core error {expected:?}, got {error:?}"),
         Ok(_) => panic!("expected core error {expected:?}"),
     }
+}
+
+fn create_dir_candidate(commit_id: &str, absolute_path: &str) -> NamespaceMutationCandidate {
+    NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
+        commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+        absolute_path: absolute_path.to_owned(),
+    })
+}
+
+fn assert_single_publish_ok(results: Vec<loonfs::Result<loonfs::CommitResponse>>) {
+    let result = results
+        .into_iter()
+        .next()
+        .expect("one publish result")
+        .expect("publish succeeds");
+    assert!(result.committed_seq.0 > 0);
 }
 
 #[test]
@@ -262,6 +279,181 @@ fn runtime_cache_can_be_disabled() {
     fs.stat_path(&namespace_id, "/docs")
         .expect("second stat should load basis again");
     assert_eq!(raw_store.wal_get_count(), 2);
+}
+
+#[test]
+fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("publish-warm-basis-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("warm-create-docs", "/docs")],
+    ));
+
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("warm-create-child", "/docs/child")],
+    ));
+    assert_eq!(
+        raw_store.wal_get_count(),
+        0,
+        "second adjacent publish should plan from the warm basis without replaying WAL"
+    );
+
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_misses, 1);
+    assert_eq!(stats.publish_warm_basis_hits, 1);
+    assert_eq!(stats.publish_warm_basis_advances, 2);
+    assert_eq!(stats.publish_warm_basis_invalidations, 0);
+
+    let stat = fs
+        .stat_path(&namespace_id, "/docs/child")
+        .expect("warm-published child is visible");
+    assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
+}
+
+#[test]
+fn runtime_publish_cold_loads_after_external_head_advance() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let first = Fs::builder(object_store.clone())
+        .writer_id("shared-publish-writer")
+        .build()
+        .expect("build first runtime");
+    let second = Fs::builder(object_store)
+        .writer_id("shared-publish-writer")
+        .build()
+        .expect("build second runtime");
+
+    first
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("external-first", "/docs")],
+    ));
+    second
+        .create_dir(&namespace_id, "/other", CreateDirOptions::default())
+        .expect("external runtime advances head");
+
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("external-after", "/docs/child")],
+    ));
+    assert!(
+        raw_store.wal_get_count() > 0,
+        "stale warm basis should be discarded and replaced by a cold replay"
+    );
+
+    let stats = first.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_hits, 0);
+    assert_eq!(stats.publish_warm_basis_misses, 2);
+    assert_eq!(stats.publish_warm_basis_invalidations, 1);
+    assert_eq!(stats.publish_warm_basis_advances, 2);
+}
+
+#[test]
+fn runtime_publish_cache_disabled_replays_for_adjacent_batches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("publish-warm-disabled-test")
+        .runtime_cache(RuntimeCacheConfig::disabled())
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("disabled-first", "/docs")],
+    ));
+
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("disabled-second", "/docs/child")],
+    ));
+    assert!(
+        raw_store.wal_get_count() > 0,
+        "cache-disabled publish path should still cold-load from WAL"
+    );
+    assert_eq!(fs.runtime_cache_stats(), Default::default());
+}
+
+#[test]
+fn runtime_publish_stale_head_invalidates_warm_basis() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("publish-warm-stale-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("stale-prime", "/docs")],
+    ));
+
+    raw_store.fail_head_cas();
+    let stale = fs
+        .publish_namespace_mutations_batch(
+            &namespace_id,
+            vec![create_dir_candidate("stale-loses-cas", "/stale")],
+        )
+        .into_iter()
+        .next()
+        .expect("one result")
+        .expect_err("head CAS failure should be stale");
+    assert_core_error_kind::<()>(Err(stale), CoreErrorKind::StaleHead);
+
+    raw_store.allow_head_cas();
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("stale-after", "/after")],
+    ));
+    assert!(
+        raw_store.wal_get_count() > 0,
+        "publish after stale-head invalidation should cold-load visible WAL"
+    );
+
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_hits, 1);
+    assert_eq!(stats.publish_warm_basis_misses, 2);
+    assert_eq!(stats.publish_warm_basis_invalidations, 1);
+    assert_eq!(stats.publish_warm_basis_advances, 2);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a runtime-owned warm-basis publish path for namespace mutations. Sequential runtime publishes can reuse a namespace basis when the head identity is unchanged, saving a significant amount of time that is otherwise needlessly re-spent scanning the WAL entries.

Benchmark shows improvements across the board from this change:
Category | Previous | Current | Change
-- | -- | -- | --
Writes | 1020.5s | 798.7s | 21.7% faster
Reads/list | 95.2s | 72.9s | 23.5% faster
Metadata renames | 319.3s | 185.6s | 41.9% faster

