### PR TITLE
refactor(core): split commit and path fingerprint domains

### DIFF
--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -18,10 +18,7 @@ pub fn wal_payload_from_materialized_commit(
         seq: prepared.plan.assigned_seq,
         apply_after_seq: prepared.plan.apply_after_seq,
         commit_id: prepared.plan.commit_id.clone(),
-        semantic_commit_fingerprint_sha256: prepared
-            .semantic_commit_fingerprint
-            .as_str()
-            .to_owned(),
+        semantic_commit_fingerprint_sha256: prepared.semantic_identity.as_str().to_owned(),
         writer_id: prepared.request.writer_id.clone(),
         writer_fence_token: prepared.request.writer_fence_token,
         message: prepared.request.message.clone(),

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -4,12 +4,13 @@ use loon_api::{payload_checksum_sha256, v0 as api_v0, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-const SEMANTIC_CORE_COMMIT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
+const CORE_COMMIT_FINGERPRINT_DOMAIN: &str = "loonfs.core.commit.semantic.v0";
+pub(crate) const PATH_INTENT_FINGERPRINT_DOMAIN: &str = "loonfs.path.intent.semantic.v0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SemanticCommitFingerprint(String);
+pub struct CoreCommitFingerprint(String);
 
-impl SemanticCommitFingerprint {
+impl CoreCommitFingerprint {
     pub(crate) fn new_unchecked(value: String) -> Self {
         Self(value)
     }
@@ -19,16 +20,44 @@ impl SemanticCommitFingerprint {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PathIntentFingerprint(String);
+
+impl PathIntentFingerprint {
+    pub(crate) fn new_unchecked(value: String) -> Self {
+        Self(value)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SemanticMutationIdentity {
+    CoreCommit(CoreCommitFingerprint),
+    PathIntent(PathIntentFingerprint),
+}
+
+impl SemanticMutationIdentity {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::CoreCommit(fingerprint) => fingerprint.as_str(),
+            Self::PathIntent(fingerprint) => fingerprint.as_str(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommitFingerprintError {
     #[error("commit fingerprint codec error: {0}")]
     Codec(String),
 }
 
-pub fn semantic_commit_fingerprint(
+pub fn core_commit_fingerprint(
     request: &CommitRequest,
-) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
-    semantic_commit_fingerprint_from_parts(
+) -> Result<CoreCommitFingerprint, CommitFingerprintError> {
+    core_commit_fingerprint_from_parts(
         &request.namespace_id,
         &request.preconditions,
         &request.ops,
@@ -37,10 +66,10 @@ pub fn semantic_commit_fingerprint(
     )
 }
 
-pub fn semantic_commit_fingerprint_for_v0_request(
+pub fn core_commit_fingerprint_for_v0_request(
     namespace_id: &NamespaceId,
     request: &api_v0::CommitRequest,
-) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
+) -> Result<CoreCommitFingerprint, CommitFingerprintError> {
     let preconditions = request
         .preconditions
         .iter()
@@ -53,7 +82,7 @@ pub fn semantic_commit_fingerprint_for_v0_request(
         .cloned()
         .map(commit_op_from_v0)
         .collect::<Vec<_>>();
-    semantic_commit_fingerprint_from_parts(
+    core_commit_fingerprint_from_parts(
         namespace_id,
         &preconditions,
         &ops,
@@ -62,15 +91,15 @@ pub fn semantic_commit_fingerprint_for_v0_request(
     )
 }
 
-fn semantic_commit_fingerprint_from_parts(
+fn core_commit_fingerprint_from_parts(
     namespace_id: &NamespaceId,
     preconditions: &[Precondition],
     ops: &[CommitOp],
     message: &Option<String>,
     annotations: &Option<api_v0::CommitAnnotations>,
-) -> Result<SemanticCommitFingerprint, CommitFingerprintError> {
+) -> Result<CoreCommitFingerprint, CommitFingerprintError> {
     #[derive(Serialize)]
-    struct CanonicalSemanticCommit<'a> {
+    struct CanonicalCoreCommit<'a> {
         domain: &'static str,
         namespace_id: &'a NamespaceId,
         preconditions: &'a [Precondition],
@@ -79,15 +108,15 @@ fn semantic_commit_fingerprint_from_parts(
         annotations: &'a Option<api_v0::CommitAnnotations>,
     }
 
-    payload_checksum_sha256(&CanonicalSemanticCommit {
-        domain: SEMANTIC_CORE_COMMIT_DOMAIN,
+    payload_checksum_sha256(&CanonicalCoreCommit {
+        domain: CORE_COMMIT_FINGERPRINT_DOMAIN,
         namespace_id,
         preconditions,
         ops,
         message,
         annotations,
     })
-    .map(SemanticCommitFingerprint::new_unchecked)
+    .map(CoreCommitFingerprint::new_unchecked)
     .map_err(|err| CommitFingerprintError::Codec(err.to_string()))
 }
 
@@ -114,29 +143,27 @@ mod tests {
     }
 
     #[test]
-    fn semantic_fingerprint_is_stable_for_same_logical_commit() {
-        let left =
-            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
+    fn core_commit_fingerprint_is_stable_for_same_logical_commit() {
+        let left = core_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
         let right =
-            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("right fingerprint");
+            core_commit_fingerprint(&core_request(FenceToken(1))).expect("right fingerprint");
 
         assert_eq!(left, right);
     }
 
     #[test]
-    fn semantic_fingerprint_excludes_writer_context_and_commit_id() {
-        let left =
-            semantic_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
-        let different_fence = semantic_commit_fingerprint(&core_request(FenceToken(2)))
+    fn core_commit_fingerprint_excludes_writer_context_and_commit_id() {
+        let left = core_commit_fingerprint(&core_request(FenceToken(1))).expect("left fingerprint");
+        let different_fence = core_commit_fingerprint(&core_request(FenceToken(2)))
             .expect("different fence fingerprint");
         let mut different_writer = core_request(FenceToken(1));
         different_writer.writer_id = "writer-b".to_owned();
         let different_writer =
-            semantic_commit_fingerprint(&different_writer).expect("different writer fingerprint");
+            core_commit_fingerprint(&different_writer).expect("different writer fingerprint");
         let mut different_commit_id = core_request(FenceToken(1));
         different_commit_id.commit_id = CommitId::parse("commit-b").expect("valid commit id");
-        let different_commit_id = semantic_commit_fingerprint(&different_commit_id)
-            .expect("different commit id fingerprint");
+        let different_commit_id =
+            core_commit_fingerprint(&different_commit_id).expect("different commit id fingerprint");
 
         assert_eq!(left, different_fence);
         assert_eq!(left, different_writer);
@@ -144,22 +171,22 @@ mod tests {
     }
 
     #[test]
-    fn semantic_fingerprint_changes_when_logical_inputs_change() {
-        let baseline = semantic_commit_fingerprint(&core_request(FenceToken(1)))
-            .expect("baseline fingerprint");
+    fn core_commit_fingerprint_changes_when_logical_inputs_change() {
+        let baseline =
+            core_commit_fingerprint(&core_request(FenceToken(1))).expect("baseline fingerprint");
         let mut changed = core_request(FenceToken(1));
         changed.ops = vec![CommitOp::CreateDir {
             parent_inode: InodeId(1),
             display_name: "drafts".to_owned(),
         }];
 
-        let changed = semantic_commit_fingerprint(&changed).expect("changed fingerprint");
+        let changed = core_commit_fingerprint(&changed).expect("changed fingerprint");
 
         assert_ne!(baseline, changed);
     }
 
     #[test]
-    fn v0_semantic_fingerprint_matches_core_semantic_fingerprint() {
+    fn v0_core_commit_fingerprint_matches_core_commit_fingerprint() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let api_request = api_v0::CommitRequest {
             commit_id: CommitId::parse("commit-a").expect("valid commit id"),
@@ -182,9 +209,9 @@ mod tests {
         .expect("core request");
 
         assert_eq!(
-            semantic_commit_fingerprint_for_v0_request(&namespace_id, &api_request)
+            core_commit_fingerprint_for_v0_request(&namespace_id, &api_request)
                 .expect("api fingerprint"),
-            semantic_commit_fingerprint(&core).expect("core fingerprint")
+            core_commit_fingerprint(&core).expect("core fingerprint")
         );
     }
 }

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -16,13 +16,14 @@ mod publish;
 
 pub use self::api_adapter::{commit_request_from_v0, CommitConversionError};
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
+pub(crate) use self::identity::PATH_INTENT_FINGERPRINT_DOMAIN;
 pub use self::identity::{
-    semantic_commit_fingerprint, semantic_commit_fingerprint_for_v0_request,
-    CommitFingerprintError, SemanticCommitFingerprint,
+    core_commit_fingerprint, core_commit_fingerprint_for_v0_request, CommitFingerprintError,
+    CoreCommitFingerprint, PathIntentFingerprint, SemanticMutationIdentity,
 };
 pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
-pub(crate) use self::prepared::CommitFingerprintSource;
+pub(crate) use self::prepared::CommitIdentitySource;
 pub use self::prepared::{
     materialize_commit, CommitExecutionContext, CommitMaterializationError, CommitPrepareError,
     MaterializedCommit, MaterializedCommitDelta, PreparedCommit,

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -1,6 +1,6 @@
 use super::{
-    semantic_commit_fingerprint, CommitFingerprintError, CommitOp, CommitPlan, CommitRequest,
-    ResolvedBinding, SemanticCommitFingerprint,
+    core_commit_fingerprint, CommitFingerprintError, CommitOp, CommitPlan, CommitRequest,
+    PathIntentFingerprint, ResolvedBinding, SemanticMutationIdentity,
 };
 use loon_api::{
     name_key_for_display_name, v0::CommitOpResult, ContentRef, FenceToken, InodeId, InodeKind,
@@ -17,16 +17,16 @@ pub struct CommitExecutionContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CommitFingerprintSource {
-    ComputeFromRequest,
-    TrustedPrecomputed(SemanticCommitFingerprint),
+pub(crate) enum CommitIdentitySource {
+    CoreCommitRequest,
+    PathIntent(PathIntentFingerprint),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedCommit {
     pub request: CommitRequest,
     pub plan: CommitPlan,
-    pub semantic_commit_fingerprint: SemanticCommitFingerprint,
+    pub semantic_identity: SemanticMutationIdentity,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,13 +89,13 @@ pub enum CommitMaterializationError {
 
 impl PreparedCommit {
     pub fn new(request: CommitRequest, plan: CommitPlan) -> Result<Self, CommitPrepareError> {
-        Self::prepare(request, plan, CommitFingerprintSource::ComputeFromRequest)
+        Self::prepare(request, plan, CommitIdentitySource::CoreCommitRequest)
     }
 
     pub(crate) fn prepare(
         request: CommitRequest,
         plan: CommitPlan,
-        fingerprint_source: CommitFingerprintSource,
+        identity_source: CommitIdentitySource,
     ) -> Result<Self, CommitPrepareError> {
         if request.namespace_id != plan.namespace_id {
             return Err(CommitPrepareError::NamespaceMismatch {
@@ -106,15 +106,19 @@ impl PreparedCommit {
         if request.commit_id != plan.commit_id {
             return Err(CommitPrepareError::CommitIdMismatch);
         }
-        let semantic_commit_fingerprint = match fingerprint_source {
-            CommitFingerprintSource::ComputeFromRequest => semantic_commit_fingerprint(&request)?,
-            CommitFingerprintSource::TrustedPrecomputed(fingerprint) => fingerprint,
+        let semantic_identity = match identity_source {
+            CommitIdentitySource::CoreCommitRequest => {
+                SemanticMutationIdentity::CoreCommit(core_commit_fingerprint(&request)?)
+            }
+            CommitIdentitySource::PathIntent(fingerprint) => {
+                SemanticMutationIdentity::PathIntent(fingerprint)
+            }
         };
 
         Ok(Self {
             request,
             plan,
-            semantic_commit_fingerprint,
+            semantic_identity,
         })
     }
 }
@@ -520,16 +524,19 @@ mod tests {
     }
 
     #[test]
-    fn prepared_commit_uses_trusted_precomputed_fingerprint() {
-        let fingerprint = SemanticCommitFingerprint::new_unchecked("trusted".to_owned());
+    fn prepared_commit_uses_path_intent_identity() {
+        let fingerprint = PathIntentFingerprint::new_unchecked("path-intent".to_owned());
         let prepared = PreparedCommit::prepare(
             request(),
             plan(),
-            CommitFingerprintSource::TrustedPrecomputed(fingerprint.clone()),
+            CommitIdentitySource::PathIntent(fingerprint.clone()),
         )
         .expect("prepare commit");
 
-        assert_eq!(prepared.semantic_commit_fingerprint, fingerprint);
+        assert_eq!(
+            prepared.semantic_identity,
+            SemanticMutationIdentity::PathIntent(fingerprint)
+        );
     }
 
     #[test]

--- a/crates/loon-core/src/path/planner.rs
+++ b/crates/loon-core/src/path/planner.rs
@@ -4,7 +4,7 @@ use super::helpers::{
 use super::intent::{PathMutationIntent, PutFileBehavior};
 use super::tombstone::reject_tombstoned_path_ancestor;
 use crate::basis::{load_verified_namespace_basis, VerifiedNamespaceBasis};
-use crate::commit::SemanticCommitFingerprint;
+use crate::commit::{PathIntentFingerprint, PATH_INTENT_FINGERPRINT_DOMAIN};
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, ResolvedVisiblePath, VisiblePathError};
 use loon_api::{
@@ -22,7 +22,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedPathMutation {
     pub commit_id: CommitId,
-    pub semantic_commit_fingerprint: SemanticCommitFingerprint,
+    pub path_intent_fingerprint: PathIntentFingerprint,
     pub commit_request: ApiCommitRequest,
 }
 
@@ -95,18 +95,27 @@ enum PathFingerprintInput {
     },
 }
 
-fn path_semantic_commit_fingerprint(
+fn path_intent_fingerprint(
     identity: &PathFingerprintInput,
-) -> Result<SemanticCommitFingerprint, CoreError> {
-    payload_checksum_sha256(identity)
-        .map(SemanticCommitFingerprint::new_unchecked)
-        .map_err(|err| CoreError::Store(err.to_string()))
+) -> Result<PathIntentFingerprint, CoreError> {
+    #[derive(Serialize)]
+    struct CanonicalPathIntent<'a> {
+        domain: &'static str,
+        intent: &'a PathFingerprintInput,
+    }
+
+    payload_checksum_sha256(&CanonicalPathIntent {
+        domain: PATH_INTENT_FINGERPRINT_DOMAIN,
+        intent: identity,
+    })
+    .map(PathIntentFingerprint::new_unchecked)
+    .map_err(|err| CoreError::Store(err.to_string()))
 }
 
-pub(crate) fn semantic_commit_fingerprint_for_path_intent(
+pub(crate) fn path_intent_fingerprint_for_path_intent(
     namespace_id: &NamespaceId,
     intent: &PathMutationIntent,
-) -> Result<SemanticCommitFingerprint, CoreError> {
+) -> Result<PathIntentFingerprint, CoreError> {
     let identity = match intent {
         PathMutationIntent::CreateDir { absolute_path, .. } => PathFingerprintInput::CreateDir {
             namespace_id: namespace_id.clone(),
@@ -151,7 +160,7 @@ pub(crate) fn semantic_commit_fingerprint_for_path_intent(
             to_path: normalized_path_for_fingerprint(to_path)?,
         },
     };
-    path_semantic_commit_fingerprint(&identity)
+    path_intent_fingerprint(&identity)
 }
 
 fn normalized_path_for_fingerprint(absolute_path: &str) -> Result<String, CoreError> {
@@ -167,7 +176,7 @@ pub(crate) fn plan_path_mutation_against_state(
     metadata_state: &MetadataState,
 ) -> Result<PlannedPathMutation, CoreError> {
     let commit_id = intent.commit_id().clone();
-    let semantic_fingerprint = semantic_commit_fingerprint_for_path_intent(namespace_id, intent)?;
+    let path_intent_fingerprint = path_intent_fingerprint_for_path_intent(namespace_id, intent)?;
     let view = PathPlanningView {
         head,
         metadata_state,
@@ -205,7 +214,7 @@ pub(crate) fn plan_path_mutation_against_state(
     };
     Ok(PlannedPathMutation {
         commit_id,
-        semantic_commit_fingerprint: semantic_fingerprint,
+        path_intent_fingerprint,
         commit_request,
     })
 }
@@ -690,12 +699,13 @@ fn resolve_parent_directory(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commit::core_commit_fingerprint_for_v0_request;
     use crate::context::MutationContext;
     use crate::error::CoreErrorKind;
     use crate::services::{
         bootstrap_namespace, delete_path, put_file_bytes, store_bytes_as_content,
     };
-    use loon_api::v0::{CommitOp, CommitPrecondition};
+    use loon_api::v0::{CommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest};
     use loon_api::RevisionNo;
     use loon_objectstore::fs::LocalFsStore;
     use tempfile::tempdir;
@@ -732,6 +742,81 @@ mod tests {
         PathPlanner::new(store)
             .plan_against_state(namespace_id, intent, &basis.head, &basis.metadata_state)
             .expect("plan")
+    }
+
+    #[test]
+    fn path_intent_fingerprint_normalizes_paths() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let left = path_intent_fingerprint_for_path_intent(
+            &namespace_id,
+            &PathMutationIntent::CreateDir {
+                commit_id: CommitId::parse("mkdir-docs-a").expect("valid commit id"),
+                absolute_path: "/docs//a/".to_owned(),
+            },
+        )
+        .expect("left fingerprint");
+        let right = path_intent_fingerprint_for_path_intent(
+            &namespace_id,
+            &PathMutationIntent::CreateDir {
+                commit_id: CommitId::parse("mkdir-docs-b").expect("valid commit id"),
+                absolute_path: "/docs/a".to_owned(),
+            },
+        )
+        .expect("right fingerprint");
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn path_intent_fingerprint_changes_when_logical_inputs_change() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let baseline = path_intent_fingerprint_for_path_intent(
+            &namespace_id,
+            &PathMutationIntent::CreateDir {
+                commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                absolute_path: "/docs".to_owned(),
+            },
+        )
+        .expect("baseline fingerprint");
+        let changed = path_intent_fingerprint_for_path_intent(
+            &namespace_id,
+            &PathMutationIntent::CreateDir {
+                commit_id: CommitId::parse("mkdir-drafts").expect("valid commit id"),
+                absolute_path: "/drafts".to_owned(),
+            },
+        )
+        .expect("changed fingerprint");
+
+        assert_ne!(baseline, changed);
+    }
+
+    #[test]
+    fn path_intent_and_core_commit_fingerprints_use_distinct_domains() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let path_fingerprint = path_intent_fingerprint_for_path_intent(
+            &namespace_id,
+            &PathMutationIntent::CreateDir {
+                commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                absolute_path: "/docs".to_owned(),
+            },
+        )
+        .expect("path fingerprint");
+        let core_fingerprint = core_commit_fingerprint_for_v0_request(
+            &namespace_id,
+            &ApiCommitRequest {
+                commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateDir {
+                    parent_inode: InodeId(1),
+                    display_name: "docs".to_owned(),
+                }],
+                message: None,
+                annotations: None,
+            },
+        )
+        .expect("core fingerprint");
+
+        assert_ne!(path_fingerprint.as_str(), core_fingerprint.as_str());
     }
 
     #[test]

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -1,10 +1,10 @@
 use crate::basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
 use crate::commit::{
-    build_commit_plan, commit_request_from_v0, materialize_commit, prepare_commit_head_publish,
-    publish_commit_head, resolve_restore_content_refs, semantic_commit_fingerprint,
-    wal_payload_from_materialized_commit, CommitExecutionContext, CommitFingerprintSource,
-    CommitOp, CommitRequest as CoreCommitRequest, CommitValidationContext, MaterializedCommit,
-    PreparedCommit, SemanticCommitFingerprint,
+    build_commit_plan, commit_request_from_v0, core_commit_fingerprint, materialize_commit,
+    prepare_commit_head_publish, publish_commit_head, resolve_restore_content_refs,
+    wal_payload_from_materialized_commit, CommitExecutionContext, CommitIdentitySource, CommitOp,
+    CommitRequest as CoreCommitRequest, CommitValidationContext, MaterializedCommit,
+    PreparedCommit, SemanticMutationIdentity,
 };
 use crate::content::{write_immutable_object, ContentValidationTracker};
 use crate::context::MutationContext;
@@ -14,7 +14,7 @@ use crate::namespace::catalog::{
     load_namespace_content_store_id, namespace_initialization_state, NamespaceInitializationError,
     NamespaceInitializationState,
 };
-use crate::path::planner::{semantic_commit_fingerprint_for_path_intent, PathPlanner};
+use crate::path::planner::{path_intent_fingerprint_for_path_intent, PathPlanner};
 use crate::publisher::NamespaceMutationCandidate;
 use crate::wal::{prepare_wal_segment, StoredWalObject};
 use crate::{
@@ -89,12 +89,12 @@ struct LoadedUploadSessionObject {
 #[derive(Debug, Clone)]
 struct InBatchRequest {
     primary_index: usize,
-    semantic_commit_fingerprint: SemanticCommitFingerprint,
+    semantic_identity: SemanticMutationIdentity,
 }
 
 struct CandidateCoreRequest {
     request: CoreCommitRequest,
-    fingerprint_source: CommitFingerprintSource,
+    identity_source: CommitIdentitySource,
 }
 
 pub fn begin_upload<S: ObjectStore + ?Sized>(
@@ -477,19 +477,17 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
                 continue;
             }
         };
-        let prepared = match PreparedCommit::prepare(
-            request,
-            plan.clone(),
-            candidate_request.fingerprint_source,
-        ) {
-            Ok(value) => value,
-            Err(error) => {
-                outcomes[index] = Some(Err(CoreError::Store(format!(
-                    "commit preparation failed: {error}"
-                ))));
-                continue;
-            }
-        };
+        let prepared =
+            match PreparedCommit::prepare(request, plan.clone(), candidate_request.identity_source)
+            {
+                Ok(value) => value,
+                Err(error) => {
+                    outcomes[index] = Some(Err(CoreError::Store(format!(
+                        "commit preparation failed: {error}"
+                    ))));
+                    continue;
+                }
+            };
         let materialized = match materialize_commit(prepared) {
             Ok(value) => value,
             Err(error) => {
@@ -643,13 +641,14 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                     return None;
                 }
             };
-            let semantic_fingerprint = match semantic_commit_fingerprint(&request) {
+            let semantic_identity = match core_commit_fingerprint(&request) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
                     return None;
                 }
             };
+            let semantic_identity = SemanticMutationIdentity::CoreCommit(semantic_identity);
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
                 &basis.metadata_state,
@@ -658,13 +657,13 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 aliases,
                 index,
                 &request.commit_id,
-                &semantic_fingerprint,
+                &semantic_identity,
             ) {
                 return None;
             }
             Some(CandidateCoreRequest {
                 request,
-                fingerprint_source: CommitFingerprintSource::ComputeFromRequest,
+                identity_source: CommitIdentitySource::CoreCommitRequest,
             })
         }
         NamespaceMutationCandidate::Path(intent) => {
@@ -672,14 +671,16 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 outcomes[index] = Some(Err(error));
                 return None;
             }
-            let semantic_fingerprint =
-                match semantic_commit_fingerprint_for_path_intent(namespace_id, intent) {
+            let path_intent_fingerprint =
+                match path_intent_fingerprint_for_path_intent(namespace_id, intent) {
                     Ok(value) => value,
                     Err(error) => {
                         outcomes[index] = Some(Err(error));
                         return None;
                     }
                 };
+            let semantic_identity =
+                SemanticMutationIdentity::PathIntent(path_intent_fingerprint.clone());
             let commit_id = intent.commit_id().clone();
             if !record_primary_request_or_complete_idempotent(
                 namespace_id,
@@ -689,7 +690,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 aliases,
                 index,
                 &commit_id,
-                &semantic_fingerprint,
+                &semantic_identity,
             ) {
                 return None;
             }
@@ -714,9 +715,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             };
             Some(CandidateCoreRequest {
                 request,
-                fingerprint_source: CommitFingerprintSource::TrustedPrecomputed(
-                    planned.semantic_commit_fingerprint,
-                ),
+                identity_source: CommitIdentitySource::PathIntent(planned.path_intent_fingerprint),
             })
         }
     }
@@ -737,11 +736,11 @@ fn record_primary_request_or_complete_idempotent(
     aliases: &mut Vec<(usize, usize)>,
     index: usize,
     commit_id: &CommitId,
-    semantic_commit_fingerprint: &SemanticCommitFingerprint,
+    semantic_identity: &SemanticMutationIdentity,
 ) -> bool {
     if let Some(existing) = find_commit_receipt(visible_metadata_state, commit_id) {
         outcomes[index] = Some(
-            if existing.semantic_commit_fingerprint_sha256 != semantic_commit_fingerprint.as_str() {
+            if existing.semantic_commit_fingerprint_sha256 != semantic_identity.as_str() {
                 Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
             } else {
                 Ok(commit_response_from_commit_receipt(namespace_id, existing))
@@ -750,7 +749,7 @@ fn record_primary_request_or_complete_idempotent(
         return false;
     }
     if let Some(existing) = in_batch_requests.get(commit_id) {
-        if existing.semantic_commit_fingerprint != *semantic_commit_fingerprint {
+        if existing.semantic_identity != *semantic_identity {
             outcomes[index] = Some(Err(CoreError::CommitIdReuseConflict(commit_id.to_string())));
         } else {
             aliases.push((index, existing.primary_index));
@@ -761,7 +760,7 @@ fn record_primary_request_or_complete_idempotent(
         commit_id.clone(),
         InBatchRequest {
             primary_index: index,
-            semantic_commit_fingerprint: semantic_commit_fingerprint.clone(),
+            semantic_identity: semantic_identity.clone(),
         },
     );
     true

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -1,9 +1,9 @@
-use crate::commit::{semantic_commit_fingerprint_for_v0_request, SemanticCommitFingerprint};
+use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::context::MutationContext;
 use crate::error::{CoreError, CoreErrorKind};
 use crate::path::intent::PathMutationIntent;
 use crate::path::planner::{
-    semantic_commit_fingerprint_for_path_intent, PathPlanner, PlannedPathMutation,
+    path_intent_fingerprint_for_path_intent, PathPlanner, PlannedPathMutation,
 };
 use crate::{
     load_namespace_head_identity, load_namespace_lease_control, load_verified_namespace_basis,
@@ -30,16 +30,16 @@ impl NamespaceMutationCandidate {
         }
     }
 
-    pub fn semantic_commit_fingerprint(
+    pub fn semantic_identity(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<SemanticCommitFingerprint, CoreError> {
+    ) -> Result<SemanticMutationIdentity, CoreError> {
         match self {
-            Self::Commit(request) => {
-                semantic_commit_fingerprint_for_v0_request(namespace_id, request)
-                    .map_err(|err| CoreError::Store(err.to_string()))
-            }
-            Self::Path(intent) => semantic_commit_fingerprint_for_path_intent(namespace_id, intent),
+            Self::Commit(request) => core_commit_fingerprint_for_v0_request(namespace_id, request)
+                .map(SemanticMutationIdentity::CoreCommit)
+                .map_err(|err| CoreError::Store(err.to_string())),
+            Self::Path(intent) => path_intent_fingerprint_for_path_intent(namespace_id, intent)
+                .map(SemanticMutationIdentity::PathIntent),
         }
     }
 }

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -1,6 +1,6 @@
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::{CommitId, NamespaceId};
-use loon_core::commit::{CommitHeadPublishError, SemanticCommitFingerprint};
+use loon_core::commit::{CommitHeadPublishError, SemanticMutationIdentity};
 use loonfs::{CoreError, Fs, NamespaceMutationCandidate, PathMutationIntent, RuntimeError};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -91,7 +91,7 @@ struct BatchCandidate {
 }
 
 struct InFlightRequest {
-    fingerprint: SemanticCommitFingerprint,
+    semantic_identity: SemanticMutationIdentity,
     waiters: Vec<oneshot::Sender<CommitResult>>,
 }
 
@@ -111,9 +111,9 @@ impl NamespacePublisher {
 
     async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
         let commit_id = candidate.commit_id().clone();
-        let fingerprint = candidate.semantic_commit_fingerprint(&self.namespace_id)?;
+        let semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
         let (sender, receiver) = oneshot::channel();
-        self.admit(commit_id, candidate, fingerprint, sender)?;
+        self.admit(commit_id, candidate, semantic_identity, sender)?;
         receiver
             .await
             .unwrap_or_else(|_| Err(CoreError::Store("publisher task stopped".to_owned())))
@@ -123,7 +123,7 @@ impl NamespacePublisher {
         &self,
         commit_id: CommitId,
         candidate: NamespaceMutationCandidate,
-        fingerprint: SemanticCommitFingerprint,
+        semantic_identity: SemanticMutationIdentity,
         waiter: oneshot::Sender<CommitResult>,
     ) -> Result<(), CoreError> {
         let mut should_spawn = false;
@@ -134,7 +134,7 @@ impl NamespacePublisher {
                 .lock()
                 .expect("namespace publisher mutex poisoned");
             if let Some(existing) = state.in_flight.get_mut(&commit_id) {
-                if existing.fingerprint != fingerprint {
+                if existing.semantic_identity != semantic_identity {
                     return Err(CoreError::CommitIdReuseConflict(commit_id.to_string()));
                 }
                 existing.waiters.push(waiter);
@@ -163,7 +163,7 @@ impl NamespacePublisher {
             state.in_flight.insert(
                 commit_id,
                 InFlightRequest {
-                    fingerprint,
+                    semantic_identity,
                     waiters: vec![waiter],
                 },
             );
@@ -530,9 +530,9 @@ mod tests {
     ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
         let commit_id = request.commit_id.clone();
         let candidate = NamespaceMutationCandidate::Commit(request);
-        let fingerprint = candidate.semantic_commit_fingerprint(namespace_id)?;
+        let semantic_identity = candidate.semantic_identity(namespace_id)?;
         let (sender, receiver) = oneshot::channel();
-        publisher.admit(commit_id, candidate, fingerprint, sender)?;
+        publisher.admit(commit_id, candidate, semantic_identity, sender)?;
         Ok(receiver)
     }
 


### PR DESCRIPTION
This PR separates core commit and path intent fingerprint types. Also cleans up the naming convention. 