### PR TITLE
refactor(core): clarify cached basis authority boundary

### DIFF
--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -41,7 +41,7 @@ pub struct NamespaceHeadSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NamespaceHeadIdentity {
+pub struct NamespaceHeadEtagProbe {
     pub head_etag: String,
 }
 
@@ -198,10 +198,10 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     })
 }
 
-pub fn load_namespace_head_identity<S: ObjectStore + ?Sized>(
+pub fn probe_namespace_head_etag<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
-) -> Result<NamespaceHeadIdentity, CoreError> {
+) -> Result<NamespaceHeadEtagProbe, CoreError> {
     NamespaceId::parse(expected_namespace.as_str())?;
     let object_key = namespace_head(expected_namespace.as_str());
     let metadata = store
@@ -223,7 +223,7 @@ pub fn load_namespace_head_identity<S: ObjectStore + ?Sized>(
         .ok_or(CoreError::Basis(BasisLoadError::MissingHeadEtag {
             object_key,
         }))?;
-    Ok(NamespaceHeadIdentity { head_etag })
+    Ok(NamespaceHeadEtagProbe { head_etag })
 }
 
 fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -19,8 +19,8 @@ pub mod services;
 pub mod wal;
 
 pub use basis::{
-    load_namespace_head_identity, load_namespace_head_summary, load_verified_namespace_basis,
-    BasisLoadError, NamespaceHeadIdentity, NamespaceHeadSummary, VerifiedNamespaceBasis,
+    load_namespace_head_summary, load_verified_namespace_basis, probe_namespace_head_etag,
+    BasisLoadError, NamespaceHeadEtagProbe, NamespaceHeadSummary, VerifiedNamespaceBasis,
 };
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, CheckpointLoadError, CheckpointLoadErrorKind,

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -6,11 +6,11 @@ use crate::path::planner::{
     path_intent_fingerprint_for_path_intent, PathPlanner, PlannedPathMutation,
 };
 use crate::{
-    load_namespace_head_identity, load_namespace_lease_control, load_verified_namespace_basis,
-    BasisLoadError, VerifiedNamespaceBasis,
+    load_namespace_lease_control, load_verified_namespace_basis, probe_namespace_head_etag,
+    BasisLoadError, NamespaceHeadEtagProbe, VerifiedNamespaceBasis,
 };
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{CommitId, MutationResult, NamespaceId};
+use loon_api::{CommitId, LeaseState, MutationResult, NamespaceId};
 use loon_objectstore::ObjectStore;
 use std::sync::Arc;
 
@@ -66,38 +66,40 @@ impl Default for PublishOptions {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WarmBasisEvent {
+pub enum BasisReuseEvent {
     Disabled,
     ColdLoaded,
-    Reused,
+    ReusedAfterHeadEtagMatch,
     InvalidatedThenColdLoaded,
 }
 
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
     pub results: Vec<Result<ApiCommitResponse, CoreError>>,
-    pub warm_basis_event: WarmBasisEvent,
-    pub warm_basis_update: WarmBasisUpdate,
+    pub basis_reuse_event: BasisReuseEvent,
+    pub verified_basis_cache_update: VerifiedBasisCacheUpdate,
 }
 
 #[derive(Debug, Clone)]
-pub enum WarmBasisUpdate {
+pub enum VerifiedBasisCacheUpdate {
     NoChange,
-    Retained(VerifiedNamespaceBasis),
-    Advanced(VerifiedNamespaceBasis),
+    ReusableAfterHeadEtagMatch(VerifiedNamespaceBasis),
+    AdvancedAfterHeadCas(VerifiedNamespaceBasis),
     Invalidated,
 }
 
-impl WarmBasisUpdate {
-    pub fn basis(&self) -> Option<&VerifiedNamespaceBasis> {
+impl VerifiedBasisCacheUpdate {
+    pub fn verified_basis_to_cache(&self) -> Option<&VerifiedNamespaceBasis> {
         match self {
-            Self::Retained(basis) | Self::Advanced(basis) => Some(basis),
+            Self::ReusableAfterHeadEtagMatch(basis) | Self::AdvancedAfterHeadCas(basis) => {
+                Some(basis)
+            }
             Self::NoChange | Self::Invalidated => None,
         }
     }
 
     pub fn is_advanced(&self) -> bool {
-        matches!(self, Self::Advanced(_))
+        matches!(self, Self::AdvancedAfterHeadCas(_))
     }
 
     pub fn is_invalidated(&self) -> bool {
@@ -108,7 +110,41 @@ impl WarmBasisUpdate {
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEngine {
     namespace_id: NamespaceId,
-    basis: Option<Arc<VerifiedNamespaceBasis>>,
+    basis: Option<CachedVerifiedBasis>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedVerifiedBasis {
+    basis: Arc<VerifiedNamespaceBasis>,
+    head_etag_reuse_token: String,
+}
+
+impl CachedVerifiedBasis {
+    fn new(basis: VerifiedNamespaceBasis) -> Self {
+        Self::from_arc(Arc::new(basis))
+    }
+
+    fn from_arc(basis: Arc<VerifiedNamespaceBasis>) -> Self {
+        Self {
+            head_etag_reuse_token: basis.head_etag.clone(),
+            basis,
+        }
+    }
+
+    fn matches_head_etag_probe(&self, probe: &NamespaceHeadEtagProbe) -> bool {
+        self.head_etag_reuse_token == probe.head_etag
+    }
+
+    fn basis_to_reuse_with_refreshed_lease(&self, lease: LeaseState) -> VerifiedNamespaceBasis {
+        let mut basis = self.basis.as_ref().clone();
+        basis.lease = lease;
+        basis
+    }
+
+    #[cfg(test)]
+    fn verified_basis(&self) -> &VerifiedNamespaceBasis {
+        self.basis.as_ref()
+    }
 }
 
 impl NamespaceCommitEngine {
@@ -132,13 +168,8 @@ impl NamespaceCommitEngine {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
-                warm_basis_event: WarmBasisEvent::Disabled,
-                warm_basis_update: self
-                    .basis
-                    .as_deref()
-                    .cloned()
-                    .map(WarmBasisUpdate::Retained)
-                    .unwrap_or(WarmBasisUpdate::NoChange),
+                basis_reuse_event: BasisReuseEvent::Disabled,
+                verified_basis_cache_update: VerifiedBasisCacheUpdate::NoChange,
             };
         }
 
@@ -149,19 +180,19 @@ impl NamespaceCommitEngine {
             self.invalidate();
             return NamespaceCommitEnginePublishResult {
                 results: repeated_error(candidate_count, CoreError::Lease(error)),
-                warm_basis_event: WarmBasisEvent::Disabled,
-                warm_basis_update: WarmBasisUpdate::Invalidated,
+                basis_reuse_event: BasisReuseEvent::Disabled,
+                verified_basis_cache_update: VerifiedBasisCacheUpdate::Invalidated,
             };
         }
 
-        let (basis, warm_basis_event) = match self.basis_for_publish(store) {
+        let (basis, basis_reuse_event) = match self.basis_for_publish(store) {
             Ok(value) => value,
             Err(error) => {
                 self.invalidate();
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, CoreError::Basis(error)),
-                    warm_basis_event: WarmBasisEvent::Disabled,
-                    warm_basis_update: WarmBasisUpdate::Invalidated,
+                    basis_reuse_event: BasisReuseEvent::Disabled,
+                    verified_basis_cache_update: VerifiedBasisCacheUpdate::Invalidated,
                 };
             }
         };
@@ -173,15 +204,15 @@ impl NamespaceCommitEngine {
             context,
             &basis,
         );
-        if should_retry_reused_warm_rejection(warm_basis_event, &published) {
+        if should_retry_reused_warm_rejection(basis_reuse_event, &published) {
             self.invalidate();
             let cold_basis = match load_verified_namespace_basis(store, &self.namespace_id) {
                 Ok(value) => value,
                 Err(error) => {
                     return NamespaceCommitEnginePublishResult {
                         results: repeated_error(candidate_count, CoreError::Basis(error)),
-                        warm_basis_event: WarmBasisEvent::InvalidatedThenColdLoaded,
-                        warm_basis_update: WarmBasisUpdate::Invalidated,
+                        basis_reuse_event: BasisReuseEvent::InvalidatedThenColdLoaded,
+                        verified_basis_cache_update: VerifiedBasisCacheUpdate::Invalidated,
                     };
                 }
             };
@@ -192,51 +223,53 @@ impl NamespaceCommitEngine {
                 context,
                 &cold_basis,
             );
-            return self.finish_publish_result(retried, WarmBasisEvent::InvalidatedThenColdLoaded);
+            return self.finish_publish_result(retried, BasisReuseEvent::InvalidatedThenColdLoaded);
         }
-        self.finish_publish_result(published, warm_basis_event)
+        self.finish_publish_result(published, basis_reuse_event)
     }
 
     fn finish_publish_result(
         &mut self,
         published: crate::protocol::PublishBatchAgainstBasisResult,
-        warm_basis_event: WarmBasisEvent,
+        basis_reuse_event: BasisReuseEvent,
     ) -> NamespaceCommitEnginePublishResult {
-        let warm_basis_update = match published.basis_promotion {
+        let verified_basis_cache_update = match published.basis_promotion {
             crate::protocol::BasisPromotion::Unchanged(basis) => {
-                self.basis = Some(Arc::new(basis.clone()));
-                WarmBasisUpdate::Retained(basis)
+                self.basis = Some(CachedVerifiedBasis::new(basis.clone()));
+                VerifiedBasisCacheUpdate::ReusableAfterHeadEtagMatch(basis)
             }
             crate::protocol::BasisPromotion::Advanced(basis) => {
-                self.basis = Some(Arc::new(basis.clone()));
-                WarmBasisUpdate::Advanced(basis)
+                self.basis = Some(CachedVerifiedBasis::new(basis.clone()));
+                VerifiedBasisCacheUpdate::AdvancedAfterHeadCas(basis)
             }
             crate::protocol::BasisPromotion::NotCacheable => {
                 self.invalidate();
-                WarmBasisUpdate::Invalidated
+                VerifiedBasisCacheUpdate::Invalidated
             }
         };
 
         NamespaceCommitEnginePublishResult {
             results: published.results,
-            warm_basis_event,
-            warm_basis_update,
+            basis_reuse_event,
+            verified_basis_cache_update,
         }
     }
 
     fn basis_for_publish<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
-    ) -> Result<(VerifiedNamespaceBasis, WarmBasisEvent), BasisLoadError> {
+    ) -> Result<(VerifiedNamespaceBasis, BasisReuseEvent), BasisLoadError> {
         let mut invalidated = false;
         if let Some(cached) = self.basis.clone() {
-            match load_namespace_head_identity(store, &self.namespace_id) {
-                Ok(identity) if identity.head_etag == cached.head_etag => {
+            match probe_namespace_head_etag(store, &self.namespace_id) {
+                Ok(probe) if cached.matches_head_etag_probe(&probe) => {
+                    // A matching ETag does not make the cache authoritative; it
+                    // only proves the durable head object is unchanged since
+                    // this basis was reconstructed and verified.
                     match load_namespace_lease_control(store, &self.namespace_id) {
                         Ok(lease) => {
-                            let mut basis = cached.as_ref().clone();
-                            basis.lease = lease.state;
-                            return Ok((basis, WarmBasisEvent::Reused));
+                            let basis = cached.basis_to_reuse_with_refreshed_lease(lease.state);
+                            return Ok((basis, BasisReuseEvent::ReusedAfterHeadEtagMatch));
                         }
                         Err(_) => {
                             self.invalidate();
@@ -253,19 +286,19 @@ impl NamespaceCommitEngine {
 
         let basis = load_verified_namespace_basis(store, &self.namespace_id)?;
         let event = if invalidated {
-            WarmBasisEvent::InvalidatedThenColdLoaded
+            BasisReuseEvent::InvalidatedThenColdLoaded
         } else {
-            WarmBasisEvent::ColdLoaded
+            BasisReuseEvent::ColdLoaded
         };
         Ok((basis, event))
     }
 }
 
 fn should_retry_reused_warm_rejection(
-    warm_basis_event: WarmBasisEvent,
+    basis_reuse_event: BasisReuseEvent,
     published: &crate::protocol::PublishBatchAgainstBasisResult,
 ) -> bool {
-    warm_basis_event == WarmBasisEvent::Reused
+    basis_reuse_event == BasisReuseEvent::ReusedAfterHeadEtagMatch
         && matches!(
             published.basis_promotion,
             crate::protocol::BasisPromotion::Unchanged(_)
@@ -362,4 +395,62 @@ pub fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
 ) -> Vec<Result<ApiCommitResponse, CoreError>> {
     let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
     engine.publish_batch(store, candidates, context).results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::MetadataState;
+    use crate::NamespaceHeadEtagProbe;
+    use loon_api::{ChangeSeq, ContentStoreId, FenceToken, HeadState, NamespaceDescriptorState};
+
+    #[test]
+    fn cached_verified_basis_refreshes_only_lease_state() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let content_store_id = ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id");
+        let mut head = HeadState::initial(namespace_id.clone());
+        head.seq = ChangeSeq(3);
+        let original_lease = LeaseState {
+            namespace_id: namespace_id.clone(),
+            holder_id: "writer-a".to_owned(),
+            fence_token: FenceToken(1),
+            lease_expires_at_ms: 10,
+        };
+        let basis = VerifiedNamespaceBasis {
+            namespace_descriptor: NamespaceDescriptorState {
+                namespace_id: namespace_id.clone(),
+                content_store_id: content_store_id.clone(),
+            },
+            content_store_id,
+            head: head.clone(),
+            head_etag: "etag-a".to_owned(),
+            lease: original_lease.clone(),
+            metadata_state: MetadataState::default(),
+        };
+        let cached = CachedVerifiedBasis::new(basis.clone());
+
+        assert!(cached.matches_head_etag_probe(&NamespaceHeadEtagProbe {
+            head_etag: "etag-a".to_owned(),
+        }));
+        assert!(!cached.matches_head_etag_probe(&NamespaceHeadEtagProbe {
+            head_etag: "etag-b".to_owned(),
+        }));
+
+        let refreshed_lease = LeaseState {
+            namespace_id,
+            holder_id: "writer-a".to_owned(),
+            fence_token: FenceToken(1),
+            lease_expires_at_ms: 20,
+        };
+        let refreshed = cached.basis_to_reuse_with_refreshed_lease(refreshed_lease.clone());
+
+        assert_eq!(cached.verified_basis().lease, original_lease);
+        assert_eq!(refreshed.lease, refreshed_lease);
+        assert_eq!(refreshed.head, basis.head);
+        assert_eq!(refreshed.head_etag, basis.head_etag);
+        assert_eq!(refreshed.metadata_state, basis.metadata_state);
+        assert_eq!(refreshed.namespace_descriptor, basis.namespace_descriptor);
+        assert_eq!(refreshed.content_store_id, basis.content_store_id);
+    }
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -16,7 +16,7 @@ pub use loon_api::{
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,
     NamespaceId, NamespaceSummary,
 };
-use loon_core::publisher::{NamespaceCommitEnginePublishResult, WarmBasisEvent};
+use loon_core::publisher::{BasisReuseEvent, NamespaceCommitEnginePublishResult};
 pub use loon_core::{
     BootstrapNamespaceError, CoreError, CoreErrorKind, NamespaceMutationCandidate,
     PathMutationIntent, PutFileBehavior,
@@ -119,12 +119,39 @@ pub struct FsBuilder {
 
 #[derive(Debug, Default)]
 struct BasisCache {
-    entries: HashMap<NamespaceId, Arc<VerifiedNamespaceBasis>>,
+    entries: HashMap<NamespaceId, CachedVerifiedBasis>,
     order: VecDeque<NamespaceId>,
 }
 
+#[derive(Debug, Clone)]
+struct CachedVerifiedBasis {
+    basis: Arc<VerifiedNamespaceBasis>,
+    head_etag_reuse_token: String,
+}
+
+impl CachedVerifiedBasis {
+    fn new(basis: Arc<VerifiedNamespaceBasis>) -> Self {
+        Self {
+            head_etag_reuse_token: basis.head_etag.clone(),
+            basis,
+        }
+    }
+
+    fn basis_arc(&self) -> Arc<VerifiedNamespaceBasis> {
+        Arc::clone(&self.basis)
+    }
+
+    fn matches_head_etag(&self, head_etag: &str) -> bool {
+        self.head_etag_reuse_token == head_etag
+    }
+
+    fn matches_head_etag_probe(&self, probe: &loon_core::NamespaceHeadEtagProbe) -> bool {
+        self.matches_head_etag(&probe.head_etag)
+    }
+}
+
 impl BasisCache {
-    fn get(&mut self, namespace_id: &NamespaceId) -> Option<Arc<VerifiedNamespaceBasis>> {
+    fn get(&mut self, namespace_id: &NamespaceId) -> Option<CachedVerifiedBasis> {
         let basis = self.entries.get(namespace_id).cloned()?;
         self.touch(namespace_id);
         Some(basis)
@@ -135,7 +162,8 @@ impl BasisCache {
             return;
         }
         let namespace_id = basis.head.namespace_id.clone();
-        self.entries.insert(namespace_id.clone(), basis);
+        self.entries
+            .insert(namespace_id.clone(), CachedVerifiedBasis::new(basis));
         self.touch(&namespace_id);
         while self.entries.len() > max_cached_namespaces {
             let Some(evicted) = self.order.pop_front() else {
@@ -391,23 +419,23 @@ impl RuntimeCacheStatsInner {
     }
 
     fn record_publish_result(&self, result: &NamespaceCommitEnginePublishResult) {
-        match result.warm_basis_event {
-            WarmBasisEvent::Reused => {
+        match result.basis_reuse_event {
+            BasisReuseEvent::ReusedAfterHeadEtagMatch => {
                 self.publish_warm_basis_hits.fetch_add(1, Ordering::SeqCst);
             }
-            WarmBasisEvent::ColdLoaded | WarmBasisEvent::InvalidatedThenColdLoaded => {
+            BasisReuseEvent::ColdLoaded | BasisReuseEvent::InvalidatedThenColdLoaded => {
                 self.publish_warm_basis_misses
                     .fetch_add(1, Ordering::SeqCst);
             }
-            WarmBasisEvent::Disabled => {}
+            BasisReuseEvent::Disabled => {}
         }
-        if result.warm_basis_event == WarmBasisEvent::InvalidatedThenColdLoaded
-            || result.warm_basis_update.is_invalidated()
+        if result.basis_reuse_event == BasisReuseEvent::InvalidatedThenColdLoaded
+            || result.verified_basis_cache_update.is_invalidated()
         {
             self.publish_warm_basis_invalidations
                 .fetch_add(1, Ordering::SeqCst);
         }
-        if result.warm_basis_update.is_advanced() {
+        if result.verified_basis_cache_update.is_advanced() {
             self.publish_warm_basis_advances
                 .fetch_add(1, Ordering::SeqCst);
         }
@@ -981,9 +1009,12 @@ impl Fs {
                 engine.publish_batch(&store, candidates, &self.mutation_context())
             };
             self.inner.cache_stats.record_publish_result(&publish);
-            if let Some(basis) = publish.warm_basis_update.basis() {
+            if let Some(basis) = publish
+                .verified_basis_cache_update
+                .verified_basis_to_cache()
+            {
                 self.cache_basis(Arc::new(basis.clone()));
-            } else if publish.warm_basis_update.is_invalidated() {
+            } else if publish.verified_basis_cache_update.is_invalidated() {
                 self.invalidate_namespace_cache(namespace_id);
             }
             return publish
@@ -1202,17 +1233,23 @@ impl Fs {
         if let Some(basis) = cached {
             if self.control_cache_enabled() {
                 match self.load_namespace_head_cached(namespace_id) {
-                    Ok(head) if head.identity.etag == basis.head_etag => {
-                        return Ok(basis);
+                    Ok(head) if basis.matches_head_etag(&head.identity.etag) => {
+                        // A matching ETag only proves the durable head object is
+                        // unchanged since this basis was reconstructed and
+                        // verified; the cache itself is not authoritative.
+                        return Ok(basis.basis_arc());
                     }
                     Ok(_) | Err(_) => {
                         self.invalidate_namespace_cache(namespace_id);
                     }
                 }
             } else {
-                match loon_core::load_namespace_head_identity(self.store(), namespace_id) {
-                    Ok(identity) if identity.head_etag == basis.head_etag => {
-                        return Ok(basis);
+                match loon_core::probe_namespace_head_etag(self.store(), namespace_id) {
+                    Ok(probe) if basis.matches_head_etag_probe(&probe) => {
+                        // A matching ETag only proves the durable head object is
+                        // unchanged since this basis was reconstructed and
+                        // verified; the cache itself is not authoritative.
+                        return Ok(basis.basis_arc());
                     }
                     Ok(_) | Err(_) => {
                         self.invalidate_namespace_cache(namespace_id);


### PR DESCRIPTION
This PR keeps the existing warm-basis reuse behavior, but renames/wraps the APIs so the code makes the invariant explicit: it should be clear to developers that a cached VerifiedNamespaceBasis is only reusable after probing the durable head object and confirming its ETag still matches the head that was originally reconstructed. So this is mostly naming and safety-boundary cleanup, not a behavior change.





