### PR TITLE
perf(maintenance): checkpoint by wal tail segment count

### DIFF
--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -36,6 +36,7 @@ pub struct NamespaceHeadSummary {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
     pub checkpoint_hint_seq: Option<ChangeSeq>,
+    pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
 
@@ -179,10 +180,20 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     let loaded_head = read_head_object(store, expected_namespace)
         .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
     let head = loaded_head.envelope.state;
+    let checkpoint_basis_seq = head.checkpoint_hint_seq.unwrap_or(ChangeSeq(0));
+    let wal_tail_segments = count_stored_wal_tail_segments(
+        store,
+        expected_namespace,
+        checkpoint_basis_seq,
+        head.seq,
+        head.visible_wal_tip.clone(),
+    )
+    .map_err(CoreError::Basis)?;
     Ok(NamespaceHeadSummary {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
         checkpoint_hint_seq: head.checkpoint_hint_seq,
+        wal_tail_segments,
         retention_floor_seq: head.retention_floor_seq,
     })
 }
@@ -264,8 +275,62 @@ fn load_stored_wal_tail<S: ObjectStore + ?Sized>(
     through_seq_inclusive: ChangeSeq,
     visible_wal_tip: Option<WalSegmentPointer>,
 ) -> Result<Vec<StoredWalObject>, BasisLoadError> {
+    let mut reversed = Vec::new();
+    walk_stored_wal_tail(
+        store,
+        expected_namespace,
+        from_seq_exclusive,
+        through_seq_inclusive,
+        visible_wal_tip,
+        |pointer, encoded_bytes| {
+            reversed.push(StoredWalObject {
+                object_key: pointer.object_key.clone(),
+                encoded_bytes,
+            });
+            Ok(())
+        },
+    )?;
+
+    reversed.reverse();
+    Ok(reversed)
+}
+
+fn count_stored_wal_tail_segments<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+    from_seq_exclusive: ChangeSeq,
+    through_seq_inclusive: ChangeSeq,
+    visible_wal_tip: Option<WalSegmentPointer>,
+) -> Result<u64, BasisLoadError> {
+    let mut count = 0u64;
+    walk_stored_wal_tail(
+        store,
+        expected_namespace,
+        from_seq_exclusive,
+        through_seq_inclusive,
+        visible_wal_tip,
+        |_pointer, _encoded_bytes| {
+            count = count.saturating_add(1);
+            Ok(())
+        },
+    )?;
+    Ok(count)
+}
+
+fn walk_stored_wal_tail<S, F>(
+    store: &S,
+    expected_namespace: &NamespaceId,
+    from_seq_exclusive: ChangeSeq,
+    through_seq_inclusive: ChangeSeq,
+    visible_wal_tip: Option<WalSegmentPointer>,
+    mut visit: F,
+) -> Result<(), BasisLoadError>
+where
+    S: ObjectStore + ?Sized,
+    F: FnMut(&WalSegmentPointer, Vec<u8>) -> Result<(), BasisLoadError>,
+{
     if through_seq_inclusive <= from_seq_exclusive {
-        return Ok(Vec::new());
+        return Ok(());
     }
 
     let prefix = format!("namespaces/{}/wal/", expected_namespace.as_str());
@@ -273,7 +338,6 @@ fn load_stored_wal_tail<S: ObjectStore + ?Sized>(
         prefix: prefix.clone(),
         seq: through_seq_inclusive,
     })?;
-    let mut reversed = Vec::new();
 
     loop {
         if pointer.end_seq <= from_seq_exclusive {
@@ -308,16 +372,12 @@ fn load_stored_wal_tail<S: ObjectStore + ?Sized>(
             ));
         }
         let prev = envelope.payload.prev_visible_segment.clone();
-        reversed.push(StoredWalObject {
-            object_key: pointer.object_key.clone(),
-            encoded_bytes,
-        });
+        visit(&pointer, encoded_bytes)?;
         let Some(prev) = prev else {
             break;
         };
         pointer = prev;
     }
 
-    reversed.reverse();
-    Ok(reversed)
+    Ok(())
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -30,7 +30,7 @@ pub use loon_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
 pub const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
-pub const DEFAULT_MAX_UNCHECKPOINTED_COMMITS: u64 = 1_000;
+pub const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
 
 pub type SharedObjectStore = Arc<dyn ObjectStore + Send + Sync>;
 pub type Result<T> = std::result::Result<T, RuntimeError>;
@@ -327,19 +327,19 @@ pub struct NamespaceStatus {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
     pub checkpoint_hint_seq: Option<ChangeSeq>,
-    pub uncheckpointed_commits: u64,
+    pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaintenanceTickOptions {
-    pub max_uncheckpointed_commits: u64,
+    pub max_wal_tail_segments: u64,
 }
 
 impl Default for MaintenanceTickOptions {
     fn default() -> Self {
         Self {
-            max_uncheckpointed_commits: DEFAULT_MAX_UNCHECKPOINTED_COMMITS,
+            max_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
         }
     }
 }
@@ -515,15 +515,11 @@ impl Fs {
 
     pub fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
         let summary = loon_core::load_namespace_head_summary(self.store(), namespace_id)?;
-        let checkpoint_seq = summary
-            .checkpoint_hint_seq
-            .map(|seq| seq.0)
-            .unwrap_or_default();
         Ok(NamespaceStatus {
             namespace_id: summary.namespace_id,
             head_seq: summary.head_seq,
             checkpoint_hint_seq: summary.checkpoint_hint_seq,
-            uncheckpointed_commits: summary.head_seq.0.saturating_sub(checkpoint_seq),
+            wal_tail_segments: summary.wal_tail_segments,
             retention_floor_seq: summary.retention_floor_seq,
         })
     }
@@ -533,15 +529,15 @@ impl Fs {
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> Result<MaintenanceTickResult> {
-        if options.max_uncheckpointed_commits == 0 {
+        if options.max_wal_tail_segments == 0 {
             return Err(RuntimeError::Config(
-                "max_uncheckpointed_commits must be greater than zero".to_owned(),
+                "max_wal_tail_segments must be greater than zero".to_owned(),
             ));
         }
 
         let status_before = self.namespace_status(namespace_id)?;
         let observed_head_seq = status_before.head_seq;
-        if status_before.uncheckpointed_commits < options.max_uncheckpointed_commits {
+        if status_before.wal_tail_segments < options.max_wal_tail_segments {
             return Ok(MaintenanceTickResult {
                 namespace_id: namespace_id.clone(),
                 status_before,

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -969,7 +969,7 @@ fn explicit_commit_appears_in_change_feed() {
 }
 
 #[test]
-fn namespace_status_reports_checkpoint_lag_from_head() {
+fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "status-test");
     let namespace_id = namespace();
@@ -982,7 +982,7 @@ fn namespace_status_reports_checkpoint_lag_from_head() {
     assert_eq!(status.namespace_id, namespace_id);
     assert_eq!(status.head_seq, ChangeSeq(0));
     assert_eq!(status.checkpoint_hint_seq, None);
-    assert_eq!(status.uncheckpointed_commits, 0);
+    assert_eq!(status.wal_tail_segments, 0);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
 
     fs.put_file_bytes(
@@ -998,7 +998,7 @@ fn namespace_status_reports_checkpoint_lag_from_head() {
         .expect("status after commit");
     assert_eq!(status.head_seq, ChangeSeq(1));
     assert_eq!(status.checkpoint_hint_seq, None);
-    assert_eq!(status.uncheckpointed_commits, 1);
+    assert_eq!(status.wal_tail_segments, 1);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
 }
 
@@ -1065,17 +1065,17 @@ fn maintenance_tick_below_threshold_is_not_needed() {
         .maintenance_tick_namespace(
             &namespace_id,
             MaintenanceTickOptions {
-                max_uncheckpointed_commits: 2,
+                max_wal_tail_segments: 2,
             },
         )
         .expect("maintenance tick");
     assert_eq!(tick.namespace_id, namespace_id);
-    assert_eq!(tick.status_before.uncheckpointed_commits, 1);
+    assert_eq!(tick.status_before.wal_tail_segments, 1);
     assert_eq!(tick.outcome, MaintenanceTickOutcome::NotNeeded);
 }
 
 #[test]
-fn maintenance_tick_at_threshold_publishes_checkpoint() {
+fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-publish-test");
     let namespace_id = namespace();
@@ -1094,7 +1094,7 @@ fn maintenance_tick_at_threshold_publishes_checkpoint() {
         .maintenance_tick_namespace(
             &namespace_id,
             MaintenanceTickOptions {
-                max_uncheckpointed_commits: 1,
+                max_wal_tail_segments: 1,
             },
         )
         .expect("maintenance tick");
@@ -1110,7 +1110,91 @@ fn maintenance_tick_at_threshold_publishes_checkpoint() {
         .namespace_status(&namespace_id)
         .expect("status after checkpoint");
     assert_eq!(status.checkpoint_hint_seq, Some(ChangeSeq(1)));
-    assert_eq!(status.uncheckpointed_commits, 0);
+    assert_eq!(status.wal_tail_segments, 0);
+}
+
+#[test]
+fn maintenance_tick_counts_segments_not_commits() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "tick-segment-count-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let first_batch = fs.commit_operations_batch(
+        &namespace_id,
+        vec![
+            CommitRequest {
+                commit_id: CommitId::parse("create-a").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "a".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+            CommitRequest {
+                commit_id: CommitId::parse("create-b").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "b".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+        ],
+    );
+    assert!(first_batch.iter().all(Result::is_ok));
+
+    let status = fs
+        .namespace_status(&namespace_id)
+        .expect("status after first batch");
+    assert_eq!(status.head_seq, ChangeSeq(2));
+    assert_eq!(status.wal_tail_segments, 1);
+
+    let tick = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_wal_tail_segments: 2,
+            },
+        )
+        .expect("maintenance tick");
+    assert_eq!(tick.outcome, MaintenanceTickOutcome::NotNeeded);
+
+    fs.commit_operations(
+        &namespace_id,
+        CommitRequest {
+            commit_id: CommitId::parse("create-c").expect("valid commit id"),
+            preconditions: Vec::new(),
+            ops: vec![CommitOp::CreateDir {
+                parent_inode: InodeId(1),
+                display_name: "c".to_owned(),
+            }],
+            message: None,
+            annotations: None,
+        },
+    )
+    .expect("second segment commit");
+
+    let tick = fs
+        .maintenance_tick_namespace(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_wal_tail_segments: 2,
+            },
+        )
+        .expect("maintenance tick at segment threshold");
+    assert_eq!(tick.status_before.head_seq, ChangeSeq(3));
+    assert_eq!(tick.status_before.wal_tail_segments, 2);
+    assert_eq!(
+        tick.outcome,
+        MaintenanceTickOutcome::CheckpointPublished {
+            checkpoint_seq: ChangeSeq(3)
+        }
+    );
 }
 
 #[test]
@@ -1125,12 +1209,12 @@ fn maintenance_tick_rejects_zero_threshold() {
         .maintenance_tick_namespace(
             &namespace_id,
             MaintenanceTickOptions {
-                max_uncheckpointed_commits: 0,
+                max_wal_tail_segments: 0,
             },
         )
         .expect_err("zero threshold should fail");
     match error {
-        RuntimeError::Config(message) => assert!(message.contains("max_uncheckpointed_commits")),
+        RuntimeError::Config(message) => assert!(message.contains("max_wal_tail_segments")),
         other => panic!("expected config error, got {other:?}"),
     }
 }
@@ -1164,7 +1248,7 @@ fn maintenance_tick_treats_checkpoint_hint_cas_loss_as_benign_race() {
         .maintenance_tick_namespace(
             &namespace_id,
             MaintenanceTickOptions {
-                max_uncheckpointed_commits: 1,
+                max_wal_tail_segments: 1,
             },
         )
         .expect("maintenance tick should not fail on checkpoint hint race");
@@ -1179,7 +1263,7 @@ fn maintenance_tick_treats_checkpoint_hint_cas_loss_as_benign_race() {
         .namespace_status(&namespace_id)
         .expect("status after lost race");
     assert_eq!(status.checkpoint_hint_seq, None);
-    assert_eq!(status.uncheckpointed_commits, 1);
+    assert_eq!(status.wal_tail_segments, 1);
 }
 
 #[test]


### PR DESCRIPTION
Switches runtime maintenance from commit-count (was 1000) to visible WAL-tail segment count. The default threshold is now 32 WAL segments, and namespace status reports `wal_tail_segments` so checkpointing is driven by replay read amplification rather than logical commit count. The benchmarks revealed that WAL segment was driving latency vs. the number of commits (1000 commits could be 1 GET or 1,000 GETs). 