### PR TITLE
refactor(loon-core): replace read variants with options

### DIFF
--- a/crates/loon-core/src/engine.rs
+++ b/crates/loon-core/src/engine.rs
@@ -1,20 +1,22 @@
+use crate::basis::{load_verified_namespace_basis, VerifiedNamespaceBasis};
 use crate::context::MutationContext;
 use crate::error::Result as CoreResult;
 use crate::namespace::{lifecycle, BootstrapNamespaceError};
-use crate::options::{BootstrapOptions, CommitOptions, ForkOptions, ReadOptions, WriteOptions};
+use crate::options::{
+    BootstrapOptions, CommitOptions, ForkOptions, ReadOptions, ReadSource, WriteOptions,
+};
 use crate::publisher::NamespaceMutationCandidate;
-use crate::{basis::VerifiedNamespaceBasis, checkpoint::MetadataTableCache};
 use loon_api::v0::{
     BeginUploadResponse, ChangesResponse, CommitRequest, CommitResponse, CompleteUploadRequest,
     CompleteUploadResponse, UploadContentResponse,
 };
-use loon_api::wire::control::HeadState;
 use loon_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     ContentRef, CreateCheckpointResponse, InodeId, ListFileRevisionsResponse, MutationResult,
     NamespaceId, NamespaceSummary, RevisionNo,
 };
 use loon_objectstore::ObjectStore;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
@@ -110,144 +112,110 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     pub fn resolve_path(
         &self,
         path: impl AsRef<str>,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<AuthoritativePathEntry> {
-        crate::path::query::resolve_path(&self.store, &self.namespace_id, path.as_ref())
-    }
-
-    pub fn resolve_path_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        path: impl AsRef<str>,
-        _options: ReadOptions,
-    ) -> CoreResult<AuthoritativePathEntry> {
-        crate::path::query::resolve_path_from_basis(basis, path.as_ref())
-    }
-
-    pub fn resolve_path_from_materialized_tables_at_head(
-        &self,
-        head: &HeadState,
-        path: impl AsRef<str>,
-        table_cache: Option<&MetadataTableCache>,
-        _options: ReadOptions,
-    ) -> CoreResult<Option<AuthoritativePathEntry>> {
-        crate::path::query::resolve_path_from_materialized_tables_at_head_with_cache(
-            &self.store,
-            &self.namespace_id,
-            head,
-            path.as_ref(),
-            table_cache,
-        )
+        let path = path.as_ref();
+        match options.source() {
+            ReadSource::PreferMaterialized => {
+                if let Some(entry) = crate::path::query::resolve_path_from_materialized_tables(
+                    &self.store,
+                    &self.namespace_id,
+                    path,
+                )? {
+                    return Ok(entry);
+                }
+            }
+            ReadSource::MaterializedTablesAtHead { head, table_cache } => {
+                if let Some(entry) =
+                    crate::path::query::resolve_path_from_materialized_tables_at_head_with_cache(
+                        &self.store,
+                        &self.namespace_id,
+                        head,
+                        path,
+                        table_cache.as_deref(),
+                    )?
+                {
+                    return Ok(entry);
+                }
+            }
+            ReadSource::FullBasis | ReadSource::VerifiedBasis(_) => {}
+        }
+        let basis = self.basis_for_read_options(options)?;
+        crate::path::query::resolve_path_from_basis(&basis, path)
     }
 
     pub fn list_path(
         &self,
         path: impl AsRef<str>,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<Vec<AuthoritativePathEntry>> {
-        crate::path::query::list_path(&self.store, &self.namespace_id, path.as_ref())
-    }
-
-    pub fn list_path_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        path: impl AsRef<str>,
-        _options: ReadOptions,
-    ) -> CoreResult<Vec<AuthoritativePathEntry>> {
-        crate::path::query::list_path_from_basis(basis, path.as_ref())
-    }
-
-    pub fn list_path_from_materialized_tables_at_head(
-        &self,
-        head: &HeadState,
-        path: impl AsRef<str>,
-        table_cache: Option<&MetadataTableCache>,
-        _options: ReadOptions,
-    ) -> CoreResult<Option<Vec<AuthoritativePathEntry>>> {
-        crate::path::query::list_path_from_materialized_tables_at_head_with_cache(
-            &self.store,
-            &self.namespace_id,
-            head,
-            path.as_ref(),
-            table_cache,
-        )
+        let path = path.as_ref();
+        match options.source() {
+            ReadSource::PreferMaterialized => {
+                if let Some(entries) = crate::path::query::list_path_from_materialized_tables(
+                    &self.store,
+                    &self.namespace_id,
+                    path,
+                )? {
+                    return Ok(entries);
+                }
+            }
+            ReadSource::MaterializedTablesAtHead { head, table_cache } => {
+                if let Some(entries) =
+                    crate::path::query::list_path_from_materialized_tables_at_head_with_cache(
+                        &self.store,
+                        &self.namespace_id,
+                        head,
+                        path,
+                        table_cache.as_deref(),
+                    )?
+                {
+                    return Ok(entries);
+                }
+            }
+            ReadSource::FullBasis | ReadSource::VerifiedBasis(_) => {}
+        }
+        let basis = self.basis_for_read_options(options)?;
+        crate::path::query::list_path_from_basis(&basis, path)
     }
 
     pub fn read_file(
         &self,
         path: impl AsRef<str>,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<AuthoritativeFileBytes> {
-        crate::path::query::read_file_bytes(&self.store, &self.namespace_id, path.as_ref())
-    }
-
-    pub fn read_file_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        path: impl AsRef<str>,
-        _options: ReadOptions,
-    ) -> CoreResult<AuthoritativeFileBytes> {
-        crate::path::query::read_file_bytes_from_basis(&self.store, basis, path.as_ref())
+        let basis = self.basis_for_read_options(options)?;
+        crate::path::query::read_file_bytes_from_basis(&self.store, &basis, path.as_ref())
     }
 
     pub fn list_file_revisions(
         &self,
         path: impl AsRef<str>,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<ListFileRevisionsResponse> {
-        crate::path::query::list_file_revisions(&self.store, &self.namespace_id, path.as_ref())
-    }
-
-    pub fn list_file_revisions_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        path: impl AsRef<str>,
-        _options: ReadOptions,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        crate::path::query::list_file_revisions_from_basis(basis, path.as_ref())
+        let basis = self.basis_for_read_options(options)?;
+        crate::path::query::list_file_revisions_from_basis(&basis, path.as_ref())
     }
 
     pub fn list_file_revisions_for_inode(
         &self,
         inode_id: InodeId,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<ListFileRevisionsResponse> {
-        crate::path::query::list_file_revisions_for_inode(&self.store, &self.namespace_id, inode_id)
-    }
-
-    pub fn list_file_revisions_for_inode_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        inode_id: InodeId,
-        _options: ReadOptions,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        crate::path::query::list_file_revisions_for_inode_from_basis(basis, inode_id)
+        let basis = self.basis_for_read_options(options)?;
+        crate::path::query::list_file_revisions_for_inode_from_basis(&basis, inode_id)
     }
 
     pub fn read_file_revision(
         &self,
         path: impl AsRef<str>,
         revision_no: RevisionNo,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<AuthoritativeFileBytes> {
-        crate::path::query::read_file_revision_bytes(
-            &self.store,
-            &self.namespace_id,
-            path.as_ref(),
-            revision_no,
-        )
-    }
-
-    pub fn read_file_revision_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        path: impl AsRef<str>,
-        revision_no: RevisionNo,
-        _options: ReadOptions,
-    ) -> CoreResult<AuthoritativeFileBytes> {
+        let basis = self.basis_for_read_options(options)?;
         crate::path::query::read_file_revision_bytes_from_basis(
             &self.store,
-            basis,
+            &basis,
             path.as_ref(),
             revision_no,
         )
@@ -257,26 +225,12 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         &self,
         inode_id: InodeId,
         revision_no: RevisionNo,
-        _options: ReadOptions,
+        options: ReadOptions,
     ) -> CoreResult<Vec<u8>> {
-        crate::path::query::read_file_revision_bytes_for_inode(
-            &self.store,
-            &self.namespace_id,
-            inode_id,
-            revision_no,
-        )
-    }
-
-    pub fn read_file_revision_for_inode_from_basis(
-        &self,
-        basis: &VerifiedNamespaceBasis,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-        _options: ReadOptions,
-    ) -> CoreResult<Vec<u8>> {
+        let basis = self.basis_for_read_options(options)?;
         crate::path::query::read_file_revision_bytes_for_inode_from_basis(
             &self.store,
-            basis,
+            &basis,
             inode_id,
             revision_no,
         )
@@ -514,6 +468,20 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    fn basis_for_read_options(
+        &self,
+        options: ReadOptions,
+    ) -> CoreResult<Arc<VerifiedNamespaceBasis>> {
+        match options.into_source() {
+            ReadSource::VerifiedBasis(basis) => Ok(basis),
+            ReadSource::PreferMaterialized
+            | ReadSource::FullBasis
+            | ReadSource::MaterializedTablesAtHead { .. } => Ok(Arc::new(
+                load_verified_namespace_basis(&self.store, &self.namespace_id)?,
+            )),
+        }
+    }
+
     fn mutation_context(&self) -> MutationContext {
         MutationContext {
             writer_id: self.writer_id.clone(),
@@ -644,7 +612,10 @@ mod tests {
         assert_eq!(engine.writer_id(), "writer-a");
         assert!(!engine.writer_version().is_empty());
         assert_eq!(engine.lease_duration_ms(), DEFAULT_LEASE_DURATION_MS);
-        assert_eq!(engine.read_options(), &ReadOptions::default());
+        assert!(matches!(
+            engine.read_options().source(),
+            ReadSource::PreferMaterialized
+        ));
         assert_eq!(engine.write_options(), &WriteOptions::default());
         assert_eq!(engine.commit_options(), &CommitOptions::default());
     }

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -55,5 +55,7 @@ pub use context::MutationContext;
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{Error, ErrorCode, ErrorKind, Result};
 pub use namespace::{list_namespaces, BootstrapNamespaceError};
-pub use options::{BootstrapOptions, CommitOptions, ForkOptions, ReadOptions, WriteOptions};
+pub use options::{
+    BootstrapOptions, CommitOptions, ForkOptions, ReadOptions, ReadSource, WriteOptions,
+};
 pub use path::intent::PutFileBehavior;

--- a/crates/loon-core/src/options.rs
+++ b/crates/loon-core/src/options.rs
@@ -1,5 +1,9 @@
-use crate::path::intent::PutFileBehavior;
+use crate::{
+    basis::VerifiedNamespaceBasis, checkpoint::MetadataTableCache, path::intent::PutFileBehavior,
+};
+use loon_api::wire::control::HeadState;
 use loon_api::CommitId;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BootstrapOptions {
@@ -9,8 +13,64 @@ pub struct BootstrapOptions {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ForkOptions {}
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ReadOptions {}
+#[derive(Debug, Clone)]
+pub struct ReadOptions {
+    source: ReadSource,
+}
+
+impl ReadOptions {
+    pub fn prefer_materialized() -> Self {
+        Self {
+            source: ReadSource::PreferMaterialized,
+        }
+    }
+
+    pub fn full_basis() -> Self {
+        Self {
+            source: ReadSource::FullBasis,
+        }
+    }
+
+    pub fn verified_basis(basis: Arc<VerifiedNamespaceBasis>) -> Self {
+        Self {
+            source: ReadSource::VerifiedBasis(basis),
+        }
+    }
+
+    pub fn materialized_tables_at_head(
+        head: HeadState,
+        table_cache: Option<Arc<MetadataTableCache>>,
+    ) -> Self {
+        Self {
+            source: ReadSource::MaterializedTablesAtHead { head, table_cache },
+        }
+    }
+
+    pub fn source(&self) -> &ReadSource {
+        &self.source
+    }
+
+    pub(crate) fn into_source(self) -> ReadSource {
+        self.source
+    }
+}
+
+impl Default for ReadOptions {
+    fn default() -> Self {
+        Self::prefer_materialized()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ReadSource {
+    PreferMaterialized,
+    FullBasis,
+    VerifiedBasis(Arc<VerifiedNamespaceBasis>),
+    MaterializedTablesAtHead {
+        head: HeadState,
+        table_cache: Option<Arc<MetadataTableCache>>,
+    },
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteOptions {

--- a/crates/loon-core/src/path/query.rs
+++ b/crates/loon-core/src/path/query.rs
@@ -1,5 +1,5 @@
 use super::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
-use crate::basis::{load_verified_namespace_basis, BasisLoadError, VerifiedNamespaceBasis};
+use crate::basis::{BasisLoadError, VerifiedNamespaceBasis};
 use crate::checkpoint::{
     checkpoint_basis_head, load_verified_checkpoint_tables_with_cache, CheckpointLoadError,
     MetadataTableCache, VerifiedCheckpointTables,
@@ -25,19 +25,6 @@ use loon_api::{
 };
 use loon_objectstore::ObjectStore;
 
-pub(crate) fn resolve_path<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-) -> Result<AuthoritativePathEntry, CoreError> {
-    if let Some(entry) = resolve_path_from_materialized_tables(store, namespace_id, absolute_path)?
-    {
-        return Ok(entry);
-    }
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    resolve_path_from_basis(&basis, absolute_path)
-}
-
 #[tracing::instrument(
     level = "info",
     name = "loon.phase",
@@ -61,18 +48,6 @@ pub(crate) fn resolve_path_from_basis(
         &basis.metadata_state,
         &resolved,
     )
-}
-
-pub(crate) fn list_path<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
-    if let Some(entries) = list_path_from_materialized_tables(store, namespace_id, absolute_path)? {
-        return Ok(entries);
-    }
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    list_path_from_basis(&basis, absolute_path)
 }
 
 #[tracing::instrument(
@@ -135,17 +110,6 @@ pub(crate) fn list_path_from_basis(
         .collect()
 }
 
-pub(crate) fn resolve_path_from_materialized_tables<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-) -> Result<Option<AuthoritativePathEntry>, CoreError> {
-    let Some(view) = MaterializedLatestView::load(store, namespace_id)? else {
-        return Ok(None);
-    };
-    Ok(Some(view.resolve_path(absolute_path)?))
-}
-
 pub(crate) fn resolve_path_from_materialized_tables_at_head_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -165,15 +129,15 @@ pub(crate) fn resolve_path_from_materialized_tables_at_head_with_cache<S: Object
     Ok(Some(view.resolve_path(absolute_path)?))
 }
 
-pub(crate) fn list_path_from_materialized_tables<S: ObjectStore + ?Sized>(
+pub(crate) fn resolve_path_from_materialized_tables<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     absolute_path: &str,
-) -> Result<Option<Vec<AuthoritativePathEntry>>, CoreError> {
+) -> Result<Option<AuthoritativePathEntry>, CoreError> {
     let Some(view) = MaterializedLatestView::load(store, namespace_id)? else {
         return Ok(None);
     };
-    Ok(Some(view.list_path(absolute_path)?))
+    Ok(Some(view.resolve_path(absolute_path)?))
 }
 
 pub(crate) fn list_path_from_materialized_tables_at_head_with_cache<S: ObjectStore + ?Sized>(
@@ -190,6 +154,17 @@ pub(crate) fn list_path_from_materialized_tables_at_head_with_cache<S: ObjectSto
         table_cache,
     )?
     else {
+        return Ok(None);
+    };
+    Ok(Some(view.list_path(absolute_path)?))
+}
+
+pub(crate) fn list_path_from_materialized_tables<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+) -> Result<Option<Vec<AuthoritativePathEntry>>, CoreError> {
+    let Some(view) = MaterializedLatestView::load(store, namespace_id)? else {
         return Ok(None);
     };
     Ok(Some(view.list_path(absolute_path)?))
@@ -854,15 +829,6 @@ fn unbind_matches_binding(unbind: &DirentryUnbindRecord, direntry: &DirentryBind
         && unbind.bind_delta_index == direntry.bind_delta_index
 }
 
-pub(crate) fn read_file_bytes<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-) -> Result<AuthoritativeFileBytes, CoreError> {
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    read_file_bytes_from_basis(store, &basis, absolute_path)
-}
-
 pub(crate) fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
     store: &S,
     basis: &VerifiedNamespaceBasis,
@@ -886,15 +852,6 @@ pub(crate) fn read_file_bytes_from_basis<S: ObjectStore + ?Sized>(
     })
 }
 
-pub(crate) fn list_file_revisions<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-) -> Result<ListFileRevisionsResponse, CoreError> {
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    list_file_revisions_from_basis(&basis, absolute_path)
-}
-
 pub(crate) fn list_file_revisions_from_basis(
     basis: &VerifiedNamespaceBasis,
     absolute_path: &str,
@@ -907,15 +864,6 @@ pub(crate) fn list_file_revisions_from_basis(
         });
     }
     list_file_revisions_for_inode_from_basis(basis, entry.inode_id)
-}
-
-pub(crate) fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    inode_id: InodeId,
-) -> Result<ListFileRevisionsResponse, CoreError> {
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    list_file_revisions_for_inode_from_basis(&basis, inode_id)
 }
 
 pub(crate) fn list_file_revisions_for_inode_from_basis(
@@ -957,16 +905,6 @@ pub(crate) fn list_file_revisions_for_inode_from_basis(
     })
 }
 
-pub(crate) fn read_file_revision_bytes<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    absolute_path: &str,
-    revision_no: RevisionNo,
-) -> Result<AuthoritativeFileBytes, CoreError> {
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    read_file_revision_bytes_from_basis(store, &basis, absolute_path, revision_no)
-}
-
 pub(crate) fn read_file_revision_bytes_from_basis<S: ObjectStore + ?Sized>(
     store: &S,
     basis: &VerifiedNamespaceBasis,
@@ -989,16 +927,6 @@ pub(crate) fn read_file_revision_bytes_from_basis<S: ObjectStore + ?Sized>(
         entry,
         bytes: read.bytes,
     })
-}
-
-pub(crate) fn read_file_revision_bytes_for_inode<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    inode_id: InodeId,
-    revision_no: RevisionNo,
-) -> Result<Vec<u8>, CoreError> {
-    let basis = load_verified_namespace_basis(store, namespace_id)?;
-    read_file_revision_bytes_for_inode_from_basis(store, &basis, inode_id, revision_no)
 }
 
 pub(crate) fn read_file_revision_bytes_for_inode_from_basis<S: ObjectStore + ?Sized>(

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -36,7 +36,7 @@ use loon_objectstore::keys::{
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -397,7 +397,7 @@ fn read_file_revision_bytes_for_inode<S: ObjectStore + ?Sized>(
     )
 }
 
-fn resolve_path_from_basis(
+fn resolve_path_using_basis_option(
     basis: &VerifiedNamespaceBasis,
     absolute_path: &str,
 ) -> Result<loon_api::AuthoritativePathEntry, CoreError> {
@@ -408,10 +408,13 @@ fn resolve_path_from_basis(
         .writer("test")
         .build()
         .expect("test engine")
-        .resolve_path_from_basis(basis, absolute_path, ReadOptions::default())
+        .resolve_path(
+            absolute_path,
+            ReadOptions::verified_basis(Arc::new(basis.clone())),
+        )
 }
 
-fn list_path_from_basis(
+fn list_path_using_basis_option(
     basis: &VerifiedNamespaceBasis,
     absolute_path: &str,
 ) -> Result<Vec<loon_api::AuthoritativePathEntry>, CoreError> {
@@ -422,7 +425,10 @@ fn list_path_from_basis(
         .writer("test")
         .build()
         .expect("test engine")
-        .list_path_from_basis(basis, absolute_path, ReadOptions::default())
+        .list_path(
+            absolute_path,
+            ReadOptions::verified_basis(Arc::new(basis.clone())),
+        )
 }
 
 fn resolve_path_with_read_source<S: ObjectStore + ?Sized>(
@@ -435,21 +441,18 @@ fn resolve_path_with_read_source<S: ObjectStore + ?Sized>(
         .map_err(BasisLoadError::LoadHead)?
         .state;
     if head.checkpoint_hint_seq.is_some() {
-        if let Some(value) = engine.resolve_path_from_materialized_tables_at_head(
-            &head,
+        let value = engine.resolve_path(
             absolute_path,
-            None,
-            ReadOptions::default(),
-        )? {
-            return Ok(MetadataRead {
-                value,
-                source: MetadataReadSource::MaterializedTables,
-            });
-        }
+            ReadOptions::materialized_tables_at_head(head.clone(), None),
+        )?;
+        return Ok(MetadataRead {
+            value,
+            source: MetadataReadSource::MaterializedTables,
+        });
     }
     let basis = load_verified_namespace_basis(store, namespace_id)?;
     Ok(MetadataRead {
-        value: engine.resolve_path_from_basis(&basis, absolute_path, ReadOptions::default())?,
+        value: engine.resolve_path(absolute_path, ReadOptions::verified_basis(Arc::new(basis)))?,
         source: MetadataReadSource::FullBasisFallback,
     })
 }
@@ -464,21 +467,18 @@ fn list_path_with_read_source<S: ObjectStore + ?Sized>(
         .map_err(BasisLoadError::LoadHead)?
         .state;
     if head.checkpoint_hint_seq.is_some() {
-        if let Some(value) = engine.list_path_from_materialized_tables_at_head(
-            &head,
+        let value = engine.list_path(
             absolute_path,
-            None,
-            ReadOptions::default(),
-        )? {
-            return Ok(MetadataRead {
-                value,
-                source: MetadataReadSource::MaterializedTables,
-            });
-        }
+            ReadOptions::materialized_tables_at_head(head.clone(), None),
+        )?;
+        return Ok(MetadataRead {
+            value,
+            source: MetadataReadSource::MaterializedTables,
+        });
     }
     let basis = load_verified_namespace_basis(store, namespace_id)?;
     Ok(MetadataRead {
-        value: engine.list_path_from_basis(&basis, absolute_path, ReadOptions::default())?,
+        value: engine.list_path(absolute_path, ReadOptions::verified_basis(Arc::new(basis)))?,
         source: MetadataReadSource::FullBasisFallback,
     })
 }
@@ -1530,10 +1530,11 @@ fn query_driven_stat_and_list_match_full_basis_with_l0_run_and_wal_overlay() {
     .expect("put wal tail");
 
     let basis = load_verified_namespace_basis(&store, &namespace_id).expect("basis");
-    let expected_stat = resolve_path_from_basis(&basis, "/docs/moved.txt").expect("basis stat");
-    let expected_list = list_path_from_basis(&basis, "/docs").expect("basis list");
+    let expected_stat =
+        resolve_path_using_basis_option(&basis, "/docs/moved.txt").expect("basis stat");
+    let expected_list = list_path_using_basis_option(&basis, "/docs").expect("basis list");
     let expected_file_list =
-        list_path_from_basis(&basis, "/docs/moved.txt").expect("basis file list");
+        list_path_using_basis_option(&basis, "/docs/moved.txt").expect("basis file list");
 
     store.reset_content_blob_get_count();
     let actual_stat = resolve_path_with_read_source(&store, &namespace_id, "/docs/moved.txt")
@@ -1597,7 +1598,7 @@ fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
     create_checkpoint(&store, &namespace_id, &context).expect("checkpoint");
 
     let basis = load_verified_namespace_basis(&store, &namespace_id).expect("basis");
-    let expected = resolve_path_from_basis(&basis, "/docs/report").expect("basis stat");
+    let expected = resolve_path_using_basis_option(&basis, "/docs/report").expect("basis stat");
     let actual = resolve_path_with_read_source(&store, &namespace_id, "/docs/report")
         .expect("materialized stat");
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -144,7 +144,7 @@ struct FsInner {
     basis_cache: Mutex<BasisCache>,
     commit_engines: Mutex<CommitEngineCache>,
     control_cache: Mutex<RuntimeControlCache>,
-    metadata_table_cache: MetadataTableCache,
+    metadata_table_cache: Arc<MetadataTableCache>,
     uploaded_content_proofs: Mutex<UploadedContentProofCache>,
     cache_stats: RuntimeCacheStatsInner,
 }
@@ -1050,8 +1050,9 @@ impl FsBuilder {
 impl Fs {
     pub fn open(store: SharedObjectStore, config: FsConfig) -> Result<Self> {
         validate_config(&config)?;
-        let metadata_table_cache =
-            MetadataTableCache::new(config.runtime_cache.metadata_table_cache.clone());
+        let metadata_table_cache = Arc::new(MetadataTableCache::new(
+            config.runtime_cache.metadata_table_cache.clone(),
+        ));
         Ok(Self {
             inner: Arc::new(FsInner {
                 store,
@@ -1219,25 +1220,24 @@ impl Fs {
         let head = self.head_for_metadata_read(namespace_id)?;
         let engine = self.namespace_engine(namespace_id);
         if head.state.checkpoint_hint_seq.is_some() {
-            if let Some(entry) = engine.resolve_path_from_materialized_tables_at_head(
-                &head.state,
+            let entry = engine.resolve_path(
                 absolute_path,
-                Some(&self.inner.metadata_table_cache),
-                loon_core::ReadOptions::default(),
-            )? {
-                span.record("cache_path", trace::CachePath::MaterializedTables.as_str());
-                self.inner
-                    .cache_stats
-                    .record_metadata_read_source(MetadataReadSource::MaterializedTables);
-                return Ok(entry);
-            }
+                loon_core::ReadOptions::materialized_tables_at_head(
+                    head.state.clone(),
+                    Some(Arc::clone(&self.inner.metadata_table_cache)),
+                ),
+            )?;
+            span.record("cache_path", trace::CachePath::MaterializedTables.as_str());
+            self.inner
+                .cache_stats
+                .record_metadata_read_source(MetadataReadSource::MaterializedTables);
+            return Ok(entry);
         }
 
         let basis = self.basis_for_read_at_head(namespace_id, &head)?;
-        let entry = engine.resolve_path_from_basis(
-            &basis,
+        let entry = engine.resolve_path(
             absolute_path,
-            loon_core::ReadOptions::default(),
+            loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
         )?;
         self.inner
             .cache_stats
@@ -1253,24 +1253,23 @@ impl Fs {
         let head = self.head_for_metadata_read(namespace_id)?;
         let engine = self.namespace_engine(namespace_id);
         if head.state.checkpoint_hint_seq.is_some() {
-            if let Some(entries) = engine.list_path_from_materialized_tables_at_head(
-                &head.state,
+            let entries = engine.list_path(
                 absolute_path,
-                Some(&self.inner.metadata_table_cache),
-                loon_core::ReadOptions::default(),
-            )? {
-                self.inner
-                    .cache_stats
-                    .record_metadata_read_source(MetadataReadSource::MaterializedTables);
-                return Ok(entries);
-            }
+                loon_core::ReadOptions::materialized_tables_at_head(
+                    head.state.clone(),
+                    Some(Arc::clone(&self.inner.metadata_table_cache)),
+                ),
+            )?;
+            self.inner
+                .cache_stats
+                .record_metadata_read_source(MetadataReadSource::MaterializedTables);
+            return Ok(entries);
         }
 
         let basis = self.basis_for_read_at_head(namespace_id, &head)?;
-        let entries = engine.list_path_from_basis(
-            &basis,
+        let entries = engine.list_path(
             absolute_path,
-            loon_core::ReadOptions::default(),
+            loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
         )?;
         self.inner
             .cache_stats
@@ -1284,10 +1283,9 @@ impl Fs {
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
         let basis = self.basis_for_read(namespace_id)?;
-        Ok(self.namespace_engine(namespace_id).read_file_from_basis(
-            basis.as_ref(),
+        Ok(self.namespace_engine(namespace_id).read_file(
             absolute_path,
-            loon_core::ReadOptions::default(),
+            loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
         )?)
     }
 
@@ -1297,13 +1295,10 @@ impl Fs {
         absolute_path: &str,
     ) -> Result<ListFileRevisionsResponse> {
         let basis = self.basis_for_read(namespace_id)?;
-        Ok(self
-            .namespace_engine(namespace_id)
-            .list_file_revisions_from_basis(
-                basis.as_ref(),
-                absolute_path,
-                loon_core::ReadOptions::default(),
-            )?)
+        Ok(self.namespace_engine(namespace_id).list_file_revisions(
+            absolute_path,
+            loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
+        )?)
     }
 
     pub fn list_file_revisions_for_inode(
@@ -1314,10 +1309,9 @@ impl Fs {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(self
             .namespace_engine(namespace_id)
-            .list_file_revisions_for_inode_from_basis(
-                basis.as_ref(),
+            .list_file_revisions_for_inode(
                 inode_id,
-                loon_core::ReadOptions::default(),
+                loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
             )?)
     }
 
@@ -1328,14 +1322,11 @@ impl Fs {
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
         let basis = self.basis_for_read(namespace_id)?;
-        Ok(self
-            .namespace_engine(namespace_id)
-            .read_file_revision_from_basis(
-                basis.as_ref(),
-                absolute_path,
-                revision_no,
-                loon_core::ReadOptions::default(),
-            )?)
+        Ok(self.namespace_engine(namespace_id).read_file_revision(
+            absolute_path,
+            revision_no,
+            loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
+        )?)
     }
 
     pub fn read_file_revision_bytes_for_inode(
@@ -1347,11 +1338,10 @@ impl Fs {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(self
             .namespace_engine(namespace_id)
-            .read_file_revision_for_inode_from_basis(
-                basis.as_ref(),
+            .read_file_revision_for_inode(
                 inode_id,
                 revision_no,
-                loon_core::ReadOptions::default(),
+                loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
             )?)
     }
 


### PR DESCRIPTION
Replaces long suffix-style read APIs with typed ReadOptions on NamespaceEngine