### PR TITLE
refactor(api): curate public API surface

### DIFF
--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -39,6 +39,13 @@ pub struct GeneratedIdValidationError {
     reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid name_key {value:?}: {reason}")]
+pub struct NameKeyValidationError {
+    value: String,
+    reason: &'static str,
+}
+
 impl NamespaceIdValidationError {
     pub fn value(&self) -> &str {
         &self.value
@@ -66,6 +73,16 @@ impl GeneratedIdValidationError {
 
     pub fn reason(&self) -> &str {
         &self.reason
+    }
+}
+
+impl NameKeyValidationError {
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn reason(&self) -> &'static str {
+        self.reason
     }
 }
 
@@ -170,6 +187,19 @@ fn validate_commit_id(value: &str) -> Result<(), CommitIdValidationError> {
     validate_id_grammar(value).map_err(|reason| commit_id_error(value, reason))
 }
 
+fn validate_name_key(value: &str) -> Result<(), NameKeyValidationError> {
+    if value.is_empty() {
+        return Err(name_key_error(value, "must not be empty"));
+    }
+    if value.contains('/') {
+        return Err(name_key_error(value, "must not contain `/`"));
+    }
+    if matches!(value, "." | "..") {
+        return Err(name_key_error(value, "must not be `.` or `..`"));
+    }
+    Ok(())
+}
+
 fn validate_id_grammar(value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
         return Err("must not be empty");
@@ -223,6 +253,13 @@ fn generated_id_error(value: &str, reason: String) -> GeneratedIdValidationError
     }
 }
 
+fn name_key_error(value: &str, reason: &'static str) -> NameKeyValidationError {
+    NameKeyValidationError {
+        value: value.to_owned(),
+        reason,
+    }
+}
+
 impl ContentStoreId {
     pub fn generate() -> Self {
         Self(generated_id("cs"))
@@ -238,6 +275,31 @@ impl ContentStoreId {
         let value = value.into();
         validate_generated_id("cs", &value)?;
         Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl NameKey {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, NameKeyValidationError> {
+        let value = value.as_ref();
+        validate_name_key(value)?;
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn try_new(value: impl Into<String>) -> Result<Self, NameKeyValidationError> {
+        let value = value.into();
+        validate_name_key(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn for_display_name(policy: crate::NamePolicy, display_name: &crate::DisplayName) -> Self {
+        Self(crate::name_key_for_display_name(
+            policy,
+            display_name.as_str(),
+        ))
     }
 
     pub fn as_str(&self) -> &str {
@@ -311,6 +373,12 @@ impl AsRef<str> for CommitId {
     }
 }
 
+impl AsRef<str> for NameKey {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl Borrow<str> for NamespaceId {
     fn borrow(&self) -> &str {
         self.as_str()
@@ -324,6 +392,12 @@ impl Borrow<str> for ContentStoreId {
 }
 
 impl Borrow<str> for CommitId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for NameKey {
     fn borrow(&self) -> &str {
         self.as_str()
     }
@@ -348,6 +422,15 @@ impl Serialize for ContentStoreId {
 }
 
 impl Serialize for CommitId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl Serialize for NameKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -386,6 +469,16 @@ impl<'de> Deserialize<'de> for ContentStoreId {
     }
 }
 
+impl<'de> Deserialize<'de> for NameKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        NameKey::try_new(value).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Numeric identity of a file or directory within a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InodeId(pub u64);
@@ -403,8 +496,8 @@ pub struct ChangeSeq(pub u64);
 pub struct FenceToken(pub u64);
 
 /// Name-policy-derived directory entry name used as a lookup key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct NameKey(pub String);
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NameKey(String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -444,6 +537,12 @@ impl fmt::Display for CommitId {
     }
 }
 
+impl fmt::Display for NameKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 impl fmt::Display for InodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "inode-{}", self.0)
@@ -454,7 +553,7 @@ impl fmt::Display for InodeId {
 mod tests {
     use super::{
         generate_upload_id, generate_wal_segment_id, validate_upload_id, validate_wal_segment_id,
-        CommitId, ContentStoreId, NamespaceId,
+        CommitId, ContentStoreId, NameKey, NamespaceId,
     };
     use std::collections::BTreeSet;
 
@@ -613,5 +712,36 @@ mod tests {
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
             "generated id body must be lowercase hex: {value}"
         );
+    }
+
+    #[test]
+    fn name_key_parse_rejects_invalid_values() {
+        assert_eq!(
+            NameKey::parse("").expect_err("empty").reason(),
+            "must not be empty"
+        );
+        assert_eq!(
+            NameKey::parse("a/b").expect_err("slash").reason(),
+            "must not contain `/`"
+        );
+        assert_eq!(
+            NameKey::parse(".").expect_err("dot").reason(),
+            "must not be `.` or `..`"
+        );
+    }
+
+    #[test]
+    fn name_key_serializes_as_string_and_validates_deserialize() {
+        let name_key = NameKey::parse("report.txt").expect("valid name key");
+
+        assert_eq!(
+            serde_json::to_string(&name_key).expect("serialize name key"),
+            "\"report.txt\""
+        );
+        assert_eq!(
+            serde_json::from_str::<NameKey>("\"report.txt\"").expect("deserialize name key"),
+            name_key
+        );
+        assert!(serde_json::from_str::<NameKey>("\"a/b\"").is_err());
     }
 }

--- a/crates/loon-api/src/lib.rs
+++ b/crates/loon-api/src/lib.rs
@@ -12,13 +12,72 @@ mod server;
 pub mod v0;
 mod wal;
 
-pub use checkpoint::*;
-pub use content::*;
-pub use control::*;
-pub use digest::*;
-pub use http::*;
-pub use ids::*;
-pub use name_policy::*;
-pub use path::*;
-pub use server::*;
-pub use wal::*;
+pub mod wire {
+    pub mod checkpoint {
+        pub use crate::checkpoint::*;
+    }
+
+    pub mod control {
+        pub use crate::control::*;
+    }
+
+    pub mod wal {
+        pub use crate::wal::*;
+    }
+}
+
+pub use content::{ContentRef, ContentRefKind};
+pub use digest::sha256_digest;
+pub use http::{
+    AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
+    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
+    FilesystemPutBehavior, ForkNamespaceRequest, ListNamespacesResponse, MutationResult,
+    NamespaceSummary,
+};
+pub use ids::{
+    generate_upload_id, generate_wal_segment_id, generated_id, validate_generated_id,
+    validate_upload_id, validate_wal_segment_id, ChangeSeq, CommitId, CommitIdValidationError,
+    ConflictDisposition, ContentStoreId, FenceToken, GeneratedIdValidationError, Identity, InodeId,
+    InodeKind, NameKey, NameKeyValidationError, NamespaceId, NamespaceIdValidationError,
+    RevisionNo,
+};
+pub use name_policy::{name_key_for_display_name, NamePolicy};
+pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
+pub use server::{AuthoritativeFileBytes, AuthoritativePathEntry};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn curated_root_exports_cover_common_public_types() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let commit_id = CommitId::generate();
+        let path = AbsolutePath::parse("/docs/report.txt").expect("valid path");
+        let display_name = DisplayName::parse("Report.txt").expect("valid display name");
+        let name_key = NameKey::for_display_name(NamePolicy::default(), &display_name);
+        let content_ref = ContentRef::whole_file_v0(b"hello");
+
+        assert_eq!(namespace_id.as_str(), "demo");
+        assert!(commit_id.as_str().starts_with("c_"));
+        assert_eq!(path.as_str(), "/docs/report.txt");
+        assert_eq!(name_key.as_str(), "report.txt");
+        assert_eq!(content_ref.size_bytes, 5);
+    }
+
+    #[test]
+    fn durable_protocol_types_are_available_under_wire() {
+        let _head = wire::control::HeadState::initial(
+            NamespaceId::parse("demo").expect("valid namespace id"),
+        );
+        let _wal_delta = wire::wal::WalDelta::TombstoneSubtree {
+            delta_index: 0,
+            root_inode: InodeId(1),
+        };
+        let _checkpoint_row = wire::checkpoint::CheckpointRow::Tombstone {
+            root_inode_id: InodeId(1),
+            tombstone_seq: ChangeSeq(1),
+            tombstone_delta_index: 0,
+        };
+    }
+}

--- a/crates/loon-api/src/path.rs
+++ b/crates/loon-api/src/path.rs
@@ -1,4 +1,3 @@
-use crate::{name_key_for_display_name, NameKey, NamePolicy};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -164,16 +163,6 @@ impl DisplayName {
     }
 }
 
-impl NameKey {
-    pub fn for_display_name(policy: NamePolicy, display_name: &DisplayName) -> Self {
-        Self(name_key_for_display_name(policy, display_name.as_str()))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
 impl PathError {
     pub fn invalid_path_input(&self) -> &str {
         match self {
@@ -190,8 +179,8 @@ impl PathError {
 
 #[cfg(test)]
 mod tests {
-    use super::{AbsolutePath, DisplayName, NameKey, PathError};
-    use crate::{name_key_for_display_name, NamePolicy};
+    use super::{AbsolutePath, DisplayName, PathError};
+    use crate::{name_key_for_display_name, NameKey, NamePolicy};
 
     #[test]
     fn absolute_path_root_is_valid() {

--- a/crates/loon-api/src/v0.rs
+++ b/crates/loon-api/src/v0.rs
@@ -1,4 +1,7 @@
-use crate::{ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo};
+use crate::{
+    ChangeSeq, CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamePolicy,
+    NamespaceId, RevisionNo,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -118,11 +121,11 @@ pub enum CommitPrecondition {
     },
     ChildNameAbsent {
         parent_inode: InodeId,
-        name_key: String,
+        name_key: NameKey,
     },
     BindingIs {
         parent_inode: InodeId,
-        name_key: String,
+        name_key: NameKey,
         child_inode: InodeId,
         bind_seq: ChangeSeq,
         bind_delta_index: u32,
@@ -185,7 +188,7 @@ pub enum CommitDelta {
         semantic_op_index: u32,
         delta_index: u32,
         parent_inode: InodeId,
-        name_key: String,
+        name_key: NameKey,
         display_name: String,
         child_inode: InodeId,
     },
@@ -193,7 +196,7 @@ pub enum CommitDelta {
         semantic_op_index: u32,
         delta_index: u32,
         parent_inode: InodeId,
-        name_key: String,
+        name_key: NameKey,
         child_inode: InodeId,
         bind_seq: ChangeSeq,
         bind_delta_index: u32,
@@ -230,4 +233,118 @@ pub struct ChangesResponse {
     pub from_exclusive_seq: ChangeSeq,
     pub through_seq: ChangeSeq,
     pub changes: Vec<CommittedChange>,
+}
+
+impl CommitPrecondition {
+    pub fn child_name_absent(parent_inode: InodeId, name_key: NameKey) -> Self {
+        Self::ChildNameAbsent {
+            parent_inode,
+            name_key,
+        }
+    }
+
+    pub fn child_display_name_absent(
+        parent_inode: InodeId,
+        name_policy: NamePolicy,
+        display_name: &DisplayName,
+    ) -> Self {
+        Self::child_name_absent(
+            parent_inode,
+            NameKey::for_display_name(name_policy, display_name),
+        )
+    }
+
+    pub fn binding_is(
+        parent_inode: InodeId,
+        name_key: NameKey,
+        child_inode: InodeId,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) -> Self {
+        Self::BindingIs {
+            parent_inode,
+            name_key,
+            child_inode,
+            bind_seq,
+            bind_delta_index,
+        }
+    }
+
+    pub fn display_name_binding_is(
+        parent_inode: InodeId,
+        name_policy: NamePolicy,
+        display_name: &DisplayName,
+        child_inode: InodeId,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) -> Self {
+        Self::binding_is(
+            parent_inode,
+            NameKey::for_display_name(name_policy, display_name),
+            child_inode,
+            bind_seq,
+            bind_delta_index,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommitDelta, CommitPrecondition};
+    use crate::{ChangeSeq, InodeId, InodeKind, NameKey};
+
+    #[test]
+    fn commit_precondition_name_key_serializes_as_plain_string() {
+        let precondition = CommitPrecondition::ChildNameAbsent {
+            parent_inode: InodeId(1),
+            name_key: NameKey::parse("report.txt").expect("valid name key"),
+        };
+
+        assert_eq!(
+            serde_json::to_string(&precondition).expect("serialize precondition"),
+            r#"{"type":"child_name_absent","parent_inode":1,"name_key":"report.txt"}"#
+        );
+    }
+
+    #[test]
+    fn commit_delta_name_key_serializes_as_plain_string() {
+        let delta = CommitDelta::BindDirentry {
+            semantic_op_index: 0,
+            delta_index: 1,
+            parent_inode: InodeId(1),
+            name_key: NameKey::parse("report.txt").expect("valid name key"),
+            display_name: "Report.txt".to_owned(),
+            child_inode: InodeId(2),
+        };
+
+        assert_eq!(
+            serde_json::to_string(&delta).expect("serialize delta"),
+            r#"{"delta":"bind_direntry","semantic_op_index":0,"delta_index":1,"parent_inode":1,"name_key":"report.txt","display_name":"Report.txt","child_inode":2}"#
+        );
+
+        let unbind = CommitDelta::UnbindDirentry {
+            semantic_op_index: 0,
+            delta_index: 2,
+            parent_inode: InodeId(1),
+            name_key: NameKey::parse("report.txt").expect("valid name key"),
+            child_inode: InodeId(2),
+            bind_seq: ChangeSeq(7),
+            bind_delta_index: 1,
+        };
+        assert_eq!(
+            serde_json::to_string(&unbind).expect("serialize unbind delta"),
+            r#"{"delta":"unbind_direntry","semantic_op_index":0,"delta_index":2,"parent_inode":1,"name_key":"report.txt","child_inode":2,"bind_seq":7,"bind_delta_index":1}"#
+        );
+
+        let create_inode = CommitDelta::CreateInode {
+            semantic_op_index: 0,
+            delta_index: 0,
+            inode_id: InodeId(2),
+            inode_kind: InodeKind::File,
+        };
+        assert_eq!(
+            serde_json::to_string(&create_inode).expect("serialize create inode"),
+            r#"{"delta":"create_inode","semantic_op_index":0,"delta_index":0,"inode_id":2,"inode_kind":"file"}"#
+        );
+    }
 }

--- a/crates/loon-api/src/wal.rs
+++ b/crates/loon-api/src/wal.rs
@@ -1,3 +1,4 @@
+use crate::control::WalSegmentPointer;
 use crate::digest::sha256_hex;
 use crate::v0::{CommitAnnotations, CommitOpResult};
 use crate::{
@@ -104,7 +105,7 @@ pub struct WalSegmentPayload {
     pub namespace_id: NamespaceId,
     pub segment_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub prev_visible_segment: Option<crate::WalSegmentPointer>,
+    pub prev_visible_segment: Option<WalSegmentPointer>,
     pub base_head_seq: ChangeSeq,
     pub start_seq: ChangeSeq,
     pub end_seq: ChangeSeq,
@@ -138,8 +139,8 @@ impl WalSegmentEnvelope {
         Ok(self.payload_checksum_sha256 == wal_payload_checksum_sha256(&self.payload)?)
     }
 
-    pub fn pointer(&self, object_key: String) -> crate::WalSegmentPointer {
-        crate::WalSegmentPointer {
+    pub fn pointer(&self, object_key: String) -> WalSegmentPointer {
+        WalSegmentPointer {
             object_key,
             segment_id: self.payload.segment_id.clone(),
             start_seq: self.payload.start_seq,

--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -13,7 +13,8 @@ use crate::wal::{
     load_validated_wal_chain, replay_validated_wal_tail_with_metadata, WalChainLoadError,
     WalChainLoadRequest, WalReplayError,
 };
-use loon_api::{ChangeSeq, ContentStoreId, HeadState, NamespaceDescriptorState, NamespaceId};
+use loon_api::wire::control::{HeadState, LeaseState, NamespaceDescriptorState};
+use loon_api::{ChangeSeq, ContentStoreId, NamespaceId};
 use loon_objectstore::{
     keys::{namespace_descriptor, namespace_head},
     ObjectStore,
@@ -27,7 +28,7 @@ pub struct VerifiedNamespaceBasis {
     pub content_store_id: ContentStoreId,
     pub head: HeadState,
     pub head_etag: String,
-    pub lease: loon_api::LeaseState,
+    pub lease: LeaseState,
     pub metadata_state: MetadataState,
 }
 

--- a/crates/loon-core/src/checkpoint.rs
+++ b/crates/loon-core/src/checkpoint.rs
@@ -8,14 +8,19 @@ use crate::metadata::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
     MetadataStateBuilder, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loon_api::{
+use loon_api::wire::checkpoint::{
     checkpoint_page_checksum_sha256, checkpoint_segment_payload_checksum_sha256,
     decode_checkpoint_manifest_json, decode_checkpoint_segment_envelope_zstd,
     encode_checkpoint_manifest_json, encode_checkpoint_segment_envelope_zstd,
-    AdvanceRetentionResponse, ChangeSeq, CheckpointManifestEnvelope, CheckpointManifestPayload,
-    CheckpointPage, CheckpointRow, CheckpointSegmentDescriptor, CheckpointSegmentEnvelope,
-    CheckpointSegmentPayload, CheckpointTableFamily, CheckpointTableManifest, ControlObjectKind,
-    CreateCheckpointResponse, FenceToken, HeadState, HeadStateEnvelope, InodeId, NamespaceId,
+    CheckpointManifestEnvelope, CheckpointManifestPayload, CheckpointPage, CheckpointRow,
+    CheckpointSegmentDescriptor, CheckpointSegmentEnvelope, CheckpointSegmentPayload,
+    CheckpointTableFamily, CheckpointTableManifest,
+};
+use loon_api::wire::control::{
+    ControlObjectKind, HeadState, HeadStateEnvelope, ProgressStateEnvelope,
+};
+use loon_api::{
+    AdvanceRetentionResponse, ChangeSeq, CreateCheckpointResponse, FenceToken, InodeId, NamespaceId,
 };
 use loon_objectstore::keys::{
     checkpoint_manifest, checkpoint_table, derived_progress,
@@ -617,7 +622,7 @@ fn ensure_required_retention_progress<S: ObjectStore + ?Sized>(
                 namespace_id.as_str()
             )));
         };
-        let progress: loon_api::ProgressStateEnvelope =
+        let progress: ProgressStateEnvelope =
             serde_json::from_slice(&bytes).map_err(|err| CoreError::Store(err.to_string()))?;
         if progress.state.through_seq < target_floor {
             return Err(CoreError::CheckpointUnavailable(format!(
@@ -1141,7 +1146,8 @@ mod tests {
         write_file_bytes, BasisLoadError, CoreError, CoreErrorKind, MutationContext,
         PutFileBehavior,
     };
-    use loon_api::{ChangeSeq, CheckpointManifestEnvelope, CheckpointManifestPayload, NamespaceId};
+    use loon_api::wire::checkpoint::{CheckpointManifestEnvelope, CheckpointManifestPayload};
+    use loon_api::{ChangeSeq, NamespaceId};
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::keys::{
         checkpoint_manifest, checkpoint_table, namespace_head, CheckpointTableFamily,

--- a/crates/loon-core/src/commit/api_adapter.rs
+++ b/crates/loon-core/src/commit/api_adapter.rs
@@ -100,7 +100,7 @@ pub(super) fn commit_precondition_from_v0(
             name_key,
         } => Precondition::ChildNameAbsent {
             parent_inode,
-            name_key,
+            name_key: name_key.as_str().to_owned(),
         },
         api_v0::CommitPrecondition::BindingIs {
             parent_inode,
@@ -110,7 +110,7 @@ pub(super) fn commit_precondition_from_v0(
             bind_delta_index,
         } => Precondition::BindingIs {
             parent_inode,
-            name_key,
+            name_key: name_key.as_str().to_owned(),
             child_inode,
             bind_seq,
             bind_delta_index,
@@ -126,7 +126,7 @@ mod tests {
     use super::*;
     use loon_api::{
         v0::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition},
-        CommitId, ContentRef, FenceToken, InodeId, NamespaceId, RevisionNo,
+        CommitId, ContentRef, FenceToken, InodeId, NameKey, NamespaceId, RevisionNo,
     };
 
     #[test]
@@ -144,11 +144,11 @@ mod tests {
                 },
                 ApiCommitPrecondition::ChildNameAbsent {
                     parent_inode: InodeId(1),
-                    name_key: "docs".to_owned(),
+                    name_key: NameKey::parse("docs").expect("valid name key"),
                 },
                 ApiCommitPrecondition::BindingIs {
                     parent_inode: InodeId(1),
-                    name_key: "file.txt".to_owned(),
+                    name_key: NameKey::parse("file.txt").expect("valid name key"),
                     child_inode: InodeId(2),
                     bind_seq: loon_api::ChangeSeq(4),
                     bind_delta_index: 1,

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -1,6 +1,6 @@
 use super::{MaterializedCommit, Precondition};
 use crate::wal::WalBuildError;
-use loon_api::{WalCommitDelta, WalCommitPayload, WalPrecondition};
+use loon_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalPrecondition};
 
 pub fn wal_payload_from_materialized_commit(
     commit: &MaterializedCommit,

--- a/crates/loon-core/src/commit/identity.rs
+++ b/crates/loon-core/src/commit/identity.rs
@@ -1,6 +1,8 @@
 use super::api_adapter::{commit_op_from_v0, commit_precondition_from_v0};
 use super::{CommitOp, CommitRequest, Precondition};
-use loon_api::{payload_checksum_sha256, v0 as api_v0, NamespaceId};
+use loon_api::v0 as api_v0;
+use loon_api::wire::control::payload_checksum_sha256;
+use loon_api::NamespaceId;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -1,9 +1,10 @@
 use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
+use loon_api::v0::{CommitAnnotations, RenameMode};
+use loon_api::wire::control::{HeadState, HeadStateEnvelope, LeaseState};
 use loon_api::{
-    v0::{CommitAnnotations, RenameMode},
-    ChangeSeq, CommitId, ContentRef, FenceToken, HeadState, HeadStateEnvelope, InodeId, InodeKind,
-    LeaseState, NamePolicy, NamespaceId, RevisionNo,
+    ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, InodeKind, NamePolicy, NamespaceId,
+    RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -2,9 +2,10 @@ use super::{
     core_commit_fingerprint, CommitFingerprintError, CommitOp, CommitPlan, CommitRequest,
     PathIntentFingerprint, ResolvedBinding, SemanticMutationIdentity,
 };
+use loon_api::wire::wal::WalDelta;
 use loon_api::{
     name_key_for_display_name, v0::CommitOpResult, ContentRef, FenceToken, InodeId, InodeKind,
-    NamePolicy, NamespaceId, RevisionNo, WalDelta,
+    NamePolicy, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -1,7 +1,8 @@
 use super::{push_unique_invariant, CommitHeadPublishError, CommitPlan, PreparedCommitHeadPublish};
 use crate::invariants::InvariantId;
 use crate::wal::PreparedWalSegment;
-use loon_api::{ChangeSeq, ControlObjectKind, HeadState, HeadStateEnvelope};
+use loon_api::wire::control::{ControlObjectKind, HeadState, HeadStateEnvelope};
+use loon_api::ChangeSeq;
 use loon_objectstore::keys::namespace_head;
 use loon_objectstore::ObjectStoreError;
 use loon_objectstore::{ObjectMetadata, ObjectStore};
@@ -127,10 +128,8 @@ fn map_object_store_error(err: ObjectStoreError) -> CommitHeadPublishError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loon_api::{
-        CommitId, FenceToken, InodeId, NamespaceId, WalCommitPayload, WalSegmentEnvelope,
-        WalSegmentPayload,
-    };
+    use loon_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload};
+    use loon_api::{CommitId, FenceToken, InodeId, NamespaceId};
 
     fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
         HeadState {

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -114,6 +114,8 @@ pub enum CoreError {
     },
     #[error("path component `{0}` is not a directory")]
     NonDirectoryPathComponent(String),
+    #[error("namespace corrupt: {0}")]
+    NamespaceCorrupt(String),
     #[error("object store error: {0}")]
     Store(String),
     #[error("namespace `{namespace_id}` already exists")]
@@ -202,6 +204,7 @@ impl CoreError {
             CoreError::DirectoryNotEmpty(_) => CoreErrorKind::DirectoryNotEmpty,
             CoreError::TombstoneConflict { .. } => CoreErrorKind::TombstoneConflict,
             CoreError::NonDirectoryPathComponent(_) => CoreErrorKind::InvalidPath,
+            CoreError::NamespaceCorrupt(_) => CoreErrorKind::NamespaceCorrupt,
         }
     }
 }

--- a/crates/loon-core/src/lease.rs
+++ b/crates/loon-core/src/lease.rs
@@ -1,9 +1,10 @@
 use crate::context::MutationContext;
 use crate::loading::{read_head_object, read_lease_object, ControlObjectLoadError};
 use crate::namespace::{next_takeover_head, HeadFenceTakeoverError};
-use loon_api::{
-    ControlObjectKind, FenceToken, HeadStateEnvelope, LeaseState, LeaseStateEnvelope, NamespaceId,
+use loon_api::wire::control::{
+    ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope,
 };
+use loon_api::{FenceToken, NamespaceId};
 use loon_objectstore::ObjectStore;
 use loon_objectstore::ObjectStoreError;
 use serde::{Deserialize, Serialize};
@@ -189,7 +190,7 @@ fn compare_and_swap_head<S: ObjectStore + ?Sized>(
     object_key: &str,
     expected_etag: &str,
     writer_version: &str,
-    next_head: loon_api::HeadState,
+    next_head: HeadState,
 ) -> Result<(), CasOutcome> {
     let envelope =
         HeadStateEnvelope::from_state(ControlObjectKind::NamespaceHead, writer_version, next_head)

--- a/crates/loon-core/src/loading.rs
+++ b/crates/loon-core/src/loading.rs
@@ -1,9 +1,9 @@
-use loon_api::{
+use loon_api::wire::control::{
     payload_checksum_sha256, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
-    ContentStoreId, ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState,
-    LeaseStateEnvelope, NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId,
-    CONTROL_OBJECT_FORMAT_VERSION,
+    ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope,
+    NamespaceDescriptorEnvelope, NamespaceDescriptorState, CONTROL_OBJECT_FORMAT_VERSION,
 };
+use loon_api::{ContentStoreId, NamespaceId};
 use loon_objectstore::keys::{
     content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
 };

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -1,7 +1,8 @@
 use crate::invariants::InvariantId;
+use loon_api::wire::wal::{WalCommitPayload, WalDelta};
 use loon_api::{
     v0::CommitOpResult, AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey,
-    NamePolicy, RevisionNo, WalCommitPayload, WalDelta,
+    NamePolicy, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;

--- a/crates/loon-core/src/namespace.rs
+++ b/crates/loon-core/src/namespace.rs
@@ -1,7 +1,7 @@
 pub(crate) mod catalog;
 
+pub use loon_api::wire::control::{HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope};
 use loon_api::FenceToken;
-pub use loon_api::{HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope};
 use thiserror::Error;
 
 pub fn head_and_lease_fence_tokens_agree(head: &HeadState, lease: &LeaseState) -> bool {

--- a/crates/loon-core/src/namespace/catalog.rs
+++ b/crates/loon-core/src/namespace/catalog.rs
@@ -1,7 +1,8 @@
 use crate::loading::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
-use loon_api::{ContentStoreId, NamespaceDescriptorState, NamespaceId, NamespaceIdValidationError};
+use loon_api::wire::control::NamespaceDescriptorState;
+use loon_api::{ContentStoreId, NamespaceId, NamespaceIdValidationError};
 use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loon_objectstore::ObjectStore;
 use thiserror::Error;

--- a/crates/loon-core/src/path/planner.rs
+++ b/crates/loon-core/src/path/planner.rs
@@ -7,14 +7,16 @@ use crate::basis::{load_verified_namespace_basis, VerifiedNamespaceBasis};
 use crate::commit::{PathIntentFingerprint, PATH_INTENT_FINGERPRINT_DOMAIN};
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, ResolvedVisiblePath, VisiblePathError};
+use loon_api::wire::control::payload_checksum_sha256;
+use loon_api::wire::control::HeadState;
+use loon_api::wire::wal::WalDelta;
 use loon_api::{
-    payload_checksum_sha256,
     v0::{
         CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
         CommitRequest as ApiCommitRequest, RenameMode,
     },
-    AbsolutePath, ChangeSeq, CommitId, ContentRef, DisplayName, HeadState, InodeId, InodeKind,
-    NameKey, NamespaceId,
+    AbsolutePath, ChangeSeq, CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey,
+    NamespaceId,
 };
 use loon_objectstore::ObjectStore;
 use serde::Serialize;
@@ -240,7 +242,8 @@ fn binding_is_precondition(
     }
     Ok(ApiCommitPrecondition::BindingIs {
         parent_inode,
-        name_key: binding.name_key,
+        name_key: NameKey::try_new(binding.name_key)
+            .map_err(|err| CoreError::InvalidPath(err.value().to_owned()))?,
         child_inode: binding.child_inode_id,
         bind_seq: binding.bind_seq,
         bind_delta_index: binding.bind_delta_index,
@@ -257,7 +260,7 @@ fn child_name_absent_precondition(
     let name_key = NameKey::for_display_name(view.head.name_policy, &display_name);
     ApiCommitPrecondition::ChildNameAbsent {
         parent_inode,
-        name_key: name_key.as_str().to_owned(),
+        name_key,
     }
 }
 
@@ -653,12 +656,12 @@ fn ensure_parent_directories(
         let applied = working.apply_committed_wal_deltas(
             committed_seq,
             &[
-                loon_api::WalDelta::CreateInode {
+                WalDelta::CreateInode {
                     delta_index,
                     inode_id: allocated,
                     inode_kind: InodeKind::Dir,
                 },
-                loon_api::WalDelta::BindDirentry {
+                WalDelta::BindDirentry {
                     delta_index: delta_index.saturating_add(1),
                     parent_inode: current_inode,
                     name_key: name_key.as_str().to_owned(),
@@ -847,7 +850,7 @@ mod tests {
                 CommitPrecondition::ChildNameAbsent {
                     parent_inode: InodeId(1),
                     name_key,
-                } if name_key == "docs"
+                } if name_key.as_str() == "docs"
             )));
     }
 
@@ -932,7 +935,7 @@ mod tests {
             .iter()
             .any(|precondition| matches!(
                 precondition,
-                CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key == "b.txt"
+                CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key.as_str() == "b.txt"
             )));
     }
 
@@ -981,7 +984,7 @@ mod tests {
             .iter()
             .any(|precondition| matches!(
                 precondition,
-                CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key == "copy.txt"
+                CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key.as_str() == "copy.txt"
             )));
     }
 

--- a/crates/loon-core/src/path/planner.rs
+++ b/crates/loon-core/src/path/planner.rs
@@ -242,8 +242,9 @@ fn binding_is_precondition(
     }
     Ok(ApiCommitPrecondition::BindingIs {
         parent_inode,
-        name_key: NameKey::try_new(binding.name_key)
-            .map_err(|err| CoreError::InvalidPath(err.value().to_owned()))?,
+        name_key: NameKey::try_new(binding.name_key).map_err(|err| {
+            CoreError::NamespaceCorrupt(format!("invalid metadata name_key: {err}"))
+        })?,
         child_inode: binding.child_inode_id,
         bind_seq: binding.bind_seq,
         bind_delta_index: binding.bind_delta_index,
@@ -705,6 +706,7 @@ mod tests {
     use crate::commit::core_commit_fingerprint_for_v0_request;
     use crate::context::MutationContext;
     use crate::error::CoreErrorKind;
+    use crate::metadata::{DirentryBindRecord, InodeRecord};
     use crate::services::{
         bootstrap_namespace, delete_path, put_file_bytes, store_bytes_as_content,
     };
@@ -937,6 +939,55 @@ mod tests {
                 precondition,
                 CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key.as_str() == "b.txt"
             )));
+    }
+
+    #[test]
+    fn binding_is_precondition_reports_invalid_durable_name_key_as_namespace_corrupt() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let mut head = HeadState::initial(namespace_id);
+        head.seq = ChangeSeq(1);
+        let metadata_state = MetadataState::from_rows(
+            vec![
+                InodeRecord {
+                    inode_id: InodeId(1),
+                    inode_kind: InodeKind::Dir,
+                    created_seq: ChangeSeq(0),
+                },
+                InodeRecord {
+                    inode_id: InodeId(2),
+                    inode_kind: InodeKind::File,
+                    created_seq: ChangeSeq(1),
+                },
+            ],
+            vec![DirentryBindRecord {
+                parent_inode_id: InodeId(1),
+                name_key: "bad/key".to_owned(),
+                display_name: "file.txt".to_owned(),
+                child_inode_id: InodeId(2),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: 0,
+            }],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let view = PathPlanningView {
+            head: &head,
+            metadata_state: &metadata_state,
+        };
+        let resolved = ResolvedVisiblePath {
+            absolute_path: "/file.txt".to_owned(),
+            inode_id: InodeId(2),
+            inode_kind: InodeKind::File,
+            parent_inode_id: Some(InodeId(1)),
+            display_name: "file.txt".to_owned(),
+        };
+
+        let error =
+            binding_is_precondition(&view, &resolved).expect_err("invalid durable name key");
+
+        assert_eq!(error.kind(), CoreErrorKind::NamespaceCorrupt);
     }
 
     #[test]

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -26,10 +26,13 @@ use loon_api::v0::{
     CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
+use loon_api::wire::control::{
+    CompletedUpload, ControlObjectKind, HeadState, UploadSessionEnvelope, UploadSessionState,
+};
+use loon_api::wire::wal::{WalCommitDelta, WalDelta};
 use loon_api::{
-    generate_upload_id, validate_upload_id, ChangeSeq, CommitId, CompletedUpload, ContentRef,
-    ContentStoreId, ControlObjectKind, HeadState, NamespaceId, UploadSessionEnvelope,
-    UploadSessionState, WalCommitDelta, WalDelta,
+    generate_upload_id, validate_upload_id, ChangeSeq, CommitId, ContentRef, ContentStoreId,
+    NameKey, NamespaceId,
 };
 use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -808,7 +811,11 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
                     message: record.message.clone(),
                     annotations: record.annotations.clone(),
                     ops: record.results.clone(),
-                    deltas: record.deltas.iter().map(commit_delta_from_wal).collect(),
+                    deltas: record
+                        .deltas
+                        .iter()
+                        .map(commit_delta_from_wal)
+                        .collect::<Result<Vec<_>, _>>()?,
                 });
             }
         }
@@ -822,9 +829,9 @@ pub fn list_changes_after<S: ObjectStore + ?Sized>(
     })
 }
 
-fn commit_delta_from_wal(delta: &WalCommitDelta) -> CommitDelta {
+fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta, CoreError> {
     let semantic_op_index = delta.semantic_op_index;
-    match &delta.delta {
+    Ok(match &delta.delta {
         WalDelta::CreateInode {
             delta_index,
             inode_id,
@@ -845,7 +852,8 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> CommitDelta {
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode: *parent_inode,
-            name_key: name_key.clone(),
+            name_key: NameKey::try_new(name_key.clone())
+                .map_err(|err| CoreError::Store(format!("invalid WAL name_key: {err}")))?,
             display_name: display_name.clone(),
             child_inode: *child_inode,
         },
@@ -860,7 +868,8 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> CommitDelta {
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode: *parent_inode,
-            name_key: name_key.clone(),
+            name_key: NameKey::try_new(name_key.clone())
+                .map_err(|err| CoreError::Store(format!("invalid WAL name_key: {err}")))?,
             child_inode: *child_inode,
             bind_seq: *bind_seq,
             bind_delta_index: *bind_delta_index,
@@ -885,7 +894,7 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> CommitDelta {
             delta_index: *delta_index,
             root_inode: *root_inode,
         },
-    }
+    })
 }
 
 fn validate_commit_content_references<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -852,8 +852,9 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta, CoreErro
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode: *parent_inode,
-            name_key: NameKey::try_new(name_key.clone())
-                .map_err(|err| CoreError::Store(format!("invalid WAL name_key: {err}")))?,
+            name_key: NameKey::try_new(name_key.clone()).map_err(|err| {
+                CoreError::NamespaceCorrupt(format!("invalid WAL name_key: {err}"))
+            })?,
             display_name: display_name.clone(),
             child_inode: *child_inode,
         },
@@ -868,8 +869,9 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta, CoreErro
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode: *parent_inode,
-            name_key: NameKey::try_new(name_key.clone())
-                .map_err(|err| CoreError::Store(format!("invalid WAL name_key: {err}")))?,
+            name_key: NameKey::try_new(name_key.clone()).map_err(|err| {
+                CoreError::NamespaceCorrupt(format!("invalid WAL name_key: {err}"))
+            })?,
             child_inode: *child_inode,
             bind_seq: *bind_seq,
             bind_delta_index: *bind_delta_index,
@@ -1029,4 +1031,48 @@ fn finish_batch_outcomes_with_aliases(
         outcomes[*alias_index] = Some(primary_outcome);
     }
     finish_batch_outcomes(outcomes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::CoreErrorKind;
+    use loon_api::{ChangeSeq, InodeId};
+
+    #[test]
+    fn invalid_wal_delta_name_key_is_namespace_corrupt() {
+        let delta = WalCommitDelta {
+            semantic_op_index: 0,
+            delta: WalDelta::BindDirentry {
+                delta_index: 0,
+                parent_inode: InodeId(1),
+                name_key: "bad/key".to_owned(),
+                display_name: "file.txt".to_owned(),
+                child_inode: InodeId(2),
+            },
+        };
+
+        let error = commit_delta_from_wal(&delta).expect_err("invalid durable WAL name key");
+
+        assert_eq!(error.kind(), CoreErrorKind::NamespaceCorrupt);
+    }
+
+    #[test]
+    fn invalid_wal_unbind_name_key_is_namespace_corrupt() {
+        let delta = WalCommitDelta {
+            semantic_op_index: 0,
+            delta: WalDelta::UnbindDirentry {
+                delta_index: 0,
+                parent_inode: InodeId(1),
+                name_key: "bad/key".to_owned(),
+                child_inode: InodeId(2),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: 0,
+            },
+        };
+
+        let error = commit_delta_from_wal(&delta).expect_err("invalid durable WAL name key");
+
+        assert_eq!(error.kind(), CoreErrorKind::NamespaceCorrupt);
+    }
 }

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -10,7 +10,8 @@ use crate::{
     BasisLoadError, NamespaceHeadEtagProbe, VerifiedNamespaceBasis,
 };
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loon_api::{CommitId, LeaseState, MutationResult, NamespaceId};
+use loon_api::wire::control::LeaseState;
+use loon_api::{CommitId, MutationResult, NamespaceId};
 use loon_objectstore::ObjectStore;
 use std::sync::Arc;
 
@@ -402,7 +403,8 @@ mod tests {
     use super::*;
     use crate::metadata::MetadataState;
     use crate::NamespaceHeadEtagProbe;
-    use loon_api::{ChangeSeq, ContentStoreId, FenceToken, HeadState, NamespaceDescriptorState};
+    use loon_api::wire::control::{HeadState, NamespaceDescriptorState};
+    use loon_api::{ChangeSeq, ContentStoreId, FenceToken};
 
     #[test]
     fn cached_verified_basis_refreshes_only_lease_state() {

--- a/crates/loon-core/src/services/namespace_lifecycle.rs
+++ b/crates/loon-core/src/services/namespace_lifecycle.rs
@@ -11,11 +11,13 @@ use crate::namespace::catalog::{
     load_namespace_descriptor, namespace_initialization_state, NamespaceInitializationError,
     NamespaceInitializationState,
 };
+use loon_api::wire::control::{
+    ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ControlObjectKind, HeadState,
+    HeadStateEnvelope, LeaseState, LeaseStateEnvelope, NamespaceDescriptorEnvelope,
+    NamespaceDescriptorState,
+};
 use loon_api::{
-    ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ContentStoreId, ControlObjectKind,
-    FenceToken, HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope,
-    NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId, NamespaceIdValidationError,
-    NamespaceSummary,
+    ContentStoreId, FenceToken, NamespaceId, NamespaceIdValidationError, NamespaceSummary,
 };
 use loon_objectstore::keys::{
     content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -1,11 +1,12 @@
 use crate::commit::{wal_payload_from_materialized_commit, MaterializedCommit};
 use crate::invariants::InvariantId;
 use crate::metadata::{MetadataApplyError, MetadataState};
-use loon_api::{
-    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, generate_wal_segment_id,
-    validate_wal_segment_id, ChangeSeq, HeadState, InodeId, NamespaceId, WalCommitDelta,
-    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload, WalSegmentPointer,
+use loon_api::wire::control::{HeadState, WalSegmentPointer};
+use loon_api::wire::wal::{
+    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, WalCommitDelta,
+    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
 };
+use loon_api::{generate_wal_segment_id, validate_wal_segment_id, ChangeSeq, InodeId, NamespaceId};
 use loon_objectstore::keys::wal_segment;
 use loon_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};

--- a/crates/loon-core/tests/differential.rs
+++ b/crates/loon-core/tests/differential.rs
@@ -1,5 +1,6 @@
+use loon_api::wire::wal::WalDelta;
 use loon_api::{
-    sha256_digest, ChangeSeq, ContentRef, ContentRefKind, InodeId, InodeKind, RevisionNo, WalDelta,
+    sha256_digest, ChangeSeq, ContentRef, ContentRefKind, InodeId, InodeKind, RevisionNo,
 };
 use loon_core::metadata::MetadataState as CoreMetadataState;
 use loon_model::metadata::MetadataState as ModelMetadataState;

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -1,12 +1,16 @@
 use loon_api::{
-    decode_wal_segment_envelope_zstd, sha256_digest,
+    sha256_digest,
     v0::{
         CommitDelta, CommitOp as ApiCommitOp, CommitPrecondition,
         CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
-    AbsolutePath, ChangeSeq, CommitId, ContentRef, ContentRefKind, ContentStoreDescriptorEnvelope,
-    ControlObjectKind, FenceToken, HeadState, InodeId, InodeKind, LeaseState,
-    NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceId, RevisionNo,
+    wire::control::{
+        ContentStoreDescriptorEnvelope, ControlObjectKind, HeadState, LeaseState,
+        NamespaceDescriptorEnvelope, NamespaceDescriptorState,
+    },
+    wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
+    AbsolutePath, ChangeSeq, CommitId, ContentRef, ContentRefKind, FenceToken, InodeId, InodeKind,
+    NameKey, NamespaceId, RevisionNo,
 };
 use loon_core::commit::{
     build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
@@ -37,14 +41,14 @@ fn wal_create_dir(
     inode_id: InodeId,
     parent_inode: InodeId,
     display_name: String,
-) -> Vec<loon_api::WalDelta> {
+) -> Vec<WalDelta> {
     vec![
-        loon_api::WalDelta::CreateInode {
+        WalDelta::CreateInode {
             delta_index,
             inode_id,
             inode_kind: InodeKind::Dir,
         },
-        loon_api::WalDelta::BindDirentry {
+        WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
             name_key: loon_api::name_key_for_display_name(
@@ -63,14 +67,14 @@ fn wal_create_file(
     parent_inode: InodeId,
     display_name: String,
     content_ref: ContentRef,
-) -> Vec<loon_api::WalDelta> {
+) -> Vec<WalDelta> {
     vec![
-        loon_api::WalDelta::CreateInode {
+        WalDelta::CreateInode {
             delta_index,
             inode_id,
             inode_kind: InodeKind::File,
         },
-        loon_api::WalDelta::BindDirentry {
+        WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode,
             name_key: loon_api::name_key_for_display_name(
@@ -80,7 +84,7 @@ fn wal_create_file(
             display_name,
             child_inode: inode_id,
         },
-        loon_api::WalDelta::AppendFileRevision {
+        WalDelta::AppendFileRevision {
             delta_index: delta_index.saturating_add(2),
             inode_id,
             revision_no: RevisionNo(1),
@@ -94,8 +98,8 @@ fn wal_append_revision(
     inode_id: InodeId,
     revision_no: RevisionNo,
     content_ref: ContentRef,
-) -> Vec<loon_api::WalDelta> {
-    vec![loon_api::WalDelta::AppendFileRevision {
+) -> Vec<WalDelta> {
+    vec![WalDelta::AppendFileRevision {
         delta_index,
         inode_id,
         revision_no,
@@ -103,8 +107,8 @@ fn wal_append_revision(
     }]
 }
 
-fn wal_tombstone(delta_index: u32, root_inode: InodeId) -> Vec<loon_api::WalDelta> {
-    vec![loon_api::WalDelta::TombstoneSubtree {
+fn wal_tombstone(delta_index: u32, root_inode: InodeId) -> Vec<WalDelta> {
+    vec![WalDelta::TombstoneSubtree {
         delta_index,
         root_inode,
     }]
@@ -492,7 +496,7 @@ fn restore_revision_overflow_is_rejected() {
         "overflow.txt".to_owned(),
         content_ref("content-max"),
     );
-    deltas[2] = loon_api::WalDelta::AppendFileRevision {
+    deltas[2] = WalDelta::AppendFileRevision {
         delta_index: 2,
         inode_id: InodeId(2),
         revision_no: RevisionNo(u64::MAX),
@@ -501,7 +505,7 @@ fn restore_revision_overflow_is_rejected() {
     let metadata_state = MetadataState::default()
         .apply_committed_wal_deltas(
             ChangeSeq(0),
-            &[loon_api::WalDelta::CreateInode {
+            &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
                 inode_kind: InodeKind::Dir,
@@ -996,7 +1000,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
     assert_eq!(segment.payload.records[0].deltas[0].semantic_op_index, 0);
     assert_eq!(segment.payload.records[0].deltas[1].semantic_op_index, 0);
     match &segment.payload.records[0].deltas[1].delta {
-        loon_api::WalDelta::BindDirentry {
+        WalDelta::BindDirentry {
             name_key,
             display_name,
             ..
@@ -1042,7 +1046,7 @@ fn batch_commit_writes_one_segment_and_expands_change_feed() {
             name_key,
             display_name,
             ..
-        } if name_key == "alpha" && display_name == "alpha"
+        } if name_key.as_str() == "alpha" && display_name == "alpha"
     ));
 }
 
@@ -1118,7 +1122,7 @@ fn binding_is_precondition_observes_earlier_batch_candidate() {
                 commit_id: CommitId::parse("delete-with-stale-binding").expect("valid commit id"),
                 preconditions: vec![CommitPrecondition::BindingIs {
                     parent_inode: docs_inode,
-                    name_key: original_binding.name_key,
+                    name_key: NameKey::try_new(original_binding.name_key).expect("valid name key"),
                     child_inode: file_inode,
                     bind_seq: original_binding.bind_seq,
                     bind_delta_index: original_binding.bind_delta_index,
@@ -2529,7 +2533,7 @@ fn path_move_writes_unbind_and_stale_binding_is_fails() {
             commit_id: CommitId::parse("delete-with-stale-binding").expect("valid commit id"),
             preconditions: vec![CommitPrecondition::BindingIs {
                 parent_inode: old_binding.parent_inode_id,
-                name_key: old_binding.name_key,
+                name_key: NameKey::try_new(old_binding.name_key).expect("valid name key"),
                 child_inode: old_binding.child_inode_id,
                 bind_seq: old_binding.bind_seq,
                 bind_delta_index: old_binding.bind_delta_index,
@@ -2902,11 +2906,11 @@ impl ObjectStore for InjectCreateFailureStore {
     }
 }
 
-fn metadata_state_after(sequences: &[Vec<loon_api::WalDelta>]) -> MetadataState {
+fn metadata_state_after(sequences: &[Vec<WalDelta>]) -> MetadataState {
     let mut state = MetadataState::default()
         .apply_committed_wal_deltas(
             ChangeSeq(0),
-            &[loon_api::WalDelta::CreateInode {
+            &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
                 inode_kind: InodeKind::Dir,

--- a/crates/loon-model/src/metadata.rs
+++ b/crates/loon-model/src/metadata.rs
@@ -1,6 +1,6 @@
+use loon_api::wire::wal::WalDelta;
 use loon_api::{
     AbsolutePath, ChangeSeq, ContentRef, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo,
-    WalDelta,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;

--- a/crates/loon-model/src/wal.rs
+++ b/crates/loon-model/src/wal.rs
@@ -1,5 +1,7 @@
 use crate::metadata::{MetadataApplyError, MetadataState};
-use loon_api::{ChangeSeq, HeadState, InodeId, WalDelta};
+use loon_api::wire::control::HeadState;
+use loon_api::wire::wal::WalDelta;
+use loon_api::{ChangeSeq, InodeId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -346,6 +346,7 @@ mod tests {
     use super::*;
     use crate::config::{ServerConfig, StoreConfig};
     use loon_api::v0::{CommitOp, CommitRequest};
+    use loon_api::wire::wal::decode_wal_segment_envelope_zstd;
     use loon_api::{ChangeSeq, InodeId};
     use loon_core::{store_bytes_as_content, PathMutationIntent, PutFileBehavior};
     use loon_objectstore::fs::LocalFsStore;
@@ -856,8 +857,7 @@ mod tests {
             .get(&wal_keys[0], None)
             .expect("read wal")
             .expect("wal exists");
-        let segment =
-            loon_api::decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode wal segment");
+        let segment = decode_wal_segment_envelope_zstd(&wal_bytes).expect("decode wal segment");
         assert_eq!(segment.payload.records.len(), 2);
     }
 }

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -3,8 +3,9 @@ use loon_api::{
         CommitAnnotations, CommitDelta, CommitOp, CommitOpResult,
         CommitRequest as ApiCommitRequest, CompleteUploadRequest,
     },
-    AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, ControlObjectKind,
-    CreateCheckpointResponse, InodeId, InodeKind, LeaseStateEnvelope, RevisionNo,
+    wire::control::{ControlObjectKind, LeaseStateEnvelope},
+    AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
+    InodeId, InodeKind, RevisionNo,
 };
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_objectstore::keys::{checkpoint_manifest, namespace_lease};
@@ -414,7 +415,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
                 name_key,
                 display_name,
                 ..
-            } if name_key == "uploaded.txt" && display_name == "uploaded.txt"
+            } if name_key.as_str() == "uploaded.txt" && display_name == "uploaded.txt"
         ));
 
         let empty = harness

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -10,7 +10,7 @@ pub use loon_api::v0::{
     CommitRequest, CommitResponse, CompleteUploadRequest, CompleteUploadResponse,
     UploadContentResponse,
 };
-use loon_api::HeadState;
+use loon_api::wire::control::HeadState;
 pub use loon_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, CommitId,
     ContentRef, CreateCheckpointResponse, FilesystemOperationResponse, InodeId, MutationResult,


### PR DESCRIPTION
Another cleanup PR, this one tightens the `loon-api` public surface: common safe data objects stay at the crate root, while durable control/WAL/checkpoint types move behind `loon_api::wire`.
