### PR TITLE
refactor(core): unify wal chain loading

### DIFF
--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -125,6 +125,7 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
             chain_base_seq: initial_head.seq,
             head_seq: loaded_head.envelope.state.seq,
             visible_tip: loaded_head.envelope.state.visible_wal_tip.clone(),
+            stop_after_seq: None,
         },
     )?;
     let replayed = replay_validated_wal_tail_with_metadata(
@@ -177,6 +178,7 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
             chain_base_seq: checkpoint_basis_seq,
             head_seq: head.seq,
             visible_tip: head.visible_wal_tip.clone(),
+            stop_after_seq: None,
         },
     )
     .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -9,11 +9,11 @@ use crate::namespace::catalog::{
     load_namespace_catalog_entry, namespace_initialization_state, NamespaceCatalogLoadError,
     NamespaceInitializationError, NamespaceInitializationState,
 };
-use crate::wal::{replay_wal_tail_with_metadata, StoredWalObject, WalReplayError};
-use loon_api::{
-    decode_wal_segment_envelope_zstd, ChangeSeq, ContentStoreId, HeadState,
-    NamespaceDescriptorState, NamespaceId, WalSegmentPointer,
+use crate::wal::{
+    load_validated_wal_chain, replay_validated_wal_tail_with_metadata, WalChainLoadError,
+    WalChainLoadRequest, WalReplayError,
 };
+use loon_api::{ChangeSeq, ContentStoreId, HeadState, NamespaceDescriptorState, NamespaceId};
 use loon_objectstore::{
     keys::{namespace_descriptor, namespace_head},
     ObjectStore,
@@ -57,25 +57,8 @@ pub enum BasisLoadError {
     LoadLease(ControlObjectLoadError),
     #[error("missing head etag for `{object_key}`")]
     MissingHeadEtag { object_key: String },
-    #[error("failed to list WAL objects under `{prefix}`: {message}")]
-    ListWal { prefix: String, message: String },
-    #[error("invalid WAL object key `{object_key}`")]
-    InvalidWalObjectKey { object_key: String },
-    #[error("duplicate WAL seq `{seq:?}` with keys `{first}` and `{second}`")]
-    DuplicateWalSeq {
-        seq: loon_api::ChangeSeq,
-        first: String,
-        second: String,
-    },
-    #[error("missing WAL object for seq `{seq:?}` under `{prefix}`")]
-    MissingWalObject {
-        prefix: String,
-        seq: loon_api::ChangeSeq,
-    },
-    #[error("failed to read WAL object `{object_key}`: {message}")]
-    ReadWal { object_key: String, message: String },
-    #[error("missing WAL object after list `{object_key}`")]
-    MissingWalObjectAfterList { object_key: String },
+    #[error(transparent)]
+    WalChainLoad(#[from] WalChainLoadError),
     #[error(transparent)]
     CheckpointLoad(#[from] CheckpointLoadError),
     #[error("wal replay failed: {0:?}")]
@@ -135,15 +118,21 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
             bootstrap_basis_metadata_state(),
         )
     };
-    let wal_tail = load_stored_wal_tail(
+    let wal_chain = load_validated_wal_chain(
         store,
-        expected_namespace,
-        initial_head.seq,
-        loaded_head.envelope.state.seq,
-        loaded_head.envelope.state.visible_wal_tip.clone(),
+        WalChainLoadRequest {
+            namespace_id: expected_namespace,
+            chain_base_seq: initial_head.seq,
+            head_seq: loaded_head.envelope.state.seq,
+            visible_tip: loaded_head.envelope.state.visible_wal_tip.clone(),
+        },
     )?;
-    let replayed = replay_wal_tail_with_metadata(&initial_head, &initial_metadata_state, &wal_tail)
-        .map_err(BasisLoadError::WalReplay)?;
+    let replayed = replay_validated_wal_tail_with_metadata(
+        &initial_head,
+        &initial_metadata_state,
+        wal_chain.segments(),
+    )
+    .map_err(BasisLoadError::WalReplay)?;
     ensure_reconstructed_head_matches(&loaded_head.envelope.state, &replayed.resulting_head)?;
 
     Ok(VerifiedNamespaceBasis {
@@ -181,14 +170,18 @@ pub fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         .map_err(|error| CoreError::Basis(BasisLoadError::LoadHead(error)))?;
     let head = loaded_head.envelope.state;
     let checkpoint_basis_seq = head.checkpoint_hint_seq.unwrap_or(ChangeSeq(0));
-    let wal_tail_segments = count_stored_wal_tail_segments(
+    let wal_chain = load_validated_wal_chain(
         store,
-        expected_namespace,
-        checkpoint_basis_seq,
-        head.seq,
-        head.visible_wal_tip.clone(),
+        WalChainLoadRequest {
+            namespace_id: expected_namespace,
+            chain_base_seq: checkpoint_basis_seq,
+            head_seq: head.seq,
+            visible_tip: head.visible_wal_tip.clone(),
+        },
     )
-    .map_err(CoreError::Basis)?;
+    .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;
+    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
+        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))?;
     Ok(NamespaceHeadSummary {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
@@ -265,119 +258,5 @@ fn ensure_reconstructed_head_matches(
             actual: Box::new(reconstructed.clone()),
         });
     }
-    Ok(())
-}
-
-fn load_stored_wal_tail<S: ObjectStore + ?Sized>(
-    store: &S,
-    expected_namespace: &NamespaceId,
-    from_seq_exclusive: ChangeSeq,
-    through_seq_inclusive: ChangeSeq,
-    visible_wal_tip: Option<WalSegmentPointer>,
-) -> Result<Vec<StoredWalObject>, BasisLoadError> {
-    let mut reversed = Vec::new();
-    walk_stored_wal_tail(
-        store,
-        expected_namespace,
-        from_seq_exclusive,
-        through_seq_inclusive,
-        visible_wal_tip,
-        |pointer, encoded_bytes| {
-            reversed.push(StoredWalObject {
-                object_key: pointer.object_key.clone(),
-                encoded_bytes,
-            });
-            Ok(())
-        },
-    )?;
-
-    reversed.reverse();
-    Ok(reversed)
-}
-
-fn count_stored_wal_tail_segments<S: ObjectStore + ?Sized>(
-    store: &S,
-    expected_namespace: &NamespaceId,
-    from_seq_exclusive: ChangeSeq,
-    through_seq_inclusive: ChangeSeq,
-    visible_wal_tip: Option<WalSegmentPointer>,
-) -> Result<u64, BasisLoadError> {
-    let mut count = 0u64;
-    walk_stored_wal_tail(
-        store,
-        expected_namespace,
-        from_seq_exclusive,
-        through_seq_inclusive,
-        visible_wal_tip,
-        |_pointer, _encoded_bytes| {
-            count = count.saturating_add(1);
-            Ok(())
-        },
-    )?;
-    Ok(count)
-}
-
-fn walk_stored_wal_tail<S, F>(
-    store: &S,
-    expected_namespace: &NamespaceId,
-    from_seq_exclusive: ChangeSeq,
-    through_seq_inclusive: ChangeSeq,
-    visible_wal_tip: Option<WalSegmentPointer>,
-    mut visit: F,
-) -> Result<(), BasisLoadError>
-where
-    S: ObjectStore + ?Sized,
-    F: FnMut(&WalSegmentPointer, Vec<u8>) -> Result<(), BasisLoadError>,
-{
-    if through_seq_inclusive <= from_seq_exclusive {
-        return Ok(());
-    }
-
-    let prefix = format!("namespaces/{}/wal/", expected_namespace.as_str());
-    let mut pointer = visible_wal_tip.ok_or_else(|| BasisLoadError::MissingWalObject {
-        prefix: prefix.clone(),
-        seq: through_seq_inclusive,
-    })?;
-
-    loop {
-        if pointer.end_seq <= from_seq_exclusive {
-            break;
-        }
-        let encoded_bytes = store
-            .get(&pointer.object_key, None)
-            .map_err(|err| BasisLoadError::ReadWal {
-                object_key: pointer.object_key.clone(),
-                message: err.to_string(),
-            })?
-            .ok_or_else(|| BasisLoadError::MissingWalObjectAfterList {
-                object_key: pointer.object_key.clone(),
-            })?;
-        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
-            .map_err(|err| BasisLoadError::WalReplay(WalReplayError::Codec(err.to_string())))?;
-        if envelope.payload.namespace_id != *expected_namespace {
-            return Err(BasisLoadError::WalReplay(
-                WalReplayError::NamespaceMismatch {
-                    expected: expected_namespace.clone(),
-                    actual: envelope.payload.namespace_id.clone(),
-                },
-            ));
-        }
-        if envelope.payload.segment_id != pointer.segment_id
-            || envelope.payload.start_seq != pointer.start_seq
-            || envelope.payload.end_seq != pointer.end_seq
-            || envelope.payload_checksum_sha256 != pointer.payload_checksum_sha256
-        {
-            return Err(BasisLoadError::WalReplay(
-                WalReplayError::SegmentSummaryMismatch,
-            ));
-        }
-        let prev = envelope.payload.prev_visible_segment.clone();
-        visit(&pointer, encoded_bytes)?;
-        let Some(prev) = prev else {
-            break;
-        };
-        pointer = prev;
-    }
-
     Ok(())
 }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -5,7 +5,7 @@ use crate::lease::LeaseAcquireError;
 use crate::loading::ControlObjectLoadError;
 use crate::metadata::{MetadataApplyError, VisiblePathError};
 use crate::namespace::catalog::NamespaceCatalogLoadError;
-use crate::wal::WalBuildError;
+use crate::wal::{WalBuildError, WalChainLoadError};
 use loon_api::{
     ChangeSeq, CommitIdValidationError, GeneratedIdValidationError, InodeId, InodeKind,
     NamespaceId, NamespaceIdValidationError,
@@ -235,19 +235,28 @@ fn classify_basis_load_error(error: &BasisLoadError) -> CoreErrorKind {
             }
             _ => classify_control_object_load_error(error),
         },
-        BasisLoadError::InvalidWalObjectKey { .. }
-        | BasisLoadError::DuplicateWalSeq { .. }
-        | BasisLoadError::MissingWalObject { .. }
-        | BasisLoadError::MissingWalObjectAfterList { .. }
-        | BasisLoadError::WalReplay(_)
-        | BasisLoadError::ReconstructedHeadMismatch { .. } => CoreErrorKind::NamespaceCorrupt,
+        BasisLoadError::WalChainLoad(error) => classify_wal_chain_load_error(error),
+        BasisLoadError::WalReplay(_) | BasisLoadError::ReconstructedHeadMismatch { .. } => {
+            CoreErrorKind::NamespaceCorrupt
+        }
         BasisLoadError::CheckpointLoad(error) => match error.kind() {
             crate::checkpoint::CheckpointLoadErrorKind::Corrupt => CoreErrorKind::NamespaceCorrupt,
             crate::checkpoint::CheckpointLoadErrorKind::Store => CoreErrorKind::ServerError,
         },
-        BasisLoadError::MissingHeadEtag { .. }
-        | BasisLoadError::ListWal { .. }
-        | BasisLoadError::ReadWal { .. } => CoreErrorKind::ServerError,
+        BasisLoadError::MissingHeadEtag { .. } => CoreErrorKind::ServerError,
+    }
+}
+
+fn classify_wal_chain_load_error(error: &WalChainLoadError) -> CoreErrorKind {
+    match error {
+        WalChainLoadError::ReadWal { .. } => CoreErrorKind::ServerError,
+        WalChainLoadError::InvalidSeqRange { .. }
+        | WalChainLoadError::MissingVisibleTip { .. }
+        | WalChainLoadError::TipEndSeqMismatch { .. }
+        | WalChainLoadError::MissingWalObject { .. }
+        | WalChainLoadError::PointerMismatch { .. }
+        | WalChainLoadError::HeadSeqMismatch { .. }
+        | WalChainLoadError::Replay(_) => CoreErrorKind::NamespaceCorrupt,
     }
 }
 

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -256,6 +256,7 @@ fn classify_wal_chain_load_error(error: &WalChainLoadError) -> CoreErrorKind {
         | WalChainLoadError::MissingWalObject { .. }
         | WalChainLoadError::PointerMismatch { .. }
         | WalChainLoadError::HeadSeqMismatch { .. }
+        | WalChainLoadError::CursorNotCovered { .. }
         | WalChainLoadError::Replay(_) => CoreErrorKind::NamespaceCorrupt,
     }
 }

--- a/crates/loon-core/src/invariants.rs
+++ b/crates/loon-core/src/invariants.rs
@@ -21,7 +21,7 @@ pub const NAMESPACE_CORE_METADATA_APPLY_INVARIANTS: &[&str] = &[
 
 pub const NAMESPACE_CORE_WAL_REPLAY_INVARIANTS: &[&str] = &[
     "wal_payload_checksum_matches_payload",
-    "wal_key_matches_committed_seq",
+    "wal_key_matches_segment_seq_range",
     "head_publish_requires_durable_wal",
     "wal_replay_requires_matching_namespace",
     "wal_replay_requires_matching_base_head_seq",
@@ -229,7 +229,7 @@ pub const INVARIANTS: &[&str] = &[
     "whole_file_content_size_matches_ref",
     "whole_file_content_digest_matches_ref",
     "wal_payload_checksum_matches_payload",
-    "wal_key_matches_committed_seq",
+    "wal_key_matches_segment_seq_range",
     "head_publish_requires_durable_wal",
     "wal_replay_requires_matching_namespace",
     "wal_replay_requires_matching_base_head_seq",

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -16,7 +16,7 @@ use crate::namespace::catalog::{
 };
 use crate::path::planner::{path_intent_fingerprint_for_path_intent, PathPlanner};
 use crate::publisher::NamespaceMutationCandidate;
-use crate::wal::{prepare_wal_segment, StoredWalObject};
+use crate::wal::{load_validated_wal_chain, prepare_wal_segment, WalChainLoadRequest};
 use crate::{
     load_content_store_descriptor_control, load_namespace_descriptor_control,
     load_namespace_head_control, load_namespace_lease_control,
@@ -27,9 +27,9 @@ use loon_api::v0::{
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loon_api::{
-    decode_wal_segment_envelope_zstd, generate_upload_id, validate_upload_id, ChangeSeq, CommitId,
-    CompletedUpload, ContentRef, ContentStoreId, ControlObjectKind, HeadState, NamespaceId,
-    UploadSessionEnvelope, UploadSessionState, WalCommitDelta, WalDelta,
+    generate_upload_id, validate_upload_id, ChangeSeq, CommitId, CompletedUpload, ContentRef,
+    ContentStoreId, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
+    UploadSessionState, WalCommitDelta, WalDelta,
 };
 use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -787,19 +787,32 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         });
     }
 
-    let wal_objects = load_wal_range(store, namespace_id, after_seq, basis.head.seq, &basis.head)?;
+    let checkpoint_basis_seq = basis.head.checkpoint_hint_seq.unwrap_or(ChangeSeq(0));
+    let chain_base_seq = if after_seq < checkpoint_basis_seq {
+        basis.head.retention_floor_seq
+    } else {
+        checkpoint_basis_seq
+    };
+    let wal_chain = load_validated_wal_chain(
+        store,
+        WalChainLoadRequest {
+            namespace_id,
+            chain_base_seq,
+            head_seq: basis.head.seq,
+            visible_tip: basis.head.visible_wal_tip.clone(),
+        },
+    )
+    .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;
     let mut changes = Vec::new();
-    for wal_object in wal_objects {
-        let envelope = decode_wal_segment_envelope_zstd(&wal_object.encoded_bytes)
-            .map_err(|err| CoreError::Store(err.to_string()))?;
-        for record in envelope.payload.records {
+    for segment in wal_chain.segments() {
+        for record in segment.records() {
             if record.seq > after_seq {
                 changes.push(CommittedChange {
                     seq: record.seq,
-                    commit_id: record.commit_id,
-                    message: record.message,
-                    annotations: record.annotations,
-                    ops: record.results,
+                    commit_id: record.commit_id.clone(),
+                    message: record.message.clone(),
+                    annotations: record.annotations.clone(),
+                    ops: record.results.clone(),
                     deltas: record.deltas.iter().map(commit_delta_from_wal).collect(),
                 });
             }
@@ -968,54 +981,6 @@ fn read_upload_session_object<S: ObjectStore + ?Sized>(
         metadata,
         envelope,
     })
-}
-
-fn load_wal_range<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    from_seq_exclusive: ChangeSeq,
-    through_seq_inclusive: ChangeSeq,
-    head: &loon_api::HeadState,
-) -> Result<Vec<crate::wal::StoredWalObject>, CoreError> {
-    if through_seq_inclusive <= from_seq_exclusive {
-        return Ok(Vec::new());
-    }
-    let prefix = format!("namespaces/{}/wal/", namespace_id.as_str());
-    let mut pointer =
-        head.visible_wal_tip
-            .clone()
-            .ok_or_else(|| BasisLoadError::MissingWalObject {
-                prefix: prefix.clone(),
-                seq: through_seq_inclusive,
-            })?;
-    let mut out = Vec::new();
-    loop {
-        if pointer.end_seq <= from_seq_exclusive {
-            break;
-        }
-        let encoded_bytes = store
-            .get(&pointer.object_key, None)
-            .map_err(|err| BasisLoadError::ReadWal {
-                object_key: pointer.object_key.clone(),
-                message: err.to_string(),
-            })?
-            .ok_or_else(|| BasisLoadError::MissingWalObjectAfterList {
-                object_key: pointer.object_key.clone(),
-            })?;
-        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
-            .map_err(|err| CoreError::Store(err.to_string()))?;
-        let prev = envelope.payload.prev_visible_segment.clone();
-        out.push(StoredWalObject {
-            object_key: pointer.object_key,
-            encoded_bytes,
-        });
-        let Some(prev) = prev else {
-            break;
-        };
-        pointer = prev;
-    }
-    out.reverse();
-    Ok(out)
 }
 
 fn find_commit_receipt<'a>(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -787,19 +787,14 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
         });
     }
 
-    let checkpoint_basis_seq = basis.head.checkpoint_hint_seq.unwrap_or(ChangeSeq(0));
-    let chain_base_seq = if after_seq < checkpoint_basis_seq {
-        basis.head.retention_floor_seq
-    } else {
-        checkpoint_basis_seq
-    };
     let wal_chain = load_validated_wal_chain(
         store,
         WalChainLoadRequest {
             namespace_id,
-            chain_base_seq,
+            chain_base_seq: basis.head.retention_floor_seq,
             head_seq: basis.head.seq,
             visible_tip: basis.head.visible_wal_tip.clone(),
+            stop_after_seq: Some(after_seq),
         },
     )
     .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -6,7 +6,9 @@ use loon_api::{
     WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
 };
 use loon_objectstore::keys::wal_segment;
+use loon_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedWalSegment {
@@ -40,6 +42,87 @@ pub enum WalBuildError {
 pub struct StoredWalObject {
     pub object_key: String,
     pub encoded_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WalChainLoadRequest<'a> {
+    pub(crate) namespace_id: &'a NamespaceId,
+    pub(crate) chain_base_seq: ChangeSeq,
+    pub(crate) head_seq: ChangeSeq,
+    pub(crate) visible_tip: Option<WalSegmentPointer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ValidatedWalSegment {
+    object_key: String,
+    envelope: WalSegmentEnvelope,
+}
+
+impl ValidatedWalSegment {
+    pub(crate) fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub(crate) fn envelope(&self) -> &WalSegmentEnvelope {
+        &self.envelope
+    }
+
+    pub(crate) fn records(&self) -> &[WalCommitPayload] {
+        &self.envelope.payload.records
+    }
+
+    fn pointer(&self) -> WalSegmentPointer {
+        self.envelope.pointer(self.object_key.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ValidatedWalChain {
+    segments: Vec<ValidatedWalSegment>,
+    checked_invariants: Vec<String>,
+}
+
+impl ValidatedWalChain {
+    pub(crate) fn segments(&self) -> &[ValidatedWalSegment] {
+        &self.segments
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub enum WalChainLoadError {
+    #[error("invalid WAL chain seq range: base `{chain_base_seq:?}` is after head `{head_seq:?}`")]
+    InvalidSeqRange {
+        chain_base_seq: ChangeSeq,
+        head_seq: ChangeSeq,
+    },
+    #[error("missing visible WAL tip for seq `{seq:?}` under `{prefix}`")]
+    MissingVisibleTip { prefix: String, seq: ChangeSeq },
+    #[error("visible WAL tip ends at `{actual:?}`, expected head seq `{expected:?}`")]
+    TipEndSeqMismatch {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
+    #[error("failed to read WAL object `{object_key}`: {message}")]
+    ReadWal { object_key: String, message: String },
+    #[error("missing WAL object `{object_key}`")]
+    MissingWalObject { object_key: String },
+    #[error("WAL pointer does not match segment payload for `{object_key}`")]
+    PointerMismatch { object_key: String },
+    #[error(
+        "WAL chain does not reach expected head seq: expected `{expected:?}`, actual `{actual:?}`"
+    )]
+    HeadSeqMismatch {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
+    #[error("wal replay validation failed: {0:?}")]
+    Replay(WalReplayError),
+}
+
+impl From<WalReplayError> for WalChainLoadError {
+    fn from(value: WalReplayError) -> Self {
+        Self::Replay(value)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -181,6 +264,103 @@ pub fn prepare_wal_segment(
     })
 }
 
+pub(crate) fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: WalChainLoadRequest<'_>,
+) -> Result<ValidatedWalChain, WalChainLoadError> {
+    if request.chain_base_seq > request.head_seq {
+        return Err(WalChainLoadError::InvalidSeqRange {
+            chain_base_seq: request.chain_base_seq,
+            head_seq: request.head_seq,
+        });
+    }
+    if request.chain_base_seq == request.head_seq {
+        return Ok(ValidatedWalChain {
+            segments: Vec::new(),
+            checked_invariants: Vec::new(),
+        });
+    }
+
+    let prefix = format!("namespaces/{}/wal/", request.namespace_id.as_str());
+    let mut pointer = request
+        .visible_tip
+        .clone()
+        .ok_or(WalChainLoadError::MissingVisibleTip {
+            prefix,
+            seq: request.head_seq,
+        })?;
+    if pointer.end_seq != request.head_seq {
+        return Err(WalChainLoadError::TipEndSeqMismatch {
+            expected: request.head_seq,
+            actual: pointer.end_seq,
+        });
+    }
+
+    let mut reversed = Vec::new();
+    loop {
+        if pointer.end_seq <= request.chain_base_seq {
+            break;
+        }
+
+        let object_key = pointer.object_key.clone();
+        let encoded_bytes = store
+            .get(&object_key, None)
+            .map_err(|err| WalChainLoadError::ReadWal {
+                object_key: object_key.clone(),
+                message: err.to_string(),
+            })?
+            .ok_or_else(|| WalChainLoadError::MissingWalObject {
+                object_key: object_key.clone(),
+            })?;
+        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
+            .map_err(|err| WalReplayError::Codec(err.to_string()))?;
+        validate_pointer_matches_envelope(&pointer, &object_key, &envelope)?;
+
+        let prev = envelope.payload.prev_visible_segment.clone();
+        reversed.push(ValidatedWalSegment {
+            object_key,
+            envelope,
+        });
+
+        if reversed
+            .last()
+            .map(|segment| segment.envelope.payload.base_head_seq <= request.chain_base_seq)
+            .unwrap_or(false)
+        {
+            break;
+        }
+
+        pointer = prev.ok_or(WalReplayError::SegmentSummaryMismatch)?;
+    }
+
+    reversed.reverse();
+
+    let mut expected_base_seq = request.chain_base_seq;
+    let mut checked_invariants = Vec::new();
+    for segment in &reversed {
+        validate_decoded_replayed_wal(
+            request.namespace_id,
+            expected_base_seq,
+            segment.object_key(),
+            segment.envelope(),
+        )?;
+        expected_base_seq = segment.envelope.payload.end_seq;
+        extend_wal_replay_invariants(&mut checked_invariants);
+    }
+
+    if expected_base_seq != request.head_seq {
+        return Err(WalChainLoadError::HeadSeqMismatch {
+            expected: request.head_seq,
+            actual: expected_base_seq,
+        });
+    }
+
+    Ok(ValidatedWalChain {
+        segments: reversed,
+        checked_invariants,
+    })
+}
+
 pub fn replay_wal_segment(
     current_head: &HeadState,
     wal_object: &StoredWalObject,
@@ -271,6 +451,44 @@ pub fn replay_wal_tail_with_metadata(
     })
 }
 
+pub(crate) fn replay_validated_wal_tail_with_metadata(
+    basis_head: &HeadState,
+    basis_metadata_state: &MetadataState,
+    wal_tail: &[ValidatedWalSegment],
+) -> Result<ReplayedWalTail, WalReplayError> {
+    let mut current_head = basis_head.clone();
+    let mut current_metadata_state = basis_metadata_state.clone();
+    let mut checked_invariants = Vec::new();
+
+    for wal_segment in wal_tail {
+        validate_decoded_replayed_wal(
+            &current_head.namespace_id,
+            current_head.seq,
+            wal_segment.object_key(),
+            wal_segment.envelope(),
+        )?;
+        for record in wal_segment.records() {
+            current_head.seq = record.seq;
+            current_head.next_inode_id =
+                replay_next_inode_id_from_commit_deltas(current_head.next_inode_id, &record.deltas);
+            let applied = current_metadata_state
+                .apply_committed_wal_record(record)
+                .map_err(WalReplayError::MetadataApply)?;
+            current_metadata_state = applied.metadata_state;
+            push_invariant(&mut checked_invariants, "wal_replay_applies_metadata_rows");
+            extend_invariants(&mut checked_invariants, &applied.checked_invariants);
+        }
+        current_head.visible_wal_tip = Some(wal_segment.pointer());
+        extend_wal_replay_invariants(&mut checked_invariants);
+    }
+
+    Ok(ReplayedWalTail {
+        resulting_head: current_head,
+        resulting_metadata_state: current_metadata_state,
+        checked_invariants,
+    })
+}
+
 impl From<&PreparedWalSegment> for StoredWalObject {
     fn from(value: &PreparedWalSegment) -> Self {
         Self {
@@ -286,6 +504,35 @@ fn decode_and_validate_replayed_wal(
 ) -> Result<WalSegmentEnvelope, WalReplayError> {
     let envelope = decode_wal_segment_envelope_zstd(&wal_object.encoded_bytes)
         .map_err(|err| WalReplayError::Codec(err.to_string()))?;
+    validate_decoded_replayed_wal(
+        &current_head.namespace_id,
+        current_head.seq,
+        &wal_object.object_key,
+        &envelope,
+    )?;
+
+    Ok(envelope)
+}
+
+fn validate_pointer_matches_envelope(
+    pointer: &WalSegmentPointer,
+    object_key: &str,
+    envelope: &WalSegmentEnvelope,
+) -> Result<(), WalChainLoadError> {
+    if envelope.pointer(object_key.to_owned()) != *pointer {
+        return Err(WalChainLoadError::PointerMismatch {
+            object_key: object_key.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_decoded_replayed_wal(
+    expected_namespace: &NamespaceId,
+    expected_base_head_seq: ChangeSeq,
+    object_key: &str,
+    envelope: &WalSegmentEnvelope,
+) -> Result<(), WalReplayError> {
     validate_wal_segment_id(&envelope.payload.segment_id)
         .map_err(|err| WalReplayError::Codec(err.to_string()))?;
     let expected_object_key = wal_segment(
@@ -295,29 +542,28 @@ fn decode_and_validate_replayed_wal(
         &envelope.payload.segment_id,
     );
 
-    if wal_object.object_key != expected_object_key {
+    if object_key != expected_object_key {
         return Err(WalReplayError::ObjectKeyMismatch {
             expected: expected_object_key,
-            actual: wal_object.object_key.clone(),
+            actual: object_key.to_owned(),
         });
     }
 
-    if envelope.payload.namespace_id != current_head.namespace_id {
+    if &envelope.payload.namespace_id != expected_namespace {
         return Err(WalReplayError::NamespaceMismatch {
-            expected: current_head.namespace_id.clone(),
+            expected: expected_namespace.clone(),
             actual: envelope.payload.namespace_id.clone(),
         });
     }
 
-    if envelope.payload.base_head_seq != current_head.seq {
+    if envelope.payload.base_head_seq != expected_base_head_seq {
         return Err(WalReplayError::BaseHeadSeqMismatch {
-            expected: current_head.seq,
+            expected: expected_base_head_seq,
             actual: envelope.payload.base_head_seq,
         });
     }
 
-    let expected_start = current_head
-        .seq
+    let expected_start = expected_base_head_seq
         .0
         .checked_add(1)
         .map(ChangeSeq)
@@ -352,15 +598,27 @@ fn decode_and_validate_replayed_wal(
                 actual: record.seq,
             });
         }
-        if record.namespace_id != current_head.namespace_id {
+        if &record.namespace_id != expected_namespace {
             return Err(WalReplayError::NamespaceMismatch {
-                expected: current_head.namespace_id.clone(),
+                expected: expected_namespace.clone(),
                 actual: record.namespace_id.clone(),
             });
         }
     }
 
-    Ok(envelope)
+    Ok(())
+}
+
+fn extend_wal_replay_invariants(checked_invariants: &mut Vec<String>) {
+    for invariant in [
+        "wal_payload_checksum_matches_payload",
+        "wal_key_matches_segment_seq_range",
+        "wal_replay_requires_matching_namespace",
+        "wal_replay_requires_matching_base_head_seq",
+        "wal_tail_seq_is_contiguous",
+    ] {
+        push_invariant(checked_invariants, invariant);
+    }
 }
 
 fn replay_next_inode_id(current_next_inode_id: InodeId, deltas: &[WalDelta]) -> InodeId {
@@ -406,6 +664,9 @@ mod tests {
     use super::*;
     use crate::commit::{materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit};
     use loon_api::{CommitId, FenceToken};
+    use loon_objectstore::fs::LocalFsStore;
+    use loon_objectstore::ObjectStore;
+    use tempfile::tempdir;
 
     #[test]
     fn build_wal_record_payload_matches_segment_record_payload() {
@@ -483,6 +744,115 @@ mod tests {
         validate_wal_segment_id(&second.segment_id).expect("second segment id shape");
     }
 
+    #[test]
+    fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let segment = prepare_wal_segment(
+            namespace_id.clone(),
+            None,
+            &[materialized_create_dir(
+                &namespace_id,
+                "c_wal_chain_a",
+                "alpha",
+                ChangeSeq(0),
+                ChangeSeq(1),
+            )],
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        store
+            .put_if_absent(&segment.object_key, &segment.encoded_bytes)
+            .expect("write wal segment");
+
+        let chain = load_validated_wal_chain(
+            &store,
+            WalChainLoadRequest {
+                namespace_id: &namespace_id,
+                chain_base_seq: ChangeSeq(0),
+                head_seq: ChangeSeq(1),
+                visible_tip: Some(segment.envelope.pointer(segment.object_key.clone())),
+            },
+        )
+        .expect("load valid chain");
+
+        assert_eq!(chain.segments().len(), 1);
+        assert_eq!(chain.segments()[0].records()[0].seq, ChangeSeq(1));
+    }
+
+    #[test]
+    fn validated_wal_chain_rejects_corrupt_visible_segments() {
+        assert_wal_chain_corruption_rejected(|object_key, _envelope, pointer| {
+            *object_key = wal_segment("demo", 1, 1, "seg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            pointer.object_key = object_key.clone();
+        });
+        assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
+            envelope.payload.namespace_id =
+                NamespaceId::parse("other").expect("valid namespace id");
+            rewrap_envelope(envelope);
+            *object_key = wal_segment(
+                envelope.payload.namespace_id.as_str(),
+                envelope.payload.start_seq.0,
+                envelope.payload.end_seq.0,
+                &envelope.payload.segment_id,
+            );
+            *pointer = envelope.pointer(object_key.clone());
+        });
+        assert_wal_chain_corruption_rejected(|_object_key, envelope, _pointer| {
+            envelope.payload.segment_id = "seg_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned();
+            rewrap_envelope(envelope);
+        });
+        assert_wal_chain_corruption_rejected(|_object_key, _envelope, pointer| {
+            pointer.payload_checksum_sha256 = "sha256:not-the-payload".to_owned();
+        });
+        assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
+            envelope.payload.records.clear();
+            rewrap_envelope(envelope);
+            *pointer = envelope.pointer(object_key.clone());
+        });
+        assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
+            envelope.payload.end_seq = ChangeSeq(2);
+            rewrap_envelope(envelope);
+            *object_key = wal_segment(
+                envelope.payload.namespace_id.as_str(),
+                envelope.payload.start_seq.0,
+                envelope.payload.end_seq.0,
+                &envelope.payload.segment_id,
+            );
+            *pointer = envelope.pointer(object_key.clone());
+        });
+        assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
+            let mut skipped = envelope.payload.records[0].clone();
+            skipped.seq = ChangeSeq(3);
+            skipped.apply_after_seq = ChangeSeq(1);
+            envelope.payload.records.push(skipped);
+            envelope.payload.end_seq = ChangeSeq(3);
+            rewrap_envelope(envelope);
+            *object_key = wal_segment(
+                envelope.payload.namespace_id.as_str(),
+                envelope.payload.start_seq.0,
+                envelope.payload.end_seq.0,
+                &envelope.payload.segment_id,
+            );
+            *pointer = envelope.pointer(object_key.clone());
+        });
+        assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
+            envelope.payload.base_head_seq = ChangeSeq(1);
+            envelope.payload.start_seq = ChangeSeq(2);
+            envelope.payload.end_seq = ChangeSeq(2);
+            envelope.payload.records[0].seq = ChangeSeq(2);
+            rewrap_envelope(envelope);
+            *object_key = wal_segment(
+                envelope.payload.namespace_id.as_str(),
+                envelope.payload.start_seq.0,
+                envelope.payload.end_seq.0,
+                &envelope.payload.segment_id,
+            );
+            *pointer = envelope.pointer(object_key.clone());
+        });
+    }
+
     fn materialized_create_dir(
         namespace_id: &NamespaceId,
         commit_id: &str,
@@ -518,5 +888,56 @@ mod tests {
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
         materialize_commit(prepared).expect("materialize commit")
+    }
+
+    fn assert_wal_chain_corruption_rejected(
+        corrupt: impl FnOnce(&mut String, &mut WalSegmentEnvelope, &mut WalSegmentPointer),
+    ) {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let segment = prepare_wal_segment(
+            namespace_id.clone(),
+            None,
+            &[materialized_create_dir(
+                &namespace_id,
+                "c_wal_corrupt",
+                "docs",
+                ChangeSeq(0),
+                ChangeSeq(1),
+            )],
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        let mut object_key = segment.object_key;
+        let mut envelope = segment.envelope;
+        let mut pointer = envelope.pointer(object_key.clone());
+
+        corrupt(&mut object_key, &mut envelope, &mut pointer);
+
+        let encoded =
+            encode_wal_segment_envelope_zstd(&envelope).expect("encode corrupted envelope");
+        store
+            .put_if_absent(&object_key, &encoded)
+            .expect("write corrupted wal segment");
+
+        load_validated_wal_chain(
+            &store,
+            WalChainLoadRequest {
+                namespace_id: &namespace_id,
+                chain_base_seq: ChangeSeq(0),
+                head_seq: pointer.end_seq,
+                visible_tip: Some(pointer),
+            },
+        )
+        .expect_err("corrupted WAL chain should be rejected");
+    }
+
+    fn rewrap_envelope(envelope: &mut WalSegmentEnvelope) {
+        *envelope = WalSegmentEnvelope::from_payload(
+            envelope.writer_version.clone(),
+            envelope.payload.clone(),
+        )
+        .expect("rewrap wal envelope");
     }
 }

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -50,6 +50,7 @@ pub(crate) struct WalChainLoadRequest<'a> {
     pub(crate) chain_base_seq: ChangeSeq,
     pub(crate) head_seq: ChangeSeq,
     pub(crate) visible_tip: Option<WalSegmentPointer>,
+    pub(crate) stop_after_seq: Option<ChangeSeq>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,6 +116,8 @@ pub enum WalChainLoadError {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("WAL chain suffix does not cover requested cursor `{after_seq:?}`")]
+    CursorNotCovered { after_seq: ChangeSeq },
     #[error("wal replay validation failed: {0:?}")]
     Replay(WalReplayError),
 }
@@ -296,9 +299,10 @@ pub(crate) fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
         });
     }
 
+    let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
     let mut reversed = Vec::new();
     loop {
-        if pointer.end_seq <= request.chain_base_seq {
+        if pointer.end_seq <= stop_after_seq {
             break;
         }
 
@@ -324,7 +328,7 @@ pub(crate) fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
 
         if reversed
             .last()
-            .map(|segment| segment.envelope.payload.base_head_seq <= request.chain_base_seq)
+            .map(|segment| segment.envelope.payload.base_head_seq <= stop_after_seq)
             .unwrap_or(false)
         {
             break;
@@ -335,7 +339,27 @@ pub(crate) fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
 
     reversed.reverse();
 
-    let mut expected_base_seq = request.chain_base_seq;
+    let Some(first_segment) = reversed.first() else {
+        return Ok(ValidatedWalChain {
+            segments: Vec::new(),
+            checked_invariants: Vec::new(),
+        });
+    };
+    if let Some(after_seq) = request.stop_after_seq {
+        if first_segment.envelope.payload.base_head_seq > after_seq
+            || first_segment.envelope.payload.end_seq <= after_seq
+        {
+            return Err(WalChainLoadError::CursorNotCovered { after_seq });
+        }
+    }
+
+    let mut expected_base_seq = first_segment.envelope.payload.base_head_seq;
+    if request.stop_after_seq.is_none() && expected_base_seq != request.chain_base_seq {
+        return Err(WalChainLoadError::HeadSeqMismatch {
+            expected: request.chain_base_seq,
+            actual: expected_base_seq,
+        });
+    }
     let mut checked_invariants = Vec::new();
     for segment in &reversed {
         validate_decoded_replayed_wal(
@@ -749,22 +773,15 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let segment = prepare_wal_segment(
-            namespace_id.clone(),
+        let segment = write_create_dir_segment(
+            &store,
+            &namespace_id,
             None,
-            &[materialized_create_dir(
-                &namespace_id,
-                "c_wal_chain_a",
-                "alpha",
-                ChangeSeq(0),
-                ChangeSeq(1),
-            )],
-            "test-writer",
-        )
-        .expect("prepare wal segment");
-        store
-            .put_if_absent(&segment.object_key, &segment.encoded_bytes)
-            .expect("write wal segment");
+            "c_wal_chain_a",
+            "alpha",
+            ChangeSeq(0),
+            ChangeSeq(1),
+        );
 
         let chain = load_validated_wal_chain(
             &store,
@@ -773,12 +790,53 @@ mod tests {
                 chain_base_seq: ChangeSeq(0),
                 head_seq: ChangeSeq(1),
                 visible_tip: Some(segment.envelope.pointer(segment.object_key.clone())),
+                stop_after_seq: None,
             },
         )
         .expect("load valid chain");
 
         assert_eq!(chain.segments().len(), 1);
         assert_eq!(chain.segments()[0].records()[0].seq, ChangeSeq(1));
+    }
+
+    #[test]
+    fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let first = write_create_dir_segment(
+            &store,
+            &namespace_id,
+            None,
+            "c_wal_suffix_a",
+            "alpha",
+            ChangeSeq(0),
+            ChangeSeq(1),
+        );
+        let second = write_create_dir_segment(
+            &store,
+            &namespace_id,
+            Some(first.envelope.pointer(first.object_key.clone())),
+            "c_wal_suffix_b",
+            "beta",
+            ChangeSeq(1),
+            ChangeSeq(2),
+        );
+
+        let chain = load_validated_wal_chain(
+            &store,
+            WalChainLoadRequest {
+                namespace_id: &namespace_id,
+                chain_base_seq: ChangeSeq(0),
+                head_seq: ChangeSeq(2),
+                visible_tip: Some(second.envelope.pointer(second.object_key.clone())),
+                stop_after_seq: Some(ChangeSeq(1)),
+            },
+        )
+        .expect("load suffix chain");
+
+        assert_eq!(chain.segments().len(), 1);
+        assert_eq!(chain.segments()[0].records()[0].seq, ChangeSeq(2));
     }
 
     #[test]
@@ -928,9 +986,38 @@ mod tests {
                 chain_base_seq: ChangeSeq(0),
                 head_seq: pointer.end_seq,
                 visible_tip: Some(pointer),
+                stop_after_seq: None,
             },
         )
         .expect_err("corrupted WAL chain should be rejected");
+    }
+
+    fn write_create_dir_segment(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+        prev_visible_segment: Option<WalSegmentPointer>,
+        commit_id: &str,
+        display_name: &str,
+        apply_after_seq: ChangeSeq,
+        assigned_seq: ChangeSeq,
+    ) -> PreparedWalSegment {
+        let segment = prepare_wal_segment(
+            namespace_id.clone(),
+            prev_visible_segment,
+            &[materialized_create_dir(
+                namespace_id,
+                commit_id,
+                display_name,
+                apply_after_seq,
+                assigned_seq,
+            )],
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        store
+            .put_if_absent(&segment.object_key, &segment.encoded_bytes)
+            .expect("write wal segment");
+        segment
     }
 
     fn rewrap_envelope(envelope: &mut WalSegmentEnvelope) {

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1047,6 +1047,29 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
 }
 
 #[test]
+fn change_feed_validates_wal_chain_before_checkpoint_hint() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    create_dir_path(&store, &namespace_id, "/docs", &context, None).expect("create docs");
+    create_checkpoint(&store, &namespace_id, &context).expect("checkpoint");
+
+    let wal_keys = store.list_prefix("namespaces/demo/wal/").expect("list wal");
+    assert_eq!(wal_keys.len(), 1);
+    store
+        .put_overwrite(&wal_keys[0], b"not a wal segment")
+        .expect("corrupt wal");
+
+    load_verified_namespace_basis(&store, &namespace_id)
+        .expect("checkpoint-backed basis should not read pre-checkpoint wal");
+    let error =
+        list_changes_after(&store, &namespace_id, ChangeSeq(0)).expect_err("corrupt wal chain");
+    assert_eq!(error.kind(), CoreErrorKind::NamespaceCorrupt);
+}
+
+#[test]
 fn binding_is_precondition_observes_earlier_batch_candidate() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");


### PR DESCRIPTION
This PR centralizes visible WAL chain loading/validation and bound change-feed cursor scans vs. splitting/duplicating this logic in multiple places. 