### PR TITLE
feat(sim): add deterministic simulation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "loon-sim"
+version = "0.1.1"
+dependencies = [
+ "loon-api",
+ "loon-core",
+ "loon-objectstore",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "loonfs"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/loon-server",
   "crates/loon-client",
   "crates/loon-cli",
+  "crates/loon-sim",
 ]
 
 [workspace.package]

--- a/crates/loon-core/src/inspection.rs
+++ b/crates/loon-core/src/inspection.rs
@@ -1,0 +1,99 @@
+use crate::error::CoreError;
+use crate::namespace::basis::VerifiedNamespaceBasis;
+use loon_api::{AuthoritativePathEntry, InodeKind};
+use sha2::{Digest, Sha256};
+
+/// Lists every visible path in a verified namespace basis.
+pub fn list_visible_paths_from_basis(
+    basis: &VerifiedNamespaceBasis,
+) -> Result<Vec<AuthoritativePathEntry>, CoreError> {
+    let mut entries = vec![crate::path::query::resolve_path_from_basis(basis, "/")?];
+    visit_visible_tree(basis, "/", &mut entries)?;
+    entries.sort_by(|left, right| left.absolute_path.cmp(&right.absolute_path));
+    Ok(entries)
+}
+
+/// Computes a deterministic hash of the visible path tree in a verified basis.
+pub fn visible_tree_hash_from_basis(basis: &VerifiedNamespaceBasis) -> Result<String, CoreError> {
+    let entries = list_visible_paths_from_basis(basis)?;
+    let bytes = serde_json::to_vec(&entries).map_err(|error| {
+        CoreError::Store(format!("failed to encode visible tree hash: {error}"))
+    })?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("sha256:{digest:x}"))
+}
+
+fn visit_visible_tree(
+    basis: &VerifiedNamespaceBasis,
+    absolute_path: &str,
+    entries: &mut Vec<AuthoritativePathEntry>,
+) -> Result<(), CoreError> {
+    for entry in crate::path::query::list_path_from_basis(basis, absolute_path)? {
+        let is_dir = entry.inode_kind == InodeKind::Dir;
+        let child_path = entry.absolute_path.clone();
+        entries.push(entry);
+        if is_dir {
+            visit_visible_tree(basis, &child_path, entries)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::load_verified_namespace_basis;
+    use crate::{BootstrapOptions, NamespaceEngine, WriteOptions};
+    use loon_api::NamespaceId;
+    use loon_objectstore::fs::LocalFsStore;
+    use std::sync::Arc;
+
+    #[test]
+    fn visible_paths_from_basis_are_sorted() {
+        let (_temp_dir, store, namespace) = populated_namespace();
+        let basis = load_verified_namespace_basis(&store, &namespace).expect("load basis");
+
+        let paths = list_visible_paths_from_basis(&basis).expect("visible paths");
+        let actual: Vec<_> = paths.into_iter().map(|entry| entry.absolute_path).collect();
+
+        assert_eq!(actual, vec!["/", "/a", "/a/file.txt", "/z"]);
+    }
+
+    #[test]
+    fn visible_tree_hash_from_basis_is_deterministic() {
+        let (_temp_dir, store, namespace) = populated_namespace();
+        let left = load_verified_namespace_basis(&store, &namespace).expect("load left basis");
+        let right = load_verified_namespace_basis(&store, &namespace).expect("load right basis");
+
+        assert_eq!(
+            visible_tree_hash_from_basis(&left).expect("left hash"),
+            visible_tree_hash_from_basis(&right).expect("right hash")
+        );
+    }
+
+    fn populated_namespace() -> (tempfile::TempDir, Arc<LocalFsStore>, NamespaceId) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+        let namespace = NamespaceId::parse("inspection").expect("valid namespace id");
+        let engine = NamespaceEngine::builder(store.clone())
+            .namespace(namespace.clone())
+            .writer("inspection-test")
+            .build()
+            .expect("engine");
+
+        engine
+            .bootstrap_namespace(BootstrapOptions::default())
+            .expect("bootstrap");
+        engine
+            .create_dir("/z", WriteOptions::default())
+            .expect("create z");
+        engine
+            .create_dir("/a", WriteOptions::default())
+            .expect("create a");
+        engine
+            .put_file("/a/file.txt", b"content", WriteOptions::default())
+            .expect("put file");
+
+        (temp_dir, store, namespace)
+    }
+}

--- a/crates/loon-core/src/lib.rs
+++ b/crates/loon-core/src/lib.rs
@@ -80,6 +80,9 @@ pub mod publish {
     };
 }
 
+#[cfg(any(test, feature = "inspection"))]
+pub mod inspection;
+
 pub use context::MutationContext;
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{Error, ErrorCode, ErrorKind, Result};

--- a/crates/loon-sim/Cargo.toml
+++ b/crates/loon-sim/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "loon-core"
+name = "loon-sim"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,20 +7,12 @@ rust-version.workspace = true
 
 [dependencies]
 loon-api = { path = "../loon-api" }
+loon-core = { path = "../loon-core", features = ["inspection"] }
 loon-objectstore = { path = "../loon-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
-
-[features]
-default = []
-inspection = []
 
 [dev-dependencies]
-loon-model = { path = "../loon-model" }
 tempfile.workspace = true
-
-[lints]
-workspace = true

--- a/crates/loon-sim/src/clock.rs
+++ b/crates/loon-sim/src/clock.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SimInstant {
+    nanos_since_epoch: u64,
+}
+
+impl SimInstant {
+    pub const fn from_nanos(nanos_since_epoch: u64) -> Self {
+        Self { nanos_since_epoch }
+    }
+
+    pub const fn as_nanos(self) -> u64 {
+        self.nanos_since_epoch
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimDuration {
+    nanos: u64,
+}
+
+impl SimDuration {
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Self { nanos }
+    }
+
+    pub const fn from_millis(millis: u64) -> Self {
+        Self {
+            nanos: millis.saturating_mul(1_000_000),
+        }
+    }
+
+    pub const fn as_nanos(self) -> u64 {
+        self.nanos
+    }
+}
+
+pub trait SimClock: Clone + Send + Sync + 'static {
+    fn now(&self) -> SimInstant;
+    fn advance(&self, delta: SimDuration);
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DeterministicClock {
+    nanos_since_epoch: Arc<Mutex<u64>>,
+}
+
+impl DeterministicClock {
+    pub fn new(start: SimInstant) -> Self {
+        Self {
+            nanos_since_epoch: Arc::new(Mutex::new(start.as_nanos())),
+        }
+    }
+}
+
+impl SimClock for DeterministicClock {
+    fn now(&self) -> SimInstant {
+        SimInstant::from_nanos(*self.nanos_since_epoch.lock().expect("clock lock poisoned"))
+    }
+
+    fn advance(&self, delta: SimDuration) {
+        let mut now = self.nanos_since_epoch.lock().expect("clock lock poisoned");
+        *now = now.saturating_add(delta.as_nanos());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_clock_advances_only_when_requested() {
+        let clock = DeterministicClock::default();
+        assert_eq!(clock.now(), SimInstant::from_nanos(0));
+
+        clock.advance(SimDuration::from_millis(2));
+        assert_eq!(clock.now(), SimInstant::from_nanos(2_000_000));
+
+        let cloned = clock.clone();
+        assert_eq!(cloned.now(), SimInstant::from_nanos(2_000_000));
+        cloned.advance(SimDuration::from_nanos(7));
+        assert_eq!(clock.now(), SimInstant::from_nanos(2_000_007));
+    }
+}

--- a/crates/loon-sim/src/failure.rs
+++ b/crates/loon-sim/src/failure.rs
@@ -1,0 +1,46 @@
+use crate::replay::ReplaySeed;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SimFailure {
+    #[error("scenario failed: {message}")]
+    Scenario {
+        message: String,
+        replay: Box<ReplaySeed>,
+        trace_path: Option<PathBuf>,
+    },
+    #[error("model mismatch at step {step}: {message}")]
+    ModelMismatch {
+        step: u64,
+        message: String,
+        replay: Box<ReplaySeed>,
+    },
+    #[error("unexpected engine error at step {step}: {source}")]
+    Engine {
+        step: u64,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+        replay: Box<ReplaySeed>,
+    },
+}
+
+impl SimFailure {
+    pub fn replay(&self) -> &ReplaySeed {
+        match self {
+            Self::Scenario { replay, .. }
+            | Self::ModelMismatch { replay, .. }
+            | Self::Engine { replay, .. } => replay,
+        }
+    }
+
+    pub fn format_summary(&self) -> String {
+        let replay = self.replay();
+        format!(
+            "Simulation failed\n\nscenario: {}\nseed:     0x{:016x}\n\nRe-run:\n{}",
+            replay.scenario,
+            replay.seed.0,
+            replay.replay_command()
+        )
+    }
+}

--- a/crates/loon-sim/src/fault.rs
+++ b/crates/loon-sim/src/fault.rs
@@ -1,0 +1,102 @@
+use crate::object_op::{ObjectOp, ObjectOpKind};
+use crate::rng::SimSeed;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectStoreFault {
+    PutReturnsTransientError,
+    PutSucceedsButResponseLost,
+    CompareAndSwapStale,
+    GetReturnsStaleValue,
+    ListOmitsRecentObject,
+    DeleteReturnsTransientError,
+    CorruptObjectBytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledFault {
+    pub step: u64,
+    pub op_kind: Option<ObjectOpKind>,
+    pub key_contains: Option<String>,
+    pub fault: ObjectStoreFault,
+}
+
+impl ScheduledFault {
+    pub fn matches(&self, op: &ObjectOp) -> bool {
+        self.step == op.step
+            && self.op_kind.is_none_or(|kind| kind == op.kind)
+            && self
+                .key_contains
+                .as_deref()
+                .is_none_or(|needle| op.key.contains(needle))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FaultSchedule {
+    pub seed: SimSeed,
+    pub faults: Vec<ScheduledFault>,
+}
+
+impl FaultSchedule {
+    pub fn empty(seed: SimSeed) -> Self {
+        Self {
+            seed,
+            faults: Vec::new(),
+        }
+    }
+
+    pub fn fault_for(&self, op: &ObjectOp) -> Option<&ScheduledFault> {
+        self.faults.iter().find(|fault| fault.matches(op))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fault_schedule_round_trips_json() {
+        let schedule = FaultSchedule {
+            seed: SimSeed(11),
+            faults: vec![ScheduledFault {
+                step: 3,
+                op_kind: Some(ObjectOpKind::PutIfAbsent),
+                key_contains: Some("head".to_owned()),
+                fault: ObjectStoreFault::PutSucceedsButResponseLost,
+            }],
+        };
+
+        let json = serde_json::to_string(&schedule).expect("serialize schedule");
+        let decoded: FaultSchedule = serde_json::from_str(&json).expect("decode schedule");
+        assert_eq!(decoded, schedule);
+    }
+
+    #[test]
+    fn fault_schedule_matches_expected_step() {
+        let schedule = FaultSchedule {
+            seed: SimSeed(1),
+            faults: vec![ScheduledFault {
+                step: 2,
+                op_kind: Some(ObjectOpKind::Get),
+                key_contains: Some("wal".to_owned()),
+                fault: ObjectStoreFault::GetReturnsStaleValue,
+            }],
+        };
+
+        let matching = ObjectOp {
+            step: 2,
+            kind: ObjectOpKind::Get,
+            key: "namespaces/ns/wal/1".to_owned(),
+        };
+        let wrong_kind = ObjectOp {
+            step: 2,
+            kind: ObjectOpKind::Head,
+            key: "namespaces/ns/wal/1".to_owned(),
+        };
+
+        assert!(schedule.fault_for(&matching).is_some());
+        assert!(schedule.fault_for(&wrong_kind).is_none());
+    }
+}

--- a/crates/loon-sim/src/fault_store.rs
+++ b/crates/loon-sim/src/fault_store.rs
@@ -1,0 +1,549 @@
+use crate::fault::{FaultSchedule, ObjectStoreFault, ScheduledFault};
+use crate::object_op::{ObjectOp, ObjectOpKind};
+use crate::trace::{RunId, SharedSimTrace, SimEventResult, SimTrace, SimTraceEvent};
+use loon_objectstore::{ByteRange, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+pub struct FaultInjectingObjectStore<S> {
+    inner: S,
+    schedule: FaultSchedule,
+    trace: SharedSimTrace,
+    next_step: AtomicU64,
+    stale_values: Mutex<HashMap<String, Vec<Vec<u8>>>>,
+    recent_writes: Mutex<Vec<String>>,
+}
+
+impl<S> FaultInjectingObjectStore<S> {
+    pub fn new(inner: S, schedule: FaultSchedule) -> Self {
+        let trace = SharedSimTrace::new(SimTrace::new(
+            RunId(format!("sim-{:016x}", schedule.seed.0)),
+            schedule.seed,
+        ));
+        Self::with_trace(inner, schedule, trace)
+    }
+
+    pub fn with_trace(inner: S, schedule: FaultSchedule, trace: SharedSimTrace) -> Self {
+        Self {
+            inner,
+            schedule,
+            trace,
+            next_step: AtomicU64::new(1),
+            stale_values: Mutex::new(HashMap::new()),
+            recent_writes: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn trace(&self) -> SharedSimTrace {
+        self.trace.clone()
+    }
+
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    fn next_object_op(&self, kind: ObjectOpKind, key: &str) -> ObjectOp {
+        ObjectOp {
+            step: self.next_step.fetch_add(1, Ordering::SeqCst),
+            kind,
+            key: key.to_owned(),
+        }
+    }
+
+    fn push_trace(
+        &self,
+        op: ObjectOp,
+        operation: impl Into<String>,
+        fault: Option<ObjectStoreFault>,
+        result: SimEventResult,
+    ) {
+        self.trace.push(SimTraceEvent {
+            step: op.step,
+            actor: None,
+            operation: operation.into(),
+            object_op: Some(op),
+            injected_fault: fault,
+            result,
+            model_hash: None,
+            core_hash: None,
+        });
+    }
+
+    fn scheduled_fault(&self, op: &ObjectOp) -> Option<ScheduledFault> {
+        self.schedule.fault_for(op).cloned()
+    }
+
+    fn remember_current_value(&self, key: &str)
+    where
+        S: ObjectStore,
+    {
+        if let Ok(Some(bytes)) = self.inner.get(key, None) {
+            self.stale_values
+                .lock()
+                .expect("stale value lock poisoned")
+                .entry(key.to_owned())
+                .or_default()
+                .push(bytes);
+        }
+    }
+
+    fn remember_successful_write(&self, key: &str) {
+        self.recent_writes
+            .lock()
+            .expect("recent writes lock poisoned")
+            .push(key.to_owned());
+    }
+
+    fn stale_value(&self, key: &str) -> Option<Vec<u8>> {
+        self.stale_values
+            .lock()
+            .expect("stale value lock poisoned")
+            .get(key)
+            .and_then(|values| values.last().cloned())
+    }
+
+    fn put_with<F>(
+        &self,
+        key: &str,
+        kind: ObjectOpKind,
+        write: F,
+    ) -> Result<ObjectMetadata, ObjectStoreError>
+    where
+        F: FnOnce(&S) -> Result<ObjectMetadata, ObjectStoreError>,
+        S: ObjectStore,
+    {
+        let op = self.next_object_op(kind, key);
+        let scheduled = self.scheduled_fault(&op);
+        match scheduled.as_ref().map(|fault| &fault.fault) {
+            Some(ObjectStoreFault::PutReturnsTransientError) => {
+                self.push_trace(
+                    op,
+                    "put_transient_error",
+                    Some(ObjectStoreFault::PutReturnsTransientError),
+                    SimEventResult::Error {
+                        class: "transport".to_owned(),
+                    },
+                );
+                Err(ObjectStoreError::Transport(
+                    "simulated transient put failure".to_owned(),
+                ))
+            }
+            Some(ObjectStoreFault::PutSucceedsButResponseLost) => {
+                self.remember_current_value(key);
+                let result = write(&self.inner);
+                if result.is_ok() {
+                    self.remember_successful_write(key);
+                    self.push_trace(
+                        op,
+                        "put_lost_success",
+                        Some(ObjectStoreFault::PutSucceedsButResponseLost),
+                        SimEventResult::Error {
+                            class: "transport".to_owned(),
+                        },
+                    );
+                    Err(ObjectStoreError::Transport(
+                        "simulated lost put response".to_owned(),
+                    ))
+                } else {
+                    self.push_trace(
+                        op,
+                        "put_lost_success_inner_failed",
+                        Some(ObjectStoreFault::PutSucceedsButResponseLost),
+                        result_class(&result),
+                    );
+                    result
+                }
+            }
+            Some(ObjectStoreFault::CompareAndSwapStale) if kind == ObjectOpKind::CompareAndSwap => {
+                self.push_trace(
+                    op,
+                    "compare_and_swap_stale",
+                    Some(ObjectStoreFault::CompareAndSwapStale),
+                    SimEventResult::Error {
+                        class: "precondition_failed".to_owned(),
+                    },
+                );
+                Err(ObjectStoreError::PreconditionFailed)
+            }
+            Some(incompatible) => {
+                let fault = incompatible.clone();
+                self.remember_current_value(key);
+                let result = write(&self.inner);
+                if result.is_ok() {
+                    self.remember_successful_write(key);
+                }
+                self.push_trace(
+                    op,
+                    "put_fault_skipped",
+                    Some(fault),
+                    SimEventResult::Skipped {
+                        reason: "fault_not_applicable_to_operation".to_owned(),
+                    },
+                );
+                result
+            }
+            None => {
+                self.remember_current_value(key);
+                let result = write(&self.inner);
+                if result.is_ok() {
+                    self.remember_successful_write(key);
+                }
+                self.push_trace(op, "put", None, result_class(&result));
+                result
+            }
+        }
+    }
+}
+
+impl<S> ObjectStore for FaultInjectingObjectStore<S>
+where
+    S: ObjectStore,
+{
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let op = self.next_object_op(ObjectOpKind::Head, key);
+        let result = self.inner.head(key);
+        self.push_trace(op, "head", None, result_class(&result));
+        result
+    }
+
+    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let op = self.next_object_op(ObjectOpKind::HeadWithChecksum, key);
+        let result = self.inner.head_with_checksum(key);
+        self.push_trace(op, "head_with_checksum", None, result_class(&result));
+        result
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        let op = self.next_object_op(ObjectOpKind::Get, key);
+        let scheduled = self.scheduled_fault(&op);
+        match scheduled.as_ref().map(|fault| &fault.fault) {
+            Some(ObjectStoreFault::GetReturnsStaleValue) => {
+                if let Some(bytes) = self.stale_value(key) {
+                    self.push_trace(
+                        op,
+                        "get_stale_value",
+                        Some(ObjectStoreFault::GetReturnsStaleValue),
+                        SimEventResult::Ok,
+                    );
+                    return Ok(Some(apply_range(bytes, range)?));
+                }
+                let result = self.inner.get(key, range);
+                self.push_trace(
+                    op,
+                    "get_stale_value_skipped",
+                    Some(ObjectStoreFault::GetReturnsStaleValue),
+                    SimEventResult::Skipped {
+                        reason: "no_stale_value_recorded".to_owned(),
+                    },
+                );
+                result
+            }
+            Some(ObjectStoreFault::CorruptObjectBytes) => {
+                let mut result = self.inner.get(key, range);
+                if let Ok(Some(bytes)) = &mut result {
+                    if let Some(first) = bytes.first_mut() {
+                        *first ^= 0x01;
+                    }
+                }
+                self.push_trace(
+                    op,
+                    "get_corrupt_bytes",
+                    Some(ObjectStoreFault::CorruptObjectBytes),
+                    result_class(&result),
+                );
+                result
+            }
+            Some(incompatible) => {
+                let result = self.inner.get(key, range);
+                self.push_trace(
+                    op,
+                    "get_fault_skipped",
+                    Some(incompatible.clone()),
+                    SimEventResult::Skipped {
+                        reason: "fault_not_applicable_to_operation".to_owned(),
+                    },
+                );
+                result
+            }
+            None => {
+                let result = self.inner.get(key, range);
+                self.push_trace(op, "get", None, result_class(&result));
+                result
+            }
+        }
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let kind = put_mode_kind(&mode);
+        self.put_with(key, kind, |inner| inner.put(key, bytes, mode))
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        let op = self.next_object_op(ObjectOpKind::Delete, key);
+        let scheduled = self.scheduled_fault(&op);
+        match scheduled.as_ref().map(|fault| &fault.fault) {
+            Some(ObjectStoreFault::DeleteReturnsTransientError) => {
+                self.push_trace(
+                    op,
+                    "delete_transient_error",
+                    Some(ObjectStoreFault::DeleteReturnsTransientError),
+                    SimEventResult::Error {
+                        class: "transport".to_owned(),
+                    },
+                );
+                Err(ObjectStoreError::Transport(
+                    "simulated transient delete failure".to_owned(),
+                ))
+            }
+            Some(incompatible) => {
+                let result = self.inner.delete(key);
+                self.push_trace(
+                    op,
+                    "delete_fault_skipped",
+                    Some(incompatible.clone()),
+                    SimEventResult::Skipped {
+                        reason: "fault_not_applicable_to_operation".to_owned(),
+                    },
+                );
+                result
+            }
+            None => {
+                let result = self.inner.delete(key);
+                self.push_trace(op, "delete", None, result_class(&result));
+                result
+            }
+        }
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        let op = self.next_object_op(ObjectOpKind::ListPrefix, prefix);
+        let scheduled = self.scheduled_fault(&op);
+        match scheduled.as_ref().map(|fault| &fault.fault) {
+            Some(ObjectStoreFault::ListOmitsRecentObject) => {
+                let mut result = self.inner.list_prefix(prefix);
+                if let Ok(keys) = &mut result {
+                    keys.sort();
+                    if let Some(index) = recent_key_to_omit(
+                        keys,
+                        prefix,
+                        &self
+                            .recent_writes
+                            .lock()
+                            .expect("recent writes lock poisoned"),
+                    ) {
+                        keys.remove(index);
+                    }
+                }
+                self.push_trace(
+                    op,
+                    "list_omits_recent_object",
+                    Some(ObjectStoreFault::ListOmitsRecentObject),
+                    result_class(&result),
+                );
+                result
+            }
+            Some(incompatible) => {
+                let result = self.inner.list_prefix(prefix);
+                self.push_trace(
+                    op,
+                    "list_fault_skipped",
+                    Some(incompatible.clone()),
+                    SimEventResult::Skipped {
+                        reason: "fault_not_applicable_to_operation".to_owned(),
+                    },
+                );
+                result
+            }
+            None => {
+                let result = self.inner.list_prefix(prefix);
+                self.push_trace(op, "list_prefix", None, result_class(&result));
+                result
+            }
+        }
+    }
+
+    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put_with(key, ObjectOpKind::Put, |inner| {
+            inner.put_overwrite(key, bytes)
+        })
+    }
+
+    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put_with(key, ObjectOpKind::PutIfAbsent, |inner| {
+            inner.put_if_absent(key, bytes)
+        })
+    }
+
+    fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: &[u8],
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put_with(key, ObjectOpKind::CompareAndSwap, |inner| {
+            inner.compare_and_swap(key, expected_etag, bytes)
+        })
+    }
+}
+
+fn put_mode_kind(mode: &PutMode) -> ObjectOpKind {
+    match mode {
+        PutMode::Overwrite => ObjectOpKind::Put,
+        PutMode::CreateIfAbsent => ObjectOpKind::PutIfAbsent,
+        PutMode::CompareAndSwap { .. } => ObjectOpKind::CompareAndSwap,
+    }
+}
+
+fn apply_range(bytes: Vec<u8>, range: Option<ByteRange>) -> Result<Vec<u8>, ObjectStoreError> {
+    let Some(range) = range else {
+        return Ok(bytes);
+    };
+    let start =
+        usize::try_from(range.start_inclusive).map_err(|_| ObjectStoreError::InvalidRange)?;
+    let end = usize::try_from(range.end_exclusive).map_err(|_| ObjectStoreError::InvalidRange)?;
+    if start > end || end > bytes.len() {
+        return Err(ObjectStoreError::InvalidRange);
+    }
+    Ok(bytes[start..end].to_vec())
+}
+
+fn recent_key_to_omit(keys: &[String], prefix: &str, recent_writes: &[String]) -> Option<usize> {
+    recent_writes
+        .iter()
+        .rev()
+        .find(|key| key.starts_with(prefix))
+        .and_then(|recent| keys.iter().position(|key| key == recent))
+}
+
+fn result_class<T>(result: &Result<T, ObjectStoreError>) -> SimEventResult {
+    match result {
+        Ok(_) => SimEventResult::Ok,
+        Err(ObjectStoreError::NotFound) => SimEventResult::Error {
+            class: "not_found".to_owned(),
+        },
+        Err(ObjectStoreError::InvalidKey(_)) => SimEventResult::Error {
+            class: "invalid_key".to_owned(),
+        },
+        Err(ObjectStoreError::InvalidRange) => SimEventResult::Error {
+            class: "invalid_range".to_owned(),
+        },
+        Err(ObjectStoreError::PreconditionFailed) => SimEventResult::Error {
+            class: "precondition_failed".to_owned(),
+        },
+        Err(ObjectStoreError::Conflict) => SimEventResult::Error {
+            class: "conflict".to_owned(),
+        },
+        Err(ObjectStoreError::Unsupported(_)) => SimEventResult::Error {
+            class: "unsupported".to_owned(),
+        },
+        Err(ObjectStoreError::Transport(_)) => SimEventResult::Error {
+            class: "transport".to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fault::ScheduledFault;
+    use crate::rng::SimSeed;
+    use loon_objectstore::fs::LocalFsStore;
+
+    fn temp_store() -> (tempfile::TempDir, LocalFsStore) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+        (temp_dir, store)
+    }
+
+    #[test]
+    fn fault_store_records_trace() {
+        let (_temp_dir, store) = temp_store();
+        let schedule = FaultSchedule::empty(SimSeed(1));
+        let store = FaultInjectingObjectStore::new(store, schedule);
+
+        store.put_overwrite("a", b"abc").expect("put");
+        store.get("a", None).expect("get");
+
+        let trace = store.trace().snapshot();
+        assert_eq!(trace.events.len(), 2);
+        assert_eq!(trace.events[0].object_op.as_ref().unwrap().step, 1);
+        assert_eq!(trace.events[1].object_op.as_ref().unwrap().step, 2);
+    }
+
+    #[test]
+    fn lost_success_fault_performs_inner_write_and_returns_error() {
+        let (_temp_dir, store) = temp_store();
+        let schedule = FaultSchedule {
+            seed: SimSeed(1),
+            faults: vec![ScheduledFault {
+                step: 1,
+                op_kind: Some(ObjectOpKind::Put),
+                key_contains: None,
+                fault: ObjectStoreFault::PutSucceedsButResponseLost,
+            }],
+        };
+        let store = FaultInjectingObjectStore::new(store, schedule);
+
+        assert!(matches!(
+            store.put_overwrite("a", b"abc"),
+            Err(ObjectStoreError::Transport(_))
+        ));
+        assert_eq!(store.inner().get("a", None).unwrap(), Some(b"abc".to_vec()));
+    }
+
+    #[test]
+    fn transient_put_fault_does_not_perform_inner_write() {
+        let (_temp_dir, store) = temp_store();
+        let schedule = FaultSchedule {
+            seed: SimSeed(1),
+            faults: vec![ScheduledFault {
+                step: 1,
+                op_kind: Some(ObjectOpKind::Put),
+                key_contains: None,
+                fault: ObjectStoreFault::PutReturnsTransientError,
+            }],
+        };
+        let store = FaultInjectingObjectStore::new(store, schedule);
+
+        assert!(matches!(
+            store.put_overwrite("a", b"abc"),
+            Err(ObjectStoreError::Transport(_))
+        ));
+        assert_eq!(store.inner().get("a", None).unwrap(), None);
+    }
+
+    #[test]
+    fn list_omission_fault_is_deterministic() {
+        let (_temp_dir, store) = temp_store();
+        let schedule = FaultSchedule {
+            seed: SimSeed(1),
+            faults: vec![ScheduledFault {
+                step: 3,
+                op_kind: Some(ObjectOpKind::ListPrefix),
+                key_contains: Some("prefix/".to_owned()),
+                fault: ObjectStoreFault::ListOmitsRecentObject,
+            }],
+        };
+        let store = FaultInjectingObjectStore::new(store, schedule);
+
+        store.put_overwrite("prefix/a", b"a").expect("put a");
+        store.put_overwrite("prefix/b", b"b").expect("put b");
+        let keys = store.list_prefix("prefix/").expect("list");
+
+        assert_eq!(keys, vec!["prefix/a".to_owned()]);
+    }
+}

--- a/crates/loon-sim/src/id.rs
+++ b/crates/loon-sim/src/id.rs
@@ -1,0 +1,40 @@
+use crate::rng::{DeterministicRng, SimRng, SimSeed};
+
+#[derive(Debug, Clone)]
+pub struct SimIdGenerator {
+    rng: DeterministicRng,
+}
+
+impl SimIdGenerator {
+    pub fn new(seed: SimSeed) -> Self {
+        Self {
+            rng: DeterministicRng::new(seed),
+        }
+    }
+
+    pub fn from_rng(rng: DeterministicRng) -> Self {
+        Self { rng }
+    }
+
+    pub fn next_id(&mut self, prefix: &'static str) -> String {
+        format!(
+            "{}_{:016x}{:016x}",
+            prefix,
+            self.rng.next_u64(),
+            self.rng.next_u64()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_ids_are_replayable() {
+        let mut left = SimIdGenerator::new(SimSeed(7));
+        let mut right = SimIdGenerator::new(SimSeed(7));
+
+        assert_eq!(left.next_id("c"), right.next_id("c"));
+    }
+}

--- a/crates/loon-sim/src/lib.rs
+++ b/crates/loon-sim/src/lib.rs
@@ -1,0 +1,27 @@
+#![forbid(unsafe_code)]
+
+pub mod clock;
+pub mod failure;
+pub mod fault;
+pub mod fault_store;
+pub mod id;
+pub mod model;
+pub mod namespace_summary;
+pub mod object_op;
+pub mod replay;
+pub mod rng;
+pub mod scenario;
+pub mod trace;
+
+pub use clock::{DeterministicClock, SimClock, SimDuration, SimInstant};
+pub use failure::SimFailure;
+pub use fault::{FaultSchedule, ObjectStoreFault, ScheduledFault};
+pub use fault_store::FaultInjectingObjectStore;
+pub use id::SimIdGenerator;
+pub use model::{ModelComparison, ModelState};
+pub use namespace_summary::{summarize_namespace_objects, SimNamespaceObjectSummary};
+pub use object_op::{ObjectOp, ObjectOpKind};
+pub use replay::{ReplayError, ReplaySeed};
+pub use rng::{DeterministicRng, SimRng, SimSeed};
+pub use scenario::{SimConfig, SimScenario};
+pub use trace::{RunId, SharedSimTrace, SimEventResult, SimTrace, SimTraceEvent};

--- a/crates/loon-sim/src/model.rs
+++ b/crates/loon-sim/src/model.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub trait ModelState {
+    fn stable_hash(&self) -> String;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelComparison {
+    pub model_hash: String,
+    pub core_hash: String,
+}
+
+impl ModelComparison {
+    pub fn matches(&self) -> bool {
+        self.model_hash == self.core_hash
+    }
+}
+
+pub fn stable_hash_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("sha256:{digest:x}")
+}

--- a/crates/loon-sim/src/namespace_summary.rs
+++ b/crates/loon-sim/src/namespace_summary.rs
@@ -1,0 +1,122 @@
+use loon_api::NamespaceId;
+use loon_objectstore::layout::{parse_object_key, DurableObjectFamily, ObjectLayout};
+use loon_objectstore::{ObjectStore, ObjectStoreError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimNamespaceObjectSummary {
+    pub namespace_id: NamespaceId,
+    pub namespace_objects: usize,
+    pub control_objects: usize,
+    pub wal_objects: usize,
+    pub manifest_objects: usize,
+    pub compacted_metadata_objects: usize,
+    pub gc_pin_objects: usize,
+    pub content_blob_count_hint: Option<usize>,
+}
+
+pub fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<SimNamespaceObjectSummary, ObjectStoreError> {
+    let layout = ObjectLayout::new();
+    let prefix = layout.namespace_root_prefix(namespace_id.as_str());
+    let keys = store.list_prefix(&prefix)?;
+    let mut summary = SimNamespaceObjectSummary {
+        namespace_id: namespace_id.clone(),
+        namespace_objects: 0,
+        control_objects: 0,
+        wal_objects: 0,
+        manifest_objects: 0,
+        compacted_metadata_objects: 0,
+        gc_pin_objects: 0,
+        content_blob_count_hint: None,
+    };
+
+    for key in keys {
+        let Some(parsed) = parse_object_key(&key) else {
+            continue;
+        };
+        if parsed.owner_namespace_id() != Some(namespace_id.as_str()) {
+            continue;
+        }
+        summary.namespace_objects += 1;
+        match parsed.family() {
+            DurableObjectFamily::NamespaceHead
+            | DurableObjectFamily::NamespaceLease
+            | DurableObjectFamily::NamespaceForkState => {
+                summary.control_objects += 1;
+            }
+            DurableObjectFamily::WalSegment => {
+                summary.wal_objects += 1;
+            }
+            DurableObjectFamily::NamespaceManifest => {
+                summary.manifest_objects += 1;
+            }
+            DurableObjectFamily::CompactedMetadataSst => {
+                summary.compacted_metadata_objects += 1;
+            }
+            DurableObjectFamily::GcPin => {
+                summary.gc_pin_objects += 1;
+            }
+            DurableObjectFamily::NamespaceDescriptor
+            | DurableObjectFamily::UploadSession
+            | DurableObjectFamily::ConflictArtifact
+            | DurableObjectFamily::NamespaceCompactions
+            | DurableObjectFamily::CompactedIndexSst
+            | DurableObjectFamily::IndexManifest
+            | DurableObjectFamily::IndexGcBoundary
+            | DurableObjectFamily::NamespaceGcBoundary
+            | DurableObjectFamily::DerivedProgress
+            | DurableObjectFamily::ContentStoreDescriptor
+            | DurableObjectFamily::ContentBlob
+            | DurableObjectFamily::QueueShard => {}
+        }
+    }
+
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loon_objectstore::fs::LocalFsStore;
+
+    #[test]
+    fn namespace_object_summary_counts_known_key_families() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+        let namespace_id = NamespaceId::parse("sim").expect("valid namespace id");
+        let layout = ObjectLayout::new();
+
+        store
+            .put_overwrite(
+                layout.namespace_head(namespace_id.as_str()).as_str(),
+                b"head",
+            )
+            .expect("head");
+        store
+            .put_overwrite(
+                layout
+                    .wal_segment(
+                        namespace_id.as_str(),
+                        "seg_00000000000000000000000000000001",
+                    )
+                    .as_str(),
+                b"wal",
+            )
+            .expect("wal");
+        store
+            .put_overwrite(
+                layout.gc_pin(namespace_id.as_str(), "pin_abc").as_str(),
+                b"pin",
+            )
+            .expect("pin");
+
+        let summary = summarize_namespace_objects(&store, &namespace_id).expect("summary");
+        assert_eq!(summary.namespace_objects, 3);
+        assert_eq!(summary.control_objects, 1);
+        assert_eq!(summary.wal_objects, 1);
+        assert_eq!(summary.gc_pin_objects, 1);
+    }
+}

--- a/crates/loon-sim/src/object_op.rs
+++ b/crates/loon-sim/src/object_op.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectOpKind {
+    Head,
+    HeadWithChecksum,
+    Get,
+    Put,
+    PutIfAbsent,
+    CompareAndSwap,
+    Delete,
+    ListPrefix,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectOp {
+    pub step: u64,
+    pub kind: ObjectOpKind,
+    pub key: String,
+}

--- a/crates/loon-sim/src/replay.rs
+++ b/crates/loon-sim/src/replay.rs
@@ -1,0 +1,78 @@
+use crate::fault::FaultSchedule;
+use crate::rng::SimSeed;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplaySeed {
+    pub schema_version: u16,
+    pub scenario: String,
+    pub seed: SimSeed,
+    pub max_steps: usize,
+    pub writers: usize,
+    pub failing_step: Option<u64>,
+    pub fault_schedule: FaultSchedule,
+}
+
+impl ReplaySeed {
+    pub fn to_json_pretty(&self) -> Result<String, ReplayError> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    pub fn from_json_str(input: &str) -> Result<Self, ReplayError> {
+        Ok(serde_json::from_str(input)?)
+    }
+
+    pub fn replay_command(&self) -> String {
+        format!(
+            "cargo run -p loon-sim-scenarios -- replay --seed-file seeds/regressions/{}-{:016x}.json",
+            self.scenario, self.seed.0
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fault::FaultSchedule;
+
+    #[test]
+    fn replay_seed_round_trips_json() {
+        let replay = ReplaySeed {
+            schema_version: 1,
+            scenario: "default_namespace_sim".to_owned(),
+            seed: SimSeed(9),
+            max_steps: 100,
+            writers: 2,
+            failing_step: Some(7),
+            fault_schedule: FaultSchedule::empty(SimSeed(9)),
+        };
+
+        let json = replay.to_json_pretty().expect("serialize replay seed");
+        assert_eq!(ReplaySeed::from_json_str(&json).unwrap(), replay);
+    }
+
+    #[test]
+    fn replay_seed_formats_command() {
+        let replay = ReplaySeed {
+            schema_version: 1,
+            scenario: "scenario".to_owned(),
+            seed: SimSeed(0x2a),
+            max_steps: 100,
+            writers: 1,
+            failing_step: None,
+            fault_schedule: FaultSchedule::empty(SimSeed(0x2a)),
+        };
+
+        assert_eq!(
+            replay.replay_command(),
+            "cargo run -p loon-sim-scenarios -- replay --seed-file seeds/regressions/scenario-000000000000002a.json"
+        );
+    }
+}

--- a/crates/loon-sim/src/rng.rs
+++ b/crates/loon-sim/src/rng.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimSeed(pub u64);
+
+pub trait SimRng {
+    fn next_u64(&mut self) -> u64;
+    fn fill_bytes(&mut self, dest: &mut [u8]);
+    fn fork(&mut self, label: &'static str) -> DeterministicRng;
+}
+
+#[derive(Debug, Clone)]
+pub struct DeterministicRng {
+    state: u64,
+}
+
+impl DeterministicRng {
+    pub fn new(seed: SimSeed) -> Self {
+        Self { state: seed.0 }
+    }
+}
+
+impl SimRng for DeterministicRng {
+    fn next_u64(&mut self) -> u64 {
+        // SplitMix64 is small, stable across platforms, and sufficient for simulation choices.
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        for chunk in dest.chunks_mut(8) {
+            let bytes = self.next_u64().to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+    }
+
+    fn fork(&mut self, label: &'static str) -> DeterministicRng {
+        let mut seed = self.next_u64();
+        for byte in label.as_bytes() {
+            seed ^= u64::from(*byte);
+            seed = seed.wrapping_mul(0x100_0000_01B3);
+        }
+        DeterministicRng::new(SimSeed(seed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_rng_repeats_for_same_seed() {
+        let mut left = DeterministicRng::new(SimSeed(42));
+        let mut right = DeterministicRng::new(SimSeed(42));
+
+        for _ in 0..16 {
+            assert_eq!(left.next_u64(), right.next_u64());
+        }
+    }
+
+    #[test]
+    fn forked_rng_depends_on_label() {
+        let mut root = DeterministicRng::new(SimSeed(42));
+        let mut left = root.fork("left");
+        let mut root = DeterministicRng::new(SimSeed(42));
+        let mut right = root.fork("right");
+
+        assert_ne!(left.next_u64(), right.next_u64());
+    }
+}

--- a/crates/loon-sim/src/scenario.rs
+++ b/crates/loon-sim/src/scenario.rs
@@ -1,0 +1,25 @@
+use crate::failure::SimFailure;
+use crate::rng::SimSeed;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimConfig {
+    pub seed: SimSeed,
+    pub max_steps: usize,
+    pub writers: usize,
+}
+
+impl Default for SimConfig {
+    fn default() -> Self {
+        Self {
+            seed: SimSeed(0xC0FFEE),
+            max_steps: 10_000,
+            writers: 3,
+        }
+    }
+}
+
+pub trait SimScenario {
+    fn name(&self) -> &'static str;
+    fn run(&self, config: SimConfig) -> Result<(), SimFailure>;
+}

--- a/crates/loon-sim/src/trace.rs
+++ b/crates/loon-sim/src/trace.rs
@@ -1,0 +1,96 @@
+use crate::fault::ObjectStoreFault;
+use crate::object_op::ObjectOp;
+use crate::rng::SimSeed;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimTrace {
+    pub run: RunId,
+    pub seed: SimSeed,
+    pub events: Vec<SimTraceEvent>,
+}
+
+impl SimTrace {
+    pub fn new(run: RunId, seed: SimSeed) -> Self {
+        Self {
+            run,
+            seed,
+            events: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimTraceEvent {
+    pub step: u64,
+    pub actor: Option<String>,
+    pub operation: String,
+    pub object_op: Option<ObjectOp>,
+    pub injected_fault: Option<ObjectStoreFault>,
+    pub result: SimEventResult,
+    pub model_hash: Option<String>,
+    pub core_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum SimEventResult {
+    Ok,
+    Error { class: String },
+    Skipped { reason: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct SharedSimTrace {
+    inner: Arc<Mutex<SimTrace>>,
+}
+
+impl SharedSimTrace {
+    pub fn new(trace: SimTrace) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(trace)),
+        }
+    }
+
+    pub fn empty(run: RunId, seed: SimSeed) -> Self {
+        Self::new(SimTrace::new(run, seed))
+    }
+
+    pub fn push(&self, event: SimTraceEvent) {
+        self.inner
+            .lock()
+            .expect("sim trace lock poisoned")
+            .events
+            .push(event);
+    }
+
+    pub fn snapshot(&self) -> SimTrace {
+        self.inner.lock().expect("sim trace lock poisoned").clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_trace_records_events() {
+        let trace = SharedSimTrace::empty(RunId("run".to_owned()), SimSeed(1));
+        trace.push(SimTraceEvent {
+            step: 1,
+            actor: Some("writer-1".to_owned()),
+            operation: "put".to_owned(),
+            object_op: None,
+            injected_fault: None,
+            result: SimEventResult::Ok,
+            model_hash: None,
+            core_hash: None,
+        });
+
+        assert_eq!(trace.snapshot().events.len(), 1);
+    }
+}


### PR DESCRIPTION
- add `loon-sim` deterministic simulation support primitives
- expose neutral `loon-core` inspection helpers behind an `inspection` feature
- keep object-layout summary logic in the sim harness instead of core
