### PR TITLE
docs(loon-core): document public engine entrypoints

### DIFF
--- a/crates/loon-api/src/content.rs
+++ b/crates/loon-api/src/content.rs
@@ -3,20 +3,31 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Kind of content reference.
 pub enum ContentRefKind {
+    /// Whole-file v0 content addressed by SHA-256.
     WholeFileV0,
+    /// Placeholder for newer content kinds unknown to this client.
     #[serde(other)]
     Unsupported,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Pointer to immutable file content.
+///
+/// A `ContentRef` is safe to publish only after the referenced bytes are
+/// durable in the namespace's content store.
 pub struct ContentRef {
+    /// Content strategy used by the referenced object.
     pub kind: ContentRefKind,
+    /// Digest string, currently `sha256:<64 lowercase hex>`.
     pub digest: String,
+    /// Complete byte length of the referenced file content.
     pub size_bytes: u64,
 }
 
 impl ContentRef {
+    /// Builds a whole-file v0 reference for these bytes.
     pub fn whole_file_v0(bytes: &[u8]) -> Self {
         Self {
             kind: ContentRefKind::WholeFileV0,

--- a/crates/loon-api/src/http.rs
+++ b/crates/loon-api/src/http.rs
@@ -2,68 +2,85 @@ use crate::{v0::RenameMode, ChangeSeq, CommitId, ContentRef, InodeId, NamespaceI
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// HTTP error body used by LoonFS APIs.
 pub struct ApiError {
+    /// Stable machine-readable reason.
     pub code: String,
+    /// Human-readable error message.
     pub message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Request to create a namespace.
 pub struct CreateNamespaceRequest {
+    /// Durable namespace id to create.
     pub namespace_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Request to fork a namespace.
 pub struct ForkNamespaceRequest {
+    /// Durable namespace id for the fork target.
     pub new_namespace_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Short namespace listing entry.
 pub struct NamespaceSummary {
+    /// Durable namespace id.
     pub namespace_id: NamespaceId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response for namespace listing.
 pub struct ListNamespacesResponse {
+    /// Complete namespaces visible to the store.
     pub namespaces: Vec<NamespaceSummary>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Result of a namespace-visible mutation.
 pub struct MutationResult {
+    /// Namespace that changed.
     pub namespace_id: NamespaceId,
+    /// Sequence number where the mutation became visible.
     pub committed_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Put behavior for path-oriented file writes.
 pub enum FilesystemPutBehavior {
+    /// Fail if the path already exists.
     CreateOnly,
+    /// Replace the current file if it exists.
     ReplaceExisting,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
+/// One path-oriented filesystem operation.
 pub enum FilesystemOperation {
-    CreateDir {
-        path: String,
-    },
+    /// Create one directory.
+    CreateDir { path: String },
+    /// Create or replace one file with an already-durable content ref.
     PutFile {
         path: String,
         content_ref: ContentRef,
         behavior: FilesystemPutBehavior,
     },
-    DeletePath {
-        path: String,
-    },
+    /// Delete one path.
+    DeletePath { path: String },
+    /// Move one path to another path.
     MovePath {
         from_path: String,
         to_path: String,
         #[serde(default = "crate::v0::default_rename_mode")]
         mode: RenameMode,
     },
-    CopyPath {
-        from_path: String,
-        to_path: String,
-    },
+    /// Copy one file path to another path.
+    CopyPath { from_path: String, to_path: String },
+    /// Restore an older revision as the current revision for a path.
     RestoreRevision {
         path: String,
         source_revision_no: RevisionNo,
@@ -71,50 +88,77 @@ pub enum FilesystemOperation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Request wrapper for one path-oriented operation.
 pub struct FilesystemOperationRequest {
+    /// Caller-supplied idempotency key for this operation.
     pub commit_id: CommitId,
+    /// Operation to apply.
     pub operation: FilesystemOperation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response for one path-oriented operation.
 pub struct FilesystemOperationResponse {
+    /// Namespace that changed.
     pub namespace_id: NamespaceId,
+    /// Sequence where the operation became visible.
     pub committed_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// One immutable file revision.
 pub struct FileRevision {
+    /// File inode that owns this revision.
     pub inode_id: InodeId,
+    /// Revision number within the file inode.
     pub revision_no: RevisionNo,
+    /// Namespace sequence that created this revision.
     pub committed_seq: ChangeSeq,
+    /// Content stored for this revision.
     pub content_ref: ContentRef,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response for listing file revisions.
 pub struct ListFileRevisionsResponse {
+    /// Namespace that was read.
     pub namespace_id: NamespaceId,
+    /// File inode whose revisions were returned.
     pub inode_id: InodeId,
+    /// Namespace head sequence used for the read.
     pub head_seq: ChangeSeq,
+    /// Retained revisions in order.
     pub revisions: Vec<FileRevision>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Request to restore a file revision by inode.
 pub struct RestoreFileRevisionRequest {
+    /// Caller-supplied idempotency key.
     pub commit_id: CommitId,
+    /// Current revision the caller expects to replace.
     pub base_revision_no: RevisionNo,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Result of creating or reusing a checkpoint.
 pub struct CreateCheckpointResponse {
+    /// Namespace that was checkpointed.
     pub namespace_id: NamespaceId,
+    /// Sequence covered by the checkpoint.
     pub checkpoint_seq: ChangeSeq,
+    /// Head's current checkpoint hint after the operation.
     pub checkpoint_hint_seq: Option<ChangeSeq>,
+    /// Whether the head now points at this checkpoint.
     pub checkpoint_hint_points_at_checkpoint: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Result of advancing the retention floor.
 pub struct AdvanceRetentionResponse {
+    /// Namespace whose retention floor changed.
     pub namespace_id: NamespaceId,
+    /// New minimum sequence for incremental replay.
     pub retention_floor_seq: ChangeSeq,
 }
 

--- a/crates/loon-api/src/ids.rs
+++ b/crates/loon-api/src/ids.rs
@@ -6,15 +6,22 @@ use uuid::Uuid;
 
 const SERVER_GENERATED_ID_BODY_LEN: usize = 32;
 
-/// Unique identifier for a namespace (a logical sync boundary).
+/// Durable id for one namespace.
+///
+/// A namespace is one filesystem history. This id is not a display name and
+/// should not be reused after destruction.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NamespaceId(String);
 
-/// Unique identifier for an immutable content store.
+/// Durable id for an immutable content store.
+///
+/// Content stores own file bytes. Namespaces point at content stores.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ContentStoreId(String);
 
-/// Client-supplied stable identifier for one logical commit.
+/// Client-supplied idempotency key for one logical commit.
+///
+/// Reuse the same `CommitId` when retrying the same request.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CommitId(String);
 
@@ -87,40 +94,47 @@ impl NameKeyValidationError {
 }
 
 impl NamespaceId {
+    /// Parses and validates a namespace id.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, NamespaceIdValidationError> {
         let value = value.as_ref();
         validate_namespace_id(value)?;
         Ok(Self(value.to_owned()))
     }
 
+    /// Builds a namespace id from an owned string after validation.
     pub fn try_new(value: impl Into<String>) -> Result<Self, NamespaceIdValidationError> {
         let value = value.into();
         validate_namespace_id(&value)?;
         Ok(Self(value))
     }
 
+    /// Returns the serialized namespace id.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 impl CommitId {
+    /// Parses and validates a commit id.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, CommitIdValidationError> {
         let value = value.as_ref();
         validate_commit_id(value)?;
         Ok(Self(value.to_owned()))
     }
 
+    /// Builds a commit id from an owned string after validation.
     pub fn try_new(value: impl Into<String>) -> Result<Self, CommitIdValidationError> {
         let value = value.into();
         validate_commit_id(&value)?;
         Ok(Self(value))
     }
 
+    /// Returns the serialized commit id.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
+    /// Generates a valid random commit id.
     pub fn generate() -> Self {
         Self(generated_id("c"))
     }
@@ -271,40 +285,47 @@ fn name_key_error(value: &str, reason: &'static str) -> NameKeyValidationError {
 }
 
 impl ContentStoreId {
+    /// Generates a valid random content-store id.
     pub fn generate() -> Self {
         Self(generated_id("cs"))
     }
 
+    /// Parses and validates a content-store id.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, GeneratedIdValidationError> {
         let value = value.as_ref();
         validate_generated_id("cs", value)?;
         Ok(Self(value.to_owned()))
     }
 
+    /// Builds a content-store id from an owned string after validation.
     pub fn try_new(value: impl Into<String>) -> Result<Self, GeneratedIdValidationError> {
         let value = value.into();
         validate_generated_id("cs", &value)?;
         Ok(Self(value))
     }
 
+    /// Returns the serialized content-store id.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 impl NameKey {
+    /// Parses and validates a stored name key.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, NameKeyValidationError> {
         let value = value.as_ref();
         validate_name_key(value)?;
         Ok(Self(value.to_owned()))
     }
 
+    /// Builds a name key from an owned string after validation.
     pub fn try_new(value: impl Into<String>) -> Result<Self, NameKeyValidationError> {
         let value = value.into();
         validate_name_key(&value)?;
         Ok(Self(value))
     }
 
+    /// Computes the lookup key for a display name under a namespace name policy.
     pub fn for_display_name(policy: crate::NamePolicy, display_name: &crate::DisplayName) -> Self {
         Self(crate::name_key_for_display_name(
             policy,
@@ -312,6 +333,7 @@ impl NameKey {
         ))
     }
 
+    /// Returns the stored lookup key.
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -490,14 +512,18 @@ impl<'de> Deserialize<'de> for NameKey {
 }
 
 /// Numeric identity of a file or directory within a namespace.
+///
+/// Inodes are stable across renames.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct InodeId(pub u64);
 
-/// Monotonically increasing file revision counter within an inode.
+/// Monotonically increasing file revision counter within one file inode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RevisionNo(pub u64);
 
 /// Monotonically increasing namespace commit sequence number.
+///
+/// This is the global visibility order for a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ChangeSeq(pub u64);
 
@@ -505,14 +531,20 @@ pub struct ChangeSeq(pub u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct FenceToken(pub u64);
 
-/// Name-policy-derived directory entry name used as a lookup key.
+/// Name-policy-derived directory entry key.
+///
+/// Use this for exact name preconditions. Keep user-facing spelling in
+/// `DisplayName`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NameKey(String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Filesystem item kind.
 pub enum InodeKind {
+    /// File with revision history.
     File,
+    /// Directory with child bindings.
     Dir,
 }
 

--- a/crates/loon-api/src/server.rs
+++ b/crates/loon-api/src/server.rs
@@ -2,21 +2,38 @@ use crate::{ChangeSeq, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Authoritative metadata for one visible path.
+///
+/// This is the result shape for stat/list style reads. File entries include
+/// revision and content summary fields; directory entries leave those empty.
 pub struct AuthoritativePathEntry {
+    /// Namespace that was read.
     pub namespace_id: NamespaceId,
+    /// Absolute path as rendered from stored display names.
     pub absolute_path: String,
+    /// Stable inode identity for this item.
     pub inode_id: InodeId,
+    /// Whether the item is a file or directory.
     pub inode_kind: InodeKind,
+    /// Namespace head sequence this answer was read from.
     pub authoritative_head_seq: ChangeSeq,
+    /// Parent directory inode, or `None` for the root.
     pub parent_inode_id: Option<InodeId>,
+    /// Stored display name for this path component.
     pub display_name: String,
+    /// Current file revision number, for files.
     pub revision_no: Option<RevisionNo>,
+    /// Current file size in bytes, for files.
     pub size_bytes: Option<u64>,
+    /// Current content reference, for files.
     pub content_ref: Option<ContentRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// File bytes plus the metadata entry they came from.
 pub struct AuthoritativeFileBytes {
+    /// Authoritative metadata for the file that was read.
     pub entry: AuthoritativePathEntry,
+    /// Validated file bytes.
     pub bytes: Vec<u8>,
 }

--- a/crates/loon-api/src/v0.rs
+++ b/crates/loon-api/src/v0.rs
@@ -10,9 +10,13 @@ pub type CommitAnnotations = BTreeMap<String, Value>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Rename behavior.
 pub enum RenameMode {
+    /// Move only if the destination name is absent.
     NoReplace,
+    /// Reserved for a future version.
     ReplaceExisting,
+    /// Reserved for a future version.
     Exchange,
 }
 
@@ -22,11 +26,14 @@ pub fn default_rename_mode() -> RenameMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Upload transport mode.
 pub enum UploadMode {
+    /// The service receives bytes and writes content to object storage.
     ServiceProxied,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response for starting an upload session.
 pub struct BeginUploadResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -34,6 +41,7 @@ pub struct BeginUploadResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response after uploading bytes into a session.
 pub struct UploadContentResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -41,11 +49,13 @@ pub struct UploadContentResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Request to complete an upload with the expected content ref.
 pub struct CompleteUploadRequest {
     pub content_ref: ContentRef,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response after an upload session is completed.
 pub struct CompleteUploadResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -53,18 +63,28 @@ pub struct CompleteUploadResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Explicit semantic commit request.
+///
+/// Use this lower-level shape when you need one commit id, optional
+/// preconditions, and multiple ordered operations.
 pub struct CommitRequest {
+    /// Client idempotency key for this logical commit.
     pub commit_id: CommitId,
+    /// Optional race checks evaluated before mutation.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preconditions: Vec<CommitPrecondition>,
+    /// Ordered semantic operations.
     pub ops: Vec<CommitOp>,
+    /// Optional human-readable note.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    /// Optional structured metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<CommitAnnotations>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Response for a committed explicit request.
 pub struct CommitResponse {
     pub namespace_id: NamespaceId,
     pub commit_id: CommitId,
@@ -74,29 +94,34 @@ pub struct CommitResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
+/// Semantic operation inside a commit request.
 pub enum CommitOp {
+    /// Create a directory under a parent inode.
     CreateDir {
         parent_inode: InodeId,
         display_name: String,
     },
+    /// Create a file under a parent inode.
     CreateFile {
         parent_inode: InodeId,
         display_name: String,
         content_ref: ContentRef,
     },
+    /// Append a new revision to an existing file.
     ReplaceFile {
         inode_id: InodeId,
         base_revision_no: RevisionNo,
         content_ref: ContentRef,
     },
+    /// Restore a prior revision as a new current revision.
     RestoreRevision {
         inode_id: InodeId,
         source_revision_no: RevisionNo,
         base_revision_no: RevisionNo,
     },
-    DeleteFile {
-        inode_id: InodeId,
-    },
+    /// Delete a file inode.
+    DeleteFile { inode_id: InodeId },
+    /// Rename or move an inode.
     Rename {
         inode_id: InodeId,
         new_parent_inode: InodeId,
@@ -104,25 +129,27 @@ pub enum CommitOp {
         #[serde(default = "default_rename_mode")]
         mode: RenameMode,
     },
-    DeleteSubtree {
-        root_inode: InodeId,
-    },
+    /// Delete a directory subtree.
+    DeleteSubtree { root_inode: InodeId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+/// Race check evaluated before a commit is accepted.
 pub enum CommitPrecondition {
+    /// File inode is still at this revision.
     InodeRevisionIs {
         inode_id: InodeId,
         revision_no: RevisionNo,
     },
-    AncestorsNotSubtreeDeleted {
-        inode_id: InodeId,
-    },
+    /// Inode ancestors have not been subtree-deleted.
+    AncestorsNotSubtreeDeleted { inode_id: InodeId },
+    /// Directory child name is still absent.
     ChildNameAbsent {
         parent_inode: InodeId,
         name_key: NameKey,
     },
+    /// Directory binding is still exactly the binding the caller saw.
     BindingIs {
         parent_inode: InodeId,
         name_key: NameKey,
@@ -130,13 +157,13 @@ pub enum CommitPrecondition {
         bind_seq: ChangeSeq,
         bind_delta_index: u32,
     },
-    DirectoryEmpty {
-        inode_id: InodeId,
-    },
+    /// Directory is still empty.
+    DirectoryEmpty { inode_id: InodeId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
+/// Per-operation result returned after a commit succeeds.
 pub enum CommitOpResult {
     CreateDir {
         op_index: u32,
@@ -177,6 +204,10 @@ pub enum CommitOpResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "delta", rename_all = "snake_case")]
+/// Durable metadata fact exposed through the change feed.
+///
+/// Most clients should use semantic operation results. Sync and projection
+/// clients can apply deltas directly.
 pub enum CommitDelta {
     CreateInode {
         semantic_op_index: u32,
@@ -216,18 +247,24 @@ pub enum CommitDelta {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// One committed change in namespace order.
 pub struct CommittedChange {
+    /// Namespace sequence for this logical commit.
     pub seq: ChangeSeq,
+    /// Client idempotency key for this logical commit.
     pub commit_id: CommitId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<CommitAnnotations>,
+    /// Semantic operation results.
     pub ops: Vec<CommitOpResult>,
+    /// Materialized metadata deltas.
     pub deltas: Vec<CommitDelta>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Change-feed response after a cursor.
 pub struct ChangesResponse {
     pub namespace_id: NamespaceId,
     pub from_exclusive_seq: ChangeSeq,

--- a/crates/loon-cli/src/lib.rs
+++ b/crates/loon-cli/src/lib.rs
@@ -1,3 +1,9 @@
+//! LoonFS command-line entrypoint.
+//!
+//! The CLI supports embedded profiles that talk directly to object storage and
+//! remote profiles that talk to a LoonFS server. It keeps command output stable
+//! for humans and scripts.
+
 #![forbid(unsafe_code)]
 
 mod args;

--- a/crates/loon-client/src/lib.rs
+++ b/crates/loon-client/src/lib.rs
@@ -1,3 +1,10 @@
+//! Blocking HTTP client for a LoonFS server.
+//!
+//! Use this crate when your process should talk to a hosted LoonFS runtime
+//! instead of embedding the runtime directly. The client keeps paths simple:
+//! pass a [`NamespacePath`] for filesystem operations and use explicit commit
+//! helpers when you need retry control.
+
 #![forbid(unsafe_code)]
 
 use http::Uri;
@@ -22,12 +29,16 @@ use thiserror::Error;
 use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Deserialize)]
+/// Client configuration loaded from TOML or built by the caller.
 pub struct ClientConfig {
+    /// Base URL for the LoonFS server.
     pub server_url: String,
+    /// Optional bearer token.
     pub auth_token: Option<String>,
 }
 
 #[derive(Debug, Clone)]
+/// Synchronous HTTP client for LoonFS.
 pub struct Client {
     base_url: String,
     auth_token: Option<String>,
@@ -35,23 +46,29 @@ pub struct Client {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Result of downloading a remote path to local storage.
 pub struct GetPathResult {
     pub destination: PathBuf,
     pub bytes_written: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Result of uploading a local path.
 pub struct PutPathResult {
     pub committed_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// A path qualified by namespace.
 pub struct NamespacePath {
+    /// Namespace id as text.
     pub namespace: String,
+    /// Absolute path inside the namespace.
     pub absolute_path: String,
 }
 
 #[derive(Debug, Error)]
+/// Error returned by the blocking HTTP client.
 pub enum ClientError {
     #[error("failed to read config: {0}")]
     ConfigIo(String),
@@ -80,6 +97,7 @@ pub enum ClientError {
 }
 
 impl ClientConfig {
+    /// Loads and validates a client config from TOML.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, ClientError> {
         let bytes =
             fs::read(path.as_ref()).map_err(|err| ClientError::ConfigIo(err.to_string()))?;
@@ -107,6 +125,7 @@ impl ClientConfig {
 }
 
 impl Client {
+    /// Creates a client from validated config.
     pub fn new(config: ClientConfig) -> Self {
         Self {
             base_url: config.server_url.trim().trim_end_matches('/').to_owned(),

--- a/crates/loon-core/src/engine.rs
+++ b/crates/loon-core/src/engine.rs
@@ -23,6 +23,11 @@ use thiserror::Error;
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
 #[derive(Debug)]
+/// A namespace-scoped core API.
+///
+/// `NamespaceEngine` owns an object store handle plus the writer identity used
+/// for mutations. It is the main entrypoint for direct reads, path writes,
+/// explicit commits, uploads, checkpoints, and retention work.
 pub struct NamespaceEngine<S> {
     store: S,
     namespace_id: NamespaceId,
@@ -35,6 +40,9 @@ pub struct NamespaceEngine<S> {
 }
 
 impl<S: ObjectStore> NamespaceEngine<S> {
+    /// Starts an engine builder for the supplied object store.
+    ///
+    /// The builder requires a namespace id and writer id before it can build.
     pub fn builder(store: S) -> NamespaceEngineBuilder<S> {
         NamespaceEngineBuilder {
             store,
@@ -48,38 +56,49 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         }
     }
 
+    /// Returns the namespace this engine is bound to.
     pub fn namespace_id(&self) -> &NamespaceId {
         &self.namespace_id
     }
 
+    /// Returns the writer id used for leases and commit publication.
     pub fn writer_id(&self) -> &str {
         &self.writer_id
     }
 
+    /// Returns the writer version reported in mutation context.
     pub fn writer_version(&self) -> &str {
         &self.writer_version
     }
 
+    /// Returns the lease duration used by write operations.
     pub fn lease_duration_ms(&self) -> u64 {
         self.lease_duration_ms
     }
 
+    /// Returns the default read options configured on the builder.
     pub fn read_options(&self) -> &ReadOptions {
         &self.read_options
     }
 
+    /// Returns the default write options configured on the builder.
     pub fn write_options(&self) -> &WriteOptions {
         &self.write_options
     }
 
+    /// Returns the default explicit-commit options configured on the builder.
     pub fn commit_options(&self) -> &CommitOptions {
         &self.commit_options
     }
 
+    /// Consumes the engine and returns the underlying object store.
     pub fn into_store(self) -> S {
         self.store
     }
 
+    /// Creates the namespace if it does not already exist.
+    ///
+    /// Use this before normal reads and writes for a new namespace.
     pub fn bootstrap_namespace(
         &self,
         options: BootstrapOptions,
@@ -92,6 +111,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Creates a new namespace at the current head of this namespace.
+    ///
+    /// The fork shares immutable file bytes but gets its own metadata history.
     pub fn fork_namespace(
         &self,
         target: &NamespaceId,
@@ -105,10 +127,12 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Lists complete namespaces visible in the object store.
     pub fn list_namespaces(&self) -> CoreResult<Vec<NamespaceSummary>> {
         catalog::list_namespaces(&self.store)
     }
 
+    /// Resolves one absolute path to the authoritative entry at the current head.
     pub fn resolve_path(
         &self,
         path: impl AsRef<str>,
@@ -144,6 +168,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::query::resolve_path_from_basis(&basis, path)
     }
 
+    /// Lists the children of a directory path.
     pub fn list_path(
         &self,
         path: impl AsRef<str>,
@@ -179,6 +204,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::query::list_path_from_basis(&basis, path)
     }
 
+    /// Reads the current bytes for a file path.
+    ///
+    /// Content bytes are validated against the file's `content_ref` before they
+    /// are returned.
     pub fn read_file(
         &self,
         path: impl AsRef<str>,
@@ -188,6 +217,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::query::read_file_bytes_from_basis(&self.store, &basis, path.as_ref())
     }
 
+    /// Lists retained revisions for the file currently visible at `path`.
     pub fn list_file_revisions(
         &self,
         path: impl AsRef<str>,
@@ -197,6 +227,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::query::list_file_revisions_from_basis(&basis, path.as_ref())
     }
 
+    /// Lists retained revisions for a file inode, independent of its current path.
     pub fn list_file_revisions_for_inode(
         &self,
         inode_id: InodeId,
@@ -206,6 +237,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::query::list_file_revisions_for_inode_from_basis(&basis, inode_id)
     }
 
+    /// Reads a retained revision for the file currently visible at `path`.
     pub fn read_file_revision(
         &self,
         path: impl AsRef<str>,
@@ -221,6 +253,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Reads a retained revision by stable inode id.
     pub fn read_file_revision_for_inode(
         &self,
         inode_id: InodeId,
@@ -236,6 +269,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Writes file bytes to a path.
+    ///
+    /// The bytes become durable content first. Metadata is published only after
+    /// that content is safe to reference.
     pub fn put_file(
         &self,
         path: impl AsRef<str>,
@@ -256,6 +293,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Publishes a file revision that points at an already-durable content ref.
+    ///
+    /// Use this when the caller staged content separately.
     pub fn put_file_content_ref(
         &self,
         path: impl AsRef<str>,
@@ -276,6 +316,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Creates a directory at an absolute path.
     pub fn create_dir(
         &self,
         path: impl AsRef<str>,
@@ -293,6 +334,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Deletes a file or directory path.
     pub fn delete_path(
         &self,
         path: impl AsRef<str>,
@@ -321,6 +363,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         }
     }
 
+    /// Moves a path within the same namespace.
     pub fn move_path(
         &self,
         source: impl AsRef<str>,
@@ -340,6 +383,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Copies a file path within the same namespace.
     pub fn copy_path(
         &self,
         source: impl AsRef<str>,
@@ -359,6 +403,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Restores a prior file revision by appending a new current revision.
     pub fn restore_file_revision(
         &self,
         path: impl AsRef<str>,
@@ -378,6 +423,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Submits one explicit semantic commit request.
+    ///
+    /// This is the lower-level surface used by clients that need their own
+    /// commit ids, preconditions, and operation lists.
     pub fn commit_operations(
         &self,
         request: CommitRequest,
@@ -391,6 +440,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Submits explicit semantic commit requests as one publication attempt.
     pub fn commit_operations_batch(
         &self,
         requests: Vec<CommitRequest>,
@@ -404,6 +454,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Publishes already-classified namespace mutation candidates.
+    ///
+    /// Server code uses this to batch path intents and explicit commits through
+    /// one namespace publisher.
     pub fn publish_namespace_mutations_batch(
         &self,
         candidates: Vec<NamespaceMutationCandidate>,
@@ -416,14 +470,17 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Reads committed changes after `after_seq`.
     pub fn list_changes_after(&self, after_seq: ChangeSeq) -> CoreResult<ChangesResponse> {
         crate::protocol::list_changes_after(&self.store, &self.namespace_id, after_seq)
     }
 
+    /// Starts a durable upload session for this namespace.
     pub fn begin_upload(&self) -> CoreResult<BeginUploadResponse> {
         crate::protocol::begin_upload(&self.store, &self.namespace_id, &self.mutation_context())
     }
 
+    /// Uploads whole-file content into an upload session.
     pub fn upload_content(
         &self,
         upload_id: &str,
@@ -438,6 +495,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Completes an upload session when the expected content ref matches.
     pub fn complete_upload(
         &self,
         upload_id: &str,
@@ -452,6 +510,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Writes or reuses a checkpoint for the current namespace head.
     pub fn create_checkpoint(&self) -> CoreResult<CreateCheckpointResponse> {
         crate::checkpoint::create_checkpoint(
             &self.store,
@@ -460,6 +519,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         )
     }
 
+    /// Advances the retention floor when a verified checkpoint makes it safe.
     pub fn advance_retention_floor(&self) -> CoreResult<AdvanceRetentionResponse> {
         crate::checkpoint::advance_retention_floor(
             &self.store,
@@ -493,6 +553,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
 }
 
 #[derive(Debug)]
+/// Builder for [`NamespaceEngine`].
+///
+/// The builder keeps construction explicit: choose a namespace, choose the
+/// writer identity, then build the engine.
 pub struct NamespaceEngineBuilder<S> {
     store: S,
     namespace_id: Option<NamespaceId>,
@@ -505,41 +569,49 @@ pub struct NamespaceEngineBuilder<S> {
 }
 
 impl<S: ObjectStore> NamespaceEngineBuilder<S> {
+    /// Sets the namespace this engine will operate on.
     pub fn namespace(mut self, namespace_id: NamespaceId) -> Self {
         self.namespace_id = Some(namespace_id);
         self
     }
 
+    /// Sets the writer identity used for leases and commits.
     pub fn writer(mut self, writer_id: impl Into<String>) -> Self {
         self.writer_id = Some(writer_id.into());
         self
     }
 
+    /// Sets a human-readable writer version.
     pub fn writer_version(mut self, writer_version: impl Into<String>) -> Self {
         self.writer_version = writer_version.into();
         self
     }
 
+    /// Sets how long this writer's namespace lease should remain valid.
     pub fn lease_duration_ms(mut self, lease_duration_ms: u64) -> Self {
         self.lease_duration_ms = lease_duration_ms;
         self
     }
 
+    /// Sets default read options stored on the engine.
     pub fn read_options(mut self, options: ReadOptions) -> Self {
         self.read_options = options;
         self
     }
 
+    /// Sets default write options stored on the engine.
     pub fn write_options(mut self, options: WriteOptions) -> Self {
         self.write_options = options;
         self
     }
 
+    /// Sets default explicit-commit options stored on the engine.
     pub fn commit_options(mut self, options: CommitOptions) -> Self {
         self.commit_options = options;
         self
     }
 
+    /// Builds the engine after required fields are present.
     pub fn build(self) -> Result<NamespaceEngine<S>, NamespaceEngineBuildError> {
         let namespace_id = self
             .namespace_id
@@ -568,13 +640,18 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+/// Error returned when a [`NamespaceEngine`] cannot be built.
 pub enum NamespaceEngineBuildError {
+    /// A namespace id was not supplied.
     #[error("namespace is required")]
     MissingNamespace,
+    /// A writer id was not supplied.
     #[error("writer identity is required")]
     MissingWriter,
+    /// The writer id was empty or whitespace.
     #[error("writer identity must not be empty")]
     EmptyWriter,
+    /// The writer version was empty or whitespace.
     #[error("writer version must not be empty")]
     EmptyWriterVersion,
 }

--- a/crates/loon-core/src/error.rs
+++ b/crates/loon-core/src/error.rs
@@ -12,30 +12,38 @@ use loon_api::{
 };
 use thiserror::Error;
 
+/// Public error type returned by `loon-core`.
+///
+/// Use [`Error::kind`] for broad caller action and [`Error::code`] for a stable
+/// machine-readable reason.
 pub type Error = CoreError;
+
+/// Result type used by `loon-core` entrypoints.
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Broad error category for caller or operator action.
 pub enum ErrorKind {
-    /// Caller input is malformed or names an unsupported operation shape.
+    /// Fix the request before retrying.
     InvalidRequest,
-    /// The requested namespace, path, inode, revision, or upload session does not exist.
+    /// The requested object does not exist. Refresh state or choose another target.
     NotFound,
-    /// The caller attempted to create a resource that already exists.
+    /// The create target already exists. Pick another id or treat this as idempotent.
     AlreadyExists,
-    /// The request conflicts with current namespace state or another writer.
+    /// The request raced with current namespace state. Re-read and retry if desired.
     Conflict,
-    /// A caller-supplied precondition was false at validation time.
+    /// A caller-supplied precondition was false. Re-plan against fresh state.
     PreconditionFailed,
-    /// The operation is temporarily unavailable and may succeed later.
+    /// The system is temporarily unavailable. Back off and retry.
     Unavailable,
-    /// Durable namespace, WAL, checkpoint, or content state is malformed.
+    /// Durable state is malformed. Treat this as operator or repair work.
     DataCorruption,
-    /// LoonFS hit an internal invariant or implementation failure.
+    /// LoonFS hit an internal failure. Capture details and report it.
     Internal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Stable machine-readable error reason.
 pub enum ErrorCode {
     InvalidPath,
     InvalidNamespaceId,
@@ -67,6 +75,10 @@ pub enum ErrorCode {
 }
 
 #[derive(Debug, Clone, Error)]
+/// Detailed core error.
+///
+/// Most callers should branch on [`CoreError::kind`] or [`CoreError::code`]
+/// instead of matching every internal variant.
 pub enum CoreError {
     #[error(transparent)]
     Basis(#[from] BasisLoadError),

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -1,3 +1,34 @@
+//! Core LoonFS namespace operations.
+//!
+//! `loon-core` is the low-level API for building directly on the LoonFS
+//! metadata protocol. Most callers should start with [`NamespaceEngine`].
+//!
+//! A namespace is one durable filesystem history. File bytes are written to
+//! object storage first, then metadata is published as a committed namespace
+//! mutation. Reads rebuild or reuse a verified view of the namespace before
+//! walking paths.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use loon_api::NamespaceId;
+//! use loon_core::{BootstrapOptions, NamespaceEngine, ReadOptions, WriteOptions};
+//! use loon_objectstore::fs::LocalFsStore;
+//!
+//! let store = LocalFsStore::new(std::env::temp_dir()).expect("store");
+//! let namespace = NamespaceId::parse("docs").expect("valid namespace id");
+//!
+//! let engine = NamespaceEngine::builder(store)
+//!     .namespace(namespace)
+//!     .writer("example-writer")
+//!     .build()
+//!     .expect("engine");
+//!
+//! let _ = engine.bootstrap_namespace(BootstrapOptions::default());
+//! let _ = engine.put_file("/plan.md", b"hello", WriteOptions::default());
+//! let _ = engine.read_file("/plan.md", ReadOptions::default());
+//! ```
+
 #![forbid(unsafe_code)]
 
 mod checkpoint;

--- a/crates/loon-core/src/namespace/basis.rs
+++ b/crates/loon-core/src/namespace/basis.rs
@@ -24,6 +24,10 @@ use std::mem::size_of;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Fully verified namespace view at one head.
+///
+/// A basis contains enough metadata to answer normal path reads and validate
+/// mutations for the head it was reconstructed from.
 pub struct VerifiedNamespaceBasis {
     pub namespace_descriptor: NamespaceDescriptorState,
     pub content_store_id: ContentStoreId,
@@ -34,12 +38,16 @@ pub struct VerifiedNamespaceBasis {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Approximate size of a verified basis.
+///
+/// Runtime caches use this as an eviction weight, not exact heap accounting.
 pub struct VerifiedNamespaceBasisWeight {
     pub rows: usize,
     pub decoded_bytes: usize,
 }
 
 impl VerifiedNamespaceBasis {
+    /// Returns the approximate cache weight for this basis.
     pub fn weight(&self) -> VerifiedNamespaceBasisWeight {
         VerifiedNamespaceBasisWeight {
             rows: self.row_count(),
@@ -47,10 +55,12 @@ impl VerifiedNamespaceBasis {
         }
     }
 
+    /// Returns the number of metadata rows in this basis.
     pub fn row_count(&self) -> usize {
         self.metadata_state.row_count()
     }
 
+    /// Returns an approximate decoded byte size for this basis.
     pub fn decoded_bytes(&self) -> usize {
         size_of::<Self>()
             + self.namespace_descriptor.namespace_id.as_str().len()
@@ -77,6 +87,7 @@ fn wal_tip_decoded_bytes(pointer: Option<&loon_api::wire::control::WalSegmentPoi
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Lightweight namespace head status.
 pub struct NamespaceHeadSummary {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
@@ -86,11 +97,16 @@ pub struct NamespaceHeadSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Opaque ETag probe for the namespace head object.
+///
+/// This only proves that the durable head object identity still matches a
+/// previously reconstructed basis.
 pub struct NamespaceHeadEtagProbe {
     pub head_etag: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+/// Error while reconstructing a verified namespace basis.
 pub enum BasisLoadError {
     #[error("failed to load namespace descriptor: {0}")]
     LoadNamespaceDescriptor(ControlObjectLoadError),
@@ -130,6 +146,7 @@ impl From<NamespaceCatalogLoadError> for BasisLoadError {
     }
 }
 
+/// Reconstructs and verifies the current namespace basis.
 pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
@@ -153,6 +170,7 @@ pub fn load_verified_namespace_basis<S: ObjectStore + ?Sized>(
     )
 }
 
+/// Reconstructs and verifies a namespace basis for an already-loaded head.
 pub fn load_verified_namespace_basis_at_head<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,

--- a/crates/loon-core/src/namespace/mod.rs
+++ b/crates/loon-core/src/namespace/mod.rs
@@ -1,3 +1,9 @@
+//! Namespace control helpers.
+//!
+//! A namespace is one durable filesystem history. Most callers should use
+//! [`crate::NamespaceEngine`]; these helpers are for runtime and admin code
+//! that needs direct namespace inspection.
+
 pub(crate) mod basis;
 pub(crate) mod bootstrap;
 pub(crate) mod catalog;
@@ -11,20 +17,25 @@ use loon_api::{FenceToken, NamespaceSummary};
 use loon_objectstore::ObjectStore;
 use thiserror::Error;
 
+/// Lists complete namespaces in the object store.
 pub fn list_namespaces<S: ObjectStore + ?Sized>(store: &S) -> crate::Result<Vec<NamespaceSummary>> {
     catalog::list_namespaces(store)
 }
 
+/// Returns true when the head and lease agree on the active writer fence.
 pub fn head_and_lease_fence_tokens_agree(head: &HeadState, lease: &LeaseState) -> bool {
     head.namespace_id == lease.namespace_id && head.active_fence_token == lease.fence_token
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+/// Error while preparing a head for writer takeover.
 pub enum HeadFenceTakeoverError {
+    /// The fence token cannot be advanced.
     #[error("head fence token overflow from `{active:?}`")]
     FenceTokenOverflow { active: FenceToken },
 }
 
+/// Builds the head state a new writer should publish during takeover.
 pub fn next_takeover_head(current_head: &HeadState) -> Result<HeadState, HeadFenceTakeoverError> {
     let next_fence = current_head.active_fence_token.0.checked_add(1).ok_or(
         HeadFenceTakeoverError::FenceTokenOverflow {

--- a/crates/loon-core/src/options.rs
+++ b/crates/loon-core/src/options.rs
@@ -7,37 +7,56 @@ use loon_api::CommitId;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Options for namespace bootstrap.
 pub struct BootstrapOptions {
+    /// If true, creating an already-existing namespace is treated as success.
     pub allow_existing: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Options for namespace fork.
+///
+/// This is currently empty, but kept as the public shape for future fork
+/// controls.
 pub struct ForkOptions {}
 
 #[derive(Debug, Clone)]
+/// Controls where read operations get their namespace view.
+///
+/// The default prefers materialized checkpoint tables when they are available,
+/// then falls back to rebuilding the full verified basis.
 pub struct ReadOptions {
     source: ReadSource,
 }
 
 impl ReadOptions {
+    /// Prefers fast materialized tables, with safe fallback to full basis reads.
     pub fn prefer_materialized() -> Self {
         Self {
             source: ReadSource::PreferMaterialized,
         }
     }
 
+    /// Forces a complete verified basis reconstruction before reading.
     pub fn full_basis() -> Self {
         Self {
             source: ReadSource::FullBasis,
         }
     }
 
+    /// Reuses a caller-supplied verified basis.
+    ///
+    /// This is useful when several reads should share the same namespace view.
     pub fn verified_basis(basis: Arc<VerifiedNamespaceBasis>) -> Self {
         Self {
             source: ReadSource::VerifiedBasis(basis),
         }
     }
 
+    /// Reads from materialized tables pinned to an already-loaded head.
+    ///
+    /// Runtime code uses this when it has already validated the head and wants
+    /// to reuse table cache state.
     pub fn materialized_tables_at_head(
         head: HeadState,
         table_cache: Option<Arc<MetadataTableCache>>,
@@ -47,6 +66,7 @@ impl ReadOptions {
         }
     }
 
+    /// Returns the selected read source.
     pub fn source(&self) -> &ReadSource {
         &self.source
     }
@@ -63,20 +83,33 @@ impl Default for ReadOptions {
 }
 
 #[derive(Debug, Clone)]
+/// Source used by [`ReadOptions`].
 pub enum ReadSource {
+    /// Use materialized tables when possible, otherwise rebuild the full basis.
     PreferMaterialized,
+    /// Always rebuild the full verified namespace basis.
     FullBasis,
+    /// Use this already-verified namespace basis.
     VerifiedBasis(Arc<VerifiedNamespaceBasis>),
+    /// Use materialized tables for a specific already-loaded head.
     MaterializedTablesAtHead {
+        /// The namespace head to read against.
         head: HeadState,
+        /// Optional decoded table cache.
         table_cache: Option<Arc<MetadataTableCache>>,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Options for path-oriented writes.
 pub struct WriteOptions {
+    /// Optional caller-provided idempotency key.
+    ///
+    /// If omitted, path helpers generate one internally.
     pub commit_id: Option<CommitId>,
+    /// Whether a file put may replace an existing file.
     pub put_file_behavior: PutFileBehavior,
+    /// Whether delete may remove a non-empty subtree.
     pub recursive_delete: bool,
 }
 
@@ -91,4 +124,8 @@ impl Default for WriteOptions {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// Options for explicit commit submission.
+///
+/// This is currently empty because the commit request carries the important
+/// choices: commit id, preconditions, operations, message, and annotations.
 pub struct CommitOptions {}

--- a/crates/loon-core/src/path/write/intent.rs
+++ b/crates/loon-core/src/path/write/intent.rs
@@ -2,39 +2,52 @@ use loon_api::{v0::RenameMode, CommitId, ContentRef, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Behavior for path-based file put operations.
 pub enum PutFileBehavior {
+    /// Create the file only if the target path is absent.
     CreateOnly,
+    /// Replace an existing file if the target path already exists.
     ReplaceExisting,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// User-facing path mutation before it is planned against namespace state.
+///
+/// Server and embedded publishers accept these intents, then resolve paths and
+/// preconditions immediately before publishing.
 pub enum PathMutationIntent {
+    /// Create one directory.
     CreateDir {
         commit_id: CommitId,
         absolute_path: String,
     },
+    /// Put one file at a path.
     PutFile {
         commit_id: CommitId,
         absolute_path: String,
         content_ref: ContentRef,
         behavior: PutFileBehavior,
     },
+    /// Delete one path.
     DeletePath {
         commit_id: CommitId,
         absolute_path: String,
         recursive: bool,
     },
+    /// Move one path to another path.
     MovePath {
         commit_id: CommitId,
         from_path: String,
         to_path: String,
         mode: RenameMode,
     },
+    /// Copy one file path to another path.
     CopyFilePath {
         commit_id: CommitId,
         from_path: String,
         to_path: String,
     },
+    /// Restore a file revision at a path.
     RestoreRevision {
         commit_id: CommitId,
         absolute_path: String,
@@ -43,6 +56,7 @@ pub enum PathMutationIntent {
 }
 
 impl PathMutationIntent {
+    /// Returns the idempotency key carried by this intent.
     pub fn commit_id(&self) -> &CommitId {
         match self {
             Self::CreateDir { commit_id, .. }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,3 +1,9 @@
+//! Embedded LoonFS runtime.
+//!
+//! `loonfs` is the ergonomic runtime layer. It wraps `loon-core` with caching,
+//! upload helpers, maintenance hooks, and optional object-store metrics. Use it
+//! when you want LoonFS in-process, or when building the reference server.
+
 #![forbid(unsafe_code)]
 
 mod trace;
@@ -57,10 +63,13 @@ pub const DEFAULT_MAX_CACHED_BASIS_DECODED_BYTES: usize = 256 * 1024 * 1024;
 const MAX_UPLOADED_CONTENT_PROOF_ENTRIES: usize = 16_384;
 const UPLOADED_CONTENT_PROOF_TTL: Duration = Duration::from_secs(30);
 
+/// Shared object-store handle used by the runtime.
 pub type SharedObjectStore = Arc<dyn ObjectStore + Send + Sync>;
+/// Result type used by the embedded runtime.
 pub type Result<T> = std::result::Result<T, RuntimeError>;
 
 #[derive(Debug, Error)]
+/// Runtime error.
 pub enum RuntimeError {
     #[error(transparent)]
     Core(#[from] CoreError),
@@ -71,16 +80,24 @@ pub enum RuntimeError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Configuration for an embedded runtime instance.
 pub struct FsConfig {
+    /// Writer id used for namespace leases and commits.
     pub writer_id: String,
+    /// Writer version reported in mutation context.
     pub writer_version: String,
+    /// Lease duration used by write operations.
     pub lease_duration_ms: u64,
+    /// Cache configuration.
     pub runtime_cache: RuntimeCacheConfig,
+    /// Tracing mode label.
     pub trace_mode: TraceMode,
+    /// Object-store kind label used by tracing.
     pub trace_store_kind: TraceStoreKind,
 }
 
 impl FsConfig {
+    /// Builds a config with default runtime settings.
     pub fn new(writer_id: impl Into<String>) -> Self {
         Self {
             writer_id: writer_id.into(),
@@ -94,16 +111,24 @@ impl FsConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Cache configuration for the embedded runtime.
 pub struct RuntimeCacheConfig {
+    /// Enables verified-basis caching.
     pub basis_cache_enabled: bool,
+    /// Enables namespace control-object caching.
     pub control_cache_enabled: bool,
+    /// Maximum namespaces retained in runtime caches.
     pub max_cached_namespaces: usize,
+    /// Maximum metadata rows retained across cached bases.
     pub max_cached_basis_rows: usize,
+    /// Approximate decoded-byte budget for cached bases.
     pub max_cached_basis_decoded_bytes: Option<usize>,
+    /// Cache settings for decoded metadata tables.
     pub metadata_table_cache: MetadataTableCacheConfig,
 }
 
 impl RuntimeCacheConfig {
+    /// Disables runtime caches.
     pub fn disabled() -> Self {
         Self {
             basis_cache_enabled: false,
@@ -134,6 +159,9 @@ impl Default for RuntimeCacheConfig {
 }
 
 #[derive(Clone)]
+/// Embedded filesystem runtime.
+///
+/// `Fs` is cheap to clone. Clones share caches and the underlying object store.
 pub struct Fs {
     inner: Arc<FsInner>,
 }
@@ -149,6 +177,7 @@ struct FsInner {
     cache_stats: RuntimeCacheStatsInner,
 }
 
+/// Builder for [`Fs`].
 pub struct FsBuilder {
     store: SharedObjectStore,
     writer_id: Option<String>,
@@ -647,6 +676,10 @@ struct CachedControl<T> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Snapshot of runtime cache counters.
+///
+/// These counters are diagnostic. They are useful for tuning cache limits and
+/// understanding read/write warmup behavior.
 pub struct RuntimeCacheStats {
     pub warm_basis_cache_hits: usize,
     pub warm_basis_cache_misses: usize,
@@ -879,16 +912,24 @@ impl RuntimeControlCache {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Current maintenance-related namespace status.
 pub struct NamespaceStatus {
+    /// Namespace being inspected.
     pub namespace_id: NamespaceId,
+    /// Current visible namespace sequence.
     pub head_seq: ChangeSeq,
+    /// Checkpoint currently hinted by the head.
     pub checkpoint_hint_seq: Option<ChangeSeq>,
+    /// Number of visible WAL segments after the checkpoint basis.
     pub wal_tail_segments: u64,
+    /// Oldest sequence still promised for incremental replay.
     pub retention_floor_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Options for one maintenance tick.
 pub struct MaintenanceTickOptions {
+    /// Publish a checkpoint when the visible WAL tail reaches this many segments.
     pub max_wal_tail_segments: u64,
 }
 
@@ -901,21 +942,23 @@ impl Default for MaintenanceTickOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Outcome of one maintenance tick.
 pub enum MaintenanceTickOutcome {
+    /// No checkpoint was needed.
     NotNeeded,
-    CheckpointPublished {
-        checkpoint_seq: ChangeSeq,
-    },
+    /// A checkpoint was published.
+    CheckpointPublished { checkpoint_seq: ChangeSeq },
+    /// Another checkpoint already covered the attempted sequence.
     CheckpointSuperseded {
         attempted_seq: ChangeSeq,
         checkpoint_hint_seq: ChangeSeq,
     },
-    CheckpointPublishRaceLost {
-        observed_head_seq: ChangeSeq,
-    },
+    /// A concurrent head update won the race.
+    CheckpointPublishRaceLost { observed_head_seq: ChangeSeq },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Result of one maintenance tick.
 pub struct MaintenanceTickResult {
     pub namespace_id: NamespaceId,
     pub status_before: NamespaceStatus,
@@ -923,13 +966,18 @@ pub struct MaintenanceTickResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// Options for creating a namespace.
 pub struct CreateNamespaceOptions {
+    /// Treat an existing namespace as success.
     pub allow_existing: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Options for writing a file path.
 pub struct PutFileOptions {
+    /// Create-only or replace-existing behavior.
     pub behavior: PutFileBehavior,
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
@@ -943,32 +991,44 @@ impl Default for PutFileOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Options for creating a directory.
 pub struct CreateDirOptions {
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Options for deleting a path.
 pub struct DeleteOptions {
+    /// Whether directory deletes may remove a subtree.
     pub recursive: bool,
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Options for moving a path.
 pub struct MoveOptions {
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Options for copying a file path.
 pub struct CopyOptions {
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Options for restoring a file revision by path.
 pub struct RestoreRevisionOptions {
+    /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }
 
 impl FsBuilder {
+    /// Starts an embedded runtime builder.
     pub fn new(store: SharedObjectStore) -> Self {
         Self {
             store,
@@ -982,31 +1042,37 @@ impl FsBuilder {
         }
     }
 
+    /// Sets the writer id used by namespace mutations.
     pub fn writer_id(mut self, writer_id: impl Into<String>) -> Self {
         self.writer_id = Some(writer_id.into());
         self
     }
 
+    /// Sets the writer version used in mutation context.
     pub fn writer_version(mut self, writer_version: impl Into<String>) -> Self {
         self.writer_version = writer_version.into();
         self
     }
 
+    /// Sets the lease duration for write operations.
     pub fn lease_duration_ms(mut self, lease_duration_ms: u64) -> Self {
         self.lease_duration_ms = lease_duration_ms;
         self
     }
 
+    /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.runtime_cache = runtime_cache;
         self
     }
 
+    /// Sets the tracing mode label.
     pub fn trace_mode(mut self, trace_mode: TraceMode) -> Self {
         self.trace_mode = trace_mode;
         self
     }
 
+    /// Sets the object-store kind label used by tracing and metrics.
     pub fn trace_store_kind(mut self, trace_store_kind: TraceStoreKind) -> Self {
         self.trace_store_kind = trace_store_kind;
         self
@@ -1021,6 +1087,7 @@ impl FsBuilder {
         self
     }
 
+    /// Opens the runtime.
     pub fn build(self) -> Result<Fs> {
         let writer_id = self
             .writer_id
@@ -1048,6 +1115,7 @@ impl FsBuilder {
 }
 
 impl Fs {
+    /// Opens an embedded runtime from an object store and config.
     pub fn open(store: SharedObjectStore, config: FsConfig) -> Result<Self> {
         validate_config(&config)?;
         let metadata_table_cache = Arc::new(MetadataTableCache::new(
@@ -1067,10 +1135,12 @@ impl Fs {
         })
     }
 
+    /// Starts a runtime builder.
     pub fn builder(store: SharedObjectStore) -> FsBuilder {
         FsBuilder::new(store)
     }
 
+    /// Returns this runtime's config.
     pub fn config(&self) -> &FsConfig {
         &self.inner.config
     }


### PR DESCRIPTION
Adds brief public rustdoc for the core engine, runtime, client, CLI, and common API types.