### PR TITLE
perf(cache): bound warm basis memory and index hot lookups

### DIFF
--- a/crates/loon-core/src/basis.rs
+++ b/crates/loon-core/src/basis.rs
@@ -20,6 +20,7 @@ use loon_objectstore::{
     ObjectStore,
 };
 use serde::{Deserialize, Serialize};
+use std::mem::size_of;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,6 +31,49 @@ pub struct VerifiedNamespaceBasis {
     pub head_etag: String,
     pub lease: LeaseState,
     pub metadata_state: MetadataState,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifiedNamespaceBasisWeight {
+    pub rows: usize,
+    pub decoded_bytes: usize,
+}
+
+impl VerifiedNamespaceBasis {
+    pub fn weight(&self) -> VerifiedNamespaceBasisWeight {
+        VerifiedNamespaceBasisWeight {
+            rows: self.row_count(),
+            decoded_bytes: self.decoded_bytes(),
+        }
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.metadata_state.row_count()
+    }
+
+    pub fn decoded_bytes(&self) -> usize {
+        size_of::<Self>()
+            + self.namespace_descriptor.namespace_id.as_str().len()
+            + self.namespace_descriptor.content_store_id.as_str().len()
+            + self.content_store_id.as_str().len()
+            + self.head.namespace_id.as_str().len()
+            + self.head_etag.len()
+            + wal_tip_decoded_bytes(self.head.visible_wal_tip.as_ref())
+            + self.lease.namespace_id.as_str().len()
+            + self.lease.holder_id.len()
+            + self.metadata_state.decoded_bytes()
+    }
+}
+
+fn wal_tip_decoded_bytes(pointer: Option<&loon_api::wire::control::WalSegmentPointer>) -> usize {
+    pointer
+        .map(|pointer| {
+            size_of::<loon_api::wire::control::WalSegmentPointer>()
+                + pointer.object_key.len()
+                + pointer.segment_id.len()
+                + pointer.payload_checksum_sha256.len()
+        })
+        .unwrap_or(0)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loon-core/src/commit/metadata_preview.rs
+++ b/crates/loon-core/src/commit/metadata_preview.rs
@@ -44,10 +44,38 @@ impl<'a> MetadataPreview<'a> {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<RevisionRecord> {
+        self.rows_latest_revision_head_at_seq(inode_id, base_seq)
+            .into_iter()
+            .chain(self.base_latest_revision_head_at_seq(inode_id, base_seq))
+            .max_by_key(|revision| {
+                (
+                    revision.revision_no,
+                    revision.committed_seq,
+                    revision.revision_delta_index,
+                )
+            })
+    }
+
+    pub(super) fn revision_at_seq(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
+        self.rows_revision_at_seq(inode_id, revision_no, base_seq)
+            .into_iter()
+            .chain(self.base_revision_at_seq(inode_id, revision_no, base_seq))
+            .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index))
+    }
+
+    fn rows_latest_revision_head_at_seq(
+        &self,
+        inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
         self.rows
             .revisions()
             .iter()
-            .chain(self.base.revisions().iter())
             .filter(|revision| revision.inode_id == inode_id && revision.committed_seq <= base_seq)
             .max_by_key(|revision| {
                 (
@@ -59,7 +87,7 @@ impl<'a> MetadataPreview<'a> {
             .cloned()
     }
 
-    pub(super) fn revision_at_seq(
+    fn rows_revision_at_seq(
         &self,
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -68,7 +96,6 @@ impl<'a> MetadataPreview<'a> {
         self.rows
             .revisions()
             .iter()
-            .chain(self.base.revisions().iter())
             .filter(|revision| {
                 revision.inode_id == inode_id
                     && revision.revision_no == revision_no
@@ -366,6 +393,31 @@ impl<'a> MetadataPreview<'a> {
             self.base.active_subtree_tombstone_at_head(root_inode_id)
         } else {
             self.base.active_subtree_tombstone(root_inode_id, base_seq)
+        }
+    }
+
+    fn base_latest_revision_head_at_seq(
+        &self,
+        inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.latest_revision_at_head(inode_id)
+        } else {
+            self.base.latest_revision_head_at_seq(inode_id, base_seq)
+        }
+    }
+
+    fn base_revision_at_seq(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
+        if base_seq >= self.base.indexed_seq() {
+            self.base.revision_at_head(inode_id, revision_no)
+        } else {
+            self.base.revision_at_seq(inode_id, revision_no, base_seq)
         }
     }
 

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -22,6 +22,7 @@ pub use basis::{
     load_namespace_head_summary, load_verified_namespace_basis,
     load_verified_namespace_basis_at_head, probe_namespace_head_etag, BasisLoadError,
     NamespaceHeadEtagProbe, NamespaceHeadSummary, VerifiedNamespaceBasis,
+    VerifiedNamespaceBasisWeight,
 };
 pub use checkpoint::{
     advance_retention_floor, create_checkpoint, create_checkpoint_with_policy, CheckpointLoadError,

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -9,7 +9,7 @@ use loon_api::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::mem::size_of;
+use std::mem::{size_of, size_of_val};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -26,6 +26,10 @@ pub struct MetadataState {
     subtree_tombstones: Vec<SubtreeTombstoneRecord>,
     #[serde(default)]
     commit_receipts: Vec<CommitReceiptRecord>,
+    #[serde(skip)]
+    row_count: usize,
+    #[serde(skip)]
+    decoded_bytes: usize,
     #[serde(skip)]
     indexes: MetadataIndexes,
 }
@@ -185,6 +189,8 @@ impl MetadataState {
             revisions,
             subtree_tombstones,
             commit_receipts,
+            row_count: 0,
+            decoded_bytes: 0,
             indexes: MetadataIndexes::default(),
         };
         state.rebuild_indexes();
@@ -220,37 +226,11 @@ impl MetadataState {
     }
 
     pub fn row_count(&self) -> usize {
-        self.inodes.len()
-            + self.direntry_binds.len()
-            + self.direntry_unbinds.len()
-            + self.revisions.len()
-            + self.subtree_tombstones.len()
-            + self.commit_receipts.len()
+        self.row_count
     }
 
     pub fn decoded_bytes(&self) -> usize {
-        self.inodes.len() * size_of::<InodeRecord>()
-            + self
-                .direntry_binds
-                .iter()
-                .map(direntry_bind_decoded_bytes)
-                .sum::<usize>()
-            + self
-                .direntry_unbinds
-                .iter()
-                .map(direntry_unbind_decoded_bytes)
-                .sum::<usize>()
-            + self
-                .revisions
-                .iter()
-                .map(revision_decoded_bytes)
-                .sum::<usize>()
-            + self.subtree_tombstones.len() * size_of::<SubtreeTombstoneRecord>()
-            + self
-                .commit_receipts
-                .iter()
-                .map(commit_receipt_decoded_bytes)
-                .sum::<usize>()
+        self.decoded_bytes
     }
 
     pub fn find_commit_receipt(&self, commit_id: &CommitId) -> Option<&CommitReceiptRecord> {
@@ -258,6 +238,22 @@ impl MetadataState {
     }
 
     fn rebuild_indexes(&mut self) {
+        self.row_count = metadata_row_count(
+            &self.inodes,
+            &self.direntry_binds,
+            &self.direntry_unbinds,
+            &self.revisions,
+            &self.subtree_tombstones,
+            &self.commit_receipts,
+        );
+        self.decoded_bytes = metadata_decoded_bytes(
+            &self.inodes,
+            &self.direntry_binds,
+            &self.direntry_unbinds,
+            &self.revisions,
+            &self.subtree_tombstones,
+            &self.commit_receipts,
+        );
         self.indexes = MetadataIndexes::rebuild(
             &self.inodes,
             &self.direntry_binds,
@@ -270,32 +266,43 @@ impl MetadataState {
 
     fn push_inode_record(&mut self, record: InodeRecord) {
         self.indexes.record_inode(&record);
+        self.record_row_weight(size_of::<InodeRecord>());
         self.inodes.push(record);
     }
 
     fn push_direntry_bind_record(&mut self, record: DirentryBindRecord) {
         self.indexes.record_bind(&record);
+        self.record_row_weight(direntry_bind_decoded_bytes(&record));
         self.direntry_binds.push(record);
     }
 
     fn push_direntry_unbind_record(&mut self, record: DirentryUnbindRecord) {
         self.indexes.record_unbind(&record);
+        self.record_row_weight(direntry_unbind_decoded_bytes(&record));
         self.direntry_unbinds.push(record);
     }
 
     fn push_revision_record(&mut self, record: RevisionRecord) {
         self.indexes.record_revision(&record);
+        self.record_row_weight(revision_decoded_bytes(&record));
         self.revisions.push(record);
     }
 
     fn push_subtree_tombstone_record(&mut self, record: SubtreeTombstoneRecord) {
         self.indexes.record_tombstone(&record);
+        self.record_row_weight(size_of::<SubtreeTombstoneRecord>());
         self.subtree_tombstones.push(record);
     }
 
     fn push_commit_receipt_record(&mut self, record: CommitReceiptRecord) {
         self.indexes.record_commit_receipt(&record);
+        self.record_row_weight(commit_receipt_decoded_bytes(&record));
         self.commit_receipts.push(record);
+    }
+
+    fn record_row_weight(&mut self, decoded_bytes: usize) {
+        self.row_count = self.row_count.saturating_add(1);
+        self.decoded_bytes = self.decoded_bytes.saturating_add(decoded_bytes);
     }
 
     pub fn apply_committed_wal_deltas(
@@ -1056,6 +1063,54 @@ fn join_display_path(base: &str, component: &str) -> String {
     }
 }
 
+fn metadata_row_count(
+    inodes: &[InodeRecord],
+    direntry_binds: &[DirentryBindRecord],
+    direntry_unbinds: &[DirentryUnbindRecord],
+    revisions: &[RevisionRecord],
+    subtree_tombstones: &[SubtreeTombstoneRecord],
+    commit_receipts: &[CommitReceiptRecord],
+) -> usize {
+    inodes
+        .len()
+        .saturating_add(direntry_binds.len())
+        .saturating_add(direntry_unbinds.len())
+        .saturating_add(revisions.len())
+        .saturating_add(subtree_tombstones.len())
+        .saturating_add(commit_receipts.len())
+}
+
+fn metadata_decoded_bytes(
+    inodes: &[InodeRecord],
+    direntry_binds: &[DirentryBindRecord],
+    direntry_unbinds: &[DirentryUnbindRecord],
+    revisions: &[RevisionRecord],
+    subtree_tombstones: &[SubtreeTombstoneRecord],
+    commit_receipts: &[CommitReceiptRecord],
+) -> usize {
+    size_of_val(inodes)
+        .saturating_add(
+            direntry_binds
+                .iter()
+                .map(direntry_bind_decoded_bytes)
+                .sum::<usize>(),
+        )
+        .saturating_add(
+            direntry_unbinds
+                .iter()
+                .map(direntry_unbind_decoded_bytes)
+                .sum::<usize>(),
+        )
+        .saturating_add(revisions.iter().map(revision_decoded_bytes).sum::<usize>())
+        .saturating_add(size_of_val(subtree_tombstones))
+        .saturating_add(
+            commit_receipts
+                .iter()
+                .map(commit_receipt_decoded_bytes)
+                .sum::<usize>(),
+        )
+}
+
 fn direntry_bind_decoded_bytes(record: &DirentryBindRecord) -> usize {
     size_of::<DirentryBindRecord>() + record.name_key.len() + record.display_name.len()
 }
@@ -1320,8 +1375,12 @@ mod tests {
 
         let encoded = serde_json::to_string(&metadata_state).expect("encode metadata");
         assert!(!encoded.contains("indexes"));
+        assert!(!encoded.contains("row_count"));
+        assert!(!encoded.contains("decoded_bytes"));
         let decoded: MetadataState = serde_json::from_str(&encoded).expect("decode metadata");
 
+        assert_eq!(decoded.row_count(), metadata_state.row_count());
+        assert_eq!(decoded.decoded_bytes(), metadata_state.decoded_bytes());
         assert_eq!(decoded.indexed_seq(), ChangeSeq(1));
         assert_eq!(
             decoded

--- a/crates/loon-core/src/metadata.rs
+++ b/crates/loon-core/src/metadata.rs
@@ -9,6 +9,7 @@ use loon_api::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::mem::size_of;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -218,11 +219,42 @@ impl MetadataState {
         &self.commit_receipts
     }
 
+    pub fn row_count(&self) -> usize {
+        self.inodes.len()
+            + self.direntry_binds.len()
+            + self.direntry_unbinds.len()
+            + self.revisions.len()
+            + self.subtree_tombstones.len()
+            + self.commit_receipts.len()
+    }
+
+    pub fn decoded_bytes(&self) -> usize {
+        self.inodes.len() * size_of::<InodeRecord>()
+            + self
+                .direntry_binds
+                .iter()
+                .map(direntry_bind_decoded_bytes)
+                .sum::<usize>()
+            + self
+                .direntry_unbinds
+                .iter()
+                .map(direntry_unbind_decoded_bytes)
+                .sum::<usize>()
+            + self
+                .revisions
+                .iter()
+                .map(revision_decoded_bytes)
+                .sum::<usize>()
+            + self.subtree_tombstones.len() * size_of::<SubtreeTombstoneRecord>()
+            + self
+                .commit_receipts
+                .iter()
+                .map(commit_receipt_decoded_bytes)
+                .sum::<usize>()
+    }
+
     pub fn find_commit_receipt(&self, commit_id: &CommitId) -> Option<&CommitReceiptRecord> {
-        self.commit_receipts
-            .iter()
-            .filter(|record| record.commit_id == *commit_id)
-            .max_by_key(|record| record.committed_seq)
+        self.indexes.commit_receipt(commit_id)
     }
 
     fn rebuild_indexes(&mut self) {
@@ -444,6 +476,21 @@ impl MetadataState {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<RevisionRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.latest_revision_at_head(inode_id);
+        }
+        self.latest_revision_head_at_seq_scan(inode_id, base_seq)
+    }
+
+    pub fn latest_revision_at_head(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        self.indexes.latest_revision(inode_id)
+    }
+
+    fn latest_revision_head_at_seq_scan(
+        &self,
+        inode_id: InodeId,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
         self.revisions
             .iter()
             .filter(|revision| revision.inode_id == inode_id && revision.committed_seq <= base_seq)
@@ -458,6 +505,26 @@ impl MetadataState {
     }
 
     pub fn revision_at_seq(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        base_seq: ChangeSeq,
+    ) -> Option<RevisionRecord> {
+        if base_seq == self.indexed_seq() {
+            return self.revision_at_head(inode_id, revision_no);
+        }
+        self.revision_at_seq_scan(inode_id, revision_no, base_seq)
+    }
+
+    pub fn revision_at_head(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Option<RevisionRecord> {
+        self.indexes.revision(inode_id, revision_no)
+    }
+
+    fn revision_at_seq_scan(
         &self,
         inode_id: InodeId,
         revision_no: RevisionNo,
@@ -989,6 +1056,48 @@ fn join_display_path(base: &str, component: &str) -> String {
     }
 }
 
+fn direntry_bind_decoded_bytes(record: &DirentryBindRecord) -> usize {
+    size_of::<DirentryBindRecord>() + record.name_key.len() + record.display_name.len()
+}
+
+fn direntry_unbind_decoded_bytes(record: &DirentryUnbindRecord) -> usize {
+    size_of::<DirentryUnbindRecord>() + record.name_key.len()
+}
+
+fn revision_decoded_bytes(record: &RevisionRecord) -> usize {
+    size_of::<RevisionRecord>() + content_ref_decoded_bytes(&record.content_ref)
+}
+
+fn commit_receipt_decoded_bytes(record: &CommitReceiptRecord) -> usize {
+    size_of::<CommitReceiptRecord>()
+        + record.commit_id.as_str().len()
+        + record.semantic_commit_fingerprint_sha256.len()
+        + record
+            .results
+            .iter()
+            .map(commit_op_result_decoded_bytes)
+            .sum::<usize>()
+}
+
+fn commit_op_result_decoded_bytes(result: &CommitOpResult) -> usize {
+    size_of::<CommitOpResult>()
+        + match result {
+            CommitOpResult::CreateFile { content_ref, .. }
+            | CommitOpResult::ReplaceFile { content_ref, .. }
+            | CommitOpResult::RestoreRevision { content_ref, .. } => {
+                content_ref_decoded_bytes(content_ref)
+            }
+            CommitOpResult::CreateDir { .. }
+            | CommitOpResult::DeleteFile { .. }
+            | CommitOpResult::Rename { .. }
+            | CommitOpResult::DeleteSubtree { .. } => 0,
+        }
+}
+
+fn content_ref_decoded_bytes(content_ref: &ContentRef) -> usize {
+    size_of::<ContentRef>() + content_ref.digest.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1413,5 +1522,97 @@ mod tests {
             .expect("receipt");
         assert_eq!(receipt.committed_seq, ChangeSeq(2));
         assert_eq!(receipt.semantic_commit_fingerprint_sha256, "new");
+    }
+
+    #[test]
+    fn revision_and_receipt_indexes_rebuild_and_update_incrementally() {
+        let commit_id = CommitId::parse("indexed-commit").expect("valid commit id");
+        let content_ref = ContentRef {
+            kind: loon_api::ContentRefKind::WholeFileV0,
+            digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_owned(),
+            size_bytes: 12,
+        };
+        let replacement_ref = ContentRef {
+            kind: loon_api::ContentRefKind::WholeFileV0,
+            digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                .to_owned(),
+            size_bytes: 24,
+        };
+
+        let mut builder = MetadataStateBuilder::default();
+        builder.push_inode(InodeRecord {
+            inode_id: InodeId(7),
+            inode_kind: InodeKind::File,
+            created_seq: ChangeSeq(1),
+        });
+        builder.push_revision(RevisionRecord {
+            inode_id: InodeId(7),
+            revision_no: RevisionNo(1),
+            committed_seq: ChangeSeq(2),
+            revision_delta_index: 0,
+            content_ref: content_ref.clone(),
+        });
+        builder.push_revision(RevisionRecord {
+            inode_id: InodeId(7),
+            revision_no: RevisionNo(2),
+            committed_seq: ChangeSeq(3),
+            revision_delta_index: 0,
+            content_ref: replacement_ref.clone(),
+        });
+        builder.push_commit_receipt(CommitReceiptRecord {
+            commit_id: commit_id.clone(),
+            semantic_commit_fingerprint_sha256: "fingerprint".to_owned(),
+            committed_seq: ChangeSeq(3),
+            results: vec![CommitOpResult::ReplaceFile {
+                op_index: 0,
+                inode_id: InodeId(7),
+                revision_no: RevisionNo(2),
+                content_ref: replacement_ref.clone(),
+            }],
+        });
+        let metadata_state = builder.finish();
+
+        assert_eq!(metadata_state.row_count(), 4);
+        assert!(metadata_state.decoded_bytes() >= metadata_state.row_count());
+        assert_eq!(
+            metadata_state
+                .latest_revision_at_head(InodeId(7))
+                .expect("latest revision")
+                .revision_no,
+            RevisionNo(2)
+        );
+        assert_eq!(
+            metadata_state
+                .revision_at_head(InodeId(7), RevisionNo(1))
+                .expect("first revision")
+                .content_ref,
+            content_ref
+        );
+        assert_eq!(
+            metadata_state
+                .find_commit_receipt(&commit_id)
+                .expect("commit receipt")
+                .committed_seq,
+            ChangeSeq(3)
+        );
+
+        let decoded: MetadataState =
+            serde_json::from_value(serde_json::to_value(&metadata_state).expect("encode"))
+                .expect("decode");
+        assert_eq!(
+            decoded
+                .latest_revision_at_head(InodeId(7))
+                .expect("latest revision after decode")
+                .content_ref,
+            replacement_ref
+        );
+        assert_eq!(
+            decoded
+                .find_commit_receipt(&commit_id)
+                .expect("receipt after decode")
+                .semantic_commit_fingerprint_sha256,
+            "fingerprint"
+        );
     }
 }

--- a/crates/loon-core/src/metadata/indexes.rs
+++ b/crates/loon-core/src/metadata/indexes.rs
@@ -2,7 +2,7 @@ use super::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneRecord,
 };
-use loon_api::{ChangeSeq, InodeId};
+use loon_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,6 +13,9 @@ pub(super) struct MetadataIndexes {
     active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
     unbound_binding_keys: HashSet<BindingKey>,
     tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
+    latest_revision_by_inode: HashMap<InodeId, RevisionRecord>,
+    revision_by_inode_no: HashMap<(InodeId, RevisionNo), RevisionRecord>,
+    commit_receipt_by_id: HashMap<CommitId, CommitReceiptRecord>,
 }
 
 impl Default for MetadataIndexes {
@@ -24,6 +27,9 @@ impl Default for MetadataIndexes {
             active_parent_by_child: HashMap::new(),
             unbound_binding_keys: HashSet::new(),
             tombstone_by_root: HashMap::new(),
+            latest_revision_by_inode: HashMap::new(),
+            revision_by_inode_no: HashMap::new(),
+            commit_receipt_by_id: HashMap::new(),
         }
     }
 }
@@ -132,6 +138,24 @@ impl MetadataIndexes {
         self.tombstone_by_root.get(&root_inode_id).cloned()
     }
 
+    pub(super) fn latest_revision(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        self.latest_revision_by_inode.get(&inode_id).cloned()
+    }
+
+    pub(super) fn revision(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Option<RevisionRecord> {
+        self.revision_by_inode_no
+            .get(&(inode_id, revision_no))
+            .cloned()
+    }
+
+    pub(super) fn commit_receipt(&self, commit_id: &CommitId) -> Option<&CommitReceiptRecord> {
+        self.commit_receipt_by_id.get(commit_id)
+    }
+
     pub(super) fn is_unbound(&self, record: &DirentryBindRecord) -> bool {
         self.unbound_binding_keys
             .contains(&BindingKey::from_bind(record))
@@ -195,6 +219,16 @@ impl MetadataIndexes {
 
     pub(super) fn record_revision(&mut self, record: &RevisionRecord) {
         self.indexed_seq = self.indexed_seq.max(record.committed_seq);
+        replace_if_newer_revision(
+            &mut self.latest_revision_by_inode,
+            record.inode_id,
+            record.clone(),
+        );
+        replace_if_newer_revision(
+            &mut self.revision_by_inode_no,
+            (record.inode_id, record.revision_no),
+            record.clone(),
+        );
     }
 
     pub(super) fn record_tombstone(&mut self, record: &SubtreeTombstoneRecord) {
@@ -208,6 +242,11 @@ impl MetadataIndexes {
 
     pub(super) fn record_commit_receipt(&mut self, record: &CommitReceiptRecord) {
         self.indexed_seq = self.indexed_seq.max(record.committed_seq);
+        replace_if_newer_receipt(
+            &mut self.commit_receipt_by_id,
+            record.commit_id.clone(),
+            record.clone(),
+        );
     }
 }
 
@@ -252,6 +291,36 @@ fn replace_if_newer_bind<K>(
     let should_replace = map
         .get(&key)
         .map(|existing| bind_order_key(&record) > bind_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn replace_if_newer_revision<K>(
+    map: &mut HashMap<K, RevisionRecord>,
+    key: K,
+    record: RevisionRecord,
+) where
+    K: Eq + std::hash::Hash,
+{
+    let should_replace = map
+        .get(&key)
+        .map(|existing| revision_order_key(&record) > revision_order_key(existing))
+        .unwrap_or(true);
+    if should_replace {
+        map.insert(key, record);
+    }
+}
+
+fn replace_if_newer_receipt(
+    map: &mut HashMap<CommitId, CommitReceiptRecord>,
+    key: CommitId,
+    record: CommitReceiptRecord,
+) {
+    let should_replace = map
+        .get(&key)
+        .map(|existing| record.committed_seq > existing.committed_seq)
         .unwrap_or(true);
     if should_replace {
         map.insert(key, record);
@@ -317,6 +386,14 @@ fn unbind_matches_bind(unbind: &DirentryUnbindRecord, bind: &DirentryBindRecord)
 
 fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {
     (record.bind_seq, record.bind_delta_index)
+}
+
+fn revision_order_key(record: &RevisionRecord) -> (RevisionNo, ChangeSeq, u32) {
+    (
+        record.revision_no,
+        record.committed_seq,
+        record.revision_delta_index,
+    )
 }
 
 fn tombstone_order_key(record: &SubtreeTombstoneRecord) -> (ChangeSeq, u32) {

--- a/crates/loon-core/src/protocol.rs
+++ b/crates/loon-core/src/protocol.rs
@@ -37,6 +37,7 @@ use loon_api::{
 use loon_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loon_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
 
@@ -48,8 +49,8 @@ pub(crate) struct PublishBatchAgainstBasisResult {
 
 #[derive(Debug, Clone)]
 pub(crate) enum BasisPromotion {
-    Unchanged(VerifiedNamespaceBasis),
-    Advanced(VerifiedNamespaceBasis),
+    Unchanged(Arc<VerifiedNamespaceBasis>),
+    Advanced(Arc<VerifiedNamespaceBasis>),
     NotCacheable,
 }
 
@@ -60,7 +61,7 @@ impl PublishBatchAgainstBasisResult {
     ) -> Self {
         Self {
             results,
-            basis_promotion: BasisPromotion::Unchanged(basis.clone()),
+            basis_promotion: BasisPromotion::Unchanged(Arc::new(basis.clone())),
         }
     }
 
@@ -70,7 +71,7 @@ impl PublishBatchAgainstBasisResult {
     ) -> Self {
         Self {
             results,
-            basis_promotion: BasisPromotion::Advanced(basis),
+            basis_promotion: BasisPromotion::Advanced(Arc::new(basis)),
         }
     }
 

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -118,12 +118,14 @@ pub struct NamespaceCommitEngine {
 struct CachedVerifiedBasis {
     basis: Arc<VerifiedNamespaceBasis>,
     head_etag_reuse_token: String,
+    weight: VerifiedNamespaceBasisWeight,
 }
 
 impl CachedVerifiedBasis {
     fn from_arc(basis: Arc<VerifiedNamespaceBasis>) -> Self {
         Self {
             head_etag_reuse_token: basis.head_etag.clone(),
+            weight: basis.weight(),
             basis,
         }
     }
@@ -133,7 +135,7 @@ impl CachedVerifiedBasis {
     }
 
     fn weight(&self) -> VerifiedNamespaceBasisWeight {
-        self.basis.weight()
+        self.weight
     }
 
     fn basis_to_reuse_with_refreshed_lease(&self, lease: LeaseState) -> VerifiedNamespaceBasis {

--- a/crates/loon-core/src/publisher.rs
+++ b/crates/loon-core/src/publisher.rs
@@ -7,7 +7,7 @@ use crate::path::planner::{
 };
 use crate::{
     load_namespace_lease_control, load_verified_namespace_basis, probe_namespace_head_etag,
-    BasisLoadError, NamespaceHeadEtagProbe, VerifiedNamespaceBasis,
+    BasisLoadError, NamespaceHeadEtagProbe, VerifiedNamespaceBasis, VerifiedNamespaceBasisWeight,
 };
 use loon_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loon_api::wire::control::LeaseState;
@@ -84,16 +84,16 @@ pub struct NamespaceCommitEnginePublishResult {
 #[derive(Debug, Clone)]
 pub enum VerifiedBasisCacheUpdate {
     NoChange,
-    ReusableAfterHeadEtagMatch(VerifiedNamespaceBasis),
-    AdvancedAfterHeadCas(VerifiedNamespaceBasis),
+    ReusableAfterHeadEtagMatch(Arc<VerifiedNamespaceBasis>),
+    AdvancedAfterHeadCas(Arc<VerifiedNamespaceBasis>),
     Invalidated,
 }
 
 impl VerifiedBasisCacheUpdate {
-    pub fn verified_basis_to_cache(&self) -> Option<&VerifiedNamespaceBasis> {
+    pub fn verified_basis_to_cache(&self) -> Option<Arc<VerifiedNamespaceBasis>> {
         match self {
             Self::ReusableAfterHeadEtagMatch(basis) | Self::AdvancedAfterHeadCas(basis) => {
-                Some(basis)
+                Some(Arc::clone(basis))
             }
             Self::NoChange | Self::Invalidated => None,
         }
@@ -121,10 +121,6 @@ struct CachedVerifiedBasis {
 }
 
 impl CachedVerifiedBasis {
-    fn new(basis: VerifiedNamespaceBasis) -> Self {
-        Self::from_arc(Arc::new(basis))
-    }
-
     fn from_arc(basis: Arc<VerifiedNamespaceBasis>) -> Self {
         Self {
             head_etag_reuse_token: basis.head_etag.clone(),
@@ -134,6 +130,10 @@ impl CachedVerifiedBasis {
 
     fn matches_head_etag_probe(&self, probe: &NamespaceHeadEtagProbe) -> bool {
         self.head_etag_reuse_token == probe.head_etag
+    }
+
+    fn weight(&self) -> VerifiedNamespaceBasisWeight {
+        self.basis.weight()
     }
 
     fn basis_to_reuse_with_refreshed_lease(&self, lease: LeaseState) -> VerifiedNamespaceBasis {
@@ -158,6 +158,10 @@ impl NamespaceCommitEngine {
 
     pub fn invalidate(&mut self) {
         self.basis = None;
+    }
+
+    pub fn cached_basis_weight(&self) -> Option<VerifiedNamespaceBasisWeight> {
+        self.basis.as_ref().map(CachedVerifiedBasis::weight)
     }
 
     pub fn publish_batch<S: ObjectStore + ?Sized>(
@@ -236,11 +240,11 @@ impl NamespaceCommitEngine {
     ) -> NamespaceCommitEnginePublishResult {
         let verified_basis_cache_update = match published.basis_promotion {
             crate::protocol::BasisPromotion::Unchanged(basis) => {
-                self.basis = Some(CachedVerifiedBasis::new(basis.clone()));
+                self.basis = Some(CachedVerifiedBasis::from_arc(Arc::clone(&basis)));
                 VerifiedBasisCacheUpdate::ReusableAfterHeadEtagMatch(basis)
             }
             crate::protocol::BasisPromotion::Advanced(basis) => {
-                self.basis = Some(CachedVerifiedBasis::new(basis.clone()));
+                self.basis = Some(CachedVerifiedBasis::from_arc(Arc::clone(&basis)));
                 VerifiedBasisCacheUpdate::AdvancedAfterHeadCas(basis)
             }
             crate::protocol::BasisPromotion::NotCacheable => {
@@ -430,7 +434,7 @@ mod tests {
             lease: original_lease.clone(),
             metadata_state: MetadataState::default(),
         };
-        let cached = CachedVerifiedBasis::new(basis.clone());
+        let cached = CachedVerifiedBasis::from_arc(Arc::new(basis.clone()));
 
         assert!(cached.matches_head_etag_probe(&NamespaceHeadEtagProbe {
             head_etag: "etag-a".to_owned(),

--- a/crates/loon-server/src/config.rs
+++ b/crates/loon-server/src/config.rs
@@ -2,6 +2,7 @@ use http::Uri;
 use loon_objectstore::r2::R2StoreConfig;
 use loon_objectstore::s3::AwsS3StoreConfig;
 use loon_objectstore::ConfiguredObjectStore;
+use loonfs::RuntimeCacheConfig;
 use serde::Deserialize;
 use std::fs;
 use std::net::SocketAddr;
@@ -15,7 +16,21 @@ pub struct ServerConfig {
     pub writer_id: String,
     pub writer_version: String,
     pub lease_duration_ms: u64,
+    #[serde(default)]
+    pub runtime_cache: RuntimeCacheConfigOverrides,
     pub store: StoreConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RuntimeCacheConfigOverrides {
+    pub basis_cache_enabled: Option<bool>,
+    pub control_cache_enabled: Option<bool>,
+    pub max_cached_namespaces: Option<usize>,
+    pub max_cached_basis_rows: Option<usize>,
+    pub max_cached_basis_decoded_bytes: Option<usize>,
+    pub metadata_table_cache_enabled: Option<bool>,
+    pub metadata_table_cache_max_blocks: Option<usize>,
+    pub metadata_table_cache_max_decoded_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -58,6 +73,35 @@ pub enum ServerConfigError {
 }
 
 impl ServerConfig {
+    pub fn runtime_cache_config(&self) -> RuntimeCacheConfig {
+        let mut config = RuntimeCacheConfig::default();
+        if let Some(value) = self.runtime_cache.basis_cache_enabled {
+            config.basis_cache_enabled = value;
+        }
+        if let Some(value) = self.runtime_cache.control_cache_enabled {
+            config.control_cache_enabled = value;
+        }
+        if let Some(value) = self.runtime_cache.max_cached_namespaces {
+            config.max_cached_namespaces = value;
+        }
+        if let Some(value) = self.runtime_cache.max_cached_basis_rows {
+            config.max_cached_basis_rows = value;
+        }
+        if let Some(value) = self.runtime_cache.max_cached_basis_decoded_bytes {
+            config.max_cached_basis_decoded_bytes = Some(value);
+        }
+        if let Some(value) = self.runtime_cache.metadata_table_cache_enabled {
+            config.metadata_table_cache.enabled = value;
+        }
+        if let Some(value) = self.runtime_cache.metadata_table_cache_max_blocks {
+            config.metadata_table_cache.max_blocks = value;
+        }
+        if let Some(value) = self.runtime_cache.metadata_table_cache_max_decoded_bytes {
+            config.metadata_table_cache.max_decoded_bytes = Some(value);
+        }
+        config
+    }
+
     pub fn object_store(&self) -> Result<ConfiguredObjectStore, ServerConfigError> {
         match &self.store {
             StoreConfig::LocalFs { root, key_prefix } => {
@@ -437,6 +481,120 @@ root = "/tmp/loon-server"
         let error = load_server_config(&path).expect_err("blank auth token");
 
         assert_invalid_field(error, "auth_token");
+    }
+
+    #[test]
+    fn load_uses_default_runtime_cache_when_omitted() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
+lease_duration_ms = 60000
+
+[store]
+kind = "local-fs"
+root = "/tmp/loon-server"
+"#,
+        );
+
+        let config = load_server_config(&path).expect("load config");
+        assert_eq!(
+            config.runtime_cache_config(),
+            loonfs::RuntimeCacheConfig::default()
+        );
+    }
+
+    #[test]
+    fn load_applies_runtime_cache_overrides() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
+lease_duration_ms = 60000
+
+[runtime_cache]
+basis_cache_enabled = true
+control_cache_enabled = false
+max_cached_namespaces = 2
+max_cached_basis_rows = 10
+max_cached_basis_decoded_bytes = 4096
+
+[store]
+kind = "local-fs"
+root = "/tmp/loon-server"
+"#,
+        );
+
+        let config = load_server_config(&path)
+            .expect("load config")
+            .runtime_cache_config();
+        assert!(config.basis_cache_enabled);
+        assert!(!config.control_cache_enabled);
+        assert_eq!(config.max_cached_namespaces, 2);
+        assert_eq!(config.max_cached_basis_rows, 10);
+        assert_eq!(config.max_cached_basis_decoded_bytes, Some(4096));
+    }
+
+    #[test]
+    fn load_accepts_disabled_runtime_cache_overrides() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
+lease_duration_ms = 60000
+
+[runtime_cache]
+basis_cache_enabled = false
+control_cache_enabled = false
+max_cached_namespaces = 0
+max_cached_basis_rows = 0
+max_cached_basis_decoded_bytes = 0
+metadata_table_cache_enabled = false
+metadata_table_cache_max_blocks = 0
+metadata_table_cache_max_decoded_bytes = 0
+
+[store]
+kind = "local-fs"
+root = "/tmp/loon-server"
+"#,
+        );
+
+        let config = load_server_config(&path)
+            .expect("load config")
+            .runtime_cache_config();
+        assert_eq!(config, loonfs::RuntimeCacheConfig::disabled());
+    }
+
+    #[test]
+    fn load_rejects_negative_runtime_cache_limits_as_decode_error() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loon-server"
+writer_version = "loon-server/0.1.0"
+lease_duration_ms = 60000
+
+[runtime_cache]
+max_cached_basis_rows = -1
+
+[store]
+kind = "local-fs"
+root = "/tmp/loon-server"
+"#,
+        );
+
+        let error = load_server_config(&path).expect_err("negative row limit");
+        match error {
+            ServerConfigError::Decode(_) => {}
+            other => panic!("expected decode error, got {other:?}"),
+        }
     }
 
     fn write_config(contents: &str) -> std::path::PathBuf {

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -21,8 +21,7 @@ use loon_api::{
 use loonfs::{
     payload_class, BootstrapNamespaceError, CoreError, CoreErrorKind, CreateNamespaceOptions, Fs,
     JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder, PathMutationIntent,
-    PutFileBehavior, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
-    TraceStoreKind,
+    PutFileBehavior, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use std::ffi::OsString;
 use std::net::SocketAddr;
@@ -162,7 +161,7 @@ fn build_fs_with_metrics_jsonl_path(
         .writer_id(config.writer_id.clone())
         .writer_version(config.writer_version.clone())
         .lease_duration_ms(config.lease_duration_ms)
-        .runtime_cache(RuntimeCacheConfig::default())
+        .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
 
@@ -825,6 +824,7 @@ impl IntoResponse for ApiResponseError {
 #[cfg(test)]
 mod tests {
     use super::{app_with_store, build_fs_with_metrics_jsonl_path, SharedStore};
+    use crate::config::RuntimeCacheConfigOverrides;
     use crate::{ServerConfig, StoreConfig};
     use loon_api::{ChangeSeq, CommitId, NamespaceId};
     use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
@@ -1297,6 +1297,7 @@ mod tests {
             writer_id: writer_id.to_owned(),
             writer_version: format!("{writer_id}/0.1.0"),
             lease_duration_ms: 60_000,
+            runtime_cache: RuntimeCacheConfigOverrides::default(),
             store: StoreConfig::LocalFs {
                 root: root.display().to_string(),
                 key_prefix: Some("http-tests".to_owned()),

--- a/crates/loon-server/src/lib.rs
+++ b/crates/loon-server/src/lib.rs
@@ -5,6 +5,8 @@ mod http;
 mod publisher;
 mod trace;
 
-pub use config::{load_server_config, ServerConfig, ServerConfigError, StoreConfig};
+pub use config::{
+    load_server_config, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
+};
 pub use http::{app, serve};
 pub use trace::{init_tracing_from_env, TraceInitError};

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -512,7 +512,7 @@ fn usize_to_u64(value: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ServerConfig, StoreConfig};
+    use crate::config::{RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
     use loon_api::v0::{CommitOp, CommitRequest};
     use loon_api::wire::wal::decode_wal_segment_envelope_zstd;
     use loon_api::{ChangeSeq, InodeId};
@@ -642,6 +642,7 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             lease_duration_ms: 60_000,
+            runtime_cache: RuntimeCacheConfigOverrides::default(),
             store: StoreConfig::LocalFs {
                 root: root.display().to_string(),
                 key_prefix: None,
@@ -955,6 +956,7 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             lease_duration_ms: 60_000,
+            runtime_cache: RuntimeCacheConfigOverrides::default(),
             store: StoreConfig::LocalFs {
                 root: temp_dir.path().display().to_string(),
                 key_prefix: None,
@@ -1007,6 +1009,7 @@ mod tests {
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             lease_duration_ms: 60_000,
+            runtime_cache: RuntimeCacheConfigOverrides::default(),
             store: StoreConfig::LocalFs {
                 root: temp_dir.path().display().to_string(),
                 key_prefix: None,

--- a/crates/loon-server/tests/http_smoke.rs
+++ b/crates/loon-server/tests/http_smoke.rs
@@ -10,7 +10,7 @@ use loon_api::{
 use loon_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loon_objectstore::keys::{checkpoint_manifest, namespace_lease};
 use loon_objectstore::{ConfiguredObjectStore, ObjectStore};
-use loon_server::{app, ServerConfig, StoreConfig};
+use loon_server::{app, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -1153,6 +1153,7 @@ fn test_config(
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         lease_duration_ms,
+        runtime_cache: RuntimeCacheConfigOverrides::default(),
         store: StoreConfig::LocalFs {
             root: store_root.display().to_string(),
             key_prefix: Some(key_prefix.to_owned()),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -274,9 +274,7 @@ impl BasisCache {
         let namespace_id = basis.head.namespace_id.clone();
         let mut eviction = self.remove_entry(&namespace_id);
         let cached = CachedVerifiedBasis::new(basis);
-        if !limits.can_cache(cached.weight()) {
-            return self.update_with_eviction(eviction);
-        }
+        debug_assert!(limits.can_cache(cached.weight()));
         self.cached_rows = self.cached_rows.saturating_add(cached.weight().rows);
         self.cached_decoded_bytes = self
             .cached_decoded_bytes
@@ -1979,7 +1977,7 @@ impl Fs {
         let weight = basis.weight();
         if !limits.can_cache(weight) {
             self.inner.cache_stats.record_warm_basis_uncacheable(weight);
-            tracing::warn!(
+            tracing::debug!(
                 namespace_id = %basis.head.namespace_id,
                 rows = weight.rows,
                 decoded_bytes = weight.decoded_bytes,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -646,6 +646,9 @@ pub struct RuntimeCacheStats {
     pub warm_basis_evictions: usize,
     pub warm_basis_evicted_rows: usize,
     pub warm_basis_evicted_decoded_bytes: usize,
+    pub warm_basis_uncacheable_count: usize,
+    pub warm_basis_uncacheable_rows: usize,
+    pub warm_basis_uncacheable_decoded_bytes: usize,
     pub warm_basis_cached_rows: usize,
     pub warm_basis_cached_decoded_bytes: usize,
     pub warm_basis_rehydrate_count: usize,
@@ -669,6 +672,9 @@ struct RuntimeCacheStatsInner {
     warm_basis_evictions: AtomicUsize,
     warm_basis_evicted_rows: AtomicUsize,
     warm_basis_evicted_decoded_bytes: AtomicUsize,
+    warm_basis_uncacheable_count: AtomicUsize,
+    warm_basis_uncacheable_rows: AtomicUsize,
+    warm_basis_uncacheable_decoded_bytes: AtomicUsize,
     warm_basis_cached_rows: AtomicUsize,
     warm_basis_cached_decoded_bytes: AtomicUsize,
     warm_basis_rehydrate_count: AtomicUsize,
@@ -693,6 +699,11 @@ impl RuntimeCacheStatsInner {
             warm_basis_evicted_rows: self.warm_basis_evicted_rows.load(Ordering::SeqCst),
             warm_basis_evicted_decoded_bytes: self
                 .warm_basis_evicted_decoded_bytes
+                .load(Ordering::SeqCst),
+            warm_basis_uncacheable_count: self.warm_basis_uncacheable_count.load(Ordering::SeqCst),
+            warm_basis_uncacheable_rows: self.warm_basis_uncacheable_rows.load(Ordering::SeqCst),
+            warm_basis_uncacheable_decoded_bytes: self
+                .warm_basis_uncacheable_decoded_bytes
                 .load(Ordering::SeqCst),
             warm_basis_cached_rows: self.warm_basis_cached_rows.load(Ordering::SeqCst),
             warm_basis_cached_decoded_bytes: self
@@ -757,6 +768,15 @@ impl RuntimeCacheStatsInner {
 
     fn record_warm_basis_cache_update(&self, update: BasisCacheUpdate) {
         self.record_warm_basis_eviction(update.eviction);
+    }
+
+    fn record_warm_basis_uncacheable(&self, weight: VerifiedNamespaceBasisWeight) {
+        self.warm_basis_uncacheable_count
+            .fetch_add(1, Ordering::SeqCst);
+        self.warm_basis_uncacheable_rows
+            .fetch_add(weight.rows, Ordering::SeqCst);
+        self.warm_basis_uncacheable_decoded_bytes
+            .fetch_add(weight.decoded_bytes, Ordering::SeqCst);
     }
 
     fn set_warm_basis_cached_weight(&self, rows: usize, decoded_bytes: usize) {
@@ -1955,12 +1975,27 @@ impl Fs {
         if !self.basis_cache_enabled() {
             return;
         }
+        let limits = BasisCacheLimits::from_config(cache_config);
+        let weight = basis.weight();
+        if !limits.can_cache(weight) {
+            self.inner.cache_stats.record_warm_basis_uncacheable(weight);
+            tracing::warn!(
+                namespace_id = %basis.head.namespace_id,
+                rows = weight.rows,
+                decoded_bytes = weight.decoded_bytes,
+                max_rows = limits.max_rows,
+                max_decoded_bytes = ?limits.max_decoded_bytes,
+                "warm basis exceeds cache limits"
+            );
+            self.prune_warm_basis_budget();
+            return;
+        }
         let update = self
             .inner
             .basis_cache
             .lock()
             .expect("basis cache lock poisoned")
-            .insert(basis, BasisCacheLimits::from_config(cache_config));
+            .insert(basis, limits);
         self.inner
             .cache_stats
             .record_warm_basis_cache_update(update);

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -27,7 +27,7 @@ pub use loon_core::{
 };
 use loon_core::{
     ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl, MutationContext,
-    NamespaceCommitEngine, VerifiedNamespaceBasis,
+    NamespaceCommitEngine, VerifiedNamespaceBasis, VerifiedNamespaceBasisWeight,
 };
 use loon_objectstore::keys::namespace_head;
 use loon_objectstore::metrics::InstrumentedObjectStore;
@@ -42,6 +42,9 @@ pub use trace::{payload_class, TraceMode, TraceStoreKind};
 
 pub const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 pub const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
+pub const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
+pub const DEFAULT_MAX_CACHED_BASIS_ROWS: usize = 1_000_000;
+pub const DEFAULT_MAX_CACHED_BASIS_DECODED_BYTES: usize = 256 * 1024 * 1024;
 const MAX_UPLOADED_CONTENT_PROOF_ENTRIES: usize = 16_384;
 const UPLOADED_CONTENT_PROOF_TTL: Duration = Duration::from_secs(30);
 
@@ -86,6 +89,8 @@ pub struct RuntimeCacheConfig {
     pub basis_cache_enabled: bool,
     pub control_cache_enabled: bool,
     pub max_cached_namespaces: usize,
+    pub max_cached_basis_rows: usize,
+    pub max_cached_basis_decoded_bytes: Option<usize>,
     pub metadata_table_cache: MetadataTableCacheConfig,
 }
 
@@ -95,10 +100,12 @@ impl RuntimeCacheConfig {
             basis_cache_enabled: false,
             control_cache_enabled: false,
             max_cached_namespaces: 0,
+            max_cached_basis_rows: 0,
+            max_cached_basis_decoded_bytes: Some(0),
             metadata_table_cache: MetadataTableCacheConfig {
                 enabled: false,
                 max_blocks: 0,
-                max_decoded_bytes: None,
+                max_decoded_bytes: Some(0),
             },
         }
     }
@@ -109,7 +116,9 @@ impl Default for RuntimeCacheConfig {
         Self {
             basis_cache_enabled: true,
             control_cache_enabled: true,
-            max_cached_namespaces: 64,
+            max_cached_namespaces: DEFAULT_MAX_CACHED_NAMESPACES,
+            max_cached_basis_rows: DEFAULT_MAX_CACHED_BASIS_ROWS,
+            max_cached_basis_decoded_bytes: Some(DEFAULT_MAX_CACHED_BASIS_DECODED_BYTES),
             metadata_table_cache: MetadataTableCacheConfig::default(),
         }
     }
@@ -146,18 +155,22 @@ pub struct FsBuilder {
 struct BasisCache {
     entries: HashMap<NamespaceId, CachedVerifiedBasis>,
     order: VecDeque<NamespaceId>,
+    cached_rows: usize,
+    cached_decoded_bytes: usize,
 }
 
 #[derive(Debug, Clone)]
 struct CachedVerifiedBasis {
     basis: Arc<VerifiedNamespaceBasis>,
     head_etag_reuse_token: String,
+    weight: VerifiedNamespaceBasisWeight,
 }
 
 impl CachedVerifiedBasis {
     fn new(basis: Arc<VerifiedNamespaceBasis>) -> Self {
         Self {
             head_etag_reuse_token: basis.head_etag.clone(),
+            weight: basis.weight(),
             basis,
         }
     }
@@ -173,6 +186,77 @@ impl CachedVerifiedBasis {
     fn matches_head_etag_probe(&self, probe: &loon_core::NamespaceHeadEtagProbe) -> bool {
         self.matches_head_etag(&probe.head_etag)
     }
+
+    fn weight(&self) -> VerifiedNamespaceBasisWeight {
+        self.weight
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BasisCacheLimits {
+    max_namespaces: usize,
+    max_rows: usize,
+    max_decoded_bytes: Option<usize>,
+}
+
+impl BasisCacheLimits {
+    fn from_config(config: &RuntimeCacheConfig) -> Self {
+        Self {
+            max_namespaces: config.max_cached_namespaces,
+            max_rows: config.max_cached_basis_rows,
+            max_decoded_bytes: config.max_cached_basis_decoded_bytes,
+        }
+    }
+
+    fn basis_cache_enabled(&self) -> bool {
+        self.max_namespaces > 0
+            && self.max_rows > 0
+            && self.max_decoded_bytes.map(|max| max > 0).unwrap_or(true)
+    }
+
+    fn can_cache(&self, weight: VerifiedNamespaceBasisWeight) -> bool {
+        self.basis_cache_enabled()
+            && weight.rows <= self.max_rows
+            && self
+                .max_decoded_bytes
+                .map(|max| weight.decoded_bytes <= max)
+                .unwrap_or(true)
+    }
+
+    fn is_over_budget(&self, namespace_count: usize, rows: usize, decoded_bytes: usize) -> bool {
+        namespace_count > self.max_namespaces
+            || rows > self.max_rows
+            || self
+                .max_decoded_bytes
+                .map(|max| decoded_bytes > max)
+                .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct BasisCacheEviction {
+    count: usize,
+    rows: usize,
+    decoded_bytes: usize,
+}
+
+impl BasisCacheEviction {
+    fn add_weight(&mut self, weight: VerifiedNamespaceBasisWeight) {
+        self.count = self.count.saturating_add(1);
+        self.rows = self.rows.saturating_add(weight.rows);
+        self.decoded_bytes = self.decoded_bytes.saturating_add(weight.decoded_bytes);
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.count = self.count.saturating_add(other.count);
+        self.rows = self.rows.saturating_add(other.rows);
+        self.decoded_bytes = self.decoded_bytes.saturating_add(other.decoded_bytes);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct BasisCacheUpdate {
+    eviction: BasisCacheEviction,
 }
 
 impl BasisCache {
@@ -182,30 +266,79 @@ impl BasisCache {
         Some(basis)
     }
 
-    fn insert(&mut self, basis: Arc<VerifiedNamespaceBasis>, max_cached_namespaces: usize) {
-        if max_cached_namespaces == 0 {
-            return;
-        }
+    fn insert(
+        &mut self,
+        basis: Arc<VerifiedNamespaceBasis>,
+        limits: BasisCacheLimits,
+    ) -> BasisCacheUpdate {
         let namespace_id = basis.head.namespace_id.clone();
-        self.entries
-            .insert(namespace_id.clone(), CachedVerifiedBasis::new(basis));
+        let mut eviction = self.remove_entry(&namespace_id);
+        let cached = CachedVerifiedBasis::new(basis);
+        if !limits.can_cache(cached.weight()) {
+            return self.update_with_eviction(eviction);
+        }
+        self.cached_rows = self.cached_rows.saturating_add(cached.weight().rows);
+        self.cached_decoded_bytes = self
+            .cached_decoded_bytes
+            .saturating_add(cached.weight().decoded_bytes);
+        self.entries.insert(namespace_id.clone(), cached);
         self.touch(&namespace_id);
-        while self.entries.len() > max_cached_namespaces {
+        while limits.is_over_budget(
+            self.entries.len(),
+            self.cached_rows,
+            self.cached_decoded_bytes,
+        ) {
             let Some(evicted) = self.order.pop_front() else {
                 break;
             };
-            self.entries.remove(&evicted);
+            eviction.merge(self.remove_entry(&evicted));
         }
+        self.update_with_eviction(eviction)
     }
 
-    fn invalidate(&mut self, namespace_id: &NamespaceId) {
-        self.entries.remove(namespace_id);
+    fn invalidate(&mut self, namespace_id: &NamespaceId) -> BasisCacheUpdate {
         self.order.retain(|candidate| candidate != namespace_id);
+        let eviction = self.remove_entry(namespace_id);
+        self.update_with_eviction(eviction)
     }
 
     fn touch(&mut self, namespace_id: &NamespaceId) {
         self.order.retain(|candidate| candidate != namespace_id);
         self.order.push_back(namespace_id.clone());
+    }
+
+    fn remove_entry(&mut self, namespace_id: &NamespaceId) -> BasisCacheEviction {
+        let Some(entry) = self.entries.remove(namespace_id) else {
+            return BasisCacheEviction::default();
+        };
+        self.order.retain(|candidate| candidate != namespace_id);
+        let weight = entry.weight();
+        self.cached_rows = self.cached_rows.saturating_sub(weight.rows);
+        self.cached_decoded_bytes = self
+            .cached_decoded_bytes
+            .saturating_sub(weight.decoded_bytes);
+        let mut eviction = BasisCacheEviction::default();
+        eviction.add_weight(weight);
+        eviction
+    }
+
+    fn update_with_eviction(&self, eviction: BasisCacheEviction) -> BasisCacheUpdate {
+        BasisCacheUpdate { eviction }
+    }
+
+    fn cached_totals(&self) -> (usize, usize, usize) {
+        (
+            self.entries.len(),
+            self.cached_rows,
+            self.cached_decoded_bytes,
+        )
+    }
+
+    fn prune_one_lru(&mut self) -> BasisCacheEviction {
+        let Some(evicted) = self.order.pop_front() else {
+            return BasisCacheEviction::default();
+        };
+        self.remove_entry(&evicted)
     }
 }
 
@@ -415,25 +548,78 @@ impl CommitEngineCache {
             let Some(evicted) = self.order.pop_front() else {
                 break;
             };
-            self.entries.remove(&evicted);
+            self.remove_entry(&evicted);
         }
         engine
     }
 
-    fn invalidate(&mut self, namespace_id: &NamespaceId) {
-        if let Some(engine) = self.entries.remove(namespace_id) {
-            engine
-                .lock()
-                .expect("commit engine lock poisoned")
-                .invalidate();
-        }
+    fn invalidate(&mut self, namespace_id: &NamespaceId) -> BasisCacheEviction {
+        let eviction = self.remove_entry(namespace_id);
         self.order.retain(|candidate| candidate != namespace_id);
+        eviction
+    }
+
+    fn cached_basis_totals(&self) -> (usize, usize, usize) {
+        self.entries
+            .values()
+            .filter_map(|engine| {
+                engine
+                    .lock()
+                    .expect("commit engine lock poisoned")
+                    .cached_basis_weight()
+            })
+            .fold(
+                (0_usize, 0_usize, 0_usize),
+                |(count, rows, decoded_bytes), weight| {
+                    (
+                        count.saturating_add(1),
+                        rows.saturating_add(weight.rows),
+                        decoded_bytes.saturating_add(weight.decoded_bytes),
+                    )
+                },
+            )
+    }
+
+    fn prune_one_lru(&mut self) -> BasisCacheEviction {
+        while let Some(evicted) = self.order.pop_front() {
+            let eviction = self.remove_entry(&evicted);
+            if eviction.count > 0 {
+                return eviction;
+            }
+        }
+        BasisCacheEviction::default()
+    }
+
+    fn remove_entry(&mut self, namespace_id: &NamespaceId) -> BasisCacheEviction {
+        let Some(engine) = self.entries.remove(namespace_id) else {
+            return BasisCacheEviction::default();
+        };
+        let mut engine = engine.lock().expect("commit engine lock poisoned");
+        let mut eviction = BasisCacheEviction::default();
+        if let Some(weight) = engine.cached_basis_weight() {
+            eviction.add_weight(weight);
+        }
+        engine.invalidate();
+        eviction
     }
 
     fn touch(&mut self, namespace_id: &NamespaceId) {
         self.order.retain(|candidate| candidate != namespace_id);
         self.order.push_back(namespace_id.clone());
     }
+}
+
+fn combined_cached_basis_totals(
+    basis_cache: &BasisCache,
+    commit_engines: &CommitEngineCache,
+) -> (usize, usize, usize) {
+    let (basis_count, basis_rows, basis_decoded_bytes) = basis_cache.cached_totals();
+    let (engine_count, engine_rows, engine_decoded_bytes) = commit_engines.cached_basis_totals();
+    (
+        basis_count.saturating_add(engine_count),
+        basis_rows.saturating_add(engine_rows),
+        basis_decoded_bytes.saturating_add(engine_decoded_bytes),
+    )
 }
 
 #[derive(Debug, Default)]
@@ -455,6 +641,15 @@ struct CachedControl<T> {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuntimeCacheStats {
+    pub warm_basis_cache_hits: usize,
+    pub warm_basis_cache_misses: usize,
+    pub warm_basis_evictions: usize,
+    pub warm_basis_evicted_rows: usize,
+    pub warm_basis_evicted_decoded_bytes: usize,
+    pub warm_basis_cached_rows: usize,
+    pub warm_basis_cached_decoded_bytes: usize,
+    pub warm_basis_rehydrate_count: usize,
+    pub warm_basis_rehydrate_ms: usize,
     pub publish_warm_basis_hits: usize,
     pub publish_warm_basis_misses: usize,
     pub publish_warm_basis_invalidations: usize,
@@ -469,6 +664,15 @@ pub struct RuntimeCacheStats {
 
 #[derive(Debug, Default)]
 struct RuntimeCacheStatsInner {
+    warm_basis_cache_hits: AtomicUsize,
+    warm_basis_cache_misses: AtomicUsize,
+    warm_basis_evictions: AtomicUsize,
+    warm_basis_evicted_rows: AtomicUsize,
+    warm_basis_evicted_decoded_bytes: AtomicUsize,
+    warm_basis_cached_rows: AtomicUsize,
+    warm_basis_cached_decoded_bytes: AtomicUsize,
+    warm_basis_rehydrate_count: AtomicUsize,
+    warm_basis_rehydrate_ms: AtomicUsize,
     publish_warm_basis_hits: AtomicUsize,
     publish_warm_basis_misses: AtomicUsize,
     publish_warm_basis_invalidations: AtomicUsize,
@@ -483,6 +687,19 @@ impl RuntimeCacheStatsInner {
         metadata_table_cache: loon_core::MetadataTableCacheStats,
     ) -> RuntimeCacheStats {
         RuntimeCacheStats {
+            warm_basis_cache_hits: self.warm_basis_cache_hits.load(Ordering::SeqCst),
+            warm_basis_cache_misses: self.warm_basis_cache_misses.load(Ordering::SeqCst),
+            warm_basis_evictions: self.warm_basis_evictions.load(Ordering::SeqCst),
+            warm_basis_evicted_rows: self.warm_basis_evicted_rows.load(Ordering::SeqCst),
+            warm_basis_evicted_decoded_bytes: self
+                .warm_basis_evicted_decoded_bytes
+                .load(Ordering::SeqCst),
+            warm_basis_cached_rows: self.warm_basis_cached_rows.load(Ordering::SeqCst),
+            warm_basis_cached_decoded_bytes: self
+                .warm_basis_cached_decoded_bytes
+                .load(Ordering::SeqCst),
+            warm_basis_rehydrate_count: self.warm_basis_rehydrate_count.load(Ordering::SeqCst),
+            warm_basis_rehydrate_ms: self.warm_basis_rehydrate_ms.load(Ordering::SeqCst),
             publish_warm_basis_hits: self.publish_warm_basis_hits.load(Ordering::SeqCst),
             publish_warm_basis_misses: self.publish_warm_basis_misses.load(Ordering::SeqCst),
             publish_warm_basis_invalidations: self
@@ -501,9 +718,11 @@ impl RuntimeCacheStatsInner {
     fn record_publish_result(&self, result: &NamespaceCommitEnginePublishResult) {
         match result.basis_reuse_event {
             BasisReuseEvent::ReusedAfterHeadEtagMatch => {
+                self.warm_basis_cache_hits.fetch_add(1, Ordering::SeqCst);
                 self.publish_warm_basis_hits.fetch_add(1, Ordering::SeqCst);
             }
             BasisReuseEvent::ColdLoaded | BasisReuseEvent::InvalidatedThenColdLoaded => {
+                self.warm_basis_cache_misses.fetch_add(1, Ordering::SeqCst);
                 self.publish_warm_basis_misses
                     .fetch_add(1, Ordering::SeqCst);
             }
@@ -519,6 +738,43 @@ impl RuntimeCacheStatsInner {
             self.publish_warm_basis_advances
                 .fetch_add(1, Ordering::SeqCst);
         }
+    }
+
+    fn record_warm_basis_hit(&self) {
+        self.warm_basis_cache_hits.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record_warm_basis_miss(&self) {
+        self.warm_basis_cache_misses.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record_warm_basis_rehydrate(&self, elapsed_ms: usize) {
+        self.warm_basis_rehydrate_count
+            .fetch_add(1, Ordering::SeqCst);
+        self.warm_basis_rehydrate_ms
+            .fetch_add(elapsed_ms, Ordering::SeqCst);
+    }
+
+    fn record_warm_basis_cache_update(&self, update: BasisCacheUpdate) {
+        self.record_warm_basis_eviction(update.eviction);
+    }
+
+    fn set_warm_basis_cached_weight(&self, rows: usize, decoded_bytes: usize) {
+        self.warm_basis_cached_rows.store(rows, Ordering::SeqCst);
+        self.warm_basis_cached_decoded_bytes
+            .store(decoded_bytes, Ordering::SeqCst);
+    }
+
+    fn record_warm_basis_eviction(&self, eviction: BasisCacheEviction) {
+        if eviction.count == 0 {
+            return;
+        }
+        self.warm_basis_evictions
+            .fetch_add(eviction.count, Ordering::SeqCst);
+        self.warm_basis_evicted_rows
+            .fetch_add(eviction.rows, Ordering::SeqCst);
+        self.warm_basis_evicted_decoded_bytes
+            .fetch_add(eviction.decoded_bytes, Ordering::SeqCst);
     }
 
     fn record_metadata_read_source(&self, source: loon_core::MetadataReadSource) {
@@ -1354,7 +1610,7 @@ impl Fs {
                     .verified_basis_cache_update
                     .verified_basis_to_cache()
                 {
-                    self.cache_basis(Arc::new(basis.clone()));
+                    self.cache_basis(basis);
                 } else if publish.verified_basis_cache_update.is_invalidated() {
                     self.invalidate_namespace_cache(namespace_id);
                 }
@@ -1516,8 +1772,13 @@ impl Fs {
                 ControlObjectLoadError::MissingObject { .. }
                 | ControlObjectLoadError::MissingObjectAfterHead { .. },
             ) => {
+                self.inner.cache_stats.record_warm_basis_miss();
+                let started = std::time::Instant::now();
                 let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
                     .map_err(CoreError::from)?;
+                self.inner
+                    .cache_stats
+                    .record_warm_basis_rehydrate(elapsed_ms_usize(started));
                 let head = CachedControl {
                     identity: ControlObjectIdentity {
                         etag: basis.head_etag.clone(),
@@ -1559,8 +1820,13 @@ impl Fs {
     }
 
     fn commit_engine_cache_enabled(&self) -> bool {
+        self.basis_cache_enabled()
+    }
+
+    fn basis_cache_enabled(&self) -> bool {
         let cache_config = &self.inner.config.runtime_cache;
-        cache_config.basis_cache_enabled && cache_config.max_cached_namespaces > 0
+        cache_config.basis_cache_enabled
+            && BasisCacheLimits::from_config(cache_config).basis_cache_enabled()
     }
 
     fn commit_engine(&self, namespace_id: &NamespaceId) -> Arc<Mutex<NamespaceCommitEngine>> {
@@ -1573,12 +1839,15 @@ impl Fs {
     }
 
     fn basis_for_read(&self, namespace_id: &NamespaceId) -> Result<Arc<VerifiedNamespaceBasis>> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
-            return Ok(Arc::new(
-                loon_core::load_verified_namespace_basis(self.store(), namespace_id)
-                    .map_err(CoreError::from)?,
-            ));
+        if !self.basis_cache_enabled() {
+            self.inner.cache_stats.record_warm_basis_miss();
+            let started = std::time::Instant::now();
+            let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
+                .map_err(CoreError::from)?;
+            self.inner
+                .cache_stats
+                .record_warm_basis_rehydrate(elapsed_ms_usize(started));
+            return Ok(Arc::new(basis));
         }
 
         let cached = self
@@ -1596,6 +1865,7 @@ impl Fs {
                         // verified; the cache itself is not authoritative.
                         tracing::Span::current()
                             .record("cache_path", trace::CachePath::WarmReuse.as_str());
+                        self.inner.cache_stats.record_warm_basis_hit();
                         return Ok(basis.basis_arc());
                     }
                     Ok(_) | Err(_) => {
@@ -1610,6 +1880,7 @@ impl Fs {
                         // verified; the cache itself is not authoritative.
                         tracing::Span::current()
                             .record("cache_path", trace::CachePath::EtagProbe.as_str());
+                        self.inner.cache_stats.record_warm_basis_hit();
                         return Ok(basis.basis_arc());
                     }
                     Ok(_) | Err(_) => {
@@ -1619,8 +1890,13 @@ impl Fs {
             }
         }
 
+        self.inner.cache_stats.record_warm_basis_miss();
+        let started = std::time::Instant::now();
         let basis = loon_core::load_verified_namespace_basis(self.store(), namespace_id)
             .map_err(CoreError::from)?;
+        self.inner
+            .cache_stats
+            .record_warm_basis_rehydrate(elapsed_ms_usize(started));
         tracing::Span::current().record("cache_path", trace::CachePath::ColdReconstruct.as_str());
         let basis = Arc::new(basis);
         self.cache_basis(Arc::clone(&basis));
@@ -1632,8 +1908,7 @@ impl Fs {
         namespace_id: &NamespaceId,
         head: &CachedControl<HeadState>,
     ) -> Result<Arc<VerifiedNamespaceBasis>> {
-        let cache_config = &self.inner.config.runtime_cache;
-        if cache_config.basis_cache_enabled && cache_config.max_cached_namespaces > 0 {
+        if self.basis_cache_enabled() {
             let cached = self
                 .inner
                 .basis_cache
@@ -1644,12 +1919,15 @@ impl Fs {
                 if basis.matches_head_etag(&head.identity.etag) {
                     tracing::Span::current()
                         .record("cache_path", trace::CachePath::WarmReuse.as_str());
+                    self.inner.cache_stats.record_warm_basis_hit();
                     return Ok(basis.basis_arc());
                 }
                 self.invalidate_namespace_cache(namespace_id);
             }
         }
 
+        self.inner.cache_stats.record_warm_basis_miss();
+        let started = std::time::Instant::now();
         let basis = loon_core::load_verified_namespace_basis_at_head(
             self.store(),
             namespace_id,
@@ -1657,6 +1935,9 @@ impl Fs {
             head.identity.etag.clone(),
         )
         .map_err(CoreError::from)?;
+        self.inner
+            .cache_stats
+            .record_warm_basis_rehydrate(elapsed_ms_usize(started));
         tracing::Span::current().record("cache_path", trace::CachePath::ColdReconstruct.as_str());
         let basis = Arc::new(basis);
         self.cache_basis(Arc::clone(&basis));
@@ -1671,14 +1952,19 @@ impl Fs {
     )]
     fn cache_basis(&self, basis: Arc<VerifiedNamespaceBasis>) {
         let cache_config = &self.inner.config.runtime_cache;
-        if !cache_config.basis_cache_enabled || cache_config.max_cached_namespaces == 0 {
+        if !self.basis_cache_enabled() {
             return;
         }
-        self.inner
+        let update = self
+            .inner
             .basis_cache
             .lock()
             .expect("basis cache lock poisoned")
-            .insert(basis, cache_config.max_cached_namespaces);
+            .insert(basis, BasisCacheLimits::from_config(cache_config));
+        self.inner
+            .cache_stats
+            .record_warm_basis_cache_update(update);
+        self.prune_warm_basis_budget();
     }
 
     #[tracing::instrument(
@@ -1688,7 +1974,8 @@ impl Fs {
         fields(phase = "update_cache")
     )]
     fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
-        self.inner
+        let basis_update = self
+            .inner
             .basis_cache
             .lock()
             .expect("basis cache lock poisoned")
@@ -1698,11 +1985,91 @@ impl Fs {
             .lock()
             .expect("control cache lock poisoned")
             .invalidate_namespace(namespace_id);
-        self.inner
+        let engine_eviction = self
+            .inner
             .commit_engines
             .lock()
             .expect("commit engine cache lock poisoned")
             .invalidate(namespace_id);
+        self.inner
+            .cache_stats
+            .record_warm_basis_cache_update(basis_update);
+        self.inner
+            .cache_stats
+            .record_warm_basis_eviction(engine_eviction);
+        self.refresh_warm_basis_cached_weight();
+    }
+
+    fn prune_warm_basis_budget(&self) {
+        if !self.basis_cache_enabled() {
+            return;
+        }
+        let limits = BasisCacheLimits::from_config(&self.inner.config.runtime_cache);
+        loop {
+            let over_budget = {
+                let basis_cache = self
+                    .inner
+                    .basis_cache
+                    .lock()
+                    .expect("basis cache lock poisoned");
+                let commit_engines = self
+                    .inner
+                    .commit_engines
+                    .lock()
+                    .expect("commit engine cache lock poisoned");
+                let (count, rows, decoded_bytes) =
+                    combined_cached_basis_totals(&basis_cache, &commit_engines);
+                limits.is_over_budget(count, rows, decoded_bytes)
+            };
+            if !over_budget {
+                break;
+            }
+
+            let basis_eviction = self
+                .inner
+                .basis_cache
+                .lock()
+                .expect("basis cache lock poisoned")
+                .prune_one_lru();
+            if basis_eviction.count > 0 {
+                self.inner
+                    .cache_stats
+                    .record_warm_basis_eviction(basis_eviction);
+                continue;
+            }
+
+            let engine_eviction = self
+                .inner
+                .commit_engines
+                .lock()
+                .expect("commit engine cache lock poisoned")
+                .prune_one_lru();
+            if engine_eviction.count == 0 {
+                break;
+            }
+            self.inner
+                .cache_stats
+                .record_warm_basis_eviction(engine_eviction);
+        }
+
+        self.refresh_warm_basis_cached_weight();
+    }
+
+    fn refresh_warm_basis_cached_weight(&self) {
+        let basis_cache = self
+            .inner
+            .basis_cache
+            .lock()
+            .expect("basis cache lock poisoned");
+        let commit_engines = self
+            .inner
+            .commit_engines
+            .lock()
+            .expect("commit engine cache lock poisoned");
+        let (_, rows, decoded_bytes) = combined_cached_basis_totals(&basis_cache, &commit_engines);
+        self.inner
+            .cache_stats
+            .set_warm_basis_cached_weight(rows, decoded_bytes);
     }
 
     fn finish_namespace_mutation<T>(
@@ -1794,6 +2161,10 @@ fn current_time_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+fn elapsed_ms_usize(started: std::time::Instant) -> usize {
+    usize::try_from(started.elapsed().as_millis()).unwrap_or(usize::MAX)
 }
 
 #[cfg(test)]

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -483,6 +483,15 @@ fn runtime_basis_cache_skips_oversized_basis() {
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_cache_misses, 2);
     assert_eq!(stats.warm_basis_cache_hits, 0);
+    assert_eq!(stats.warm_basis_uncacheable_count, 2);
+    assert_eq!(
+        stats.warm_basis_uncacheable_rows,
+        basis_weight.rows.saturating_mul(2)
+    );
+    assert_eq!(
+        stats.warm_basis_uncacheable_decoded_bytes,
+        basis_weight.decoded_bytes.saturating_mul(2)
+    );
     assert_eq!(stats.warm_basis_cached_rows, 0);
     assert_eq!(stats.warm_basis_cached_decoded_bytes, 0);
 }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -324,6 +324,170 @@ fn runtime_cache_can_be_disabled() {
 }
 
 #[test]
+fn runtime_basis_cache_evicts_by_namespace_count() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = Fs::builder(store(temp_dir.path()))
+        .writer_id("basis-count-budget")
+        .runtime_cache(RuntimeCacheConfig {
+            max_cached_namespaces: 1,
+            ..RuntimeCacheConfig::default()
+        })
+        .build()
+        .expect("build runtime");
+    let first = NamespaceId::parse("first").expect("valid namespace id");
+    let second = NamespaceId::parse("second").expect("valid namespace id");
+    fs.create_namespace(&first, CreateNamespaceOptions::default())
+        .expect("create first namespace");
+    fs.create_namespace(&second, CreateNamespaceOptions::default())
+        .expect("create second namespace");
+
+    fs.stat_path(&first, "/").expect("cache first basis");
+    fs.stat_path(&second, "/")
+        .expect("cache second basis and evict first");
+    let after_second = fs.runtime_cache_stats();
+    assert_eq!(after_second.warm_basis_evictions, 1);
+    assert_eq!(after_second.warm_basis_cached_rows, 1);
+
+    fs.stat_path(&first, "/")
+        .expect("first basis rehydrates after eviction");
+    let after_reload = fs.runtime_cache_stats();
+    assert_eq!(after_reload.warm_basis_cache_misses, 3);
+    assert_eq!(after_reload.warm_basis_evictions, 2);
+}
+
+#[test]
+fn runtime_basis_cache_evicts_by_row_budget() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = Fs::builder(store(temp_dir.path()))
+        .writer_id("basis-row-budget")
+        .runtime_cache(RuntimeCacheConfig {
+            max_cached_basis_rows: 1,
+            max_cached_basis_decoded_bytes: None,
+            ..RuntimeCacheConfig::default()
+        })
+        .build()
+        .expect("build runtime");
+    let first = NamespaceId::parse("row-one").expect("valid namespace id");
+    let second = NamespaceId::parse("row-two").expect("valid namespace id");
+    fs.create_namespace(&first, CreateNamespaceOptions::default())
+        .expect("create first namespace");
+    fs.create_namespace(&second, CreateNamespaceOptions::default())
+        .expect("create second namespace");
+
+    fs.stat_path(&first, "/").expect("cache first basis");
+    fs.stat_path(&second, "/")
+        .expect("cache second basis and evict first by rows");
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.warm_basis_evictions, 1);
+    assert_eq!(stats.warm_basis_evicted_rows, 1);
+    assert_eq!(stats.warm_basis_cached_rows, 1);
+}
+
+#[test]
+fn runtime_basis_budget_includes_commit_engine_bases() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("combined-budget").expect("valid namespace id");
+    let fs = Fs::builder(store(temp_dir.path()))
+        .writer_id("combined-basis-budget")
+        .runtime_cache(RuntimeCacheConfig {
+            max_cached_basis_rows: 2,
+            max_cached_basis_decoded_bytes: None,
+            ..RuntimeCacheConfig::default()
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.stat_path(&namespace_id, "/").expect("cache read basis");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+        &namespace_id,
+        vec![create_dir_candidate("combined-budget-create-docs", "/docs")],
+    ));
+
+    let stats = fs.runtime_cache_stats();
+    assert!(stats.warm_basis_evictions > 0);
+    assert!(stats.warm_basis_cached_rows <= 2);
+
+    let misses_before = stats.warm_basis_cache_misses;
+    fs.stat_path(&namespace_id, "/docs")
+        .expect("read still works after aggregate budget pruning");
+    let stats = fs.runtime_cache_stats();
+    assert!(stats.warm_basis_cache_misses > misses_before);
+    assert!(stats.warm_basis_cached_rows <= 2);
+}
+
+#[test]
+fn runtime_basis_cache_evicts_by_decoded_byte_budget() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup = runtime(temp_dir.path(), "basis-byte-budget-setup");
+    let first = NamespaceId::parse("byte-one").expect("valid namespace id");
+    let second = NamespaceId::parse("byte-two").expect("valid namespace id");
+    setup
+        .create_namespace(&first, CreateNamespaceOptions::default())
+        .expect("create first namespace");
+    setup
+        .create_namespace(&second, CreateNamespaceOptions::default())
+        .expect("create second namespace");
+    let raw_store = store(temp_dir.path());
+    let basis_weight = loon_core::load_verified_namespace_basis(raw_store.as_ref(), &first)
+        .expect("load basis")
+        .weight();
+    assert!(basis_weight.decoded_bytes > 1);
+
+    let fs = Fs::builder(raw_store)
+        .writer_id("basis-byte-budget")
+        .runtime_cache(RuntimeCacheConfig {
+            max_cached_basis_decoded_bytes: Some(basis_weight.decoded_bytes),
+            ..RuntimeCacheConfig::default()
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.stat_path(&first, "/").expect("cache first basis");
+    fs.stat_path(&second, "/")
+        .expect("cache second basis and evict first by bytes");
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.warm_basis_evictions, 1);
+    assert!(stats.warm_basis_evicted_decoded_bytes >= basis_weight.decoded_bytes);
+    assert_eq!(stats.warm_basis_cached_rows, basis_weight.rows);
+}
+
+#[test]
+fn runtime_basis_cache_skips_oversized_basis() {
+    let temp_dir = tempdir().expect("tempdir");
+    let setup = runtime(temp_dir.path(), "basis-oversized-setup");
+    let namespace_id = namespace();
+    setup
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let raw_store = store(temp_dir.path());
+    let basis_weight = loon_core::load_verified_namespace_basis(raw_store.as_ref(), &namespace_id)
+        .expect("load basis")
+        .weight();
+    assert!(basis_weight.decoded_bytes > 1);
+
+    let fs = Fs::builder(raw_store)
+        .writer_id("basis-oversized")
+        .runtime_cache(RuntimeCacheConfig {
+            max_cached_basis_decoded_bytes: Some(basis_weight.decoded_bytes - 1),
+            ..RuntimeCacheConfig::default()
+        })
+        .build()
+        .expect("build runtime");
+
+    fs.stat_path(&namespace_id, "/")
+        .expect("first stat reconstructs oversized basis");
+    fs.stat_path(&namespace_id, "/")
+        .expect("second stat reconstructs oversized basis again");
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.warm_basis_cache_misses, 2);
+    assert_eq!(stats.warm_basis_cache_hits, 0);
+    assert_eq!(stats.warm_basis_cached_rows, 0);
+    assert_eq!(stats.warm_basis_cached_decoded_bytes, 0);
+}
+
+#[test]
 fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
@@ -991,10 +1155,8 @@ fn control_cache_eviction_reloads_head_for_basis_validation() {
     let fs = Fs::builder(object_store)
         .writer_id("control-cache-eviction-test")
         .runtime_cache(RuntimeCacheConfig {
-            basis_cache_enabled: true,
-            control_cache_enabled: true,
             max_cached_namespaces: 1,
-            metadata_table_cache: Default::default(),
+            ..RuntimeCacheConfig::default()
         })
         .build()
         .expect("build runtime");


### PR DESCRIPTION
Bounds warm-basis caching by namespace count, row count, and approximate decoded bytes, so that they don't grow forever and eat up all memory (and OOM). Also finishes current-head revision/receipt indexes and adds runtime cache stats/config knobs for benchmarking.