### PR TITLE
docs: add object storage provider reference

### DIFF
--- a/docs/appendices/096-object-storage-provider-reference.md
+++ b/docs/appendices/096-object-storage-provider-reference.md
@@ -1,0 +1,108 @@
+# 096. Object Storage Provider Reference
+
+This reference collects useful provider limits and performance data points for LoonFS design work. It is a quick engineering reference, useful for high-level design discussions, but not a substitute for provider conformance tests.
+
+## 096.1. Frequently Used Data Points
+
+- Do not assume any CAS object can be updated faster than **once per second**. GCS documents one write per second to the same object name; R2 documents one concurrent write per second to the same object key.[^1][^2]
+- `ETag` cannot be assumed to be a portable content hash, and is not consistent across providers, especially for multipart uploads.
+- GET HEAD is usually around 30ms, and a full GET of a small object (with content) should be assumed to be ~200ms. GET HEAD (or GET if-none-match) is a useful acceleration for evaluating control objects. 
+
+## 096.2. Provider Matrix
+
+| Feature | AWS S3 | Google Cloud Storage | Cloudflare R2 | Azure Blob Storage | S3-Compatible |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| **CAS / conditional write** | Yes. | Yes. | Yes. | Yes. | Unknown until tested. |
+| **Same-key CAS/write ceiling to remember** | No documented 1/s same-key cap found. | **1 write/s to the same object name and 1 metadata update/s to the same object; exceeding this can throttle.[^12]** | **1 concurrent write/s to the same object key; excess concurrent writes can return 429.[^23]** | No 1/s same-key cap found.[^35][^36] | Unknown. Some providers may impose same-key, partition, account, or hidden fairness limits. |
+| **Multipart / large upload** | Yes. Up to 10,000 parts. [^4] | Yes. [^13][^14] | Yes. Single upload up to 5 GiB; multipart up to 5 TiB, 10,000 parts, 5 MiB-5 GiB per part; SDKs can upload parts in parallel.[^24][^25] | Native block-blob upload: Put Block plus Put Block List. Up to 50,000 blocks, 4,000 MiB/block, and about 190.7 TiB max block blob for current service versions.[^37][^38][^39] | Usually S3-like, but limits and checksum semantics vary. |
+| **Parallel/ranged download** | Yes: Range and partNumber. [^5] | Yes: sliced object downloads use parallel ranged GETs.[^15] | Yes. S3 API GetObject supports Range and PartNumber.[^26][^27] | Yes.[^40] | Unknown until tested. |
+| **ETag and full-object checksums** | ETag is opaque in many cases. S3 supports stored object checksums including CRC64NVME, CRC32/CRC32C, SHA-1, SHA-256, MD5, and others; full-object checksums can be stored for single or multipart uploads.[^6][^7] | All objects have CRC32C. MD5 is absent for composite and XML API multipart objects. ETags exist, but values can differ across XML/JSON APIs.[^16][^17] | S3 API supports full-object CRC64NVME and composite CRC32/CRC32C/SHA-1/SHA-256. Multipart ETags follow S3-style multipart MD5-of-part-MD5s format.[^28][^29][^30] | ETag is for conditional operations, not a portable hash. Full-blob Content-MD5 can be set/returned for full reads; range MD5/CRC64 are limited to <=4 MiB ranges.[^41][^42] | Never assume ETag is MD5. Check documentation. |
+| **Availability SLA / target** | S3 Standard family service credits begin when monthly uptime is below 99.9%; some IA classes use 99.0% thresholds.[^8] | Standard: 99.95% for multi-region / dual-region and 99.9% for regional; other storage classes and locations vary.[^18] | R2 docs state an availability SLA of 99.9% and 99.999999999% designed annual durability.[^31] | Availability depends on redundancy/access tier. Redundancy table: read/write at least 99.9% for common hot tiers; RA-GRS/RA-GZRS read availability at least 99.99%; cool/cold/archive can be lower.[^43] | Vendor/contract-specific. |
+| **Request scale, partitions, throughput** | At least 3,500 write-class requests/s and 5,500 GET/HEAD requests/s per partitioned prefix; unlimited prefixes; scaling is gradual and may return 503 Slow Down. AWS also cites up to 100 Gb/s from a single EC2 instance and aggregate multi-Tb/s workloads.[^9] | Initial bucket scale is about 1,000 writes/s and 5,000 reads/s, then auto-scales. Ramp no faster than roughly doubling every 20 minutes. Sequential names can hotspot; random prefixes improve initial fanout. Internet egress default quota is commonly 200 Gbps per region, subject to account history and quotas.[^19][^20] | Public r2.dev buckets are test-only and may throttle at hundreds of req/s; production should use custom domains or direct APIs. Cloudflare REST management API is not for high-throughput object I/O; use S3-compatible or Workers APIs.[^32] | Standard GPv2/blob accounts: default max request rate 40,000 req/s in many listed regions, 20,000 elsewhere; ingress commonly 60/25 Gbps and egress 200/50 Gbps by region, increaseable by request. Partition hot spots can cause 503/500; use distribution and backoff.[^44][^45] | Vendor-specific. Run compatibility and load tests before relying on any numbers. |
+| **Published GET/HEAD latency** | AWS publishes rough general S3 small-object / first-byte latencies of about 100-200 ms.[^10] | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | Need to benchmark to verify. |
+
+## 096.3. LoonFS Design Implications
+
+1. **WAL/head flush cadence:** a 1 update per second is the single key CAS ceiling for GCS and R2. For more throughput, write immutable segment objects and update multiple sharded heads or a batched manifest.
+2. **Immutable content path:** content-addressed or monotonic keys can scale through multipart upload and distributed prefixes. 
+4. **Checksums:** LoonFS should own end-to-end integrity. Provider checksums help validate transport/storage, but ETag/checksum semantics diverge sharply across providers and multipart modes.
+
+## 096.4. Sources
+
+[^1]: Google Cloud Storage, "Quotas & limits": [https://cloud.google.com/storage/quotas](https://cloud.google.com/storage/quotas)
+
+[^2]: Cloudflare R2, "Limits": [https://developers.cloudflare.com/r2/platform/limits/](https://developers.cloudflare.com/r2/platform/limits/)
+
+[^4]: AWS S3 User Guide, "Uploading and copying objects using multipart upload": [https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)
+
+[^5]: AWS S3 API Reference, `GetObject`: [https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)
+
+[^6]: AWS S3 User Guide, "Checking object integrity": [https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
+
+[^7]: AWS S3 API Reference, `HeadObject`: [https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)
+
+[^8]: AWS S3 Service Level Agreement: [https://aws.amazon.com/s3/sla/](https://aws.amazon.com/s3/sla/)
+
+[^9]: AWS S3 User Guide, "Best practices design patterns: optimizing Amazon S3 performance": [https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html)
+
+[^10]: AWS S3 User Guide, "Best practices design patterns: optimizing Amazon S3 performance": [https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html)
+
+[^12]: Google Cloud Storage, "Quotas & limits": [https://cloud.google.com/storage/quotas](https://cloud.google.com/storage/quotas)
+
+[^13]: Google Cloud Storage, "XML API multipart uploads": [https://cloud.google.com/storage/docs/multipart-uploads](https://cloud.google.com/storage/docs/multipart-uploads)
+
+[^14]: Google Cloud Storage, "Request preconditions": [https://cloud.google.com/storage/docs/request-preconditions](https://cloud.google.com/storage/docs/request-preconditions)
+
+[^15]: Google Cloud Storage, "Sliced object downloads": [https://cloud.google.com/storage/docs/sliced-object-downloads](https://cloud.google.com/storage/docs/sliced-object-downloads)
+
+[^16]: Google Cloud Storage, "Object metadata": [https://cloud.google.com/storage/docs/metadata](https://cloud.google.com/storage/docs/metadata)
+
+[^17]: Google Cloud Storage, "Data validation and checksums": [https://cloud.google.com/storage/docs/data-validation](https://cloud.google.com/storage/docs/data-validation)
+
+[^18]: Google Cloud Storage SLA: [https://cloud.google.com/storage/sla](https://cloud.google.com/storage/sla)
+
+[^19]: Google Cloud Storage, "Request rate and access distribution guidelines": [https://cloud.google.com/storage/docs/request-rate](https://cloud.google.com/storage/docs/request-rate)
+
+[^20]: Google Cloud Storage, "Quotas & limits - Bandwidth": [https://cloud.google.com/storage/quotas#bandwidth](https://cloud.google.com/storage/quotas#bandwidth)
+
+[^23]: Cloudflare R2, "Limits": [https://developers.cloudflare.com/r2/platform/limits/](https://developers.cloudflare.com/r2/platform/limits/)
+
+[^24]: Cloudflare R2, "Upload objects": [https://developers.cloudflare.com/r2/objects/upload-objects/](https://developers.cloudflare.com/r2/objects/upload-objects/)
+
+[^25]: Cloudflare R2, "Limits": [https://developers.cloudflare.com/r2/platform/limits/](https://developers.cloudflare.com/r2/platform/limits/)
+
+[^26]: Cloudflare R2, "S3 API compatibility": [https://developers.cloudflare.com/r2/api/s3/api/](https://developers.cloudflare.com/r2/api/s3/api/)
+
+[^27]: Cloudflare R2, "Workers API reference": [https://developers.cloudflare.com/r2/api/workers/workers-api-reference/](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/)
+
+[^28]: Cloudflare R2, "S3 API compatibility": [https://developers.cloudflare.com/r2/api/s3/api/](https://developers.cloudflare.com/r2/api/s3/api/)
+
+[^29]: Cloudflare R2, "Upload objects": [https://developers.cloudflare.com/r2/objects/upload-objects/](https://developers.cloudflare.com/r2/objects/upload-objects/)
+
+[^30]: Cloudflare R2 Workers API reference, checksum metadata: [https://developers.cloudflare.com/r2/api/workers/workers-api-reference/](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/)
+
+[^31]: Cloudflare R2, "Durability": [https://developers.cloudflare.com/r2/reference/durability/](https://developers.cloudflare.com/r2/reference/durability/)
+
+[^32]: Cloudflare R2, "Limits": [https://developers.cloudflare.com/r2/platform/limits/](https://developers.cloudflare.com/r2/platform/limits/)
+
+[^35]: Microsoft Learn, "Scalability and performance targets for Blob storage": [https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets](https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets)
+
+[^36]: Microsoft Learn, "Manage concurrency in Blob Storage": [https://learn.microsoft.com/en-us/azure/storage/blobs/concurrency-manage](https://learn.microsoft.com/en-us/azure/storage/blobs/concurrency-manage)
+
+[^37]: Microsoft Learn, "Scalability and performance targets for Blob storage": [https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets](https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets)
+
+[^38]: Microsoft Learn, "Put Block": [https://learn.microsoft.com/en-us/rest/api/storageservices/put-block](https://learn.microsoft.com/en-us/rest/api/storageservices/put-block)
+
+[^39]: Microsoft Learn, "Put Block List": [https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list](https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list)
+
+[^40]: Microsoft Learn, "Get Blob": [https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob](https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob)
+
+[^41]: Microsoft Learn, "Get Blob": [https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob](https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob)
+
+[^42]: Microsoft Learn, "Put Block List": [https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list](https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list)
+
+[^43]: Microsoft Learn, "Azure Storage redundancy": [https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy)
+
+[^44]: Microsoft Learn, "Scalability and performance targets for standard storage accounts": [https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account](https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account)
+
+[^45]: Microsoft Learn, "Performance checklist for Blob Storage": [https://learn.microsoft.com/en-us/azure/storage/blobs/storage-performance-checklist](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-performance-checklist)


### PR DESCRIPTION
Adds an appendix with a short object storage provider reference matrix for design guidance
