### PR TITLE
refactor(api): make public identity types strict

### DIFF
--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
 use std::fmt;
 use thiserror::Error;
 use uuid::Uuid;
@@ -7,15 +8,15 @@ const SERVER_GENERATED_ID_BODY_LEN: usize = 32;
 
 /// Unique identifier for a namespace (a logical sync boundary).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct NamespaceId(pub String);
+pub struct NamespaceId(String);
 
 /// Unique identifier for an immutable content store.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ContentStoreId(pub String);
+pub struct ContentStoreId(String);
 
 /// Client-supplied stable identifier for one logical commit.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct CommitId(pub String);
+pub struct CommitId(String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid namespace_id {value:?}: {reason}")]
@@ -69,12 +70,6 @@ impl GeneratedIdValidationError {
 }
 
 impl NamespaceId {
-    /// Constructs a namespace id without validation. Use [`NamespaceId::parse`]
-    /// for user-supplied or durable-boundary input.
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
     pub fn parse(value: impl AsRef<str>) -> Result<Self, NamespaceIdValidationError> {
         let value = value.as_ref();
         validate_namespace_id(value)?;
@@ -93,12 +88,6 @@ impl NamespaceId {
 }
 
 impl CommitId {
-    /// Constructs a commit id without validation. Use [`CommitId::parse`]
-    /// for user-supplied or durable-boundary input.
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
     pub fn parse(value: impl AsRef<str>) -> Result<Self, CommitIdValidationError> {
         let value = value.as_ref();
         validate_commit_id(value)?;
@@ -235,10 +224,6 @@ fn generated_id_error(value: &str, reason: String) -> GeneratedIdValidationError
 }
 
 impl ContentStoreId {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
     pub fn generate() -> Self {
         Self(generated_id("cs"))
     }
@@ -260,39 +245,87 @@ impl ContentStoreId {
     }
 }
 
-impl From<&str> for NamespaceId {
-    fn from(value: &str) -> Self {
-        Self::new(value)
+impl TryFrom<&str> for NamespaceId {
+    type Error = NamespaceIdValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
     }
 }
 
-impl From<String> for NamespaceId {
-    fn from(value: String) -> Self {
-        Self::new(value)
+impl TryFrom<String> for NamespaceId {
+    type Error = NamespaceIdValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_new(value)
     }
 }
 
-impl From<&str> for ContentStoreId {
-    fn from(value: &str) -> Self {
-        Self::new(value)
+impl TryFrom<&str> for ContentStoreId {
+    type Error = GeneratedIdValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
     }
 }
 
-impl From<String> for ContentStoreId {
-    fn from(value: String) -> Self {
-        Self::new(value)
+impl TryFrom<String> for ContentStoreId {
+    type Error = GeneratedIdValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_new(value)
     }
 }
 
-impl From<&str> for CommitId {
-    fn from(value: &str) -> Self {
-        Self::new(value)
+impl TryFrom<&str> for CommitId {
+    type Error = CommitIdValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
     }
 }
 
-impl From<String> for CommitId {
-    fn from(value: String) -> Self {
-        Self::new(value)
+impl TryFrom<String> for CommitId {
+    type Error = CommitIdValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl AsRef<str> for NamespaceId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for ContentStoreId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for CommitId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for NamespaceId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for ContentStoreId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for CommitId {
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 
@@ -328,7 +361,8 @@ impl<'de> Deserialize<'de> for NamespaceId {
     where
         D: Deserializer<'de>,
     {
-        Ok(Self(String::deserialize(deserializer)?))
+        let value = String::deserialize(deserializer)?;
+        NamespaceId::try_new(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -448,19 +482,66 @@ mod tests {
     }
 
     #[test]
-    fn namespace_id_unchecked_construction_remains_available() {
-        let namespace_id = NamespaceId::from("invalid/name");
-
-        assert_eq!(namespace_id.as_str(), "invalid/name");
-    }
-
-    #[test]
     fn commit_id_parse_uses_same_allowed_grammar() {
         let parsed = CommitId::parse("c_demo-1").expect("valid commit_id");
 
         assert_eq!(parsed.as_str(), "c_demo-1");
         assert!(CommitId::parse("c/demo").is_err());
         assert!(CommitId::parse("C_demo").is_err());
+    }
+
+    #[test]
+    fn identity_try_from_validates_values() {
+        assert_eq!(
+            NamespaceId::try_from("demo")
+                .expect("valid namespace id")
+                .as_str(),
+            "demo"
+        );
+        assert_eq!(
+            CommitId::try_from("commit-1")
+                .expect("valid commit id")
+                .as_str(),
+            "commit-1"
+        );
+        assert_eq!(
+            ContentStoreId::try_from("cs_00000000000000000000000000000001")
+                .expect("valid content store id")
+                .as_str(),
+            "cs_00000000000000000000000000000001"
+        );
+
+        assert!(NamespaceId::try_from("invalid/name").is_err());
+        assert!(CommitId::try_from("invalid/name").is_err());
+        assert!(ContentStoreId::try_from("cs_0000000000000000000000000000000g").is_err());
+    }
+
+    #[test]
+    fn identity_deserialize_validates_values() {
+        let namespace_id: NamespaceId =
+            serde_json::from_str(r#""demo""#).expect("valid namespace id json");
+        assert_eq!(namespace_id.as_str(), "demo");
+        let commit_id: CommitId =
+            serde_json::from_str(r#""commit-1""#).expect("valid commit id json");
+        assert_eq!(commit_id.as_str(), "commit-1");
+        let content_store_id: ContentStoreId =
+            serde_json::from_str(r#""cs_00000000000000000000000000000001""#)
+                .expect("valid content store id json");
+        assert_eq!(
+            content_store_id.as_str(),
+            "cs_00000000000000000000000000000001"
+        );
+
+        let namespace_error = serde_json::from_str::<NamespaceId>(r#""invalid/name""#)
+            .expect_err("invalid namespace id json");
+        assert!(namespace_error.to_string().contains("namespace_id"));
+        let commit_error = serde_json::from_str::<CommitId>(r#""invalid/name""#)
+            .expect_err("invalid commit id json");
+        assert!(commit_error.to_string().contains("commit_id"));
+        let content_store_error =
+            serde_json::from_str::<ContentStoreId>(r#""cs_0000000000000000000000000000000g""#)
+                .expect_err("invalid content store id json");
+        assert!(content_store_error.to_string().contains("generated id"));
     }
 
     #[test]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -568,7 +568,10 @@ mod tests {
         let changes = target
             .backend
             .fs
-            .list_changes_after(&NamespaceId::from("demo"), ChangeSeq(0))
+            .list_changes_after(
+                &NamespaceId::parse("demo").expect("valid namespace id"),
+                ChangeSeq(0),
+            )
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
         assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());

--- a/crates/loon-cli/src/render.rs
+++ b/crates/loon-cli/src/render.rs
@@ -218,7 +218,7 @@ mod tests {
     use crate::error::CliError;
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
-    use loon_api::NamespaceSummary;
+    use loon_api::{NamespaceId, NamespaceSummary};
 
     #[test]
     fn human_profile_list_snapshot() {
@@ -254,10 +254,10 @@ mod tests {
             data: CommandData::NamespaceList {
                 namespaces: vec![
                     NamespaceSummary {
-                        namespace_id: "alpha".into(),
+                        namespace_id: NamespaceId::parse("alpha").expect("valid namespace id"),
                     },
                     NamespaceSummary {
-                        namespace_id: "prod".into(),
+                        namespace_id: NamespaceId::parse("prod").expect("valid namespace id"),
                     },
                 ],
             },

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -1154,7 +1154,7 @@ mod tests {
     fn checkpoint_round_trip_uses_checkpoint_basis_for_mixed_namespace() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         write_file_bytes(
@@ -1202,7 +1202,7 @@ mod tests {
     fn checkpoint_round_trip_preserves_direntry_unbind_rows() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         write_file_bytes(
@@ -1243,7 +1243,7 @@ mod tests {
     fn checkpoint_round_trip_supports_empty_namespace() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1256,7 +1256,7 @@ mod tests {
     fn strict_checkpoint_consumption_fails_when_manifest_is_corrupted() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         write_file_bytes(
@@ -1284,7 +1284,7 @@ mod tests {
     #[test]
     fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         let manifest_key = checkpoint_manifest(namespace_id.as_str(), 1);
         let store = ConflictOnManifestCreateStore::new(
@@ -1318,7 +1318,7 @@ mod tests {
     fn retention_advancement_requires_published_checkpoint_and_updates_floor_only() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1360,7 +1360,7 @@ mod tests {
     fn checkpoint_materialization_uses_written_segments() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         write_file_bytes(
@@ -1398,7 +1398,7 @@ mod tests {
     fn older_checkpoint_can_publish_after_head_advances() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         write_file_bytes(
@@ -1463,7 +1463,7 @@ mod tests {
     #[test]
     fn checkpoint_hint_cas_retry_exhaustion_is_stale_head() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         let store = HeadCasFailureStore::new(
             LocalFsStore::new(temp_dir.path()).expect("store"),

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -133,7 +133,7 @@ mod tests {
     fn api_adapter_maps_all_v0_ops_and_preconditions() {
         let content_ref = ContentRef::whole_file_v0(b"hello");
         let request = api_v0::CommitRequest {
-            commit_id: CommitId::from("commit-a"),
+            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             preconditions: vec![
                 ApiCommitPrecondition::InodeRevisionIs {
                     inode_id: InodeId(2),
@@ -196,7 +196,7 @@ mod tests {
 
         let core = commit_request_from_v0(
             CommitExecutionContext {
-                namespace_id: NamespaceId::from("demo"),
+                namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
                 writer_id: "writer-a".to_owned(),
                 writer_fence_token: FenceToken(9),
             },

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -94,10 +94,10 @@ mod tests {
 
     #[test]
     fn durable_adapter_builds_expected_wal_payload() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let request = CommitRequest {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from("c_wal_payload"),
+            commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::CreateDir {
@@ -110,7 +110,7 @@ mod tests {
         };
         let plan = CommitPlan {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from("c_wal_payload"),
+            commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -99,8 +99,8 @@ mod tests {
 
     fn core_request(writer_fence_token: FenceToken) -> CommitRequest {
         CommitRequest {
-            namespace_id: NamespaceId::from("demo"),
-            commit_id: CommitId::from("commit-a"),
+            namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
+            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token,
             ops: vec![CommitOp::CreateDir {
@@ -134,7 +134,7 @@ mod tests {
         let different_writer =
             semantic_commit_fingerprint(&different_writer).expect("different writer fingerprint");
         let mut different_commit_id = core_request(FenceToken(1));
-        different_commit_id.commit_id = CommitId::from("commit-b");
+        different_commit_id.commit_id = CommitId::parse("commit-b").expect("valid commit id");
         let different_commit_id = semantic_commit_fingerprint(&different_commit_id)
             .expect("different commit id fingerprint");
 
@@ -160,9 +160,9 @@ mod tests {
 
     #[test]
     fn v0_semantic_fingerprint_matches_core_semantic_fingerprint() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let api_request = api_v0::CommitRequest {
-            commit_id: CommitId::from("commit-a"),
+            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![api_v0::CommitOp::CreateDir {
                 parent_inode: InodeId(1),

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -459,8 +459,8 @@ mod tests {
 
     fn request() -> CommitRequest {
         CommitRequest {
-            namespace_id: NamespaceId::from("demo"),
-            commit_id: CommitId::from("commit-a"),
+            namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
+            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::CreateDir {
@@ -475,8 +475,8 @@ mod tests {
 
     fn plan() -> CommitPlan {
         CommitPlan {
-            namespace_id: NamespaceId::from("demo"),
-            commit_id: CommitId::from("commit-a"),
+            namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
+            commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn prepared_commit_rejects_namespace_mismatch() {
         let mut plan = plan();
-        plan.namespace_id = NamespaceId::from("other");
+        plan.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
 
         assert!(matches!(
             PreparedCommit::new(request(), plan),
@@ -503,7 +503,7 @@ mod tests {
     #[test]
     fn prepared_commit_rejects_commit_id_mismatch() {
         let mut plan = plan();
-        plan.commit_id = CommitId::from("commit-b");
+        plan.commit_id = CommitId::parse("commit-b").expect("valid commit id");
 
         assert!(matches!(
             PreparedCommit::new(request(), plan),

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -144,7 +144,7 @@ mod tests {
     fn plan(namespace_id: NamespaceId, assigned_seq: ChangeSeq) -> CommitPlan {
         CommitPlan {
             namespace_id,
-            commit_id: CommitId::from("publish-plan"),
+            commit_id: CommitId::parse("publish-plan").expect("valid commit id"),
             apply_after_seq: ChangeSeq(assigned_seq.0.saturating_sub(1)),
             assigned_seq,
             allocated_inode_ids: Vec::new(),
@@ -172,7 +172,8 @@ mod tests {
                     namespace_id: namespace_id.clone(),
                     seq,
                     apply_after_seq: ChangeSeq(seq.0.saturating_sub(1)),
-                    commit_id: CommitId::from(format!("publish-record-{index}")),
+                    commit_id: CommitId::try_new(format!("publish-record-{index}"))
+                        .expect("valid commit id"),
                     semantic_commit_fingerprint_sha256: format!("fingerprint-{index}"),
                     writer_id: "writer-a".to_owned(),
                     writer_fence_token: FenceToken(1),
@@ -211,7 +212,7 @@ mod tests {
 
     #[test]
     fn head_publish_accepts_segment_connecting_current_head_to_plan() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(9), 2);
@@ -228,7 +229,7 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_segment_base_after_current_head() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(8), ChangeSeq(9), ChangeSeq(9), 1);
@@ -244,7 +245,7 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_segment_base_before_current_head() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(6), ChangeSeq(7), ChangeSeq(9), 3);
@@ -260,7 +261,7 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_empty_segment() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(9), 0);
@@ -273,7 +274,7 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_segment_start_that_skips_current_head() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(9), ChangeSeq(9), 1);
@@ -289,7 +290,7 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_segment_end_that_differs_from_plan() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let current_head = head(namespace_id.clone(), ChangeSeq(7));
         let plan = plan(namespace_id.clone(), ChangeSeq(9));
         let wal = wal_segment(namespace_id, ChangeSeq(7), ChangeSeq(8), ChangeSeq(10), 3);
@@ -305,10 +306,16 @@ mod tests {
 
     #[test]
     fn head_publish_rejects_segment_namespace_mismatch() {
-        let current_head = head(NamespaceId::from("demo"), ChangeSeq(7));
-        let plan = plan(NamespaceId::from("demo"), ChangeSeq(9));
+        let current_head = head(
+            NamespaceId::parse("demo").expect("valid namespace id"),
+            ChangeSeq(7),
+        );
+        let plan = plan(
+            NamespaceId::parse("demo").expect("valid namespace id"),
+            ChangeSeq(9),
+        );
         let wal = wal_segment(
-            NamespaceId::from("other"),
+            NamespaceId::parse("other").expect("valid namespace id"),
             ChangeSeq(7),
             ChangeSeq(8),
             ChangeSeq(9),
@@ -318,7 +325,7 @@ mod tests {
         assert!(matches!(
             prepare_commit_head_publish(&current_head, &plan, &wal, "test-writer"),
             Err(CommitHeadPublishError::WalSegmentNamespaceMismatch { head, wal })
-                if head == NamespaceId::from("demo") && wal == NamespaceId::from("other")
+                if head == NamespaceId::parse("demo").expect("valid namespace id") && wal == NamespaceId::parse("other").expect("valid namespace id")
         ));
     }
 }

--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -327,7 +327,8 @@ mod tests {
     fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let content_store_id = ContentStoreId::from("cs_00000000000000000000000000000001");
+        let content_store_id = ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id");
         (temp_dir, store, content_store_id)
     }
 

--- a/crates/loon-core/src/lease.rs
+++ b/crates/loon-core/src/lease.rs
@@ -355,7 +355,7 @@ mod tests {
     }
 
     fn namespace_id() -> NamespaceId {
-        NamespaceId::from("demo")
+        NamespaceId::parse("demo").expect("valid namespace id")
     }
 
     fn context(writer_id: &str, now_ms: u64) -> MutationContext {
@@ -369,7 +369,7 @@ mod tests {
 
     fn create_dir_request(commit_id: &str, display_name: &str) -> ApiCommitRequest {
         ApiCommitRequest {
-            commit_id: CommitId::from(commit_id),
+            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateDir {
                 parent_inode: InodeId(1),

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn find_commit_receipt_returns_latest_matching_receipt() {
-        let commit_id = CommitId::from("same-commit");
+        let commit_id = CommitId::parse("same-commit").expect("valid commit id");
         let metadata_state = MetadataState::from_rows(
             Vec::new(),
             Vec::new(),
@@ -862,7 +862,7 @@ mod tests {
                     results: Vec::new(),
                 },
                 CommitReceiptRecord {
-                    commit_id: CommitId::from("other-commit"),
+                    commit_id: CommitId::parse("other-commit").expect("valid commit id"),
                     semantic_commit_fingerprint_sha256: "other".to_owned(),
                     committed_seq: ChangeSeq(3),
                     results: Vec::new(),

--- a/crates/loon-core/src/path/planner.rs
+++ b/crates/loon-core/src/path/planner.rs
@@ -717,7 +717,7 @@ mod tests {
     ) {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let context = test_context();
         bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
         (temp_dir, store, namespace_id, context)
@@ -741,7 +741,7 @@ mod tests {
             &store,
             &namespace_id,
             &PathMutationIntent::CreateDir {
-                commit_id: CommitId::from("mkdir-docs"),
+                commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
                 absolute_path: "/docs".to_owned(),
             },
         );
@@ -774,7 +774,7 @@ mod tests {
             &store,
             &namespace_id,
             &PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-nested"),
+                commit_id: CommitId::parse("put-nested").expect("valid commit id"),
                 absolute_path: "/docs/nested/a.txt".to_owned(),
                 content_ref: staged.content_ref.clone(),
                 behavior: PutFileBehavior::CreateOnly,
@@ -821,7 +821,7 @@ mod tests {
             &store,
             &namespace_id,
             &PathMutationIntent::MovePath {
-                commit_id: CommitId::from("move-file"),
+                commit_id: CommitId::parse("move-file").expect("valid commit id"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/b.txt".to_owned(),
                 mode: RenameMode::NoReplace,
@@ -869,7 +869,7 @@ mod tests {
             &store,
             &namespace_id,
             &PathMutationIntent::CopyFilePath {
-                commit_id: CommitId::from("copy-file"),
+                commit_id: CommitId::parse("copy-file").expect("valid commit id"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/copy.txt".to_owned(),
             },
@@ -927,7 +927,7 @@ mod tests {
             .plan_against_state(
                 &namespace_id,
                 &PathMutationIntent::PutFile {
-                    commit_id: CommitId::from("put-under-dead"),
+                    commit_id: CommitId::parse("put-under-dead").expect("valid commit id"),
                     absolute_path: "/dead/new.txt".to_owned(),
                     content_ref: staged.content_ref,
                     behavior: PutFileBehavior::CreateOnly,

--- a/crates/loon-core/src/services/namespace_lifecycle.rs
+++ b/crates/loon-core/src/services/namespace_lifecycle.rs
@@ -353,7 +353,7 @@ pub fn list_namespaces<S: ObjectStore + ?Sized>(
         if leaf != "descriptor.json" {
             continue;
         }
-        let namespace_id = NamespaceId::from(namespace.to_owned());
+        let namespace_id = NamespaceId::parse(namespace)?;
         load_namespace_descriptor(store, &namespace_id)?;
         names.insert(namespace_id);
     }

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -409,10 +409,10 @@ mod tests {
 
     #[test]
     fn build_wal_record_payload_matches_segment_record_payload() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let request = CommitRequest {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from("c_wal_payload"),
+            commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::CreateDir {
@@ -425,7 +425,7 @@ mod tests {
         };
         let plan = CommitPlan {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from("c_wal_payload"),
+            commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
             allocated_inode_ids: vec![InodeId(2)],
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn prepared_wal_segments_use_unique_segment_ids_and_object_keys() {
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let record = materialized_create_dir(
             &namespace_id,
             "c_wal_unique",
@@ -492,7 +492,7 @@ mod tests {
     ) -> MaterializedCommit {
         let request = CommitRequest {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from(commit_id),
+            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::CreateDir {
@@ -505,7 +505,7 @@ mod tests {
         };
         let plan = CommitPlan {
             namespace_id: namespace_id.clone(),
-            commit_id: CommitId::from(commit_id),
+            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
             apply_after_seq,
             assigned_seq,
             allocated_inode_ids: vec![InodeId(2)],

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -126,7 +126,7 @@ fn stale_revision_precondition_is_rejected() {
     let context = validation_context(metadata_state, ChangeSeq(3), InodeId(4));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        commit_id: CommitId::from("stale-revision"),
+        commit_id: CommitId::parse("stale-revision").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::ReplaceFile {
@@ -168,7 +168,7 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
     let create_error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("create-under-tombstone"),
+            commit_id: CommitId::parse("create-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::CreateFile {
@@ -194,7 +194,7 @@ fn create_and_replace_under_ancestor_tombstone_are_rejected() {
     let replace_error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("replace-under-tombstone"),
+            commit_id: CommitId::parse("replace-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::ReplaceFile {
@@ -225,7 +225,7 @@ fn restore_revision_validation_rejects_missing_inode() {
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        commit_id: CommitId::from("restore-missing-inode"),
+        commit_id: CommitId::parse("restore-missing-inode").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
@@ -254,7 +254,7 @@ fn restore_revision_validation_rejects_non_file_target() {
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        commit_id: CommitId::from("restore-non-file"),
+        commit_id: CommitId::parse("restore-non-file").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
@@ -295,7 +295,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
     let stale_base = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("restore-stale-base"),
+            commit_id: CommitId::parse("restore-stale-base").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
@@ -322,7 +322,7 @@ fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
     let missing_source = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("restore-missing-source"),
+            commit_id: CommitId::parse("restore-missing-source").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
@@ -363,7 +363,7 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
     let plan = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("restore-same-request-source"),
+            commit_id: CommitId::parse("restore-same-request-source").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![
@@ -409,7 +409,8 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
     let plan = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("restore-after-restore-same-request"),
+            commit_id: CommitId::parse("restore-after-restore-same-request")
+                .expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![
@@ -458,7 +459,7 @@ fn restore_revision_under_tombstoned_ancestor_is_rejected() {
     let error = build_commit_plan(
         &CommitRequest {
             namespace_id: namespace_id(),
-            commit_id: CommitId::from("restore-under-tombstone"),
+            commit_id: CommitId::parse("restore-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_fence_token: FenceToken(1),
             ops: vec![CommitOp::RestoreRevision {
@@ -514,7 +515,7 @@ fn restore_revision_overflow_is_rejected() {
     let context = validation_context(metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
-        commit_id: CommitId::from("restore-overflow"),
+        commit_id: CommitId::parse("restore-overflow").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_fence_token: FenceToken(1),
         ops: vec![CommitOp::RestoreRevision {
@@ -603,8 +604,13 @@ fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].namespace_id.as_str(), "demo");
 
-    let partial_error = bootstrap_namespace(&store, &NamespaceId::from("partial"), &context, false)
-        .expect_err("partial namespace should be rejected");
+    let partial_error = bootstrap_namespace(
+        &store,
+        &NamespaceId::parse("partial").expect("valid namespace id"),
+        &context,
+        false,
+    )
+    .expect_err("partial namespace should be rejected");
     assert!(matches!(
         partial_error,
         loon_core::BootstrapNamespaceError::NamespacePartiallyInitialized { .. }
@@ -642,70 +648,10 @@ fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
 }
 
 #[test]
-fn public_namespace_operations_reject_invalid_namespace_id_before_key_construction() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    let invalid_namespace = NamespaceId::from("bad/name");
-
-    let bootstrap_error = bootstrap_namespace(&store, &invalid_namespace, &context, false)
-        .expect_err("invalid namespace_id");
-    match bootstrap_error {
-        loon_core::BootstrapNamespaceError::InvalidNamespaceId(error) => {
-            assert_eq!(error.value(), "bad/name");
-        }
-        other => panic!("expected invalid namespace_id, got {other:?}"),
-    }
-    assert_eq!(
-        store
-            .list_prefix("namespaces/")
-            .expect("list namespace objects"),
-        Vec::<String>::new()
-    );
-
-    let read_error = resolve_path(&store, &invalid_namespace, "/")
-        .expect_err("invalid namespace_id should be rejected before lookup");
-    assert_eq!(read_error.kind(), CoreErrorKind::InvalidNamespaceId);
-
-    let begin_upload_error = begin_upload(&store, &invalid_namespace, &context)
-        .expect_err("invalid namespace_id should be rejected before upload session creation");
-    assert_eq!(begin_upload_error.kind(), CoreErrorKind::InvalidNamespaceId);
-
-    let delete_error = delete_path_non_recursive(
-        &store,
-        &invalid_namespace,
-        "/missing.txt",
-        &context,
-        Some("invalid-delete"),
-    )
-    .expect_err("invalid namespace_id should be rejected before retry lookup");
-    assert_eq!(delete_error.kind(), CoreErrorKind::InvalidNamespaceId);
-
-    let complete_error = complete_upload(
-        &store,
-        &invalid_namespace,
-        "upl_invalid",
-        &CompleteUploadRequest {
-            content_ref: ContentRef::whole_file_v0(b""),
-        },
-        &context,
-    )
-    .expect_err("invalid namespace_id should be rejected before upload key lookup");
-    assert_eq!(complete_error.kind(), CoreErrorKind::InvalidNamespaceId);
-
-    assert_eq!(
-        store
-            .list_prefix("namespaces/")
-            .expect("list namespace objects"),
-        Vec::<String>::new()
-    );
-}
-
-#[test]
 fn begin_upload_rejects_missing_and_partial_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     let missing_error =
@@ -726,7 +672,7 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
 fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
     let temp_dir = tempdir().expect("tempdir");
     let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     bootstrap_namespace(&setup_store, &namespace_id, &context, false).expect("bootstrap");
@@ -762,7 +708,7 @@ fn begin_upload_does_not_read_checkpoint_or_wal_replay_objects() {
 fn complete_upload_does_not_get_content_blob_after_staging() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
@@ -829,7 +775,7 @@ fn complete_upload_does_not_get_content_blob_after_staging() {
 fn path_put_file_validates_cold_content_once() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
@@ -841,7 +787,7 @@ fn path_put_file_validates_cold_content_once() {
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-cold-content"),
+                commit_id: CommitId::parse("put-cold-content").expect("valid commit id"),
                 absolute_path: "/docs/hello.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -858,7 +804,7 @@ fn path_put_file_validates_cold_content_once() {
 fn path_planning_does_not_validate_content() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
@@ -869,7 +815,7 @@ fn path_planning_does_not_validate_content() {
         .plan_path_intent(
             &namespace_id,
             &PathMutationIntent::PutFile {
-                commit_id: CommitId::from("plan-put-content"),
+                commit_id: CommitId::parse("plan-put-content").expect("valid commit id"),
                 absolute_path: "/docs/planned.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -877,7 +823,10 @@ fn path_planning_does_not_validate_content() {
         )
         .expect("plan path intent");
 
-    assert_eq!(planned.commit_id, CommitId::from("plan-put-content"));
+    assert_eq!(
+        planned.commit_id,
+        CommitId::parse("plan-put-content").expect("valid commit id")
+    );
     assert_eq!(store.content_blob_get_count(), 0);
 }
 
@@ -885,7 +834,7 @@ fn path_planning_does_not_validate_content() {
 fn path_batch_validates_repeated_content_ref_once() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
@@ -897,13 +846,13 @@ fn path_batch_validates_repeated_content_ref_once() {
         &namespace_id,
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-shared-a"),
+                commit_id: CommitId::parse("put-shared-a").expect("valid commit id"),
                 absolute_path: "/docs/a.txt".to_owned(),
                 content_ref: content.content_ref.clone(),
                 behavior: PutFileBehavior::CreateOnly,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-shared-b"),
+                commit_id: CommitId::parse("put-shared-b").expect("valid commit id"),
                 absolute_path: "/docs/b.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -967,42 +916,10 @@ fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
 }
 
 #[test]
-fn commit_operations_reject_invalid_commit_id_before_wal_key_construction() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
-
-    let error = commit_operations(
-        &store,
-        &namespace_id,
-        ApiCommitRequest {
-            commit_id: CommitId::from("bad/commit"),
-            preconditions: Vec::new(),
-            ops: vec![ApiCommitOp::CreateDir {
-                parent_inode: InodeId(1),
-                display_name: "docs".to_owned(),
-            }],
-            message: None,
-            annotations: None,
-        },
-        &context,
-    )
-    .expect_err("invalid commit_id should be rejected");
-
-    assert_eq!(error.kind(), CoreErrorKind::InvalidCommitId);
-    assert_eq!(
-        store.list_prefix("namespaces/demo/wal/").expect("list wal"),
-        Vec::<String>::new()
-    );
-}
-
-#[test]
 fn upload_content_rejects_invalid_upload_id_before_key_construction() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1029,7 +946,7 @@ fn upload_content_rejects_invalid_upload_id_before_key_construction() {
 fn batch_commit_writes_one_segment_and_expands_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1038,7 +955,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                commit_id: CommitId::from("req-batch-a"),
+                commit_id: CommitId::parse("req-batch-a").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1048,7 +965,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
                 annotations: None,
             },
             ApiCommitRequest {
-                commit_id: CommitId::from("req-batch-b"),
+                commit_id: CommitId::parse("req-batch-b").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1098,8 +1015,14 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 2);
-    assert_eq!(changes.changes[0].commit_id, CommitId::from("req-batch-a"));
-    assert_eq!(changes.changes[1].commit_id, CommitId::from("req-batch-b"));
+    assert_eq!(
+        changes.changes[0].commit_id,
+        CommitId::parse("req-batch-a").expect("valid commit id")
+    );
+    assert_eq!(
+        changes.changes[1].commit_id,
+        CommitId::parse("req-batch-b").expect("valid commit id")
+    );
     assert_eq!(changes.changes[0].ops, first.results);
     assert_eq!(changes.changes[0].deltas.len(), 2);
     assert!(matches!(
@@ -1127,7 +1050,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 fn binding_is_precondition_observes_earlier_batch_candidate() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
     write_file_bytes(
@@ -1156,7 +1079,8 @@ fn binding_is_precondition_observes_earlier_batch_candidate() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                commit_id: CommitId::from("move-before-child-name-check"),
+                commit_id: CommitId::parse("move-before-child-name-check")
+                    .expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::Rename {
                     inode_id: file_inode,
@@ -1168,7 +1092,7 @@ fn binding_is_precondition_observes_earlier_batch_candidate() {
                 annotations: None,
             },
             ApiCommitRequest {
-                commit_id: CommitId::from("delete-with-stale-binding"),
+                commit_id: CommitId::parse("delete-with-stale-binding").expect("valid commit id"),
                 preconditions: vec![CommitPrecondition::BindingIs {
                     parent_inode: docs_inode,
                     name_key: original_binding.name_key,
@@ -1200,14 +1124,14 @@ fn binding_is_precondition_observes_earlier_batch_candidate() {
 fn directory_empty_precondition_observes_earlier_batch_candidate() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
     let seed = commit_operations(
         &store,
         &namespace_id,
         ApiCommitRequest {
-            commit_id: CommitId::from("seed-empty-dir"),
+            commit_id: CommitId::parse("seed-empty-dir").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -1230,7 +1154,8 @@ fn directory_empty_precondition_observes_earlier_batch_candidate() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                commit_id: CommitId::from("create-child-before-empty-check"),
+                commit_id: CommitId::parse("create-child-before-empty-check")
+                    .expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateFile {
                     parent_inode: docs_inode,
@@ -1241,7 +1166,8 @@ fn directory_empty_precondition_observes_earlier_batch_candidate() {
                 annotations: None,
             },
             ApiCommitRequest {
-                commit_id: CommitId::from("delete-dir-with-stale-empty-check"),
+                commit_id: CommitId::parse("delete-dir-with-stale-empty-check")
+                    .expect("valid commit id"),
                 preconditions: vec![CommitPrecondition::DirectoryEmpty {
                     inode_id: docs_inode,
                 }],
@@ -1268,7 +1194,7 @@ fn directory_empty_precondition_observes_earlier_batch_candidate() {
 #[test]
 fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     let store = StaleHeadAfterWalWriteStore::new(temp_dir.path(), &namespace_id);
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
@@ -1279,7 +1205,7 @@ fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("retry-after-orphan"),
+                commit_id: CommitId::parse("retry-after-orphan").expect("valid commit id"),
                 absolute_path: "/retry.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -1319,14 +1245,14 @@ fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     assert_eq!(visible_segment.payload.records.len(), 1);
     assert_eq!(
         visible_segment.payload.records[0].commit_id,
-        CommitId::from("retry-after-orphan")
+        CommitId::parse("retry-after-orphan").expect("valid commit id")
     );
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(
         changes.changes[0].commit_id,
-        CommitId::from("retry-after-orphan")
+        CommitId::parse("retry-after-orphan").expect("valid commit id")
     );
 }
 
@@ -1334,12 +1260,12 @@ fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
 fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
     let request = ApiCommitRequest {
-        commit_id: CommitId::from("req-duplicate"),
+        commit_id: CommitId::parse("req-duplicate").expect("valid commit id"),
         preconditions: Vec::new(),
         ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
@@ -1372,7 +1298,7 @@ fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(
         changes.changes[0].commit_id,
-        CommitId::from("req-duplicate")
+        CommitId::parse("req-duplicate").expect("valid commit id")
     );
 }
 
@@ -1380,12 +1306,12 @@ fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
 fn visible_commit_id_retry_aliases_across_writer_takeover() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer_a = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &writer_a, false).expect("bootstrap");
 
     let request = ApiCommitRequest {
-        commit_id: CommitId::from("retry-across-writer"),
+        commit_id: CommitId::parse("retry-across-writer").expect("valid commit id"),
         preconditions: Vec::new(),
         ops: vec![ApiCommitOp::CreateDir {
             parent_inode: InodeId(1),
@@ -1417,7 +1343,7 @@ fn visible_commit_id_retry_aliases_across_writer_takeover() {
 fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1426,7 +1352,7 @@ fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
         &namespace_id,
         vec![
             ApiCommitRequest {
-                commit_id: CommitId::from("req-conflict"),
+                commit_id: CommitId::parse("req-conflict").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1436,7 +1362,7 @@ fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
                 annotations: None,
             },
             ApiCommitRequest {
-                commit_id: CommitId::from("req-conflict"),
+                commit_id: CommitId::parse("req-conflict").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![ApiCommitOp::CreateDir {
                     parent_inode: InodeId(1),
@@ -1467,14 +1393,17 @@ fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect("changes");
     assert_eq!(changes.changes.len(), 1);
-    assert_eq!(changes.changes[0].commit_id, CommitId::from("req-conflict"));
+    assert_eq!(
+        changes.changes[0].commit_id,
+        CommitId::parse("req-conflict").expect("valid commit id")
+    );
 }
 
 #[test]
 fn explicit_commit_rejects_invalid_display_names() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
@@ -1482,7 +1411,7 @@ fn explicit_commit_rejects_invalid_display_names() {
         &store,
         &namespace_id,
         ApiCommitRequest {
-            commit_id: CommitId::from("invalid-create-name"),
+            commit_id: CommitId::parse("invalid-create-name").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -1525,7 +1454,7 @@ fn explicit_commit_rejects_invalid_display_names() {
         &store,
         &namespace_id,
         ApiCommitRequest {
-            commit_id: CommitId::from("invalid-rename-name"),
+            commit_id: CommitId::parse("invalid-rename-name").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::Rename {
                 inode_id: file.inode_id,
@@ -1552,7 +1481,7 @@ fn explicit_commit_rejects_invalid_display_names() {
 fn direct_publisher_path_intents_cover_basic_mutations() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
     let publisher = DirectObjectStorePublisher::new(&store);
@@ -1562,7 +1491,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-path"),
+                commit_id: CommitId::parse("put-path").expect("valid commit id"),
                 absolute_path: "/docs/a.txt".to_owned(),
                 content_ref: content.content_ref.clone(),
                 behavior: PutFileBehavior::CreateOnly,
@@ -1577,7 +1506,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::MovePath {
-                commit_id: CommitId::from("move-path"),
+                commit_id: CommitId::parse("move-path").expect("valid commit id"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/b.txt".to_owned(),
                 mode: loon_api::v0::RenameMode::NoReplace,
@@ -1592,7 +1521,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::CopyFilePath {
-                commit_id: CommitId::from("copy-path"),
+                commit_id: CommitId::parse("copy-path").expect("valid commit id"),
                 from_path: "/docs/b.txt".to_owned(),
                 to_path: "/docs/c.txt".to_owned(),
             },
@@ -1606,7 +1535,7 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::DeletePath {
-                commit_id: CommitId::from("delete-path"),
+                commit_id: CommitId::parse("delete-path").expect("valid commit id"),
                 absolute_path: "/docs/b.txt".to_owned(),
                 recursive: false,
             },
@@ -1625,14 +1554,14 @@ fn direct_publisher_path_intents_cover_basic_mutations() {
 fn direct_publisher_uses_durable_path_commit_receipt_index() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
     let publisher = DirectObjectStorePublisher::new(&store);
     let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
 
     let intent = PathMutationIntent::PutFile {
-        commit_id: CommitId::from("same-path-request"),
+        commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
         absolute_path: "/same//path.txt".to_owned(),
         content_ref: content.content_ref.clone(),
         behavior: PutFileBehavior::CreateOnly,
@@ -1649,7 +1578,7 @@ fn direct_publisher_uses_durable_path_commit_receipt_index() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("same-path-request"),
+                commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
                 absolute_path: "/same/path.txt".to_owned(),
                 content_ref: content.content_ref.clone(),
                 behavior: PutFileBehavior::CreateOnly,
@@ -1664,7 +1593,7 @@ fn direct_publisher_uses_durable_path_commit_receipt_index() {
         .submit_path_intent(
             &namespace_id,
             PathMutationIntent::DeletePath {
-                commit_id: CommitId::from("same-path-request"),
+                commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
                 absolute_path: "/same/path.txt".to_owned(),
                 recursive: false,
             },
@@ -1685,7 +1614,7 @@ fn direct_publisher_uses_durable_path_commit_receipt_index() {
 fn path_intents_in_one_batch_see_tentative_state() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::from("demo");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
     let content = store_bytes_as_content(&store, &namespace_id, b"hello").expect("stage content");
@@ -1695,13 +1624,13 @@ fn path_intents_in_one_batch_see_tentative_state() {
         &namespace_id,
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-batched-path"),
+                commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
                 absolute_path: "/docs/a.txt".to_owned(),
                 content_ref: content.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
-                commit_id: CommitId::from("move-batched-path"),
+                commit_id: CommitId::parse("move-batched-path").expect("valid commit id"),
                 from_path: "/docs/a.txt".to_owned(),
                 to_path: "/docs/b.txt".to_owned(),
                 mode: loon_api::v0::RenameMode::NoReplace,
@@ -1768,7 +1697,7 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
     let source_namespace_id = namespace_id();
-    let clone_namespace_id = NamespaceId::from("clone");
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
 
     bootstrap_namespace(&store, &source_namespace_id, &context, false)
         .expect("bootstrap source namespace");
@@ -1902,7 +1831,7 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
 fn fork_target_head_reservation_failure_writes_no_checkpoint_artifacts() {
     let temp_dir = tempdir().expect("tempdir");
     let source_namespace_id = namespace_id();
-    let clone_namespace_id = NamespaceId::from("clone");
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -1934,7 +1863,7 @@ fn fork_target_head_reservation_failure_writes_no_checkpoint_artifacts() {
 fn fork_failure_after_target_head_reserves_partial_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let source_namespace_id = namespace_id();
-    let clone_namespace_id = NamespaceId::from("clone");
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -1972,7 +1901,7 @@ fn fork_failure_after_target_head_reserves_partial_namespace() {
 fn fork_failure_after_target_checkpoint_artifacts_remains_partial() {
     let temp_dir = tempdir().expect("tempdir");
     let source_namespace_id = namespace_id();
-    let clone_namespace_id = NamespaceId::from("clone");
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -2017,7 +1946,7 @@ fn fork_failure_after_target_checkpoint_artifacts_remains_partial() {
 fn fork_target_control_conflict_rechecks_complete_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let source_namespace_id = namespace_id();
-    let clone_namespace_id = NamespaceId::from("clone");
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     seed_source_namespace_for_fork(&inner, &source_namespace_id, &context);
@@ -2076,7 +2005,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("restore-create"),
+            commit_id: CommitId::parse("restore-create").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
@@ -2099,7 +2028,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("restore-replace"),
+            commit_id: CommitId::parse("restore-replace").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
@@ -2124,7 +2053,7 @@ fn restore_revision_revalidates_durable_content_before_publish() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("restore-missing-content"),
+            commit_id: CommitId::parse("restore-missing-content").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
@@ -2169,7 +2098,7 @@ fn metadata_only_commit_does_not_validate_content_store_refs() {
         &guarded_store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("metadata-only-delete"),
+            commit_id: CommitId::parse("metadata-only-delete").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::DeleteFile { inode_id }],
             message: None,
@@ -2198,7 +2127,8 @@ fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("create-missing-parent-missing-content"),
+            commit_id: CommitId::parse("create-missing-parent-missing-content")
+                .expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(99),
@@ -2242,7 +2172,7 @@ fn replace_file_prioritizes_missing_durable_content_over_stale_revision() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("replace-stale-missing-content"),
+            commit_id: CommitId::parse("replace-stale-missing-content").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
@@ -2286,7 +2216,7 @@ fn restore_revision_missing_source_is_revision_not_found() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("restore-missing-source"),
+            commit_id: CommitId::parse("restore-missing-source").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::RestoreRevision {
                 inode_id,
@@ -2314,7 +2244,8 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("resolve-before-durable-check-create"),
+            commit_id: CommitId::parse("resolve-before-durable-check-create")
+                .expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode: InodeId(1),
@@ -2344,7 +2275,8 @@ fn restore_revision_resolves_same_request_source_before_durable_content_validati
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("resolve-before-durable-check-commit"),
+            commit_id: CommitId::parse("resolve-before-durable-check-commit")
+                .expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![
                 ApiCommitOp::ReplaceFile {
@@ -2571,7 +2503,7 @@ fn path_move_writes_unbind_and_stale_binding_is_fails() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("delete-with-stale-binding"),
+            commit_id: CommitId::parse("delete-with-stale-binding").expect("valid commit id"),
             preconditions: vec![CommitPrecondition::BindingIs {
                 parent_inode: old_binding.parent_inode_id,
                 name_key: old_binding.name_key,
@@ -2620,7 +2552,7 @@ fn unsupported_rename_mode_is_named_bad_request_failure() {
         &store,
         &namespace_id(),
         ApiCommitRequest {
-            commit_id: CommitId::from("unsupported-rename-mode"),
+            commit_id: CommitId::parse("unsupported-rename-mode").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::Rename {
                 inode_id: file.inode_id,
@@ -3011,7 +2943,7 @@ fn mutation_context() -> MutationContext {
 }
 
 fn namespace_id() -> NamespaceId {
-    NamespaceId::from("demo".to_owned())
+    NamespaceId::parse("demo").expect("valid namespace id")
 }
 
 fn content_ref(seed: &str) -> ContentRef {

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -687,7 +687,7 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let fs = test_runtime(store.clone(), "runtime-writer");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .expect("create namespace through runtime");
         fs.put_file_bytes(
@@ -696,7 +696,7 @@ mod tests {
             b"hello from runtime",
             PutFileOptions {
                 behavior: PutFileBehavior::CreateOnly,
-                commit_id: Some(CommitId::from("runtime-put")),
+                commit_id: Some(CommitId::parse("runtime-put").expect("valid commit id")),
             },
         )
         .expect("write file through runtime");
@@ -738,7 +738,10 @@ mod tests {
         .expect("join blocking task");
 
         let file = fs
-            .read_file_bytes(&NamespaceId::from("demo"), "/notes/from-http.txt")
+            .read_file_bytes(
+                &NamespaceId::parse("demo").expect("valid namespace id"),
+                "/notes/from-http.txt",
+            )
             .expect("read file through runtime");
         assert_eq!(file.bytes, b"hello from http");
 
@@ -807,7 +810,7 @@ mod tests {
         let now_ms = now_ms();
         bootstrap_namespace(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             &context("server-writer", now_ms),
             false,
         )
@@ -835,11 +838,11 @@ mod tests {
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let now_ms = now_ms();
         let context = context("server-writer", now_ms);
-        bootstrap_namespace(store.as_ref(), &"demo".into(), &context, false)
+        bootstrap_namespace(store.as_ref(), &namespace_id("demo"), &context, false)
             .expect("bootstrap namespace");
         write_file_bytes(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/docs/readme.txt",
             b"readme",
             &context,
@@ -848,7 +851,7 @@ mod tests {
         .expect("seed docs");
         write_file_bytes(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/tmp/a.txt",
             b"from tmp",
             &context,
@@ -857,7 +860,7 @@ mod tests {
         .expect("seed tmp");
         write_file_bytes(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/docs/a.txt",
             b"in docs",
             &context,
@@ -896,11 +899,11 @@ mod tests {
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let now_ms = now_ms();
         let context = context("server-writer", now_ms);
-        bootstrap_namespace(store.as_ref(), &"demo".into(), &context, false)
+        bootstrap_namespace(store.as_ref(), &namespace_id("demo"), &context, false)
             .expect("bootstrap namespace");
         write_file_bytes(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/docs/old.txt",
             b"old",
             &context,
@@ -909,7 +912,7 @@ mod tests {
         .expect("seed docs");
         write_file_bytes(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/tmp/source.txt",
             b"source",
             &context,
@@ -918,7 +921,7 @@ mod tests {
         .expect("seed source");
         delete_path(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             "/docs",
             &context,
             Some("delete-docs"),
@@ -957,7 +960,7 @@ mod tests {
         let now_ms = now_ms();
         bootstrap_namespace(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             &context("server-writer", now_ms),
             false,
         )
@@ -985,7 +988,7 @@ mod tests {
         let now_ms = now_ms();
         bootstrap_namespace(
             store.as_ref(),
-            &"demo".into(),
+            &namespace_id("demo"),
             &context("other-writer", now_ms),
             false,
         )
@@ -1066,6 +1069,10 @@ mod tests {
             now_ms,
             lease_duration_ms: 60_000,
         }
+    }
+
+    fn namespace_id(value: &str) -> NamespaceId {
+        NamespaceId::parse(value).expect("valid namespace id")
     }
 
     fn now_ms() -> u64 {

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -504,7 +504,7 @@ mod tests {
         display_name: impl Into<String>,
     ) -> CommitRequest {
         CommitRequest {
-            commit_id: CommitId::from(commit_id.into()),
+            commit_id: CommitId::try_new(commit_id.into()).expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -549,7 +549,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn publisher_admits_pending_batch_while_active_publish_blocks() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
@@ -602,7 +602,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
@@ -643,7 +643,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
@@ -710,7 +710,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn publisher_full_batch_does_not_wait_on_missed_full_notification() {
         let temp_dir = tempdir().expect("tempdir");
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
@@ -761,13 +761,13 @@ mod tests {
                 key_prefix: None,
             },
         });
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
         create_namespace(&fs, &namespace_id);
         let registry = PublisherRegistry::new(fs);
 
         let request_a = CommitRequest {
-            commit_id: CommitId::from("req-a"),
+            commit_id: CommitId::parse("req-a").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -777,7 +777,7 @@ mod tests {
             annotations: None,
         };
         let request_b = CommitRequest {
-            commit_id: CommitId::from("req-b"),
+            commit_id: CommitId::parse("req-b").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -813,7 +813,7 @@ mod tests {
                 key_prefix: None,
             },
         });
-        let namespace_id = NamespaceId::from("demo");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
         create_namespace(&fs, &namespace_id);
         let content =
@@ -821,7 +821,7 @@ mod tests {
         let registry = PublisherRegistry::new(fs);
 
         let explicit = CommitRequest {
-            commit_id: CommitId::from("explicit-commit"),
+            commit_id: CommitId::parse("explicit-commit").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateDir {
                 parent_inode: InodeId(1),
@@ -831,7 +831,7 @@ mod tests {
             annotations: None,
         };
         let path_intent = PathMutationIntent::PutFile {
-            commit_id: CommitId::from("path-put"),
+            commit_id: CommitId::parse("path-put").expect("valid commit id"),
             absolute_path: "/file.txt".to_owned(),
             content_ref: content.content_ref,
             behavior: PutFileBehavior::CreateOnly,

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -343,7 +343,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         annotations.insert("source".to_owned(), json!("http-smoke"));
         annotations.insert("kind".to_owned(), json!("service-proxied"));
         let commit_request = ApiCommitRequest {
-            commit_id: CommitId::from("req-phase-2a-create-file"),
+            commit_id: CommitId::parse("req-phase-2a-create-file").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(1),
@@ -357,7 +357,10 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             .client
             .commit_operations(namespace, &commit_request)
             .expect("commit uploaded file");
-        assert_eq!(commit.commit_id, CommitId::from("req-phase-2a-create-file"));
+        assert_eq!(
+            commit.commit_id,
+            CommitId::parse("req-phase-2a-create-file").expect("valid commit id")
+        );
         assert_eq!(commit.committed_seq, ChangeSeq(1));
         assert_eq!(
             commit.results,
@@ -452,7 +455,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    commit_id: CommitId::from("req-restore-create"),
+                    commit_id: CommitId::parse("req-restore-create").expect("valid commit id"),
                     preconditions: Vec::new(),
                     ops: vec![CommitOp::CreateFile {
                         parent_inode: InodeId(1),
@@ -476,7 +479,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    commit_id: CommitId::from("req-restore-replace"),
+                    commit_id: CommitId::parse("req-restore-replace").expect("valid commit id"),
                     preconditions: Vec::new(),
                     ops: vec![CommitOp::ReplaceFile {
                         inode_id,
@@ -495,7 +498,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    commit_id: CommitId::from("req-restore-restore"),
+                    commit_id: CommitId::parse("req-restore-restore").expect("valid commit id"),
                     preconditions: Vec::new(),
                     ops: vec![CommitOp::RestoreRevision {
                         inode_id,
@@ -538,7 +541,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
         assert_eq!(changes.changes.len(), 3);
         assert_eq!(
             changes.changes[2].commit_id,
-            CommitId::from("req-restore-restore")
+            CommitId::parse("req-restore-restore").expect("valid commit id")
         );
         assert_eq!(changes.changes[2].ops, restore.results);
     })
@@ -573,7 +576,8 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             .commit_operations(
                 namespace,
                 &ApiCommitRequest {
-                    commit_id: CommitId::from("req-restore-missing-source-create"),
+                    commit_id: CommitId::parse("req-restore-missing-source-create")
+                        .expect("valid commit id"),
                     preconditions: Vec::new(),
                     ops: vec![CommitOp::CreateFile {
                         parent_inode: InodeId(1),
@@ -593,7 +597,8 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
         match harness.client.commit_operations(
             namespace,
             &ApiCommitRequest {
-                commit_id: CommitId::from("req-restore-missing-source-restore"),
+                commit_id: CommitId::parse("req-restore-missing-source-restore")
+                    .expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![CommitOp::RestoreRevision {
                     inode_id,
@@ -638,7 +643,7 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
         let first_content_ref =
             stage_uploaded_content_ref(&harness.client, namespace, b"first payload\n");
         let first_request = ApiCommitRequest {
-            commit_id: CommitId::from("req-phase-2a-conflict"),
+            commit_id: CommitId::parse("req-phase-2a-conflict").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![CommitOp::CreateFile {
                 parent_inode: InodeId(1),

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -701,7 +701,7 @@ fn upload_then_path_put_uses_private_uploaded_content_cache() {
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-cached-upload"),
+                commit_id: CommitId::parse("put-cached-upload").expect("valid commit id"),
                 absolute_path: "/docs/cached.txt".to_owned(),
                 content_ref: staged.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -745,7 +745,7 @@ fn disabled_runtime_cache_falls_back_to_durable_content_validation() {
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
-                commit_id: CommitId::from("put-uncached-upload"),
+                commit_id: CommitId::parse("put-uncached-upload").expect("valid commit id"),
                 absolute_path: "/docs/uncached.txt".to_owned(),
                 content_ref: staged.content_ref,
                 behavior: PutFileBehavior::CreateOnly,
@@ -1030,7 +1030,7 @@ fn explicit_commit_appears_in_change_feed() {
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let commit_id = CommitId::new("explicit-create-dir");
+    let commit_id = CommitId::parse("explicit-create-dir").expect("valid commit id");
     let response = fs
         .commit_operations(
             &namespace_id,

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -44,9 +44,11 @@ LoonFS uses distinct naming conventions for distinct surfaces:
 - Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41`, `upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c`, and `seg_b7c14a0d9e6f42a38c5d21f0e8a739bc`.
 - Durable work-class names use lowercase-kebab, e.g. `checkpoint-builder`.
 - JSON enum values use snake_case.
-- Namespace IDs are human/operator slugs; prefer lowercase kebab-case while preserving the namespace grammar.
+- Namespace IDs are human/operator slugs. They use the durable slug grammar: 1-128 bytes, no leading or trailing whitespace, not `.` or `..`, first character lowercase ASCII letter or digit, and remaining characters lowercase ASCII letters, digits, `.`, `_`, or `-`. Prefer lowercase kebab-case within that grammar.
 
 Namespace IDs are durable storage identities. A `namespace_id` must not be reused after namespace destruction; future user-facing display names or aliases may be reused only by mapping them to a new namespace ID.
+
+Implementations must reject invalid namespace IDs before object-key construction. Durable objects that deserialize to invalid typed namespace IDs must be treated as invalid at load boundaries rather than coerced or normalized.
 
 Generated runtime IDs must be unguessable, high-entropy, and never reused within the relevant namespace incarnation.
 


### PR DESCRIPTION
This PR makes all the public durable IDs validate at construction/deserialization. We also add a note about the namespace ID grammar. This is a minor cleanup but is important to standardize (we had various implementations in the codebase)