### PR TITLE
perf(metadata): add maintained indexes for validation

### DIFF
--- a/crates/loon-core/src/commit/metadata_preview.rs
+++ b/crates/loon-core/src/commit/metadata_preview.rs
@@ -35,11 +35,8 @@ impl<'a> MetadataPreview<'a> {
         base_seq: ChangeSeq,
     ) -> Option<InodeRecord> {
         self.rows
-            .inodes()
-            .iter()
-            .chain(self.base.inodes().iter())
-            .find(|inode| inode.inode_id == inode_id && inode.created_seq <= base_seq)
-            .cloned()
+            .inode_at_seq(inode_id, base_seq)
+            .or_else(|| self.base_inode_at_seq(inode_id, base_seq))
     }
 
     pub(super) fn latest_revision_head_at_seq(
@@ -166,10 +163,11 @@ impl<'a> MetadataPreview<'a> {
             .rows
             .direntry_binds()
             .iter()
-            .chain(self.base.direntry_binds().iter())
             .filter(|direntry| {
                 direntry.parent_inode_id == parent_inode_id && direntry.bind_seq <= base_seq
             })
+            .cloned()
+            .chain(self.base_visible_children(parent_inode_id, base_seq))
             .filter(|direntry| {
                 self.active_child_binding_at_seq(parent_inode_id, &direntry.name_key, base_seq)
                     .map(|active| {
@@ -183,7 +181,6 @@ impl<'a> MetadataPreview<'a> {
                 self.visible_inode(direntry.child_inode_id, base_seq)
                     .is_some()
             })
-            .cloned()
             .collect::<Vec<_>>();
         children.sort_by(|left, right| {
             left.display_name
@@ -226,7 +223,6 @@ impl<'a> MetadataPreview<'a> {
         self.rows
             .direntry_binds()
             .iter()
-            .chain(self.base.direntry_binds().iter())
             .filter(|direntry| {
                 direntry.parent_inode_id == parent_inode_id
                     && direntry.name_key == name_key
@@ -234,6 +230,9 @@ impl<'a> MetadataPreview<'a> {
             })
             .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
             .cloned()
+            .into_iter()
+            .chain(self.base_bound_child_at_seq(parent_inode_id, name_key, base_seq))
+            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
     }
 
     fn active_subtree_tombstone(
@@ -244,12 +243,14 @@ impl<'a> MetadataPreview<'a> {
         self.rows
             .subtree_tombstones()
             .iter()
-            .chain(self.base.subtree_tombstones().iter())
             .filter(|tombstone| {
                 tombstone.root_inode_id == root_inode_id && tombstone.tombstone_seq <= base_seq
             })
             .max_by_key(|tombstone| (tombstone.tombstone_seq, tombstone.tombstone_delta_index))
             .cloned()
+            .into_iter()
+            .chain(self.base_active_subtree_tombstone(root_inode_id, base_seq))
+            .max_by_key(|tombstone| (tombstone.tombstone_seq, tombstone.tombstone_delta_index))
     }
 
     fn active_child_binding_at_seq(
@@ -284,12 +285,14 @@ impl<'a> MetadataPreview<'a> {
         self.rows
             .direntry_binds()
             .iter()
-            .chain(self.base.direntry_binds().iter())
             .filter(|direntry| {
                 direntry.child_inode_id == child_inode_id && direntry.bind_seq <= base_seq
             })
             .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
             .cloned()
+            .into_iter()
+            .chain(self.base_current_parent_binding_for_child(child_inode_id, base_seq))
+            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
     }
 
     fn is_direntry_unbound_at_seq(
@@ -297,17 +300,84 @@ impl<'a> MetadataPreview<'a> {
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
     ) -> bool {
-        self.rows
-            .direntry_unbinds()
-            .iter()
-            .chain(self.base.direntry_unbinds().iter())
-            .any(|unbind| {
-                unbind.unbind_seq <= base_seq
-                    && unbind.parent_inode_id == direntry.parent_inode_id
-                    && unbind.name_key == direntry.name_key
-                    && unbind.child_inode_id == direntry.child_inode_id
-                    && unbind.bind_seq == direntry.bind_seq
-                    && unbind.bind_delta_index == direntry.bind_delta_index
-            })
+        self.rows.direntry_unbinds().iter().any(|unbind| {
+            unbind.unbind_seq <= base_seq
+                && unbind.parent_inode_id == direntry.parent_inode_id
+                && unbind.name_key == direntry.name_key
+                && unbind.child_inode_id == direntry.child_inode_id
+                && unbind.bind_seq == direntry.bind_seq
+                && unbind.bind_delta_index == direntry.bind_delta_index
+        }) || self.base_is_direntry_unbound_at_seq(direntry, base_seq)
+    }
+
+    fn base_inode_at_seq(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.inode_at_head(inode_id)
+        } else {
+            self.base.inode_at_seq(inode_id, base_seq)
+        }
+    }
+
+    fn base_bound_child_at_seq(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+        base_seq: ChangeSeq,
+    ) -> Option<DirentryBindRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.visible_child_at_head(parent_inode_id, name_key)
+        } else {
+            self.base.visible_child(parent_inode_id, name_key, base_seq)
+        }
+    }
+
+    fn base_visible_children(
+        &self,
+        parent_inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Vec<DirentryBindRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.visible_children_at_head(parent_inode_id)
+        } else {
+            self.base.visible_children(parent_inode_id, base_seq)
+        }
+    }
+
+    fn base_current_parent_binding_for_child(
+        &self,
+        child_inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<DirentryBindRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base
+                .current_parent_binding_for_child_at_head(child_inode_id)
+        } else {
+            self.base
+                .current_parent_binding_for_child(child_inode_id, base_seq)
+        }
+    }
+
+    fn base_active_subtree_tombstone(
+        &self,
+        root_inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<SubtreeTombstoneRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.active_subtree_tombstone_at_head(root_inode_id)
+        } else {
+            self.base.active_subtree_tombstone(root_inode_id, base_seq)
+        }
+    }
+
+    fn base_is_direntry_unbound_at_seq(
+        &self,
+        direntry: &DirentryBindRecord,
+        base_seq: ChangeSeq,
+    ) -> bool {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.is_direntry_unbound_at_head(direntry)
+        } else {
+            self.base.is_direntry_unbound_at_seq(direntry, base_seq)
+        }
     }
 }

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -5,10 +5,10 @@ use loon_api::{
     NamePolicy, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MetadataState {
     #[serde(default)]
     inodes: Vec<InodeRecord>,
@@ -22,6 +22,108 @@ pub struct MetadataState {
     subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
     commit_receipts: Vec<CommitReceiptRecord>,
+    #[serde(skip)]
+    indexes: MetadataIndexes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+struct MetadataStateRows {
+    #[serde(default)]
+    inodes: Vec<InodeRecord>,
+    #[serde(default)]
+    direntry_binds: Vec<DirentryBindRecord>,
+    #[serde(default)]
+    direntry_unbinds: Vec<DirentryUnbindRecord>,
+    #[serde(default)]
+    revisions: Vec<RevisionRecord>,
+    #[serde(default)]
+    subtree_tombstones: Vec<SubtreeTombstoneRecord>,
+    #[serde(default)]
+    commit_receipts: Vec<CommitReceiptRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetadataIndexes {
+    indexed_seq: ChangeSeq,
+    inode_by_id: HashMap<InodeId, InodeRecord>,
+    active_child_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
+    active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
+    unbound_binding_keys: HashSet<BindingKey>,
+    tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
+}
+
+impl Default for MetadataIndexes {
+    fn default() -> Self {
+        Self {
+            indexed_seq: ChangeSeq(0),
+            inode_by_id: HashMap::new(),
+            active_child_by_parent_name: HashMap::new(),
+            active_parent_by_child: HashMap::new(),
+            unbound_binding_keys: HashSet::new(),
+            tombstone_by_root: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BindingKey {
+    parent_inode_id: InodeId,
+    name_key: String,
+    child_inode_id: InodeId,
+    bind_seq: ChangeSeq,
+    bind_delta_index: u32,
+}
+
+impl BindingKey {
+    fn from_bind(record: &DirentryBindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: record.name_key.clone(),
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+
+    fn from_unbind(record: &DirentryUnbindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: record.name_key.clone(),
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+}
+
+impl Default for MetadataState {
+    fn default() -> Self {
+        Self::from_rows(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for MetadataState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let rows = MetadataStateRows::deserialize(deserializer)?;
+        Ok(Self::from_rows(
+            rows.inodes,
+            rows.direntry_binds,
+            rows.direntry_unbinds,
+            rows.revisions,
+            rows.subtree_tombstones,
+            rows.commit_receipts,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,14 +228,21 @@ impl MetadataState {
         subtree_tombstones: Vec<SubtreeTombstoneRecord>,
         commit_receipts: Vec<CommitReceiptRecord>,
     ) -> Self {
-        Self {
+        let mut state = Self {
             inodes,
             direntry_binds,
             direntry_unbinds,
             revisions,
             subtree_tombstones,
             commit_receipts,
-        }
+            indexes: MetadataIndexes::default(),
+        };
+        state.rebuild_indexes();
+        state
+    }
+
+    pub fn indexed_seq(&self) -> ChangeSeq {
+        self.indexes.indexed_seq
     }
 
     pub fn inodes(&self) -> &[InodeRecord] {
@@ -167,6 +276,176 @@ impl MetadataState {
             .max_by_key(|record| record.committed_seq)
     }
 
+    fn rebuild_indexes(&mut self) {
+        let mut indexes = MetadataIndexes::default();
+
+        for inode in &self.inodes {
+            indexes.indexed_seq = indexes.indexed_seq.max(inode.created_seq);
+            indexes.inode_by_id.insert(inode.inode_id, inode.clone());
+        }
+
+        let mut latest_by_parent_name = HashMap::<(InodeId, String), DirentryBindRecord>::new();
+        let mut latest_by_child = HashMap::<InodeId, DirentryBindRecord>::new();
+        for bind in &self.direntry_binds {
+            indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
+            replace_if_newer_bind(
+                &mut latest_by_parent_name,
+                (bind.parent_inode_id, bind.name_key.clone()),
+                bind.clone(),
+            );
+            replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
+        }
+
+        for unbind in &self.direntry_unbinds {
+            indexes.indexed_seq = indexes.indexed_seq.max(unbind.unbind_seq);
+            indexes
+                .unbound_binding_keys
+                .insert(BindingKey::from_unbind(unbind));
+        }
+
+        for bind in latest_by_parent_name.values() {
+            if indexes
+                .unbound_binding_keys
+                .contains(&BindingKey::from_bind(bind))
+            {
+                continue;
+            }
+            let Some(latest_child_bind) = latest_by_child.get(&bind.child_inode_id) else {
+                continue;
+            };
+            if !same_binding(bind, latest_child_bind) {
+                continue;
+            }
+            indexes
+                .active_child_by_parent_name
+                .insert((bind.parent_inode_id, bind.name_key.clone()), bind.clone());
+            indexes
+                .active_parent_by_child
+                .insert(bind.child_inode_id, bind.clone());
+        }
+
+        for revision in &self.revisions {
+            indexes.indexed_seq = indexes.indexed_seq.max(revision.committed_seq);
+        }
+
+        for tombstone in &self.subtree_tombstones {
+            indexes.indexed_seq = indexes.indexed_seq.max(tombstone.tombstone_seq);
+            replace_if_newer_tombstone(
+                &mut indexes.tombstone_by_root,
+                tombstone.root_inode_id,
+                tombstone.clone(),
+            );
+        }
+
+        for receipt in &self.commit_receipts {
+            indexes.indexed_seq = indexes.indexed_seq.max(receipt.committed_seq);
+        }
+
+        self.indexes = indexes;
+    }
+
+    fn push_inode_record(&mut self, record: InodeRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.created_seq);
+        self.indexes
+            .inode_by_id
+            .insert(record.inode_id, record.clone());
+        self.inodes.push(record);
+    }
+
+    fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.bind_seq);
+        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+
+        if let Some(previous_child_at_name) = self
+            .indexes
+            .active_child_by_parent_name
+            .remove(&parent_name_key)
+        {
+            remove_active_parent_if_same(
+                &mut self.indexes.active_parent_by_child,
+                &previous_child_at_name,
+            );
+        }
+
+        if let Some(previous_parent_for_child) = self
+            .indexes
+            .active_parent_by_child
+            .remove(&record.child_inode_id)
+        {
+            remove_active_child_if_same(
+                &mut self.indexes.active_child_by_parent_name,
+                &previous_parent_for_child,
+            );
+        }
+
+        if !self
+            .indexes
+            .unbound_binding_keys
+            .contains(&BindingKey::from_bind(&record))
+        {
+            self.indexes
+                .active_child_by_parent_name
+                .insert(parent_name_key, record.clone());
+            self.indexes
+                .active_parent_by_child
+                .insert(record.child_inode_id, record.clone());
+        }
+
+        self.direntry_binds.push(record);
+    }
+
+    fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.unbind_seq);
+        let binding_key = BindingKey::from_unbind(&record);
+        self.indexes.unbound_binding_keys.insert(binding_key);
+
+        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+        if self
+            .indexes
+            .active_child_by_parent_name
+            .get(&parent_name_key)
+            .map(|active| unbind_matches_bind(&record, active))
+            .unwrap_or(false)
+        {
+            self.indexes
+                .active_child_by_parent_name
+                .remove(&parent_name_key);
+        }
+        if self
+            .indexes
+            .active_parent_by_child
+            .get(&record.child_inode_id)
+            .map(|active| unbind_matches_bind(&record, active))
+            .unwrap_or(false)
+        {
+            self.indexes
+                .active_parent_by_child
+                .remove(&record.child_inode_id);
+        }
+
+        self.direntry_unbinds.push(record);
+    }
+
+    fn push_revision_record(&mut self, record: RevisionRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.committed_seq);
+        self.revisions.push(record);
+    }
+
+    fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.tombstone_seq);
+        replace_if_newer_tombstone(
+            &mut self.indexes.tombstone_by_root,
+            record.root_inode_id,
+            record.clone(),
+        );
+        self.subtree_tombstones.push(record);
+    }
+
+    fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
+        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.committed_seq);
+        self.commit_receipts.push(record);
+    }
+
     pub fn apply_committed_wal_deltas(
         &self,
         committed_seq: ChangeSeq,
@@ -196,7 +475,7 @@ impl MetadataState {
                     inode_id,
                     inode_kind,
                 } => {
-                    self.inodes.push(InodeRecord {
+                    self.push_inode_record(InodeRecord {
                         inode_id: *inode_id,
                         inode_kind: inode_kind.clone(),
                         created_seq: committed_seq,
@@ -213,7 +492,7 @@ impl MetadataState {
                     display_name,
                     child_inode,
                 } => {
-                    self.direntry_binds.push(DirentryBindRecord {
+                    self.push_direntry_bind_record(DirentryBindRecord {
                         parent_inode_id: *parent_inode,
                         name_key: name_key.clone(),
                         display_name: display_name.clone(),
@@ -234,7 +513,7 @@ impl MetadataState {
                     bind_seq,
                     bind_delta_index,
                 } => {
-                    self.direntry_unbinds.push(DirentryUnbindRecord {
+                    self.push_direntry_unbind_record(DirentryUnbindRecord {
                         parent_inode_id: *parent_inode,
                         name_key: name_key.clone(),
                         child_inode_id: *child_inode,
@@ -254,7 +533,7 @@ impl MetadataState {
                     revision_no,
                     content_ref,
                 } => {
-                    self.revisions.push(RevisionRecord {
+                    self.push_revision_record(RevisionRecord {
                         inode_id: *inode_id,
                         revision_no: *revision_no,
                         committed_seq,
@@ -270,7 +549,7 @@ impl MetadataState {
                     delta_index,
                     root_inode,
                 } => {
-                    self.subtree_tombstones.push(SubtreeTombstoneRecord {
+                    self.push_subtree_tombstone_record(SubtreeTombstoneRecord {
                         root_inode_id: *root_inode,
                         tombstone_seq: committed_seq,
                         tombstone_delta_index: *delta_index,
@@ -309,7 +588,7 @@ impl MetadataState {
             .map(|delta| delta.delta.clone())
             .collect::<Vec<_>>();
         let mut checked_invariants = self.apply_committed_wal_deltas_mut(record.seq, &deltas)?;
-        self.commit_receipts.push(CommitReceiptRecord {
+        self.push_commit_receipt_record(CommitReceiptRecord {
             commit_id: record.commit_id.clone(),
             semantic_commit_fingerprint_sha256: record.semantic_commit_fingerprint_sha256.clone(),
             committed_seq: record.seq,
@@ -323,6 +602,17 @@ impl MetadataState {
     }
 
     pub fn inode_at_seq(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.inode_at_head(inode_id);
+        }
+        self.inode_at_seq_scan(inode_id, base_seq)
+    }
+
+    pub fn inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        self.indexes.inode_by_id.get(&inode_id).cloned()
+    }
+
+    fn inode_at_seq_scan(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
         self.inodes
             .iter()
             .find(|inode| inode.inode_id == inode_id && inode.created_seq <= base_seq)
@@ -370,6 +660,15 @@ impl MetadataState {
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
+        self.bound_child_at_seq_scan(parent_inode_id, name_key, base_seq)
+    }
+
+    fn bound_child_at_seq_scan(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+        base_seq: ChangeSeq,
+    ) -> Option<DirentryBindRecord> {
         self.direntry_binds
             .iter()
             .filter(|direntry| {
@@ -386,6 +685,9 @@ impl MetadataState {
         child_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.current_parent_binding_for_child_at_head(child_inode_id);
+        }
         let direntry = self.latest_parent_binding_for_child_at_seq(child_inode_id, base_seq)?;
         if self.is_direntry_unbound_at_seq(&direntry, base_seq) {
             return None;
@@ -393,7 +695,35 @@ impl MetadataState {
         Some(direntry)
     }
 
+    pub fn current_parent_binding_for_child_at_head(
+        &self,
+        child_inode_id: InodeId,
+    ) -> Option<DirentryBindRecord> {
+        self.indexes
+            .active_parent_by_child
+            .get(&child_inode_id)
+            .cloned()
+    }
+
     pub fn active_subtree_tombstone(
+        &self,
+        root_inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<SubtreeTombstoneRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.active_subtree_tombstone_at_head(root_inode_id);
+        }
+        self.active_subtree_tombstone_scan(root_inode_id, base_seq)
+    }
+
+    pub fn active_subtree_tombstone_at_head(
+        &self,
+        root_inode_id: InodeId,
+    ) -> Option<SubtreeTombstoneRecord> {
+        self.indexes.tombstone_by_root.get(&root_inode_id).cloned()
+    }
+
+    fn active_subtree_tombstone_scan(
         &self,
         root_inode_id: InodeId,
         base_seq: ChangeSeq,
@@ -412,6 +742,10 @@ impl MetadataState {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<SubtreeTombstoneRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.covering_subtree_tombstone_at_head(inode_id);
+        }
+
         let mut current = Some(inode_id);
         let mut visited = BTreeSet::new();
 
@@ -432,12 +766,49 @@ impl MetadataState {
         None
     }
 
+    pub fn covering_subtree_tombstone_at_head(
+        &self,
+        inode_id: InodeId,
+    ) -> Option<SubtreeTombstoneRecord> {
+        let mut current = Some(inode_id);
+        let mut visited = BTreeSet::new();
+
+        while let Some(candidate_inode_id) = current {
+            if !visited.insert(candidate_inode_id.0) {
+                break;
+            }
+
+            if let Some(tombstone) = self.active_subtree_tombstone_at_head(candidate_inode_id) {
+                return Some(tombstone);
+            }
+
+            current = self
+                .current_parent_binding_for_child_at_head(candidate_inode_id)
+                .map(|direntry| direntry.parent_inode_id);
+        }
+
+        None
+    }
+
     pub fn visible_inode(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.visible_inode_at_head(inode_id);
+        }
+
         let inode = self.inode_at_seq(inode_id, base_seq)?;
         if self
             .covering_subtree_tombstone(inode_id, base_seq)
             .is_some()
         {
+            return None;
+        }
+
+        Some(inode)
+    }
+
+    pub fn visible_inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        let inode = self.inode_at_head(inode_id)?;
+        if self.covering_subtree_tombstone_at_head(inode_id).is_some() {
             return None;
         }
 
@@ -459,6 +830,10 @@ impl MetadataState {
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.visible_child_at_head(parent_inode_id, name_key);
+        }
+
         let parent = self.visible_inode(parent_inode_id, base_seq)?;
         if parent.inode_kind != InodeKind::Dir {
             return None;
@@ -469,11 +844,34 @@ impl MetadataState {
         Some(direntry)
     }
 
+    pub fn visible_child_at_head(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Option<DirentryBindRecord> {
+        let parent = self.visible_inode_at_head(parent_inode_id)?;
+        if parent.inode_kind != InodeKind::Dir {
+            return None;
+        }
+
+        let direntry = self
+            .indexes
+            .active_child_by_parent_name
+            .get(&(parent_inode_id, name_key.to_owned()))?
+            .clone();
+        self.visible_inode_at_head(direntry.child_inode_id)?;
+        Some(direntry)
+    }
+
     pub fn visible_children(
         &self,
         parent_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Vec<DirentryBindRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.visible_children_at_head(parent_inode_id);
+        }
+
         let Some(parent) = self.visible_inode(parent_inode_id, base_seq) else {
             return Vec::new();
         };
@@ -498,6 +896,33 @@ impl MetadataState {
             })
             .filter(|direntry| {
                 self.visible_inode(direntry.child_inode_id, base_seq)
+                    .is_some()
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        children.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
+        });
+        children
+    }
+
+    pub fn visible_children_at_head(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
+        let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
+            return Vec::new();
+        };
+        if parent.inode_kind != InodeKind::Dir {
+            return Vec::new();
+        }
+
+        let mut children = self
+            .indexes
+            .active_child_by_parent_name
+            .values()
+            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+            .filter(|direntry| {
+                self.visible_inode_at_head(direntry.child_inode_id)
                     .is_some()
             })
             .cloned()
@@ -585,6 +1010,14 @@ impl MetadataState {
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
+        if base_seq == self.indexed_seq() {
+            return self
+                .indexes
+                .active_child_by_parent_name
+                .get(&(parent_inode_id, name_key.to_owned()))
+                .cloned();
+        }
+
         let direntry = self.bound_child_at_seq(parent_inode_id, name_key, base_seq)?;
         if self.is_direntry_unbound_at_seq(&direntry, base_seq) {
             return None;
@@ -622,6 +1055,23 @@ impl MetadataState {
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
     ) -> bool {
+        if base_seq == self.indexed_seq() {
+            return self.is_direntry_unbound_at_head(direntry);
+        }
+        self.is_direntry_unbound_at_seq_scan(direntry, base_seq)
+    }
+
+    pub(crate) fn is_direntry_unbound_at_head(&self, direntry: &DirentryBindRecord) -> bool {
+        self.indexes
+            .unbound_binding_keys
+            .contains(&BindingKey::from_bind(direntry))
+    }
+
+    fn is_direntry_unbound_at_seq_scan(
+        &self,
+        direntry: &DirentryBindRecord,
+        base_seq: ChangeSeq,
+    ) -> bool {
         self.direntry_unbinds.iter().any(|unbind| {
             unbind.unbind_seq <= base_seq
                 && unbind.parent_inode_id == direntry.parent_inode_id
@@ -638,6 +1088,10 @@ impl MetadataState {
         new_parent_inode: InodeId,
         base_seq: ChangeSeq,
     ) -> bool {
+        if base_seq == self.indexed_seq() {
+            return self.would_create_directory_cycle_at_head(inode_id, new_parent_inode);
+        }
+
         let mut current = Some(new_parent_inode);
         let mut visited = BTreeSet::new();
 
@@ -655,6 +1109,29 @@ impl MetadataState {
 
         false
     }
+
+    pub fn would_create_directory_cycle_at_head(
+        &self,
+        inode_id: InodeId,
+        new_parent_inode: InodeId,
+    ) -> bool {
+        let mut current = Some(new_parent_inode);
+        let mut visited = BTreeSet::new();
+
+        while let Some(candidate_inode_id) = current {
+            if !visited.insert(candidate_inode_id.0) {
+                break;
+            }
+            if candidate_inode_id == inode_id {
+                return true;
+            }
+            current = self
+                .current_parent_binding_for_child_at_head(candidate_inode_id)
+                .map(|direntry| direntry.parent_inode_id);
+        }
+
+        false
+    }
 }
 
 #[derive(Debug, Default)]
@@ -664,30 +1141,31 @@ pub(crate) struct MetadataStateBuilder {
 
 impl MetadataStateBuilder {
     pub(crate) fn push_inode(&mut self, record: InodeRecord) {
-        self.state.inodes.push(record);
+        self.state.push_inode_record(record);
     }
 
     pub(crate) fn push_direntry_bind(&mut self, record: DirentryBindRecord) {
-        self.state.direntry_binds.push(record);
+        self.state.push_direntry_bind_record(record);
     }
 
     pub(crate) fn push_direntry_unbind(&mut self, record: DirentryUnbindRecord) {
-        self.state.direntry_unbinds.push(record);
+        self.state.push_direntry_unbind_record(record);
     }
 
     pub(crate) fn push_revision(&mut self, record: RevisionRecord) {
-        self.state.revisions.push(record);
+        self.state.push_revision_record(record);
     }
 
     pub(crate) fn push_subtree_tombstone(&mut self, record: SubtreeTombstoneRecord) {
-        self.state.subtree_tombstones.push(record);
+        self.state.push_subtree_tombstone_record(record);
     }
 
     pub(crate) fn push_commit_receipt(&mut self, record: CommitReceiptRecord) {
-        self.state.commit_receipts.push(record);
+        self.state.push_commit_receipt_record(record);
     }
 
-    pub(crate) fn finish(self) -> MetadataState {
+    pub(crate) fn finish(mut self) -> MetadataState {
+        self.state.rebuild_indexes();
         self.state
     }
 }
@@ -696,6 +1174,87 @@ fn push_unique_invariant(invariants: &mut Vec<InvariantId>, id: InvariantId) {
     if !invariants.contains(&id) {
         invariants.push(id);
     }
+}
+
+fn replace_if_newer_bind<K>(
+    map: &mut HashMap<K, DirentryBindRecord>,
+    key: K,
+    record: DirentryBindRecord,
+) where
+    K: Eq + std::hash::Hash,
+{
+    let should_replace = map
+        .get(&key)
+        .map(|existing| bind_order_key(&record) > bind_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn replace_if_newer_tombstone(
+    map: &mut HashMap<InodeId, SubtreeTombstoneRecord>,
+    key: InodeId,
+    record: SubtreeTombstoneRecord,
+) {
+    let should_replace = map
+        .get(&key)
+        .map(|existing| tombstone_order_key(&record) > tombstone_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn remove_active_parent_if_same(
+    active_parent_by_child: &mut HashMap<InodeId, DirentryBindRecord>,
+    record: &DirentryBindRecord,
+) {
+    if active_parent_by_child
+        .get(&record.child_inode_id)
+        .map(|active| same_binding(active, record))
+        .unwrap_or(false)
+    {
+        active_parent_by_child.remove(&record.child_inode_id);
+    }
+}
+
+fn remove_active_child_if_same(
+    active_child_by_parent_name: &mut HashMap<(InodeId, String), DirentryBindRecord>,
+    record: &DirentryBindRecord,
+) {
+    let key = (record.parent_inode_id, record.name_key.clone());
+    if active_child_by_parent_name
+        .get(&key)
+        .map(|active| same_binding(active, record))
+        .unwrap_or(false)
+    {
+        active_child_by_parent_name.remove(&key);
+    }
+}
+
+fn same_binding(left: &DirentryBindRecord, right: &DirentryBindRecord) -> bool {
+    left.parent_inode_id == right.parent_inode_id
+        && left.name_key == right.name_key
+        && left.child_inode_id == right.child_inode_id
+        && left.bind_seq == right.bind_seq
+        && left.bind_delta_index == right.bind_delta_index
+}
+
+fn unbind_matches_bind(unbind: &DirentryUnbindRecord, bind: &DirentryBindRecord) -> bool {
+    unbind.parent_inode_id == bind.parent_inode_id
+        && unbind.name_key == bind.name_key
+        && unbind.child_inode_id == bind.child_inode_id
+        && unbind.bind_seq == bind.bind_seq
+        && unbind.bind_delta_index == bind.bind_delta_index
+}
+
+fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {
+    (record.bind_seq, record.bind_delta_index)
+}
+
+fn tombstone_order_key(record: &SubtreeTombstoneRecord) -> (ChangeSeq, u32) {
+    (record.tombstone_seq, record.tombstone_delta_index)
 }
 
 fn join_display_path(base: &str, component: &str) -> String {
@@ -766,6 +1325,233 @@ mod tests {
             .is_some());
         assert!(metadata_state
             .visible_child(InodeId(1), "Report.TXT", ChangeSeq(1))
+            .is_none());
+    }
+
+    #[test]
+    fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
+        let metadata_state = MetadataState::from_rows(
+            vec![
+                InodeRecord {
+                    inode_id: InodeId(1),
+                    inode_kind: InodeKind::Dir,
+                    created_seq: ChangeSeq(0),
+                },
+                InodeRecord {
+                    inode_id: InodeId(2),
+                    inode_kind: InodeKind::Dir,
+                    created_seq: ChangeSeq(1),
+                },
+                InodeRecord {
+                    inode_id: InodeId(3),
+                    inode_kind: InodeKind::File,
+                    created_seq: ChangeSeq(2),
+                },
+            ],
+            vec![
+                DirentryBindRecord {
+                    parent_inode_id: InodeId(1),
+                    name_key: "docs".to_owned(),
+                    display_name: "docs".to_owned(),
+                    child_inode_id: InodeId(2),
+                    bind_seq: ChangeSeq(1),
+                    bind_delta_index: 0,
+                },
+                DirentryBindRecord {
+                    parent_inode_id: InodeId(2),
+                    name_key: "report.txt".to_owned(),
+                    display_name: "report.txt".to_owned(),
+                    child_inode_id: InodeId(3),
+                    bind_seq: ChangeSeq(2),
+                    bind_delta_index: 0,
+                },
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(metadata_state.indexed_seq(), ChangeSeq(2));
+        assert!(metadata_state.inode_at_head(InodeId(2)).is_some());
+        assert_eq!(
+            metadata_state
+                .visible_child_at_head(InodeId(1), "docs")
+                .expect("docs visible")
+                .child_inode_id,
+            InodeId(2)
+        );
+        assert_eq!(
+            metadata_state
+                .current_parent_binding_for_child_at_head(InodeId(2))
+                .expect("parent binding")
+                .parent_inode_id,
+            InodeId(1)
+        );
+
+        let metadata_state = metadata_state
+            .apply_committed_wal_deltas(
+                ChangeSeq(3),
+                &[WalDelta::UnbindDirentry {
+                    delta_index: 0,
+                    parent_inode: InodeId(1),
+                    name_key: "docs".to_owned(),
+                    child_inode: InodeId(2),
+                    bind_seq: ChangeSeq(1),
+                    bind_delta_index: 0,
+                }],
+            )
+            .expect("unbind")
+            .metadata_state;
+        assert!(metadata_state
+            .visible_child_at_head(InodeId(1), "docs")
+            .is_none());
+        assert!(metadata_state
+            .current_parent_binding_for_child_at_head(InodeId(2))
+            .is_none());
+
+        let metadata_state = metadata_state
+            .apply_committed_wal_deltas(
+                ChangeSeq(4),
+                &[WalDelta::BindDirentry {
+                    delta_index: 0,
+                    parent_inode: InodeId(1),
+                    name_key: "renamed".to_owned(),
+                    display_name: "renamed".to_owned(),
+                    child_inode: InodeId(2),
+                }],
+            )
+            .expect("rebind")
+            .metadata_state;
+        assert!(metadata_state
+            .visible_child_at_head(InodeId(1), "docs")
+            .is_none());
+        assert_eq!(
+            metadata_state
+                .visible_child_at_head(InodeId(1), "renamed")
+                .expect("renamed visible")
+                .child_inode_id,
+            InodeId(2)
+        );
+
+        let metadata_state = metadata_state
+            .apply_committed_wal_deltas(
+                ChangeSeq(5),
+                &[WalDelta::TombstoneSubtree {
+                    delta_index: 0,
+                    root_inode: InodeId(2),
+                }],
+            )
+            .expect("tombstone")
+            .metadata_state;
+        assert!(metadata_state
+            .visible_child_at_head(InodeId(1), "renamed")
+            .is_none());
+        assert_eq!(
+            metadata_state
+                .covering_subtree_tombstone_at_head(InodeId(3))
+                .expect("descendant tombstone")
+                .root_inode_id,
+            InodeId(2)
+        );
+    }
+
+    #[test]
+    fn rebuilt_indexes_answer_current_head_queries_after_deserialize() {
+        let metadata_state = MetadataState::from_rows(
+            vec![
+                InodeRecord {
+                    inode_id: InodeId(1),
+                    inode_kind: InodeKind::Dir,
+                    created_seq: ChangeSeq(0),
+                },
+                InodeRecord {
+                    inode_id: InodeId(2),
+                    inode_kind: InodeKind::File,
+                    created_seq: ChangeSeq(1),
+                },
+            ],
+            vec![DirentryBindRecord {
+                parent_inode_id: InodeId(1),
+                name_key: "file.txt".to_owned(),
+                display_name: "file.txt".to_owned(),
+                child_inode_id: InodeId(2),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: 0,
+            }],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let encoded = serde_json::to_string(&metadata_state).expect("encode metadata");
+        assert!(!encoded.contains("indexes"));
+        let decoded: MetadataState = serde_json::from_str(&encoded).expect("decode metadata");
+
+        assert_eq!(decoded.indexed_seq(), ChangeSeq(1));
+        assert_eq!(
+            decoded
+                .visible_child_at_head(InodeId(1), "file.txt")
+                .expect("indexed child")
+                .child_inode_id,
+            InodeId(2)
+        );
+    }
+
+    #[test]
+    fn stale_binding_is_not_active_after_newer_bind_claims_same_name() {
+        let metadata_state = MetadataState::from_rows(
+            vec![
+                InodeRecord {
+                    inode_id: InodeId(1),
+                    inode_kind: InodeKind::Dir,
+                    created_seq: ChangeSeq(0),
+                },
+                InodeRecord {
+                    inode_id: InodeId(2),
+                    inode_kind: InodeKind::File,
+                    created_seq: ChangeSeq(1),
+                },
+                InodeRecord {
+                    inode_id: InodeId(3),
+                    inode_kind: InodeKind::File,
+                    created_seq: ChangeSeq(2),
+                },
+            ],
+            vec![
+                DirentryBindRecord {
+                    parent_inode_id: InodeId(1),
+                    name_key: "report".to_owned(),
+                    display_name: "report".to_owned(),
+                    child_inode_id: InodeId(2),
+                    bind_seq: ChangeSeq(1),
+                    bind_delta_index: 0,
+                },
+                DirentryBindRecord {
+                    parent_inode_id: InodeId(1),
+                    name_key: "report".to_owned(),
+                    display_name: "report".to_owned(),
+                    child_inode_id: InodeId(3),
+                    bind_seq: ChangeSeq(2),
+                    bind_delta_index: 0,
+                },
+            ],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            metadata_state
+                .visible_child_at_head(InodeId(1), "report")
+                .expect("latest child")
+                .child_inode_id,
+            InodeId(3)
+        );
+        assert!(metadata_state
+            .current_parent_binding_for_child_at_head(InodeId(2))
             .is_none());
     }
 

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -1,11 +1,14 @@
+mod indexes;
+
 use crate::invariants::InvariantId;
+use indexes::MetadataIndexes;
 use loon_api::wire::wal::{WalCommitPayload, WalDelta};
 use loon_api::{
     v0::CommitOpResult, AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey,
     NamePolicy, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -40,60 +43,6 @@ struct MetadataStateRows {
     subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
     commit_receipts: Vec<CommitReceiptRecord>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct MetadataIndexes {
-    indexed_seq: ChangeSeq,
-    inode_by_id: HashMap<InodeId, InodeRecord>,
-    active_child_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
-    active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
-    unbound_binding_keys: HashSet<BindingKey>,
-    tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
-}
-
-impl Default for MetadataIndexes {
-    fn default() -> Self {
-        Self {
-            indexed_seq: ChangeSeq(0),
-            inode_by_id: HashMap::new(),
-            active_child_by_parent_name: HashMap::new(),
-            active_parent_by_child: HashMap::new(),
-            unbound_binding_keys: HashSet::new(),
-            tombstone_by_root: HashMap::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct BindingKey {
-    parent_inode_id: InodeId,
-    name_key: String,
-    child_inode_id: InodeId,
-    bind_seq: ChangeSeq,
-    bind_delta_index: u32,
-}
-
-impl BindingKey {
-    fn from_bind(record: &DirentryBindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
-
-    fn from_unbind(record: &DirentryUnbindRecord) -> Self {
-        Self {
-            parent_inode_id: record.parent_inode_id,
-            name_key: record.name_key.clone(),
-            child_inode_id: record.child_inode_id,
-            bind_seq: record.bind_seq,
-            bind_delta_index: record.bind_delta_index,
-        }
-    }
 }
 
 impl Default for MetadataState {
@@ -242,7 +191,7 @@ impl MetadataState {
     }
 
     pub fn indexed_seq(&self) -> ChangeSeq {
-        self.indexes.indexed_seq
+        self.indexes.indexed_seq()
     }
 
     pub fn inodes(&self) -> &[InodeRecord] {
@@ -277,172 +226,43 @@ impl MetadataState {
     }
 
     fn rebuild_indexes(&mut self) {
-        let mut indexes = MetadataIndexes::default();
-
-        for inode in &self.inodes {
-            indexes.indexed_seq = indexes.indexed_seq.max(inode.created_seq);
-            indexes.inode_by_id.insert(inode.inode_id, inode.clone());
-        }
-
-        let mut latest_by_parent_name = HashMap::<(InodeId, String), DirentryBindRecord>::new();
-        let mut latest_by_child = HashMap::<InodeId, DirentryBindRecord>::new();
-        for bind in &self.direntry_binds {
-            indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
-            replace_if_newer_bind(
-                &mut latest_by_parent_name,
-                (bind.parent_inode_id, bind.name_key.clone()),
-                bind.clone(),
-            );
-            replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
-        }
-
-        for unbind in &self.direntry_unbinds {
-            indexes.indexed_seq = indexes.indexed_seq.max(unbind.unbind_seq);
-            indexes
-                .unbound_binding_keys
-                .insert(BindingKey::from_unbind(unbind));
-        }
-
-        for bind in latest_by_parent_name.values() {
-            if indexes
-                .unbound_binding_keys
-                .contains(&BindingKey::from_bind(bind))
-            {
-                continue;
-            }
-            let Some(latest_child_bind) = latest_by_child.get(&bind.child_inode_id) else {
-                continue;
-            };
-            if !same_binding(bind, latest_child_bind) {
-                continue;
-            }
-            indexes
-                .active_child_by_parent_name
-                .insert((bind.parent_inode_id, bind.name_key.clone()), bind.clone());
-            indexes
-                .active_parent_by_child
-                .insert(bind.child_inode_id, bind.clone());
-        }
-
-        for revision in &self.revisions {
-            indexes.indexed_seq = indexes.indexed_seq.max(revision.committed_seq);
-        }
-
-        for tombstone in &self.subtree_tombstones {
-            indexes.indexed_seq = indexes.indexed_seq.max(tombstone.tombstone_seq);
-            replace_if_newer_tombstone(
-                &mut indexes.tombstone_by_root,
-                tombstone.root_inode_id,
-                tombstone.clone(),
-            );
-        }
-
-        for receipt in &self.commit_receipts {
-            indexes.indexed_seq = indexes.indexed_seq.max(receipt.committed_seq);
-        }
-
-        self.indexes = indexes;
+        self.indexes = MetadataIndexes::rebuild(
+            &self.inodes,
+            &self.direntry_binds,
+            &self.direntry_unbinds,
+            &self.revisions,
+            &self.subtree_tombstones,
+            &self.commit_receipts,
+        );
     }
 
     fn push_inode_record(&mut self, record: InodeRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.created_seq);
-        self.indexes
-            .inode_by_id
-            .insert(record.inode_id, record.clone());
+        self.indexes.record_inode(&record);
         self.inodes.push(record);
     }
 
     fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.bind_seq);
-        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
-
-        if let Some(previous_child_at_name) = self
-            .indexes
-            .active_child_by_parent_name
-            .remove(&parent_name_key)
-        {
-            remove_active_parent_if_same(
-                &mut self.indexes.active_parent_by_child,
-                &previous_child_at_name,
-            );
-        }
-
-        if let Some(previous_parent_for_child) = self
-            .indexes
-            .active_parent_by_child
-            .remove(&record.child_inode_id)
-        {
-            remove_active_child_if_same(
-                &mut self.indexes.active_child_by_parent_name,
-                &previous_parent_for_child,
-            );
-        }
-
-        if !self
-            .indexes
-            .unbound_binding_keys
-            .contains(&BindingKey::from_bind(&record))
-        {
-            self.indexes
-                .active_child_by_parent_name
-                .insert(parent_name_key, record.clone());
-            self.indexes
-                .active_parent_by_child
-                .insert(record.child_inode_id, record.clone());
-        }
-
+        self.indexes.record_bind(&record);
         self.direntry_binds.push(record);
     }
 
     fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.unbind_seq);
-        let binding_key = BindingKey::from_unbind(&record);
-        self.indexes.unbound_binding_keys.insert(binding_key);
-
-        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
-        if self
-            .indexes
-            .active_child_by_parent_name
-            .get(&parent_name_key)
-            .map(|active| unbind_matches_bind(&record, active))
-            .unwrap_or(false)
-        {
-            self.indexes
-                .active_child_by_parent_name
-                .remove(&parent_name_key);
-        }
-        if self
-            .indexes
-            .active_parent_by_child
-            .get(&record.child_inode_id)
-            .map(|active| unbind_matches_bind(&record, active))
-            .unwrap_or(false)
-        {
-            self.indexes
-                .active_parent_by_child
-                .remove(&record.child_inode_id);
-        }
-
+        self.indexes.record_unbind(&record);
         self.direntry_unbinds.push(record);
     }
 
     fn push_revision_record(&mut self, record: RevisionRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.committed_seq);
+        self.indexes.record_revision(&record);
         self.revisions.push(record);
     }
 
     fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.tombstone_seq);
-        replace_if_newer_tombstone(
-            &mut self.indexes.tombstone_by_root,
-            record.root_inode_id,
-            record.clone(),
-        );
+        self.indexes.record_tombstone(&record);
         self.subtree_tombstones.push(record);
     }
 
     fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
-        self.indexes.indexed_seq = self.indexes.indexed_seq.max(record.committed_seq);
+        self.indexes.record_commit_receipt(&record);
         self.commit_receipts.push(record);
     }
 
@@ -609,7 +429,7 @@ impl MetadataState {
     }
 
     pub fn inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
-        self.indexes.inode_by_id.get(&inode_id).cloned()
+        self.indexes.inode(inode_id)
     }
 
     fn inode_at_seq_scan(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
@@ -699,10 +519,7 @@ impl MetadataState {
         &self,
         child_inode_id: InodeId,
     ) -> Option<DirentryBindRecord> {
-        self.indexes
-            .active_parent_by_child
-            .get(&child_inode_id)
-            .cloned()
+        self.indexes.active_parent_for_child(child_inode_id)
     }
 
     pub fn active_subtree_tombstone(
@@ -720,7 +537,7 @@ impl MetadataState {
         &self,
         root_inode_id: InodeId,
     ) -> Option<SubtreeTombstoneRecord> {
-        self.indexes.tombstone_by_root.get(&root_inode_id).cloned()
+        self.indexes.active_tombstone(root_inode_id)
     }
 
     fn active_subtree_tombstone_scan(
@@ -854,11 +671,7 @@ impl MetadataState {
             return None;
         }
 
-        let direntry = self
-            .indexes
-            .active_child_by_parent_name
-            .get(&(parent_inode_id, name_key.to_owned()))?
-            .clone();
+        let direntry = self.indexes.active_child(parent_inode_id, name_key)?;
         self.visible_inode_at_head(direntry.child_inode_id)?;
         Some(direntry)
     }
@@ -918,14 +731,12 @@ impl MetadataState {
 
         let mut children = self
             .indexes
-            .active_child_by_parent_name
-            .values()
-            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+            .active_children(parent_inode_id)
+            .into_iter()
             .filter(|direntry| {
                 self.visible_inode_at_head(direntry.child_inode_id)
                     .is_some()
             })
-            .cloned()
             .collect::<Vec<_>>();
         children.sort_by(|left, right| {
             left.display_name
@@ -1011,11 +822,7 @@ impl MetadataState {
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
         if base_seq == self.indexed_seq() {
-            return self
-                .indexes
-                .active_child_by_parent_name
-                .get(&(parent_inode_id, name_key.to_owned()))
-                .cloned();
+            return self.indexes.active_child(parent_inode_id, name_key);
         }
 
         let direntry = self.bound_child_at_seq(parent_inode_id, name_key, base_seq)?;
@@ -1062,9 +869,7 @@ impl MetadataState {
     }
 
     pub(crate) fn is_direntry_unbound_at_head(&self, direntry: &DirentryBindRecord) -> bool {
-        self.indexes
-            .unbound_binding_keys
-            .contains(&BindingKey::from_bind(direntry))
+        self.indexes.is_unbound(direntry)
     }
 
     fn is_direntry_unbound_at_seq_scan(
@@ -1174,87 +979,6 @@ fn push_unique_invariant(invariants: &mut Vec<InvariantId>, id: InvariantId) {
     if !invariants.contains(&id) {
         invariants.push(id);
     }
-}
-
-fn replace_if_newer_bind<K>(
-    map: &mut HashMap<K, DirentryBindRecord>,
-    key: K,
-    record: DirentryBindRecord,
-) where
-    K: Eq + std::hash::Hash,
-{
-    let should_replace = map
-        .get(&key)
-        .map(|existing| bind_order_key(&record) > bind_order_key(existing))
-        .unwrap_or(true);
-    if should_replace {
-        map.insert(key, record);
-    }
-}
-
-fn replace_if_newer_tombstone(
-    map: &mut HashMap<InodeId, SubtreeTombstoneRecord>,
-    key: InodeId,
-    record: SubtreeTombstoneRecord,
-) {
-    let should_replace = map
-        .get(&key)
-        .map(|existing| tombstone_order_key(&record) > tombstone_order_key(existing))
-        .unwrap_or(true);
-    if should_replace {
-        map.insert(key, record);
-    }
-}
-
-fn remove_active_parent_if_same(
-    active_parent_by_child: &mut HashMap<InodeId, DirentryBindRecord>,
-    record: &DirentryBindRecord,
-) {
-    if active_parent_by_child
-        .get(&record.child_inode_id)
-        .map(|active| same_binding(active, record))
-        .unwrap_or(false)
-    {
-        active_parent_by_child.remove(&record.child_inode_id);
-    }
-}
-
-fn remove_active_child_if_same(
-    active_child_by_parent_name: &mut HashMap<(InodeId, String), DirentryBindRecord>,
-    record: &DirentryBindRecord,
-) {
-    let key = (record.parent_inode_id, record.name_key.clone());
-    if active_child_by_parent_name
-        .get(&key)
-        .map(|active| same_binding(active, record))
-        .unwrap_or(false)
-    {
-        active_child_by_parent_name.remove(&key);
-    }
-}
-
-fn same_binding(left: &DirentryBindRecord, right: &DirentryBindRecord) -> bool {
-    left.parent_inode_id == right.parent_inode_id
-        && left.name_key == right.name_key
-        && left.child_inode_id == right.child_inode_id
-        && left.bind_seq == right.bind_seq
-        && left.bind_delta_index == right.bind_delta_index
-}
-
-fn unbind_matches_bind(unbind: &DirentryUnbindRecord, bind: &DirentryBindRecord) -> bool {
-    unbind.parent_inode_id == bind.parent_inode_id
-        && unbind.name_key == bind.name_key
-        && unbind.child_inode_id == bind.child_inode_id
-        && unbind.bind_seq == bind.bind_seq
-        && unbind.bind_delta_index == bind.bind_delta_index
-}
-
-fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {
-    (record.bind_seq, record.bind_delta_index)
-}
-
-fn tombstone_order_key(record: &SubtreeTombstoneRecord) -> (ChangeSeq, u32) {
-    (record.tombstone_seq, record.tombstone_delta_index)
 }
 
 fn join_display_path(base: &str, component: &str) -> String {

--- a/crates/loon-core/src/metadata/indexes.rs
+++ b/crates/loon-core/src/metadata/indexes.rs
@@ -1,0 +1,324 @@
+use super::{
+    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
+    SubtreeTombstoneRecord,
+};
+use loon_api::{ChangeSeq, InodeId};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MetadataIndexes {
+    indexed_seq: ChangeSeq,
+    inode_by_id: HashMap<InodeId, InodeRecord>,
+    active_child_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
+    active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
+    unbound_binding_keys: HashSet<BindingKey>,
+    tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
+}
+
+impl Default for MetadataIndexes {
+    fn default() -> Self {
+        Self {
+            indexed_seq: ChangeSeq(0),
+            inode_by_id: HashMap::new(),
+            active_child_by_parent_name: HashMap::new(),
+            active_parent_by_child: HashMap::new(),
+            unbound_binding_keys: HashSet::new(),
+            tombstone_by_root: HashMap::new(),
+        }
+    }
+}
+
+impl MetadataIndexes {
+    pub(super) fn rebuild(
+        inodes: &[InodeRecord],
+        binds: &[DirentryBindRecord],
+        unbinds: &[DirentryUnbindRecord],
+        revisions: &[RevisionRecord],
+        tombstones: &[SubtreeTombstoneRecord],
+        receipts: &[CommitReceiptRecord],
+    ) -> Self {
+        let mut indexes = Self::default();
+
+        for inode in inodes {
+            indexes.record_inode(inode);
+        }
+
+        let mut latest_by_parent_name = HashMap::<(InodeId, String), DirentryBindRecord>::new();
+        let mut latest_by_child = HashMap::<InodeId, DirentryBindRecord>::new();
+        for bind in binds {
+            indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
+            replace_if_newer_bind(
+                &mut latest_by_parent_name,
+                (bind.parent_inode_id, bind.name_key.clone()),
+                bind.clone(),
+            );
+            replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
+        }
+
+        for unbind in unbinds {
+            indexes.record_unbind(unbind);
+        }
+
+        for bind in latest_by_parent_name.values() {
+            if indexes.is_unbound(bind) {
+                continue;
+            }
+            let Some(latest_child_bind) = latest_by_child.get(&bind.child_inode_id) else {
+                continue;
+            };
+            if !same_binding(bind, latest_child_bind) {
+                continue;
+            }
+            indexes
+                .active_child_by_parent_name
+                .insert((bind.parent_inode_id, bind.name_key.clone()), bind.clone());
+            indexes
+                .active_parent_by_child
+                .insert(bind.child_inode_id, bind.clone());
+        }
+
+        for revision in revisions {
+            indexes.record_revision(revision);
+        }
+
+        for tombstone in tombstones {
+            indexes.record_tombstone(tombstone);
+        }
+
+        for receipt in receipts {
+            indexes.record_commit_receipt(receipt);
+        }
+
+        indexes
+    }
+
+    pub(super) fn indexed_seq(&self) -> ChangeSeq {
+        self.indexed_seq
+    }
+
+    pub(super) fn inode(&self, inode_id: InodeId) -> Option<InodeRecord> {
+        self.inode_by_id.get(&inode_id).cloned()
+    }
+
+    pub(super) fn active_child(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Option<DirentryBindRecord> {
+        self.active_child_by_parent_name
+            .get(&(parent_inode_id, name_key.to_owned()))
+            .cloned()
+    }
+
+    pub(super) fn active_children(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
+        self.active_child_by_parent_name
+            .values()
+            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+            .cloned()
+            .collect()
+    }
+
+    pub(super) fn active_parent_for_child(
+        &self,
+        child_inode_id: InodeId,
+    ) -> Option<DirentryBindRecord> {
+        self.active_parent_by_child.get(&child_inode_id).cloned()
+    }
+
+    pub(super) fn active_tombstone(
+        &self,
+        root_inode_id: InodeId,
+    ) -> Option<SubtreeTombstoneRecord> {
+        self.tombstone_by_root.get(&root_inode_id).cloned()
+    }
+
+    pub(super) fn is_unbound(&self, record: &DirentryBindRecord) -> bool {
+        self.unbound_binding_keys
+            .contains(&BindingKey::from_bind(record))
+    }
+
+    pub(super) fn record_inode(&mut self, record: &InodeRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.created_seq);
+        self.inode_by_id.insert(record.inode_id, record.clone());
+    }
+
+    pub(super) fn record_bind(&mut self, record: &DirentryBindRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.bind_seq);
+        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+
+        if let Some(previous_child_at_name) =
+            self.active_child_by_parent_name.remove(&parent_name_key)
+        {
+            remove_active_parent_if_same(&mut self.active_parent_by_child, &previous_child_at_name);
+        }
+
+        if let Some(previous_parent_for_child) =
+            self.active_parent_by_child.remove(&record.child_inode_id)
+        {
+            remove_active_child_if_same(
+                &mut self.active_child_by_parent_name,
+                &previous_parent_for_child,
+            );
+        }
+
+        if !self.is_unbound(record) {
+            self.active_child_by_parent_name
+                .insert(parent_name_key, record.clone());
+            self.active_parent_by_child
+                .insert(record.child_inode_id, record.clone());
+        }
+    }
+
+    pub(super) fn record_unbind(&mut self, record: &DirentryUnbindRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.unbind_seq);
+        self.unbound_binding_keys
+            .insert(BindingKey::from_unbind(record));
+
+        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+        if self
+            .active_child_by_parent_name
+            .get(&parent_name_key)
+            .map(|active| unbind_matches_bind(record, active))
+            .unwrap_or(false)
+        {
+            self.active_child_by_parent_name.remove(&parent_name_key);
+        }
+        if self
+            .active_parent_by_child
+            .get(&record.child_inode_id)
+            .map(|active| unbind_matches_bind(record, active))
+            .unwrap_or(false)
+        {
+            self.active_parent_by_child.remove(&record.child_inode_id);
+        }
+    }
+
+    pub(super) fn record_revision(&mut self, record: &RevisionRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.committed_seq);
+    }
+
+    pub(super) fn record_tombstone(&mut self, record: &SubtreeTombstoneRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.tombstone_seq);
+        replace_if_newer_tombstone(
+            &mut self.tombstone_by_root,
+            record.root_inode_id,
+            record.clone(),
+        );
+    }
+
+    pub(super) fn record_commit_receipt(&mut self, record: &CommitReceiptRecord) {
+        self.indexed_seq = self.indexed_seq.max(record.committed_seq);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BindingKey {
+    parent_inode_id: InodeId,
+    name_key: String,
+    child_inode_id: InodeId,
+    bind_seq: ChangeSeq,
+    bind_delta_index: u32,
+}
+
+impl BindingKey {
+    fn from_bind(record: &DirentryBindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: record.name_key.clone(),
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+
+    fn from_unbind(record: &DirentryUnbindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: record.name_key.clone(),
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+}
+
+fn replace_if_newer_bind<K>(
+    map: &mut HashMap<K, DirentryBindRecord>,
+    key: K,
+    record: DirentryBindRecord,
+) where
+    K: Eq + std::hash::Hash,
+{
+    let should_replace = map
+        .get(&key)
+        .map(|existing| bind_order_key(&record) > bind_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn replace_if_newer_tombstone(
+    map: &mut HashMap<InodeId, SubtreeTombstoneRecord>,
+    key: InodeId,
+    record: SubtreeTombstoneRecord,
+) {
+    let should_replace = map
+        .get(&key)
+        .map(|existing| tombstone_order_key(&record) > tombstone_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn remove_active_parent_if_same(
+    active_parent_by_child: &mut HashMap<InodeId, DirentryBindRecord>,
+    record: &DirentryBindRecord,
+) {
+    if active_parent_by_child
+        .get(&record.child_inode_id)
+        .map(|active| same_binding(active, record))
+        .unwrap_or(false)
+    {
+        active_parent_by_child.remove(&record.child_inode_id);
+    }
+}
+
+fn remove_active_child_if_same(
+    active_child_by_parent_name: &mut HashMap<(InodeId, String), DirentryBindRecord>,
+    record: &DirentryBindRecord,
+) {
+    let key = (record.parent_inode_id, record.name_key.clone());
+    if active_child_by_parent_name
+        .get(&key)
+        .map(|active| same_binding(active, record))
+        .unwrap_or(false)
+    {
+        active_child_by_parent_name.remove(&key);
+    }
+}
+
+fn same_binding(left: &DirentryBindRecord, right: &DirentryBindRecord) -> bool {
+    left.parent_inode_id == right.parent_inode_id
+        && left.name_key == right.name_key
+        && left.child_inode_id == right.child_inode_id
+        && left.bind_seq == right.bind_seq
+        && left.bind_delta_index == right.bind_delta_index
+}
+
+fn unbind_matches_bind(unbind: &DirentryUnbindRecord, bind: &DirentryBindRecord) -> bool {
+    unbind.parent_inode_id == bind.parent_inode_id
+        && unbind.name_key == bind.name_key
+        && unbind.child_inode_id == bind.child_inode_id
+        && unbind.bind_seq == bind.bind_seq
+        && unbind.bind_delta_index == bind.bind_delta_index
+}
+
+fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {
+    (record.bind_seq, record.bind_delta_index)
+}
+
+fn tombstone_order_key(record: &SubtreeTombstoneRecord) -> (ChangeSeq, u32) {
+    (record.tombstone_seq, record.tombstone_delta_index)
+}


### PR DESCRIPTION
Adds private maintained `MetadataState` indexes for current-head validation lookups. Keeps durable row vectors as the source of truth.

Second project in a series of performance updates, and made a lot of progress in flattening the performance curve as namespaces grow. 

Metric | Previous | Current | Change
-- | -- | -- | --
Total time | 40.6s | 25.4s | 37.5% faster
Throughput | 246 ops/s | 394 ops/s | +60.1%
p50 | 2.77s | 2.05s | 26.0% lower


