### PR TITLE
refactor(core): type invariant ids

### DIFF
--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -1,3 +1,4 @@
+use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
 use loon_api::{
     v0::{CommitAnnotations, RenameMode},
@@ -126,7 +127,7 @@ pub struct CommitPlan {
     pub resulting_next_inode_id: InodeId,
     pub name_policy: NamePolicy,
     pub metadata_preconditions: Vec<Precondition>,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -144,7 +145,7 @@ pub struct PreparedCommitHeadPublish {
     pub resulting_head: HeadState,
     pub envelope: HeadStateEnvelope,
     pub encoded_bytes: Vec<u8>,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -359,8 +360,8 @@ pub enum CommitHeadPublishError {
     Store(String),
 }
 
-pub(crate) fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
-    if !invariants.iter().any(|existing| existing == name) {
-        invariants.push(name.to_owned());
+pub(crate) fn push_unique_invariant(invariants: &mut Vec<InvariantId>, id: InvariantId) {
+    if !invariants.contains(&id) {
+        invariants.push(id);
     }
 }

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -4,7 +4,7 @@ use super::{
     push_unique_invariant, CommitMaterializationError, CommitOp, CommitPlan, CommitRequest,
     CommitValidationContext, CommitValidationError, Precondition, ResolvedBinding,
 };
-use crate::invariants::INVARIANTS;
+use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
 use loon_api::{
     name_key_for_display_name, ChangeSeq, ContentRef, DisplayName, InodeId, InodeKind, NamePolicy,
@@ -77,19 +77,11 @@ pub fn build_commit_plan(
 ) -> Result<CommitPlan, CommitValidationError> {
     validate_commit_request_frame(request, context)?;
 
-    let mut checked_invariants = INVARIANTS
-        .iter()
-        .copied()
-        .filter(|name| {
-            matches!(
-                *name,
-                "stale_writer_cannot_publish"
-                    | "head_and_lease_fence_tokens_agree"
-                    | "next_inode_id_is_monotonic"
-            )
-        })
-        .map(str::to_owned)
-        .collect::<Vec<_>>();
+    let mut checked_invariants = vec![
+        InvariantId::StaleWriterCannotPublish,
+        InvariantId::HeadAndLeaseFenceTokensAgree,
+        InvariantId::NextInodeIdIsMonotonic,
+    ];
     let shape = compute_commit_shape(request, context)?;
     let resolved_metadata = validate_metadata_preconditions(
         request,
@@ -103,7 +95,7 @@ pub fn build_commit_plan(
     if !shape.allocated_inode_ids.is_empty() {
         push_unique_invariant(
             &mut checked_invariants,
-            "create_mutation_consumes_next_inode_id",
+            InvariantId::CreateMutationConsumesNextInodeId,
         );
     }
     if request
@@ -113,7 +105,7 @@ pub fn build_commit_plan(
     {
         push_unique_invariant(
             &mut checked_invariants,
-            "create_file_requires_durable_content",
+            InvariantId::CreateFileRequiresDurableContent,
         );
     }
     if request
@@ -123,7 +115,7 @@ pub fn build_commit_plan(
     {
         push_unique_invariant(
             &mut checked_invariants,
-            "replace_file_requires_durable_content",
+            InvariantId::ReplaceFileRequiresDurableContent,
         );
     }
     if request
@@ -133,7 +125,7 @@ pub fn build_commit_plan(
     {
         push_unique_invariant(
             &mut checked_invariants,
-            "restore_revision_requires_durable_content",
+            InvariantId::RestoreRevisionRequiresDurableContent,
         );
     }
 
@@ -204,7 +196,7 @@ fn validate_metadata_preconditions(
     committed_seq: ChangeSeq,
     allocated_inode_ids: &[InodeId],
     name_policy: NamePolicy,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<ResolvedMetadataPreconditions, CommitValidationError> {
     let mut ephemeral_metadata_state = metadata_state.clone();
     let mut allocated_inode_ids = allocated_inode_ids.iter().copied();
@@ -484,7 +476,7 @@ fn validate_explicit_preconditions(
     preconditions: &[Precondition],
     metadata_state: &MetadataState,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     for precondition in preconditions {
         match precondition {
@@ -762,7 +754,7 @@ fn validate_ancestors_not_subtree_deleted(
     metadata_state: &MetadataState,
     inode_id: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
     is_create: bool,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
@@ -783,7 +775,7 @@ fn validate_ancestors_not_subtree_deleted(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }
@@ -792,7 +784,7 @@ fn validate_restore_not_covered(
     metadata_state: &MetadataState,
     inode_id: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
         return Err(
@@ -806,7 +798,7 @@ fn validate_restore_not_covered(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }
@@ -851,7 +843,7 @@ fn validate_delete_file_not_covered(
     metadata_state: &MetadataState,
     inode_id: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
         return Err(CommitValidationError::DeleteFileCoveredByTombstone {
@@ -863,7 +855,7 @@ fn validate_delete_file_not_covered(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }
@@ -872,7 +864,7 @@ fn validate_delete_subtree_not_covered(
     metadata_state: &MetadataState,
     root_inode: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(root_inode, base_seq) {
         return Err(CommitValidationError::DeleteSubtreeRootCoveredByTombstone {
@@ -884,7 +876,7 @@ fn validate_delete_subtree_not_covered(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }
@@ -971,7 +963,7 @@ fn validate_rename_inode_not_covered(
     metadata_state: &MetadataState,
     inode_id: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id, base_seq) {
         return Err(CommitValidationError::RenameInodeUnderSubtreeTombstone {
@@ -983,7 +975,7 @@ fn validate_rename_inode_not_covered(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }
@@ -992,7 +984,7 @@ fn validate_rename_target_parent_not_covered(
     metadata_state: &MetadataState,
     parent_inode: InodeId,
     base_seq: ChangeSeq,
-    checked_invariants: &mut Vec<String>,
+    checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CommitValidationError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(parent_inode, base_seq) {
         return Err(
@@ -1006,7 +998,7 @@ fn validate_rename_target_parent_not_covered(
 
     push_unique_invariant(
         checked_invariants,
-        "subtree_tombstone_blocks_descendant_mutation",
+        InvariantId::SubtreeTombstoneBlocksDescendantMutation,
     );
     Ok(())
 }

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -1,4 +1,5 @@
 use super::{push_unique_invariant, CommitHeadPublishError, CommitPlan, PreparedCommitHeadPublish};
+use crate::invariants::InvariantId;
 use crate::wal::PreparedWalSegment;
 use loon_api::{ChangeSeq, ControlObjectKind, HeadState, HeadStateEnvelope};
 use loon_objectstore::keys::namespace_head;
@@ -82,7 +83,10 @@ pub fn prepare_commit_head_publish(
         .map_err(|err| CommitHeadPublishError::Codec(err.to_string()))?;
 
     let mut checked_invariants = plan.checked_invariants.clone();
-    push_unique_invariant(&mut checked_invariants, "head_publish_requires_durable_wal");
+    push_unique_invariant(
+        &mut checked_invariants,
+        InvariantId::HeadPublishRequiresDurableWal,
+    );
 
     Ok(PreparedCommitHeadPublish {
         object_key: namespace_head(current_head.namespace_id.as_str()),

--- a/crates/loon-core/src/content.rs
+++ b/crates/loon-core/src/content.rs
@@ -1,4 +1,5 @@
 use crate::error::CoreError;
+use crate::invariants::InvariantId;
 use crate::namespace::catalog::load_namespace_content_store_id;
 use loon_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId, NamespaceId};
 use loon_objectstore::keys::content_blob;
@@ -13,7 +14,7 @@ pub struct ValidatedDurableContent {
     pub object_key: String,
     pub file_size_bytes: u64,
     pub file_digest_sha256: String,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,10 +155,10 @@ fn validate_loaded_content_bytes(
         file_size_bytes: actual_size,
         file_digest_sha256: actual_digest,
         checked_invariants: vec![
-            "whole_file_content_ref_kind_is_supported".to_owned(),
-            "whole_file_content_object_key_matches_digest".to_owned(),
-            "whole_file_content_size_matches_ref".to_owned(),
-            "whole_file_content_digest_matches_ref".to_owned(),
+            InvariantId::WholeFileContentRefKindIsSupported,
+            InvariantId::WholeFileContentObjectKeyMatchesDigest,
+            InvariantId::WholeFileContentSizeMatchesRef,
+            InvariantId::WholeFileContentDigestMatchesRef,
         ],
     })
 }

--- a/crates/loon-core/src/invariants.rs
+++ b/crates/loon-core/src/invariants.rs
@@ -1,364 +1,337 @@
-pub const NAMESPACE_CORE_COMMIT_FRAME_INVARIANTS: &[&str] = &[
-    "stale_writer_cannot_publish",
-    "head_and_lease_fence_tokens_agree",
-    "next_inode_id_is_monotonic",
-    "create_mutation_consumes_next_inode_id",
-    "create_file_requires_durable_content",
-    "replace_file_requires_durable_content",
-    "restore_revision_requires_durable_content",
-    "subtree_tombstone_blocks_descendant_mutation",
-];
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
 
-pub const NAMESPACE_CORE_METADATA_APPLY_INVARIANTS: &[&str] = &[
-    "create_dir_writes_inode_and_direntry_rows",
-    "create_file_writes_inode_direntry_and_initial_revision",
-    "replace_file_appends_new_revision_head",
-    "restore_creates_new_revision_head",
-    "delete_file_writes_tombstone_row",
-    "rename_appends_new_direntry_binding",
-    "delete_subtree_writes_tombstone_row",
-];
+macro_rules! define_invariant_ids {
+    ($(($const_name:ident, $wire_name:literal)),+ $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum InvariantId {
+            $($const_name,)+
+        }
 
-pub const NAMESPACE_CORE_WAL_REPLAY_INVARIANTS: &[&str] = &[
-    "wal_payload_checksum_matches_payload",
-    "wal_key_matches_segment_seq_range",
-    "head_publish_requires_durable_wal",
-    "wal_replay_requires_matching_namespace",
-    "wal_replay_requires_matching_base_head_seq",
-    "wal_tail_seq_is_contiguous",
-    "wal_replay_applies_metadata_rows",
-];
+        impl InvariantId {
+            pub const ALL: &'static [Self] = &[
+                $(Self::$const_name,)+
+            ];
 
-pub const NAMESPACE_CORE_CHECKPOINT_REPLAY_INVARIANTS: &[&str] = &[
-    "checkpoint_manifest_checksum_matches_payload",
-    "checkpoint_manifest_key_matches_seq",
-    "checkpoint_manifest_must_be_verified",
-    "checkpoint_replay_requires_all_manifest_segments",
-    "checkpoint_segment_descriptor_matches_payload",
-    "checkpoint_segment_rows_restore_basis_metadata",
-    "checkpoint_plus_wal_tail_reproduces_head",
-    "checkpoint_plus_wal_tail_reproduces_metadata",
-];
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$const_name => $wire_name,)+
+                }
+            }
+        }
 
-pub const BACKGROUND_WORK_PROGRESS_INVARIANTS: &[&str] = &[
-    "progress_object_checksum_matches_payload",
-    "progress_object_key_matches_namespace_and_work_class",
-    "progress_through_seq_advances_monotonically",
-];
+        impl FromStr for InvariantId {
+            type Err = UnknownInvariantId;
 
-pub const BACKGROUND_WORK_QUEUE_SHARD_OBJECT_INVARIANTS: &[&str] = &[
-    "queue_shard_checksum_matches_payload",
-    "queue_shard_key_matches_shard_id",
-    "queue_shard_cas_protects_updates",
-];
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                match value {
+                    $($wire_name => Ok(Self::$const_name),)+
+                    _ => Err(UnknownInvariantId(value.to_owned())),
+                }
+            }
+        }
+    };
+}
 
-pub const BACKGROUND_WORK_QUEUE_MUTATION_INVARIANTS: &[&str] = &[
-    "lost_enqueue_repair_enqueues_when_head_outpaces_progress",
-    "checkpoint_repair_dedupe_key_is_namespace_scoped",
-    "checkpoint_repair_claimed_job_gets_follow_up",
-    "broker_lease_takeover_increments_epoch",
-    "active_broker_lease_required_for_shard_mutation",
-    "claim_timeout_allows_steal",
-    "worker_heartbeat_requires_matching_claim_token",
-    "stale_claim_token_cannot_complete",
-    "stolen_job_completes_once",
-];
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownInvariantId(String);
 
-pub const BACKGROUND_WORK_CHECKPOINT_HEAD_PUBLISH_INVARIANTS: &[&str] = &[
-    "checkpoint_publish_requires_verified_checkpoint",
-    "checkpoint_hint_seq_advances_monotonically",
-    "retention_floor_seq_advances_monotonically",
-    "retention_floor_seq_requires_checkpoint_coverage",
-    "retention_floor_seq_requires_derived_progress",
-    "retention_floor_seq_respects_policy_gate",
-];
+impl fmt::Display for UnknownInvariantId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "unknown invariant id `{}`", self.0)
+    }
+}
 
-pub const CONTENT_OBJECT_FILE_INVARIANTS: &[&str] = &[
-    "whole_file_content_ref_kind_is_supported",
-    "whole_file_content_object_key_matches_digest",
-    "whole_file_content_size_matches_ref",
-    "whole_file_content_digest_matches_ref",
-];
+impl std::error::Error for UnknownInvariantId {}
 
-pub const CHECKPOINT_OBJECT_IMMUTABLE_INVARIANTS: &[&str] = &[
-    "checkpoint_segment_payload_checksum_matches_payload",
-    "checkpoint_segment_key_matches_family_and_index",
-    "verified_checkpoint_manifest_requires_durable_segments",
-    "checkpoint_manifest_preserves_head_summary",
-    "checkpoint_manifest_preserves_basis_metadata",
-];
+impl fmt::Display for InvariantId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
-pub const CLIENT_TRANSFER_DOWNLOAD_INVARIANTS: &[&str] = &[
-    "download_transfer_byte_range_advances_monotonically",
-    "download_transfer_reset_records_durable_issue",
-    "download_completion_clears_transfer_ledger",
-    "download_materialization_updates_local_state_and_sync_anchor",
-];
+impl Serialize for InvariantId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
 
-pub const CLIENT_TRANSFER_INODE_UPLOAD_INVARIANTS: &[&str] = &[
-    "inode_upload_content_progress_advances_monotonically",
-    "inode_upload_dispatch_waits_for_staged_content",
-    "inode_upload_retry_reuses_pending_inode_mutation",
-    "inode_upload_completion_clears_transfer_ledger",
-    "inode_upload_transfer_reset_records_durable_issue",
-];
+impl<'de> Deserialize<'de> for InvariantId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
+    }
+}
 
-pub const CLIENT_TRANSFER_LOCAL_ONLY_UPLOAD_INVARIANTS: &[&str] = &[
-    "local_only_upload_content_progress_advances_monotonically",
-    "local_only_upload_dispatch_waits_for_staged_content",
-    "local_only_upload_retry_reuses_pending_client_mutation",
-    "local_only_upload_completion_clears_temp_transfer_ledger",
-    "local_only_upload_bind_clears_temp_issue_and_transfer_ledger",
-    "local_only_upload_transfer_reset_records_durable_issue",
-];
+define_invariant_ids! {
+    // Namespace core commit frame invariants.
+    (StaleWriterCannotPublish, "stale_writer_cannot_publish"),
+    (HeadAndLeaseFenceTokensAgree, "head_and_lease_fence_tokens_agree"),
+    (NextInodeIdIsMonotonic, "next_inode_id_is_monotonic"),
+    (CreateMutationConsumesNextInodeId, "create_mutation_consumes_next_inode_id"),
+    (CreateFileRequiresDurableContent, "create_file_requires_durable_content"),
+    (ReplaceFileRequiresDurableContent, "replace_file_requires_durable_content"),
+    (RestoreRevisionRequiresDurableContent, "restore_revision_requires_durable_content"),
+    (SubtreeTombstoneBlocksDescendantMutation, "subtree_tombstone_blocks_descendant_mutation"),
 
-pub const CLIENT_RECONCILIATION_INVARIANTS: &[&str] = &[
-    "same_inode_conflict_preserves_loser_artifact",
-    "same_inode_conflict_keeps_canonical_path",
-    "delete_vs_edit_conflict_preserves_loser_artifact",
-    "delete_vs_edit_conflict_removes_canonical_path",
-    "rename_vs_edit_conflict_preserves_loser_artifact",
-    "rename_vs_edit_conflict_converges_remote_winner",
-    "path_binding_collision_preserves_loser_artifact",
-    "path_binding_collision_keeps_winner_canonical_path",
-    "subtree_delete_conflict_preserves_loser_artifact",
-    "subtree_delete_conflict_preserves_full_subtree_entries",
-    "subtree_delete_conflict_removes_canonical_path",
-    "subtree_delete_conflict_clears_preserved_temp_rows",
-    "subtree_rename_conflict_preserves_loser_artifact",
-    "subtree_rename_conflict_reverts_bound_descendants_to_winner_state",
-    "subtree_rename_conflict_keeps_winner_canonical_path",
-    "subtree_rename_conflict_clears_preserved_temp_rows",
-    "subtree_conflict_artifact_key_matches_namespace_and_id",
-    "subtree_conflict_artifact_entries_are_durable",
-    "stable_paths_default_does_not_materialize_visible_sibling",
-    "stable_paths_default_does_not_materialize_visible_sibling_tree",
-    "conflict_artifact_key_matches_namespace_and_id",
-    "conflict_artifact_loser_content_is_durable",
-    "remote_observation_convergence_clears_dirty_and_planned_action",
-    "remote_observation_convergence_clears_pending_inode_mutation",
-    "remote_observation_convergence_advances_sync_anchor",
-    "remote_observation_late_bind_establishes_remote_local_and_anchor",
-    "remote_observation_late_bind_clears_temp_local_state",
-    "remote_observation_late_bind_clears_temp_transfer_and_issue_rows",
-    "remote_observation_late_bind_retains_pending_client_mutation_until_response",
-    "remote_observation_ambiguous_bind_records_durable_issue",
-    "remote_observation_ambiguous_bind_avoids_partial_migration",
-    "remote_observation_active_upload_preserves_transfer_and_pending_inode_mutation",
-    "remote_observation_active_download_preserves_transfer_ledger",
-    "remote_only_materialization_waits_for_parent_materialization",
-    "remote_only_directory_materialization_updates_local_state_and_sync_anchor",
-    "remote_only_directory_materialization_clears_planned_action",
-    "remote_only_directory_materialization_failure_records_durable_issue",
-    "remote_delete_plans_apply_remote_delete",
-    "apply_remote_delete_preserves_remote_tombstone",
-    "apply_remote_delete_clears_local_state_and_sync_anchor",
-    "apply_remote_delete_clears_planned_action",
-    "apply_remote_delete_failure_records_durable_issue",
-    "remote_subtree_delete_plans_apply_remote_subtree_delete",
-    "apply_remote_subtree_delete_preserves_root_remote_tombstone",
-    "apply_remote_subtree_delete_clears_descendant_remote_rows",
-    "apply_remote_subtree_delete_clears_remote_only_descendants",
-    "apply_remote_subtree_delete_clears_local_state_and_sync_anchor_for_subtree",
-    "apply_remote_subtree_delete_clears_subtree_planned_actions",
-    "apply_remote_subtree_delete_failure_records_durable_issue",
-    "remote_subtree_path_change_plans_apply_remote_subtree_rename",
-    "materialized_target_parent_unblocks_apply_remote_subtree_rename",
-    "apply_remote_subtree_rename_updates_root_local_state_and_sync_anchor",
-    "apply_remote_subtree_rename_preserves_descendant_durable_state",
-    "apply_remote_subtree_rename_preserves_remote_only_descendants",
-    "apply_remote_subtree_rename_clears_root_planned_action",
-    "apply_remote_subtree_rename_failure_records_durable_issue",
-    "remote_path_change_plans_apply_remote_rename",
-    "materialized_target_parent_unblocks_apply_remote_rename",
-    "apply_remote_rename_updates_local_state_and_sync_anchor",
-    "apply_remote_rename_clears_planned_action",
-    "apply_remote_rename_failure_records_durable_issue",
-];
+    // Namespace core metadata apply invariants.
+    (CreateDirWritesInodeAndDirentryRows, "create_dir_writes_inode_and_direntry_rows"),
+    (CreateFileWritesInodeDirentryAndInitialRevision, "create_file_writes_inode_direntry_and_initial_revision"),
+    (ReplaceFileAppendsNewRevisionHead, "replace_file_appends_new_revision_head"),
+    (RestoreCreatesNewRevisionHead, "restore_creates_new_revision_head"),
+    (DeleteFileWritesTombstoneRow, "delete_file_writes_tombstone_row"),
+    (RenameAppendsNewDirentryBinding, "rename_appends_new_direntry_binding"),
+    (DeleteSubtreeWritesTombstoneRow, "delete_subtree_writes_tombstone_row"),
 
-pub const CLIENT_CONFLICT_ARTIFACT_RECOVERY_INVARIANTS: &[&str] = &[
-    "conflict_artifact_discovery_caches_namespace_artifacts",
-    "conflict_artifact_show_reports_implicit_active_state",
-    "conflict_artifact_unarchive_restores_active_visibility",
-    "conflict_artifact_restore_does_not_change_archive_state",
-    "file_conflict_artifact_restore_reproduces_loser_content",
-    "file_conflict_artifact_restore_keeps_canonical_path_untouched",
-    "subtree_conflict_artifact_restore_reproduces_full_loser_tree",
-    "subtree_conflict_artifact_restore_uses_deterministic_entry_order",
-    "subtree_conflict_artifact_restore_keeps_canonical_tree_untouched",
-    "conflict_artifact_restore_requires_explicit_absent_destination",
-];
+    // Namespace core WAL replay invariants.
+    (WalPayloadChecksumMatchesPayload, "wal_payload_checksum_matches_payload"),
+    (WalKeyMatchesSegmentSeqRange, "wal_key_matches_segment_seq_range"),
+    (HeadPublishRequiresDurableWal, "head_publish_requires_durable_wal"),
+    (WalReplayRequiresMatchingNamespace, "wal_replay_requires_matching_namespace"),
+    (WalReplayRequiresMatchingBaseHeadSeq, "wal_replay_requires_matching_base_head_seq"),
+    (WalTailSeqIsContiguous, "wal_tail_seq_is_contiguous"),
+    (WalReplayAppliesMetadataRows, "wal_replay_applies_metadata_rows"),
 
-pub const SIM_INTERLEAVING_INVARIANTS: &[&str] = &[
-    "client_retry_reuses_pending_request_after_delayed_response",
-    "duplicate_response_is_idempotent",
-    "late_remote_observation_does_not_duplicate_winner_apply",
-    "response_after_newer_observation_is_idempotent",
-    "sim_trace_order_is_seed_stable",
-    "stale_writer_publish_remains_fenced_after_handover",
-    "stale_writer_fence_survives_inflight_client_request",
-    "checkpoint_publish_waits_for_required_progress_under_interleaving",
-    "checkpoint_publish_preserves_monotonic_head_summary_under_interleaving",
-    "repair_lost_enqueue_tracks_latest_visible_head_seq",
-    "checkpoint_publish_uses_latest_visible_head_after_client_server_advance",
-    "repair_lost_enqueue_tracks_latest_visible_head_after_client_server_advance",
-    "queue_sim_trace_order_is_seed_stable",
-    "background_sim_trace_order_is_seed_stable",
-    "unified_namespace_sim_trace_order_is_seed_stable",
-];
+    // Namespace core checkpoint replay invariants.
+    (CheckpointManifestChecksumMatchesPayload, "checkpoint_manifest_checksum_matches_payload"),
+    (CheckpointManifestKeyMatchesSeq, "checkpoint_manifest_key_matches_seq"),
+    (CheckpointManifestMustBeVerified, "checkpoint_manifest_must_be_verified"),
+    (CheckpointReplayRequiresAllManifestSegments, "checkpoint_replay_requires_all_manifest_segments"),
+    (CheckpointSegmentDescriptorMatchesPayload, "checkpoint_segment_descriptor_matches_payload"),
+    (CheckpointSegmentRowsRestoreBasisMetadata, "checkpoint_segment_rows_restore_basis_metadata"),
+    (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
+    (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
-pub const INVARIANTS: &[&str] = &[
-    "no_orphaned_live_entry",
-    "visible_revision_points_to_durable_content",
-    "stale_writer_cannot_publish",
-    "head_and_lease_fence_tokens_agree",
-    "next_inode_id_is_monotonic",
-    "create_mutation_consumes_next_inode_id",
-    "create_file_requires_durable_content",
-    "replace_file_requires_durable_content",
-    "restore_revision_requires_durable_content",
-    "create_dir_writes_inode_and_direntry_rows",
-    "create_file_writes_inode_direntry_and_initial_revision",
-    "replace_file_appends_new_revision_head",
-    "restore_creates_new_revision_head",
-    "delete_file_writes_tombstone_row",
-    "rename_appends_new_direntry_binding",
-    "delete_subtree_writes_tombstone_row",
-    "whole_file_content_ref_kind_is_supported",
-    "whole_file_content_object_key_matches_digest",
-    "whole_file_content_size_matches_ref",
-    "whole_file_content_digest_matches_ref",
-    "wal_payload_checksum_matches_payload",
-    "wal_key_matches_segment_seq_range",
-    "head_publish_requires_durable_wal",
-    "wal_replay_requires_matching_namespace",
-    "wal_replay_requires_matching_base_head_seq",
-    "wal_tail_seq_is_contiguous",
-    "wal_replay_applies_metadata_rows",
-    "checkpoint_manifest_checksum_matches_payload",
-    "checkpoint_manifest_key_matches_seq",
-    "checkpoint_manifest_must_be_verified",
-    "checkpoint_plus_wal_tail_reproduces_head",
-    "checkpoint_plus_wal_tail_reproduces_metadata",
-    "checkpoint_segment_payload_checksum_matches_payload",
-    "checkpoint_segment_key_matches_family_and_index",
-    "verified_checkpoint_manifest_requires_durable_segments",
-    "checkpoint_manifest_preserves_head_summary",
-    "checkpoint_manifest_preserves_basis_metadata",
-    "checkpoint_replay_requires_all_manifest_segments",
-    "checkpoint_segment_descriptor_matches_payload",
-    "checkpoint_segment_rows_restore_basis_metadata",
-    "progress_object_checksum_matches_payload",
-    "progress_object_key_matches_namespace_and_work_class",
-    "progress_through_seq_advances_monotonically",
-    "queue_shard_checksum_matches_payload",
-    "queue_shard_key_matches_shard_id",
-    "queue_shard_cas_protects_updates",
-    "checkpoint_publish_requires_verified_checkpoint",
-    "checkpoint_hint_seq_advances_monotonically",
-    "retention_floor_seq_advances_monotonically",
-    "retention_floor_seq_requires_checkpoint_coverage",
-    "retention_floor_seq_requires_derived_progress",
-    "retention_floor_seq_respects_policy_gate",
-    "lost_enqueue_repair_enqueues_when_head_outpaces_progress",
-    "checkpoint_repair_dedupe_key_is_namespace_scoped",
-    "checkpoint_repair_claimed_job_gets_follow_up",
-    "broker_lease_takeover_increments_epoch",
-    "active_broker_lease_required_for_shard_mutation",
-    "claim_timeout_allows_steal",
-    "worker_heartbeat_requires_matching_claim_token",
-    "stale_claim_token_cannot_complete",
-    "stolen_job_completes_once",
-    "download_transfer_byte_range_advances_monotonically",
-    "download_transfer_reset_records_durable_issue",
-    "download_completion_clears_transfer_ledger",
-    "download_materialization_updates_local_state_and_sync_anchor",
-    "inode_upload_content_progress_advances_monotonically",
-    "inode_upload_dispatch_waits_for_staged_content",
-    "inode_upload_retry_reuses_pending_inode_mutation",
-    "inode_upload_completion_clears_transfer_ledger",
-    "inode_upload_transfer_reset_records_durable_issue",
-    "local_only_upload_content_progress_advances_monotonically",
-    "local_only_upload_dispatch_waits_for_staged_content",
-    "local_only_upload_retry_reuses_pending_client_mutation",
-    "local_only_upload_completion_clears_temp_transfer_ledger",
-    "local_only_upload_bind_clears_temp_issue_and_transfer_ledger",
-    "local_only_upload_transfer_reset_records_durable_issue",
-    "same_inode_conflict_preserves_loser_artifact",
-    "same_inode_conflict_keeps_canonical_path",
-    "delete_vs_edit_conflict_preserves_loser_artifact",
-    "delete_vs_edit_conflict_removes_canonical_path",
-    "rename_vs_edit_conflict_preserves_loser_artifact",
-    "rename_vs_edit_conflict_converges_remote_winner",
-    "path_binding_collision_preserves_loser_artifact",
-    "path_binding_collision_keeps_winner_canonical_path",
-    "stable_paths_default_does_not_materialize_visible_sibling",
-    "conflict_artifact_key_matches_namespace_and_id",
-    "conflict_artifact_loser_content_is_durable",
-    "remote_observation_convergence_clears_dirty_and_planned_action",
-    "remote_observation_convergence_clears_pending_inode_mutation",
-    "remote_observation_convergence_advances_sync_anchor",
-    "remote_observation_late_bind_establishes_remote_local_and_anchor",
-    "remote_observation_late_bind_clears_temp_local_state",
-    "remote_observation_late_bind_clears_temp_transfer_and_issue_rows",
-    "remote_observation_late_bind_retains_pending_client_mutation_until_response",
-    "remote_observation_ambiguous_bind_records_durable_issue",
-    "remote_observation_ambiguous_bind_avoids_partial_migration",
-    "remote_observation_active_upload_preserves_transfer_and_pending_inode_mutation",
-    "remote_observation_active_download_preserves_transfer_ledger",
-    "remote_only_materialization_waits_for_parent_materialization",
-    "remote_only_directory_materialization_updates_local_state_and_sync_anchor",
-    "remote_only_directory_materialization_clears_planned_action",
-    "remote_only_directory_materialization_failure_records_durable_issue",
-    "remote_delete_plans_apply_remote_delete",
-    "apply_remote_delete_preserves_remote_tombstone",
-    "apply_remote_delete_clears_local_state_and_sync_anchor",
-    "apply_remote_delete_clears_planned_action",
-    "apply_remote_delete_failure_records_durable_issue",
-    "remote_subtree_delete_plans_apply_remote_subtree_delete",
-    "apply_remote_subtree_delete_preserves_root_remote_tombstone",
-    "apply_remote_subtree_delete_clears_descendant_remote_rows",
-    "apply_remote_subtree_delete_clears_remote_only_descendants",
-    "apply_remote_subtree_delete_clears_local_state_and_sync_anchor_for_subtree",
-    "apply_remote_subtree_delete_clears_subtree_planned_actions",
-    "apply_remote_subtree_delete_failure_records_durable_issue",
-    "remote_subtree_path_change_plans_apply_remote_subtree_rename",
-    "materialized_target_parent_unblocks_apply_remote_subtree_rename",
-    "apply_remote_subtree_rename_updates_root_local_state_and_sync_anchor",
-    "apply_remote_subtree_rename_preserves_descendant_durable_state",
-    "apply_remote_subtree_rename_preserves_remote_only_descendants",
-    "apply_remote_subtree_rename_clears_root_planned_action",
-    "apply_remote_subtree_rename_failure_records_durable_issue",
-    "remote_path_change_plans_apply_remote_rename",
-    "materialized_target_parent_unblocks_apply_remote_rename",
-    "apply_remote_rename_updates_local_state_and_sync_anchor",
-    "apply_remote_rename_clears_planned_action",
-    "apply_remote_rename_failure_records_durable_issue",
-    "conflict_artifact_discovery_caches_namespace_artifacts",
-    "conflict_artifact_show_reports_implicit_active_state",
-    "conflict_artifact_unarchive_restores_active_visibility",
-    "conflict_artifact_restore_does_not_change_archive_state",
-    "file_conflict_artifact_restore_reproduces_loser_content",
-    "file_conflict_artifact_restore_keeps_canonical_path_untouched",
-    "subtree_conflict_artifact_restore_reproduces_full_loser_tree",
-    "subtree_conflict_artifact_restore_uses_deterministic_entry_order",
-    "subtree_conflict_artifact_restore_keeps_canonical_tree_untouched",
-    "conflict_artifact_restore_requires_explicit_absent_destination",
-    "client_retry_reuses_pending_request_after_delayed_response",
-    "duplicate_response_is_idempotent",
-    "late_remote_observation_does_not_duplicate_winner_apply",
-    "response_after_newer_observation_is_idempotent",
-    "sim_trace_order_is_seed_stable",
-    "stale_writer_publish_remains_fenced_after_handover",
-    "stale_writer_fence_survives_inflight_client_request",
-    "checkpoint_publish_waits_for_required_progress_under_interleaving",
-    "checkpoint_publish_preserves_monotonic_head_summary_under_interleaving",
-    "repair_lost_enqueue_tracks_latest_visible_head_seq",
-    "checkpoint_publish_uses_latest_visible_head_after_client_server_advance",
-    "repair_lost_enqueue_tracks_latest_visible_head_after_client_server_advance",
-    "queue_sim_trace_order_is_seed_stable",
-    "background_sim_trace_order_is_seed_stable",
-    "unified_namespace_sim_trace_order_is_seed_stable",
-    "subtree_tombstone_blocks_descendant_mutation",
-    "restore_creates_new_revision_head",
-];
+    // Background work progress invariants.
+    (ProgressObjectChecksumMatchesPayload, "progress_object_checksum_matches_payload"),
+    (ProgressObjectKeyMatchesNamespaceAndWorkClass, "progress_object_key_matches_namespace_and_work_class"),
+    (ProgressThroughSeqAdvancesMonotonically, "progress_through_seq_advances_monotonically"),
+
+    // Background work queue shard object invariants.
+    (QueueShardChecksumMatchesPayload, "queue_shard_checksum_matches_payload"),
+    (QueueShardKeyMatchesShardId, "queue_shard_key_matches_shard_id"),
+    (QueueShardCasProtectsUpdates, "queue_shard_cas_protects_updates"),
+
+    // Background work queue mutation invariants.
+    (LostEnqueueRepairEnqueuesWhenHeadOutpacesProgress, "lost_enqueue_repair_enqueues_when_head_outpaces_progress"),
+    (CheckpointRepairDedupeKeyIsNamespaceScoped, "checkpoint_repair_dedupe_key_is_namespace_scoped"),
+    (CheckpointRepairClaimedJobGetsFollowUp, "checkpoint_repair_claimed_job_gets_follow_up"),
+    (BrokerLeaseTakeoverIncrementsEpoch, "broker_lease_takeover_increments_epoch"),
+    (ActiveBrokerLeaseRequiredForShardMutation, "active_broker_lease_required_for_shard_mutation"),
+    (ClaimTimeoutAllowsSteal, "claim_timeout_allows_steal"),
+    (WorkerHeartbeatRequiresMatchingClaimToken, "worker_heartbeat_requires_matching_claim_token"),
+    (StaleClaimTokenCannotComplete, "stale_claim_token_cannot_complete"),
+    (StolenJobCompletesOnce, "stolen_job_completes_once"),
+
+    // Background work checkpoint head publish invariants.
+    (CheckpointPublishRequiresVerifiedCheckpoint, "checkpoint_publish_requires_verified_checkpoint"),
+    (CheckpointHintSeqAdvancesMonotonically, "checkpoint_hint_seq_advances_monotonically"),
+    (RetentionFloorSeqAdvancesMonotonically, "retention_floor_seq_advances_monotonically"),
+    (RetentionFloorSeqRequiresCheckpointCoverage, "retention_floor_seq_requires_checkpoint_coverage"),
+    (RetentionFloorSeqRequiresDerivedProgress, "retention_floor_seq_requires_derived_progress"),
+    (RetentionFloorSeqRespectsPolicyGate, "retention_floor_seq_respects_policy_gate"),
+
+    // Content object file invariants.
+    (WholeFileContentRefKindIsSupported, "whole_file_content_ref_kind_is_supported"),
+    (WholeFileContentObjectKeyMatchesDigest, "whole_file_content_object_key_matches_digest"),
+    (WholeFileContentSizeMatchesRef, "whole_file_content_size_matches_ref"),
+    (WholeFileContentDigestMatchesRef, "whole_file_content_digest_matches_ref"),
+
+    // Checkpoint object immutable invariants.
+    (CheckpointSegmentPayloadChecksumMatchesPayload, "checkpoint_segment_payload_checksum_matches_payload"),
+    (CheckpointSegmentKeyMatchesFamilyAndIndex, "checkpoint_segment_key_matches_family_and_index"),
+    (VerifiedCheckpointManifestRequiresDurableSegments, "verified_checkpoint_manifest_requires_durable_segments"),
+    (CheckpointManifestPreservesHeadSummary, "checkpoint_manifest_preserves_head_summary"),
+    (CheckpointManifestPreservesBasisMetadata, "checkpoint_manifest_preserves_basis_metadata"),
+
+    // Client transfer download invariants.
+    (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),
+    (DownloadTransferResetRecordsDurableIssue, "download_transfer_reset_records_durable_issue"),
+    (DownloadCompletionClearsTransferLedger, "download_completion_clears_transfer_ledger"),
+    (DownloadMaterializationUpdatesLocalStateAndSyncAnchor, "download_materialization_updates_local_state_and_sync_anchor"),
+
+    // Client transfer inode upload invariants.
+    (InodeUploadContentProgressAdvancesMonotonically, "inode_upload_content_progress_advances_monotonically"),
+    (InodeUploadDispatchWaitsForStagedContent, "inode_upload_dispatch_waits_for_staged_content"),
+    (InodeUploadRetryReusesPendingInodeMutation, "inode_upload_retry_reuses_pending_inode_mutation"),
+    (InodeUploadCompletionClearsTransferLedger, "inode_upload_completion_clears_transfer_ledger"),
+    (InodeUploadTransferResetRecordsDurableIssue, "inode_upload_transfer_reset_records_durable_issue"),
+
+    // Client transfer local-only upload invariants.
+    (LocalOnlyUploadContentProgressAdvancesMonotonically, "local_only_upload_content_progress_advances_monotonically"),
+    (LocalOnlyUploadDispatchWaitsForStagedContent, "local_only_upload_dispatch_waits_for_staged_content"),
+    (LocalOnlyUploadRetryReusesPendingClientMutation, "local_only_upload_retry_reuses_pending_client_mutation"),
+    (LocalOnlyUploadCompletionClearsTempTransferLedger, "local_only_upload_completion_clears_temp_transfer_ledger"),
+    (LocalOnlyUploadBindClearsTempIssueAndTransferLedger, "local_only_upload_bind_clears_temp_issue_and_transfer_ledger"),
+    (LocalOnlyUploadTransferResetRecordsDurableIssue, "local_only_upload_transfer_reset_records_durable_issue"),
+
+    // Client reconciliation invariants.
+    (SameInodeConflictPreservesLoserArtifact, "same_inode_conflict_preserves_loser_artifact"),
+    (SameInodeConflictKeepsCanonicalPath, "same_inode_conflict_keeps_canonical_path"),
+    (DeleteVsEditConflictPreservesLoserArtifact, "delete_vs_edit_conflict_preserves_loser_artifact"),
+    (DeleteVsEditConflictRemovesCanonicalPath, "delete_vs_edit_conflict_removes_canonical_path"),
+    (RenameVsEditConflictPreservesLoserArtifact, "rename_vs_edit_conflict_preserves_loser_artifact"),
+    (RenameVsEditConflictConvergesRemoteWinner, "rename_vs_edit_conflict_converges_remote_winner"),
+    (PathBindingCollisionPreservesLoserArtifact, "path_binding_collision_preserves_loser_artifact"),
+    (PathBindingCollisionKeepsWinnerCanonicalPath, "path_binding_collision_keeps_winner_canonical_path"),
+    (SubtreeDeleteConflictPreservesLoserArtifact, "subtree_delete_conflict_preserves_loser_artifact"),
+    (SubtreeDeleteConflictPreservesFullSubtreeEntries, "subtree_delete_conflict_preserves_full_subtree_entries"),
+    (SubtreeDeleteConflictRemovesCanonicalPath, "subtree_delete_conflict_removes_canonical_path"),
+    (SubtreeDeleteConflictClearsPreservedTempRows, "subtree_delete_conflict_clears_preserved_temp_rows"),
+    (SubtreeRenameConflictPreservesLoserArtifact, "subtree_rename_conflict_preserves_loser_artifact"),
+    (SubtreeRenameConflictRevertsBoundDescendantsToWinnerState, "subtree_rename_conflict_reverts_bound_descendants_to_winner_state"),
+    (SubtreeRenameConflictKeepsWinnerCanonicalPath, "subtree_rename_conflict_keeps_winner_canonical_path"),
+    (SubtreeRenameConflictClearsPreservedTempRows, "subtree_rename_conflict_clears_preserved_temp_rows"),
+    (SubtreeConflictArtifactKeyMatchesNamespaceAndId, "subtree_conflict_artifact_key_matches_namespace_and_id"),
+    (SubtreeConflictArtifactEntriesAreDurable, "subtree_conflict_artifact_entries_are_durable"),
+    (StablePathsDefaultDoesNotMaterializeVisibleSibling, "stable_paths_default_does_not_materialize_visible_sibling"),
+    (StablePathsDefaultDoesNotMaterializeVisibleSiblingTree, "stable_paths_default_does_not_materialize_visible_sibling_tree"),
+    (ConflictArtifactKeyMatchesNamespaceAndId, "conflict_artifact_key_matches_namespace_and_id"),
+    (ConflictArtifactLoserContentIsDurable, "conflict_artifact_loser_content_is_durable"),
+    (RemoteObservationConvergenceClearsDirtyAndPlannedAction, "remote_observation_convergence_clears_dirty_and_planned_action"),
+    (RemoteObservationConvergenceClearsPendingInodeMutation, "remote_observation_convergence_clears_pending_inode_mutation"),
+    (RemoteObservationConvergenceAdvancesSyncAnchor, "remote_observation_convergence_advances_sync_anchor"),
+    (RemoteObservationLateBindEstablishesRemoteLocalAndAnchor, "remote_observation_late_bind_establishes_remote_local_and_anchor"),
+    (RemoteObservationLateBindClearsTempLocalState, "remote_observation_late_bind_clears_temp_local_state"),
+    (RemoteObservationLateBindClearsTempTransferAndIssueRows, "remote_observation_late_bind_clears_temp_transfer_and_issue_rows"),
+    (RemoteObservationLateBindRetainsPendingClientMutationUntilResponse, "remote_observation_late_bind_retains_pending_client_mutation_until_response"),
+    (RemoteObservationAmbiguousBindRecordsDurableIssue, "remote_observation_ambiguous_bind_records_durable_issue"),
+    (RemoteObservationAmbiguousBindAvoidsPartialMigration, "remote_observation_ambiguous_bind_avoids_partial_migration"),
+    (RemoteObservationActiveUploadPreservesTransferAndPendingInodeMutation, "remote_observation_active_upload_preserves_transfer_and_pending_inode_mutation"),
+    (RemoteObservationActiveDownloadPreservesTransferLedger, "remote_observation_active_download_preserves_transfer_ledger"),
+    (RemoteOnlyMaterializationWaitsForParentMaterialization, "remote_only_materialization_waits_for_parent_materialization"),
+    (RemoteOnlyDirectoryMaterializationUpdatesLocalStateAndSyncAnchor, "remote_only_directory_materialization_updates_local_state_and_sync_anchor"),
+    (RemoteOnlyDirectoryMaterializationClearsPlannedAction, "remote_only_directory_materialization_clears_planned_action"),
+    (RemoteOnlyDirectoryMaterializationFailureRecordsDurableIssue, "remote_only_directory_materialization_failure_records_durable_issue"),
+    (RemoteDeletePlansApplyRemoteDelete, "remote_delete_plans_apply_remote_delete"),
+    (ApplyRemoteDeletePreservesRemoteTombstone, "apply_remote_delete_preserves_remote_tombstone"),
+    (ApplyRemoteDeleteClearsLocalStateAndSyncAnchor, "apply_remote_delete_clears_local_state_and_sync_anchor"),
+    (ApplyRemoteDeleteClearsPlannedAction, "apply_remote_delete_clears_planned_action"),
+    (ApplyRemoteDeleteFailureRecordsDurableIssue, "apply_remote_delete_failure_records_durable_issue"),
+    (RemoteSubtreeDeletePlansApplyRemoteSubtreeDelete, "remote_subtree_delete_plans_apply_remote_subtree_delete"),
+    (ApplyRemoteSubtreeDeletePreservesRootRemoteTombstone, "apply_remote_subtree_delete_preserves_root_remote_tombstone"),
+    (ApplyRemoteSubtreeDeleteClearsDescendantRemoteRows, "apply_remote_subtree_delete_clears_descendant_remote_rows"),
+    (ApplyRemoteSubtreeDeleteClearsRemoteOnlyDescendants, "apply_remote_subtree_delete_clears_remote_only_descendants"),
+    (ApplyRemoteSubtreeDeleteClearsLocalStateAndSyncAnchorForSubtree, "apply_remote_subtree_delete_clears_local_state_and_sync_anchor_for_subtree"),
+    (ApplyRemoteSubtreeDeleteClearsSubtreePlannedActions, "apply_remote_subtree_delete_clears_subtree_planned_actions"),
+    (ApplyRemoteSubtreeDeleteFailureRecordsDurableIssue, "apply_remote_subtree_delete_failure_records_durable_issue"),
+    (RemoteSubtreePathChangePlansApplyRemoteSubtreeRename, "remote_subtree_path_change_plans_apply_remote_subtree_rename"),
+    (MaterializedTargetParentUnblocksApplyRemoteSubtreeRename, "materialized_target_parent_unblocks_apply_remote_subtree_rename"),
+    (ApplyRemoteSubtreeRenameUpdatesRootLocalStateAndSyncAnchor, "apply_remote_subtree_rename_updates_root_local_state_and_sync_anchor"),
+    (ApplyRemoteSubtreeRenamePreservesDescendantDurableState, "apply_remote_subtree_rename_preserves_descendant_durable_state"),
+    (ApplyRemoteSubtreeRenamePreservesRemoteOnlyDescendants, "apply_remote_subtree_rename_preserves_remote_only_descendants"),
+    (ApplyRemoteSubtreeRenameClearsRootPlannedAction, "apply_remote_subtree_rename_clears_root_planned_action"),
+    (ApplyRemoteSubtreeRenameFailureRecordsDurableIssue, "apply_remote_subtree_rename_failure_records_durable_issue"),
+    (RemotePathChangePlansApplyRemoteRename, "remote_path_change_plans_apply_remote_rename"),
+    (MaterializedTargetParentUnblocksApplyRemoteRename, "materialized_target_parent_unblocks_apply_remote_rename"),
+    (ApplyRemoteRenameUpdatesLocalStateAndSyncAnchor, "apply_remote_rename_updates_local_state_and_sync_anchor"),
+    (ApplyRemoteRenameClearsPlannedAction, "apply_remote_rename_clears_planned_action"),
+    (ApplyRemoteRenameFailureRecordsDurableIssue, "apply_remote_rename_failure_records_durable_issue"),
+
+    // Client conflict artifact recovery invariants.
+    (ConflictArtifactDiscoveryCachesNamespaceArtifacts, "conflict_artifact_discovery_caches_namespace_artifacts"),
+    (ConflictArtifactShowReportsImplicitActiveState, "conflict_artifact_show_reports_implicit_active_state"),
+    (ConflictArtifactUnarchiveRestoresActiveVisibility, "conflict_artifact_unarchive_restores_active_visibility"),
+    (ConflictArtifactRestoreDoesNotChangeArchiveState, "conflict_artifact_restore_does_not_change_archive_state"),
+    (FileConflictArtifactRestoreReproducesLoserContent, "file_conflict_artifact_restore_reproduces_loser_content"),
+    (FileConflictArtifactRestoreKeepsCanonicalPathUntouched, "file_conflict_artifact_restore_keeps_canonical_path_untouched"),
+    (SubtreeConflictArtifactRestoreReproducesFullLoserTree, "subtree_conflict_artifact_restore_reproduces_full_loser_tree"),
+    (SubtreeConflictArtifactRestoreUsesDeterministicEntryOrder, "subtree_conflict_artifact_restore_uses_deterministic_entry_order"),
+    (SubtreeConflictArtifactRestoreKeepsCanonicalTreeUntouched, "subtree_conflict_artifact_restore_keeps_canonical_tree_untouched"),
+    (ConflictArtifactRestoreRequiresExplicitAbsentDestination, "conflict_artifact_restore_requires_explicit_absent_destination"),
+
+    // Simulation interleaving invariants.
+    (ClientRetryReusesPendingRequestAfterDelayedResponse, "client_retry_reuses_pending_request_after_delayed_response"),
+    (DuplicateResponseIsIdempotent, "duplicate_response_is_idempotent"),
+    (LateRemoteObservationDoesNotDuplicateWinnerApply, "late_remote_observation_does_not_duplicate_winner_apply"),
+    (ResponseAfterNewerObservationIsIdempotent, "response_after_newer_observation_is_idempotent"),
+    (SimTraceOrderIsSeedStable, "sim_trace_order_is_seed_stable"),
+    (StaleWriterPublishRemainsFencedAfterHandover, "stale_writer_publish_remains_fenced_after_handover"),
+    (StaleWriterFenceSurvivesInflightClientRequest, "stale_writer_fence_survives_inflight_client_request"),
+    (CheckpointPublishWaitsForRequiredProgressUnderInterleaving, "checkpoint_publish_waits_for_required_progress_under_interleaving"),
+    (CheckpointPublishPreservesMonotonicHeadSummaryUnderInterleaving, "checkpoint_publish_preserves_monotonic_head_summary_under_interleaving"),
+    (RepairLostEnqueueTracksLatestVisibleHeadSeq, "repair_lost_enqueue_tracks_latest_visible_head_seq"),
+    (CheckpointPublishUsesLatestVisibleHeadAfterClientServerAdvance, "checkpoint_publish_uses_latest_visible_head_after_client_server_advance"),
+    (RepairLostEnqueueTracksLatestVisibleHeadAfterClientServerAdvance, "repair_lost_enqueue_tracks_latest_visible_head_after_client_server_advance"),
+    (QueueSimTraceOrderIsSeedStable, "queue_sim_trace_order_is_seed_stable"),
+    (BackgroundSimTraceOrderIsSeedStable, "background_sim_trace_order_is_seed_stable"),
+    (UnifiedNamespaceSimTraceOrderIsSeedStable, "unified_namespace_sim_trace_order_is_seed_stable"),
+
+    // Production invariant report IDs that were previously only in the flat catalogue.
+    (NoOrphanedLiveEntry, "no_orphaned_live_entry"),
+    (VisibleRevisionPointsToDurableContent, "visible_revision_points_to_durable_content"),
+
+    // Normalized WAL delta apply invariants.
+    (CreateInodeWritesInodeRow, "create_inode_writes_inode_row"),
+    (BindDirentryWritesDirentryBindRow, "bind_direntry_writes_direntry_bind_row"),
+    (UnbindDirentryWritesUnbindRow, "unbind_direntry_writes_unbind_row"),
+    (AppendFileRevisionWritesRevisionRow, "append_file_revision_writes_revision_row"),
+    (TombstoneSubtreeWritesTombstoneRow, "tombstone_subtree_writes_tombstone_row"),
+    (WalReplayRecordsCommitReceipt, "wal_replay_records_commit_receipt"),
+}
+
+pub const INVARIANTS: &[InvariantId] = InvariantId::ALL;
+
+#[cfg(test)]
+mod tests {
+    use super::InvariantId;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn invariant_ids_round_trip_as_stable_strings() {
+        for id in InvariantId::ALL {
+            let encoded = serde_json::to_string(id).expect("serialize invariant id");
+            let decoded: InvariantId =
+                serde_json::from_str(&encoded).expect("deserialize invariant id");
+            assert_eq!(*id, decoded);
+            assert_eq!(encoded, format!("\"{}\"", id.as_str()));
+        }
+    }
+
+    #[test]
+    fn invariant_report_fields_serialize_as_stable_strings() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct InvariantReport {
+            checked_invariants: Vec<InvariantId>,
+        }
+
+        let report = InvariantReport {
+            checked_invariants: vec![
+                InvariantId::WalPayloadChecksumMatchesPayload,
+                InvariantId::HeadPublishRequiresDurableWal,
+            ],
+        };
+
+        let encoded = serde_json::to_string(&report).expect("serialize report");
+        assert_eq!(
+            encoded,
+            "{\"checked_invariants\":[\"wal_payload_checksum_matches_payload\",\"head_publish_requires_durable_wal\"]}"
+        );
+
+        let decoded: InvariantReport = serde_json::from_str(&encoded).expect("deserialize report");
+        assert_eq!(decoded, report);
+    }
+
+    #[test]
+    fn invariant_ids_have_no_duplicate_strings() {
+        let names = InvariantId::ALL
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names.len(), InvariantId::ALL.len());
+    }
+
+    #[test]
+    fn unknown_invariant_ids_fail_deserialization() {
+        let error =
+            serde_json::from_str::<InvariantId>("\"not_a_real_invariant\"").expect_err("unknown");
+        assert!(error.to_string().contains("unknown invariant id"));
+    }
+}

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -1,3 +1,4 @@
+use crate::invariants::InvariantId;
 use loon_api::{
     v0::CommitOpResult, AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey,
     NamePolicy, RevisionNo, WalCommitPayload, WalDelta,
@@ -77,7 +78,7 @@ pub struct CommitReceiptRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppliedMetadataState {
     pub metadata_state: MetadataState,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -185,7 +186,10 @@ impl MetadataState {
                         inode_kind: inode_kind.clone(),
                         created_seq: committed_seq,
                     });
-                    push_unique_invariant(&mut checked_invariants, "create_inode_writes_inode_row");
+                    push_unique_invariant(
+                        &mut checked_invariants,
+                        InvariantId::CreateInodeWritesInodeRow,
+                    );
                 }
                 WalDelta::BindDirentry {
                     delta_index,
@@ -204,7 +208,7 @@ impl MetadataState {
                     });
                     push_unique_invariant(
                         &mut checked_invariants,
-                        "bind_direntry_writes_direntry_bind_row",
+                        InvariantId::BindDirentryWritesDirentryBindRow,
                     );
                 }
                 WalDelta::UnbindDirentry {
@@ -226,7 +230,7 @@ impl MetadataState {
                     });
                     push_unique_invariant(
                         &mut checked_invariants,
-                        "unbind_direntry_writes_unbind_row",
+                        InvariantId::UnbindDirentryWritesUnbindRow,
                     );
                 }
                 WalDelta::AppendFileRevision {
@@ -244,7 +248,7 @@ impl MetadataState {
                     });
                     push_unique_invariant(
                         &mut checked_invariants,
-                        "append_file_revision_writes_revision_row",
+                        InvariantId::AppendFileRevisionWritesRevisionRow,
                     );
                 }
                 WalDelta::TombstoneSubtree {
@@ -260,7 +264,7 @@ impl MetadataState {
                         });
                     push_unique_invariant(
                         &mut checked_invariants,
-                        "tombstone_subtree_writes_tombstone_row",
+                        InvariantId::TombstoneSubtreeWritesTombstoneRow,
                     );
                 }
             }
@@ -295,7 +299,7 @@ impl MetadataState {
             });
         push_unique_invariant(
             &mut applied.checked_invariants,
-            "wal_replay_records_commit_receipt",
+            InvariantId::WalReplayRecordsCommitReceipt,
         );
         Ok(applied)
     }
@@ -670,9 +674,9 @@ impl MetadataStateBuilder {
     }
 }
 
-fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
-    if !invariants.iter().any(|existing| existing == name) {
-        invariants.push(name.to_owned());
+fn push_unique_invariant(invariants: &mut Vec<InvariantId>, id: InvariantId) {
+    if !invariants.contains(&id) {
+        invariants.push(id);
     }
 }
 

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -1,4 +1,5 @@
 use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
+use crate::invariants::InvariantId;
 use crate::metadata::{MetadataApplyError, MetadataState};
 use loon_api::{
     decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, generate_wal_segment_id,
@@ -16,7 +17,7 @@ pub struct PreparedWalSegment {
     pub segment_id: String,
     pub envelope: WalSegmentEnvelope,
     pub encoded_bytes: Vec<u8>,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,7 +81,7 @@ impl ValidatedWalSegment {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ValidatedWalChain {
     segments: Vec<ValidatedWalSegment>,
-    checked_invariants: Vec<String>,
+    checked_invariants: Vec<InvariantId>,
 }
 
 impl ValidatedWalChain {
@@ -133,7 +134,7 @@ pub struct ReplayedWalSegment {
     pub object_key: String,
     pub envelope: WalSegmentEnvelope,
     pub resulting_head: HeadState,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -142,14 +143,14 @@ pub struct ReplayedWalSegmentWithMetadata {
     pub envelope: WalSegmentEnvelope,
     pub resulting_head: HeadState,
     pub resulting_metadata_state: MetadataState,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplayedWalTail {
     pub resulting_head: HeadState,
     pub resulting_metadata_state: MetadataState,
-    pub checked_invariants: Vec<String>,
+    pub checked_invariants: Vec<InvariantId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -260,9 +261,9 @@ pub fn prepare_wal_segment(
         envelope,
         encoded_bytes,
         checked_invariants: vec![
-            "wal_payload_checksum_matches_payload".to_owned(),
-            "wal_key_matches_segment_seq_range".to_owned(),
-            "head_publish_requires_durable_wal".to_owned(),
+            InvariantId::WalPayloadChecksumMatchesPayload,
+            InvariantId::WalKeyMatchesSegmentSeqRange,
+            InvariantId::HeadPublishRequiresDurableWal,
         ],
     })
 }
@@ -403,11 +404,11 @@ pub fn replay_wal_segment(
         envelope,
         resulting_head,
         checked_invariants: vec![
-            "wal_payload_checksum_matches_payload".to_owned(),
-            "wal_key_matches_segment_seq_range".to_owned(),
-            "wal_replay_requires_matching_namespace".to_owned(),
-            "wal_replay_requires_matching_base_head_seq".to_owned(),
-            "wal_tail_seq_is_contiguous".to_owned(),
+            InvariantId::WalPayloadChecksumMatchesPayload,
+            InvariantId::WalKeyMatchesSegmentSeqRange,
+            InvariantId::WalReplayRequiresMatchingNamespace,
+            InvariantId::WalReplayRequiresMatchingBaseHeadSeq,
+            InvariantId::WalTailSeqIsContiguous,
         ],
     })
 }
@@ -425,7 +426,10 @@ pub fn replay_wal_segment_with_metadata(
             .apply_committed_wal_record(record)
             .map_err(WalReplayError::MetadataApply)?;
         current_metadata_state = applied.metadata_state;
-        push_invariant(&mut checked_invariants, "wal_replay_applies_metadata_rows");
+        push_invariant(
+            &mut checked_invariants,
+            InvariantId::WalReplayAppliesMetadataRows,
+        );
         extend_invariants(&mut checked_invariants, &applied.checked_invariants);
     }
 
@@ -499,7 +503,10 @@ pub(crate) fn replay_validated_wal_tail_with_metadata(
                 .apply_committed_wal_record(record)
                 .map_err(WalReplayError::MetadataApply)?;
             current_metadata_state = applied.metadata_state;
-            push_invariant(&mut checked_invariants, "wal_replay_applies_metadata_rows");
+            push_invariant(
+                &mut checked_invariants,
+                InvariantId::WalReplayAppliesMetadataRows,
+            );
             extend_invariants(&mut checked_invariants, &applied.checked_invariants);
         }
         current_head.visible_wal_tip = Some(wal_segment.pointer());
@@ -633,13 +640,13 @@ fn validate_decoded_replayed_wal(
     Ok(())
 }
 
-fn extend_wal_replay_invariants(checked_invariants: &mut Vec<String>) {
+fn extend_wal_replay_invariants(checked_invariants: &mut Vec<InvariantId>) {
     for invariant in [
-        "wal_payload_checksum_matches_payload",
-        "wal_key_matches_segment_seq_range",
-        "wal_replay_requires_matching_namespace",
-        "wal_replay_requires_matching_base_head_seq",
-        "wal_tail_seq_is_contiguous",
+        InvariantId::WalPayloadChecksumMatchesPayload,
+        InvariantId::WalKeyMatchesSegmentSeqRange,
+        InvariantId::WalReplayRequiresMatchingNamespace,
+        InvariantId::WalReplayRequiresMatchingBaseHeadSeq,
+        InvariantId::WalTailSeqIsContiguous,
     ] {
         push_invariant(checked_invariants, invariant);
     }
@@ -668,18 +675,15 @@ fn replay_next_inode_id_from_commit_deltas(
     })
 }
 
-fn extend_invariants(checked_invariants: &mut Vec<String>, new_invariants: &[String]) {
+fn extend_invariants(checked_invariants: &mut Vec<InvariantId>, new_invariants: &[InvariantId]) {
     for invariant in new_invariants {
-        push_invariant(checked_invariants, invariant);
+        push_invariant(checked_invariants, *invariant);
     }
 }
 
-fn push_invariant(checked_invariants: &mut Vec<String>, invariant: &str) {
-    if !checked_invariants
-        .iter()
-        .any(|existing| existing == invariant)
-    {
-        checked_invariants.push(invariant.to_owned());
+fn push_invariant(checked_invariants: &mut Vec<InvariantId>, invariant: InvariantId) {
+    if !checked_invariants.contains(&invariant) {
+        checked_invariants.push(invariant);
     }
 }
 


### PR DESCRIPTION
This is a cleanup PR that replaces "string" checked-invariant reports with typed IDs that still serialize as stable strings. Nicer for static validation of invariant types. 