### PR TITLE
refactor(core): split validation from WAL materialization

### DIFF
--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -86,7 +86,9 @@ impl From<&Precondition> for WalPrecondition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit};
+    use crate::commit::{
+        materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit, ValidatedOp,
+    };
     use loon_api::{ChangeSeq, CommitId, FenceToken, InodeId, NamespaceId};
 
     #[test]
@@ -110,12 +112,16 @@ mod tests {
             commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
-            allocated_inode_ids: vec![InodeId(2)],
-            resolved_restore_content_refs: vec![None],
-            resolved_source_bindings: vec![None],
+            validated_ops: vec![ValidatedOp::CreateDir {
+                op_index: 0,
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+                name_key: "docs".to_owned(),
+                child_inode: InodeId(2),
+                create_inode_delta_index: 0,
+                bind_delta_index: 1,
+            }],
             resulting_next_inode_id: InodeId(3),
-            name_policy: loon_api::NamePolicy::default(),
-            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");

--- a/crates/loon-core/src/commit/durable_adapter.rs
+++ b/crates/loon-core/src/commit/durable_adapter.rs
@@ -125,7 +125,7 @@ mod tests {
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
-        let materialized = materialize_commit(prepared).expect("materialize commit");
+        let materialized = materialize_commit(prepared);
 
         let payload =
             wal_payload_from_materialized_commit(&materialized).expect("build wal payload");

--- a/crates/loon-core/src/commit/metadata_preview.rs
+++ b/crates/loon-core/src/commit/metadata_preview.rs
@@ -1,9 +1,8 @@
-use crate::invariants::InvariantId;
+use super::ValidatedOp;
 use crate::metadata::{
-    DirentryBindRecord, InodeRecord, MetadataApplyError, MetadataState, RevisionRecord,
+    DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState, RevisionRecord,
     SubtreeTombstoneRecord,
 };
-use loon_api::wire::wal::WalDelta;
 use loon_api::{ChangeSeq, InodeId, InodeKind, RevisionNo};
 use std::collections::BTreeSet;
 
@@ -20,13 +19,118 @@ impl<'a> MetadataPreview<'a> {
         }
     }
 
-    pub(super) fn apply_committed_wal_deltas_mut(
-        &mut self,
-        committed_seq: ChangeSeq,
-        deltas: &[WalDelta],
-    ) -> Result<Vec<InvariantId>, MetadataApplyError> {
-        self.rows
-            .apply_committed_wal_deltas_mut(committed_seq, deltas)
+    pub(super) fn apply_validated_op_mut(&mut self, committed_seq: ChangeSeq, op: &ValidatedOp) {
+        match op {
+            ValidatedOp::CreateDir {
+                parent_inode,
+                display_name,
+                name_key,
+                child_inode,
+                create_inode_delta_index: _,
+                bind_delta_index,
+                ..
+            } => {
+                self.push_inode(*child_inode, InodeKind::Dir, committed_seq);
+                self.push_bind(
+                    *parent_inode,
+                    name_key.clone(),
+                    display_name.clone(),
+                    *child_inode,
+                    committed_seq,
+                    *bind_delta_index,
+                );
+            }
+            ValidatedOp::CreateFile {
+                parent_inode,
+                display_name,
+                name_key,
+                child_inode,
+                content_ref,
+                create_inode_delta_index: _,
+                bind_delta_index,
+                revision_delta_index,
+                ..
+            } => {
+                self.push_inode(*child_inode, InodeKind::File, committed_seq);
+                self.push_bind(
+                    *parent_inode,
+                    name_key.clone(),
+                    display_name.clone(),
+                    *child_inode,
+                    committed_seq,
+                    *bind_delta_index,
+                );
+                self.push_revision(
+                    *child_inode,
+                    RevisionNo(1),
+                    committed_seq,
+                    *revision_delta_index,
+                    content_ref.clone(),
+                );
+            }
+            ValidatedOp::ReplaceFile {
+                inode_id,
+                revision_no,
+                content_ref,
+                revision_delta_index,
+                ..
+            }
+            | ValidatedOp::RestoreRevision {
+                inode_id,
+                revision_no,
+                content_ref,
+                revision_delta_index,
+                ..
+            } => {
+                self.push_revision(
+                    *inode_id,
+                    *revision_no,
+                    committed_seq,
+                    *revision_delta_index,
+                    content_ref.clone(),
+                );
+            }
+            ValidatedOp::DeleteFile {
+                inode_id,
+                source_binding,
+                unbind_delta_index,
+                tombstone_delta_index,
+                ..
+            } => {
+                self.push_unbind(source_binding, committed_seq, *unbind_delta_index);
+                self.push_tombstone(*inode_id, committed_seq, *tombstone_delta_index);
+            }
+            ValidatedOp::Rename {
+                inode_id,
+                source_binding,
+                new_parent_inode,
+                new_display_name,
+                new_name_key,
+                unbind_delta_index,
+                bind_delta_index,
+                ..
+            } => {
+                self.push_unbind(source_binding, committed_seq, *unbind_delta_index);
+                self.push_bind(
+                    *new_parent_inode,
+                    new_name_key.clone(),
+                    new_display_name.clone(),
+                    *inode_id,
+                    committed_seq,
+                    *bind_delta_index,
+                );
+            }
+            ValidatedOp::DeleteSubtree {
+                root_inode,
+                source_binding,
+                unbind_delta_index,
+                tombstone_delta_index,
+                ..
+            } => {
+                self.push_unbind(source_binding, committed_seq, *unbind_delta_index);
+                self.push_tombstone(*root_inode, committed_seq, *tombstone_delta_index);
+            }
+        }
     }
 
     pub(super) fn inode_at_seq(
@@ -379,5 +483,80 @@ impl<'a> MetadataPreview<'a> {
         } else {
             self.base.is_direntry_unbound_at_seq(direntry, base_seq)
         }
+    }
+
+    fn push_inode(&mut self, inode_id: InodeId, inode_kind: InodeKind, created_seq: ChangeSeq) {
+        self.rows.push_inode_record(InodeRecord {
+            inode_id,
+            inode_kind,
+            created_seq,
+        });
+    }
+
+    fn push_bind(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: String,
+        display_name: String,
+        child_inode_id: InodeId,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) {
+        self.rows.push_direntry_bind_record(DirentryBindRecord {
+            parent_inode_id,
+            name_key,
+            display_name,
+            child_inode_id,
+            bind_seq,
+            bind_delta_index,
+        });
+    }
+
+    fn push_unbind(
+        &mut self,
+        source_binding: &super::ResolvedBinding,
+        unbind_seq: ChangeSeq,
+        unbind_delta_index: u32,
+    ) {
+        self.rows.push_direntry_unbind_record(DirentryUnbindRecord {
+            parent_inode_id: source_binding.parent_inode,
+            name_key: source_binding.name_key.clone(),
+            child_inode_id: source_binding.child_inode,
+            bind_seq: source_binding.bind_seq,
+            bind_delta_index: source_binding.bind_delta_index,
+            unbind_seq,
+            unbind_delta_index,
+        });
+    }
+
+    fn push_revision(
+        &mut self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        committed_seq: ChangeSeq,
+        revision_delta_index: u32,
+        content_ref: loon_api::ContentRef,
+    ) {
+        self.rows.push_revision_record(RevisionRecord {
+            inode_id,
+            revision_no,
+            committed_seq,
+            revision_delta_index,
+            content_ref,
+        });
+    }
+
+    fn push_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+        tombstone_seq: ChangeSeq,
+        tombstone_delta_index: u32,
+    ) {
+        self.rows
+            .push_subtree_tombstone_record(SubtreeTombstoneRecord {
+                root_inode_id,
+                tombstone_seq,
+                tombstone_delta_index,
+            });
     }
 }

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -3,8 +3,7 @@ use crate::metadata::MetadataState;
 use loon_api::v0::{CommitAnnotations, RenameMode};
 use loon_api::wire::control::{HeadState, HeadStateEnvelope, LeaseState};
 use loon_api::{
-    ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, InodeKind, NamePolicy, NamespaceId,
-    RevisionNo,
+    ChangeSeq, CommitId, ContentRef, FenceToken, InodeId, InodeKind, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -123,13 +122,72 @@ pub struct CommitPlan {
     pub commit_id: CommitId,
     pub apply_after_seq: ChangeSeq,
     pub assigned_seq: ChangeSeq,
-    pub allocated_inode_ids: Vec<InodeId>,
-    pub resolved_restore_content_refs: Vec<Option<ContentRef>>,
-    pub resolved_source_bindings: Vec<Option<ResolvedBinding>>,
+    pub(crate) validated_ops: Vec<ValidatedOp>,
     pub resulting_next_inode_id: InodeId,
-    pub name_policy: NamePolicy,
-    pub metadata_preconditions: Vec<Precondition>,
     pub checked_invariants: Vec<InvariantId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ValidatedOp {
+    CreateDir {
+        op_index: u32,
+        parent_inode: InodeId,
+        display_name: String,
+        name_key: String,
+        child_inode: InodeId,
+        create_inode_delta_index: u32,
+        bind_delta_index: u32,
+    },
+    CreateFile {
+        op_index: u32,
+        parent_inode: InodeId,
+        display_name: String,
+        name_key: String,
+        child_inode: InodeId,
+        content_ref: ContentRef,
+        create_inode_delta_index: u32,
+        bind_delta_index: u32,
+        revision_delta_index: u32,
+    },
+    ReplaceFile {
+        op_index: u32,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        content_ref: ContentRef,
+        revision_delta_index: u32,
+    },
+    RestoreRevision {
+        op_index: u32,
+        inode_id: InodeId,
+        source_revision_no: RevisionNo,
+        revision_no: RevisionNo,
+        content_ref: ContentRef,
+        revision_delta_index: u32,
+    },
+    DeleteFile {
+        op_index: u32,
+        inode_id: InodeId,
+        source_binding: ResolvedBinding,
+        unbind_delta_index: u32,
+        tombstone_delta_index: u32,
+    },
+    Rename {
+        op_index: u32,
+        inode_id: InodeId,
+        source_binding: ResolvedBinding,
+        new_parent_inode: InodeId,
+        new_display_name: String,
+        new_name_key: String,
+        unbind_delta_index: u32,
+        bind_delta_index: u32,
+    },
+    DeleteSubtree {
+        op_index: u32,
+        root_inode: InodeId,
+        source_binding: ResolvedBinding,
+        unbind_delta_index: u32,
+        tombstone_delta_index: u32,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -328,6 +386,7 @@ pub enum CommitValidationError {
     SeqOverflow,
     NextInodeOverflow,
     OpIndexOverflow,
+    DeltaIndexOverflow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-core/src/commit/mod.rs
+++ b/crates/loon-core/src/commit/mod.rs
@@ -27,8 +27,8 @@ pub use self::ordered::build_commit_plan;
 pub(crate) use self::ordered::resolve_restore_content_refs;
 pub(crate) use self::prepared::CommitIdentitySource;
 pub use self::prepared::{
-    materialize_commit, CommitExecutionContext, CommitMaterializationError, CommitPrepareError,
-    MaterializedCommit, MaterializedCommitDelta, PreparedCommit,
+    materialize_commit, CommitExecutionContext, CommitPrepareError, MaterializedCommit,
+    MaterializedCommitDelta, PreparedCommit,
 };
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 

--- a/crates/loon-core/src/commit/ordered.rs
+++ b/crates/loon-core/src/commit/ordered.rs
@@ -1,9 +1,8 @@
 use super::frame::validate_commit_request_frame;
 use super::metadata_preview::MetadataPreview;
-use super::prepared::materialize_commit_op;
 use super::{
-    push_unique_invariant, CommitMaterializationError, CommitOp, CommitPlan, CommitRequest,
-    CommitValidationContext, CommitValidationError, Precondition, ResolvedBinding,
+    push_unique_invariant, CommitOp, CommitPlan, CommitRequest, CommitValidationContext,
+    CommitValidationError, Precondition, ResolvedBinding, ValidatedOp,
 };
 use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
@@ -19,9 +18,8 @@ struct CommitShape {
     resulting_next_inode_id: InodeId,
 }
 
-struct ResolvedMetadataPreconditions {
-    resolved_restore_content_refs: Vec<Option<ContentRef>>,
-    resolved_source_bindings: Vec<Option<ResolvedBinding>>,
+struct ValidatedMetadataOps {
+    validated_ops: Vec<ValidatedOp>,
 }
 
 pub(crate) fn resolve_restore_content_refs(
@@ -84,7 +82,7 @@ pub fn build_commit_plan(
         InvariantId::NextInodeIdIsMonotonic,
     ];
     let shape = compute_commit_shape(request, context)?;
-    let resolved_metadata = validate_metadata_preconditions(
+    let validated_metadata = validate_metadata_preconditions(
         request,
         context.metadata_state,
         shape.assigned_seq,
@@ -135,12 +133,8 @@ pub fn build_commit_plan(
         commit_id: request.commit_id.clone(),
         apply_after_seq: context.head.seq,
         assigned_seq: shape.assigned_seq,
-        allocated_inode_ids: shape.allocated_inode_ids,
-        resolved_restore_content_refs: resolved_metadata.resolved_restore_content_refs,
-        resolved_source_bindings: resolved_metadata.resolved_source_bindings,
+        validated_ops: validated_metadata.validated_ops,
         resulting_next_inode_id: shape.resulting_next_inode_id,
-        name_policy: context.head.name_policy,
-        metadata_preconditions: request.preconditions.clone(),
         checked_invariants,
     })
 }
@@ -198,11 +192,10 @@ fn validate_metadata_preconditions(
     allocated_inode_ids: &[InodeId],
     name_policy: NamePolicy,
     checked_invariants: &mut Vec<InvariantId>,
-) -> Result<ResolvedMetadataPreconditions, CommitValidationError> {
+) -> Result<ValidatedMetadataOps, CommitValidationError> {
     let mut ephemeral_metadata_state = MetadataPreview::new(metadata_state);
     let mut allocated_inode_ids = allocated_inode_ids.iter().copied();
-    let mut resolved_restore_content_refs = Vec::with_capacity(request.ops.len());
-    let mut resolved_source_bindings = Vec::with_capacity(request.ops.len());
+    let mut validated_ops = Vec::with_capacity(request.ops.len());
     let mut next_delta_index = 0u32;
 
     validate_explicit_preconditions(
@@ -215,75 +208,12 @@ fn validate_metadata_preconditions(
     for (op_index, op) in request.ops.iter().enumerate() {
         let op_index =
             u32::try_from(op_index).map_err(|_| CommitValidationError::OpIndexOverflow)?;
-        let resolved_restore_content_ref = match op {
-            CommitOp::RestoreRevision {
-                inode_id,
-                source_revision_no,
-                base_revision_no,
-            } => {
-                validate_restore_target(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    *base_revision_no,
-                    committed_seq,
-                )?;
-                let source_revision_no = validate_restore_source_revision(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    *source_revision_no,
-                    committed_seq,
-                )?;
-                if base_revision_no.0.checked_add(1).is_none() {
-                    return Err(CommitValidationError::RestoreRevisionOverflow {
-                        inode_id: *inode_id,
-                        base_revision_no: *base_revision_no,
-                    });
-                }
-                validate_restore_not_covered(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    committed_seq,
-                    checked_invariants,
-                )?;
-                Some(source_revision_no.content_ref)
-            }
-            _ => None,
-        };
-        let resolved_source_binding = match op {
-            CommitOp::DeleteFile { inode_id } => Some(resolve_current_binding_for_mutation(
-                &ephemeral_metadata_state,
-                *inode_id,
-                committed_seq,
-            )?),
-            CommitOp::Rename { inode_id, mode, .. } => {
-                if *mode != loon_api::v0::RenameMode::NoReplace {
-                    return Err(CommitValidationError::UnsupportedRenameMode { mode: *mode });
-                }
-                Some(resolve_current_binding_for_mutation(
-                    &ephemeral_metadata_state,
-                    *inode_id,
-                    committed_seq,
-                )?)
-            }
-            CommitOp::DeleteSubtree { root_inode } => Some(resolve_current_binding_for_mutation(
-                &ephemeral_metadata_state,
-                *root_inode,
-                committed_seq,
-            )?),
-            _ => None,
-        };
-
-        match op {
+        let validated_op = match op {
             CommitOp::CreateDir {
                 parent_inode,
                 display_name,
-            }
-            | CommitOp::CreateFile {
-                parent_inode,
-                display_name,
-                ..
             } => {
-                validate_child_name_absent(
+                let name_key = validate_child_name_absent(
                     &ephemeral_metadata_state,
                     *parent_inode,
                     display_name,
@@ -297,11 +227,57 @@ fn validate_metadata_preconditions(
                     checked_invariants,
                     true,
                 )?;
+                ValidatedOp::CreateDir {
+                    op_index,
+                    parent_inode: *parent_inode,
+                    display_name: display_name.clone(),
+                    name_key,
+                    child_inode: next_allocated_inode(
+                        &mut allocated_inode_ids,
+                        CommitValidationError::NextInodeOverflow,
+                    )?,
+                    create_inode_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    bind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
+            }
+            CommitOp::CreateFile {
+                parent_inode,
+                display_name,
+                content_ref,
+            } => {
+                let name_key = validate_child_name_absent(
+                    &ephemeral_metadata_state,
+                    *parent_inode,
+                    display_name,
+                    committed_seq,
+                    name_policy,
+                )?;
+                validate_ancestors_not_subtree_deleted(
+                    &ephemeral_metadata_state,
+                    *parent_inode,
+                    committed_seq,
+                    checked_invariants,
+                    true,
+                )?;
+                ValidatedOp::CreateFile {
+                    op_index,
+                    parent_inode: *parent_inode,
+                    display_name: display_name.clone(),
+                    name_key,
+                    child_inode: next_allocated_inode(
+                        &mut allocated_inode_ids,
+                        CommitValidationError::NextInodeOverflow,
+                    )?,
+                    content_ref: content_ref.clone(),
+                    create_inode_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    bind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    revision_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
             }
             CommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no,
-                ..
+                content_ref,
             } => {
                 validate_inode_revision_is(
                     &ephemeral_metadata_state,
@@ -309,12 +285,7 @@ fn validate_metadata_preconditions(
                     *base_revision_no,
                     committed_seq,
                 )?;
-                if base_revision_no.0.checked_add(1).is_none() {
-                    return Err(CommitValidationError::ReplaceFileRevisionOverflow {
-                        inode_id: *inode_id,
-                        base_revision_no: *base_revision_no,
-                    });
-                }
+                let revision_no = next_revision_no(*inode_id, *base_revision_no, true)?;
                 validate_ancestors_not_subtree_deleted(
                     &ephemeral_metadata_state,
                     *inode_id,
@@ -322,9 +293,53 @@ fn validate_metadata_preconditions(
                     checked_invariants,
                     false,
                 )?;
+                ValidatedOp::ReplaceFile {
+                    op_index,
+                    inode_id: *inode_id,
+                    revision_no,
+                    content_ref: content_ref.clone(),
+                    revision_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
             }
-            CommitOp::RestoreRevision { .. } => {}
+            CommitOp::RestoreRevision {
+                inode_id,
+                source_revision_no,
+                base_revision_no,
+            } => {
+                validate_restore_target(
+                    &ephemeral_metadata_state,
+                    *inode_id,
+                    *base_revision_no,
+                    committed_seq,
+                )?;
+                let source_revision = validate_restore_source_revision(
+                    &ephemeral_metadata_state,
+                    *inode_id,
+                    *source_revision_no,
+                    committed_seq,
+                )?;
+                let revision_no = next_revision_no(*inode_id, *base_revision_no, false)?;
+                validate_restore_not_covered(
+                    &ephemeral_metadata_state,
+                    *inode_id,
+                    committed_seq,
+                    checked_invariants,
+                )?;
+                ValidatedOp::RestoreRevision {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_revision_no: *source_revision_no,
+                    revision_no,
+                    content_ref: source_revision.content_ref,
+                    revision_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
+            }
             CommitOp::DeleteFile { inode_id } => {
+                let source_binding = resolve_current_binding_for_mutation(
+                    &ephemeral_metadata_state,
+                    *inode_id,
+                    committed_seq,
+                )?;
                 validate_delete_file_target(&ephemeral_metadata_state, *inode_id, committed_seq)?;
                 validate_delete_file_not_covered(
                     &ephemeral_metadata_state,
@@ -332,15 +347,30 @@ fn validate_metadata_preconditions(
                     committed_seq,
                     checked_invariants,
                 )?;
+                ValidatedOp::DeleteFile {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_binding,
+                    unbind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    tombstone_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
             }
             CommitOp::Rename {
                 inode_id,
                 new_parent_inode,
                 new_display_name,
-                ..
+                mode,
             } => {
+                if *mode != loon_api::v0::RenameMode::NoReplace {
+                    return Err(CommitValidationError::UnsupportedRenameMode { mode: *mode });
+                }
+                let source_binding = resolve_current_binding_for_mutation(
+                    &ephemeral_metadata_state,
+                    *inode_id,
+                    committed_seq,
+                )?;
                 validate_rename_source(&ephemeral_metadata_state, *inode_id, committed_seq)?;
-                validate_rename_target_name_absent(
+                let new_name_key = validate_rename_target_name_absent(
                     &ephemeral_metadata_state,
                     *new_parent_inode,
                     new_display_name,
@@ -365,8 +395,23 @@ fn validate_metadata_preconditions(
                     committed_seq,
                     checked_invariants,
                 )?;
+                ValidatedOp::Rename {
+                    op_index,
+                    inode_id: *inode_id,
+                    source_binding,
+                    new_parent_inode: *new_parent_inode,
+                    new_display_name: new_display_name.clone(),
+                    new_name_key,
+                    unbind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    bind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
             }
             CommitOp::DeleteSubtree { root_inode } => {
+                let source_binding = resolve_current_binding_for_mutation(
+                    &ephemeral_metadata_state,
+                    *root_inode,
+                    committed_seq,
+                )?;
                 validate_delete_subtree_root(
                     &ephemeral_metadata_state,
                     *root_inode,
@@ -378,96 +423,55 @@ fn validate_metadata_preconditions(
                     committed_seq,
                     checked_invariants,
                 )?;
+                ValidatedOp::DeleteSubtree {
+                    op_index,
+                    root_inode: *root_inode,
+                    source_binding,
+                    unbind_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                    tombstone_delta_index: reserve_delta_index(&mut next_delta_index)?,
+                }
             }
-        }
-        resolved_restore_content_refs.push(resolved_restore_content_ref.clone());
-        resolved_source_bindings.push(resolved_source_binding.clone());
-
-        let (deltas, _result) = materialize_commit_op(
-            op,
-            op_index,
-            name_policy,
-            resolved_restore_content_ref.as_ref(),
-            resolved_source_binding.as_ref(),
-            &mut allocated_inode_ids,
-            &mut next_delta_index,
-        )
-        .map_err(|err| materialization_error_to_validation_error(err, op))?;
-        let deltas = deltas
-            .iter()
-            .map(|delta| delta.wal_delta.clone())
-            .collect::<Vec<_>>();
-        ephemeral_metadata_state
-            .apply_committed_wal_deltas_mut(committed_seq, &deltas)
-            .expect("validated commit ops should always apply into ephemeral metadata state");
+        };
+        ephemeral_metadata_state.apply_validated_op_mut(committed_seq, &validated_op);
+        validated_ops.push(validated_op);
     }
 
-    Ok(ResolvedMetadataPreconditions {
-        resolved_restore_content_refs,
-        resolved_source_bindings,
+    Ok(ValidatedMetadataOps { validated_ops })
+}
+
+fn next_allocated_inode(
+    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
+    error: CommitValidationError,
+) -> Result<InodeId, CommitValidationError> {
+    allocated_inode_ids.next().ok_or(error)
+}
+
+fn reserve_delta_index(next_delta_index: &mut u32) -> Result<u32, CommitValidationError> {
+    let delta_index = *next_delta_index;
+    *next_delta_index = next_delta_index
+        .checked_add(1)
+        .ok_or(CommitValidationError::DeltaIndexOverflow)?;
+    Ok(delta_index)
+}
+
+fn next_revision_no(
+    inode_id: InodeId,
+    base_revision_no: RevisionNo,
+    is_replace: bool,
+) -> Result<RevisionNo, CommitValidationError> {
+    base_revision_no.0.checked_add(1).map(RevisionNo).ok_or({
+        if is_replace {
+            CommitValidationError::ReplaceFileRevisionOverflow {
+                inode_id,
+                base_revision_no,
+            }
+        } else {
+            CommitValidationError::RestoreRevisionOverflow {
+                inode_id,
+                base_revision_no,
+            }
+        }
     })
-}
-
-fn materialization_error_to_validation_error(
-    error: CommitMaterializationError,
-    op: &CommitOp,
-) -> CommitValidationError {
-    match (error, op) {
-        (
-            CommitMaterializationError::MissingResolvedRestoreContentRef { .. },
-            CommitOp::RestoreRevision {
-                inode_id,
-                source_revision_no,
-                ..
-            },
-        ) => CommitValidationError::RestoreRevisionSourceRevisionMissing {
-            inode_id: *inode_id,
-            source_revision_no: *source_revision_no,
-        },
-        (
-            CommitMaterializationError::ReplaceRevisionOverflow { .. },
-            CommitOp::ReplaceFile {
-                inode_id,
-                base_revision_no,
-                ..
-            },
-        ) => CommitValidationError::ReplaceFileRevisionOverflow {
-            inode_id: *inode_id,
-            base_revision_no: *base_revision_no,
-        },
-        (
-            CommitMaterializationError::RestoreRevisionOverflow { .. },
-            CommitOp::RestoreRevision {
-                inode_id,
-                base_revision_no,
-                ..
-            },
-        ) => CommitValidationError::RestoreRevisionOverflow {
-            inode_id: *inode_id,
-            base_revision_no: *base_revision_no,
-        },
-        (CommitMaterializationError::OpIndexOverflow, _) => CommitValidationError::OpIndexOverflow,
-        (CommitMaterializationError::DeltaIndexOverflow, _) => {
-            CommitValidationError::OpIndexOverflow
-        }
-        (CommitMaterializationError::MissingResolvedSourceBinding { op_index }, _) => {
-            CommitValidationError::SourceBindingMissing {
-                inode_id: request_op_inode(op).unwrap_or(InodeId(u64::from(op_index))),
-            }
-        }
-        _ => CommitValidationError::NextInodeOverflow,
-    }
-}
-
-fn request_op_inode(op: &CommitOp) -> Option<InodeId> {
-    match op {
-        CommitOp::ReplaceFile { inode_id, .. }
-        | CommitOp::RestoreRevision { inode_id, .. }
-        | CommitOp::DeleteFile { inode_id }
-        | CommitOp::Rename { inode_id, .. } => Some(*inode_id),
-        CommitOp::DeleteSubtree { root_inode } => Some(*root_inode),
-        CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. } => None,
-    }
 }
 
 fn validate_explicit_preconditions(
@@ -648,7 +652,7 @@ fn validate_child_name_absent(
     display_name: &str,
     base_seq: ChangeSeq,
     name_policy: NamePolicy,
-) -> Result<(), CommitValidationError> {
+) -> Result<String, CommitValidationError> {
     validate_display_name(display_name)?;
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
@@ -669,7 +673,7 @@ fn validate_child_name_absent(
         });
     }
 
-    Ok(())
+    Ok(name_key)
 }
 
 fn validate_inode_revision_is(
@@ -903,7 +907,7 @@ fn validate_rename_target_name_absent(
     display_name: &str,
     base_seq: ChangeSeq,
     name_policy: NamePolicy,
-) -> Result<(), CommitValidationError> {
+) -> Result<String, CommitValidationError> {
     validate_display_name(display_name)?;
     let parent = metadata_state
         .inode_at_seq(parent_inode, base_seq)
@@ -924,7 +928,7 @@ fn validate_rename_target_name_absent(
         });
     }
 
-    Ok(())
+    Ok(name_key)
 }
 
 fn validate_display_name(display_name: &str) -> Result<(), CommitValidationError> {

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -54,12 +54,6 @@ pub enum CommitPrepareError {
     Fingerprint(#[from] CommitFingerprintError),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum CommitMaterializationError {
-    #[error("commit delta index overflow")]
-    DeltaIndexOverflow,
-}
-
 impl PreparedCommit {
     pub fn new(request: CommitRequest, plan: CommitPlan) -> Result<Self, CommitPrepareError> {
         Self::prepare(request, plan, CommitIdentitySource::CoreCommitRequest)
@@ -96,9 +90,7 @@ impl PreparedCommit {
     }
 }
 
-pub fn materialize_commit(
-    prepared: PreparedCommit,
-) -> Result<MaterializedCommit, CommitMaterializationError> {
+pub fn materialize_commit(prepared: PreparedCommit) -> MaterializedCommit {
     let mut deltas = Vec::new();
     let mut results = Vec::with_capacity(prepared.plan.validated_ops.len());
     for op in &prepared.plan.validated_ops {
@@ -107,11 +99,11 @@ pub fn materialize_commit(
         results.push(result);
     }
 
-    Ok(MaterializedCommit {
+    MaterializedCommit {
         prepared,
         deltas,
         results,
-    })
+    }
 }
 
 fn materialize_validated_op(op: &ValidatedOp) -> (Vec<MaterializedCommitDelta>, CommitOpResult) {
@@ -457,8 +449,7 @@ mod tests {
     #[test]
     fn materialize_commit_outputs_wal_ops_and_results_once() {
         let materialized =
-            materialize_commit(PreparedCommit::new(request(), plan()).expect("prepare commit"))
-                .expect("materialize commit");
+            materialize_commit(PreparedCommit::new(request(), plan()).expect("prepare commit"));
 
         assert_eq!(materialized.deltas.len(), 2);
         assert!(matches!(

--- a/crates/loon-core/src/commit/prepared.rs
+++ b/crates/loon-core/src/commit/prepared.rs
@@ -1,12 +1,9 @@
 use super::{
-    core_commit_fingerprint, CommitFingerprintError, CommitOp, CommitPlan, CommitRequest,
-    PathIntentFingerprint, ResolvedBinding, SemanticMutationIdentity,
+    core_commit_fingerprint, CommitFingerprintError, CommitPlan, CommitRequest,
+    PathIntentFingerprint, ResolvedBinding, SemanticMutationIdentity, ValidatedOp,
 };
 use loon_api::wire::wal::WalDelta;
-use loon_api::{
-    name_key_for_display_name, v0::CommitOpResult, ContentRef, FenceToken, InodeId, InodeKind,
-    NamePolicy, NamespaceId, RevisionNo,
-};
+use loon_api::{v0::CommitOpResult, FenceToken, InodeKind, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -59,33 +56,8 @@ pub enum CommitPrepareError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommitMaterializationError {
-    #[error("commit op index overflow")]
-    OpIndexOverflow,
     #[error("commit delta index overflow")]
     DeltaIndexOverflow,
-    #[error(
-        "allocated inode count mismatch: request_create_ops={request_create_ops}, plan_allocated_count={plan_allocated_count}"
-    )]
-    AllocatedInodeCountMismatch {
-        request_create_ops: usize,
-        plan_allocated_count: usize,
-    },
-    #[error("missing allocated inode for op index {op_index}")]
-    MissingAllocatedInode { op_index: u32 },
-    #[error("missing resolved restore content ref for op index {op_index}")]
-    MissingResolvedRestoreContentRef { op_index: u32 },
-    #[error("missing resolved source binding for op index {op_index}")]
-    MissingResolvedSourceBinding { op_index: u32 },
-    #[error("replace_file revision overflow for inode {inode_id:?} at base {base_revision_no:?}")]
-    ReplaceRevisionOverflow {
-        inode_id: InodeId,
-        base_revision_no: RevisionNo,
-    },
-    #[error("restore_revision overflow for inode {inode_id:?} at base {base_revision_no:?}")]
-    RestoreRevisionOverflow {
-        inode_id: InodeId,
-        base_revision_no: RevisionNo,
-    },
 }
 
 impl PreparedCommit {
@@ -127,45 +99,10 @@ impl PreparedCommit {
 pub fn materialize_commit(
     prepared: PreparedCommit,
 ) -> Result<MaterializedCommit, CommitMaterializationError> {
-    let request_create_ops = prepared
-        .request
-        .ops
-        .iter()
-        .filter(|op| matches!(op, CommitOp::CreateDir { .. } | CommitOp::CreateFile { .. }))
-        .count();
-    if request_create_ops != prepared.plan.allocated_inode_ids.len() {
-        return Err(CommitMaterializationError::AllocatedInodeCountMismatch {
-            request_create_ops,
-            plan_allocated_count: prepared.plan.allocated_inode_ids.len(),
-        });
-    }
-
-    let mut allocated_inode_ids = prepared.plan.allocated_inode_ids.iter().copied();
-    let mut deltas = Vec::with_capacity(prepared.request.ops.len());
-    let mut results = Vec::with_capacity(prepared.request.ops.len());
-    let mut next_delta_index = 0u32;
-    for (op_index, op) in prepared.request.ops.iter().enumerate() {
-        let op_index =
-            u32::try_from(op_index).map_err(|_| CommitMaterializationError::OpIndexOverflow)?;
-        let resolved_restore_content_ref = prepared
-            .plan
-            .resolved_restore_content_refs
-            .get(op_index as usize)
-            .and_then(|content_ref| content_ref.as_ref());
-        let resolved_source_binding = prepared
-            .plan
-            .resolved_source_bindings
-            .get(op_index as usize)
-            .and_then(|binding| binding.as_ref());
-        let (mut op_deltas, result) = materialize_commit_op(
-            op,
-            op_index,
-            prepared.plan.name_policy,
-            resolved_restore_content_ref,
-            resolved_source_binding,
-            &mut allocated_inode_ids,
-            &mut next_delta_index,
-        )?;
+    let mut deltas = Vec::new();
+    let mut results = Vec::with_capacity(prepared.plan.validated_ops.len());
+    for op in &prepared.plan.validated_ops {
+        let (mut op_deltas, result) = materialize_validated_op(op);
         deltas.append(&mut op_deltas);
         results.push(result);
     }
@@ -177,237 +114,226 @@ pub fn materialize_commit(
     })
 }
 
-pub(super) fn materialize_commit_op(
-    op: &CommitOp,
-    op_index: u32,
-    name_policy: NamePolicy,
-    resolved_restore_content_ref: Option<&ContentRef>,
-    resolved_source_binding: Option<&ResolvedBinding>,
-    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
-    next_delta_index: &mut u32,
-) -> Result<(Vec<MaterializedCommitDelta>, CommitOpResult), CommitMaterializationError> {
+fn materialize_validated_op(op: &ValidatedOp) -> (Vec<MaterializedCommitDelta>, CommitOpResult) {
     let mut deltas = Vec::new();
     let result = match op {
-        CommitOp::CreateDir {
+        ValidatedOp::CreateDir {
+            op_index,
             parent_inode,
             display_name,
+            name_key,
+            child_inode,
+            create_inode_delta_index,
+            bind_delta_index,
         } => {
-            let inode_id = allocated_inode_ids
-                .next()
-                .ok_or(CommitMaterializationError::MissingAllocatedInode { op_index })?;
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::CreateInode {
-                    delta_index: 0,
-                    inode_id,
+                    delta_index: *create_inode_delta_index,
+                    inode_id: *child_inode,
                     inode_kind: InodeKind::Dir,
                 },
-            )?;
+            );
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::BindDirentry {
-                    delta_index: 0,
+                    delta_index: *bind_delta_index,
                     parent_inode: *parent_inode,
-                    name_key: name_key_for_display_name(name_policy, display_name),
+                    name_key: name_key.clone(),
                     display_name: display_name.clone(),
-                    child_inode: inode_id,
+                    child_inode: *child_inode,
                 },
-            )?;
-            CommitOpResult::CreateDir { op_index, inode_id }
+            );
+            CommitOpResult::CreateDir {
+                op_index: *op_index,
+                inode_id: *child_inode,
+            }
         }
-        CommitOp::CreateFile {
+        ValidatedOp::CreateFile {
+            op_index,
             parent_inode,
             display_name,
+            name_key,
+            child_inode,
             content_ref,
+            create_inode_delta_index,
+            bind_delta_index,
+            revision_delta_index,
         } => {
-            let inode_id = allocated_inode_ids
-                .next()
-                .ok_or(CommitMaterializationError::MissingAllocatedInode { op_index })?;
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::CreateInode {
-                    delta_index: 0,
-                    inode_id,
+                    delta_index: *create_inode_delta_index,
+                    inode_id: *child_inode,
                     inode_kind: InodeKind::File,
                 },
-            )?;
+            );
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::BindDirentry {
-                    delta_index: 0,
+                    delta_index: *bind_delta_index,
                     parent_inode: *parent_inode,
-                    name_key: name_key_for_display_name(name_policy, display_name),
+                    name_key: name_key.clone(),
                     display_name: display_name.clone(),
-                    child_inode: inode_id,
+                    child_inode: *child_inode,
                 },
-            )?;
+            );
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::AppendFileRevision {
-                    delta_index: 0,
-                    inode_id,
+                    delta_index: *revision_delta_index,
+                    inode_id: *child_inode,
                     revision_no: RevisionNo(1),
                     content_ref: content_ref.clone(),
                 },
-            )?;
+            );
             CommitOpResult::CreateFile {
-                op_index,
-                inode_id,
+                op_index: *op_index,
+                inode_id: *child_inode,
                 revision_no: RevisionNo(1),
                 content_ref: content_ref.clone(),
             }
         }
-        CommitOp::ReplaceFile {
+        ValidatedOp::ReplaceFile {
+            op_index,
             inode_id,
-            base_revision_no,
+            revision_no,
             content_ref,
+            revision_delta_index,
         } => {
-            let revision_no = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
-                CommitMaterializationError::ReplaceRevisionOverflow {
-                    inode_id: *inode_id,
-                    base_revision_no: *base_revision_no,
-                },
-            )?;
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::AppendFileRevision {
-                    delta_index: 0,
+                    delta_index: *revision_delta_index,
                     inode_id: *inode_id,
-                    revision_no,
+                    revision_no: *revision_no,
                     content_ref: content_ref.clone(),
                 },
-            )?;
+            );
             CommitOpResult::ReplaceFile {
-                op_index,
+                op_index: *op_index,
                 inode_id: *inode_id,
-                revision_no,
+                revision_no: *revision_no,
                 content_ref: content_ref.clone(),
             }
         }
-        CommitOp::RestoreRevision {
+        ValidatedOp::RestoreRevision {
+            op_index,
             inode_id,
             source_revision_no,
-            base_revision_no,
+            revision_no,
+            content_ref,
+            revision_delta_index,
         } => {
-            let content_ref = resolved_restore_content_ref
-                .ok_or(CommitMaterializationError::MissingResolvedRestoreContentRef { op_index })?
-                .clone();
-            let revision_no = base_revision_no.0.checked_add(1).map(RevisionNo).ok_or(
-                CommitMaterializationError::RestoreRevisionOverflow {
-                    inode_id: *inode_id,
-                    base_revision_no: *base_revision_no,
-                },
-            )?;
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::AppendFileRevision {
-                    delta_index: 0,
+                    delta_index: *revision_delta_index,
                     inode_id: *inode_id,
-                    revision_no,
+                    revision_no: *revision_no,
                     content_ref: content_ref.clone(),
                 },
-            )?;
+            );
             CommitOpResult::RestoreRevision {
-                op_index,
+                op_index: *op_index,
                 inode_id: *inode_id,
                 source_revision_no: *source_revision_no,
-                revision_no,
-                content_ref,
+                revision_no: *revision_no,
+                content_ref: content_ref.clone(),
             }
         }
-        CommitOp::DeleteFile { inode_id } => {
-            let binding = resolved_source_binding
-                .ok_or(CommitMaterializationError::MissingResolvedSourceBinding { op_index })?;
-            push_unbind_delta(&mut deltas, op_index, next_delta_index, binding)?;
+        ValidatedOp::DeleteFile {
+            op_index,
+            inode_id,
+            source_binding,
+            unbind_delta_index,
+            tombstone_delta_index,
+        } => {
+            push_unbind_delta(&mut deltas, *op_index, *unbind_delta_index, source_binding);
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::TombstoneSubtree {
-                    delta_index: 0,
+                    delta_index: *tombstone_delta_index,
                     root_inode: *inode_id,
                 },
-            )?;
+            );
             CommitOpResult::DeleteFile {
-                op_index,
+                op_index: *op_index,
                 inode_id: *inode_id,
             }
         }
-        CommitOp::Rename {
+        ValidatedOp::Rename {
+            op_index,
             inode_id,
             new_parent_inode,
             new_display_name,
-            ..
+            new_name_key,
+            source_binding,
+            unbind_delta_index,
+            bind_delta_index,
         } => {
-            let binding = resolved_source_binding
-                .ok_or(CommitMaterializationError::MissingResolvedSourceBinding { op_index })?;
-            push_unbind_delta(&mut deltas, op_index, next_delta_index, binding)?;
+            push_unbind_delta(&mut deltas, *op_index, *unbind_delta_index, source_binding);
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::BindDirentry {
-                    delta_index: 0,
+                    delta_index: *bind_delta_index,
                     parent_inode: *new_parent_inode,
-                    name_key: name_key_for_display_name(name_policy, new_display_name),
+                    name_key: new_name_key.clone(),
                     display_name: new_display_name.clone(),
                     child_inode: *inode_id,
                 },
-            )?;
+            );
             CommitOpResult::Rename {
-                op_index,
+                op_index: *op_index,
                 inode_id: *inode_id,
             }
         }
-        CommitOp::DeleteSubtree { root_inode } => {
-            let binding = resolved_source_binding
-                .ok_or(CommitMaterializationError::MissingResolvedSourceBinding { op_index })?;
-            push_unbind_delta(&mut deltas, op_index, next_delta_index, binding)?;
+        ValidatedOp::DeleteSubtree {
+            op_index,
+            root_inode,
+            source_binding,
+            unbind_delta_index,
+            tombstone_delta_index,
+        } => {
+            push_unbind_delta(&mut deltas, *op_index, *unbind_delta_index, source_binding);
             push_delta(
                 &mut deltas,
-                op_index,
-                next_delta_index,
+                *op_index,
                 WalDelta::TombstoneSubtree {
-                    delta_index: 0,
+                    delta_index: *tombstone_delta_index,
                     root_inode: *root_inode,
                 },
-            )?;
+            );
             CommitOpResult::DeleteSubtree {
-                op_index,
+                op_index: *op_index,
                 root_inode: *root_inode,
             }
         }
     };
 
-    Ok((deltas, result))
+    (deltas, result)
 }
 
 fn push_unbind_delta(
     deltas: &mut Vec<MaterializedCommitDelta>,
     semantic_op_index: u32,
-    next_delta_index: &mut u32,
+    delta_index: u32,
     binding: &ResolvedBinding,
-) -> Result<(), CommitMaterializationError> {
+) {
     push_delta(
         deltas,
         semantic_op_index,
-        next_delta_index,
         WalDelta::UnbindDirentry {
-            delta_index: 0,
+            delta_index,
             parent_inode: binding.parent_inode,
             name_key: binding.name_key.clone(),
             child_inode: binding.child_inode,
@@ -420,39 +346,23 @@ fn push_unbind_delta(
 fn push_delta(
     deltas: &mut Vec<MaterializedCommitDelta>,
     semantic_op_index: u32,
-    next_delta_index: &mut u32,
-    mut wal_delta: WalDelta,
-) -> Result<(), CommitMaterializationError> {
-    let delta_index = *next_delta_index;
-    *next_delta_index = next_delta_index
-        .checked_add(1)
-        .ok_or(CommitMaterializationError::DeltaIndexOverflow)?;
-    set_wal_delta_index(&mut wal_delta, delta_index);
+    wal_delta: WalDelta,
+) {
+    let delta_index = wal_delta_index(&wal_delta);
     deltas.push(MaterializedCommitDelta {
         semantic_op_index,
         delta_index,
         wal_delta,
     });
-    Ok(())
 }
 
-fn set_wal_delta_index(wal_delta: &mut WalDelta, delta_index: u32) {
+fn wal_delta_index(wal_delta: &WalDelta) -> u32 {
     match wal_delta {
-        WalDelta::CreateInode {
-            delta_index: slot, ..
-        }
-        | WalDelta::BindDirentry {
-            delta_index: slot, ..
-        }
-        | WalDelta::UnbindDirentry {
-            delta_index: slot, ..
-        }
-        | WalDelta::AppendFileRevision {
-            delta_index: slot, ..
-        }
-        | WalDelta::TombstoneSubtree {
-            delta_index: slot, ..
-        } => *slot = delta_index,
+        WalDelta::CreateInode { delta_index, .. }
+        | WalDelta::BindDirentry { delta_index, .. }
+        | WalDelta::UnbindDirentry { delta_index, .. }
+        | WalDelta::AppendFileRevision { delta_index, .. }
+        | WalDelta::TombstoneSubtree { delta_index, .. } => *delta_index,
     }
 }
 
@@ -460,7 +370,7 @@ fn set_wal_delta_index(wal_delta: &mut WalDelta, delta_index: u32) {
 mod tests {
     use super::*;
     use crate::commit::CommitOp;
-    use loon_api::{ChangeSeq, CommitId};
+    use loon_api::{ChangeSeq, CommitId, InodeId};
 
     fn request() -> CommitRequest {
         CommitRequest {
@@ -484,12 +394,16 @@ mod tests {
             commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
-            allocated_inode_ids: vec![InodeId(2)],
-            resolved_restore_content_refs: vec![None],
-            resolved_source_bindings: vec![None],
+            validated_ops: vec![ValidatedOp::CreateDir {
+                op_index: 0,
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+                name_key: "docs".to_owned(),
+                child_inode: InodeId(2),
+                create_inode_delta_index: 0,
+                bind_delta_index: 1,
+            }],
             resulting_next_inode_id: InodeId(3),
-            name_policy: loon_api::NamePolicy::default(),
-            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         }
     }

--- a/crates/loon-core/src/commit/publish.rs
+++ b/crates/loon-core/src/commit/publish.rs
@@ -150,12 +150,8 @@ mod tests {
             commit_id: CommitId::parse("publish-plan").expect("valid commit id"),
             apply_after_seq: ChangeSeq(assigned_seq.0.saturating_sub(1)),
             assigned_seq,
-            allocated_inode_ids: Vec::new(),
-            resolved_restore_content_refs: Vec::new(),
-            resolved_source_bindings: Vec::new(),
+            validated_ops: Vec::new(),
             resulting_next_inode_id: InodeId(10),
-            name_policy: loon_api::NamePolicy::default(),
-            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         }
     }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -372,7 +372,8 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> CoreErrorK
         | CommitValidationError::ReplaceFileRevisionOverflow { .. }
         | CommitValidationError::SeqOverflow
         | CommitValidationError::NextInodeOverflow
-        | CommitValidationError::OpIndexOverflow => CoreErrorKind::ServerError,
+        | CommitValidationError::OpIndexOverflow
+        | CommitValidationError::DeltaIndexOverflow => CoreErrorKind::ServerError,
     }
 }
 

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -236,32 +236,32 @@ impl MetadataState {
         );
     }
 
-    fn push_inode_record(&mut self, record: InodeRecord) {
+    pub(crate) fn push_inode_record(&mut self, record: InodeRecord) {
         self.indexes.record_inode(&record);
         self.inodes.push(record);
     }
 
-    fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
+    pub(crate) fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
         self.indexes.record_bind(&record);
         self.direntry_binds.push(record);
     }
 
-    fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
+    pub(crate) fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
         self.indexes.record_unbind(&record);
         self.direntry_unbinds.push(record);
     }
 
-    fn push_revision_record(&mut self, record: RevisionRecord) {
+    pub(crate) fn push_revision_record(&mut self, record: RevisionRecord) {
         self.indexes.record_revision(&record);
         self.revisions.push(record);
     }
 
-    fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
+    pub(crate) fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
         self.indexes.record_tombstone(&record);
         self.subtree_tombstones.push(record);
     }
 
-    fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
+    pub(crate) fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
         self.indexes.record_commit_receipt(&record);
         self.commit_receipts.push(record);
     }

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -515,15 +515,7 @@ pub(crate) fn publish_namespace_mutations_batch_against_basis<S: ObjectStore + ?
         };
         let materialized = {
             let _span = tracing::info_span!("loon.phase", phase = "materialize_commit").entered();
-            match materialize_commit(prepared) {
-                Ok(value) => value,
-                Err(error) => {
-                    outcomes[index] = Some(Err(CoreError::Store(format!(
-                        "commit materialization failed: {error}"
-                    ))));
-                    continue;
-                }
-            }
+            materialize_commit(prepared)
         };
         let preview = {
             let _span =

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -696,7 +696,9 @@ fn push_invariant(checked_invariants: &mut Vec<InvariantId>, invariant: Invarian
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit};
+    use crate::commit::{
+        materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit, ValidatedOp,
+    };
     use loon_api::{CommitId, FenceToken};
     use loon_objectstore::fs::LocalFsStore;
     use loon_objectstore::ObjectStore;
@@ -723,12 +725,16 @@ mod tests {
             commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             apply_after_seq: ChangeSeq(0),
             assigned_seq: ChangeSeq(1),
-            allocated_inode_ids: vec![InodeId(2)],
-            resolved_restore_content_refs: vec![None],
-            resolved_source_bindings: vec![None],
+            validated_ops: vec![ValidatedOp::CreateDir {
+                op_index: 0,
+                parent_inode: InodeId(1),
+                display_name: "docs".to_owned(),
+                name_key: "docs".to_owned(),
+                child_inode: InodeId(2),
+                create_inode_delta_index: 0,
+                bind_delta_index: 1,
+            }],
             resulting_next_inode_id: InodeId(3),
-            name_policy: loon_api::NamePolicy::default(),
-            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
@@ -946,12 +952,19 @@ mod tests {
             commit_id: CommitId::parse(commit_id).expect("valid commit id"),
             apply_after_seq,
             assigned_seq,
-            allocated_inode_ids: vec![InodeId(2)],
-            resolved_restore_content_refs: vec![None],
-            resolved_source_bindings: vec![None],
+            validated_ops: vec![ValidatedOp::CreateDir {
+                op_index: 0,
+                parent_inode: InodeId(1),
+                display_name: display_name.to_owned(),
+                name_key: loon_api::name_key_for_display_name(
+                    loon_api::NamePolicy::default(),
+                    display_name,
+                ),
+                child_inode: InodeId(2),
+                create_inode_delta_index: 0,
+                bind_delta_index: 1,
+            }],
             resulting_next_inode_id: InodeId(3),
-            name_policy: loon_api::NamePolicy::default(),
-            metadata_preconditions: Vec::new(),
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");

--- a/crates/loon-core/src/wal.rs
+++ b/crates/loon-core/src/wal.rs
@@ -738,7 +738,7 @@ mod tests {
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
-        let record = materialize_commit(prepared).expect("materialize commit");
+        let record = materialize_commit(prepared);
 
         let segment = prepare_wal_segment(
             namespace_id,
@@ -968,7 +968,7 @@ mod tests {
             checked_invariants: Vec::new(),
         };
         let prepared = PreparedCommit::new(request, plan).expect("prepare commit");
-        materialize_commit(prepared).expect("materialize commit")
+        materialize_commit(prepared)
     }
 
     fn assert_wal_chain_corruption_rejected(

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -13,7 +13,8 @@ use loon_api::{
     NameKey, NamespaceId, RevisionNo,
 };
 use loon_core::commit::{
-    build_commit_plan, CommitOp, CommitRequest, CommitValidationContext, CommitValidationError,
+    build_commit_plan, materialize_commit, CommitOp, CommitRequest, CommitValidationContext,
+    CommitValidationError, PreparedCommit,
 };
 use loon_core::metadata::MetadataState;
 use loon_core::{
@@ -409,35 +410,40 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
     ]);
     let context = validation_context(&metadata_state, ChangeSeq(2), InodeId(4));
 
-    let plan = build_commit_plan(
-        &CommitRequest {
-            namespace_id: namespace_id(),
-            commit_id: CommitId::parse("restore-same-request-source").expect("valid commit id"),
-            writer_id: "writer-a".to_owned(),
-            writer_fence_token: FenceToken(1),
-            ops: vec![
-                CommitOp::ReplaceFile {
-                    inode_id: InodeId(3),
-                    base_revision_no: RevisionNo(1),
-                    content_ref: content_ref("content-2"),
-                },
-                CommitOp::RestoreRevision {
-                    inode_id: InodeId(3),
-                    source_revision_no: RevisionNo(2),
-                    base_revision_no: RevisionNo(2),
-                },
-            ],
-            preconditions: Vec::new(),
-            message: None,
-            annotations: None,
-        },
-        &context,
-    )
-    .expect("replace then restore in same request should validate");
-    assert_eq!(
-        plan.resolved_restore_content_refs,
-        vec![None, Some(content_ref("content-2"))]
-    );
+    let request = CommitRequest {
+        namespace_id: namespace_id(),
+        commit_id: CommitId::parse("restore-same-request-source").expect("valid commit id"),
+        writer_id: "writer-a".to_owned(),
+        writer_fence_token: FenceToken(1),
+        ops: vec![
+            CommitOp::ReplaceFile {
+                inode_id: InodeId(3),
+                base_revision_no: RevisionNo(1),
+                content_ref: content_ref("content-2"),
+            },
+            CommitOp::RestoreRevision {
+                inode_id: InodeId(3),
+                source_revision_no: RevisionNo(2),
+                base_revision_no: RevisionNo(2),
+            },
+        ],
+        preconditions: Vec::new(),
+        message: None,
+        annotations: None,
+    };
+    let plan = build_commit_plan(&request, &context)
+        .expect("replace then restore in same request should validate");
+    let materialized =
+        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"))
+            .expect("materialize commit");
+    let expected = content_ref("content-2");
+    assert!(matches!(
+        &materialized.results[1],
+        loon_api::v0::CommitOpResult::RestoreRevision {
+            content_ref,
+            ..
+        } if *content_ref == expected
+    ));
 }
 
 #[test]
@@ -455,39 +461,47 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
     ]);
     let context = validation_context(&metadata_state, ChangeSeq(3), InodeId(4));
 
-    let plan = build_commit_plan(
-        &CommitRequest {
-            namespace_id: namespace_id(),
-            commit_id: CommitId::parse("restore-after-restore-same-request")
-                .expect("valid commit id"),
-            writer_id: "writer-a".to_owned(),
-            writer_fence_token: FenceToken(1),
-            ops: vec![
-                CommitOp::RestoreRevision {
-                    inode_id: InodeId(3),
-                    source_revision_no: RevisionNo(1),
-                    base_revision_no: RevisionNo(2),
-                },
-                CommitOp::RestoreRevision {
-                    inode_id: InodeId(3),
-                    source_revision_no: RevisionNo(3),
-                    base_revision_no: RevisionNo(3),
-                },
-            ],
-            preconditions: Vec::new(),
-            message: None,
-            annotations: None,
-        },
-        &context,
-    )
-    .expect("restore then restore in same request should validate");
-    assert_eq!(
-        plan.resolved_restore_content_refs,
-        vec![
-            Some(content_ref("content-1")),
-            Some(content_ref("content-1"))
-        ]
-    );
+    let request = CommitRequest {
+        namespace_id: namespace_id(),
+        commit_id: CommitId::parse("restore-after-restore-same-request").expect("valid commit id"),
+        writer_id: "writer-a".to_owned(),
+        writer_fence_token: FenceToken(1),
+        ops: vec![
+            CommitOp::RestoreRevision {
+                inode_id: InodeId(3),
+                source_revision_no: RevisionNo(1),
+                base_revision_no: RevisionNo(2),
+            },
+            CommitOp::RestoreRevision {
+                inode_id: InodeId(3),
+                source_revision_no: RevisionNo(3),
+                base_revision_no: RevisionNo(3),
+            },
+        ],
+        preconditions: Vec::new(),
+        message: None,
+        annotations: None,
+    };
+    let plan = build_commit_plan(&request, &context)
+        .expect("restore then restore in same request should validate");
+    let materialized =
+        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"))
+            .expect("materialize commit");
+    let expected = content_ref("content-1");
+    assert!(matches!(
+        &materialized.results[0],
+        loon_api::v0::CommitOpResult::RestoreRevision {
+            content_ref,
+            ..
+        } if *content_ref == expected
+    ));
+    assert!(matches!(
+        &materialized.results[1],
+        loon_api::v0::CommitOpResult::RestoreRevision {
+            content_ref,
+            ..
+        } if *content_ref == expected
+    ));
 }
 
 #[test]

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -434,8 +434,7 @@ fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
     let plan = build_commit_plan(&request, &context)
         .expect("replace then restore in same request should validate");
     let materialized =
-        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"))
-            .expect("materialize commit");
+        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"));
     let expected = content_ref("content-2");
     assert!(matches!(
         &materialized.results[1],
@@ -485,8 +484,7 @@ fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
     let plan = build_commit_plan(&request, &context)
         .expect("restore then restore in same request should validate");
     let materialized =
-        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"))
-            .expect("materialize commit");
+        materialize_commit(PreparedCommit::new(request, plan).expect("prepare commit"));
     let expected = content_ref("content-1");
     assert!(matches!(
         &materialized.results[0],


### PR DESCRIPTION
Refactors commit planning so validation produces resolved ops before WAL materialization. Before this PR, validation solved for “is this commit valid?” by first calculating WAL deltas, then applying those deltas to a preview state.
