### PR TITLE
refactor(objectstore): add async provider boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "toml",
  "ureq",
 ]
@@ -1204,6 +1205,7 @@ dependencies = [
  "loon-objectstore",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,306 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-credential-types"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a66ac8ef5fa9cf01c2d999f39d16812e90ec1467bd382cbbb74ba23ea86201"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "fastrand",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-http"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e626370f9ba806ae4c439e49675fd871f5767b093075cdf4fef16cac42ba900"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "lazy_static",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-runtime"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ac5cf0ff19c1bca0cea7932e11b239d1025a45696a4f44f72ea86e2b8bdd07"
-dependencies = [
- "aws-credential-types",
- "aws-http",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "percent-encoding",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a531d010f9f556bf65eb3bcd8d24f1937600ab6940fede4d454cd9b1f031fb34"
-dependencies = [
- "aws-credential-types",
- "aws-http",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-checksums",
- "aws-smithy-client",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "regex",
- "tokio-stream",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b28f4910bb956b7ab320b62e98096402354eca976c587d1eeccd523d9bac03"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "bytes",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "once_cell",
- "percent-encoding",
- "regex",
- "sha2",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdb73f85528b9d19c23a496034ac53703955a59323d581c06aa27b4e4e247af"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb15946af1b8d3beeff53ad991d9bff68ac22426b6d40372b958a75fa61eaed"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "crc32c",
- "crc32fast",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-client"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27b2756264c82f830a91cb4d2d485b2d19ad5bea476d9a966e03d27f27ba59a"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls",
- "lazy_static",
- "pin-project-lite",
- "rustls 0.21.12",
- "tokio",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850233feab37b591b7377fd52063aa37af615687f5896807abe7f49bd4e1d25b"
-dependencies = [
- "aws-smithy-types",
- "bytes",
- "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822de399d0ce62829a69dfa8c5cd08efdbe61a7426b953e2268f8b8b52a607bd"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "pin-project-lite",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1e7ab8fa7ad10c193af7ae56d2420989e9f4758bf03601a342573333ea34f"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745e096b3553e7e0f40622aa04971ce52765af82bebdeeac53aa6fc82fe801e6"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d0ae0c9cfd57944e9711ea610b48a963fb174a53aabacc08c5794a594b1d02"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
-dependencies = [
- "base64-simd",
- "itoa",
- "num-integer",
- "ryu",
- "serde",
- "time",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01d2dedcdd8023043716cfeeb3c6c59f2d447fce365d8e194838891794b23b6"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aa0451bf8af1bf22a4f028d5d28054507a14be43cb8ac0597a8471fba9edfe"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
- "http 0.2.12",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,9 +116,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -424,7 +133,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -440,7 +149,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -453,25 +162,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
 
 [[package]]
 name = "bitflags"
@@ -501,16 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +210,24 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -627,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -648,15 +349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
 ]
 
 [[package]]
@@ -685,15 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +398,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -801,12 +483,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -814,6 +512,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -833,8 +559,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -865,8 +596,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -876,9 +609,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -896,16 +631,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -946,21 +681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,17 +714,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1022,7 +731,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1039,28 +748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "humantime"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1072,30 +763,32 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1104,13 +797,45 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1247,10 +972,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1307,6 +1047,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1394,10 +1143,12 @@ dependencies = [
 name = "loon-objectstore"
 version = "0.1.1"
 dependencies = [
- "aws-sdk-s3",
- "base64 0.22.1",
+ "async-trait",
+ "bytes",
+ "futures",
  "http 0.2.12",
  "loon-api",
+ "object_store",
  "serde",
  "serde_json",
  "sha2",
@@ -1455,6 +1206,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1524,27 +1281,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object_store"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -1561,15 +1338,32 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "outref"
-version = "0.5.2"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1578,36 +1372,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1625,10 +1393,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1647,6 +1418,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1671,15 +1507,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "rand"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1700,6 +1562,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,13 +1618,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
+name = "rustc-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1737,18 +1638,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -1757,30 +1646,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -1789,17 +1669,8 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1844,20 +1715,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "scopeguard"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1958,17 +1825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,16 +1892,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -2088,6 +1934,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2163,36 +2012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,7 +2047,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2246,22 +2065,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
+ "rustls",
  "tokio",
 ]
 
@@ -2321,22 +2129,6 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2349,6 +2141,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2495,11 +2305,11 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2561,12 +2371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2424,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2677,6 +2495,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +2517,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2716,10 +2567,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2914,12 +2818,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,14 @@ categories = ["filesystem", "command-line-utilities"]
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1"
 axum = "0.7"
-aws-sdk-s3 = "=0.30.0"
-base64 = "0.22"
 bytes = "1"
 ciborium = "0.2"
 clap = { version = "4.5", features = ["derive"] }
 http = "0.2"
+futures = "0.3"
+object_store = { version = "=0.12.4", default-features = false, features = ["aws"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/loon-cli/Cargo.toml
+++ b/crates/loon-cli/Cargo.toml
@@ -21,6 +21,7 @@ loonfs = { path = "../loonfs" }
 loon-objectstore = { path = "../loon-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 toml.workspace = true
 
 [dev-dependencies]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -11,6 +11,7 @@ use loonfs::{
     RestoreRevisionOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
     TraceStoreKind,
 };
+use std::future::Future;
 use std::sync::Arc;
 
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
@@ -188,14 +189,34 @@ fn map_client_error(error: ClientError) -> CliError {
 
 pub struct EmbeddedBackend {
     fs: Fs,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl EmbeddedBackend {
+    fn block_on<T, F>(&self, future: F) -> Result<T, CliError>
+    where
+        F: Future<Output = loonfs::Result<T>>,
+    {
+        self.runtime.block_on(future).map_err(map_runtime_error)
+    }
+
+    fn block_on_scoped<T, F>(&self, namespace: &str, future: F) -> Result<T, CliError>
+    where
+        F: Future<Output = loonfs::Result<T>>,
+    {
+        self.runtime
+            .block_on(future)
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace, error))
+    }
 }
 
 impl Backend for EmbeddedBackend {
     fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
         let ns_id = parse_namespace_id(namespace_id)?;
-        self.fs
-            .create_namespace(&ns_id, CreateNamespaceOptions::default())
-            .map_err(map_runtime_error)
+        self.block_on(
+            self.fs
+                .create_namespace(&ns_id, CreateNamespaceOptions::default()),
+        )
     }
 
     fn fork_namespace(
@@ -205,35 +226,38 @@ impl Backend for EmbeddedBackend {
     ) -> Result<NamespaceSummary, CliError> {
         let source_namespace_id = parse_namespace_id(source)?;
         let new_namespace_id = parse_namespace_id(new_namespace_id)?;
-        self.fs
-            .fork_namespace(&source_namespace_id, &new_namespace_id)
-            .map_err(map_runtime_error)
+        self.block_on(
+            self.fs
+                .fork_namespace(&source_namespace_id, &new_namespace_id),
+        )
     }
 
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
-        self.fs.list_namespaces().map_err(map_runtime_error)
+        self.block_on(self.fs.list_namespaces())
     }
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .list_path(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.list_path(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .stat_path(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.stat_path(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        let result = self
-            .fs
-            .read_file_bytes(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+        let result = self.block_on_scoped(
+            &spec.namespace,
+            self.fs.read_file_bytes(&ns_id, &spec.absolute_path),
+        )?;
         Ok(result.bytes)
     }
 
@@ -243,10 +267,11 @@ impl Backend for EmbeddedBackend {
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        let result = self
-            .fs
-            .read_file_revision_bytes(&ns_id, &spec.absolute_path, revision_no)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+        let result = self.block_on_scoped(
+            &spec.namespace,
+            self.fs
+                .read_file_revision_bytes(&ns_id, &spec.absolute_path, revision_no),
+        )?;
         Ok(result.bytes)
     }
 
@@ -255,9 +280,10 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
     ) -> Result<ListFileRevisionsResponse, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .list_file_revisions(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.list_file_revisions(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn put_file_bytes(
@@ -273,8 +299,9 @@ impl Backend for EmbeddedBackend {
             PutFileBehavior::CreateOnly
         };
         let commit_id = generated_commit_id();
-        self.fs
-            .put_file_bytes(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.put_file_bytes(
                 &ns_id,
                 &spec.absolute_path,
                 bytes,
@@ -282,37 +309,39 @@ impl Backend for EmbeddedBackend {
                     behavior,
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .delete_path(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.delete_path(
                 &ns_id,
                 &spec.absolute_path,
                 DeleteOptions {
                     recursive: false,
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .create_dir(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.create_dir(
                 &ns_id,
                 &spec.absolute_path,
                 CreateDirOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn move_path(
@@ -322,16 +351,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .move_path(
+        self.block_on_scoped(
+            &from.namespace,
+            self.fs.move_path(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
                 MoveOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
+            ),
+        )
     }
 
     fn copy_path(
@@ -341,16 +371,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .copy_path(
+        self.block_on_scoped(
+            &from.namespace,
+            self.fs.copy_path(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
                 CopyOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
+            ),
+        )
     }
 
     fn restore_file_revision(
@@ -360,16 +391,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .restore_file_revision(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.restore_file_revision(
                 &ns_id,
                 &spec.absolute_path,
                 source_revision_no,
                 RestoreRevisionOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 }
 
@@ -386,6 +418,7 @@ fn map_runtime_error(error: RuntimeError) -> CliError {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
+        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
     }
 }
 
@@ -394,6 +427,7 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
+        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
     }
 }
 
@@ -526,7 +560,11 @@ impl EmbeddedTarget {
             },
         )
         .map_err(map_runtime_error)?;
-        let backend = EmbeddedBackend { fs };
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| CliError::invalid_config(error.to_string()))?;
+        let backend = EmbeddedBackend { fs, runtime };
         Ok(Self { backend })
     }
 }
@@ -633,12 +671,14 @@ mod tests {
             )
             .expect("put file");
 
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let changes = target
             .backend
-            .fs
-            .list_changes_after(
-                &NamespaceId::parse("demo").expect("valid namespace id"),
-                ChangeSeq(0),
+            .block_on(
+                target
+                    .backend
+                    .fs
+                    .list_changes_after(&namespace_id, ChangeSeq(0)),
             )
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);

--- a/crates/loon-objectstore/Cargo.toml
+++ b/crates/loon-objectstore/Cargo.toml
@@ -6,10 +6,12 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aws-sdk-s3.workspace = true
-base64.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+futures.workspace = true
 http.workspace = true
 loon-api = { path = "../loon-api" }
+object_store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/loon-objectstore/src/blocking.rs
+++ b/crates/loon-objectstore/src/blocking.rs
@@ -1,0 +1,226 @@
+use crate::object_store::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode, SharedObjectStore,
+};
+use bytes::Bytes;
+use std::sync::Arc;
+use tokio::runtime::{Builder, Runtime};
+
+/// Temporary synchronous compatibility facade for current callers.
+///
+/// New storage/cache/table code should depend on the async [`ObjectStore`] trait instead.
+pub trait BlockingObjectStore {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError>;
+    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.head(key)
+    }
+    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError>;
+    fn get(&self, key: &str, range: Option<ByteRange>)
+        -> Result<Option<Vec<u8>>, ObjectStoreError>;
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError>;
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError>;
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError>;
+
+    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put(key, bytes, PutMode::Overwrite)
+    }
+
+    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put(key, bytes, PutMode::CreateIfAbsent)
+    }
+
+    fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: &[u8],
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put(
+            key,
+            bytes,
+            PutMode::CompareAndSwap {
+                expected_etag: expected_etag.to_owned(),
+            },
+        )
+    }
+}
+
+impl<T> BlockingObjectStore for &T
+where
+    T: BlockingObjectStore + ?Sized,
+{
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        (*self).head(key)
+    }
+
+    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        (*self).head_with_checksum(key)
+    }
+
+    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        (*self).get_with_metadata(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        (*self).get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        (*self).put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        (*self).delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        (*self).list_prefix(prefix)
+    }
+
+    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        (*self).put_overwrite(key, bytes)
+    }
+
+    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        (*self).put_if_absent(key, bytes)
+    }
+
+    fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: &[u8],
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        (*self).compare_and_swap(key, expected_etag, bytes)
+    }
+}
+
+impl<T> BlockingObjectStore for Arc<T>
+where
+    T: BlockingObjectStore + ?Sized,
+{
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.as_ref().head(key)
+    }
+
+    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.as_ref().head_with_checksum(key)
+    }
+
+    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.as_ref().get_with_metadata(key)
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.as_ref().get(key, range)
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.as_ref().put(key, bytes, mode)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.as_ref().delete(key)
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.as_ref().list_prefix(prefix)
+    }
+
+    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.as_ref().put_overwrite(key, bytes)
+    }
+
+    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.as_ref().put_if_absent(key, bytes)
+    }
+
+    fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: &[u8],
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.as_ref().compare_and_swap(key, expected_etag, bytes)
+    }
+}
+
+#[derive(Debug)]
+pub struct BlockingObjectStoreAdapter {
+    inner: SharedObjectStore,
+    runtime: Runtime,
+}
+
+impl BlockingObjectStoreAdapter {
+    pub fn new(inner: SharedObjectStore) -> Result<Self, ObjectStoreError> {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+        Ok(Self { inner, runtime })
+    }
+}
+
+impl BlockingObjectStore for BlockingObjectStoreAdapter {
+    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.runtime.block_on(self.inner.head(key))
+    }
+
+    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.runtime.block_on(self.inner.head_with_checksum(key))
+    }
+
+    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.runtime.block_on(self.inner.get_with_metadata(key))
+    }
+
+    fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+        self.runtime
+            .block_on(self.inner.get(key, range))
+            .map(|maybe| maybe.map(|bytes| bytes.to_vec()))
+    }
+
+    fn put(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.runtime
+            .block_on(self.inner.put(key, Bytes::copy_from_slice(bytes), mode))
+    }
+
+    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.runtime.block_on(self.inner.delete(key))
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.runtime.block_on(self.inner.list_prefix(prefix))
+    }
+}

--- a/crates/loon-objectstore/src/checksum.rs
+++ b/crates/loon-objectstore/src/checksum.rs
@@ -1,27 +1,8 @@
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine as _;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
 
 pub(crate) fn sha256_digest(bytes: &[u8]) -> String {
     format!("sha256:{}", sha256_hex_bytes(Sha256::digest(bytes)))
-}
-
-pub(crate) fn sha256_base64(bytes: &[u8]) -> String {
-    STANDARD.encode(Sha256::digest(bytes))
-}
-
-pub(crate) fn sha256_digest_from_base64(encoded: &str) -> Result<String, String> {
-    let bytes = STANDARD
-        .decode(encoded)
-        .map_err(|err| format!("invalid base64 SHA-256 checksum: {err}"))?;
-    if bytes.len() != 32 {
-        return Err(format!(
-            "invalid SHA-256 checksum length: expected 32 bytes, got {}",
-            bytes.len()
-        ));
-    }
-    Ok(format!("sha256:{}", sha256_hex_bytes(bytes)))
 }
 
 fn sha256_hex_bytes(bytes: impl AsRef<[u8]>) -> String {
@@ -31,24 +12,4 @@ fn sha256_hex_bytes(bytes: impl AsRef<[u8]>) -> String {
         write!(&mut encoded, "{byte:02x}").expect("writing to a String should not fail");
     }
     encoded
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{sha256_base64, sha256_digest, sha256_digest_from_base64};
-
-    #[test]
-    fn sha256_base64_round_trips_to_normalized_digest() {
-        let bytes = b"checksum bytes";
-        let encoded = sha256_base64(bytes);
-        assert_eq!(
-            sha256_digest_from_base64(&encoded).expect("decode checksum"),
-            sha256_digest(bytes)
-        );
-    }
-
-    #[test]
-    fn sha256_digest_from_base64_rejects_wrong_length() {
-        assert!(sha256_digest_from_base64("aGVsbG8=").is_err());
-    }
 }

--- a/crates/loon-objectstore/src/configured.rs
+++ b/crates/loon-objectstore/src/configured.rs
@@ -1,4 +1,5 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::blocking::BlockingObjectStoreAdapter;
 use crate::fs::LocalFsStore;
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
@@ -7,6 +8,7 @@ use crate::r2::{R2Store, R2StoreConfig};
 use crate::s3::{AwsS3Store, AwsS3StoreConfig};
 use crate::ObjectStoreError;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfiguredObjectStoreKind {
@@ -27,8 +29,8 @@ enum ConfiguredObjectStoreInner {
         store: LocalFsStore,
         key_prefix: Option<String>,
     },
-    AwsS3(AwsS3Store),
-    CloudflareR2(R2Store),
+    AwsS3(BlockingObjectStoreAdapter),
+    CloudflareR2(BlockingObjectStoreAdapter),
 }
 
 impl ConfiguredObjectStore {
@@ -46,16 +48,22 @@ impl ConfiguredObjectStore {
     }
 
     pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self, ObjectStoreError> {
+        let store = AwsS3Store::new(config)?;
         Ok(Self {
             kind: ConfiguredObjectStoreKind::AwsS3,
-            inner: ConfiguredObjectStoreInner::AwsS3(AwsS3Store::new(config)?),
+            inner: ConfiguredObjectStoreInner::AwsS3(BlockingObjectStoreAdapter::new(Arc::new(
+                store,
+            ))?),
         })
     }
 
     pub fn cloudflare_r2(config: R2StoreConfig) -> Result<Self, ObjectStoreError> {
+        let store = R2Store::new(config)?;
         Ok(Self {
             kind: ConfiguredObjectStoreKind::CloudflareR2,
-            inner: ConfiguredObjectStoreInner::CloudflareR2(R2Store::new(config)?),
+            inner: ConfiguredObjectStoreInner::CloudflareR2(BlockingObjectStoreAdapter::new(
+                Arc::new(store),
+            )?),
         })
     }
 

--- a/crates/loon-objectstore/src/fs.rs
+++ b/crates/loon-objectstore/src/fs.rs
@@ -1,7 +1,11 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::checksum;
 use crate::keyspace::validate_segments;
+use crate::AsyncObjectStore;
 use crate::ObjectStoreError;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -70,6 +74,7 @@ impl LocalFsStore {
 
         Ok(ObjectMetadata {
             etag: Some(format!("{:x}-{:x}", metadata.len(), modified_nanos)),
+            version: None,
             size_bytes: metadata.len(),
             checksum_sha256,
         })
@@ -225,8 +230,7 @@ impl ObjectStore for LocalFsStore {
                 Self::create_new_object(&path, bytes)?;
             }
             PutMode::CompareAndSwap { expected_etag } => {
-                let current = self
-                    .head(key)?
+                let current = <Self as ObjectStore>::head(self, key)?
                     .ok_or(ObjectStoreError::PreconditionFailed)?;
                 if current.etag.as_deref() != Some(expected_etag.as_str()) {
                     return Err(ObjectStoreError::PreconditionFailed);
@@ -267,6 +271,55 @@ impl ObjectStore for LocalFsStore {
         keys.retain(|key| key.starts_with(prefix));
         keys.sort();
         Ok(keys)
+    }
+}
+
+#[async_trait]
+impl AsyncObjectStore for LocalFsStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        <Self as ObjectStore>::head(self, key)
+    }
+
+    async fn head_with_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        <Self as ObjectStore>::head_with_checksum(self, key)
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        <Self as ObjectStore>::get_with_metadata(self, key)
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        <Self as ObjectStore>::get(self, key, range).map(|maybe| maybe.map(Bytes::from))
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        <Self as ObjectStore>::put(self, key, &bytes, mode)
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        <Self as ObjectStore>::delete(self, key)
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        match <Self as ObjectStore>::list_prefix(self, prefix) {
+            Ok(keys) => Box::pin(stream::iter(keys.into_iter().map(Ok))),
+            Err(err) => Box::pin(stream::once(async { Err(err) })),
+        }
     }
 }
 

--- a/crates/loon-objectstore/src/lib.rs
+++ b/crates/loon-objectstore/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+mod blocking;
 mod checksum;
 mod configured;
 pub mod fs;
@@ -9,13 +10,19 @@ pub mod layout;
 pub mod metrics;
 pub mod probes;
 pub mod provider;
+mod provider_object_store;
 pub mod r2;
 pub mod s3;
 mod s3_compatible;
 
+pub use blocking::{BlockingObjectStore, BlockingObjectStoreAdapter};
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 pub use object_store::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore as AsyncObjectStore, ObjectStoreError,
+    PutMode, SharedObjectStore,
 };
+pub use provider_object_store::{ProviderObjectStore, ProviderObjectStoreConfig};
 
-mod object_store;
+pub use blocking::BlockingObjectStore as ObjectStore;
+
+pub mod object_store;

--- a/crates/loon-objectstore/src/object_store.rs
+++ b/crates/loon-objectstore/src/object_store.rs
@@ -1,6 +1,12 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{BoxStream, TryStreamExt};
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
+
+pub type SharedObjectStore = Arc<dyn ObjectStore>;
 
 /// Metadata returned by a successful `head`, full-object `get`, or `put` call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,6 +16,8 @@ pub struct ObjectMetadata {
     /// This is suitable for immediate compare-and-swap on the same object key. It is not
     /// canonical content identity and callers must not derive provider-specific meaning from it.
     pub etag: Option<String>,
+    /// Provider version identifier when available.
+    pub version: Option<String>,
     pub size_bytes: u64,
     /// Provider-verified full-object SHA-256 when available, normalized as `sha256:<64hex>`.
     ///
@@ -63,36 +71,66 @@ pub enum ObjectStoreError {
     Transport(String),
 }
 
-pub trait ObjectStore {
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError>;
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.head(key)
-    }
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError>;
-    fn get(&self, key: &str, range: Option<ByteRange>)
-        -> Result<Option<Vec<u8>>, ObjectStoreError>;
-    fn put(
+#[async_trait]
+pub trait ObjectStore: Send + Sync + Debug + 'static {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError>;
+
+    async fn head_with_checksum(
         &self,
         key: &str,
-        bytes: &[u8],
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError>;
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError>;
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError>;
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError>;
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError>;
 
-    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.put(key, bytes, PutMode::Overwrite)
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError>;
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>>;
+
+    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        let mut keys: Vec<String> = self.list_prefix_stream(prefix).try_collect().await?;
+        keys.sort();
+        Ok(keys)
     }
 
-    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.put(key, bytes, PutMode::CreateIfAbsent)
+    async fn put_overwrite(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put(key, bytes, PutMode::Overwrite).await
     }
 
-    fn compare_and_swap(
+    async fn put_if_absent(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.put(key, bytes, PutMode::CreateIfAbsent).await
+    }
+
+    async fn compare_and_swap(
         &self,
         key: &str,
         expected_etag: &str,
-        bytes: &[u8],
+        bytes: Bytes,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         self.put(
             key,
@@ -101,123 +139,6 @@ pub trait ObjectStore {
                 expected_etag: expected_etag.to_owned(),
             },
         )
-    }
-}
-
-impl<T> ObjectStore for &T
-where
-    T: ObjectStore + ?Sized,
-{
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        (*self).head(key)
-    }
-
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        (*self).head_with_checksum(key)
-    }
-
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        (*self).get_with_metadata(key)
-    }
-
-    fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
-        (*self).get(key, range)
-    }
-
-    fn put(
-        &self,
-        key: &str,
-        bytes: &[u8],
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        (*self).put(key, bytes, mode)
-    }
-
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        (*self).delete(key)
-    }
-
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        (*self).list_prefix(prefix)
-    }
-
-    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        (*self).put_overwrite(key, bytes)
-    }
-
-    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        (*self).put_if_absent(key, bytes)
-    }
-
-    fn compare_and_swap(
-        &self,
-        key: &str,
-        expected_etag: &str,
-        bytes: &[u8],
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        (*self).compare_and_swap(key, expected_etag, bytes)
-    }
-}
-
-impl<T> ObjectStore for Arc<T>
-where
-    T: ObjectStore + ?Sized,
-{
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.as_ref().head(key)
-    }
-
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.as_ref().head_with_checksum(key)
-    }
-
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.as_ref().get_with_metadata(key)
-    }
-
-    fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
-        self.as_ref().get(key, range)
-    }
-
-    fn put(
-        &self,
-        key: &str,
-        bytes: &[u8],
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.as_ref().put(key, bytes, mode)
-    }
-
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.as_ref().delete(key)
-    }
-
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        self.as_ref().list_prefix(prefix)
-    }
-
-    fn put_overwrite(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.as_ref().put_overwrite(key, bytes)
-    }
-
-    fn put_if_absent(&self, key: &str, bytes: &[u8]) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.as_ref().put_if_absent(key, bytes)
-    }
-
-    fn compare_and_swap(
-        &self,
-        key: &str,
-        expected_etag: &str,
-        bytes: &[u8],
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.as_ref().compare_and_swap(key, expected_etag, bytes)
+        .await
     }
 }

--- a/crates/loon-objectstore/src/provider_object_store.rs
+++ b/crates/loon-objectstore/src/provider_object_store.rs
@@ -1,0 +1,430 @@
+use crate::checksum;
+use crate::keyspace::{
+    normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
+};
+use crate::{AsyncObjectStore, ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream, StreamExt};
+use object_store as provider_store;
+use provider_store::path::Path;
+use provider_store::{
+    GetOptions, GetRange, ObjectMeta, PutOptions, PutPayload, PutResult, UpdateVersion,
+};
+use std::fmt;
+use std::ops::Range;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderObjectStoreConfig {
+    pub key_prefix: Option<String>,
+    pub sha256_checksum_metadata: bool,
+}
+
+#[derive(Clone)]
+pub struct ProviderObjectStore {
+    inner: Arc<dyn provider_store::ObjectStore>,
+    key_prefix: Option<String>,
+    sha256_checksum_metadata: bool,
+}
+
+impl fmt::Debug for ProviderObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProviderObjectStore")
+            .field("key_prefix", &self.key_prefix)
+            .field("sha256_checksum_metadata", &self.sha256_checksum_metadata)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProviderObjectStore {
+    pub fn new(
+        inner: Arc<dyn provider_store::ObjectStore>,
+        config: ProviderObjectStoreConfig,
+    ) -> Result<Self, ObjectStoreError> {
+        Ok(Self {
+            inner,
+            key_prefix: normalize_key_prefix(config.key_prefix.as_deref())?,
+            sha256_checksum_metadata: config.sha256_checksum_metadata,
+        })
+    }
+
+    fn to_path(&self, key: &str) -> Result<Path, ObjectStoreError> {
+        let scoped = scope_object_key(self.key_prefix.as_deref(), key)?;
+        Path::parse(scoped).map_err(|err| ObjectStoreError::InvalidKey(err.to_string()))
+    }
+
+    fn list_path(&self, prefix: &str) -> Result<Option<Path>, ObjectStoreError> {
+        let scoped = scope_list_prefix(self.key_prefix.as_deref(), prefix)?;
+        if scoped.is_empty() {
+            return Ok(None);
+        }
+        Path::parse(scoped)
+            .map(Some)
+            .map_err(|err| ObjectStoreError::InvalidKey(err.to_string()))
+    }
+
+    fn from_meta(meta: ObjectMeta, checksum_sha256: Option<String>) -> ObjectMetadata {
+        ObjectMetadata {
+            etag: meta.e_tag,
+            version: meta.version,
+            size_bytes: meta.size,
+            checksum_sha256,
+        }
+    }
+
+    fn from_put_result(
+        result: PutResult,
+        size_bytes: u64,
+        checksum_sha256: Option<String>,
+    ) -> ObjectMetadata {
+        ObjectMetadata {
+            etag: result.e_tag,
+            version: result.version,
+            size_bytes,
+            checksum_sha256,
+        }
+    }
+
+    async fn provider_range(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<ProviderRange>, ObjectStoreError> {
+        let Some(range) = range else {
+            return Ok(None);
+        };
+        let metadata = match self.head(key).await? {
+            Some(metadata) => metadata,
+            None => return Err(ObjectStoreError::NotFound),
+        };
+        if range.end_exclusive < range.start_inclusive
+            || range.start_inclusive > metadata.size_bytes
+        {
+            return Err(ObjectStoreError::InvalidRange);
+        }
+
+        let bounded_end = range.end_exclusive.min(metadata.size_bytes);
+        if bounded_end == range.start_inclusive {
+            return Ok(Some(ProviderRange::Empty));
+        }
+        Ok(Some(ProviderRange::Bounded(GetRange::Bounded(Range {
+            start: range.start_inclusive,
+            end: bounded_end,
+        }))))
+    }
+}
+
+#[async_trait]
+impl AsyncObjectStore for ProviderObjectStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let path = self.to_path(key)?;
+        match self.inner.head(&path).await {
+            Ok(meta) => Ok(Some(Self::from_meta(meta, None))),
+            Err(err) if provider_not_found(&err) => Ok(None),
+            Err(err) => Err(map_provider_error(err)),
+        }
+    }
+
+    async fn head_with_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let path = self.to_path(key)?;
+        match self.inner.get(&path).await {
+            Ok(result) => {
+                let metadata = Self::from_meta(result.meta.clone(), None);
+                let bytes = result.bytes().await.map_err(map_provider_error)?;
+                Ok(Some(ObjectBody {
+                    metadata,
+                    bytes: bytes.to_vec(),
+                }))
+            }
+            Err(err) if provider_not_found(&err) => Ok(None),
+            Err(err) => Err(map_provider_error(err)),
+        }
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let path = self.to_path(key)?;
+        let Some(provider_range) = self.provider_range(key, range).await? else {
+            return match self.inner.get(&path).await {
+                Ok(result) => result.bytes().await.map(Some).map_err(map_provider_error),
+                Err(err) if provider_not_found(&err) => Ok(None),
+                Err(err) => Err(map_provider_error(err)),
+            };
+        };
+
+        let ProviderRange::Bounded(provider_range) = provider_range else {
+            return Ok(Some(Bytes::new()));
+        };
+
+        let options = GetOptions {
+            range: Some(provider_range),
+            ..Default::default()
+        };
+        match self.inner.get_opts(&path, options).await {
+            Ok(result) => result.bytes().await.map(Some).map_err(map_provider_error),
+            Err(err) if provider_not_found(&err) => Ok(None),
+            Err(err) => Err(map_provider_error(err)),
+        }
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let path = self.to_path(key)?;
+        let checksum_sha256 = self
+            .sha256_checksum_metadata
+            .then(|| checksum::sha256_digest(&bytes));
+        let size_bytes = bytes.len() as u64;
+        let options = PutOptions {
+            mode: map_put_mode(mode),
+            ..Default::default()
+        };
+
+        match self
+            .inner
+            .put_opts(&path, PutPayload::from(bytes), options)
+            .await
+        {
+            Ok(result) => Ok(Self::from_put_result(result, size_bytes, checksum_sha256)),
+            Err(err) => Err(map_provider_error(err)),
+        }
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        let path = self.to_path(key)?;
+        match self.inner.delete(&path).await {
+            Ok(()) => Ok(()),
+            Err(err) if provider_not_found(&err) => Ok(()),
+            Err(err) => Err(map_provider_error(err)),
+        }
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        let prefix_path = match self.list_path(prefix) {
+            Ok(prefix_path) => prefix_path,
+            Err(err) => return stream::once(async { Err(err) }).boxed(),
+        };
+        let key_prefix = self.key_prefix.clone();
+        self.inner
+            .list(prefix_path.as_ref())
+            .filter_map(move |result| {
+                let key_prefix = key_prefix.clone();
+                async move {
+                    match result {
+                        Ok(meta) => {
+                            let key = meta.location.as_ref();
+                            match key_prefix.as_deref() {
+                                Some(prefix) => unscope_listed_key(Some(prefix), key).map(Ok),
+                                None => Some(Ok(key.to_owned())),
+                            }
+                        }
+                        Err(err) => Some(Err(map_provider_error(err))),
+                    }
+                }
+            })
+            .boxed()
+    }
+}
+
+fn map_put_mode(mode: PutMode) -> provider_store::PutMode {
+    match mode {
+        PutMode::Overwrite => provider_store::PutMode::Overwrite,
+        PutMode::CreateIfAbsent => provider_store::PutMode::Create,
+        PutMode::CompareAndSwap { expected_etag } => {
+            provider_store::PutMode::Update(UpdateVersion {
+                e_tag: Some(expected_etag),
+                version: None,
+            })
+        }
+    }
+}
+
+enum ProviderRange {
+    Empty,
+    Bounded(GetRange),
+}
+
+fn provider_not_found(err: &provider_store::Error) -> bool {
+    matches!(err, provider_store::Error::NotFound { .. })
+}
+
+fn map_provider_error(err: provider_store::Error) -> ObjectStoreError {
+    match err {
+        provider_store::Error::NotFound { .. } => ObjectStoreError::NotFound,
+        provider_store::Error::AlreadyExists { .. }
+        | provider_store::Error::Precondition { .. }
+        | provider_store::Error::NotModified { .. } => ObjectStoreError::PreconditionFailed,
+        provider_store::Error::InvalidPath { source } => {
+            ObjectStoreError::InvalidKey(source.to_string())
+        }
+        provider_store::Error::NotSupported { .. } | provider_store::Error::NotImplemented => {
+            ObjectStoreError::Unsupported("provider object store operation")
+        }
+        provider_store::Error::Generic { source, .. } => {
+            ObjectStoreError::Transport(source.to_string())
+        }
+        provider_store::Error::JoinError { source } => {
+            ObjectStoreError::Transport(source.to_string())
+        }
+        provider_store::Error::PermissionDenied { source, .. }
+        | provider_store::Error::Unauthenticated { source, .. } => {
+            ObjectStoreError::Transport(source.to_string())
+        }
+        provider_store::Error::UnknownConfigurationKey { key, store } => {
+            ObjectStoreError::Transport(format!("unknown {store} configuration key `{key}`"))
+        }
+        other => ObjectStoreError::Transport(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use object_store::memory::InMemory;
+
+    fn memory_store() -> ProviderObjectStore {
+        ProviderObjectStore::new(
+            Arc::new(InMemory::default()),
+            ProviderObjectStoreConfig {
+                key_prefix: Some("tenant-a".to_owned()),
+                sha256_checksum_metadata: true,
+            },
+        )
+        .expect("provider store")
+    }
+
+    #[tokio::test]
+    async fn provider_store_preserves_put_get_head_and_prefix_scoping() {
+        let store = memory_store();
+        let key = "namespaces/demo/control/head.json";
+
+        let metadata = store
+            .put_if_absent(key, Bytes::from_static(b"head"))
+            .await
+            .expect("put");
+        assert_eq!(metadata.size_bytes, 4);
+        assert!(metadata.etag.is_some());
+        assert_eq!(
+            metadata.checksum_sha256,
+            Some(checksum::sha256_digest(b"head"))
+        );
+
+        let head = store.head(key).await.expect("head").expect("head exists");
+        assert_eq!(head.size_bytes, 4);
+        assert_eq!(
+            store.get(key, None).await.expect("get"),
+            Some(Bytes::from_static(b"head"))
+        );
+        assert_eq!(
+            store.list_prefix("namespaces/demo/").await.expect("list"),
+            vec![key.to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_store_enforces_create_and_cas_preconditions() {
+        let store = memory_store();
+        let key = "namespaces/demo/control/head.json";
+        let first = store
+            .put_if_absent(key, Bytes::from_static(b"one"))
+            .await
+            .expect("first put");
+
+        assert!(matches!(
+            store.put_if_absent(key, Bytes::from_static(b"two")).await,
+            Err(ObjectStoreError::PreconditionFailed)
+        ));
+        assert!(matches!(
+            store
+                .compare_and_swap(key, "stale", Bytes::from_static(b"two"))
+                .await,
+            Err(ObjectStoreError::PreconditionFailed)
+        ));
+        let etag = first.etag.expect("etag");
+        store
+            .compare_and_swap(key, &etag, Bytes::from_static(b"two"))
+            .await
+            .expect("cas");
+        assert_eq!(
+            store.get(key, None).await.expect("get"),
+            Some(Bytes::from_static(b"two"))
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_store_range_semantics_match_blocking_contract() {
+        let store = memory_store();
+        let key = "content-stores/cs_0123456789abcdef0123456789abcdef/blobs/sha256/ab/cd/abcdef";
+        store
+            .put_overwrite(key, Bytes::from_static(b"abcdef"))
+            .await
+            .expect("put");
+
+        assert_eq!(
+            store
+                .get(
+                    key,
+                    Some(ByteRange {
+                        start_inclusive: 2,
+                        end_exclusive: 4,
+                    }),
+                )
+                .await
+                .expect("range"),
+            Some(Bytes::from_static(b"cd"))
+        );
+        assert_eq!(
+            store
+                .get(
+                    key,
+                    Some(ByteRange {
+                        start_inclusive: 6,
+                        end_exclusive: 10,
+                    }),
+                )
+                .await
+                .expect("empty"),
+            Some(Bytes::new())
+        );
+        assert!(matches!(
+            store
+                .get(
+                    key,
+                    Some(ByteRange {
+                        start_inclusive: 7,
+                        end_exclusive: 8,
+                    }),
+                )
+                .await,
+            Err(ObjectStoreError::InvalidRange)
+        ));
+    }
+
+    #[tokio::test]
+    async fn provider_stream_reports_invalid_prefix() {
+        let store = memory_store();
+        let mut stream = store.list_prefix_stream("../");
+        assert!(matches!(
+            stream.next().await,
+            Some(Err(ObjectStoreError::InvalidKey(_)))
+        ));
+    }
+}

--- a/crates/loon-objectstore/src/r2.rs
+++ b/crates/loon-objectstore/src/r2.rs
@@ -1,6 +1,9 @@
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
-use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use super::{AsyncObjectStore, ByteRange, ObjectBody, ObjectMetadata, PutMode};
 use crate::ObjectStoreError;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct R2StoreConfig {
@@ -42,41 +45,48 @@ impl R2Store {
     }
 }
 
-impl ObjectStore for R2Store {
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key)
+#[async_trait]
+impl AsyncObjectStore for R2Store {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
     }
 
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key)
+    async fn head_with_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
     }
 
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key)
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
     }
 
-    fn get(
+    async fn get(
         &self,
         key: &str,
         range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
-        self.inner.get(key, range)
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
     }
 
-    fn put(
+    async fn put(
         &self,
         key: &str,
-        bytes: &[u8],
+        bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode)
+        self.inner.put(key, bytes, mode).await
     }
 
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key)
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
     }
 
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        self.inner.list_prefix(prefix)
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loon-objectstore/src/s3.rs
+++ b/crates/loon-objectstore/src/s3.rs
@@ -1,6 +1,9 @@
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
-use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use super::{AsyncObjectStore, ByteRange, ObjectBody, ObjectMetadata, PutMode};
 use crate::ObjectStoreError;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwsS3StoreConfig {
@@ -38,41 +41,48 @@ impl AwsS3Store {
     }
 }
 
-impl ObjectStore for AwsS3Store {
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key)
+#[async_trait]
+impl AsyncObjectStore for AwsS3Store {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
     }
 
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head_with_checksum(key)
+    async fn head_with_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head_with_checksum(key).await
     }
 
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key)
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
     }
 
-    fn get(
+    async fn get(
         &self,
         key: &str,
         range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
-        self.inner.get(key, range)
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
     }
 
-    fn put(
+    async fn put(
         &self,
         key: &str,
-        bytes: &[u8],
+        bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode)
+        self.inner.put(key, bytes, mode).await
     }
 
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key)
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
     }
 
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        self.inner.list_prefix(prefix)
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loon-objectstore/src/s3_compatible.rs
+++ b/crates/loon-objectstore/src/s3_compatible.rs
@@ -1,20 +1,13 @@
-use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
-use crate::checksum;
-use crate::keyspace::{
-    normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
+use crate::{
+    AsyncObjectStore, ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, ProviderObjectStore,
+    ProviderObjectStoreConfig, PutMode,
 };
-use crate::ObjectStoreError;
-use aws_sdk_s3::config::{Credentials, Region};
-use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumMode};
-use aws_sdk_s3::Client;
-use http::header::{IF_MATCH, IF_NONE_MATCH};
-use http::HeaderValue;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use object_store::aws::{AmazonS3Builder, Checksum};
 use std::fmt;
-use std::sync::OnceLock;
-use std::thread;
-use tokio::runtime::{Builder, Runtime};
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct S3CompatibleConfig {
@@ -30,571 +23,138 @@ pub(crate) struct S3CompatibleConfig {
     pub sha256_checksum_metadata: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct S3CompatibleStore {
     provider_name: &'static str,
-    bucket: String,
-    key_prefix: Option<String>,
-    sha256_checksum_metadata: bool,
-    client_config: S3CompatibleConfig,
-    client: OnceLock<Client>,
-    runtime: BlockingRuntime,
+    inner: ProviderObjectStore,
 }
 
 impl fmt::Debug for S3CompatibleStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("S3CompatibleStore")
             .field("provider_name", &self.provider_name)
-            .field("bucket", &self.bucket)
-            .field("key_prefix", &self.key_prefix)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
 impl S3CompatibleStore {
     pub(crate) fn new(config: S3CompatibleConfig) -> Result<Self, ObjectStoreError> {
-        if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
-                "bucket must not be empty".to_owned(),
-            ));
+        validate_config(&config)?;
+
+        let mut builder = AmazonS3Builder::new()
+            .with_bucket_name(config.bucket)
+            .with_region(config.region)
+            .with_access_key_id(config.access_key_id)
+            .with_secret_access_key(config.secret_access_key)
+            .with_virtual_hosted_style_request(!config.force_path_style);
+
+        if let Some(endpoint_url) = config.endpoint_url {
+            let allow_http = endpoint_url.starts_with("http://");
+            builder = builder
+                .with_endpoint(endpoint_url)
+                .with_allow_http(allow_http);
         }
-        if config.region.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
-                "region must not be empty".to_owned(),
-            ));
+        if let Some(session_token) = config.session_token {
+            builder = builder.with_token(session_token);
         }
-        if config.access_key_id.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
-                "access key id must not be empty".to_owned(),
-            ));
-        }
-        if config.secret_access_key.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
-                "secret access key must not be empty".to_owned(),
-            ));
+        if config.sha256_checksum_metadata {
+            builder = builder.with_checksum_algorithm(Checksum::SHA256);
         }
 
-        let key_prefix = normalize_key_prefix(config.key_prefix.as_deref())?;
+        let provider = builder
+            .build()
+            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+        let inner = ProviderObjectStore::new(
+            Arc::new(provider),
+            ProviderObjectStoreConfig {
+                key_prefix: config.key_prefix,
+                sha256_checksum_metadata: config.sha256_checksum_metadata,
+            },
+        )?;
+
         Ok(Self {
             provider_name: config.provider_name,
-            bucket: config.bucket.clone(),
-            key_prefix,
-            sha256_checksum_metadata: config.sha256_checksum_metadata,
-            client_config: config,
-            client: OnceLock::new(),
-            runtime: BlockingRuntime::new()?,
+            inner,
         })
     }
+}
 
-    fn client(&self) -> &Client {
-        self.client
-            .get_or_init(|| build_client(self.client_config.clone()))
+#[async_trait]
+impl AsyncObjectStore for S3CompatibleStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
     }
 
-    fn scoped_key(&self, key: &str) -> Result<String, ObjectStoreError> {
-        scope_object_key(self.key_prefix.as_deref(), key)
-    }
-
-    fn scoped_list_prefix(&self, prefix: &str) -> Result<String, ObjectStoreError> {
-        scope_list_prefix(self.key_prefix.as_deref(), prefix)
-    }
-
-    fn run_async<F, T>(&self, future: F) -> Result<T, ObjectStoreError>
-    where
-        F: std::future::Future<Output = Result<T, ObjectStoreError>>,
-    {
-        self.runtime.block_on(future)
-    }
-
-    async fn head_scoped(
+    async fn head_with_checksum(
         &self,
-        scoped_key: &str,
-        include_checksum: bool,
+        key: &str,
     ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        let mut request = self
-            .client()
-            .head_object()
-            .bucket(&self.bucket)
-            .key(scoped_key);
-        let include_sha256_checksum = include_checksum && self.sha256_checksum_metadata;
-        if include_sha256_checksum {
-            request = request.checksum_mode(ChecksumMode::Enabled);
-        }
-
-        match request.send().await {
-            Ok(output) => {
-                let checksum_sha256 = if include_sha256_checksum {
-                    output
-                        .checksum_sha256()
-                        .map(checksum::sha256_digest_from_base64)
-                        .transpose()
-                        .map_err(ObjectStoreError::Transport)?
-                } else {
-                    None
-                };
-                Ok(Some(ObjectMetadata {
-                    etag: output.e_tag().map(ToOwned::to_owned),
-                    size_bytes: output.content_length().try_into().unwrap_or_default(),
-                    checksum_sha256,
-                }))
-            }
-            Err(err) if is_not_found(&err) => Ok(None),
-            Err(err) => Err(map_sdk_error(err)),
-        }
+        self.inner.head_with_checksum(key).await
     }
 
-    async fn put_scoped(
-        &self,
-        scoped_key: &str,
-        bytes: &[u8],
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let checksum_sha256 = self
-            .sha256_checksum_metadata
-            .then(|| checksum::sha256_base64(bytes));
-        let result = match &mode {
-            PutMode::Overwrite => {
-                let mut request = self
-                    .client()
-                    .put_object()
-                    .bucket(&self.bucket)
-                    .key(scoped_key)
-                    .content_length(bytes.len() as i64);
-                if let Some(checksum) = checksum_sha256.as_deref() {
-                    request = request
-                        .checksum_algorithm(ChecksumAlgorithm::Sha256)
-                        .checksum_sha256(checksum);
-                }
-                request.body(ByteStream::from(bytes.to_vec())).send().await
-            }
-            PutMode::CreateIfAbsent => {
-                let mut request = self
-                    .client()
-                    .put_object()
-                    .bucket(&self.bucket)
-                    .key(scoped_key)
-                    .content_length(bytes.len() as i64);
-                if let Some(checksum) = checksum_sha256.as_deref() {
-                    request = request
-                        .checksum_algorithm(ChecksumAlgorithm::Sha256)
-                        .checksum_sha256(checksum);
-                }
-                request
-                    .body(ByteStream::from(bytes.to_vec()))
-                    .customize()
-                    .await
-                    .map_err(map_sdk_error)?
-                    .mutate_request(|request| {
-                        request
-                            .headers_mut()
-                            .insert(IF_NONE_MATCH, HeaderValue::from_static("*"));
-                    })
-                    .send()
-                    .await
-            }
-            PutMode::CompareAndSwap { expected_etag } => {
-                let if_match = HeaderValue::from_str(expected_etag).map_err(|err| {
-                    ObjectStoreError::Transport(format!(
-                        "invalid expected etag for If-Match header: {err}"
-                    ))
-                })?;
-
-                let mut request = self
-                    .client()
-                    .put_object()
-                    .bucket(&self.bucket)
-                    .key(scoped_key)
-                    .content_length(bytes.len() as i64);
-                if let Some(checksum) = checksum_sha256.as_deref() {
-                    request = request
-                        .checksum_algorithm(ChecksumAlgorithm::Sha256)
-                        .checksum_sha256(checksum);
-                }
-                request
-                    .body(ByteStream::from(bytes.to_vec()))
-                    .customize()
-                    .await
-                    .map_err(map_sdk_error)?
-                    .mutate_request(move |request| {
-                        request.headers_mut().insert(IF_MATCH, if_match.clone());
-                    })
-                    .send()
-                    .await
-            }
-        };
-
-        match result {
-            Ok(_) => {
-                let mut metadata = self.head_scoped(scoped_key, false).await?.ok_or_else(|| {
-                    ObjectStoreError::Transport(format!(
-                        "provider {} reported success for {} but object head is missing",
-                        self.provider_name, scoped_key
-                    ))
-                })?;
-                if self.sha256_checksum_metadata {
-                    metadata.checksum_sha256 = Some(checksum::sha256_digest(bytes));
-                }
-                Ok(metadata)
-            }
-            Err(err) if put_error_maps_to_precondition_failed(&mode, &err) => {
-                Err(ObjectStoreError::PreconditionFailed)
-            }
-            Err(err) => Err(map_sdk_error(err)),
-        }
-    }
-}
-
-struct BlockingRuntime(Option<Runtime>);
-
-impl BlockingRuntime {
-    fn new() -> Result<Self, ObjectStoreError> {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map(Some)
-            .map(Self)
-            .map_err(|err| ObjectStoreError::Transport(err.to_string()))
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
     }
 
-    fn block_on<F, T>(&self, future: F) -> Result<T, ObjectStoreError>
-    where
-        F: std::future::Future<Output = Result<T, ObjectStoreError>>,
-    {
-        self.0
-            .as_ref()
-            .expect("blocking runtime available")
-            .block_on(future)
-    }
-}
-
-impl Drop for BlockingRuntime {
-    fn drop(&mut self) {
-        let Some(runtime) = self.0.take() else {
-            return;
-        };
-        if tokio::runtime::Handle::try_current().is_ok() {
-            let _ = thread::spawn(move || drop(runtime)).join();
-        } else {
-            drop(runtime);
-        }
-    }
-}
-
-fn build_client(config: S3CompatibleConfig) -> Client {
-    let credentials = Credentials::new(
-        config.access_key_id,
-        config.secret_access_key,
-        config.session_token,
-        None,
-        "loondb-objectstore",
-    );
-    let mut builder = aws_sdk_s3::config::Builder::new()
-        .region(Region::new(config.region))
-        .credentials_provider(credentials)
-        .force_path_style(config.force_path_style);
-    if let Some(endpoint_url) = config.endpoint_url {
-        builder = builder.endpoint_url(endpoint_url);
-    }
-    Client::from_conf(builder.build())
-}
-
-impl ObjectStore for S3CompatibleStore {
-    fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async { self.head_scoped(&scoped_key, false).await })
-    }
-
-    fn head_with_checksum(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async { self.head_scoped(&scoped_key, true).await })
-    }
-
-    fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async {
-            let mut request = self
-                .client()
-                .get_object()
-                .bucket(&self.bucket)
-                .key(&scoped_key);
-            if self.sha256_checksum_metadata {
-                request = request.checksum_mode(ChecksumMode::Enabled);
-            }
-
-            match request.send().await {
-                Ok(output) => {
-                    let checksum_sha256 = if self.sha256_checksum_metadata {
-                        output
-                            .checksum_sha256()
-                            .map(checksum::sha256_digest_from_base64)
-                            .transpose()
-                            .map_err(ObjectStoreError::Transport)?
-                    } else {
-                        None
-                    };
-                    let metadata = ObjectMetadata {
-                        etag: output.e_tag().map(ToOwned::to_owned),
-                        size_bytes: output.content_length().try_into().unwrap_or_default(),
-                        checksum_sha256,
-                    };
-                    let collected = output
-                        .body
-                        .collect()
-                        .await
-                        .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
-                    Ok(Some(ObjectBody {
-                        metadata,
-                        bytes: collected.into_bytes().to_vec(),
-                    }))
-                }
-                Err(err) if is_not_found(&err) => Ok(None),
-                Err(err) => Err(map_sdk_error(err)),
-            }
-        })
-    }
-
-    fn get(
+    async fn get(
         &self,
         key: &str,
         range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async {
-            let range_header = match range {
-                None => None,
-                Some(range) => {
-                    let metadata = match self.head_scoped(&scoped_key, false).await? {
-                        Some(metadata) => metadata,
-                        None => return Ok(None),
-                    };
-                    if range.end_exclusive < range.start_inclusive
-                        || range.start_inclusive > metadata.size_bytes
-                    {
-                        return Err(ObjectStoreError::InvalidRange);
-                    }
-
-                    let bounded_end = range.end_exclusive.min(metadata.size_bytes);
-                    if bounded_end == range.start_inclusive {
-                        return Ok(Some(Vec::new()));
-                    }
-
-                    Some(format!(
-                        "bytes={}-{}",
-                        range.start_inclusive,
-                        bounded_end.saturating_sub(1)
-                    ))
-                }
-            };
-
-            let mut request = self
-                .client()
-                .get_object()
-                .bucket(&self.bucket)
-                .key(&scoped_key);
-            if let Some(range_header) = range_header {
-                request = request.range(range_header);
-            }
-
-            match request.send().await {
-                Ok(output) => {
-                    let collected = output
-                        .body
-                        .collect()
-                        .await
-                        .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
-                    Ok(Some(collected.into_bytes().to_vec()))
-                }
-                Err(err) if is_not_found(&err) => Ok(None),
-                Err(err) if is_invalid_range(&err) => Err(ObjectStoreError::InvalidRange),
-                Err(err) => Err(map_sdk_error(err)),
-            }
-        })
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
     }
 
-    fn put(
+    async fn put(
         &self,
         key: &str,
-        bytes: &[u8],
+        bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async { self.put_scoped(&scoped_key, bytes, mode).await })
+        self.inner.put(key, bytes, mode).await
     }
 
-    fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        let scoped_key = self.scoped_key(key)?;
-        self.run_async(async {
-            match self
-                .client()
-                .delete_object()
-                .bucket(&self.bucket)
-                .key(&scoped_key)
-                .send()
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(err) if is_not_found(&err) => Ok(()),
-                Err(err) => Err(map_sdk_error(err)),
-            }
-        })
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
     }
 
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        let scoped_prefix = self.scoped_list_prefix(prefix)?;
-        self.run_async(async {
-            let mut keys = Vec::new();
-            let mut continuation_token = None;
-
-            loop {
-                let mut request = self
-                    .client()
-                    .list_objects_v2()
-                    .bucket(&self.bucket)
-                    .prefix(&scoped_prefix);
-                if let Some(token) = continuation_token.as_deref() {
-                    request = request.continuation_token(token);
-                }
-
-                let output = request.send().await.map_err(map_sdk_error)?;
-                if let Some(objects) = output.contents() {
-                    for object in objects {
-                        if let Some(key) = object.key() {
-                            match self.key_prefix.as_deref() {
-                                Some(key_prefix) => {
-                                    if let Some(unscoped) =
-                                        unscope_listed_key(Some(key_prefix), key)
-                                    {
-                                        keys.push(unscoped);
-                                    }
-                                }
-                                None => keys.push(key.to_owned()),
-                            }
-                        }
-                    }
-                }
-
-                if !output.is_truncated() {
-                    break;
-                }
-                continuation_token = output.next_continuation_token().map(ToOwned::to_owned);
-            }
-
-            keys.sort();
-            Ok(keys)
-        })
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
     }
 }
 
-fn is_not_found<E, R>(err: &SdkError<E, R>) -> bool
-where
-    E: ProvideErrorMetadata,
-{
-    matches!(
-        service_error_code(err),
-        Some("NotFound" | "NoSuchKey" | "404")
-    )
-}
-
-fn is_invalid_range<E, R>(err: &SdkError<E, R>) -> bool
-where
-    E: ProvideErrorMetadata,
-{
-    matches!(service_error_code(err), Some("InvalidRange"))
-}
-
-fn is_precondition_failure<E, R>(err: &SdkError<E, R>) -> bool
-where
-    E: ProvideErrorMetadata,
-{
-    put_error_code_maps_to_precondition_failed(&PutMode::Overwrite, service_error_code(err))
-}
-
-fn service_error_code<E, R>(err: &SdkError<E, R>) -> Option<&str>
-where
-    E: ProvideErrorMetadata,
-{
-    err.code()
-}
-
-fn put_error_maps_to_precondition_failed<E, R>(mode: &PutMode, err: &SdkError<E, R>) -> bool
-where
-    E: ProvideErrorMetadata,
-{
-    put_error_code_maps_to_precondition_failed(mode, service_error_code(err))
-}
-
-fn put_error_code_maps_to_precondition_failed(mode: &PutMode, code: Option<&str>) -> bool {
-    matches!(
-        code,
-        Some("PreconditionFailed" | "ConditionalRequestConflict")
-    ) || (matches!(mode, PutMode::CompareAndSwap { .. })
-        && matches!(code, Some("NotFound" | "NoSuchKey" | "404")))
-}
-
-fn map_sdk_error<E, R>(err: SdkError<E, R>) -> ObjectStoreError
-where
-    E: ProvideErrorMetadata + fmt::Debug,
-    R: fmt::Debug,
-{
-    if is_precondition_failure(&err) {
-        return ObjectStoreError::PreconditionFailed;
+fn validate_config(config: &S3CompatibleConfig) -> Result<(), ObjectStoreError> {
+    if config.bucket.trim().is_empty() {
+        return Err(ObjectStoreError::Transport(
+            "bucket must not be empty".to_owned(),
+        ));
     }
-    if is_not_found(&err) {
-        return ObjectStoreError::NotFound;
+    if config.region.trim().is_empty() {
+        return Err(ObjectStoreError::Transport(
+            "region must not be empty".to_owned(),
+        ));
     }
-    if is_invalid_range(&err) {
-        return ObjectStoreError::InvalidRange;
+    if config.access_key_id.trim().is_empty() {
+        return Err(ObjectStoreError::Transport(
+            "access key id must not be empty".to_owned(),
+        ));
     }
-
-    let mut details = Vec::new();
-    if let Some(code) = err.code() {
-        details.push(format!("code={code}"));
+    if config.secret_access_key.trim().is_empty() {
+        return Err(ObjectStoreError::Transport(
+            "secret access key must not be empty".to_owned(),
+        ));
     }
-    if let Some(message) = err.message() {
-        details.push(format!("message={message}"));
-    }
-
-    let detail_suffix = if details.is_empty() {
-        String::new()
-    } else {
-        format!(" ({})", details.join(", "))
-    };
-
-    ObjectStoreError::Transport(format!("{err:?}{detail_suffix}"))
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        put_error_code_maps_to_precondition_failed, S3CompatibleConfig, S3CompatibleStore,
-    };
-    use crate::PutMode;
+    use super::{S3CompatibleConfig, S3CompatibleStore};
 
-    #[test]
-    fn compare_and_swap_maps_missing_object_codes_to_precondition_failed() {
-        let mode = PutMode::CompareAndSwap {
-            expected_etag: "etag".to_owned(),
-        };
-        for code in ["NotFound", "NoSuchKey", "404"] {
-            assert!(
-                put_error_code_maps_to_precondition_failed(&mode, Some(code)),
-                "expected CAS missing-object code {code} to map to PreconditionFailed"
-            );
-        }
-    }
-
-    #[test]
-    fn overwrite_does_not_map_missing_object_codes_to_precondition_failed() {
-        for code in ["NotFound", "NoSuchKey", "404"] {
-            assert!(
-                !put_error_code_maps_to_precondition_failed(&PutMode::Overwrite, Some(code)),
-                "did not expect overwrite missing-object code {code} to map to PreconditionFailed"
-            );
-        }
-    }
-
-    #[test]
-    fn store_reuses_one_runtime_across_calls() {
-        let store = S3CompatibleStore::new(S3CompatibleConfig {
+    fn test_config() -> S3CompatibleConfig {
+        S3CompatibleConfig {
             provider_name: "test-s3",
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
@@ -605,35 +165,20 @@ mod tests {
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
             sha256_checksum_metadata: true,
-        })
-        .expect("construct store");
-
-        let first = store
-            .run_async(async { Ok::<_, crate::ObjectStoreError>(1usize) })
-            .expect("first block_on");
-        let second = store
-            .run_async(async { Ok::<_, crate::ObjectStoreError>(2usize) })
-            .expect("second block_on");
-
-        assert_eq!((first, second), (1, 2));
+        }
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn store_can_drop_inside_async_context() {
-        let store = S3CompatibleStore::new(S3CompatibleConfig {
-            provider_name: "test-s3",
-            bucket: "bucket".to_owned(),
-            region: "us-east-1".to_owned(),
-            endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
-            session_token: None,
-            key_prefix: Some("tenant-a".to_owned()),
-            force_path_style: true,
-            sha256_checksum_metadata: true,
-        })
-        .expect("construct store");
+    #[test]
+    fn s3_compatible_store_builds_without_hidden_runtime() {
+        let store = S3CompatibleStore::new(test_config()).expect("construct store");
+        let debug = format!("{store:?}");
+        assert!(debug.contains("test-s3"));
+    }
 
-        drop(store);
+    #[test]
+    fn s3_compatible_store_rejects_blank_credentials() {
+        let mut config = test_config();
+        config.access_key_id.clear();
+        assert!(S3CompatibleStore::new(config).is_err());
     }
 }

--- a/crates/loon-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loon-objectstore/tests/metrics_instrumented_object_store.rs
@@ -337,6 +337,7 @@ impl DelegatingWriteStore {
             .push(call);
         ObjectMetadata {
             etag: Some(format!("{call}-etag")),
+            version: None,
             size_bytes: 0,
             checksum_sha256: None,
         }

--- a/crates/loon-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loon-objectstore/tests/objectstore_conformance.rs
@@ -11,6 +11,7 @@ use loon_objectstore::probes::run_contract_probes;
 use loon_objectstore::provider::{Expectation, AWS_S3, CLOUDFLARE_R2, LOCAL_FS};
 use loon_objectstore::r2::{R2Store, R2StoreConfig};
 use loon_objectstore::s3::{AwsS3Store, AwsS3StoreConfig};
+use loon_objectstore::BlockingObjectStoreAdapter;
 use loon_objectstore::ObjectStoreError;
 use loon_objectstore::{ByteRange, ObjectStore};
 use provider_env::{
@@ -291,6 +292,8 @@ fn aws_s3_real_provider_conformance() {
         force_path_style: false,
     })
     .expect("create AWS S3 object store");
+    let store = BlockingObjectStoreAdapter::new(std::sync::Arc::new(store))
+        .expect("create blocking adapter");
 
     assert_provider_conformance(&store);
 }
@@ -309,6 +312,8 @@ fn cloudflare_r2_real_provider_conformance() {
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
+    let store = BlockingObjectStoreAdapter::new(std::sync::Arc::new(store))
+        .expect("create blocking adapter");
 
     assert_provider_conformance(&store);
 }

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -26,7 +26,6 @@ use loonfs::{
 use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::task;
 use tracing::Instrument;
 
 type SharedStore = SharedObjectStore;
@@ -227,13 +226,12 @@ async fn create_namespace(
     Json(request): Json<CreateNamespaceRequest>,
 ) -> Result<Json<loon_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(request.namespace_id)?;
-    let summary = run_blocking(move || {
-        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let summary = state
+        .fs
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(summary))
 }
 
@@ -242,9 +240,11 @@ async fn list_namespaces_handler(
     headers: HeaderMap,
 ) -> Result<Json<ListNamespacesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
-    let namespaces =
-        run_blocking(move || fs.list_namespaces().map_err(ApiResponseError::runtime)).await?;
+    let namespaces = state
+        .fs
+        .list_namespaces()
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(ListNamespacesResponse { namespaces }))
 }
 
@@ -255,14 +255,13 @@ async fn fork_namespace_handler(
     Json(request): Json<ForkNamespaceRequest>,
 ) -> Result<Json<loon_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let source_namespace_id = parse_namespace_id(namespace)?;
     let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
-    let summary = run_blocking(move || {
-        fs.fork_namespace(&source_namespace_id, &new_namespace_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))
-    })
-    .await?;
+    let summary = state
+        .fs
+        .fork_namespace(&source_namespace_id, &new_namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
     Ok(Json(summary))
 }
 
@@ -273,14 +272,13 @@ async fn list_entries(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<Vec<loon_api::AuthoritativePathEntry>>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let entries = run_blocking(move || {
-        fs.list_path(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let entries = state
+        .fs
+        .list_path(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entries))
 }
 
@@ -291,14 +289,13 @@ async fn stat_entry(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<loon_api::AuthoritativePathEntry>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let entry = run_blocking(move || {
-        fs.stat_path(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let entry = state
+        .fs
+        .stat_path(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entry))
 }
 
@@ -309,7 +306,6 @@ async fn get_content(
     Query(query): Query<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let revision_no = query
@@ -317,14 +313,16 @@ async fn get_content(
         .as_deref()
         .map(parse_revision_no)
         .transpose()?;
-    let file = run_blocking(move || {
-        match revision_no {
-            Some(revision_no) => fs.read_file_revision_bytes(&namespace_id, &path, revision_no),
-            None => fs.read_file_bytes(&namespace_id, &path),
+    let file = match revision_no {
+        Some(revision_no) => {
+            state
+                .fs
+                .read_file_revision_bytes(&namespace_id, &path, revision_no)
+                .await
         }
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+        None => state.fs.read_file_bytes(&namespace_id, &path).await,
+    }
+    .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, file.bytes).into_response())
 }
 
@@ -335,14 +333,13 @@ async fn list_path_revisions(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let response = run_blocking(move || {
-        fs.list_file_revisions(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_file_revisions(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -352,14 +349,13 @@ async fn list_inode_revisions(
     headers: HeaderMap,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let inode_id = parse_inode_id(&inode_id)?;
-    let response = run_blocking(move || {
-        fs.list_file_revisions_for_inode(&namespace_id, inode_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_file_revisions_for_inode(&namespace_id, inode_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -369,15 +365,14 @@ async fn get_inode_revision_content(
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let inode_id = parse_inode_id(&inode_id)?;
     let revision_no = parse_revision_no(&revision_no)?;
-    let bytes = run_blocking(move || {
-        fs.read_file_revision_bytes_for_inode(&namespace_id, inode_id, revision_no)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let bytes = state
+        .fs
+        .read_file_revision_bytes_for_inode(&namespace_id, inode_id, revision_no)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, bytes).into_response())
 }
 
@@ -509,13 +504,12 @@ async fn begin_upload_handler(
     headers: HeaderMap,
 ) -> Result<Json<BeginUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.begin_upload(&namespace_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .begin_upload(&namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -526,14 +520,13 @@ async fn upload_content_handler(
     body: Bytes,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let bytes = body.to_vec();
-    let response = run_blocking(move || {
-        fs.upload_content(&namespace_id, &upload_id, &bytes)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .upload_content(&namespace_id, &upload_id, &bytes)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -544,13 +537,12 @@ async fn complete_upload_handler(
     Json(request): Json<CompleteUploadRequest>,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.complete_upload(&namespace_id, &upload_id, &request)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .complete_upload(&namespace_id, &upload_id, &request)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -577,14 +569,13 @@ async fn list_changes_handler(
     Query(query): Query<ChangesQuery>,
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let after_seq = loon_api::ChangeSeq(query.after_seq);
-    let response = run_blocking(move || {
-        fs.list_changes_after(&namespace_id, after_seq)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_changes_after(&namespace_id, after_seq)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -594,13 +585,12 @@ async fn create_checkpoint_handler(
     headers: HeaderMap,
 ) -> Result<Json<CreateCheckpointResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.create_checkpoint(&namespace_id)
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let response = state
+        .fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
 }
 
@@ -610,13 +600,12 @@ async fn advance_retention_handler(
     headers: HeaderMap,
 ) -> Result<Json<AdvanceRetentionResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.advance_retention_floor(&namespace_id)
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let response = state
+        .fs
+        .advance_retention_floor(&namespace_id)
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
 }
 
@@ -668,20 +657,6 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
             &format!("invalid revision_no `{value}`: {err}"),
         )
     })
-}
-
-async fn run_blocking<T, F>(operation: F) -> Result<T, ApiResponseError>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, ApiResponseError> + Send + 'static,
-{
-    task::spawn_blocking(operation).await.map_err(|err| {
-        ApiResponseError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "server_error",
-            &format!("blocking operation failed: {err}"),
-        )
-    })?
 }
 
 struct ApiResponseError {
@@ -740,6 +715,11 @@ impl ApiResponseError {
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
             }
+            error @ RuntimeError::RuntimeTask(_) => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                &error.to_string(),
+            ),
         }
     }
 
@@ -767,6 +747,11 @@ impl ApiResponseError {
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
             }
+            error @ RuntimeError::RuntimeTask(_) => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                &error.to_string(),
+            ),
         }
     }
 }
@@ -909,7 +894,16 @@ mod tests {
                 Some(metrics_path.clone().into_os_string()),
             )
             .expect("build fs");
-            fs.create_namespace(&namespace_id("metrics"), CreateNamespaceOptions::default())
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime")
+                .block_on(
+                    fs.create_namespace(
+                        &namespace_id("metrics"),
+                        CreateNamespaceOptions::default(),
+                    ),
+                )
                 .expect("create namespace");
         }
 
@@ -925,6 +919,7 @@ mod tests {
         let fs = test_runtime(store.clone(), "runtime-writer");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
             .expect("create namespace through runtime");
         fs.put_file_bytes(
             &namespace_id,
@@ -935,6 +930,7 @@ mod tests {
                 commit_id: Some(CommitId::parse("runtime-put").expect("valid commit id")),
             },
         )
+        .await
         .expect("write file through runtime");
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
@@ -978,6 +974,7 @@ mod tests {
                 &NamespaceId::parse("demo").expect("valid namespace id"),
                 "/notes/from-http.txt",
             )
+            .await
             .expect("read file through runtime");
         assert_eq!(file.bytes, b"hello from http");
 

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -315,18 +315,13 @@ impl NamespacePublisher {
                     .iter()
                     .map(|candidate| candidate.candidate.clone())
                     .collect::<Vec<_>>();
-                let namespace_id = self.namespace_id.clone();
-                let fs = self.fs.clone();
-                results = tokio::task::spawn_blocking(move || {
-                    fs.publish_namespace_mutations_batch(&namespace_id, batch_candidates)
-                        .into_iter()
-                        .map(|result| result.map_err(runtime_error_to_core))
-                        .collect()
-                })
-                .await
-                .unwrap_or_else(|err| {
-                    vec![Err(CoreError::Store(err.to_string())); candidates.len()]
-                });
+                results = self
+                    .fs
+                    .publish_namespace_mutations_batch(&self.namespace_id, batch_candidates)
+                    .await
+                    .into_iter()
+                    .map(|result| result.map_err(runtime_error_to_core))
+                    .collect();
                 if !results.iter().any(is_head_publish_stale) {
                     break;
                 }
@@ -466,6 +461,7 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
         RuntimeError::Core(error) => error,
         RuntimeError::Bootstrap(error) => CoreError::Store(error.to_string()),
         RuntimeError::Config(message) => CoreError::Store(message),
+        RuntimeError::RuntimeTask(message) => CoreError::Store(message),
     }
 }
 
@@ -684,8 +680,9 @@ mod tests {
         )
     }
 
-    fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
+    async fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
         fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
             .expect("bootstrap");
     }
 
@@ -771,7 +768,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -824,7 +821,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -865,7 +862,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -932,7 +929,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -981,7 +978,7 @@ mod tests {
         });
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let registry = PublisherRegistry::new(fs);
 
         let request_a = CommitRequest {
@@ -1034,7 +1031,7 @@ mod tests {
         });
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let content =
             store_bytes_as_content(store.as_ref(), &namespace_id, b"hello").expect("stage content");
         let registry = PublisherRegistry::new(fs);

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -10,6 +10,7 @@ loon-api = { path = "../loon-api" }
 loon-core = { path = "../loon-core" }
 loon-objectstore = { path = "../loon-objectstore" }
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -5,7 +5,8 @@ use loonfs::{
 use std::sync::Arc;
 
 #[allow(clippy::print_stdout)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This example intentionally prints the file content it just read.
     let root = std::env::temp_dir().join("loonfs-embedded-local-fs-example");
     let store: SharedObjectStore = Arc::new(LocalFsStore::new(root)?);
@@ -17,7 +18,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         CreateNamespaceOptions {
             allow_existing: true,
         },
-    )?;
+    )
+    .await?;
     fs.put_file_bytes(
         &namespace_id,
         "/hello.txt",
@@ -26,9 +28,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             behavior: PutFileBehavior::ReplaceExisting,
             commit_id: None,
         },
-    )?;
+    )
+    .await?;
 
-    let file = fs.read_file_bytes(&namespace_id, "/hello.txt")?;
+    let file = fs.read_file_bytes(&namespace_id, "/hello.txt").await?;
     println!("{}", String::from_utf8_lossy(&file.bytes));
     Ok(())
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -481,6 +481,7 @@ impl UploadedContentProofStore<'_> {
             .get(self.namespace_id, &digest)?;
         Some(ObjectMetadata {
             etag: None,
+            version: None,
             size_bytes: content_ref.size_bytes,
             checksum_sha256: Some(content_ref.digest),
         })

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -77,6 +77,8 @@ pub enum RuntimeError {
     Bootstrap(#[from] BootstrapNamespaceError),
     #[error("invalid runtime config: {0}")]
     Config(String),
+    #[error("runtime task failed: {0}")]
+    RuntimeTask(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -689,6 +691,7 @@ struct CachedControl<T> {
 /// These counters are diagnostic. They are useful for tuning cache limits and
 /// understanding read/write warmup behavior.
 pub struct RuntimeCacheStats {
+    pub async_engine_calls: usize,
     pub warm_basis_cache_hits: usize,
     pub warm_basis_cache_misses: usize,
     pub warm_basis_evictions: usize,
@@ -721,6 +724,7 @@ enum MetadataReadSource {
 
 #[derive(Debug, Default)]
 struct RuntimeCacheStatsInner {
+    async_engine_calls: AtomicUsize,
     warm_basis_cache_hits: AtomicUsize,
     warm_basis_cache_misses: AtomicUsize,
     warm_basis_evictions: AtomicUsize,
@@ -744,6 +748,7 @@ struct RuntimeCacheStatsInner {
 impl RuntimeCacheStatsInner {
     fn snapshot(&self, metadata_table_cache: MetadataTableCacheStats) -> RuntimeCacheStats {
         RuntimeCacheStats {
+            async_engine_calls: self.async_engine_calls.load(Ordering::SeqCst),
             warm_basis_cache_hits: self.warm_basis_cache_hits.load(Ordering::SeqCst),
             warm_basis_cache_misses: self.warm_basis_cache_misses.load(Ordering::SeqCst),
             warm_basis_evictions: self.warm_basis_evictions.load(Ordering::SeqCst),
@@ -775,6 +780,10 @@ impl RuntimeCacheStatsInner {
             metadata_table_cache_inserts: metadata_table_cache.inserts,
             metadata_table_cache_evictions: metadata_table_cache.evictions,
         }
+    }
+
+    fn record_async_engine_call(&self) {
+        self.async_engine_calls.fetch_add(1, Ordering::SeqCst);
     }
 
     fn record_publish_result(&self, result: &NamespaceCommitEnginePublishResult) {
@@ -1160,7 +1169,33 @@ impl Fs {
         span.record("store_kind", self.inner.config.trace_store_kind.as_str());
     }
 
-    pub fn create_namespace(
+    async fn run_engine_blocking<T, F>(&self, operation: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(Fs) -> Result<T> + Send + 'static,
+    {
+        self.inner.cache_stats.record_async_engine_call();
+        let fs = self.clone();
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
+            operation(fs)
+        })
+        .await
+        .map_err(|error| RuntimeError::RuntimeTask(error.to_string()))?
+    }
+
+    pub async fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> Result<NamespaceSummary> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.create_namespace_blocking(&namespace_id, options))
+            .await
+    }
+
+    fn create_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
@@ -1174,7 +1209,18 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn fork_namespace(
+    pub async fn fork_namespace(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> Result<NamespaceSummary> {
+        let source = source.clone();
+        let target = target.clone();
+        self.run_engine_blocking(move |fs| fs.fork_namespace_blocking(&source, &target))
+            .await
+    }
+
+    fn fork_namespace_blocking(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
@@ -1192,11 +1238,22 @@ impl Fs {
         result
     }
 
-    pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
+    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
+        self.run_engine_blocking(|fs| fs.list_namespaces_blocking())
+            .await
+    }
+
+    fn list_namespaces_blocking(&self) -> Result<Vec<NamespaceSummary>> {
         Ok(loon_core::list_namespaces(self.store())?)
     }
 
-    pub fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
+    pub async fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.namespace_status_blocking(&namespace_id))
+            .await
+    }
+
+    fn namespace_status_blocking(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
         let summary = load_namespace_head_summary(self.store(), namespace_id)?;
         Ok(NamespaceStatus {
             namespace_id: summary.namespace_id,
@@ -1219,20 +1276,32 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub fn maintenance_tick_namespace(
+    pub async fn maintenance_tick_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> Result<MaintenanceTickResult> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.maintenance_tick_namespace_blocking(&namespace_id, options)
+        })
+        .await
+    }
+
+    fn maintenance_tick_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> Result<MaintenanceTickResult> {
         if options.max_wal_tail_segments == 0 {
             return Err(RuntimeError::Config(
                 "max_wal_tail_segments must be greater than zero".to_owned(),
             ));
         }
 
-        let status_before = self.namespace_status(namespace_id)?;
+        let status_before = self.namespace_status_blocking(namespace_id)?;
         let observed_head_seq = status_before.head_seq;
         if status_before.wal_tail_segments < options.max_wal_tail_segments {
             return Ok(MaintenanceTickResult {
@@ -1242,7 +1311,7 @@ impl Fs {
             });
         }
 
-        let checkpoint = match self.create_checkpoint(namespace_id) {
+        let checkpoint = match self.create_checkpoint_blocking(namespace_id) {
             Ok(checkpoint) => checkpoint,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
                 return Ok(MaintenanceTickResult {
@@ -1291,13 +1360,24 @@ impl Fs {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub fn stat_path(
+    pub async fn stat_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativePathEntry> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| fs.stat_path_blocking(&namespace_id, &absolute_path))
+            .await
+    }
+
+    fn stat_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativePathEntry> {
         let head = self.head_for_metadata_read(namespace_id)?;
         let engine = self.namespace_engine(namespace_id);
         if head.state.current_manifest_id.is_some() {
@@ -1308,7 +1388,8 @@ impl Fs {
                     Some(Arc::clone(&self.inner.metadata_table_cache)),
                 ),
             )?;
-            span.record("cache_path", trace::CachePath::MaterializedTables.as_str());
+            tracing::Span::current()
+                .record("cache_path", trace::CachePath::MaterializedTables.as_str());
             self.inner
                 .cache_stats
                 .record_metadata_read_source(MetadataReadSource::MaterializedTables);
@@ -1326,7 +1407,18 @@ impl Fs {
         Ok(entry)
     }
 
-    pub fn list_path(
+    pub async fn list_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<Vec<AuthoritativePathEntry>> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| fs.list_path_blocking(&namespace_id, &absolute_path))
+            .await
+    }
+
+    fn list_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1358,7 +1450,20 @@ impl Fs {
         Ok(entries)
     }
 
-    pub fn read_file_bytes(
+    pub async fn read_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativeFileBytes> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_bytes_blocking(&namespace_id, &absolute_path)
+        })
+        .await
+    }
+
+    fn read_file_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1370,7 +1475,20 @@ impl Fs {
         )?)
     }
 
-    pub fn list_file_revisions(
+    pub async fn list_file_revisions(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<ListFileRevisionsResponse> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.list_file_revisions_blocking(&namespace_id, &absolute_path)
+        })
+        .await
+    }
+
+    fn list_file_revisions_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1382,7 +1500,19 @@ impl Fs {
         )?)
     }
 
-    pub fn list_file_revisions_for_inode(
+    pub async fn list_file_revisions_for_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+    ) -> Result<ListFileRevisionsResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.list_file_revisions_for_inode_blocking(&namespace_id, inode_id)
+        })
+        .await
+    }
+
+    fn list_file_revisions_for_inode_blocking(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1396,7 +1526,21 @@ impl Fs {
             )?)
     }
 
-    pub fn read_file_revision_bytes(
+    pub async fn read_file_revision_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        revision_no: RevisionNo,
+    ) -> Result<AuthoritativeFileBytes> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_revision_bytes_blocking(&namespace_id, &absolute_path, revision_no)
+        })
+        .await
+    }
+
+    fn read_file_revision_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1410,7 +1554,20 @@ impl Fs {
         )?)
     }
 
-    pub fn read_file_revision_bytes_for_inode(
+    pub async fn read_file_revision_bytes_for_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_revision_bytes_for_inode_blocking(&namespace_id, inode_id, revision_no)
+        })
+        .await
+    }
+
+    fn read_file_revision_bytes_for_inode_blocking(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1438,7 +1595,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub fn put_file_bytes(
+    pub async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1448,6 +1605,22 @@ impl Fs {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", trace::payload_class(bytes.len()));
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        let bytes = bytes.to_vec();
+        self.run_engine_blocking(move |fs| {
+            fs.put_file_bytes_blocking(&namespace_id, &absolute_path, &bytes, options)
+        })
+        .await
+    }
+
+    fn put_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let store = self.uploaded_content_proof_store(namespace_id);
         let result = self
             .namespace_engine_with_store(namespace_id, store)
@@ -1476,7 +1649,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub fn put_file_content_ref(
+    pub async fn put_file_content_ref(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1489,6 +1662,21 @@ impl Fs {
             "payload_class",
             trace::payload_class(usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX)),
         );
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.put_file_content_ref_blocking(&namespace_id, &absolute_path, content_ref, options)
+        })
+        .await
+    }
+
+    fn put_file_content_ref_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        content_ref: ContentRef,
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let store = self.uploaded_content_proof_store(namespace_id);
         let result = self
             .namespace_engine_with_store(namespace_id, store)
@@ -1505,7 +1693,21 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn create_dir(
+    pub async fn create_dir(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.create_dir_blocking(&namespace_id, &absolute_path, options)
+        })
+        .await
+    }
+
+    fn create_dir_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1524,7 +1726,21 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn delete_path(
+    pub async fn delete_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.delete_path_blocking(&namespace_id, &absolute_path, options)
+        })
+        .await
+    }
+
+    fn delete_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1544,7 +1760,23 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn move_path(
+    pub async fn move_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let from_path = from_path.to_owned();
+        let to_path = to_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.move_path_blocking(&namespace_id, &from_path, &to_path, options)
+        })
+        .await
+    }
+
+    fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -1565,7 +1797,23 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn copy_path(
+    pub async fn copy_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let from_path = from_path.to_owned();
+        let to_path = to_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.copy_path_blocking(&namespace_id, &from_path, &to_path, options)
+        })
+        .await
+    }
+
+    fn copy_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -1586,7 +1834,27 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn restore_file_revision(
+    pub async fn restore_file_revision(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        source_revision_no: RevisionNo,
+        options: RestoreRevisionOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.restore_file_revision_blocking(
+                &namespace_id,
+                &absolute_path,
+                source_revision_no,
+                options,
+            )
+        })
+        .await
+    }
+
+    fn restore_file_revision_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1607,7 +1875,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn restore_file_revision_for_inode(
+    pub async fn restore_file_revision_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1630,14 +1898,35 @@ impl Fs {
             message: None,
             annotations: None,
         };
-        self.commit_operations(namespace_id, request)
+        self.commit_operations(namespace_id, request).await
     }
 
-    pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
+    pub async fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.begin_upload_blocking(&namespace_id))
+            .await
+    }
+
+    fn begin_upload_blocking(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
         Ok(self.namespace_engine(namespace_id).begin_upload()?)
     }
 
-    pub fn upload_content(
+    pub async fn upload_content(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> Result<UploadContentResponse> {
+        let namespace_id = namespace_id.clone();
+        let upload_id = upload_id.to_owned();
+        let bytes = bytes.to_vec();
+        self.run_engine_blocking(move |fs| {
+            fs.upload_content_blocking(&namespace_id, &upload_id, &bytes)
+        })
+        .await
+    }
+
+    fn upload_content_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
@@ -1649,7 +1938,22 @@ impl Fs {
             .upload_content(upload_id, bytes)?)
     }
 
-    pub fn complete_upload(
+    pub async fn complete_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> Result<CompleteUploadResponse> {
+        let namespace_id = namespace_id.clone();
+        let upload_id = upload_id.to_owned();
+        let request = request.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.complete_upload_blocking(&namespace_id, &upload_id, &request)
+        })
+        .await
+    }
+
+    fn complete_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
@@ -1660,7 +1964,7 @@ impl Fs {
             .complete_upload(upload_id, request)?)
     }
 
-    pub fn commit_operations(
+    pub async fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
@@ -1669,6 +1973,7 @@ impl Fs {
             namespace_id,
             vec![NamespaceMutationCandidate::Commit(request)],
         )
+        .await
         .into_iter()
         .next()
         .unwrap_or_else(|| {
@@ -1678,7 +1983,7 @@ impl Fs {
         })
     }
 
-    pub fn commit_operations_batch(
+    pub async fn commit_operations_batch(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
@@ -1690,9 +1995,28 @@ impl Fs {
                 .map(NamespaceMutationCandidate::Commit)
                 .collect(),
         )
+        .await
     }
 
-    pub fn publish_namespace_mutations_batch(
+    pub async fn publish_namespace_mutations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<Result<CommitResponse>> {
+        let result_count = candidates.len();
+        let namespace_id = namespace_id.clone();
+        match self
+            .run_engine_blocking(move |fs| {
+                Ok(fs.publish_namespace_mutations_batch_blocking(&namespace_id, candidates))
+            })
+            .await
+        {
+            Ok(results) => results,
+            Err(error) => repeat_runtime_error(result_count, error),
+        }
+    }
+
+    fn publish_namespace_mutations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
@@ -1757,7 +2081,17 @@ impl Fs {
             .snapshot(self.inner.metadata_table_cache.stats())
     }
 
-    pub fn list_changes_after(
+    pub async fn list_changes_after(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> Result<ChangesResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.list_changes_after_blocking(&namespace_id, after_seq))
+            .await
+    }
+
+    fn list_changes_after_blocking(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
@@ -1778,12 +2112,21 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub fn create_checkpoint(
+    pub async fn create_checkpoint(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.create_checkpoint_blocking(&namespace_id))
+            .await
+    }
+
+    fn create_checkpoint_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<CreateCheckpointResponse> {
         let result = self
             .namespace_engine(namespace_id)
             .create_checkpoint()
@@ -1791,7 +2134,16 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn advance_retention_floor(
+    pub async fn advance_retention_floor(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<AdvanceRetentionResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.advance_retention_floor_blocking(&namespace_id))
+            .await
+    }
+
+    fn advance_retention_floor_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
@@ -2289,6 +2641,20 @@ fn should_invalidate_after_result<T>(result: &Result<T>) -> bool {
         Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => true,
         _ => false,
     }
+}
+
+fn repeat_runtime_error<T>(count: usize, error: RuntimeError) -> Vec<Result<T>> {
+    let message = error.to_string();
+    (0..count)
+        .map(|_| {
+            Err(match &error {
+                RuntimeError::Core(error) => RuntimeError::Core(error.clone()),
+                RuntimeError::Config(message) => RuntimeError::Config(message.clone()),
+                RuntimeError::RuntimeTask(message) => RuntimeError::RuntimeTask(message.clone()),
+                RuntimeError::Bootstrap(_) => RuntimeError::RuntimeTask(message.clone()),
+            })
+        })
+        .collect()
 }
 
 fn current_time_ms() -> u64 {

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -12,12 +12,16 @@ use loon_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use loonfs::{
-    ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
+    AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadResponse,
+    ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest, CommitResponse,
+    CompleteUploadRequest, CompleteUploadResponse, CopyOptions, CreateCheckpointResponse,
     CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ErrorCode, Fs, FsConfig, InodeId,
-    MaintenanceTickOptions, MaintenanceTickOutcome, ManifestId, MoveOptions, NamespaceId,
-    NamespaceMutationCandidate, PathMutationIntent, PutFileBehavior, PutFileOptions,
-    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
+    MutationResult, NamespaceId, NamespaceMutationCandidate, NamespaceStatus, PathMutationIntent,
+    PutFileBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
+    TraceMode, TraceStoreKind, UploadContentResponse,
 };
+use std::future::Future;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -36,6 +40,309 @@ fn runtime(root: &Path, writer_id: &str) -> Fs {
 
 fn namespace() -> NamespaceId {
     NamespaceId::parse("demo").expect("valid namespace id")
+}
+
+fn block_on<T>(future: impl Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(future)
+}
+
+trait FsTestExt {
+    fn create_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> loonfs::Result<loonfs::NamespaceSummary>;
+    fn fork_namespace_blocking(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> loonfs::Result<loonfs::NamespaceSummary>;
+    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>>;
+    fn namespace_status_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<NamespaceStatus>;
+    fn maintenance_tick_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> loonfs::Result<MaintenanceTickResult>;
+    fn stat_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativePathEntry>;
+    fn list_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<Vec<AuthoritativePathEntry>>;
+    fn read_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativeFileBytes>;
+    fn put_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn create_dir_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn delete_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn move_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn copy_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn begin_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<BeginUploadResponse>;
+    fn upload_content_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> loonfs::Result<UploadContentResponse>;
+    fn complete_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> loonfs::Result<CompleteUploadResponse>;
+    fn commit_operations_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> loonfs::Result<CommitResponse>;
+    fn commit_operations_batch_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<CommitRequest>,
+    ) -> Vec<loonfs::Result<CommitResponse>>;
+    fn publish_namespace_mutations_batch_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<loonfs::Result<CommitResponse>>;
+    fn list_changes_after_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> loonfs::Result<ChangesResponse>;
+    fn create_checkpoint_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<CreateCheckpointResponse>;
+    fn advance_retention_floor_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<AdvanceRetentionResponse>;
+}
+
+impl FsTestExt for Fs {
+    fn create_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> loonfs::Result<loonfs::NamespaceSummary> {
+        block_on(self.create_namespace(namespace_id, options))
+    }
+
+    fn fork_namespace_blocking(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> loonfs::Result<loonfs::NamespaceSummary> {
+        block_on(self.fork_namespace(source, target))
+    }
+
+    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>> {
+        block_on(self.list_namespaces())
+    }
+
+    fn namespace_status_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<NamespaceStatus> {
+        block_on(self.namespace_status(namespace_id))
+    }
+
+    fn maintenance_tick_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> loonfs::Result<MaintenanceTickResult> {
+        block_on(self.maintenance_tick_namespace(namespace_id, options))
+    }
+
+    fn stat_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativePathEntry> {
+        block_on(self.stat_path(namespace_id, absolute_path))
+    }
+
+    fn list_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
+        block_on(self.list_path(namespace_id, absolute_path))
+    }
+
+    fn read_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativeFileBytes> {
+        block_on(self.read_file_bytes(namespace_id, absolute_path))
+    }
+
+    fn put_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.put_file_bytes(namespace_id, absolute_path, bytes, options))
+    }
+
+    fn create_dir_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.create_dir(namespace_id, absolute_path, options))
+    }
+
+    fn delete_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.delete_path(namespace_id, absolute_path, options))
+    }
+
+    fn move_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.move_path(namespace_id, from_path, to_path, options))
+    }
+
+    fn copy_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.copy_path(namespace_id, from_path, to_path, options))
+    }
+
+    fn begin_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<BeginUploadResponse> {
+        block_on(self.begin_upload(namespace_id))
+    }
+
+    fn upload_content_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> loonfs::Result<UploadContentResponse> {
+        block_on(self.upload_content(namespace_id, upload_id, bytes))
+    }
+
+    fn complete_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> loonfs::Result<CompleteUploadResponse> {
+        block_on(self.complete_upload(namespace_id, upload_id, request))
+    }
+
+    fn commit_operations_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> loonfs::Result<CommitResponse> {
+        block_on(self.commit_operations(namespace_id, request))
+    }
+
+    fn commit_operations_batch_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<CommitRequest>,
+    ) -> Vec<loonfs::Result<CommitResponse>> {
+        block_on(self.commit_operations_batch(namespace_id, requests))
+    }
+
+    fn publish_namespace_mutations_batch_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<loonfs::Result<CommitResponse>> {
+        block_on(self.publish_namespace_mutations_batch(namespace_id, candidates))
+    }
+
+    fn list_changes_after_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> loonfs::Result<ChangesResponse> {
+        block_on(self.list_changes_after(namespace_id, after_seq))
+    }
+
+    fn create_checkpoint_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<CreateCheckpointResponse> {
+        block_on(self.create_checkpoint(namespace_id))
+    }
+
+    fn advance_retention_floor_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<AdvanceRetentionResponse> {
+        block_on(self.advance_retention_floor(namespace_id))
+    }
 }
 
 fn assert_config_error(result: loonfs::Result<Fs>, expected: &str) {
@@ -142,7 +449,7 @@ fn builder_metrics_recorder_instruments_object_store() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace(), CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace(), CreateNamespaceOptions::default())
         .expect("create namespace");
 
     let samples = recorder.samples();
@@ -161,9 +468,9 @@ fn filesystem_operations_match_core_semantics() {
     let fs = runtime(temp_dir.path(), "filesystem-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -172,21 +479,23 @@ fn filesystem_operations_match_core_semantics() {
     .expect("put file");
 
     let stat = fs
-        .stat_path(&namespace_id, "/docs/hello.txt")
+        .stat_path_blocking(&namespace_id, "/docs/hello.txt")
         .expect("stat file");
     assert_eq!(stat.absolute_path, "/docs/hello.txt");
     assert_eq!(stat.size_bytes, Some(5));
 
-    let entries = fs.list_path(&namespace_id, "/docs").expect("list docs");
+    let entries = fs
+        .list_path_blocking(&namespace_id, "/docs")
+        .expect("list docs");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].absolute_path, "/docs/hello.txt");
 
     let read = fs
-        .read_file_bytes(&namespace_id, "/docs/hello.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/hello.txt")
         .expect("read file");
     assert_eq!(read.bytes, b"hello");
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"updated",
@@ -197,18 +506,18 @@ fn filesystem_operations_match_core_semantics() {
     )
     .expect("replace file");
     let read = fs
-        .read_file_bytes(&namespace_id, "/docs/hello.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/hello.txt")
         .expect("read replaced file");
     assert_eq!(read.bytes, b"updated");
 
-    fs.copy_path(
+    fs.copy_path_blocking(
         &namespace_id,
         "/docs/hello.txt",
         "/docs/copy.txt",
         CopyOptions::default(),
     )
     .expect("copy file");
-    fs.move_path(
+    fs.move_path_blocking(
         &namespace_id,
         "/docs/copy.txt",
         "/docs/moved.txt",
@@ -216,11 +525,40 @@ fn filesystem_operations_match_core_semantics() {
     )
     .expect("move file");
     assert_eq!(
-        fs.read_file_bytes(&namespace_id, "/docs/moved.txt")
+        fs.read_file_bytes_blocking(&namespace_id, "/docs/moved.txt")
             .expect("read moved copy")
             .bytes,
         b"updated"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_runtime_methods_are_the_engine_boundary() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "async-runtime-test");
+    let namespace_id = namespace();
+
+    Fs::create_namespace(&fs, &namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    Fs::put_file_bytes(
+        &fs,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+
+    let async_stat = Fs::stat_path(&fs, &namespace_id, "/docs/hello.txt")
+        .await
+        .expect("async stat");
+
+    assert_eq!(async_stat.absolute_path, "/docs/hello.txt");
+    assert_eq!(async_stat.size_bytes, Some(5));
+    let stats = fs.runtime_cache_stats();
+    assert!(stats.async_engine_calls >= 3);
 }
 
 #[test]
@@ -237,24 +575,24 @@ fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first stat should load basis");
     assert_eq!(raw_store.wal_get_count(), 1);
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second stat should reuse cached basis");
     assert_eq!(raw_store.wal_get_count(), 1);
 
-    fs.create_dir(&namespace_id, "/other", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/other", CreateDirOptions::default())
         .expect("create other");
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("stat after mutation should reload basis");
     assert!(raw_store.wal_get_count() > 0);
 }
@@ -278,23 +616,23 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
         .expect("build writer runtime");
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime reader cache");
 
     writer
-        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
         .expect("advance head from another runtime");
 
     raw_store.reset_wal_get_count();
     let stat = reader
-        .stat_path(&namespace_id, "/docs/new")
+        .stat_path_blocking(&namespace_id, "/docs/new")
         .expect("reader should observe external head advance");
     assert_eq!(stat.absolute_path, "/docs/new");
     assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
@@ -316,15 +654,15 @@ fn runtime_cache_can_be_disabled() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first stat should load basis");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second stat should load basis again");
     assert_eq!(raw_store.wal_get_count(), 2);
 }
@@ -342,19 +680,20 @@ fn runtime_basis_cache_evicts_by_namespace_count() {
         .expect("build runtime");
     let first = NamespaceId::parse("first").expect("valid namespace id");
     let second = NamespaceId::parse("second").expect("valid namespace id");
-    fs.create_namespace(&first, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
-    fs.create_namespace(&second, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first");
     let after_second = fs.runtime_cache_stats();
     assert_eq!(after_second.warm_basis_evictions, 1);
     assert_eq!(after_second.warm_basis_cached_rows, 1);
 
-    fs.stat_path(&first, "/")
+    fs.stat_path_blocking(&first, "/")
         .expect("first basis rehydrates after eviction");
     let after_reload = fs.runtime_cache_stats();
     assert_eq!(after_reload.warm_basis_cache_misses, 3);
@@ -375,13 +714,14 @@ fn runtime_basis_cache_evicts_by_row_budget() {
         .expect("build runtime");
     let first = NamespaceId::parse("row-one").expect("valid namespace id");
     let second = NamespaceId::parse("row-two").expect("valid namespace id");
-    fs.create_namespace(&first, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
-    fs.create_namespace(&second, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first by rows");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_evictions, 1);
@@ -403,10 +743,11 @@ fn runtime_basis_budget_includes_commit_engine_bases() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.stat_path(&namespace_id, "/").expect("cache read basis");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    fs.stat_path_blocking(&namespace_id, "/")
+        .expect("cache read basis");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("combined-budget-create-docs", "/docs")],
     ));
@@ -416,7 +757,7 @@ fn runtime_basis_budget_includes_commit_engine_bases() {
     assert!(stats.warm_basis_cached_rows <= 2);
 
     let misses_before = stats.warm_basis_cache_misses;
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("read still works after aggregate budget pruning");
     let stats = fs.runtime_cache_stats();
     assert!(stats.warm_basis_cache_misses > misses_before);
@@ -430,10 +771,10 @@ fn runtime_basis_cache_evicts_by_decoded_byte_budget() {
     let first = NamespaceId::parse("byte-one").expect("valid namespace id");
     let second = NamespaceId::parse("byte-two").expect("valid namespace id");
     setup
-        .create_namespace(&first, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
     setup
-        .create_namespace(&second, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
     let raw_store = store(temp_dir.path());
     let basis_weight = load_verified_namespace_basis(raw_store.as_ref(), &first)
@@ -450,8 +791,9 @@ fn runtime_basis_cache_evicts_by_decoded_byte_budget() {
         .build()
         .expect("build runtime");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first by bytes");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_evictions, 1);
@@ -465,7 +807,7 @@ fn runtime_basis_cache_skips_oversized_basis() {
     let setup = runtime(temp_dir.path(), "basis-oversized-setup");
     let namespace_id = namespace();
     setup
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let raw_store = store(temp_dir.path());
     let basis_weight = load_verified_namespace_basis(raw_store.as_ref(), &namespace_id)
@@ -482,9 +824,9 @@ fn runtime_basis_cache_skips_oversized_basis() {
         .build()
         .expect("build runtime");
 
-    fs.stat_path(&namespace_id, "/")
+    fs.stat_path_blocking(&namespace_id, "/")
         .expect("first stat reconstructs oversized basis");
-    fs.stat_path(&namespace_id, "/")
+    fs.stat_path_blocking(&namespace_id, "/")
         .expect("second stat reconstructs oversized basis again");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_cache_misses, 2);
@@ -516,15 +858,15 @@ fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("warm-create-docs", "/docs")],
     ));
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("warm-create-child", "/docs/child")],
     ));
@@ -541,7 +883,7 @@ fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
     assert_eq!(stats.publish_warm_basis_invalidations, 0);
 
     let stat = fs
-        .stat_path(&namespace_id, "/docs/child")
+        .stat_path_blocking(&namespace_id, "/docs/child")
         .expect("warm-published child is visible");
     assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
 }
@@ -565,18 +907,18 @@ fn runtime_publish_cold_loads_after_external_head_advance() {
         .expect("build second runtime");
 
     first
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("external-first", "/docs")],
     ));
     second
-        .create_dir(&namespace_id, "/other", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/other", CreateDirOptions::default())
         .expect("external runtime advances head");
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("external-after", "/docs/child")],
     ));
@@ -611,18 +953,18 @@ fn runtime_publish_retries_warm_rejection_after_external_head_race() {
         .expect("build second runtime");
 
     first
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("race-prime", "/docs")],
     ));
     second
-        .create_dir(&namespace_id, "/a", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/a", CreateDirOptions::default())
         .expect("external runtime creates /a");
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![delete_candidate("race-delete-a", "/a")],
     ));
@@ -632,7 +974,7 @@ fn runtime_publish_retries_warm_rejection_after_external_head_race() {
     );
 
     assert_core_error_kind(
-        first.stat_path(&namespace_id, "/a"),
+        first.stat_path_blocking(&namespace_id, "/a"),
         ErrorCode::PathNotFound,
     );
     let stats = first.runtime_cache_stats();
@@ -657,15 +999,15 @@ fn runtime_publish_cache_disabled_replays_for_adjacent_batches() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("disabled-first", "/docs")],
     ));
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("disabled-second", "/docs/child")],
     ));
@@ -673,7 +1015,11 @@ fn runtime_publish_cache_disabled_replays_for_adjacent_batches() {
         raw_store.wal_get_count() > 0,
         "cache-disabled publish path should still cold-load from WAL"
     );
-    assert_eq!(fs.runtime_cache_stats(), Default::default());
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.warm_basis_cache_hits, 0);
+    assert_eq!(stats.warm_basis_cache_misses, 0);
+    assert_eq!(stats.publish_warm_basis_hits, 0);
+    assert_eq!(stats.publish_warm_basis_misses, 0);
 }
 
 #[test]
@@ -690,16 +1036,16 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("stale-prime", "/docs")],
     ));
 
     raw_store.fail_head_cas();
     let stale = fs
-        .publish_namespace_mutations_batch(
+        .publish_namespace_mutations_batch_blocking(
             &namespace_id,
             vec![create_dir_candidate("stale-loses-cas", "/stale")],
         )
@@ -711,7 +1057,7 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
 
     raw_store.allow_head_cas();
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("stale-after", "/after")],
     ));
@@ -741,22 +1087,22 @@ fn stale_head_write_error_invalidates_runtime_cache() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
 
     raw_store.fail_head_cas();
     assert_core_error_kind(
-        fs.create_dir(&namespace_id, "/stale", CreateDirOptions::default()),
+        fs.create_dir_blocking(&namespace_id, "/stale", CreateDirOptions::default()),
         ErrorCode::StaleHead,
     );
 
     raw_store.allow_head_cas();
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("read after stale head should reload basis");
     assert!(raw_store.wal_get_count() > 0);
 }
@@ -767,9 +1113,9 @@ fn delete_options_select_recursive_behavior() {
     let fs = runtime(temp_dir.path(), "delete-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -778,14 +1124,14 @@ fn delete_options_select_recursive_behavior() {
     .expect("put file");
 
     let error = fs
-        .delete_path(&namespace_id, "/docs", DeleteOptions::default())
+        .delete_path_blocking(&namespace_id, "/docs", DeleteOptions::default())
         .expect_err("non-recursive delete should reject non-empty directory");
     assert!(matches!(
         error,
         RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::DirectoryNotEmpty
     ));
 
-    fs.delete_path(
+    fs.delete_path_blocking(
         &namespace_id,
         "/docs",
         DeleteOptions {
@@ -795,7 +1141,7 @@ fn delete_options_select_recursive_behavior() {
     )
     .expect("recursive delete");
     let error = fs
-        .stat_path(&namespace_id, "/docs/hello.txt")
+        .stat_path_blocking(&namespace_id, "/docs/hello.txt")
         .expect_err("deleted file should not stat");
     assert!(matches!(
         error,
@@ -810,26 +1156,27 @@ fn forked_namespace_shares_content_then_diverges() {
     let source = namespace();
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
 
-    fs.create_namespace(&source, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
         .expect("create source namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &source,
         "/docs/shared.txt",
         b"source",
         PutFileOptions::default(),
     )
     .expect("put source file");
-    fs.fork_namespace(&source, &clone).expect("fork namespace");
+    fs.fork_namespace_blocking(&source, &clone)
+        .expect("fork namespace");
 
     let source_entry = fs
-        .stat_path(&source, "/docs/shared.txt")
+        .stat_path_blocking(&source, "/docs/shared.txt")
         .expect("stat source");
     let clone_entry = fs
-        .stat_path(&clone, "/docs/shared.txt")
+        .stat_path_blocking(&clone, "/docs/shared.txt")
         .expect("stat clone");
     assert_eq!(source_entry.content_ref, clone_entry.content_ref);
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &clone,
         "/docs/shared.txt",
         b"clone",
@@ -841,13 +1188,13 @@ fn forked_namespace_shares_content_then_diverges() {
     .expect("replace clone file");
 
     assert_eq!(
-        fs.read_file_bytes(&source, "/docs/shared.txt")
+        fs.read_file_bytes_blocking(&source, "/docs/shared.txt")
             .expect("read source")
             .bytes,
         b"source"
     );
     assert_eq!(
-        fs.read_file_bytes(&clone, "/docs/shared.txt")
+        fs.read_file_bytes_blocking(&clone, "/docs/shared.txt")
             .expect("read clone")
             .bytes,
         b"clone"
@@ -860,14 +1207,16 @@ fn upload_flow_is_available_from_runtime() {
     let fs = runtime(temp_dir.path(), "upload-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
     let staged_again = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("repeat upload content");
     assert_eq!(staged.content_ref, staged_again.content_ref);
 
@@ -875,10 +1224,10 @@ fn upload_flow_is_available_from_runtime() {
         content_ref: staged.content_ref,
     };
     let completed = fs
-        .complete_upload(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
         .expect("complete upload");
     let completed_again = fs
-        .complete_upload(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
         .expect("repeat complete upload");
     assert_eq!(completed.content_ref, completed_again.content_ref);
 }
@@ -894,13 +1243,15 @@ fn upload_then_path_put_uses_memory_proof_without_blob_validation_call() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
-    fs.complete_upload(
+    fs.complete_upload_blocking(
         &namespace_id,
         &begin.upload_id,
         &CompleteUploadRequest {
@@ -910,7 +1261,7 @@ fn upload_then_path_put_uses_memory_proof_without_blob_validation_call() {
     .expect("complete upload");
 
     raw_store.reset_content_blob_counters();
-    let responses = fs.publish_namespace_mutations_batch(
+    let responses = fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
@@ -939,13 +1290,15 @@ fn disabled_runtime_cache_still_uses_memory_proof_without_blob_validation_call()
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
-    fs.complete_upload(
+    fs.complete_upload_blocking(
         &namespace_id,
         &begin.upload_id,
         &CompleteUploadRequest {
@@ -955,7 +1308,7 @@ fn disabled_runtime_cache_still_uses_memory_proof_without_blob_validation_call()
     .expect("complete upload");
 
     raw_store.reset_content_blob_counters();
-    let responses = fs.publish_namespace_mutations_batch(
+    let responses = fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
@@ -978,13 +1331,15 @@ fn stat_and_list_record_full_basis_fallback_without_checkpoint() {
     let namespace_id = namespace();
     let fs = runtime(temp_dir.path(), "read-fallback-test");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
-    fs.stat_path(&namespace_id, "/docs").expect("stat docs");
-    fs.list_path(&namespace_id, "/").expect("list root");
+    fs.stat_path_blocking(&namespace_id, "/docs")
+        .expect("stat docs");
+    fs.list_path_blocking(&namespace_id, "/")
+        .expect("list root");
 
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.read_full_basis_fallbacks, 2);
@@ -1002,21 +1357,22 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/file.txt",
         b"file",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
 
     raw_store.reset_content_blob_counters();
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("stat materialized file");
-    fs.list_path(&namespace_id, "/docs")
+    fs.list_path_blocking(&namespace_id, "/docs")
         .expect("list materialized docs");
 
     let stats = fs.runtime_cache_stats();
@@ -1032,21 +1388,22 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
     let namespace_id = namespace();
     let fs = runtime(temp_dir.path(), "metadata-table-cache-test");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/file.txt",
         b"file",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
 
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("first materialized stat");
     let after_first = fs.runtime_cache_stats();
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("second materialized stat");
     let after_second = fs.runtime_cache_stats();
 
@@ -1067,11 +1424,11 @@ fn put_file_bytes_uses_memory_proof_without_blob_validation_call() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
     raw_store.reset_content_blob_counters();
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/direct.txt",
         b"direct bytes",
@@ -1097,17 +1454,18 @@ fn begin_upload_validates_controls_without_replay_reads() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
-    fs.put_file_bytes(
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"updated",
@@ -1119,8 +1477,10 @@ fn begin_upload_validates_controls_without_replay_reads() {
     .expect("replace file");
 
     raw_store.reset_control_get_counts();
-    fs.begin_upload(&namespace_id).expect("first begin upload");
-    fs.begin_upload(&namespace_id).expect("second begin upload");
+    fs.begin_upload_blocking(&namespace_id)
+        .expect("first begin upload");
+    fs.begin_upload_blocking(&namespace_id)
+        .expect("second begin upload");
 
     assert_eq!(raw_store.wal_get_count(), 0);
     assert_eq!(raw_store.manifest_get_count(), 0);
@@ -1140,18 +1500,18 @@ fn runtime_control_cache_reuses_head_for_basis_validation() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
 
     raw_store.reset_control_get_counts();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first cached basis validation reuses cached head state");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second cached basis validation reuses cached head state");
 
     assert_eq!(raw_store.head_get_count(), 0);
@@ -1176,24 +1536,24 @@ fn control_cache_eviction_reloads_head_for_basis_validation() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
-    fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&other_namespace, CreateNamespaceOptions::default())
         .expect("create other namespace");
-    fs.create_dir(&other_namespace, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&other_namespace, "/docs", CreateDirOptions::default())
         .expect("create other docs");
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime first namespace basis");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime first namespace head cache");
 
     raw_store.reset_control_get_counts();
-    fs.stat_path(&other_namespace, "/docs")
+    fs.stat_path_blocking(&other_namespace, "/docs")
         .expect("load other namespace basis and evict first head cache");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("reload first namespace basis and head cache");
 
     assert_eq!(raw_store.head_get_count(), 1);
@@ -1218,29 +1578,29 @@ fn runtime_control_cache_reloads_head_after_external_change() {
         .expect("build writer runtime");
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
     raw_store.reset_control_get_counts();
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime control cache");
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("reuse unchanged control cache");
     assert_eq!(raw_store.head_get_count(), 0);
 
     writer
-        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
         .expect("advance head");
     raw_store.reset_control_get_counts();
     reader
-        .stat_path(&namespace_id, "/docs/new")
+        .stat_path_blocking(&namespace_id, "/docs/new")
         .expect("reload changed head");
     assert!(raw_store.head_get_count() > 0);
 }
@@ -1256,15 +1616,21 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespaceNotFound);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespaceNotFound,
+    );
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .delete(&namespace_descriptor(namespace_id.as_str()))
         .expect("delete namespace descriptor");
 
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespacePartial);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespacePartial,
+    );
 }
 
 #[test]
@@ -1278,7 +1644,7 @@ fn begin_upload_rejects_malformed_descriptors() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .put_overwrite(
@@ -1286,10 +1652,13 @@ fn begin_upload_rejects_malformed_descriptors() {
             br#"{"not":"a namespace descriptor"}"#,
         )
         .expect("corrupt namespace descriptor");
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespaceCorrupt,
+    );
 
     let content_bad = NamespaceId::parse("content-bad").expect("valid namespace id");
-    fs.create_namespace(&content_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&content_bad, CreateNamespaceOptions::default())
         .expect("create content-bad namespace");
     for key in raw_store
         .list_prefix("content-stores/")
@@ -1301,7 +1670,10 @@ fn begin_upload_rejects_malformed_descriptors() {
             .put_overwrite(&key, br#"{"not":"a content store descriptor"}"#)
             .expect("corrupt content store descriptor");
     }
-    assert_core_error_kind(fs.begin_upload(&content_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&content_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 }
 
 #[test]
@@ -1316,15 +1688,18 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
         .expect("build runtime");
 
     let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
-    fs.create_namespace(&head_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&head_bad, CreateNamespaceOptions::default())
         .expect("create head-bad namespace");
     raw_store
         .put_overwrite(&namespace_head(head_bad.as_str()), br#"{"not":"a head"}"#)
         .expect("corrupt head");
-    assert_core_error_kind(fs.begin_upload(&head_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&head_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 
     let lease_bad = NamespaceId::parse("lease-bad").expect("valid namespace id");
-    fs.create_namespace(&lease_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&lease_bad, CreateNamespaceOptions::default())
         .expect("create lease-bad namespace");
     raw_store
         .put_overwrite(
@@ -1332,7 +1707,10 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
             br#"{"not":"a lease"}"#,
         )
         .expect("corrupt lease");
-    assert_core_error_kind(fs.begin_upload(&lease_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&lease_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 }
 
 #[test]
@@ -1341,11 +1719,11 @@ fn explicit_commit_appears_in_change_feed() {
     let fs = runtime(temp_dir.path(), "commit-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let commit_id = CommitId::parse("explicit-create-dir").expect("valid commit id");
     let response = fs
-        .commit_operations(
+        .commit_operations_blocking(
             &namespace_id,
             CommitRequest {
                 commit_id: commit_id.clone(),
@@ -1361,7 +1739,7 @@ fn explicit_commit_appears_in_change_feed() {
         .expect("commit operation");
 
     let changes = fs
-        .list_changes_after(&namespace_id, ChangeSeq(0))
+        .list_changes_after_blocking(&namespace_id, ChangeSeq(0))
         .expect("list changes");
     assert_eq!(changes.through_seq, response.committed_seq);
     assert_eq!(changes.changes.len(), 1);
@@ -1374,10 +1752,10 @@ fn namespace_status_reports_wal_tail_segments() {
     let fs = runtime(temp_dir.path(), "status-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status for new namespace");
     assert_eq!(status.namespace_id, namespace_id);
     assert_eq!(status.head_seq, ChangeSeq(0));
@@ -1385,7 +1763,7 @@ fn namespace_status_reports_wal_tail_segments() {
     assert_eq!(status.wal_tail_segments, 0);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1394,7 +1772,7 @@ fn namespace_status_reports_wal_tail_segments() {
     .expect("put file");
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after commit");
     assert_eq!(status.head_seq, ChangeSeq(1));
     assert_eq!(status.current_manifest_id, None);
@@ -1409,11 +1787,11 @@ fn namespace_status_and_tick_reject_missing_namespace() {
     let namespace_id = namespace();
 
     assert_core_error_kind(
-        fs.namespace_status(&namespace_id),
+        fs.namespace_status_blocking(&namespace_id),
         ErrorCode::NamespaceNotFound,
     );
     assert_core_error_kind(
-        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        fs.maintenance_tick_namespace_blocking(&namespace_id, MaintenanceTickOptions::default()),
         ErrorCode::NamespaceNotFound,
     );
 }
@@ -1429,18 +1807,18 @@ fn namespace_status_and_tick_reject_partial_namespace() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .delete(&namespace_descriptor(namespace_id.as_str()))
         .expect("delete namespace descriptor");
 
     assert_core_error_kind(
-        fs.namespace_status(&namespace_id),
+        fs.namespace_status_blocking(&namespace_id),
         ErrorCode::NamespacePartial,
     );
     assert_core_error_kind(
-        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        fs.maintenance_tick_namespace_blocking(&namespace_id, MaintenanceTickOptions::default()),
         ErrorCode::NamespacePartial,
     );
 }
@@ -1451,9 +1829,9 @@ fn maintenance_tick_below_threshold_is_not_needed() {
     let fs = runtime(temp_dir.path(), "tick-not-needed-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1462,7 +1840,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
     .expect("put file");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -1480,9 +1858,9 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     let fs = runtime(temp_dir.path(), "tick-publish-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1491,7 +1869,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     .expect("put file");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -1507,7 +1885,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     );
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after checkpoint");
     assert_eq!(status.current_manifest_id, Some(ManifestId(1)));
     assert_eq!(status.wal_tail_segments, 0);
@@ -1519,16 +1897,16 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     let fs = runtime(temp_dir.path(), "tick-l0-run-publish-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
         PutFileOptions::default(),
     )
     .expect("put first file");
-    fs.maintenance_tick_namespace(
+    fs.maintenance_tick_namespace_blocking(
         &namespace_id,
         MaintenanceTickOptions {
             max_wal_tail_segments: 1,
@@ -1536,7 +1914,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     )
     .expect("first maintenance tick");
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/second.txt",
         b"second",
@@ -1544,7 +1922,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     )
     .expect("put second file");
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -1559,7 +1937,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     );
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after l0 checkpoint");
     assert_eq!(status.current_manifest_id, Some(ManifestId(2)));
     assert_eq!(status.wal_tail_segments, 0);
@@ -1590,9 +1968,9 @@ fn maintenance_tick_counts_segments_not_commits() {
     let fs = runtime(temp_dir.path(), "tick-segment-count-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let first_batch = fs.commit_operations_batch(
+    let first_batch = fs.commit_operations_batch_blocking(
         &namespace_id,
         vec![
             CommitRequest {
@@ -1620,13 +1998,13 @@ fn maintenance_tick_counts_segments_not_commits() {
     assert!(first_batch.iter().all(Result::is_ok));
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after first batch");
     assert_eq!(status.head_seq, ChangeSeq(2));
     assert_eq!(status.wal_tail_segments, 1);
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -1635,7 +2013,7 @@ fn maintenance_tick_counts_segments_not_commits() {
         .expect("maintenance tick");
     assert_eq!(tick.outcome, MaintenanceTickOutcome::NotNeeded);
 
-    fs.commit_operations(
+    fs.commit_operations_blocking(
         &namespace_id,
         CommitRequest {
             commit_id: CommitId::parse("create-c").expect("valid commit id"),
@@ -1651,7 +2029,7 @@ fn maintenance_tick_counts_segments_not_commits() {
     .expect("second segment commit");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -1674,10 +2052,10 @@ fn maintenance_tick_rejects_zero_threshold() {
     let fs = runtime(temp_dir.path(), "tick-config-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let error = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 0,
@@ -1704,9 +2082,9 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1716,7 +2094,7 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
 
     raw_store.fail_head_cas();
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -1731,7 +2109,7 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
         }
     );
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after lost race");
     assert_eq!(status.current_manifest_id, None);
     assert_eq!(status.wal_tail_segments, 1);
@@ -1743,9 +2121,9 @@ fn checkpoint_and_retention_hooks_are_available() {
     let fs = runtime(temp_dir.path(), "maintenance-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1754,10 +2132,10 @@ fn checkpoint_and_retention_hooks_are_available() {
     .expect("put file");
 
     let checkpoint = fs
-        .create_checkpoint(&namespace_id)
+        .create_checkpoint_blocking(&namespace_id)
         .expect("create checkpoint");
     let retention = fs
-        .advance_retention_floor(&namespace_id)
+        .advance_retention_floor_blocking(&namespace_id)
         .expect("advance retention");
     assert_eq!(retention.retention_floor_seq, checkpoint.checkpoint_seq);
 }
@@ -1770,10 +2148,10 @@ fn separate_runtime_instances_share_object_store_state() {
     let namespace_id = namespace();
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .put_file_bytes(
+        .put_file_bytes_blocking(
             &namespace_id,
             "/docs/shared.txt",
             b"shared",
@@ -1781,11 +2159,11 @@ fn separate_runtime_instances_share_object_store_state() {
         )
         .expect("put file");
 
-    let namespaces = reader.list_namespaces().expect("list namespaces");
+    let namespaces = reader.list_namespaces_blocking().expect("list namespaces");
     assert_eq!(namespaces.len(), 1);
     assert_eq!(namespaces[0].namespace_id, namespace_id);
     let file = reader
-        .read_file_bytes(&namespace_id, "/docs/shared.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");
     assert_eq!(file.bytes, b"shared");
 }


### PR DESCRIPTION
Adds the async object-store boundary and wraps it in a temporary "blocking" wrapper to make it look sync for compatability. We need to migrate to async GETs to support scalable performance as our LSM strategy begins to weigh down synchronous object store GET paths. 
