### PR TITLE
feat(core): record namespace fork provenance

### DIFF
--- a/crates/loon-api/src/control.rs
+++ b/crates/loon-api/src/control.rs
@@ -11,6 +11,7 @@ pub enum ControlObjectKind {
     ContentStoreDescriptor,
     NamespaceHead,
     NamespaceLease,
+    NamespaceForkState,
     NamespaceProgress,
     UploadSession,
     QueueShard,
@@ -25,6 +26,16 @@ pub struct NamespaceDescriptorState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContentStoreDescriptorState {
     pub content_store_id: ContentStoreId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespaceForkState {
+    pub namespace_id: NamespaceId,
+    pub source_namespace_id: NamespaceId,
+    pub fork_seq: ChangeSeq,
+    pub source_checkpoint_seq: ChangeSeq,
+    pub source_head_seq: ChangeSeq,
+    pub created_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -140,6 +151,7 @@ pub type ProgressStateEnvelope = ControlObjectEnvelope<ProgressState>;
 pub type UploadSessionEnvelope = ControlObjectEnvelope<UploadSessionState>;
 pub type NamespaceDescriptorEnvelope = ControlObjectEnvelope<NamespaceDescriptorState>;
 pub type ContentStoreDescriptorEnvelope = ControlObjectEnvelope<ContentStoreDescriptorState>;
+pub type NamespaceForkStateEnvelope = ControlObjectEnvelope<NamespaceForkState>;
 
 pub fn payload_checksum_sha256<T>(value: &T) -> Result<String, serde_json::Error>
 where

--- a/crates/loon-core/src/namespace/fork.rs
+++ b/crates/loon-core/src/namespace/fork.rs
@@ -11,10 +11,13 @@ use crate::namespace::catalog::{
 };
 use loon_api::wire::control::{
     ControlObjectKind, HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope,
-    NamespaceDescriptorEnvelope, NamespaceDescriptorState,
+    NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceForkState,
+    NamespaceForkStateEnvelope,
 };
 use loon_api::{FenceToken, NamespaceId, NamespaceSummary};
-use loon_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
+use loon_objectstore::keys::{
+    namespace_descriptor, namespace_fork_state, namespace_head, namespace_lease,
+};
 use loon_objectstore::{ObjectStore, ObjectStoreError};
 
 pub(crate) fn fork_namespace<S: ObjectStore + ?Sized>(
@@ -83,8 +86,22 @@ pub(crate) fn fork_namespace<S: ObjectStore + ?Sized>(
         initial_lease,
     )
     .map_err(|err| CoreError::Store(err.to_string()))?;
+    let fork_state = NamespaceForkStateEnvelope::from_state(
+        ControlObjectKind::NamespaceForkState,
+        &context.writer_version,
+        NamespaceForkState {
+            namespace_id: new_namespace_id.clone(),
+            source_namespace_id: source_namespace_id.clone(),
+            fork_seq,
+            source_checkpoint_seq: fork_seq,
+            source_head_seq: fork_seq,
+            created_at_ms: context.now_ms,
+        },
+    )
+    .map_err(|err| CoreError::Store(err.to_string()))?;
 
     let head_key = namespace_head(new_namespace_id.as_str());
+    let fork_state_key = namespace_fork_state(new_namespace_id.as_str());
     let lease_key = namespace_lease(new_namespace_id.as_str());
     let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
     put_target_namespace_control_object(
@@ -104,6 +121,12 @@ pub(crate) fn fork_namespace<S: ObjectStore + ?Sized>(
             metadata_state: &source_checkpoint.metadata_state,
             writer_version: &context.writer_version,
         },
+    )?;
+    put_target_namespace_control_object(
+        store,
+        new_namespace_id,
+        &fork_state_key,
+        &serde_json::to_vec(&fork_state).map_err(|err| CoreError::Store(err.to_string()))?,
     )?;
     put_target_namespace_control_object(
         store,

--- a/crates/loon-core/tests/mutation_guards.rs
+++ b/crates/loon-core/tests/mutation_guards.rs
@@ -9,7 +9,7 @@ use loon_api::{
     },
     wire::control::{
         ContentStoreDescriptorEnvelope, ControlObjectKind, HeadState, LeaseState,
-        NamespaceDescriptorEnvelope, NamespaceDescriptorState,
+        NamespaceDescriptorEnvelope, NamespaceDescriptorState, NamespaceForkStateEnvelope,
     },
     wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
     AbsolutePath, ChangeSeq, CommitId, ContentRef, ContentRefKind, FenceToken, InodeId, InodeKind,
@@ -33,8 +33,8 @@ use loon_core::{
 };
 use loon_objectstore::fs::LocalFsStore;
 use loon_objectstore::keys::{
-    content_blob, content_store_descriptor, namespace_descriptor, namespace_head, namespace_lease,
-    upload_session_prefix,
+    content_blob, content_store_descriptor, namespace_descriptor, namespace_fork_state,
+    namespace_head, namespace_lease, upload_session_prefix,
 };
 use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use std::path::Path;
@@ -1075,6 +1075,13 @@ fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
     assert_eq!(descriptor.state.namespace_id, namespace_id);
     assert_eq!(descriptor.state.content_store_id, basis.content_store_id);
     assert!(descriptor.has_valid_payload_checksum().expect("checksum"));
+    assert!(
+        store
+            .head(&namespace_fork_state(namespace_id.as_str()))
+            .expect("head root fork state")
+            .is_none(),
+        "root namespace creation must not write fork provenance"
+    );
 
     let content_descriptor_key = content_store_descriptor(basis.content_store_id.as_str());
     let content_descriptor_bytes = store
@@ -2538,6 +2545,22 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
         .expect("fork namespace");
 
+    let fork_state_key = namespace_fork_state(clone_namespace_id.as_str());
+    let fork_state_bytes = store
+        .get(&fork_state_key, None)
+        .expect("read fork state")
+        .expect("fork state exists");
+    let fork_state: NamespaceForkStateEnvelope =
+        serde_json::from_slice(&fork_state_bytes).expect("decode fork state");
+    assert_eq!(fork_state.kind, ControlObjectKind::NamespaceForkState);
+    assert_eq!(fork_state.state.namespace_id, clone_namespace_id);
+    assert_eq!(fork_state.state.source_namespace_id, source_namespace_id);
+    assert_eq!(fork_state.state.fork_seq, ChangeSeq(1));
+    assert_eq!(fork_state.state.source_checkpoint_seq, ChangeSeq(1));
+    assert_eq!(fork_state.state.source_head_seq, ChangeSeq(1));
+    assert!(fork_state.state.created_at_ms > 0);
+    assert!(fork_state.has_valid_payload_checksum().expect("checksum"));
+
     let blobs_after = store
         .list_prefix(&format!(
             "content-stores/{}/blobs/",
@@ -2566,6 +2589,22 @@ fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     assert_eq!(
         read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
             .expect("read clone")
+            .bytes,
+        b"base"
+    );
+    store.delete(&fork_state_key).expect("delete fork state");
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("read clone without fork state")
+            .bytes,
+        b"base"
+    );
+    store
+        .put_overwrite(&fork_state_key, b"not-json")
+        .expect("corrupt fork state");
+    assert_eq!(
+        read_file_bytes(&store, &clone_namespace_id, "/docs/shared.txt")
+            .expect("read clone with corrupt fork state")
             .bytes,
         b"base"
     );
@@ -2703,6 +2742,58 @@ fn fork_failure_after_target_head_reserves_partial_namespace() {
             .expect("head target descriptor")
             .is_none(),
         "descriptor must remain unpublished"
+    );
+    assert_namespace_partial(&store, &clone_namespace_id, &context);
+}
+
+#[test]
+fn fork_failure_after_target_checkpoint_before_fork_state_remains_partial() {
+    let temp_dir = tempdir().expect("tempdir");
+    let source_namespace_id = namespace_id();
+    let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Exact(namespace_fork_state(clone_namespace_id.as_str())),
+        InjectedCreateFailure::Transport {
+            message: "injected target fork state failure",
+        },
+    );
+    seed_source_namespace_for_fork(&store, &source_namespace_id, &context);
+
+    let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("target fork-state write should fail");
+    assert_eq!(error.code(), ErrorCode::ServerError);
+    assert!(
+        store
+            .head(&namespace_head(clone_namespace_id.as_str()))
+            .expect("head target head")
+            .is_some(),
+        "target head should still reserve namespace"
+    );
+    assert!(
+        store
+            .head(&namespace_descriptor(clone_namespace_id.as_str()))
+            .expect("head target descriptor")
+            .is_none(),
+        "descriptor must remain unpublished"
+    );
+    let target_snapshot_keys = store
+        .list_prefix(&format!(
+            "namespaces/{}/compacted/checkpoints/",
+            clone_namespace_id.as_str()
+        ))
+        .expect("list target snapshots");
+    assert!(
+        !target_snapshot_keys.is_empty(),
+        "target checkpoint artifacts should have been written before fork-state failure"
+    );
+    assert!(
+        store
+            .head(&namespace_fork_state(clone_namespace_id.as_str()))
+            .expect("head target fork state")
+            .is_none(),
+        "fork state should not be durable after injected fork-state failure"
     );
     assert_namespace_partial(&store, &clone_namespace_id, &context);
 }

--- a/crates/loon-objectstore/src/keys.rs
+++ b/crates/loon-objectstore/src/keys.rs
@@ -53,6 +53,12 @@ pub fn namespace_lease(namespace: &str) -> String {
     ObjectLayout::new().namespace_lease(namespace).into_string()
 }
 
+pub fn namespace_fork_state(namespace: &str) -> String {
+    ObjectLayout::new()
+        .namespace_fork_state(namespace)
+        .into_string()
+}
+
 pub fn wal_segment(namespace: &str, start_seq: u64, end_seq: u64, segment_id: &str) -> String {
     ObjectLayout::new()
         .wal_segment(namespace, start_seq, end_seq, segment_id)
@@ -128,8 +134,9 @@ mod tests {
     use super::{
         checkpoint_manifest, checkpoint_run_table, conflict_artifact, conflict_artifact_prefix,
         content_blob, content_store_descriptor, derived_progress, namespace_descriptor,
-        namespace_head, namespace_lease, queue_shard, sha256_hex_from_digest, upload_session,
-        upload_session_prefix, wal_segment, CheckpointTableFamily, DerivedWorkClass,
+        namespace_fork_state, namespace_head, namespace_lease, queue_shard, sha256_hex_from_digest,
+        upload_session, upload_session_prefix, wal_segment, CheckpointTableFamily,
+        DerivedWorkClass,
     };
 
     #[test]
@@ -142,6 +149,10 @@ mod tests {
         assert_eq!(
             namespace_lease("ns-1"),
             "namespaces/ns-1/control/lease.json"
+        );
+        assert_eq!(
+            namespace_fork_state("ns-1"),
+            "namespaces/ns-1/control/fork.json"
         );
         assert_eq!(
             content_store_descriptor("cs_00000000000000000000000000000001"),

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -47,7 +47,7 @@ derived indexes, compaction control, and garbage collection:
 
 | Family | Current status | Standard object key pattern |
 | --- | --- | --- |
-| **Namespace fork state** | Reserved for fork provenance/debug control. | `namespaces/{namespace_id}/control/fork.json` |
+| **Namespace fork state** | Target-local fork provenance/debug control. | `namespaces/{namespace_id}/control/fork.json` |
 | **Namespace manifests** | Reserved for namespace-root manifest snapshots. | `namespaces/{namespace_id}/manifest/{manifest_id}.manifest` |
 | **Compaction plans** | Reserved for compaction control artifacts. | `namespaces/{namespace_id}/compactions/{compactions_id}.compactions` |
 | **Compacted metadata SSTs** | Reserved for immutable metadata file sets referenced by manifests. | `namespaces/{namespace_id}/compacted/metadata/{table_id}.sst` |

--- a/docs/specs/030-object-store-contract.md
+++ b/docs/specs/030-object-store-contract.md
@@ -47,7 +47,7 @@ derived indexes, compaction control, and garbage collection:
 
 | Family | Current status | Standard object key pattern |
 | --- | --- | --- |
-| **Namespace fork state** | Target-local fork provenance/debug control. | `namespaces/{namespace_id}/control/fork.json` |
+| **Namespace fork state** | Written for forked namespaces to record which namespace was copied and at which sequence. | `namespaces/{namespace_id}/control/fork.json` |
 | **Namespace manifests** | Reserved for namespace-root manifest snapshots. | `namespaces/{namespace_id}/manifest/{manifest_id}.manifest` |
 | **Compaction plans** | Reserved for compaction control artifacts. | `namespaces/{namespace_id}/compactions/{compactions_id}.compactions` |
 | **Compacted metadata SSTs** | Reserved for immutable metadata file sets referenced by manifests. | `namespaces/{namespace_id}/compacted/metadata/{table_id}.sst` |

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -188,9 +188,9 @@ Namespace deletion does not imply content-store deletion. In v0, content-store d
 
 ## 6. Forks
 
-Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, writes the target head first to reserve the namespace, rewrites checkpoint artifacts under the new namespace id and object keys, writes target-local fork provenance to `control/fork.json`, writes the target lease, and writes the namespace descriptor last as the publish/list marker.
+Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, reserves the target namespace by writing its head first, copies checkpoint metadata under the target namespace's object keys, writes `control/fork.json` to record where the fork came from, writes the target lease, and writes the namespace descriptor last as the publish/list marker.
 
-The `control/fork.json` object records provenance for inspection, but it is not recovery authority in v0. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
+The `control/fork.json` object is informational. It records the source namespace and fork sequence so operators can see where the namespace came from. Normal reads and recovery do not load it in v0. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
 
 ## 7. Mounts
 

--- a/docs/specs/040-filesystem-and-storage-model.md
+++ b/docs/specs/040-filesystem-and-storage-model.md
@@ -188,9 +188,9 @@ Namespace deletion does not imply content-store deletion. In v0, content-store d
 
 ## 6. Forks
 
-Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, writes the target head first to reserve the namespace, rewrites checkpoint artifacts under the new namespace id and object keys, writes the target lease, and writes the namespace descriptor last as the publish/list marker.
+Forking a namespace creates a new namespace with independent metadata history and the same `content_store_id` as the source namespace. The fork point is the source namespace's current head. The implementation creates or reuses a verified source checkpoint at that head, writes the target head first to reserve the namespace, rewrites checkpoint artifacts under the new namespace id and object keys, writes target-local fork provenance to `control/fork.json`, writes the target lease, and writes the namespace descriptor last as the publish/list marker.
 
-No durable parent/child relationship is part of v0 namespace state. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
+The `control/fork.json` object records provenance for inspection, but it is not recovery authority in v0. After fork, the clone must remain readable even if the source namespace metadata is deleted or corrupted. Source writes after the fork do not affect the clone, and clone writes do not affect the source.
 
 ## 7. Mounts
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -236,15 +236,15 @@ The fork protocol is:
 1. Check the target namespace initialization state. A complete target is rejected as existing, and a partial target is rejected as partially initialized.
 2. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
 3. Create or reuse a verified source checkpoint at the current source head.
-4. Build the target head, fork provenance, lease, and descriptor using the source namespace's `content_store_id`.
+4. Build the target head, fork record, lease, and descriptor using the source namespace's `content_store_id`.
 5. Write the target `head.json` first to reserve the namespace.
 6. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
-7. Write target-local fork provenance to `control/fork.json`.
+7. Write `control/fork.json` with the source namespace id and fork sequence.
 8. Write the target `lease.json`.
 9. Write the target `descriptor.json` last as the publish/list marker.
 10. Start the new namespace WAL independently at `fork_seq + 1`.
 
-The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. If initialization fails after the target head exists but before the descriptor is published, the target is partial. A successful fork has independent namespace history from the fork point. The target's `control/fork.json` records provenance for inspection, but recovery remains target-local because checkpoint artifacts are still copied into the target namespace.
+The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. If initialization fails after the target head exists but before the descriptor is published, the target is partial. A successful fork has independent namespace history from the fork point. The target's `control/fork.json` is only a record of where the namespace came from; recovery remains target-local because checkpoint artifacts are copied into the target namespace.
 
 ## 10. Long-running operations
 

--- a/docs/specs/050-write-read-protocol.md
+++ b/docs/specs/050-write-read-protocol.md
@@ -236,14 +236,15 @@ The fork protocol is:
 1. Check the target namespace initialization state. A complete target is rejected as existing, and a partial target is rejected as partially initialized.
 2. Resolve and verify the source namespace descriptor, content-store descriptor, head, lease, checkpoint, and WAL basis.
 3. Create or reuse a verified source checkpoint at the current source head.
-4. Build the target head, lease, and descriptor using the source namespace's `content_store_id`.
+4. Build the target head, fork provenance, lease, and descriptor using the source namespace's `content_store_id`.
 5. Write the target `head.json` first to reserve the namespace.
 6. Rebuild checkpoint artifacts under the new namespace id with fresh checksums and object keys.
-7. Write the target `lease.json`.
-8. Write the target `descriptor.json` last as the publish/list marker.
-9. Start the new namespace WAL independently at `fork_seq + 1`.
+7. Write target-local fork provenance to `control/fork.json`.
+8. Write the target `lease.json`.
+9. Write the target `descriptor.json` last as the publish/list marker.
+10. Start the new namespace WAL independently at `fork_seq + 1`.
 
-The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. If initialization fails after the target head exists but before the descriptor is published, the target is partial. A successful fork has independent namespace history from the fork point. It also does not create a durable parent/child relationship; provenance may be recorded later as audit metadata outside the core namespace model.
+The fork copies namespace-local checkpoint metadata only. It does not copy content-store blobs. If initialization fails after the target head exists but before the descriptor is published, the target is partial. A successful fork has independent namespace history from the fork point. The target's `control/fork.json` records provenance for inspection, but recovery remains target-local because checkpoint artifacts are still copied into the target namespace.
 
 ## 10. Long-running operations
 


### PR DESCRIPTION
Adds a small fork record under the target namespace so forked namespaces remember where they came from. Reads and recovery still use the target namespace metadata, not the fork record.