### PR TITLE
refactor(objectstore): centralize namespace object layout

### DIFF
--- a/crates/loon-core/src/checkpoint/mod.rs
+++ b/crates/loon-core/src/checkpoint/mod.rs
@@ -3087,7 +3087,7 @@ mod tests {
         let basis_after = load_verified_namespace_basis(&store, &namespace_id).expect("basis");
         let compacted_run_keys = run_segment_object_keys(&compacted_materialized.manifest);
         let compacted_run_prefix = format!(
-            "namespaces/{}/checkpoints/{:020}/runs/",
+            "namespaces/{}/compacted/checkpoints/{:020}/runs/",
             namespace_id.as_str(),
             compacted.checkpoint_seq.0
         );

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -2659,7 +2659,7 @@ fn fork_target_head_reservation_failure_writes_no_checkpoint_artifacts() {
     assert!(
         store
             .list_prefix(&format!(
-                "namespaces/{}/checkpoints/",
+                "namespaces/{}/compacted/checkpoints/",
                 clone_namespace_id.as_str()
             ))
             .expect("list target snapshots")
@@ -2678,7 +2678,7 @@ fn fork_failure_after_target_head_reserves_partial_namespace() {
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         KeyMatcher::Prefix(format!(
-            "namespaces/{}/checkpoints/",
+            "namespaces/{}/compacted/checkpoints/",
             clone_namespace_id.as_str()
         )),
         InjectedCreateFailure::Transport {
@@ -2741,7 +2741,7 @@ fn fork_failure_after_target_checkpoint_artifacts_remains_partial() {
     );
     let target_snapshot_keys = store
         .list_prefix(&format!(
-            "namespaces/{}/checkpoints/",
+            "namespaces/{}/compacted/checkpoints/",
             clone_namespace_id.as_str()
         ))
         .expect("list target snapshots");
@@ -3776,7 +3776,7 @@ impl ReplayReadGuardStore {
             inner: LocalFsStore::new(root.as_ref()).expect("store"),
             guarded_prefixes: vec![
                 format!("namespaces/{namespace}/wal/"),
-                format!("namespaces/{namespace}/checkpoints/"),
+                format!("namespaces/{namespace}/compacted/checkpoints/"),
             ],
             guarded_gets: AtomicUsize::new(0),
         }

--- a/crates/loon-objectstore/src/configured.rs
+++ b/crates/loon-objectstore/src/configured.rs
@@ -147,6 +147,7 @@ impl ObjectStore for ConfiguredObjectStore {
 mod tests {
     use super::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
     use crate::fs::LocalFsStore;
+    use crate::keys::namespace_head;
     use crate::r2::R2StoreConfig;
     use crate::s3::AwsS3StoreConfig;
     use crate::ObjectStore;
@@ -160,21 +161,22 @@ mod tests {
         let temp_dir = unique_temp_dir("configured-store-local");
         let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
             .expect("construct configured local fs store");
+        let head_key = namespace_head("ns-1");
 
         store
-            .put_overwrite("namespaces/ns-1/head.json", br#"{"ok":true}"#)
+            .put_overwrite(&head_key, br#"{"ok":true}"#)
             .expect("write scoped object");
 
         let raw_store = LocalFsStore::new(&temp_dir).expect("open raw store");
         assert!(raw_store
-            .head("tenant-a/namespaces/ns-1/head.json")
+            .head(&format!("tenant-a/{head_key}"))
             .expect("head raw scoped object")
             .is_some());
         assert_eq!(
             store
                 .list_prefix("namespaces/ns-1/")
                 .expect("list scoped prefix"),
-            vec!["namespaces/ns-1/head.json".to_owned()]
+            vec![head_key]
         );
     }
 

--- a/crates/loon-objectstore/src/fs.rs
+++ b/crates/loon-objectstore/src/fs.rs
@@ -348,6 +348,7 @@ fn io_error(err: std::io::Error) -> ObjectStoreError {
 mod tests {
     use super::LocalFsStore;
     use super::{ObjectStore, PutMode};
+    use crate::keys::{namespace_head, namespace_lease};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -356,20 +357,20 @@ mod tests {
     fn overwrite_refreshes_head_and_visible_bytes() {
         let temp_dir = TestDir::new("overwrite");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = "namespaces/ns-1/head.json";
+        let key = namespace_head("ns-1");
 
         let first = store
-            .put(key, br#"{"seq":1}"#, PutMode::Overwrite)
+            .put(&key, br#"{"seq":1}"#, PutMode::Overwrite)
             .expect("seed first object");
         let second = store
-            .put(key, br#"{"seq":2}"#, PutMode::Overwrite)
+            .put(&key, br#"{"seq":2}"#, PutMode::Overwrite)
             .expect("overwrite object");
 
         assert_eq!(
-            store.get(key, None).expect("get object"),
+            store.get(&key, None).expect("get object"),
             Some(br#"{"seq":2}"#.to_vec())
         );
-        let head = store.head(key).expect("head object").expect("head exists");
+        let head = store.head(&key).expect("head object").expect("head exists");
         assert_eq!(head.etag, second.etag);
         assert_eq!(head.size_bytes, second.size_bytes);
         assert_ne!(first, second);
@@ -379,15 +380,15 @@ mod tests {
     fn delete_is_idempotent_and_head_reflects_removal() {
         let temp_dir = TestDir::new("delete");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = "namespaces/ns-1/lease.json";
+        let key = namespace_lease("ns-1");
 
         store
-            .put_if_absent(key, br#"{"holder":"writer-a"}"#)
+            .put_if_absent(&key, br#"{"holder":"writer-a"}"#)
             .expect("seed lease object");
-        assert!(store.head(key).expect("head before delete").is_some());
-        store.delete(key).expect("delete existing object");
-        store.delete(key).expect("delete missing object");
-        assert_eq!(store.head(key).expect("head after delete"), None);
+        assert!(store.head(&key).expect("head before delete").is_some());
+        store.delete(&key).expect("delete existing object");
+        store.delete(&key).expect("delete missing object");
+        assert_eq!(store.head(&key).expect("head after delete"), None);
     }
 
     struct TestDir {

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -1,3 +1,4 @@
+use crate::layout::{self, ObjectLayout};
 use crate::ObjectStoreError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,53 +40,61 @@ impl DerivedWorkClass {
 }
 
 pub fn namespace_head(namespace: &str) -> String {
-    format!("namespaces/{namespace}/head.json")
+    ObjectLayout::new().namespace_head(namespace).into_string()
 }
 
 pub fn namespace_descriptor(namespace: &str) -> String {
-    format!("namespaces/{namespace}/descriptor.json")
+    ObjectLayout::new()
+        .namespace_descriptor(namespace)
+        .into_string()
 }
 
 pub fn namespace_lease(namespace: &str) -> String {
-    format!("namespaces/{namespace}/lease.json")
+    ObjectLayout::new().namespace_lease(namespace).into_string()
 }
 
 pub fn wal_segment(namespace: &str, start_seq: u64, end_seq: u64, segment_id: &str) -> String {
-    format!("namespaces/{namespace}/wal/{start_seq:020}-{end_seq:020}-{segment_id}.cbor.zst")
+    ObjectLayout::new()
+        .wal_segment(namespace, start_seq, end_seq, segment_id)
+        .into_string()
 }
 
 pub fn content_store_descriptor(content_store: &str) -> String {
-    format!("content-stores/{content_store}/descriptor.json")
+    ObjectLayout::new()
+        .content_store_descriptor(content_store)
+        .into_string()
 }
 
 pub fn content_blob(content_store: &str, digest: &str) -> Result<String, ObjectStoreError> {
-    let hex = sha256_hex_from_digest(digest)?;
-    Ok(format!(
-        "content-stores/{content_store}/blobs/sha256/{}/{}/{}",
-        &hex[0..2],
-        &hex[2..4],
-        hex
-    ))
+    ObjectLayout::new()
+        .content_blob(content_store, digest)
+        .map(|key| key.into_string())
 }
 
 pub fn conflict_artifact(namespace: &str, conflict_id: &str) -> String {
-    format!("namespaces/{namespace}/conflicts/{conflict_id}.json")
+    ObjectLayout::new()
+        .conflict_artifact(namespace, conflict_id)
+        .into_string()
 }
 
 pub fn conflict_artifact_prefix(namespace: &str) -> String {
-    format!("namespaces/{namespace}/conflicts/")
+    ObjectLayout::new().conflict_artifact_prefix(namespace)
 }
 
 pub fn upload_session(namespace: &str, upload_id: &str) -> String {
-    format!("namespaces/{namespace}/control/uploads/{upload_id}.json")
+    ObjectLayout::new()
+        .upload_session(namespace, upload_id)
+        .into_string()
 }
 
 pub fn upload_session_prefix(namespace: &str) -> String {
-    format!("namespaces/{namespace}/control/uploads/")
+    ObjectLayout::new().upload_session_prefix(namespace)
 }
 
 pub fn checkpoint_manifest(namespace: &str, seq: u64) -> String {
-    format!("namespaces/{namespace}/checkpoints/{seq:020}/manifest.json")
+    ObjectLayout::new()
+        .checkpoint_manifest(namespace, seq)
+        .into_string()
 }
 
 pub fn checkpoint_run_table(
@@ -95,35 +104,23 @@ pub fn checkpoint_run_table(
     family: CheckpointTableFamily,
     segment_index: u32,
 ) -> String {
-    format!(
-        "namespaces/{namespace}/checkpoints/{run_seq:020}/runs/{run_id}/tables/{}-{segment_index:05}.sst.zst",
-        family.as_str()
-    )
+    ObjectLayout::new()
+        .checkpoint_run_table(namespace, run_seq, run_id, family, segment_index)
+        .into_string()
 }
 
 pub fn derived_progress(namespace: &str, work_class: DerivedWorkClass) -> String {
-    let work_class = work_class.as_str();
-    format!("namespaces/{namespace}/derived/{work_class}/progress.json")
+    ObjectLayout::new()
+        .derived_progress(namespace, work_class)
+        .into_string()
 }
 
 pub fn queue_shard(shard_index: u32) -> String {
-    format!("queue/shards/{shard_index:05}.json")
+    ObjectLayout::new().queue_shard(shard_index).into_string()
 }
 
 pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
-    let Some(hex) = digest.strip_prefix("sha256:") else {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
-    };
-    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
-    }
-    if !hex
-        .bytes()
-        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
-    }
-    Ok(hex)
+    layout::sha256_hex_from_digest(digest)
 }
 
 #[cfg(test)]
@@ -137,12 +134,15 @@ mod tests {
 
     #[test]
     fn key_builders_match_spec_examples() {
-        assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/head.json");
+        assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/control/head.json");
         assert_eq!(
             namespace_descriptor("ns-1"),
             "namespaces/ns-1/descriptor.json"
         );
-        assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
+        assert_eq!(
+            namespace_lease("ns-1"),
+            "namespaces/ns-1/control/lease.json"
+        );
         assert_eq!(
             content_store_descriptor("cs_00000000000000000000000000000001"),
             "content-stores/cs_00000000000000000000000000000001/descriptor.json"
@@ -153,7 +153,7 @@ mod tests {
         );
         assert_eq!(
             checkpoint_manifest("ns-1", 400),
-            "namespaces/ns-1/checkpoints/00000000000000000400/manifest.json"
+            "namespaces/ns-1/compacted/checkpoints/00000000000000000400/manifest.json"
         );
         assert_eq!(
             checkpoint_run_table(
@@ -163,7 +163,7 @@ mod tests {
                 CheckpointTableFamily::DirentryBinds,
                 7
             ),
-            "namespaces/ns-1/checkpoints/00000000000000000400/runs/run_00000000000000000000000000000001/tables/direntry-binds-00007.sst.zst"
+            "namespaces/ns-1/compacted/checkpoints/00000000000000000400/runs/run_00000000000000000000000000000001/tables/direntry-binds/00007.sst.zst"
         );
         assert_eq!(
             derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder),
@@ -188,12 +188,9 @@ mod tests {
         );
         assert_eq!(
             upload_session("ns-1", "upl_00000000000000000000000000000001"),
-            "namespaces/ns-1/control/uploads/upl_00000000000000000000000000000001.json"
+            "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
         );
-        assert_eq!(
-            upload_session_prefix("ns-1"),
-            "namespaces/ns-1/control/uploads/"
-        );
+        assert_eq!(upload_session_prefix("ns-1"), "namespaces/ns-1/uploads/");
     }
 
     #[test]

--- a/crates/loon-objectstore/src/keyspace.rs
+++ b/crates/loon-objectstore/src/keyspace.rs
@@ -89,6 +89,7 @@ mod tests {
         normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
         validate_segments,
     };
+    use crate::keys::namespace_head;
     use crate::ObjectStoreError;
 
     #[test]
@@ -114,20 +115,24 @@ mod tests {
 
     #[test]
     fn scoped_key_helpers_keep_prefix_isolation() {
+        let head_key = namespace_head("ns-1");
         assert!(matches!(
-            scope_object_key(Some("tenant-a"), "namespaces/ns-1/head.json"),
-            Ok(scoped) if scoped == "tenant-a/namespaces/ns-1/head.json"
+            scope_object_key(Some("tenant-a"), &head_key),
+            Ok(scoped) if scoped == format!("tenant-a/{head_key}")
         ));
         assert!(matches!(
             scope_list_prefix(Some("tenant-a"), "namespaces/ns-1/"),
             Ok(scoped) if scoped == "tenant-a/namespaces/ns-1/"
         ));
         assert_eq!(
-            unscope_listed_key(Some("tenant-a"), "tenant-a/namespaces/ns-1/head.json"),
-            Some("namespaces/ns-1/head.json".to_owned())
+            unscope_listed_key(Some("tenant-a"), &format!("tenant-a/{head_key}")),
+            Some(head_key)
         );
         assert_eq!(
-            unscope_listed_key(Some("tenant-a"), "tenant-b/namespaces/ns-1/head.json"),
+            unscope_listed_key(
+                Some("tenant-a"),
+                "tenant-b/namespaces/ns-1/control/head.json"
+            ),
             None
         );
     }

--- a/crates/loon-objectstore/src/layout.rs
+++ b/crates/loon-objectstore/src/layout.rs
@@ -1,0 +1,275 @@
+use crate::keys::{CheckpointTableFamily, DerivedWorkClass};
+use crate::ObjectStoreError;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ObjectLayout;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ObjectKey(String);
+
+macro_rules! typed_key {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(ObjectKey);
+
+        impl $name {
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+
+            pub fn into_string(self) -> String {
+                self.0.into_string()
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(key: $name) -> Self {
+                key.into_string()
+            }
+        }
+    };
+}
+
+typed_key!(NamespaceDescriptorKey);
+typed_key!(NamespaceHeadKey);
+typed_key!(NamespaceLeaseKey);
+typed_key!(WalSegmentKey);
+typed_key!(ContentStoreDescriptorKey);
+typed_key!(ContentBlobKey);
+typed_key!(ConflictArtifactKey);
+typed_key!(UploadSessionKey);
+typed_key!(CheckpointManifestKey);
+typed_key!(CheckpointRunTableKey);
+typed_key!(DerivedProgressKey);
+typed_key!(QueueShardKey);
+
+impl ObjectKey {
+    fn new(key: impl Into<String>) -> Self {
+        Self(key.into())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl ObjectLayout {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn namespace_descriptor(&self, namespace: &str) -> NamespaceDescriptorKey {
+        NamespaceDescriptorKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/descriptor.json"
+        )))
+    }
+
+    pub fn namespace_head(&self, namespace: &str) -> NamespaceHeadKey {
+        NamespaceHeadKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/control/head.json"
+        )))
+    }
+
+    pub fn namespace_lease(&self, namespace: &str) -> NamespaceLeaseKey {
+        NamespaceLeaseKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/control/lease.json"
+        )))
+    }
+
+    pub fn wal_segment(
+        &self,
+        namespace: &str,
+        start_seq: u64,
+        end_seq: u64,
+        segment_id: &str,
+    ) -> WalSegmentKey {
+        WalSegmentKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/wal/{start_seq:020}-{end_seq:020}-{segment_id}.cbor.zst"
+        )))
+    }
+
+    pub fn content_store_descriptor(&self, content_store: &str) -> ContentStoreDescriptorKey {
+        ContentStoreDescriptorKey(ObjectKey::new(format!(
+            "content-stores/{content_store}/descriptor.json"
+        )))
+    }
+
+    pub fn content_blob(
+        &self,
+        content_store: &str,
+        digest: &str,
+    ) -> Result<ContentBlobKey, ObjectStoreError> {
+        let hex = sha256_hex_from_digest(digest)?;
+        Ok(ContentBlobKey(ObjectKey::new(format!(
+            "content-stores/{content_store}/blobs/sha256/{}/{}/{}",
+            &hex[0..2],
+            &hex[2..4],
+            hex
+        ))))
+    }
+
+    pub fn conflict_artifact(&self, namespace: &str, conflict_id: &str) -> ConflictArtifactKey {
+        ConflictArtifactKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/conflicts/{conflict_id}.json"
+        )))
+    }
+
+    pub fn conflict_artifact_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/conflicts/")
+    }
+
+    pub fn upload_session(&self, namespace: &str, upload_id: &str) -> UploadSessionKey {
+        UploadSessionKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/uploads/{upload_id}.json"
+        )))
+    }
+
+    pub fn upload_session_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/uploads/")
+    }
+
+    pub fn checkpoint_manifest(&self, namespace: &str, seq: u64) -> CheckpointManifestKey {
+        CheckpointManifestKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/compacted/checkpoints/{seq:020}/manifest.json"
+        )))
+    }
+
+    pub fn checkpoint_run_table(
+        &self,
+        namespace: &str,
+        run_seq: u64,
+        run_id: &str,
+        family: CheckpointTableFamily,
+        segment_index: u32,
+    ) -> CheckpointRunTableKey {
+        CheckpointRunTableKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/compacted/checkpoints/{run_seq:020}/runs/{run_id}/tables/{}/{segment_index:05}.sst.zst",
+            family.as_str()
+        )))
+    }
+
+    pub fn derived_progress(
+        &self,
+        namespace: &str,
+        work_class: DerivedWorkClass,
+    ) -> DerivedProgressKey {
+        let work_class = work_class.as_str();
+        DerivedProgressKey(ObjectKey::new(format!(
+            "namespaces/{namespace}/derived/{work_class}/progress.json"
+        )))
+    }
+
+    pub fn queue_shard(&self, shard_index: u32) -> QueueShardKey {
+        QueueShardKey(ObjectKey::new(format!(
+            "queue/shards/{shard_index:05}.json"
+        )))
+    }
+}
+
+pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+    };
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+    }
+    if !hex
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+    }
+    Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sha256_hex_from_digest, ObjectLayout};
+    use crate::keys::{CheckpointTableFamily, DerivedWorkClass};
+
+    #[test]
+    fn layout_golden_tree_matches_expected_paths() {
+        let layout = ObjectLayout::new();
+
+        assert_eq!(
+            layout.namespace_descriptor("ns-1").as_str(),
+            "namespaces/ns-1/descriptor.json"
+        );
+        assert_eq!(
+            layout.namespace_head("ns-1").as_str(),
+            "namespaces/ns-1/control/head.json"
+        );
+        assert_eq!(
+            layout.namespace_lease("ns-1").as_str(),
+            "namespaces/ns-1/control/lease.json"
+        );
+        assert_eq!(
+            layout
+                .content_store_descriptor("cs_00000000000000000000000000000001")
+                .as_str(),
+            "content-stores/cs_00000000000000000000000000000001/descriptor.json"
+        );
+        assert_eq!(
+            layout
+                .wal_segment("ns-1", 420, 425, "seg_00000000000000000000000000000001")
+                .as_str(),
+            "namespaces/ns-1/wal/00000000000000000420-00000000000000000425-seg_00000000000000000000000000000001.cbor.zst"
+        );
+        assert_eq!(
+            layout.checkpoint_manifest("ns-1", 400).as_str(),
+            "namespaces/ns-1/compacted/checkpoints/00000000000000000400/manifest.json"
+        );
+        assert_eq!(
+            layout
+                .checkpoint_run_table(
+                    "ns-1",
+                    400,
+                    "run_00000000000000000000000000000001",
+                    CheckpointTableFamily::DirentryBinds,
+                    7
+                )
+                .as_str(),
+            "namespaces/ns-1/compacted/checkpoints/00000000000000000400/runs/run_00000000000000000000000000000001/tables/direntry-binds/00007.sst.zst"
+        );
+        assert_eq!(
+            layout
+                .derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder)
+                .as_str(),
+            "namespaces/ns-1/derived/checkpoint-builder/progress.json"
+        );
+        assert_eq!(
+            layout
+                .upload_session("ns-1", "upl_00000000000000000000000000000001")
+                .as_str(),
+            "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
+        );
+        assert_eq!(layout.queue_shard(17).as_str(), "queue/shards/00017.json");
+        assert_eq!(
+            layout
+                .content_blob(
+                    "cs_00000000000000000000000000000001",
+                    "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                )
+                .expect("content key")
+                .as_str(),
+            "content-stores/cs_00000000000000000000000000000001/blobs/sha256/ab/cd/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        );
+    }
+
+    #[test]
+    fn content_blob_rejects_invalid_sha256_digest() {
+        assert!(sha256_hex_from_digest("sha1:abcdef").is_err());
+        assert!(sha256_hex_from_digest("sha256:abcd").is_err());
+        assert!(sha256_hex_from_digest(
+            "sha256:ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+        .is_err());
+        assert!(ObjectLayout::new()
+            .content_blob("ns-1", "sha256:not-hex")
+            .is_err());
+    }
+}

--- a/crates/loon-objectstore/src/lib.rs
+++ b/crates/loon-objectstore/src/lib.rs
@@ -5,6 +5,7 @@ mod configured;
 pub mod fs;
 pub mod keys;
 mod keyspace;
+pub mod layout;
 pub mod metrics;
 pub mod probes;
 pub mod provider;

--- a/crates/loon-objectstore/src/metrics.rs
+++ b/crates/loon-objectstore/src/metrics.rs
@@ -400,11 +400,15 @@ fn classify_key(key: &str) -> KeyClass {
     match segments.as_slice() {
         ["content-stores", _, "blobs", ..] => KeyClass::Content,
         ["content-stores", ..] => KeyClass::Metadata,
-        ["namespaces", _, "head.json"] => KeyClass::NamespaceHead,
-        ["namespaces", _, "lease.json"] => KeyClass::Lease,
+        ["namespaces", _, "control", "head.json"] => KeyClass::NamespaceHead,
+        ["namespaces", _, "control", "lease.json"] => KeyClass::Lease,
         ["namespaces", _, "wal", ..] => KeyClass::WalSegment,
-        ["namespaces", _, "checkpoints", _, "manifest.json"] => KeyClass::CheckpointManifest,
-        ["namespaces", _, "checkpoints", _, "runs", _, "tables", ..] => KeyClass::CheckpointTable,
+        ["namespaces", _, "compacted", "checkpoints", _, "manifest.json"] => {
+            KeyClass::CheckpointManifest
+        }
+        ["namespaces", _, "compacted", "checkpoints", _, "runs", _, "tables", ..] => {
+            KeyClass::CheckpointTable
+        }
         ["namespaces", _, "derived", .., "progress.json"] => KeyClass::DerivedProgress,
         ["namespaces", ..] | ["queue", ..] => KeyClass::Metadata,
         _ => KeyClass::Unknown,

--- a/crates/loon-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loon-objectstore/tests/metrics_instrumented_object_store.rs
@@ -1,6 +1,7 @@
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
-    checkpoint_manifest, checkpoint_run_table, wal_segment, CheckpointTableFamily,
+    checkpoint_manifest, checkpoint_run_table, namespace_head, namespace_lease, wal_segment,
+    CheckpointTableFamily,
 };
 use loon_objectstore::metrics::{
     InstrumentedObjectStore, JsonlObjectStoreMetricsRecorder, KeyClass, ObjectStoreMetricsRecorder,
@@ -18,11 +19,7 @@ fn records_put_success() {
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
 
     store
-        .put(
-            "namespaces/ns-1/head.json",
-            b"head",
-            PutMode::CreateIfAbsent,
-        )
+        .put(&namespace_head("ns-1"), b"head", PutMode::CreateIfAbsent)
         .expect("put object");
 
     let samples = recorder.samples();
@@ -43,13 +40,13 @@ fn delegates_convenience_writes_to_inner_store() {
     let store = InstrumentedObjectStore::new(DelegatingWriteStore::default(), recorder.clone());
 
     store
-        .put_overwrite("namespaces/ns-1/head.json", b"overwrite")
+        .put_overwrite(&namespace_head("ns-1"), b"overwrite")
         .expect("put overwrite");
     store
-        .put_if_absent("namespaces/ns-1/head.json", b"create")
+        .put_if_absent(&namespace_head("ns-1"), b"create")
         .expect("put if absent");
     store
-        .compare_and_swap("namespaces/ns-1/head.json", "etag-old", b"swap")
+        .compare_and_swap(&namespace_head("ns-1"), "etag-old", b"swap")
         .expect("compare and swap");
 
     let inner = store.into_inner();
@@ -102,11 +99,11 @@ fn records_head_and_head_with_checksum_as_distinct_operations() {
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
 
     store
-        .put_overwrite("namespaces/ns-1/lease.json", b"lease")
+        .put_overwrite(&namespace_lease("ns-1"), b"lease")
         .expect("put object");
-    store.head("namespaces/ns-1/lease.json").expect("head");
+    store.head(&namespace_lease("ns-1")).expect("head");
     store
-        .head_with_checksum("namespaces/ns-1/lease.json")
+        .head_with_checksum(&namespace_lease("ns-1"))
         .expect("head with checksum");
 
     let samples = recorder.samples();
@@ -162,7 +159,7 @@ fn records_list_count() {
         .put_overwrite("namespaces/ns-1/descriptor.json", b"descriptor")
         .expect("put descriptor");
     store
-        .put_overwrite("namespaces/ns-1/head.json", b"head")
+        .put_overwrite(&namespace_head("ns-1"), b"head")
         .expect("put head");
     let keys = store
         .list_prefix("namespaces/ns-1/")
@@ -220,7 +217,7 @@ fn jsonl_recorder_writes_privacy_safe_samples() {
     let raw_key = "namespaces/ns-1/wal/secret-segment.cbor.zst";
 
     store
-        .put_overwrite("namespaces/ns-1/head.json", b"head")
+        .put_overwrite(&namespace_head("ns-1"), b"head")
         .expect("put object");
     assert!(store.get(raw_key, None).expect("get missing").is_none());
     recorder.flush().expect("flush metrics");

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -131,8 +131,11 @@ fn key_builders_cover_locked_object_families() {
         namespace_descriptor("ns-1"),
         "namespaces/ns-1/descriptor.json"
     );
-    assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/head.json");
-    assert_eq!(namespace_lease("ns-1"), "namespaces/ns-1/lease.json");
+    assert_eq!(namespace_head("ns-1"), "namespaces/ns-1/control/head.json");
+    assert_eq!(
+        namespace_lease("ns-1"),
+        "namespaces/ns-1/control/lease.json"
+    );
     assert_eq!(
         content_store_descriptor("cs_00000000000000000000000000000001"),
         "content-stores/cs_00000000000000000000000000000001/descriptor.json"
@@ -151,7 +154,7 @@ fn key_builders_cover_locked_object_families() {
     );
     assert_eq!(
         checkpoint_manifest("ns-1", 420),
-        "namespaces/ns-1/checkpoints/00000000000000000420/manifest.json"
+        "namespaces/ns-1/compacted/checkpoints/00000000000000000420/manifest.json"
     );
     assert_eq!(
         checkpoint_run_table(
@@ -161,7 +164,7 @@ fn key_builders_cover_locked_object_families() {
             CheckpointTableFamily::Inodes,
             3
         ),
-        "namespaces/ns-1/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/inodes-00003.sst.zst"
+        "namespaces/ns-1/compacted/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/inodes/00003.sst.zst"
     );
     assert_eq!(
         checkpoint_run_table(
@@ -171,7 +174,7 @@ fn key_builders_cover_locked_object_families() {
             CheckpointTableFamily::DirentryChildBinds,
             4
         ),
-        "namespaces/ns-1/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/direntry-child-binds-00004.sst.zst"
+        "namespaces/ns-1/compacted/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/direntry-child-binds/00004.sst.zst"
     );
     assert_eq!(
         checkpoint_run_table(
@@ -181,7 +184,7 @@ fn key_builders_cover_locked_object_families() {
             CheckpointTableFamily::CommitReceipts,
             0
         ),
-        "namespaces/ns-1/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/commit-receipts-00000.sst.zst"
+        "namespaces/ns-1/compacted/checkpoints/00000000000000000420/runs/run_00000000000000000000000000000001/tables/commit-receipts/00000.sst.zst"
     );
     assert_eq!(
         derived_progress("ns-1", DerivedWorkClass::CheckpointBuilder),

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1804,7 +1804,7 @@ impl HeadCasFailureStore {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             head_key: namespace_head(namespace),
             wal_prefix: format!("namespaces/{namespace}/wal/"),
-            checkpoint_prefix: format!("namespaces/{namespace}/checkpoints/"),
+            checkpoint_prefix: format!("namespaces/{namespace}/compacted/checkpoints/"),
             fail_head_cas: AtomicBool::new(false),
             wal_get_count: AtomicUsize::new(0),
             checkpoint_get_count: AtomicUsize::new(0),

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -26,13 +26,13 @@ The required durable object families and standard key patterns are:
 | Family | Mutability | Purpose | Standard object key pattern |
 | --- | --- | --- | --- |
 | **Namespace descriptor** | Immutable | Record namespace identity and its immutable content-store relationship. | `namespaces/{namespace_id}/descriptor.json` |
-| **Namespace head** | Mutable | Record the current visible boundary, replay hints, and visible WAL tip. | `namespaces/{namespace_id}/head.json` |
-| **Namespace lease** | Mutable | Fence concurrent publishers when the deployment uses more than one possible writer. | `namespaces/{namespace_id}/lease.json` |
+| **Namespace head** | Mutable | Record the current visible boundary, replay hints, and visible WAL tip. | `namespaces/{namespace_id}/control/head.json` |
+| **Namespace lease** | Mutable | Fence concurrent publishers when the deployment uses more than one possible writer. | `namespaces/{namespace_id}/control/lease.json` |
 | **Content-store descriptor** | Immutable | Record content-store identity. | `content-stores/{content_store_id}/descriptor.json` |
 | **Content objects** | Immutable | Store whole-file v0 bytes. | `content-stores/{content_store_id}/blobs/sha256/{hex[0..2]}/{hex[2..4]}/{hex}` |
 | **WAL segments** | Immutable | Record one or more logical commits with a contiguous sequence range. | `namespaces/{namespace_id}/wal/{start_seq}-{end_seq}-{segment_id}.cbor.zst` |
-| **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced materialization tables. | `namespaces/{namespace_id}/checkpoints/{checkpoint_seq}/manifest.json` |
-| **Checkpoint run tables** | Immutable | Store one verified metadata materialization run. Runs may be full materializations or WAL-derived runs, and a checkpoint manifest may reference multiple runs. | `namespaces/{namespace_id}/checkpoints/{run_seq}/runs/{run_id}/tables/{family}-{segment_index}.sst.zst` |
+| **Checkpoint manifest** | Immutable | Record the verified checkpoint summary and referenced materialization tables. | `namespaces/{namespace_id}/compacted/checkpoints/{checkpoint_seq}/manifest.json` |
+| **Checkpoint run tables** | Immutable | Store one verified metadata materialization run. Runs may be full materializations or WAL-derived runs, and a checkpoint manifest may reference multiple runs. | `namespaces/{namespace_id}/compacted/checkpoints/{run_seq}/runs/{run_id}/tables/{family}/{segment_index}.sst.zst` |
 
 These key shapes are part of the interoperable storage contract. Implementations may add other control-plane objects.
 
@@ -40,7 +40,7 @@ These key shapes are part of the interoperable storage contract. Implementations
 
 LoonFS uses distinct naming conventions for distinct surfaces:
 
-- Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `commit-receipts`, and `control/uploads`.
+- Fixed object-store path segments use lowercase words or lowercase-kebab, e.g. `content-stores`, `commit-receipts`, and `uploads`.
 - Generated opaque IDs use underscore-prefixed tokens with 32 lowercase hex characters, e.g. `cs_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41`, `upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c`, and `seg_b7c14a0d9e6f42a38c5d21f0e8a739bc`.
 - Durable work-class names use lowercase-kebab, e.g. `checkpoint-builder`.
 - JSON enum values use snake_case.


### PR DESCRIPTION
Centralizes object-store key creation in loon-objectstore and moves namespace control, uploads, and checkpoint materialization paths under the namespace-root layout
