### PR TITLE
perf(content): avoid blob validation on metadata hot paths

### DIFF
--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -67,20 +67,46 @@ pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
 ) -> Result<ValidatedDurableContent, DurableContentValidationError> {
+    let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
+    let bytes = load_required_object(store, &object_key)?;
+    validate_loaded_content_bytes(object_key, content_ref, &bytes)
+}
+
+pub fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    content_ref: &ContentRef,
+) -> Result<ReadDurableContent, DurableContentValidationError> {
+    let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
+    let bytes = load_required_object(store, &object_key)?;
+    let validated = validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
+
+    Ok(ReadDurableContent { validated, bytes })
+}
+
+fn content_object_key_for_ref(
+    content_store_id: &ContentStoreId,
+    content_ref: &ContentRef,
+) -> Result<String, DurableContentValidationError> {
     if content_ref.kind != ContentRefKind::WholeFileV0 {
         return Err(DurableContentValidationError::UnsupportedContentRefKind {
             kind: content_ref.kind,
         });
     }
 
-    let object_key =
-        content_blob(content_store_id.as_str(), &content_ref.digest).map_err(|err| {
-            DurableContentValidationError::InvalidDigest {
-                digest: content_ref.digest.clone(),
-                message: err.to_string(),
-            }
-        })?;
-    let bytes = load_required_object(store, &object_key)?;
+    content_blob(content_store_id.as_str(), &content_ref.digest).map_err(|err| {
+        DurableContentValidationError::InvalidDigest {
+            digest: content_ref.digest.clone(),
+            message: err.to_string(),
+        }
+    })
+}
+
+fn validate_loaded_content_bytes(
+    object_key: String,
+    content_ref: &ContentRef,
+    bytes: &[u8],
+) -> Result<ValidatedDurableContent, DurableContentValidationError> {
     let actual_size = bytes.len() as u64;
     if actual_size != content_ref.size_bytes {
         return Err(DurableContentValidationError::ContentLengthMismatch {
@@ -90,7 +116,7 @@ pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
         });
     }
 
-    let actual_digest = sha256_digest(&bytes);
+    let actual_digest = sha256_digest(bytes);
     if actual_digest != content_ref.digest {
         return Err(DurableContentValidationError::ContentDigestMismatch {
             object_key,
@@ -111,17 +137,6 @@ pub fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
             "whole_file_content_digest_matches_ref".to_owned(),
         ],
     })
-}
-
-pub fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: &ContentStoreId,
-    content_ref: &ContentRef,
-) -> Result<ReadDurableContent, DurableContentValidationError> {
-    let validated = validate_durable_content_reference(store, content_store_id, content_ref)?;
-    let bytes = load_required_object(store, &validated.object_key)?;
-
-    Ok(ReadDurableContent { validated, bytes })
 }
 
 pub fn store_bytes_as_content<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/path/query.rs
+++ b/crates/loon-core/src/path/query.rs
@@ -1,11 +1,11 @@
 use super::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::basis::load_verified_namespace_basis;
-use crate::content::{read_durable_content_bytes, validate_durable_content_reference};
+use crate::content::read_durable_content_bytes;
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, ResolvedVisiblePath};
 use loon_api::{
-    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentStoreId,
-    DisplayName, InodeKind, NamespaceId,
+    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, DisplayName,
+    InodeKind, NamespaceId,
 };
 use loon_objectstore::ObjectStore;
 
@@ -15,11 +15,10 @@ pub fn resolve_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<AuthoritativePathEntry, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
-    resolve_path_from_basis(store, &basis, absolute_path)
+    resolve_path_from_basis(&basis, absolute_path)
 }
 
-pub fn resolve_path_from_basis<S: ObjectStore + ?Sized>(
-    store: &S,
+pub fn resolve_path_from_basis(
     basis: &crate::VerifiedNamespaceBasis,
     absolute_path: &str,
 ) -> Result<AuthoritativePathEntry, CoreError> {
@@ -30,9 +29,7 @@ pub fn resolve_path_from_basis<S: ObjectStore + ?Sized>(
         basis.head.seq,
     )?;
     build_authoritative_path_entry(
-        store,
         &basis.head.namespace_id,
-        &basis.content_store_id,
         basis.head.seq,
         &basis.metadata_state,
         &resolved,
@@ -45,11 +42,10 @@ pub fn list_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id)?;
-    list_path_from_basis(store, &basis, absolute_path)
+    list_path_from_basis(&basis, absolute_path)
 }
 
-pub fn list_path_from_basis<S: ObjectStore + ?Sized>(
-    store: &S,
+pub fn list_path_from_basis(
     basis: &crate::VerifiedNamespaceBasis,
     absolute_path: &str,
 ) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
@@ -61,9 +57,7 @@ pub fn list_path_from_basis<S: ObjectStore + ?Sized>(
     )?;
     if resolved.inode_kind == InodeKind::File {
         return Ok(vec![build_authoritative_path_entry(
-            store,
             &basis.head.namespace_id,
-            &basis.content_store_id,
             basis.head.seq,
             &basis.metadata_state,
             &resolved,
@@ -89,9 +83,7 @@ pub fn list_path_from_basis<S: ObjectStore + ?Sized>(
                 .map_err(map_path_error_to_core)?
                 .join(&DisplayName::parse(&direntry.display_name).map_err(map_path_error_to_core)?);
             build_authoritative_path_entry(
-                store,
                 &basis.head.namespace_id,
-                &basis.content_store_id,
                 basis.head.seq,
                 &basis.metadata_state,
                 &ResolvedVisiblePath {
@@ -120,7 +112,7 @@ pub fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
     basis: &crate::VerifiedNamespaceBasis,
     absolute_path: &str,
 ) -> Result<AuthoritativeFileBytes, CoreError> {
-    let entry = resolve_path_from_basis(store, basis, absolute_path)?;
+    let entry = resolve_path_from_basis(basis, absolute_path)?;
     if entry.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: entry.absolute_path,
@@ -138,10 +130,8 @@ pub fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
     })
 }
 
-fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
-    store: &S,
+fn build_authoritative_path_entry(
     namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
     head_seq: ChangeSeq,
     metadata_state: &MetadataState,
     resolved: &ResolvedVisiblePath,
@@ -150,14 +140,9 @@ fn build_authoritative_path_entry<S: ObjectStore + ?Sized>(
     let content_ref = revision
         .as_ref()
         .map(|revision| revision.content_ref.clone());
-    let size_bytes = match content_ref.as_ref() {
-        Some(content_ref) => {
-            let validated =
-                validate_durable_content_reference(store, content_store_id, content_ref)?;
-            Some(validated.file_size_bytes)
-        }
-        None => None,
-    };
+    let size_bytes = content_ref
+        .as_ref()
+        .map(|content_ref| content_ref.size_bytes);
 
     Ok(AuthoritativePathEntry {
         namespace_id: namespace_id.clone(),

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -295,8 +295,6 @@ pub fn complete_upload<S: ObjectStore + ?Sized>(
                 "completed content ref does not match staged content".to_owned(),
             ));
         }
-        let content_store_id = load_namespace_content_store_id(store, namespace_id)?;
-        validate_durable_content_reference(store, &content_store_id, &request.content_ref)?;
 
         let mut next_state = loaded.envelope.state.clone();
         next_state.completed = Some(CompletedUpload {

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -15,8 +15,8 @@ use loon_core::metadata::MetadataState;
 use loon_core::{
     begin_upload, bootstrap_namespace, commit_operations, commit_operations_batch, complete_upload,
     copy_file_path, create_checkpoint, create_dir_path, delete_path, delete_path_non_recursive,
-    fork_namespace, list_changes_after, list_namespaces, load_verified_namespace_basis, move_path,
-    publish_namespace_mutations_batch, put_file_bytes, read_file_bytes, resolve_path,
+    fork_namespace, list_changes_after, list_namespaces, list_path, load_verified_namespace_basis,
+    move_path, publish_namespace_mutations_batch, put_file_bytes, read_file_bytes, resolve_path,
     store_bytes_as_content, upload_content, write_file_bytes, CoreError, CoreErrorKind,
     DirectObjectStorePublisher, MutationContext, NamespaceMutationCandidate, PathMutationIntent,
     PublishOptions, PutFileBehavior,
@@ -756,6 +756,123 @@ fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
     let begin = begin_upload(&guarded_store, &namespace_id, &context).expect("begin upload");
     assert_eq!(begin.namespace_id, namespace_id);
     assert_eq!(guarded_store.guarded_get_count(), 0);
+}
+
+#[test]
+fn complete_upload_does_not_get_content_blob_after_staging() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let namespace_id = NamespaceId::from("demo");
+    let context = mutation_context();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let begin = begin_upload(&store, &namespace_id, &context).expect("begin upload");
+    let uploaded = upload_content(&store, &namespace_id, &begin.upload_id, b"hello", &context)
+        .expect("upload content");
+
+    store.reset_content_blob_get_count();
+    let completed = complete_upload(
+        &store,
+        &namespace_id,
+        &begin.upload_id,
+        &CompleteUploadRequest {
+            content_ref: uploaded.content_ref.clone(),
+        },
+        &context,
+    )
+    .expect("complete upload");
+    assert_eq!(completed.content_ref, uploaded.content_ref);
+    assert_eq!(store.content_blob_get_count(), 0);
+
+    store.reset_content_blob_get_count();
+    let completed_again = complete_upload(
+        &store,
+        &namespace_id,
+        &begin.upload_id,
+        &CompleteUploadRequest {
+            content_ref: uploaded.content_ref,
+        },
+        &context,
+    )
+    .expect("complete upload idempotently");
+    assert_eq!(completed_again.content_ref, completed.content_ref);
+    assert_eq!(store.content_blob_get_count(), 0);
+
+    let mismatch_begin = begin_upload(&store, &namespace_id, &context).expect("begin mismatch");
+    let mismatch_uploaded = upload_content(
+        &store,
+        &namespace_id,
+        &mismatch_begin.upload_id,
+        b"staged",
+        &context,
+    )
+    .expect("upload mismatch content");
+    let wrong_ref = ContentRef::whole_file_v0(b"different");
+    assert_ne!(wrong_ref, mismatch_uploaded.content_ref);
+
+    store.reset_content_blob_get_count();
+    let mismatch = complete_upload(
+        &store,
+        &namespace_id,
+        &mismatch_begin.upload_id,
+        &CompleteUploadRequest {
+            content_ref: wrong_ref,
+        },
+        &context,
+    )
+    .expect_err("mismatched content ref");
+    assert_eq!(mismatch.kind(), CoreErrorKind::InvalidUploadContent);
+    assert_eq!(store.content_blob_get_count(), 0);
+}
+
+#[test]
+fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    create_dir_path(&store, &namespace_id, "/docs", &context, Some("mkdir-docs"))
+        .expect("create docs");
+
+    for index in 0..3 {
+        let path = format!("/docs/file-{index}.txt");
+        let bytes = format!("file-{index}-bytes");
+        let commit_id = format!("put-file-{index}");
+        put_file_bytes(
+            &store,
+            &namespace_id,
+            &path,
+            bytes.as_bytes(),
+            PutFileBehavior::CreateOnly,
+            &context,
+            Some(&commit_id),
+        )
+        .expect("put file");
+    }
+
+    store.reset_content_blob_get_count();
+    let stat = resolve_path(&store, &namespace_id, "/docs/file-1.txt").expect("stat file");
+    assert_eq!(stat.inode_kind, InodeKind::File);
+    assert_eq!(stat.size_bytes, Some("file-1-bytes".len() as u64));
+    assert!(stat.content_ref.is_some());
+    assert_eq!(store.content_blob_get_count(), 0);
+
+    store.reset_content_blob_get_count();
+    let entries = list_path(&store, &namespace_id, "/docs").expect("list docs");
+    assert_eq!(entries.len(), 3);
+    for entry in entries {
+        assert_eq!(entry.inode_kind, InodeKind::File);
+        assert_eq!(entry.size_bytes, Some("file-0-bytes".len() as u64));
+        assert!(entry.content_ref.is_some());
+    }
+    assert_eq!(store.content_blob_get_count(), 0);
+
+    store.reset_content_blob_get_count();
+    let read = read_file_bytes(&store, &namespace_id, "/docs/file-1.txt").expect("read file");
+    assert_eq!(read.bytes, b"file-1-bytes");
+    assert_eq!(store.content_blob_get_count(), 1);
 }
 
 #[test]
@@ -2862,6 +2979,66 @@ impl ObjectStore for ReplayReadGuardStore {
         range: Option<ByteRange>,
     ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
         self.reject_replay_read(key)?;
+        self.inner.get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix)
+    }
+}
+
+struct ContentBlobGetCountingStore {
+    inner: LocalFsStore,
+    content_blob_gets: AtomicUsize,
+}
+
+impl ContentBlobGetCountingStore {
+    fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("store"),
+            content_blob_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn content_blob_get_count(&self) -> usize {
+        self.content_blob_gets.load(Ordering::SeqCst)
+    }
+
+    fn reset_content_blob_get_count(&self) {
+        self.content_blob_gets.store(0, Ordering::SeqCst);
+    }
+
+    fn record_content_blob_get(&self, key: &str) {
+        if key.starts_with("content-stores/") && key.contains("/blobs/") {
+            self.content_blob_gets.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+impl ObjectStore for ContentBlobGetCountingStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.record_content_blob_get(key);
         self.inner.get(key, range)
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -593,7 +593,6 @@ impl Fs {
     ) -> Result<AuthoritativePathEntry> {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(loon_core::resolve_path_from_basis(
-            self.store(),
             basis.as_ref(),
             absolute_path,
         )?)
@@ -606,7 +605,6 @@ impl Fs {
     ) -> Result<Vec<AuthoritativePathEntry>> {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(loon_core::list_path_from_basis(
-            self.store(),
             basis.as_ref(),
             absolute_path,
         )?)

--- a/docs/specs/060-interfaces-and-clients.md
+++ b/docs/specs/060-interfaces-and-clients.md
@@ -180,10 +180,10 @@ The upload transport standardizes staged content publication, not one specific b
 The semantic rule is:
 
 - `PUT /content` stores the immutable whole-file object and records the staged `content_ref`;
-- `complete` succeeds only after the expected `content_ref` is durable and matches the staged upload; and
+- `complete` finalizes the upload session only when the expected `content_ref` exactly matches the service-computed staged ref; and
 - the returned `content_ref` is then safe to reference from a commit.
 
-Repeating `PUT /content` with the same bytes for the same upload id is idempotent. Repeating it with different bytes is a conflict. Completing an upload fails if no content was staged, if the expected `content_ref` differs from the staged one, or if the durable content validation rules from the write protocol fail.
+Repeating `PUT /content` with the same bytes for the same upload id is idempotent. Repeating it with different bytes is a conflict. Completing an upload fails if no content was staged or if the expected `content_ref` differs from the staged one. Generic metadata publication still applies the durable content validation rules from the write protocol before arbitrary `content_ref`s become visible.
 
 Representative begin-upload response:
 


### PR DESCRIPTION
This PR removes unnecessary content-blob reads on hot metadata paths. Upload completion now finalizes the staged ref without re-auditing the blob, stat/list derives size from metadata, and file reads validate with a single blob fetch.

Pretty good improvements from this change:

Workload | Previous run | Current run | Change
-- | -- | -- | --
broad_write | 394.76s | 406.18s | 2.9% slower
broad_read | 2.80s | 1.90s | 32.2% faster
metadata_mv_broad | 84.09s | 18.46s | 78.0% faster
busy_write | 404.63s | 395.73s | 2.2% faster
busy_read_list | 69.32s | 2.29s | 96.7% faster
metadata_mv_busy | 98.69s | 27.44s | 72.2% faster

