### PR TITLE
refactor(loonfs): add async runtime boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,7 @@ dependencies = [
  "loon-objectstore",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "toml",
  "ureq",
 ]

--- a/crates/loon-cli/Cargo.toml
+++ b/crates/loon-cli/Cargo.toml
@@ -21,6 +21,7 @@ loonfs = { path = "../loonfs" }
 loon-objectstore = { path = "../loon-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 toml.workspace = true
 
 [dev-dependencies]

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -215,7 +215,7 @@ impl Backend for EmbeddedBackend {
         let ns_id = parse_namespace_id(namespace_id)?;
         self.block_on(
             self.fs
-                .create_namespace_async(&ns_id, CreateNamespaceOptions::default()),
+                .create_namespace(&ns_id, CreateNamespaceOptions::default()),
         )
     }
 
@@ -228,19 +228,19 @@ impl Backend for EmbeddedBackend {
         let new_namespace_id = parse_namespace_id(new_namespace_id)?;
         self.block_on(
             self.fs
-                .fork_namespace_async(&source_namespace_id, &new_namespace_id),
+                .fork_namespace(&source_namespace_id, &new_namespace_id),
         )
     }
 
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
-        self.block_on(self.fs.list_namespaces_async())
+        self.block_on(self.fs.list_namespaces())
     }
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.list_path_async(&ns_id, &spec.absolute_path),
+            self.fs.list_path(&ns_id, &spec.absolute_path),
         )
     }
 
@@ -248,7 +248,7 @@ impl Backend for EmbeddedBackend {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.stat_path_async(&ns_id, &spec.absolute_path),
+            self.fs.stat_path(&ns_id, &spec.absolute_path),
         )
     }
 
@@ -256,7 +256,7 @@ impl Backend for EmbeddedBackend {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let result = self.block_on_scoped(
             &spec.namespace,
-            self.fs.read_file_bytes_async(&ns_id, &spec.absolute_path),
+            self.fs.read_file_bytes(&ns_id, &spec.absolute_path),
         )?;
         Ok(result.bytes)
     }
@@ -270,7 +270,7 @@ impl Backend for EmbeddedBackend {
         let result = self.block_on_scoped(
             &spec.namespace,
             self.fs
-                .read_file_revision_bytes_async(&ns_id, &spec.absolute_path, revision_no),
+                .read_file_revision_bytes(&ns_id, &spec.absolute_path, revision_no),
         )?;
         Ok(result.bytes)
     }
@@ -282,8 +282,7 @@ impl Backend for EmbeddedBackend {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
-            self.fs
-                .list_file_revisions_async(&ns_id, &spec.absolute_path),
+            self.fs.list_file_revisions(&ns_id, &spec.absolute_path),
         )
     }
 
@@ -302,7 +301,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.put_file_bytes_async(
+            self.fs.put_file_bytes(
                 &ns_id,
                 &spec.absolute_path,
                 bytes,
@@ -319,7 +318,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.delete_path_async(
+            self.fs.delete_path(
                 &ns_id,
                 &spec.absolute_path,
                 DeleteOptions {
@@ -335,7 +334,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.create_dir_async(
+            self.fs.create_dir(
                 &ns_id,
                 &spec.absolute_path,
                 CreateDirOptions {
@@ -354,7 +353,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &from.namespace,
-            self.fs.move_path_async(
+            self.fs.move_path(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
@@ -374,7 +373,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &from.namespace,
-            self.fs.copy_path_async(
+            self.fs.copy_path(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
@@ -394,7 +393,7 @@ impl Backend for EmbeddedBackend {
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.restore_file_revision_async(
+            self.fs.restore_file_revision(
                 &ns_id,
                 &spec.absolute_path,
                 source_revision_no,
@@ -679,7 +678,7 @@ mod tests {
                 target
                     .backend
                     .fs
-                    .list_changes_after_async(&namespace_id, ChangeSeq(0)),
+                    .list_changes_after(&namespace_id, ChangeSeq(0)),
             )
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -386,6 +386,9 @@ fn map_runtime_error(error: RuntimeError) -> CliError {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
+        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
+            CliError::new("runtime_error", error.to_string())
+        }
     }
 }
 
@@ -394,6 +397,9 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
+        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
+            CliError::new("runtime_error", error.to_string())
+        }
     }
 }
 

--- a/crates/loon-cli/src/backend.rs
+++ b/crates/loon-cli/src/backend.rs
@@ -11,6 +11,7 @@ use loonfs::{
     RestoreRevisionOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
     TraceStoreKind,
 };
+use std::future::Future;
 use std::sync::Arc;
 
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
@@ -188,14 +189,34 @@ fn map_client_error(error: ClientError) -> CliError {
 
 pub struct EmbeddedBackend {
     fs: Fs,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl EmbeddedBackend {
+    fn block_on<T, F>(&self, future: F) -> Result<T, CliError>
+    where
+        F: Future<Output = loonfs::Result<T>>,
+    {
+        self.runtime.block_on(future).map_err(map_runtime_error)
+    }
+
+    fn block_on_scoped<T, F>(&self, namespace: &str, future: F) -> Result<T, CliError>
+    where
+        F: Future<Output = loonfs::Result<T>>,
+    {
+        self.runtime
+            .block_on(future)
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace, error))
+    }
 }
 
 impl Backend for EmbeddedBackend {
     fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
         let ns_id = parse_namespace_id(namespace_id)?;
-        self.fs
-            .create_namespace(&ns_id, CreateNamespaceOptions::default())
-            .map_err(map_runtime_error)
+        self.block_on(
+            self.fs
+                .create_namespace_async(&ns_id, CreateNamespaceOptions::default()),
+        )
     }
 
     fn fork_namespace(
@@ -205,35 +226,38 @@ impl Backend for EmbeddedBackend {
     ) -> Result<NamespaceSummary, CliError> {
         let source_namespace_id = parse_namespace_id(source)?;
         let new_namespace_id = parse_namespace_id(new_namespace_id)?;
-        self.fs
-            .fork_namespace(&source_namespace_id, &new_namespace_id)
-            .map_err(map_runtime_error)
+        self.block_on(
+            self.fs
+                .fork_namespace_async(&source_namespace_id, &new_namespace_id),
+        )
     }
 
     fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
-        self.fs.list_namespaces().map_err(map_runtime_error)
+        self.block_on(self.fs.list_namespaces_async())
     }
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .list_path(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.list_path_async(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .stat_path(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.stat_path_async(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        let result = self
-            .fs
-            .read_file_bytes(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+        let result = self.block_on_scoped(
+            &spec.namespace,
+            self.fs.read_file_bytes_async(&ns_id, &spec.absolute_path),
+        )?;
         Ok(result.bytes)
     }
 
@@ -243,10 +267,11 @@ impl Backend for EmbeddedBackend {
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        let result = self
-            .fs
-            .read_file_revision_bytes(&ns_id, &spec.absolute_path, revision_no)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+        let result = self.block_on_scoped(
+            &spec.namespace,
+            self.fs
+                .read_file_revision_bytes_async(&ns_id, &spec.absolute_path, revision_no),
+        )?;
         Ok(result.bytes)
     }
 
@@ -255,9 +280,11 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
     ) -> Result<ListFileRevisionsResponse, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
-        self.fs
-            .list_file_revisions(&ns_id, &spec.absolute_path)
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs
+                .list_file_revisions_async(&ns_id, &spec.absolute_path),
+        )
     }
 
     fn put_file_bytes(
@@ -273,8 +300,9 @@ impl Backend for EmbeddedBackend {
             PutFileBehavior::CreateOnly
         };
         let commit_id = generated_commit_id();
-        self.fs
-            .put_file_bytes(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.put_file_bytes_async(
                 &ns_id,
                 &spec.absolute_path,
                 bytes,
@@ -282,37 +310,39 @@ impl Backend for EmbeddedBackend {
                     behavior,
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .delete_path(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.delete_path_async(
                 &ns_id,
                 &spec.absolute_path,
                 DeleteOptions {
                     recursive: false,
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .create_dir(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.create_dir_async(
                 &ns_id,
                 &spec.absolute_path,
                 CreateDirOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 
     fn move_path(
@@ -322,16 +352,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .move_path(
+        self.block_on_scoped(
+            &from.namespace,
+            self.fs.move_path_async(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
                 MoveOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
+            ),
+        )
     }
 
     fn copy_path(
@@ -341,16 +372,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .copy_path(
+        self.block_on_scoped(
+            &from.namespace,
+            self.fs.copy_path_async(
                 &ns_id,
                 &from.absolute_path,
                 &to.absolute_path,
                 CopyOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
+            ),
+        )
     }
 
     fn restore_file_revision(
@@ -360,16 +392,17 @@ impl Backend for EmbeddedBackend {
     ) -> Result<MutationResult, CliError> {
         let ns_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
-        self.fs
-            .restore_file_revision(
+        self.block_on_scoped(
+            &spec.namespace,
+            self.fs.restore_file_revision_async(
                 &ns_id,
                 &spec.absolute_path,
                 source_revision_no,
                 RestoreRevisionOptions {
                     commit_id: Some(commit_id),
                 },
-            )
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            ),
+        )
     }
 }
 
@@ -386,9 +419,7 @@ fn map_runtime_error(error: RuntimeError) -> CliError {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
-        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
-            CliError::new("runtime_error", error.to_string())
-        }
+        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
     }
 }
 
@@ -397,9 +428,7 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
-        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
-            CliError::new("runtime_error", error.to_string())
-        }
+        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
     }
 }
 
@@ -532,7 +561,11 @@ impl EmbeddedTarget {
             },
         )
         .map_err(map_runtime_error)?;
-        let backend = EmbeddedBackend { fs };
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| CliError::invalid_config(error.to_string()))?;
+        let backend = EmbeddedBackend { fs, runtime };
         Ok(Self { backend })
     }
 }
@@ -639,12 +672,14 @@ mod tests {
             )
             .expect("put file");
 
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let changes = target
             .backend
-            .fs
-            .list_changes_after(
-                &NamespaceId::parse("demo").expect("valid namespace id"),
-                ChangeSeq(0),
+            .block_on(
+                target
+                    .backend
+                    .fs
+                    .list_changes_after_async(&namespace_id, ChangeSeq(0)),
             )
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -229,7 +229,7 @@ async fn create_namespace(
     let namespace_id = parse_namespace_id(request.namespace_id)?;
     let summary = state
         .fs
-        .create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(summary))
@@ -242,7 +242,7 @@ async fn list_namespaces_handler(
     authorize(&state.config, &headers)?;
     let namespaces = state
         .fs
-        .list_namespaces_async()
+        .list_namespaces()
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(ListNamespacesResponse { namespaces }))
@@ -259,7 +259,7 @@ async fn fork_namespace_handler(
     let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
     let summary = state
         .fs
-        .fork_namespace_async(&source_namespace_id, &new_namespace_id)
+        .fork_namespace(&source_namespace_id, &new_namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
     Ok(Json(summary))
@@ -276,7 +276,7 @@ async fn list_entries(
     let path = query.path;
     let entries = state
         .fs
-        .list_path_async(&namespace_id, &path)
+        .list_path(&namespace_id, &path)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entries))
@@ -293,7 +293,7 @@ async fn stat_entry(
     let path = query.path;
     let entry = state
         .fs
-        .stat_path_async(&namespace_id, &path)
+        .stat_path(&namespace_id, &path)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entry))
@@ -317,10 +317,10 @@ async fn get_content(
         Some(revision_no) => {
             state
                 .fs
-                .read_file_revision_bytes_async(&namespace_id, &path, revision_no)
+                .read_file_revision_bytes(&namespace_id, &path, revision_no)
                 .await
         }
-        None => state.fs.read_file_bytes_async(&namespace_id, &path).await,
+        None => state.fs.read_file_bytes(&namespace_id, &path).await,
     }
     .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, file.bytes).into_response())
@@ -337,7 +337,7 @@ async fn list_path_revisions(
     let path = query.path;
     let response = state
         .fs
-        .list_file_revisions_async(&namespace_id, &path)
+        .list_file_revisions(&namespace_id, &path)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -353,7 +353,7 @@ async fn list_inode_revisions(
     let inode_id = parse_inode_id(&inode_id)?;
     let response = state
         .fs
-        .list_file_revisions_for_inode_async(&namespace_id, inode_id)
+        .list_file_revisions_for_inode(&namespace_id, inode_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -370,7 +370,7 @@ async fn get_inode_revision_content(
     let revision_no = parse_revision_no(&revision_no)?;
     let bytes = state
         .fs
-        .read_file_revision_bytes_for_inode_async(&namespace_id, inode_id, revision_no)
+        .read_file_revision_bytes_for_inode(&namespace_id, inode_id, revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, bytes).into_response())
@@ -507,7 +507,7 @@ async fn begin_upload_handler(
     let namespace_id = parse_namespace_id(namespace)?;
     let response = state
         .fs
-        .begin_upload_async(&namespace_id)
+        .begin_upload(&namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -524,7 +524,7 @@ async fn upload_content_handler(
     let bytes = body.to_vec();
     let response = state
         .fs
-        .upload_content_async(&namespace_id, &upload_id, &bytes)
+        .upload_content(&namespace_id, &upload_id, &bytes)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -540,7 +540,7 @@ async fn complete_upload_handler(
     let namespace_id = parse_namespace_id(namespace)?;
     let response = state
         .fs
-        .complete_upload_async(&namespace_id, &upload_id, &request)
+        .complete_upload(&namespace_id, &upload_id, &request)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -573,7 +573,7 @@ async fn list_changes_handler(
     let after_seq = loon_api::ChangeSeq(query.after_seq);
     let response = state
         .fs
-        .list_changes_after_async(&namespace_id, after_seq)
+        .list_changes_after(&namespace_id, after_seq)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -588,7 +588,7 @@ async fn create_checkpoint_handler(
     let namespace_id = parse_namespace_id(namespace)?;
     let response = state
         .fs
-        .create_checkpoint_async(&namespace_id)
+        .create_checkpoint(&namespace_id)
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
@@ -603,7 +603,7 @@ async fn advance_retention_handler(
     let namespace_id = parse_namespace_id(namespace)?;
     let response = state
         .fs
-        .advance_retention_floor_async(&namespace_id)
+        .advance_retention_floor(&namespace_id)
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
@@ -898,10 +898,12 @@ mod tests {
                 .enable_all()
                 .build()
                 .expect("runtime")
-                .block_on(fs.create_namespace_async(
-                    &namespace_id("metrics"),
-                    CreateNamespaceOptions::default(),
-                ))
+                .block_on(
+                    fs.create_namespace(
+                        &namespace_id("metrics"),
+                        CreateNamespaceOptions::default(),
+                    ),
+                )
                 .expect("create namespace");
         }
 
@@ -916,10 +918,10 @@ mod tests {
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let fs = test_runtime(store.clone(), "runtime-writer");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        fs.create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace through runtime");
-        fs.put_file_bytes_async(
+        fs.put_file_bytes(
             &namespace_id,
             "/notes/hello.txt",
             b"hello from runtime",
@@ -968,7 +970,7 @@ mod tests {
         .expect("join blocking task");
 
         let file = fs
-            .read_file_bytes_async(
+            .read_file_bytes(
                 &NamespaceId::parse("demo").expect("valid namespace id"),
                 "/notes/from-http.txt",
             )

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -715,14 +715,11 @@ impl ApiResponseError {
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
             }
-            error
-            @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
-                Self::new(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    &error.to_string(),
-                )
-            }
+            error @ RuntimeError::RuntimeTask(_) => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                &error.to_string(),
+            ),
         }
     }
 
@@ -750,14 +747,11 @@ impl ApiResponseError {
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
             }
-            error
-            @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
-                Self::new(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    &error.to_string(),
-                )
-            }
+            error @ RuntimeError::RuntimeTask(_) => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                &error.to_string(),
+            ),
         }
     }
 }
@@ -900,7 +894,14 @@ mod tests {
                 Some(metrics_path.clone().into_os_string()),
             )
             .expect("build fs");
-            fs.create_namespace(&namespace_id("metrics"), CreateNamespaceOptions::default())
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime")
+                .block_on(fs.create_namespace_async(
+                    &namespace_id("metrics"),
+                    CreateNamespaceOptions::default(),
+                ))
                 .expect("create namespace");
         }
 

--- a/crates/loon-server/src/http.rs
+++ b/crates/loon-server/src/http.rs
@@ -26,7 +26,6 @@ use loonfs::{
 use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::task;
 use tracing::Instrument;
 
 type SharedStore = SharedObjectStore;
@@ -227,13 +226,12 @@ async fn create_namespace(
     Json(request): Json<CreateNamespaceRequest>,
 ) -> Result<Json<loon_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(request.namespace_id)?;
-    let summary = run_blocking(move || {
-        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let summary = state
+        .fs
+        .create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(summary))
 }
 
@@ -242,9 +240,11 @@ async fn list_namespaces_handler(
     headers: HeaderMap,
 ) -> Result<Json<ListNamespacesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
-    let namespaces =
-        run_blocking(move || fs.list_namespaces().map_err(ApiResponseError::runtime)).await?;
+    let namespaces = state
+        .fs
+        .list_namespaces_async()
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(ListNamespacesResponse { namespaces }))
 }
 
@@ -255,14 +255,13 @@ async fn fork_namespace_handler(
     Json(request): Json<ForkNamespaceRequest>,
 ) -> Result<Json<loon_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let source_namespace_id = parse_namespace_id(namespace)?;
     let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
-    let summary = run_blocking(move || {
-        fs.fork_namespace(&source_namespace_id, &new_namespace_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))
-    })
-    .await?;
+    let summary = state
+        .fs
+        .fork_namespace_async(&source_namespace_id, &new_namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
     Ok(Json(summary))
 }
 
@@ -273,14 +272,13 @@ async fn list_entries(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<Vec<loon_api::AuthoritativePathEntry>>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let entries = run_blocking(move || {
-        fs.list_path(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let entries = state
+        .fs
+        .list_path_async(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entries))
 }
 
@@ -291,14 +289,13 @@ async fn stat_entry(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<loon_api::AuthoritativePathEntry>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let entry = run_blocking(move || {
-        fs.stat_path(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let entry = state
+        .fs
+        .stat_path_async(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entry))
 }
 
@@ -309,7 +306,6 @@ async fn get_content(
     Query(query): Query<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let revision_no = query
@@ -317,14 +313,16 @@ async fn get_content(
         .as_deref()
         .map(parse_revision_no)
         .transpose()?;
-    let file = run_blocking(move || {
-        match revision_no {
-            Some(revision_no) => fs.read_file_revision_bytes(&namespace_id, &path, revision_no),
-            None => fs.read_file_bytes(&namespace_id, &path),
+    let file = match revision_no {
+        Some(revision_no) => {
+            state
+                .fs
+                .read_file_revision_bytes_async(&namespace_id, &path, revision_no)
+                .await
         }
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+        None => state.fs.read_file_bytes_async(&namespace_id, &path).await,
+    }
+    .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, file.bytes).into_response())
 }
 
@@ -335,14 +333,13 @@ async fn list_path_revisions(
     Query(query): Query<PathQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
-    let response = run_blocking(move || {
-        fs.list_file_revisions(&namespace_id, &path)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_file_revisions_async(&namespace_id, &path)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -352,14 +349,13 @@ async fn list_inode_revisions(
     headers: HeaderMap,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let inode_id = parse_inode_id(&inode_id)?;
-    let response = run_blocking(move || {
-        fs.list_file_revisions_for_inode(&namespace_id, inode_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_file_revisions_for_inode_async(&namespace_id, inode_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -369,15 +365,14 @@ async fn get_inode_revision_content(
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let inode_id = parse_inode_id(&inode_id)?;
     let revision_no = parse_revision_no(&revision_no)?;
-    let bytes = run_blocking(move || {
-        fs.read_file_revision_bytes_for_inode(&namespace_id, inode_id, revision_no)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let bytes = state
+        .fs
+        .read_file_revision_bytes_for_inode_async(&namespace_id, inode_id, revision_no)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, bytes).into_response())
 }
 
@@ -509,13 +504,12 @@ async fn begin_upload_handler(
     headers: HeaderMap,
 ) -> Result<Json<BeginUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.begin_upload(&namespace_id)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .begin_upload_async(&namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -526,14 +520,13 @@ async fn upload_content_handler(
     body: Bytes,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let bytes = body.to_vec();
-    let response = run_blocking(move || {
-        fs.upload_content(&namespace_id, &upload_id, &bytes)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .upload_content_async(&namespace_id, &upload_id, &bytes)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -544,13 +537,12 @@ async fn complete_upload_handler(
     Json(request): Json<CompleteUploadRequest>,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.complete_upload(&namespace_id, &upload_id, &request)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .complete_upload_async(&namespace_id, &upload_id, &request)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -577,14 +569,13 @@ async fn list_changes_handler(
     Query(query): Query<ChangesQuery>,
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
     let after_seq = loon_api::ChangeSeq(query.after_seq);
-    let response = run_blocking(move || {
-        fs.list_changes_after(&namespace_id, after_seq)
-            .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))
-    })
-    .await?;
+    let response = state
+        .fs
+        .list_changes_after_async(&namespace_id, after_seq)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -594,13 +585,12 @@ async fn create_checkpoint_handler(
     headers: HeaderMap,
 ) -> Result<Json<CreateCheckpointResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.create_checkpoint(&namespace_id)
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let response = state
+        .fs
+        .create_checkpoint_async(&namespace_id)
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
 }
 
@@ -610,13 +600,12 @@ async fn advance_retention_handler(
     headers: HeaderMap,
 ) -> Result<Json<AdvanceRetentionResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let fs = state.fs.clone();
     let namespace_id = parse_namespace_id(namespace)?;
-    let response = run_blocking(move || {
-        fs.advance_retention_floor(&namespace_id)
-            .map_err(ApiResponseError::runtime)
-    })
-    .await?;
+    let response = state
+        .fs
+        .advance_retention_floor_async(&namespace_id)
+        .await
+        .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
 }
 
@@ -668,20 +657,6 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
             &format!("invalid revision_no `{value}`: {err}"),
         )
     })
-}
-
-async fn run_blocking<T, F>(operation: F) -> Result<T, ApiResponseError>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, ApiResponseError> + Send + 'static,
-{
-    task::spawn_blocking(operation).await.map_err(|err| {
-        ApiResponseError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "server_error",
-            &format!("blocking operation failed: {err}"),
-        )
-    })?
 }
 
 struct ApiResponseError {
@@ -740,6 +715,14 @@ impl ApiResponseError {
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
             }
+            error
+            @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
+                Self::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    &error.to_string(),
+                )
+            }
         }
     }
 
@@ -766,6 +749,14 @@ impl ApiResponseError {
             RuntimeError::Bootstrap(error) => Self::bootstrap(error),
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, "invalid_config", &message)
+            }
+            error
+            @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
+                Self::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    &error.to_string(),
+                )
             }
         }
     }
@@ -924,9 +915,10 @@ mod tests {
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let fs = test_runtime(store.clone(), "runtime-writer");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        fs.create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+            .await
             .expect("create namespace through runtime");
-        fs.put_file_bytes(
+        fs.put_file_bytes_async(
             &namespace_id,
             "/notes/hello.txt",
             b"hello from runtime",
@@ -935,6 +927,7 @@ mod tests {
                 commit_id: Some(CommitId::parse("runtime-put").expect("valid commit id")),
             },
         )
+        .await
         .expect("write file through runtime");
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
@@ -974,10 +967,11 @@ mod tests {
         .expect("join blocking task");
 
         let file = fs
-            .read_file_bytes(
+            .read_file_bytes_async(
                 &NamespaceId::parse("demo").expect("valid namespace id"),
                 "/notes/from-http.txt",
             )
+            .await
             .expect("read file through runtime");
         assert_eq!(file.bytes, b"hello from http");
 

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -315,18 +315,13 @@ impl NamespacePublisher {
                     .iter()
                     .map(|candidate| candidate.candidate.clone())
                     .collect::<Vec<_>>();
-                let namespace_id = self.namespace_id.clone();
-                let fs = self.fs.clone();
-                results = tokio::task::spawn_blocking(move || {
-                    fs.publish_namespace_mutations_batch(&namespace_id, batch_candidates)
-                        .into_iter()
-                        .map(|result| result.map_err(runtime_error_to_core))
-                        .collect()
-                })
-                .await
-                .unwrap_or_else(|err| {
-                    vec![Err(CoreError::Store(err.to_string())); candidates.len()]
-                });
+                results = self
+                    .fs
+                    .publish_namespace_mutations_batch_async(&self.namespace_id, batch_candidates)
+                    .await
+                    .into_iter()
+                    .map(|result| result.map_err(runtime_error_to_core))
+                    .collect();
                 if !results.iter().any(is_head_publish_stale) {
                     break;
                 }
@@ -466,6 +461,9 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
         RuntimeError::Core(error) => error,
         RuntimeError::Bootstrap(error) => CoreError::Store(error.to_string()),
         RuntimeError::Config(message) => CoreError::Store(message),
+        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
+            CoreError::Store(error.to_string())
+        }
     }
 }
 
@@ -684,8 +682,9 @@ mod tests {
         )
     }
 
-    fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
-        fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+    async fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
+        fs.create_namespace_async(namespace_id, CreateNamespaceOptions::default())
+            .await
             .expect("bootstrap");
     }
 
@@ -771,7 +770,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -824,7 +823,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -865,7 +864,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -932,7 +931,7 @@ mod tests {
         let shared = store.clone() as SharedStore;
         let config = test_config(temp_dir.path());
         let fs = test_fs(shared.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
 
         store.arm_next_head_cas();
@@ -981,7 +980,7 @@ mod tests {
         });
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let registry = PublisherRegistry::new(fs);
 
         let request_a = CommitRequest {
@@ -1034,7 +1033,7 @@ mod tests {
         });
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
-        create_namespace(&fs, &namespace_id);
+        create_namespace(&fs, &namespace_id).await;
         let content =
             store_bytes_as_content(store.as_ref(), &namespace_id, b"hello").expect("stage content");
         let registry = PublisherRegistry::new(fs);

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -317,7 +317,7 @@ impl NamespacePublisher {
                     .collect::<Vec<_>>();
                 results = self
                     .fs
-                    .publish_namespace_mutations_batch_async(&self.namespace_id, batch_candidates)
+                    .publish_namespace_mutations_batch(&self.namespace_id, batch_candidates)
                     .await
                     .into_iter()
                     .map(|result| result.map_err(runtime_error_to_core))
@@ -681,7 +681,7 @@ mod tests {
     }
 
     async fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
-        fs.create_namespace_async(namespace_id, CreateNamespaceOptions::default())
+        fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("bootstrap");
     }

--- a/crates/loon-server/src/publisher.rs
+++ b/crates/loon-server/src/publisher.rs
@@ -461,9 +461,7 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
         RuntimeError::Core(error) => error,
         RuntimeError::Bootstrap(error) => CoreError::Store(error.to_string()),
         RuntimeError::Config(message) => CoreError::Store(message),
-        error @ (RuntimeError::CannotBlockInsideAsyncRuntime | RuntimeError::RuntimeTask(_)) => {
-            CoreError::Store(error.to_string())
-        }
+        RuntimeError::RuntimeTask(message) => CoreError::Store(message),
     }
 }
 

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -10,6 +10,7 @@ loon-api = { path = "../loon-api" }
 loon-core = { path = "../loon-core" }
 loon-objectstore = { path = "../loon-objectstore" }
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -13,14 +13,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fs = Fs::builder(store).writer_id("embedded-example").build()?;
 
     let namespace_id = NamespaceId::parse("demo")?;
-    fs.create_namespace_async(
+    fs.create_namespace(
         &namespace_id,
         CreateNamespaceOptions {
             allow_existing: true,
         },
     )
     .await?;
-    fs.put_file_bytes_async(
+    fs.put_file_bytes(
         &namespace_id,
         "/hello.txt",
         b"hello from embedded LoonFS\n",
@@ -31,9 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let file = fs
-        .read_file_bytes_async(&namespace_id, "/hello.txt")
-        .await?;
+    let file = fs.read_file_bytes(&namespace_id, "/hello.txt").await?;
     println!("{}", String::from_utf8_lossy(&file.bytes));
     Ok(())
 }

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -5,20 +5,22 @@ use loonfs::{
 use std::sync::Arc;
 
 #[allow(clippy::print_stdout)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This example intentionally prints the file content it just read.
     let root = std::env::temp_dir().join("loonfs-embedded-local-fs-example");
     let store: SharedObjectStore = Arc::new(LocalFsStore::new(root)?);
     let fs = Fs::builder(store).writer_id("embedded-example").build()?;
 
     let namespace_id = NamespaceId::parse("demo")?;
-    fs.create_namespace(
+    fs.create_namespace_async(
         &namespace_id,
         CreateNamespaceOptions {
             allow_existing: true,
         },
-    )?;
-    fs.put_file_bytes(
+    )
+    .await?;
+    fs.put_file_bytes_async(
         &namespace_id,
         "/hello.txt",
         b"hello from embedded LoonFS\n",
@@ -26,9 +28,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             behavior: PutFileBehavior::ReplaceExisting,
             commit_id: None,
         },
-    )?;
+    )
+    .await?;
 
-    let file = fs.read_file_bytes(&namespace_id, "/hello.txt")?;
+    let file = fs
+        .read_file_bytes_async(&namespace_id, "/hello.txt")
+        .await?;
     println!("{}", String::from_utf8_lossy(&file.bytes));
     Ok(())
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1185,7 +1185,7 @@ impl Fs {
         .map_err(|error| RuntimeError::RuntimeTask(error.to_string()))?
     }
 
-    pub async fn create_namespace_async(
+    pub async fn create_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
@@ -1209,7 +1209,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn fork_namespace_async(
+    pub async fn fork_namespace(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
@@ -1238,7 +1238,7 @@ impl Fs {
         result
     }
 
-    pub async fn list_namespaces_async(&self) -> Result<Vec<NamespaceSummary>> {
+    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
         self.run_engine_blocking(|fs| fs.list_namespaces_blocking())
             .await
     }
@@ -1247,10 +1247,7 @@ impl Fs {
         Ok(loon_core::list_namespaces(self.store())?)
     }
 
-    pub async fn namespace_status_async(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> Result<NamespaceStatus> {
+    pub async fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
         let namespace_id = namespace_id.clone();
         self.run_engine_blocking(move |fs| fs.namespace_status_blocking(&namespace_id))
             .await
@@ -1279,7 +1276,7 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn maintenance_tick_namespace_async(
+    pub async fn maintenance_tick_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
@@ -1363,7 +1360,7 @@ impl Fs {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub async fn stat_path_async(
+    pub async fn stat_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1410,7 +1407,7 @@ impl Fs {
         Ok(entry)
     }
 
-    pub async fn list_path_async(
+    pub async fn list_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1453,7 +1450,7 @@ impl Fs {
         Ok(entries)
     }
 
-    pub async fn read_file_bytes_async(
+    pub async fn read_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1478,7 +1475,7 @@ impl Fs {
         )?)
     }
 
-    pub async fn list_file_revisions_async(
+    pub async fn list_file_revisions(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1503,7 +1500,7 @@ impl Fs {
         )?)
     }
 
-    pub async fn list_file_revisions_for_inode_async(
+    pub async fn list_file_revisions_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1529,7 +1526,7 @@ impl Fs {
             )?)
     }
 
-    pub async fn read_file_revision_bytes_async(
+    pub async fn read_file_revision_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1557,7 +1554,7 @@ impl Fs {
         )?)
     }
 
-    pub async fn read_file_revision_bytes_for_inode_async(
+    pub async fn read_file_revision_bytes_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1598,7 +1595,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub async fn put_file_bytes_async(
+    pub async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1652,7 +1649,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub async fn put_file_content_ref_async(
+    pub async fn put_file_content_ref(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1696,7 +1693,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn create_dir_async(
+    pub async fn create_dir(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1729,7 +1726,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn delete_path_async(
+    pub async fn delete_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1763,7 +1760,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn move_path_async(
+    pub async fn move_path(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -1800,7 +1797,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn copy_path_async(
+    pub async fn copy_path(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -1837,7 +1834,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn restore_file_revision_async(
+    pub async fn restore_file_revision(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1878,7 +1875,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn restore_file_revision_for_inode_async(
+    pub async fn restore_file_revision_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1901,13 +1898,10 @@ impl Fs {
             message: None,
             annotations: None,
         };
-        self.commit_operations_async(namespace_id, request).await
+        self.commit_operations(namespace_id, request).await
     }
 
-    pub async fn begin_upload_async(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> Result<BeginUploadResponse> {
+    pub async fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
         let namespace_id = namespace_id.clone();
         self.run_engine_blocking(move |fs| fs.begin_upload_blocking(&namespace_id))
             .await
@@ -1917,7 +1911,7 @@ impl Fs {
         Ok(self.namespace_engine(namespace_id).begin_upload()?)
     }
 
-    pub async fn upload_content_async(
+    pub async fn upload_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
@@ -1944,7 +1938,7 @@ impl Fs {
             .upload_content(upload_id, bytes)?)
     }
 
-    pub async fn complete_upload_async(
+    pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
@@ -1970,12 +1964,12 @@ impl Fs {
             .complete_upload(upload_id, request)?)
     }
 
-    pub async fn commit_operations_async(
+    pub async fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_namespace_mutations_batch_async(
+        self.publish_namespace_mutations_batch(
             namespace_id,
             vec![NamespaceMutationCandidate::Commit(request)],
         )
@@ -1989,12 +1983,12 @@ impl Fs {
         })
     }
 
-    pub async fn commit_operations_batch_async(
+    pub async fn commit_operations_batch(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        self.publish_namespace_mutations_batch_async(
+        self.publish_namespace_mutations_batch(
             namespace_id,
             requests
                 .into_iter()
@@ -2004,7 +1998,7 @@ impl Fs {
         .await
     }
 
-    pub async fn publish_namespace_mutations_batch_async(
+    pub async fn publish_namespace_mutations_batch(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
@@ -2087,7 +2081,7 @@ impl Fs {
             .snapshot(self.inner.metadata_table_cache.stats())
     }
 
-    pub async fn list_changes_after_async(
+    pub async fn list_changes_after(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
@@ -2118,7 +2112,7 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn create_checkpoint_async(
+    pub async fn create_checkpoint(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
@@ -2140,7 +2134,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub async fn advance_retention_floor_async(
+    pub async fn advance_retention_floor(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -9,7 +9,6 @@
 mod trace;
 
 use std::collections::{HashMap, VecDeque};
-use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -78,8 +77,6 @@ pub enum RuntimeError {
     Bootstrap(#[from] BootstrapNamespaceError),
     #[error("invalid runtime config: {0}")]
     Config(String),
-    #[error("synchronous LoonFS calls cannot block inside an async runtime; use the async API")]
-    CannotBlockInsideAsyncRuntime,
     #[error("runtime task failed: {0}")]
     RuntimeTask(String),
 }
@@ -174,71 +171,12 @@ pub struct Fs {
 struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
-    sync_runtime: SyncRuntimeFacade,
     basis_cache: Mutex<BasisCache>,
     commit_engines: Mutex<CommitEngineCache>,
     control_cache: Mutex<RuntimeControlCache>,
     metadata_table_cache: Arc<MetadataTableCache>,
     uploaded_content_proofs: Mutex<UploadedContentProofCache>,
     cache_stats: RuntimeCacheStatsInner,
-}
-
-struct SyncRuntimeFacade {
-    runtime: Mutex<Option<tokio::runtime::Runtime>>,
-}
-
-impl SyncRuntimeFacade {
-    fn new() -> Result<Self> {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .map_err(|error| RuntimeError::Config(error.to_string()))?;
-        Ok(Self {
-            runtime: Mutex::new(Some(runtime)),
-        })
-    }
-
-    fn block_on_outside_tokio<T, F>(&self, stats: &RuntimeCacheStatsInner, future: F) -> Result<T>
-    where
-        F: Future<Output = Result<T>>,
-    {
-        self.block_on_value_outside_tokio(stats, future)?
-    }
-
-    fn block_on_value_outside_tokio<T, F>(
-        &self,
-        stats: &RuntimeCacheStatsInner,
-        future: F,
-    ) -> Result<T>
-    where
-        F: Future<Output = T>,
-    {
-        if tokio::runtime::Handle::try_current().is_ok() {
-            stats
-                .block_inside_tokio_errors
-                .fetch_add(1, Ordering::SeqCst);
-            return Err(RuntimeError::CannotBlockInsideAsyncRuntime);
-        }
-        stats.sync_facade_calls.fetch_add(1, Ordering::SeqCst);
-        let runtime = self.runtime.lock().expect("sync runtime lock poisoned");
-        let runtime = runtime
-            .as_ref()
-            .expect("sync runtime should be available until drop");
-        Ok(runtime.block_on(future))
-    }
-}
-
-impl Drop for SyncRuntimeFacade {
-    fn drop(&mut self) {
-        if let Some(runtime) = self
-            .runtime
-            .get_mut()
-            .expect("sync runtime lock poisoned")
-            .take()
-        {
-            runtime.shutdown_background();
-        }
-    }
 }
 
 /// Builder for [`Fs`].
@@ -753,9 +691,7 @@ struct CachedControl<T> {
 /// These counters are diagnostic. They are useful for tuning cache limits and
 /// understanding read/write warmup behavior.
 pub struct RuntimeCacheStats {
-    pub sync_facade_calls: usize,
     pub async_engine_calls: usize,
-    pub block_inside_tokio_errors: usize,
     pub warm_basis_cache_hits: usize,
     pub warm_basis_cache_misses: usize,
     pub warm_basis_evictions: usize,
@@ -788,9 +724,7 @@ enum MetadataReadSource {
 
 #[derive(Debug, Default)]
 struct RuntimeCacheStatsInner {
-    sync_facade_calls: AtomicUsize,
     async_engine_calls: AtomicUsize,
-    block_inside_tokio_errors: AtomicUsize,
     warm_basis_cache_hits: AtomicUsize,
     warm_basis_cache_misses: AtomicUsize,
     warm_basis_evictions: AtomicUsize,
@@ -814,9 +748,7 @@ struct RuntimeCacheStatsInner {
 impl RuntimeCacheStatsInner {
     fn snapshot(&self, metadata_table_cache: MetadataTableCacheStats) -> RuntimeCacheStats {
         RuntimeCacheStats {
-            sync_facade_calls: self.sync_facade_calls.load(Ordering::SeqCst),
             async_engine_calls: self.async_engine_calls.load(Ordering::SeqCst),
-            block_inside_tokio_errors: self.block_inside_tokio_errors.load(Ordering::SeqCst),
             warm_basis_cache_hits: self.warm_basis_cache_hits.load(Ordering::SeqCst),
             warm_basis_cache_misses: self.warm_basis_cache_misses.load(Ordering::SeqCst),
             warm_basis_evictions: self.warm_basis_evictions.load(Ordering::SeqCst),
@@ -1212,7 +1144,6 @@ impl Fs {
             inner: Arc::new(FsInner {
                 store,
                 config,
-                sync_runtime: SyncRuntimeFacade::new()?,
                 basis_cache: Mutex::new(BasisCache::default()),
                 commit_engines: Mutex::new(CommitEngineCache::default()),
                 control_cache: Mutex::new(RuntimeControlCache::default()),
@@ -1238,24 +1169,6 @@ impl Fs {
         span.record("store_kind", self.inner.config.trace_store_kind.as_str());
     }
 
-    fn block_on_sync<T, F>(&self, future: F) -> Result<T>
-    where
-        F: Future<Output = Result<T>>,
-    {
-        self.inner
-            .sync_runtime
-            .block_on_outside_tokio(&self.inner.cache_stats, future)
-    }
-
-    fn block_on_sync_value<T, F>(&self, future: F) -> Result<T>
-    where
-        F: Future<Output = T>,
-    {
-        self.inner
-            .sync_runtime
-            .block_on_value_outside_tokio(&self.inner.cache_stats, future)
-    }
-
     async fn run_engine_blocking<T, F>(&self, operation: F) -> Result<T>
     where
         T: Send + 'static,
@@ -1270,14 +1183,6 @@ impl Fs {
         })
         .await
         .map_err(|error| RuntimeError::RuntimeTask(error.to_string()))?
-    }
-
-    pub fn create_namespace(
-        &self,
-        namespace_id: &NamespaceId,
-        options: CreateNamespaceOptions,
-    ) -> Result<NamespaceSummary> {
-        self.block_on_sync(self.create_namespace_async(namespace_id, options))
     }
 
     pub async fn create_namespace_async(
@@ -1302,14 +1207,6 @@ impl Fs {
             })
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    pub fn fork_namespace(
-        &self,
-        source: &NamespaceId,
-        target: &NamespaceId,
-    ) -> Result<NamespaceSummary> {
-        self.block_on_sync(self.fork_namespace_async(source, target))
     }
 
     pub async fn fork_namespace_async(
@@ -1341,10 +1238,6 @@ impl Fs {
         result
     }
 
-    pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
-        self.block_on_sync(self.list_namespaces_async())
-    }
-
     pub async fn list_namespaces_async(&self) -> Result<Vec<NamespaceSummary>> {
         self.run_engine_blocking(|fs| fs.list_namespaces_blocking())
             .await
@@ -1352,10 +1245,6 @@ impl Fs {
 
     fn list_namespaces_blocking(&self) -> Result<Vec<NamespaceSummary>> {
         Ok(loon_core::list_namespaces(self.store())?)
-    }
-
-    pub fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
-        self.block_on_sync(self.namespace_status_async(namespace_id))
     }
 
     pub async fn namespace_status_async(
@@ -1377,25 +1266,6 @@ impl Fs {
             wal_tail_segments: summary.wal_tail_segments,
             retention_floor_seq: summary.retention_floor_seq,
         })
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loon.compaction",
-        err,
-        skip_all,
-        fields(
-            operation = "compaction",
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub fn maintenance_tick_namespace(
-        &self,
-        namespace_id: &NamespaceId,
-        options: MaintenanceTickOptions,
-    ) -> Result<MaintenanceTickResult> {
-        self.block_on_sync(self.maintenance_tick_namespace_async(namespace_id, options))
     }
 
     #[tracing::instrument(
@@ -1493,26 +1363,6 @@ impl Fs {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub fn stat_path(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<AuthoritativePathEntry> {
-        self.block_on_sync(self.stat_path_async(namespace_id, absolute_path))
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loon.stat",
-        err,
-        skip_all,
-        fields(
-            operation = "stat",
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-            cache_path = tracing::field::Empty,
-        )
-    )]
     pub async fn stat_path_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1560,14 +1410,6 @@ impl Fs {
         Ok(entry)
     }
 
-    pub fn list_path(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<Vec<AuthoritativePathEntry>> {
-        self.block_on_sync(self.list_path_async(namespace_id, absolute_path))
-    }
-
     pub async fn list_path_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1611,14 +1453,6 @@ impl Fs {
         Ok(entries)
     }
 
-    pub fn read_file_bytes(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<AuthoritativeFileBytes> {
-        self.block_on_sync(self.read_file_bytes_async(namespace_id, absolute_path))
-    }
-
     pub async fn read_file_bytes_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1642,14 +1476,6 @@ impl Fs {
             absolute_path,
             loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
         )?)
-    }
-
-    pub fn list_file_revisions(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<ListFileRevisionsResponse> {
-        self.block_on_sync(self.list_file_revisions_async(namespace_id, absolute_path))
     }
 
     pub async fn list_file_revisions_async(
@@ -1677,14 +1503,6 @@ impl Fs {
         )?)
     }
 
-    pub fn list_file_revisions_for_inode(
-        &self,
-        namespace_id: &NamespaceId,
-        inode_id: InodeId,
-    ) -> Result<ListFileRevisionsResponse> {
-        self.block_on_sync(self.list_file_revisions_for_inode_async(namespace_id, inode_id))
-    }
-
     pub async fn list_file_revisions_for_inode_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1709,19 +1527,6 @@ impl Fs {
                 inode_id,
                 loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
             )?)
-    }
-
-    pub fn read_file_revision_bytes(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        revision_no: RevisionNo,
-    ) -> Result<AuthoritativeFileBytes> {
-        self.block_on_sync(self.read_file_revision_bytes_async(
-            namespace_id,
-            absolute_path,
-            revision_no,
-        ))
     }
 
     pub async fn read_file_revision_bytes_async(
@@ -1752,19 +1557,6 @@ impl Fs {
         )?)
     }
 
-    pub fn read_file_revision_bytes_for_inode(
-        &self,
-        namespace_id: &NamespaceId,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-    ) -> Result<Vec<u8>> {
-        self.block_on_sync(self.read_file_revision_bytes_for_inode_async(
-            namespace_id,
-            inode_id,
-            revision_no,
-        ))
-    }
-
     pub async fn read_file_revision_bytes_for_inode_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1792,28 +1584,6 @@ impl Fs {
                 revision_no,
                 loon_core::ReadOptions::verified_basis(Arc::clone(&basis)),
             )?)
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loon.put",
-        err,
-        skip_all,
-        fields(
-            operation = "put",
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-            payload_class = tracing::field::Empty,
-        )
-    )]
-    pub fn put_file_bytes(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        bytes: &[u8],
-        options: PutFileOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.put_file_bytes_async(namespace_id, absolute_path, bytes, options))
     }
 
     #[tracing::instrument(
@@ -1882,33 +1652,6 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub fn put_file_content_ref(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        content_ref: ContentRef,
-        options: PutFileOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.put_file_content_ref_async(
-            namespace_id,
-            absolute_path,
-            content_ref,
-            options,
-        ))
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loon.put",
-        err,
-        skip_all,
-        fields(
-            operation = "put",
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-            payload_class = tracing::field::Empty,
-        )
-    )]
     pub async fn put_file_content_ref_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1953,15 +1696,6 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn create_dir(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        options: CreateDirOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.create_dir_async(namespace_id, absolute_path, options))
-    }
-
     pub async fn create_dir_async(
         &self,
         namespace_id: &NamespaceId,
@@ -1993,15 +1727,6 @@ impl Fs {
             )
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    pub fn delete_path(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        options: DeleteOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.delete_path_async(namespace_id, absolute_path, options))
     }
 
     pub async fn delete_path_async(
@@ -2036,16 +1761,6 @@ impl Fs {
             )
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    pub fn move_path(
-        &self,
-        namespace_id: &NamespaceId,
-        from_path: &str,
-        to_path: &str,
-        options: MoveOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.move_path_async(namespace_id, from_path, to_path, options))
     }
 
     pub async fn move_path_async(
@@ -2085,16 +1800,6 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn copy_path(
-        &self,
-        namespace_id: &NamespaceId,
-        from_path: &str,
-        to_path: &str,
-        options: CopyOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.copy_path_async(namespace_id, from_path, to_path, options))
-    }
-
     pub async fn copy_path_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2130,21 +1835,6 @@ impl Fs {
             )
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    pub fn restore_file_revision(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        source_revision_no: RevisionNo,
-        options: RestoreRevisionOptions,
-    ) -> Result<MutationResult> {
-        self.block_on_sync(self.restore_file_revision_async(
-            namespace_id,
-            absolute_path,
-            source_revision_no,
-            options,
-        ))
     }
 
     pub async fn restore_file_revision_async(
@@ -2188,23 +1878,6 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub fn restore_file_revision_for_inode(
-        &self,
-        namespace_id: &NamespaceId,
-        inode_id: InodeId,
-        source_revision_no: RevisionNo,
-        base_revision_no: RevisionNo,
-        options: RestoreRevisionOptions,
-    ) -> Result<CommitResponse> {
-        self.block_on_sync(self.restore_file_revision_for_inode_async(
-            namespace_id,
-            inode_id,
-            source_revision_no,
-            base_revision_no,
-            options,
-        ))
-    }
-
     pub async fn restore_file_revision_for_inode_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2231,10 +1904,6 @@ impl Fs {
         self.commit_operations_async(namespace_id, request).await
     }
 
-    pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
-        self.block_on_sync(self.begin_upload_async(namespace_id))
-    }
-
     pub async fn begin_upload_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2246,15 +1915,6 @@ impl Fs {
 
     fn begin_upload_blocking(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
         Ok(self.namespace_engine(namespace_id).begin_upload()?)
-    }
-
-    pub fn upload_content(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &str,
-        bytes: &[u8],
-    ) -> Result<UploadContentResponse> {
-        self.block_on_sync(self.upload_content_async(namespace_id, upload_id, bytes))
     }
 
     pub async fn upload_content_async(
@@ -2284,15 +1944,6 @@ impl Fs {
             .upload_content(upload_id, bytes)?)
     }
 
-    pub fn complete_upload(
-        &self,
-        namespace_id: &NamespaceId,
-        upload_id: &str,
-        request: &CompleteUploadRequest,
-    ) -> Result<CompleteUploadResponse> {
-        self.block_on_sync(self.complete_upload_async(namespace_id, upload_id, request))
-    }
-
     pub async fn complete_upload_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2319,14 +1970,6 @@ impl Fs {
             .complete_upload(upload_id, request)?)
     }
 
-    pub fn commit_operations(
-        &self,
-        namespace_id: &NamespaceId,
-        request: CommitRequest,
-    ) -> Result<CommitResponse> {
-        self.block_on_sync(self.commit_operations_async(namespace_id, request))
-    }
-
     pub async fn commit_operations_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2346,18 +1989,6 @@ impl Fs {
         })
     }
 
-    pub fn commit_operations_batch(
-        &self,
-        namespace_id: &NamespaceId,
-        requests: Vec<CommitRequest>,
-    ) -> Vec<Result<CommitResponse>> {
-        let result_count = requests.len();
-        match self.block_on_sync_value(self.commit_operations_batch_async(namespace_id, requests)) {
-            Ok(results) => results,
-            Err(error) => repeat_runtime_error(result_count, error),
-        }
-    }
-
     pub async fn commit_operations_batch_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2371,20 +2002,6 @@ impl Fs {
                 .collect(),
         )
         .await
-    }
-
-    pub fn publish_namespace_mutations_batch(
-        &self,
-        namespace_id: &NamespaceId,
-        candidates: Vec<NamespaceMutationCandidate>,
-    ) -> Vec<Result<CommitResponse>> {
-        let result_count = candidates.len();
-        match self.block_on_sync_value(
-            self.publish_namespace_mutations_batch_async(namespace_id, candidates),
-        ) {
-            Ok(results) => results,
-            Err(error) => repeat_runtime_error(result_count, error),
-        }
     }
 
     pub async fn publish_namespace_mutations_batch_async(
@@ -2470,14 +2087,6 @@ impl Fs {
             .snapshot(self.inner.metadata_table_cache.stats())
     }
 
-    pub fn list_changes_after(
-        &self,
-        namespace_id: &NamespaceId,
-        after_seq: ChangeSeq,
-    ) -> Result<ChangesResponse> {
-        self.block_on_sync(self.list_changes_after_async(namespace_id, after_seq))
-    }
-
     pub async fn list_changes_after_async(
         &self,
         namespace_id: &NamespaceId,
@@ -2496,24 +2105,6 @@ impl Fs {
         Ok(self
             .namespace_engine(namespace_id)
             .list_changes_after(after_seq)?)
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loon.compaction",
-        err,
-        skip_all,
-        fields(
-            operation = "compaction",
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub fn create_checkpoint(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> Result<CreateCheckpointResponse> {
-        self.block_on_sync(self.create_checkpoint_async(namespace_id))
     }
 
     #[tracing::instrument(
@@ -2547,13 +2138,6 @@ impl Fs {
             .create_checkpoint()
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)
-    }
-
-    pub fn advance_retention_floor(
-        &self,
-        namespace_id: &NamespaceId,
-    ) -> Result<AdvanceRetentionResponse> {
-        self.block_on_sync(self.advance_retention_floor_async(namespace_id))
     }
 
     pub async fn advance_retention_floor_async(
@@ -3072,9 +2656,6 @@ fn repeat_runtime_error<T>(count: usize, error: RuntimeError) -> Vec<Result<T>> 
             Err(match &error {
                 RuntimeError::Core(error) => RuntimeError::Core(error.clone()),
                 RuntimeError::Config(message) => RuntimeError::Config(message.clone()),
-                RuntimeError::CannotBlockInsideAsyncRuntime => {
-                    RuntimeError::CannotBlockInsideAsyncRuntime
-                }
                 RuntimeError::RuntimeTask(message) => RuntimeError::RuntimeTask(message.clone()),
                 RuntimeError::Bootstrap(_) => RuntimeError::RuntimeTask(message.clone()),
             })

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -9,6 +9,7 @@
 mod trace;
 
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -77,6 +78,10 @@ pub enum RuntimeError {
     Bootstrap(#[from] BootstrapNamespaceError),
     #[error("invalid runtime config: {0}")]
     Config(String),
+    #[error("synchronous LoonFS calls cannot block inside an async runtime; use the async API")]
+    CannotBlockInsideAsyncRuntime,
+    #[error("runtime task failed: {0}")]
+    RuntimeTask(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -169,12 +174,71 @@ pub struct Fs {
 struct FsInner {
     store: SharedObjectStore,
     config: FsConfig,
+    sync_runtime: SyncRuntimeFacade,
     basis_cache: Mutex<BasisCache>,
     commit_engines: Mutex<CommitEngineCache>,
     control_cache: Mutex<RuntimeControlCache>,
     metadata_table_cache: Arc<MetadataTableCache>,
     uploaded_content_proofs: Mutex<UploadedContentProofCache>,
     cache_stats: RuntimeCacheStatsInner,
+}
+
+struct SyncRuntimeFacade {
+    runtime: Mutex<Option<tokio::runtime::Runtime>>,
+}
+
+impl SyncRuntimeFacade {
+    fn new() -> Result<Self> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| RuntimeError::Config(error.to_string()))?;
+        Ok(Self {
+            runtime: Mutex::new(Some(runtime)),
+        })
+    }
+
+    fn block_on_outside_tokio<T, F>(&self, stats: &RuntimeCacheStatsInner, future: F) -> Result<T>
+    where
+        F: Future<Output = Result<T>>,
+    {
+        self.block_on_value_outside_tokio(stats, future)?
+    }
+
+    fn block_on_value_outside_tokio<T, F>(
+        &self,
+        stats: &RuntimeCacheStatsInner,
+        future: F,
+    ) -> Result<T>
+    where
+        F: Future<Output = T>,
+    {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            stats
+                .block_inside_tokio_errors
+                .fetch_add(1, Ordering::SeqCst);
+            return Err(RuntimeError::CannotBlockInsideAsyncRuntime);
+        }
+        stats.sync_facade_calls.fetch_add(1, Ordering::SeqCst);
+        let runtime = self.runtime.lock().expect("sync runtime lock poisoned");
+        let runtime = runtime
+            .as_ref()
+            .expect("sync runtime should be available until drop");
+        Ok(runtime.block_on(future))
+    }
+}
+
+impl Drop for SyncRuntimeFacade {
+    fn drop(&mut self) {
+        if let Some(runtime) = self
+            .runtime
+            .get_mut()
+            .expect("sync runtime lock poisoned")
+            .take()
+        {
+            runtime.shutdown_background();
+        }
+    }
 }
 
 /// Builder for [`Fs`].
@@ -689,6 +753,9 @@ struct CachedControl<T> {
 /// These counters are diagnostic. They are useful for tuning cache limits and
 /// understanding read/write warmup behavior.
 pub struct RuntimeCacheStats {
+    pub sync_facade_calls: usize,
+    pub async_engine_calls: usize,
+    pub block_inside_tokio_errors: usize,
     pub warm_basis_cache_hits: usize,
     pub warm_basis_cache_misses: usize,
     pub warm_basis_evictions: usize,
@@ -721,6 +788,9 @@ enum MetadataReadSource {
 
 #[derive(Debug, Default)]
 struct RuntimeCacheStatsInner {
+    sync_facade_calls: AtomicUsize,
+    async_engine_calls: AtomicUsize,
+    block_inside_tokio_errors: AtomicUsize,
     warm_basis_cache_hits: AtomicUsize,
     warm_basis_cache_misses: AtomicUsize,
     warm_basis_evictions: AtomicUsize,
@@ -744,6 +814,9 @@ struct RuntimeCacheStatsInner {
 impl RuntimeCacheStatsInner {
     fn snapshot(&self, metadata_table_cache: MetadataTableCacheStats) -> RuntimeCacheStats {
         RuntimeCacheStats {
+            sync_facade_calls: self.sync_facade_calls.load(Ordering::SeqCst),
+            async_engine_calls: self.async_engine_calls.load(Ordering::SeqCst),
+            block_inside_tokio_errors: self.block_inside_tokio_errors.load(Ordering::SeqCst),
             warm_basis_cache_hits: self.warm_basis_cache_hits.load(Ordering::SeqCst),
             warm_basis_cache_misses: self.warm_basis_cache_misses.load(Ordering::SeqCst),
             warm_basis_evictions: self.warm_basis_evictions.load(Ordering::SeqCst),
@@ -775,6 +848,10 @@ impl RuntimeCacheStatsInner {
             metadata_table_cache_inserts: metadata_table_cache.inserts,
             metadata_table_cache_evictions: metadata_table_cache.evictions,
         }
+    }
+
+    fn record_async_engine_call(&self) {
+        self.async_engine_calls.fetch_add(1, Ordering::SeqCst);
     }
 
     fn record_publish_result(&self, result: &NamespaceCommitEnginePublishResult) {
@@ -1135,6 +1212,7 @@ impl Fs {
             inner: Arc::new(FsInner {
                 store,
                 config,
+                sync_runtime: SyncRuntimeFacade::new()?,
                 basis_cache: Mutex::new(BasisCache::default()),
                 commit_engines: Mutex::new(CommitEngineCache::default()),
                 control_cache: Mutex::new(RuntimeControlCache::default()),
@@ -1160,7 +1238,59 @@ impl Fs {
         span.record("store_kind", self.inner.config.trace_store_kind.as_str());
     }
 
+    fn block_on_sync<T, F>(&self, future: F) -> Result<T>
+    where
+        F: Future<Output = Result<T>>,
+    {
+        self.inner
+            .sync_runtime
+            .block_on_outside_tokio(&self.inner.cache_stats, future)
+    }
+
+    fn block_on_sync_value<T, F>(&self, future: F) -> Result<T>
+    where
+        F: Future<Output = T>,
+    {
+        self.inner
+            .sync_runtime
+            .block_on_value_outside_tokio(&self.inner.cache_stats, future)
+    }
+
+    async fn run_engine_blocking<T, F>(&self, operation: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(Fs) -> Result<T> + Send + 'static,
+    {
+        self.inner.cache_stats.record_async_engine_call();
+        let fs = self.clone();
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
+            operation(fs)
+        })
+        .await
+        .map_err(|error| RuntimeError::RuntimeTask(error.to_string()))?
+    }
+
     pub fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> Result<NamespaceSummary> {
+        self.block_on_sync(self.create_namespace_async(namespace_id, options))
+    }
+
+    pub async fn create_namespace_async(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> Result<NamespaceSummary> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.create_namespace_blocking(&namespace_id, options))
+            .await
+    }
+
+    fn create_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
@@ -1179,6 +1309,25 @@ impl Fs {
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> Result<NamespaceSummary> {
+        self.block_on_sync(self.fork_namespace_async(source, target))
+    }
+
+    pub async fn fork_namespace_async(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> Result<NamespaceSummary> {
+        let source = source.clone();
+        let target = target.clone();
+        self.run_engine_blocking(move |fs| fs.fork_namespace_blocking(&source, &target))
+            .await
+    }
+
+    fn fork_namespace_blocking(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> Result<NamespaceSummary> {
         let result = self
             .namespace_engine(source)
             .fork_namespace(target, loon_core::ForkOptions::default())
@@ -1193,10 +1342,32 @@ impl Fs {
     }
 
     pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
+        self.block_on_sync(self.list_namespaces_async())
+    }
+
+    pub async fn list_namespaces_async(&self) -> Result<Vec<NamespaceSummary>> {
+        self.run_engine_blocking(|fs| fs.list_namespaces_blocking())
+            .await
+    }
+
+    fn list_namespaces_blocking(&self) -> Result<Vec<NamespaceSummary>> {
         Ok(loon_core::list_namespaces(self.store())?)
     }
 
     pub fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
+        self.block_on_sync(self.namespace_status_async(namespace_id))
+    }
+
+    pub async fn namespace_status_async(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceStatus> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.namespace_status_blocking(&namespace_id))
+            .await
+    }
+
+    fn namespace_status_blocking(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
         let summary = load_namespace_head_summary(self.store(), namespace_id)?;
         Ok(NamespaceStatus {
             namespace_id: summary.namespace_id,
@@ -1224,15 +1395,46 @@ impl Fs {
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> Result<MaintenanceTickResult> {
+        self.block_on_sync(self.maintenance_tick_namespace_async(namespace_id, options))
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.compaction",
+        err,
+        skip_all,
+        fields(
+            operation = "compaction",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn maintenance_tick_namespace_async(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> Result<MaintenanceTickResult> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.maintenance_tick_namespace_blocking(&namespace_id, options)
+        })
+        .await
+    }
+
+    fn maintenance_tick_namespace_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> Result<MaintenanceTickResult> {
         if options.max_wal_tail_segments == 0 {
             return Err(RuntimeError::Config(
                 "max_wal_tail_segments must be greater than zero".to_owned(),
             ));
         }
 
-        let status_before = self.namespace_status(namespace_id)?;
+        let status_before = self.namespace_status_blocking(namespace_id)?;
         let observed_head_seq = status_before.head_seq;
         if status_before.wal_tail_segments < options.max_wal_tail_segments {
             return Ok(MaintenanceTickResult {
@@ -1242,7 +1444,7 @@ impl Fs {
             });
         }
 
-        let checkpoint = match self.create_checkpoint(namespace_id) {
+        let checkpoint = match self.create_checkpoint_blocking(namespace_id) {
             Ok(checkpoint) => checkpoint,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
                 return Ok(MaintenanceTickResult {
@@ -1296,8 +1498,39 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativePathEntry> {
+        self.block_on_sync(self.stat_path_async(namespace_id, absolute_path))
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.stat",
+        err,
+        skip_all,
+        fields(
+            operation = "stat",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            cache_path = tracing::field::Empty,
+        )
+    )]
+    pub async fn stat_path_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativePathEntry> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| fs.stat_path_blocking(&namespace_id, &absolute_path))
+            .await
+    }
+
+    fn stat_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativePathEntry> {
         let head = self.head_for_metadata_read(namespace_id)?;
         let engine = self.namespace_engine(namespace_id);
         if head.state.current_manifest_id.is_some() {
@@ -1308,7 +1541,8 @@ impl Fs {
                     Some(Arc::clone(&self.inner.metadata_table_cache)),
                 ),
             )?;
-            span.record("cache_path", trace::CachePath::MaterializedTables.as_str());
+            tracing::Span::current()
+                .record("cache_path", trace::CachePath::MaterializedTables.as_str());
             self.inner
                 .cache_stats
                 .record_metadata_read_source(MetadataReadSource::MaterializedTables);
@@ -1327,6 +1561,25 @@ impl Fs {
     }
 
     pub fn list_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<Vec<AuthoritativePathEntry>> {
+        self.block_on_sync(self.list_path_async(namespace_id, absolute_path))
+    }
+
+    pub async fn list_path_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<Vec<AuthoritativePathEntry>> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| fs.list_path_blocking(&namespace_id, &absolute_path))
+            .await
+    }
+
+    fn list_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1363,6 +1616,27 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
+        self.block_on_sync(self.read_file_bytes_async(namespace_id, absolute_path))
+    }
+
+    pub async fn read_file_bytes_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativeFileBytes> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_bytes_blocking(&namespace_id, &absolute_path)
+        })
+        .await
+    }
+
+    fn read_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<AuthoritativeFileBytes> {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(self.namespace_engine(namespace_id).read_file(
             absolute_path,
@@ -1375,6 +1649,27 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<ListFileRevisionsResponse> {
+        self.block_on_sync(self.list_file_revisions_async(namespace_id, absolute_path))
+    }
+
+    pub async fn list_file_revisions_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<ListFileRevisionsResponse> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.list_file_revisions_blocking(&namespace_id, &absolute_path)
+        })
+        .await
+    }
+
+    fn list_file_revisions_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> Result<ListFileRevisionsResponse> {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(self.namespace_engine(namespace_id).list_file_revisions(
             absolute_path,
@@ -1383,6 +1678,26 @@ impl Fs {
     }
 
     pub fn list_file_revisions_for_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+    ) -> Result<ListFileRevisionsResponse> {
+        self.block_on_sync(self.list_file_revisions_for_inode_async(namespace_id, inode_id))
+    }
+
+    pub async fn list_file_revisions_for_inode_async(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+    ) -> Result<ListFileRevisionsResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.list_file_revisions_for_inode_blocking(&namespace_id, inode_id)
+        })
+        .await
+    }
+
+    fn list_file_revisions_for_inode_blocking(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1402,6 +1717,33 @@ impl Fs {
         absolute_path: &str,
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
+        self.block_on_sync(self.read_file_revision_bytes_async(
+            namespace_id,
+            absolute_path,
+            revision_no,
+        ))
+    }
+
+    pub async fn read_file_revision_bytes_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        revision_no: RevisionNo,
+    ) -> Result<AuthoritativeFileBytes> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_revision_bytes_blocking(&namespace_id, &absolute_path, revision_no)
+        })
+        .await
+    }
+
+    fn read_file_revision_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        revision_no: RevisionNo,
+    ) -> Result<AuthoritativeFileBytes> {
         let basis = self.basis_for_read(namespace_id)?;
         Ok(self.namespace_engine(namespace_id).read_file_revision(
             absolute_path,
@@ -1411,6 +1753,32 @@ impl Fs {
     }
 
     pub fn read_file_revision_bytes_for_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>> {
+        self.block_on_sync(self.read_file_revision_bytes_for_inode_async(
+            namespace_id,
+            inode_id,
+            revision_no,
+        ))
+    }
+
+    pub async fn read_file_revision_bytes_for_inode_async(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.read_file_revision_bytes_for_inode_blocking(&namespace_id, inode_id, revision_no)
+        })
+        .await
+    }
+
+    fn read_file_revision_bytes_for_inode_blocking(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -1445,9 +1813,47 @@ impl Fs {
         bytes: &[u8],
         options: PutFileOptions,
     ) -> Result<MutationResult> {
+        self.block_on_sync(self.put_file_bytes_async(namespace_id, absolute_path, bytes, options))
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.put",
+        err,
+        skip_all,
+        fields(
+            operation = "put",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
+    pub async fn put_file_bytes_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", trace::payload_class(bytes.len()));
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        let bytes = bytes.to_vec();
+        self.run_engine_blocking(move |fs| {
+            fs.put_file_bytes_blocking(&namespace_id, &absolute_path, &bytes, options)
+        })
+        .await
+    }
+
+    fn put_file_bytes_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let store = self.uploaded_content_proof_store(namespace_id);
         let result = self
             .namespace_engine_with_store(namespace_id, store)
@@ -1483,12 +1889,54 @@ impl Fs {
         content_ref: ContentRef,
         options: PutFileOptions,
     ) -> Result<MutationResult> {
+        self.block_on_sync(self.put_file_content_ref_async(
+            namespace_id,
+            absolute_path,
+            content_ref,
+            options,
+        ))
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.put",
+        err,
+        skip_all,
+        fields(
+            operation = "put",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
+    pub async fn put_file_content_ref_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        content_ref: ContentRef,
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record(
             "payload_class",
             trace::payload_class(usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX)),
         );
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.put_file_content_ref_blocking(&namespace_id, &absolute_path, content_ref, options)
+        })
+        .await
+    }
+
+    fn put_file_content_ref_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        content_ref: ContentRef,
+        options: PutFileOptions,
+    ) -> Result<MutationResult> {
         let store = self.uploaded_content_proof_store(namespace_id);
         let result = self
             .namespace_engine_with_store(namespace_id, store)
@@ -1506,6 +1954,29 @@ impl Fs {
     }
 
     pub fn create_dir(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> Result<MutationResult> {
+        self.block_on_sync(self.create_dir_async(namespace_id, absolute_path, options))
+    }
+
+    pub async fn create_dir_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.create_dir_blocking(&namespace_id, &absolute_path, options)
+        })
+        .await
+    }
+
+    fn create_dir_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1530,6 +2001,29 @@ impl Fs {
         absolute_path: &str,
         options: DeleteOptions,
     ) -> Result<MutationResult> {
+        self.block_on_sync(self.delete_path_async(namespace_id, absolute_path, options))
+    }
+
+    pub async fn delete_path_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.delete_path_blocking(&namespace_id, &absolute_path, options)
+        })
+        .await
+    }
+
+    fn delete_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> Result<MutationResult> {
         let result = self
             .namespace_engine(namespace_id)
             .delete_path(
@@ -1545,6 +2039,32 @@ impl Fs {
     }
 
     pub fn move_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> Result<MutationResult> {
+        self.block_on_sync(self.move_path_async(namespace_id, from_path, to_path, options))
+    }
+
+    pub async fn move_path_async(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let from_path = from_path.to_owned();
+        let to_path = to_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.move_path_blocking(&namespace_id, &from_path, &to_path, options)
+        })
+        .await
+    }
+
+    fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -1572,6 +2092,32 @@ impl Fs {
         to_path: &str,
         options: CopyOptions,
     ) -> Result<MutationResult> {
+        self.block_on_sync(self.copy_path_async(namespace_id, from_path, to_path, options))
+    }
+
+    pub async fn copy_path_async(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let from_path = from_path.to_owned();
+        let to_path = to_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.copy_path_blocking(&namespace_id, &from_path, &to_path, options)
+        })
+        .await
+    }
+
+    fn copy_path_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> Result<MutationResult> {
         let result = self
             .namespace_engine(namespace_id)
             .copy_path(
@@ -1587,6 +2133,41 @@ impl Fs {
     }
 
     pub fn restore_file_revision(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        source_revision_no: RevisionNo,
+        options: RestoreRevisionOptions,
+    ) -> Result<MutationResult> {
+        self.block_on_sync(self.restore_file_revision_async(
+            namespace_id,
+            absolute_path,
+            source_revision_no,
+            options,
+        ))
+    }
+
+    pub async fn restore_file_revision_async(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        source_revision_no: RevisionNo,
+        options: RestoreRevisionOptions,
+    ) -> Result<MutationResult> {
+        let namespace_id = namespace_id.clone();
+        let absolute_path = absolute_path.to_owned();
+        self.run_engine_blocking(move |fs| {
+            fs.restore_file_revision_blocking(
+                &namespace_id,
+                &absolute_path,
+                source_revision_no,
+                options,
+            )
+        })
+        .await
+    }
+
+    fn restore_file_revision_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -1615,6 +2196,23 @@ impl Fs {
         base_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
     ) -> Result<CommitResponse> {
+        self.block_on_sync(self.restore_file_revision_for_inode_async(
+            namespace_id,
+            inode_id,
+            source_revision_no,
+            base_revision_no,
+            options,
+        ))
+    }
+
+    pub async fn restore_file_revision_for_inode_async(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        source_revision_no: RevisionNo,
+        base_revision_no: RevisionNo,
+        options: RestoreRevisionOptions,
+    ) -> Result<CommitResponse> {
         let commit_id = options.commit_id.unwrap_or_else(CommitId::generate);
         let request = CommitRequest {
             commit_id,
@@ -1630,14 +2228,51 @@ impl Fs {
             message: None,
             annotations: None,
         };
-        self.commit_operations(namespace_id, request)
+        self.commit_operations_async(namespace_id, request).await
     }
 
     pub fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
+        self.block_on_sync(self.begin_upload_async(namespace_id))
+    }
+
+    pub async fn begin_upload_async(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<BeginUploadResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.begin_upload_blocking(&namespace_id))
+            .await
+    }
+
+    fn begin_upload_blocking(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
         Ok(self.namespace_engine(namespace_id).begin_upload()?)
     }
 
     pub fn upload_content(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> Result<UploadContentResponse> {
+        self.block_on_sync(self.upload_content_async(namespace_id, upload_id, bytes))
+    }
+
+    pub async fn upload_content_async(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> Result<UploadContentResponse> {
+        let namespace_id = namespace_id.clone();
+        let upload_id = upload_id.to_owned();
+        let bytes = bytes.to_vec();
+        self.run_engine_blocking(move |fs| {
+            fs.upload_content_blocking(&namespace_id, &upload_id, &bytes)
+        })
+        .await
+    }
+
+    fn upload_content_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
@@ -1655,6 +2290,30 @@ impl Fs {
         upload_id: &str,
         request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse> {
+        self.block_on_sync(self.complete_upload_async(namespace_id, upload_id, request))
+    }
+
+    pub async fn complete_upload_async(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> Result<CompleteUploadResponse> {
+        let namespace_id = namespace_id.clone();
+        let upload_id = upload_id.to_owned();
+        let request = request.clone();
+        self.run_engine_blocking(move |fs| {
+            fs.complete_upload_blocking(&namespace_id, &upload_id, &request)
+        })
+        .await
+    }
+
+    fn complete_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> Result<CompleteUploadResponse> {
         Ok(self
             .namespace_engine(namespace_id)
             .complete_upload(upload_id, request)?)
@@ -1665,10 +2324,19 @@ impl Fs {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_namespace_mutations_batch(
+        self.block_on_sync(self.commit_operations_async(namespace_id, request))
+    }
+
+    pub async fn commit_operations_async(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> Result<CommitResponse> {
+        self.publish_namespace_mutations_batch_async(
             namespace_id,
             vec![NamespaceMutationCandidate::Commit(request)],
         )
+        .await
         .into_iter()
         .next()
         .unwrap_or_else(|| {
@@ -1683,16 +2351,61 @@ impl Fs {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        self.publish_namespace_mutations_batch(
+        let result_count = requests.len();
+        match self.block_on_sync_value(self.commit_operations_batch_async(namespace_id, requests)) {
+            Ok(results) => results,
+            Err(error) => repeat_runtime_error(result_count, error),
+        }
+    }
+
+    pub async fn commit_operations_batch_async(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<CommitRequest>,
+    ) -> Vec<Result<CommitResponse>> {
+        self.publish_namespace_mutations_batch_async(
             namespace_id,
             requests
                 .into_iter()
                 .map(NamespaceMutationCandidate::Commit)
                 .collect(),
         )
+        .await
     }
 
     pub fn publish_namespace_mutations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<Result<CommitResponse>> {
+        let result_count = candidates.len();
+        match self.block_on_sync_value(
+            self.publish_namespace_mutations_batch_async(namespace_id, candidates),
+        ) {
+            Ok(results) => results,
+            Err(error) => repeat_runtime_error(result_count, error),
+        }
+    }
+
+    pub async fn publish_namespace_mutations_batch_async(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<Result<CommitResponse>> {
+        let result_count = candidates.len();
+        let namespace_id = namespace_id.clone();
+        match self
+            .run_engine_blocking(move |fs| {
+                Ok(fs.publish_namespace_mutations_batch_blocking(&namespace_id, candidates))
+            })
+            .await
+        {
+            Ok(results) => results,
+            Err(error) => repeat_runtime_error(result_count, error),
+        }
+    }
+
+    fn publish_namespace_mutations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
@@ -1762,6 +2475,24 @@ impl Fs {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> Result<ChangesResponse> {
+        self.block_on_sync(self.list_changes_after_async(namespace_id, after_seq))
+    }
+
+    pub async fn list_changes_after_async(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> Result<ChangesResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.list_changes_after_blocking(&namespace_id, after_seq))
+            .await
+    }
+
+    fn list_changes_after_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> Result<ChangesResponse> {
         Ok(self
             .namespace_engine(namespace_id)
             .list_changes_after(after_seq)?)
@@ -1782,8 +2513,35 @@ impl Fs {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
+        self.block_on_sync(self.create_checkpoint_async(namespace_id))
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.compaction",
+        err,
+        skip_all,
+        fields(
+            operation = "compaction",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub async fn create_checkpoint_async(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<CreateCheckpointResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.create_checkpoint_blocking(&namespace_id))
+            .await
+    }
+
+    fn create_checkpoint_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<CreateCheckpointResponse> {
         let result = self
             .namespace_engine(namespace_id)
             .create_checkpoint()
@@ -1792,6 +2550,22 @@ impl Fs {
     }
 
     pub fn advance_retention_floor(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<AdvanceRetentionResponse> {
+        self.block_on_sync(self.advance_retention_floor_async(namespace_id))
+    }
+
+    pub async fn advance_retention_floor_async(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<AdvanceRetentionResponse> {
+        let namespace_id = namespace_id.clone();
+        self.run_engine_blocking(move |fs| fs.advance_retention_floor_blocking(&namespace_id))
+            .await
+    }
+
+    fn advance_retention_floor_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
@@ -2289,6 +3063,23 @@ fn should_invalidate_after_result<T>(result: &Result<T>) -> bool {
         Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => true,
         _ => false,
     }
+}
+
+fn repeat_runtime_error<T>(count: usize, error: RuntimeError) -> Vec<Result<T>> {
+    let message = error.to_string();
+    (0..count)
+        .map(|_| {
+            Err(match &error {
+                RuntimeError::Core(error) => RuntimeError::Core(error.clone()),
+                RuntimeError::Config(message) => RuntimeError::Config(message.clone()),
+                RuntimeError::CannotBlockInsideAsyncRuntime => {
+                    RuntimeError::CannotBlockInsideAsyncRuntime
+                }
+                RuntimeError::RuntimeTask(message) => RuntimeError::RuntimeTask(message.clone()),
+                RuntimeError::Bootstrap(_) => RuntimeError::RuntimeTask(message.clone()),
+            })
+        })
+        .collect()
 }
 
 fn current_time_ms() -> u64 {

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -51,285 +51,297 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
 }
 
 trait FsTestExt {
-    fn create_namespace(
+    fn create_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> loonfs::Result<loonfs::NamespaceSummary>;
-    fn fork_namespace(
+    fn fork_namespace_blocking(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> loonfs::Result<loonfs::NamespaceSummary>;
-    fn list_namespaces(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>>;
-    fn namespace_status(&self, namespace_id: &NamespaceId) -> loonfs::Result<NamespaceStatus>;
-    fn maintenance_tick_namespace(
+    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>>;
+    fn namespace_status_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<NamespaceStatus>;
+    fn maintenance_tick_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> loonfs::Result<MaintenanceTickResult>;
-    fn stat_path(
+    fn stat_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativePathEntry>;
-    fn list_path(
+    fn list_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<Vec<AuthoritativePathEntry>>;
-    fn read_file_bytes(
+    fn read_file_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativeFileBytes>;
-    fn put_file_bytes(
+    fn put_file_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn create_dir(
+    fn create_dir_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn delete_path(
+    fn delete_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn move_path(
+    fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn copy_path(
+    fn copy_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn begin_upload(&self, namespace_id: &NamespaceId) -> loonfs::Result<BeginUploadResponse>;
-    fn upload_content(
+    fn begin_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<BeginUploadResponse>;
+    fn upload_content_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
         bytes: &[u8],
     ) -> loonfs::Result<UploadContentResponse>;
-    fn complete_upload(
+    fn complete_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
         request: &CompleteUploadRequest,
     ) -> loonfs::Result<CompleteUploadResponse>;
-    fn commit_operations(
+    fn commit_operations_blocking(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> loonfs::Result<CommitResponse>;
-    fn commit_operations_batch(
+    fn commit_operations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<loonfs::Result<CommitResponse>>;
-    fn publish_namespace_mutations_batch(
+    fn publish_namespace_mutations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<loonfs::Result<CommitResponse>>;
-    fn list_changes_after(
+    fn list_changes_after_blocking(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> loonfs::Result<ChangesResponse>;
-    fn create_checkpoint(
+    fn create_checkpoint_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<CreateCheckpointResponse>;
-    fn advance_retention_floor(
+    fn advance_retention_floor_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<AdvanceRetentionResponse>;
 }
 
 impl FsTestExt for Fs {
-    fn create_namespace(
+    fn create_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> loonfs::Result<loonfs::NamespaceSummary> {
-        block_on(self.create_namespace_async(namespace_id, options))
+        block_on(self.create_namespace(namespace_id, options))
     }
 
-    fn fork_namespace(
+    fn fork_namespace_blocking(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> loonfs::Result<loonfs::NamespaceSummary> {
-        block_on(self.fork_namespace_async(source, target))
+        block_on(self.fork_namespace(source, target))
     }
 
-    fn list_namespaces(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>> {
-        block_on(self.list_namespaces_async())
+    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>> {
+        block_on(self.list_namespaces())
     }
 
-    fn namespace_status(&self, namespace_id: &NamespaceId) -> loonfs::Result<NamespaceStatus> {
-        block_on(self.namespace_status_async(namespace_id))
+    fn namespace_status_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<NamespaceStatus> {
+        block_on(self.namespace_status(namespace_id))
     }
 
-    fn maintenance_tick_namespace(
+    fn maintenance_tick_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> loonfs::Result<MaintenanceTickResult> {
-        block_on(self.maintenance_tick_namespace_async(namespace_id, options))
+        block_on(self.maintenance_tick_namespace(namespace_id, options))
     }
 
-    fn stat_path(
+    fn stat_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativePathEntry> {
-        block_on(self.stat_path_async(namespace_id, absolute_path))
+        block_on(self.stat_path(namespace_id, absolute_path))
     }
 
-    fn list_path(
+    fn list_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
-        block_on(self.list_path_async(namespace_id, absolute_path))
+        block_on(self.list_path(namespace_id, absolute_path))
     }
 
-    fn read_file_bytes(
+    fn read_file_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativeFileBytes> {
-        block_on(self.read_file_bytes_async(namespace_id, absolute_path))
+        block_on(self.read_file_bytes(namespace_id, absolute_path))
     }
 
-    fn put_file_bytes(
+    fn put_file_bytes_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.put_file_bytes_async(namespace_id, absolute_path, bytes, options))
+        block_on(self.put_file_bytes(namespace_id, absolute_path, bytes, options))
     }
 
-    fn create_dir(
+    fn create_dir_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.create_dir_async(namespace_id, absolute_path, options))
+        block_on(self.create_dir(namespace_id, absolute_path, options))
     }
 
-    fn delete_path(
+    fn delete_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.delete_path_async(namespace_id, absolute_path, options))
+        block_on(self.delete_path(namespace_id, absolute_path, options))
     }
 
-    fn move_path(
+    fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.move_path_async(namespace_id, from_path, to_path, options))
+        block_on(self.move_path(namespace_id, from_path, to_path, options))
     }
 
-    fn copy_path(
+    fn copy_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.copy_path_async(namespace_id, from_path, to_path, options))
+        block_on(self.copy_path(namespace_id, from_path, to_path, options))
     }
 
-    fn begin_upload(&self, namespace_id: &NamespaceId) -> loonfs::Result<BeginUploadResponse> {
-        block_on(self.begin_upload_async(namespace_id))
+    fn begin_upload_blocking(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<BeginUploadResponse> {
+        block_on(self.begin_upload(namespace_id))
     }
 
-    fn upload_content(
+    fn upload_content_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
         bytes: &[u8],
     ) -> loonfs::Result<UploadContentResponse> {
-        block_on(self.upload_content_async(namespace_id, upload_id, bytes))
+        block_on(self.upload_content(namespace_id, upload_id, bytes))
     }
 
-    fn complete_upload(
+    fn complete_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &str,
         request: &CompleteUploadRequest,
     ) -> loonfs::Result<CompleteUploadResponse> {
-        block_on(self.complete_upload_async(namespace_id, upload_id, request))
+        block_on(self.complete_upload(namespace_id, upload_id, request))
     }
 
-    fn commit_operations(
+    fn commit_operations_blocking(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> loonfs::Result<CommitResponse> {
-        block_on(self.commit_operations_async(namespace_id, request))
+        block_on(self.commit_operations(namespace_id, request))
     }
 
-    fn commit_operations_batch(
+    fn commit_operations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<loonfs::Result<CommitResponse>> {
-        block_on(self.commit_operations_batch_async(namespace_id, requests))
+        block_on(self.commit_operations_batch(namespace_id, requests))
     }
 
-    fn publish_namespace_mutations_batch(
+    fn publish_namespace_mutations_batch_blocking(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<loonfs::Result<CommitResponse>> {
-        block_on(self.publish_namespace_mutations_batch_async(namespace_id, candidates))
+        block_on(self.publish_namespace_mutations_batch(namespace_id, candidates))
     }
 
-    fn list_changes_after(
+    fn list_changes_after_blocking(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> loonfs::Result<ChangesResponse> {
-        block_on(self.list_changes_after_async(namespace_id, after_seq))
+        block_on(self.list_changes_after(namespace_id, after_seq))
     }
 
-    fn create_checkpoint(
+    fn create_checkpoint_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<CreateCheckpointResponse> {
-        block_on(self.create_checkpoint_async(namespace_id))
+        block_on(self.create_checkpoint(namespace_id))
     }
 
-    fn advance_retention_floor(
+    fn advance_retention_floor_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<AdvanceRetentionResponse> {
-        block_on(self.advance_retention_floor_async(namespace_id))
+        block_on(self.advance_retention_floor(namespace_id))
     }
 }
 
@@ -437,7 +449,7 @@ fn builder_metrics_recorder_instruments_object_store() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace(), CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace(), CreateNamespaceOptions::default())
         .expect("create namespace");
 
     let samples = recorder.samples();
@@ -456,9 +468,9 @@ fn filesystem_operations_match_core_semantics() {
     let fs = runtime(temp_dir.path(), "filesystem-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -467,21 +479,23 @@ fn filesystem_operations_match_core_semantics() {
     .expect("put file");
 
     let stat = fs
-        .stat_path(&namespace_id, "/docs/hello.txt")
+        .stat_path_blocking(&namespace_id, "/docs/hello.txt")
         .expect("stat file");
     assert_eq!(stat.absolute_path, "/docs/hello.txt");
     assert_eq!(stat.size_bytes, Some(5));
 
-    let entries = fs.list_path(&namespace_id, "/docs").expect("list docs");
+    let entries = fs
+        .list_path_blocking(&namespace_id, "/docs")
+        .expect("list docs");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].absolute_path, "/docs/hello.txt");
 
     let read = fs
-        .read_file_bytes(&namespace_id, "/docs/hello.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/hello.txt")
         .expect("read file");
     assert_eq!(read.bytes, b"hello");
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"updated",
@@ -492,18 +506,18 @@ fn filesystem_operations_match_core_semantics() {
     )
     .expect("replace file");
     let read = fs
-        .read_file_bytes(&namespace_id, "/docs/hello.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/hello.txt")
         .expect("read replaced file");
     assert_eq!(read.bytes, b"updated");
 
-    fs.copy_path(
+    fs.copy_path_blocking(
         &namespace_id,
         "/docs/hello.txt",
         "/docs/copy.txt",
         CopyOptions::default(),
     )
     .expect("copy file");
-    fs.move_path(
+    fs.move_path_blocking(
         &namespace_id,
         "/docs/copy.txt",
         "/docs/moved.txt",
@@ -511,7 +525,7 @@ fn filesystem_operations_match_core_semantics() {
     )
     .expect("move file");
     assert_eq!(
-        fs.read_file_bytes(&namespace_id, "/docs/moved.txt")
+        fs.read_file_bytes_blocking(&namespace_id, "/docs/moved.txt")
             .expect("read moved copy")
             .bytes,
         b"updated"
@@ -524,10 +538,11 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     let fs = runtime(temp_dir.path(), "async-runtime-test");
     let namespace_id = namespace();
 
-    fs.create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+    Fs::create_namespace(&fs, &namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    fs.put_file_bytes_async(
+    Fs::put_file_bytes(
+        &fs,
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -536,8 +551,7 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     .await
     .expect("put file");
 
-    let async_stat = fs
-        .stat_path_async(&namespace_id, "/docs/hello.txt")
+    let async_stat = Fs::stat_path(&fs, &namespace_id, "/docs/hello.txt")
         .await
         .expect("async stat");
 
@@ -561,24 +575,24 @@ fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first stat should load basis");
     assert_eq!(raw_store.wal_get_count(), 1);
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second stat should reuse cached basis");
     assert_eq!(raw_store.wal_get_count(), 1);
 
-    fs.create_dir(&namespace_id, "/other", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/other", CreateDirOptions::default())
         .expect("create other");
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("stat after mutation should reload basis");
     assert!(raw_store.wal_get_count() > 0);
 }
@@ -602,23 +616,23 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
         .expect("build writer runtime");
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime reader cache");
 
     writer
-        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
         .expect("advance head from another runtime");
 
     raw_store.reset_wal_get_count();
     let stat = reader
-        .stat_path(&namespace_id, "/docs/new")
+        .stat_path_blocking(&namespace_id, "/docs/new")
         .expect("reader should observe external head advance");
     assert_eq!(stat.absolute_path, "/docs/new");
     assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
@@ -640,15 +654,15 @@ fn runtime_cache_can_be_disabled() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first stat should load basis");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second stat should load basis again");
     assert_eq!(raw_store.wal_get_count(), 2);
 }
@@ -666,19 +680,20 @@ fn runtime_basis_cache_evicts_by_namespace_count() {
         .expect("build runtime");
     let first = NamespaceId::parse("first").expect("valid namespace id");
     let second = NamespaceId::parse("second").expect("valid namespace id");
-    fs.create_namespace(&first, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
-    fs.create_namespace(&second, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first");
     let after_second = fs.runtime_cache_stats();
     assert_eq!(after_second.warm_basis_evictions, 1);
     assert_eq!(after_second.warm_basis_cached_rows, 1);
 
-    fs.stat_path(&first, "/")
+    fs.stat_path_blocking(&first, "/")
         .expect("first basis rehydrates after eviction");
     let after_reload = fs.runtime_cache_stats();
     assert_eq!(after_reload.warm_basis_cache_misses, 3);
@@ -699,13 +714,14 @@ fn runtime_basis_cache_evicts_by_row_budget() {
         .expect("build runtime");
     let first = NamespaceId::parse("row-one").expect("valid namespace id");
     let second = NamespaceId::parse("row-two").expect("valid namespace id");
-    fs.create_namespace(&first, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
-    fs.create_namespace(&second, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first by rows");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_evictions, 1);
@@ -727,10 +743,11 @@ fn runtime_basis_budget_includes_commit_engine_bases() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.stat_path(&namespace_id, "/").expect("cache read basis");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    fs.stat_path_blocking(&namespace_id, "/")
+        .expect("cache read basis");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("combined-budget-create-docs", "/docs")],
     ));
@@ -740,7 +757,7 @@ fn runtime_basis_budget_includes_commit_engine_bases() {
     assert!(stats.warm_basis_cached_rows <= 2);
 
     let misses_before = stats.warm_basis_cache_misses;
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("read still works after aggregate budget pruning");
     let stats = fs.runtime_cache_stats();
     assert!(stats.warm_basis_cache_misses > misses_before);
@@ -754,10 +771,10 @@ fn runtime_basis_cache_evicts_by_decoded_byte_budget() {
     let first = NamespaceId::parse("byte-one").expect("valid namespace id");
     let second = NamespaceId::parse("byte-two").expect("valid namespace id");
     setup
-        .create_namespace(&first, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&first, CreateNamespaceOptions::default())
         .expect("create first namespace");
     setup
-        .create_namespace(&second, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&second, CreateNamespaceOptions::default())
         .expect("create second namespace");
     let raw_store = store(temp_dir.path());
     let basis_weight = load_verified_namespace_basis(raw_store.as_ref(), &first)
@@ -774,8 +791,9 @@ fn runtime_basis_cache_evicts_by_decoded_byte_budget() {
         .build()
         .expect("build runtime");
 
-    fs.stat_path(&first, "/").expect("cache first basis");
-    fs.stat_path(&second, "/")
+    fs.stat_path_blocking(&first, "/")
+        .expect("cache first basis");
+    fs.stat_path_blocking(&second, "/")
         .expect("cache second basis and evict first by bytes");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_evictions, 1);
@@ -789,7 +807,7 @@ fn runtime_basis_cache_skips_oversized_basis() {
     let setup = runtime(temp_dir.path(), "basis-oversized-setup");
     let namespace_id = namespace();
     setup
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let raw_store = store(temp_dir.path());
     let basis_weight = load_verified_namespace_basis(raw_store.as_ref(), &namespace_id)
@@ -806,9 +824,9 @@ fn runtime_basis_cache_skips_oversized_basis() {
         .build()
         .expect("build runtime");
 
-    fs.stat_path(&namespace_id, "/")
+    fs.stat_path_blocking(&namespace_id, "/")
         .expect("first stat reconstructs oversized basis");
-    fs.stat_path(&namespace_id, "/")
+    fs.stat_path_blocking(&namespace_id, "/")
         .expect("second stat reconstructs oversized basis again");
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.warm_basis_cache_misses, 2);
@@ -840,15 +858,15 @@ fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("warm-create-docs", "/docs")],
     ));
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("warm-create-child", "/docs/child")],
     ));
@@ -865,7 +883,7 @@ fn runtime_publish_reuses_warm_basis_for_adjacent_batches() {
     assert_eq!(stats.publish_warm_basis_invalidations, 0);
 
     let stat = fs
-        .stat_path(&namespace_id, "/docs/child")
+        .stat_path_blocking(&namespace_id, "/docs/child")
         .expect("warm-published child is visible");
     assert_eq!(stat.authoritative_head_seq, ChangeSeq(2));
 }
@@ -889,18 +907,18 @@ fn runtime_publish_cold_loads_after_external_head_advance() {
         .expect("build second runtime");
 
     first
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("external-first", "/docs")],
     ));
     second
-        .create_dir(&namespace_id, "/other", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/other", CreateDirOptions::default())
         .expect("external runtime advances head");
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("external-after", "/docs/child")],
     ));
@@ -935,18 +953,18 @@ fn runtime_publish_retries_warm_rejection_after_external_head_race() {
         .expect("build second runtime");
 
     first
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("race-prime", "/docs")],
     ));
     second
-        .create_dir(&namespace_id, "/a", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/a", CreateDirOptions::default())
         .expect("external runtime creates /a");
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(first.publish_namespace_mutations_batch(
+    assert_single_publish_ok(first.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![delete_candidate("race-delete-a", "/a")],
     ));
@@ -956,7 +974,7 @@ fn runtime_publish_retries_warm_rejection_after_external_head_race() {
     );
 
     assert_core_error_kind(
-        first.stat_path(&namespace_id, "/a"),
+        first.stat_path_blocking(&namespace_id, "/a"),
         ErrorCode::PathNotFound,
     );
     let stats = first.runtime_cache_stats();
@@ -981,15 +999,15 @@ fn runtime_publish_cache_disabled_replays_for_adjacent_batches() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("disabled-first", "/docs")],
     ));
 
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("disabled-second", "/docs/child")],
     ));
@@ -1018,16 +1036,16 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("stale-prime", "/docs")],
     ));
 
     raw_store.fail_head_cas();
     let stale = fs
-        .publish_namespace_mutations_batch(
+        .publish_namespace_mutations_batch_blocking(
             &namespace_id,
             vec![create_dir_candidate("stale-loses-cas", "/stale")],
         )
@@ -1039,7 +1057,7 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
 
     raw_store.allow_head_cas();
     raw_store.reset_wal_get_count();
-    assert_single_publish_ok(fs.publish_namespace_mutations_batch(
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![create_dir_candidate("stale-after", "/after")],
     ));
@@ -1069,22 +1087,22 @@ fn stale_head_write_error_invalidates_runtime_cache() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
 
     raw_store.fail_head_cas();
     assert_core_error_kind(
-        fs.create_dir(&namespace_id, "/stale", CreateDirOptions::default()),
+        fs.create_dir_blocking(&namespace_id, "/stale", CreateDirOptions::default()),
         ErrorCode::StaleHead,
     );
 
     raw_store.allow_head_cas();
     raw_store.reset_wal_get_count();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("read after stale head should reload basis");
     assert!(raw_store.wal_get_count() > 0);
 }
@@ -1095,9 +1113,9 @@ fn delete_options_select_recursive_behavior() {
     let fs = runtime(temp_dir.path(), "delete-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1106,14 +1124,14 @@ fn delete_options_select_recursive_behavior() {
     .expect("put file");
 
     let error = fs
-        .delete_path(&namespace_id, "/docs", DeleteOptions::default())
+        .delete_path_blocking(&namespace_id, "/docs", DeleteOptions::default())
         .expect_err("non-recursive delete should reject non-empty directory");
     assert!(matches!(
         error,
         RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::DirectoryNotEmpty
     ));
 
-    fs.delete_path(
+    fs.delete_path_blocking(
         &namespace_id,
         "/docs",
         DeleteOptions {
@@ -1123,7 +1141,7 @@ fn delete_options_select_recursive_behavior() {
     )
     .expect("recursive delete");
     let error = fs
-        .stat_path(&namespace_id, "/docs/hello.txt")
+        .stat_path_blocking(&namespace_id, "/docs/hello.txt")
         .expect_err("deleted file should not stat");
     assert!(matches!(
         error,
@@ -1138,26 +1156,27 @@ fn forked_namespace_shares_content_then_diverges() {
     let source = namespace();
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
 
-    fs.create_namespace(&source, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
         .expect("create source namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &source,
         "/docs/shared.txt",
         b"source",
         PutFileOptions::default(),
     )
     .expect("put source file");
-    fs.fork_namespace(&source, &clone).expect("fork namespace");
+    fs.fork_namespace_blocking(&source, &clone)
+        .expect("fork namespace");
 
     let source_entry = fs
-        .stat_path(&source, "/docs/shared.txt")
+        .stat_path_blocking(&source, "/docs/shared.txt")
         .expect("stat source");
     let clone_entry = fs
-        .stat_path(&clone, "/docs/shared.txt")
+        .stat_path_blocking(&clone, "/docs/shared.txt")
         .expect("stat clone");
     assert_eq!(source_entry.content_ref, clone_entry.content_ref);
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &clone,
         "/docs/shared.txt",
         b"clone",
@@ -1169,13 +1188,13 @@ fn forked_namespace_shares_content_then_diverges() {
     .expect("replace clone file");
 
     assert_eq!(
-        fs.read_file_bytes(&source, "/docs/shared.txt")
+        fs.read_file_bytes_blocking(&source, "/docs/shared.txt")
             .expect("read source")
             .bytes,
         b"source"
     );
     assert_eq!(
-        fs.read_file_bytes(&clone, "/docs/shared.txt")
+        fs.read_file_bytes_blocking(&clone, "/docs/shared.txt")
             .expect("read clone")
             .bytes,
         b"clone"
@@ -1188,14 +1207,16 @@ fn upload_flow_is_available_from_runtime() {
     let fs = runtime(temp_dir.path(), "upload-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
     let staged_again = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("repeat upload content");
     assert_eq!(staged.content_ref, staged_again.content_ref);
 
@@ -1203,10 +1224,10 @@ fn upload_flow_is_available_from_runtime() {
         content_ref: staged.content_ref,
     };
     let completed = fs
-        .complete_upload(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
         .expect("complete upload");
     let completed_again = fs
-        .complete_upload(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
         .expect("repeat complete upload");
     assert_eq!(completed.content_ref, completed_again.content_ref);
 }
@@ -1222,13 +1243,15 @@ fn upload_then_path_put_uses_memory_proof_without_blob_validation_call() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
-    fs.complete_upload(
+    fs.complete_upload_blocking(
         &namespace_id,
         &begin.upload_id,
         &CompleteUploadRequest {
@@ -1238,7 +1261,7 @@ fn upload_then_path_put_uses_memory_proof_without_blob_validation_call() {
     .expect("complete upload");
 
     raw_store.reset_content_blob_counters();
-    let responses = fs.publish_namespace_mutations_batch(
+    let responses = fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
@@ -1267,13 +1290,15 @@ fn disabled_runtime_cache_still_uses_memory_proof_without_blob_validation_call()
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let begin = fs.begin_upload(&namespace_id).expect("begin upload");
+    let begin = fs
+        .begin_upload_blocking(&namespace_id)
+        .expect("begin upload");
     let staged = fs
-        .upload_content(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
         .expect("upload content");
-    fs.complete_upload(
+    fs.complete_upload_blocking(
         &namespace_id,
         &begin.upload_id,
         &CompleteUploadRequest {
@@ -1283,7 +1308,7 @@ fn disabled_runtime_cache_still_uses_memory_proof_without_blob_validation_call()
     .expect("complete upload");
 
     raw_store.reset_content_blob_counters();
-    let responses = fs.publish_namespace_mutations_batch(
+    let responses = fs.publish_namespace_mutations_batch_blocking(
         &namespace_id,
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
@@ -1306,13 +1331,15 @@ fn stat_and_list_record_full_basis_fallback_without_checkpoint() {
     let namespace_id = namespace();
     let fs = runtime(temp_dir.path(), "read-fallback-test");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
-    fs.stat_path(&namespace_id, "/docs").expect("stat docs");
-    fs.list_path(&namespace_id, "/").expect("list root");
+    fs.stat_path_blocking(&namespace_id, "/docs")
+        .expect("stat docs");
+    fs.list_path_blocking(&namespace_id, "/")
+        .expect("list root");
 
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.read_full_basis_fallbacks, 2);
@@ -1330,21 +1357,22 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/file.txt",
         b"file",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
 
     raw_store.reset_content_blob_counters();
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("stat materialized file");
-    fs.list_path(&namespace_id, "/docs")
+    fs.list_path_blocking(&namespace_id, "/docs")
         .expect("list materialized docs");
 
     let stats = fs.runtime_cache_stats();
@@ -1360,21 +1388,22 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
     let namespace_id = namespace();
     let fs = runtime(temp_dir.path(), "metadata-table-cache-test");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/file.txt",
         b"file",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
 
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("first materialized stat");
     let after_first = fs.runtime_cache_stats();
-    fs.stat_path(&namespace_id, "/docs/file.txt")
+    fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("second materialized stat");
     let after_second = fs.runtime_cache_stats();
 
@@ -1395,11 +1424,11 @@ fn put_file_bytes_uses_memory_proof_without_blob_validation_call() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
     raw_store.reset_content_blob_counters();
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/direct.txt",
         b"direct bytes",
@@ -1425,17 +1454,18 @@ fn begin_upload_validates_controls_without_replay_reads() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
         PutFileOptions::default(),
     )
     .expect("put file");
-    fs.create_checkpoint(&namespace_id).expect("checkpoint");
-    fs.put_file_bytes(
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"updated",
@@ -1447,8 +1477,10 @@ fn begin_upload_validates_controls_without_replay_reads() {
     .expect("replace file");
 
     raw_store.reset_control_get_counts();
-    fs.begin_upload(&namespace_id).expect("first begin upload");
-    fs.begin_upload(&namespace_id).expect("second begin upload");
+    fs.begin_upload_blocking(&namespace_id)
+        .expect("first begin upload");
+    fs.begin_upload_blocking(&namespace_id)
+        .expect("second begin upload");
 
     assert_eq!(raw_store.wal_get_count(), 0);
     assert_eq!(raw_store.manifest_get_count(), 0);
@@ -1468,18 +1500,18 @@ fn runtime_control_cache_reuses_head_for_basis_validation() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
 
     raw_store.reset_control_get_counts();
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("first cached basis validation reuses cached head state");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("second cached basis validation reuses cached head state");
 
     assert_eq!(raw_store.head_get_count(), 0);
@@ -1504,24 +1536,24 @@ fn control_cache_eviction_reloads_head_for_basis_validation() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
-    fs.create_namespace(&other_namespace, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&other_namespace, CreateNamespaceOptions::default())
         .expect("create other namespace");
-    fs.create_dir(&other_namespace, "/docs", CreateDirOptions::default())
+    fs.create_dir_blocking(&other_namespace, "/docs", CreateDirOptions::default())
         .expect("create other docs");
 
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime first namespace basis");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime first namespace head cache");
 
     raw_store.reset_control_get_counts();
-    fs.stat_path(&other_namespace, "/docs")
+    fs.stat_path_blocking(&other_namespace, "/docs")
         .expect("load other namespace basis and evict first head cache");
-    fs.stat_path(&namespace_id, "/docs")
+    fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("reload first namespace basis and head cache");
 
     assert_eq!(raw_store.head_get_count(), 1);
@@ -1546,29 +1578,29 @@ fn runtime_control_cache_reloads_head_after_external_change() {
         .expect("build writer runtime");
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime basis cache");
     raw_store.reset_control_get_counts();
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("prime control cache");
     reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path_blocking(&namespace_id, "/docs")
         .expect("reuse unchanged control cache");
     assert_eq!(raw_store.head_get_count(), 0);
 
     writer
-        .create_dir(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
         .expect("advance head");
     raw_store.reset_control_get_counts();
     reader
-        .stat_path(&namespace_id, "/docs/new")
+        .stat_path_blocking(&namespace_id, "/docs/new")
         .expect("reload changed head");
     assert!(raw_store.head_get_count() > 0);
 }
@@ -1584,15 +1616,21 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespaceNotFound);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespaceNotFound,
+    );
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .delete(&namespace_descriptor(namespace_id.as_str()))
         .expect("delete namespace descriptor");
 
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespacePartial);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespacePartial,
+    );
 }
 
 #[test]
@@ -1606,7 +1644,7 @@ fn begin_upload_rejects_malformed_descriptors() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .put_overwrite(
@@ -1614,10 +1652,13 @@ fn begin_upload_rejects_malformed_descriptors() {
             br#"{"not":"a namespace descriptor"}"#,
         )
         .expect("corrupt namespace descriptor");
-    assert_core_error_kind(fs.begin_upload(&namespace_id), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&namespace_id),
+        ErrorCode::NamespaceCorrupt,
+    );
 
     let content_bad = NamespaceId::parse("content-bad").expect("valid namespace id");
-    fs.create_namespace(&content_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&content_bad, CreateNamespaceOptions::default())
         .expect("create content-bad namespace");
     for key in raw_store
         .list_prefix("content-stores/")
@@ -1629,7 +1670,10 @@ fn begin_upload_rejects_malformed_descriptors() {
             .put_overwrite(&key, br#"{"not":"a content store descriptor"}"#)
             .expect("corrupt content store descriptor");
     }
-    assert_core_error_kind(fs.begin_upload(&content_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&content_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 }
 
 #[test]
@@ -1644,15 +1688,18 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
         .expect("build runtime");
 
     let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
-    fs.create_namespace(&head_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&head_bad, CreateNamespaceOptions::default())
         .expect("create head-bad namespace");
     raw_store
         .put_overwrite(&namespace_head(head_bad.as_str()), br#"{"not":"a head"}"#)
         .expect("corrupt head");
-    assert_core_error_kind(fs.begin_upload(&head_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&head_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 
     let lease_bad = NamespaceId::parse("lease-bad").expect("valid namespace id");
-    fs.create_namespace(&lease_bad, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&lease_bad, CreateNamespaceOptions::default())
         .expect("create lease-bad namespace");
     raw_store
         .put_overwrite(
@@ -1660,7 +1707,10 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
             br#"{"not":"a lease"}"#,
         )
         .expect("corrupt lease");
-    assert_core_error_kind(fs.begin_upload(&lease_bad), ErrorCode::NamespaceCorrupt);
+    assert_core_error_kind(
+        fs.begin_upload_blocking(&lease_bad),
+        ErrorCode::NamespaceCorrupt,
+    );
 }
 
 #[test]
@@ -1669,11 +1719,11 @@ fn explicit_commit_appears_in_change_feed() {
     let fs = runtime(temp_dir.path(), "commit-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let commit_id = CommitId::parse("explicit-create-dir").expect("valid commit id");
     let response = fs
-        .commit_operations(
+        .commit_operations_blocking(
             &namespace_id,
             CommitRequest {
                 commit_id: commit_id.clone(),
@@ -1689,7 +1739,7 @@ fn explicit_commit_appears_in_change_feed() {
         .expect("commit operation");
 
     let changes = fs
-        .list_changes_after(&namespace_id, ChangeSeq(0))
+        .list_changes_after_blocking(&namespace_id, ChangeSeq(0))
         .expect("list changes");
     assert_eq!(changes.through_seq, response.committed_seq);
     assert_eq!(changes.changes.len(), 1);
@@ -1702,10 +1752,10 @@ fn namespace_status_reports_wal_tail_segments() {
     let fs = runtime(temp_dir.path(), "status-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status for new namespace");
     assert_eq!(status.namespace_id, namespace_id);
     assert_eq!(status.head_seq, ChangeSeq(0));
@@ -1713,7 +1763,7 @@ fn namespace_status_reports_wal_tail_segments() {
     assert_eq!(status.wal_tail_segments, 0);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1722,7 +1772,7 @@ fn namespace_status_reports_wal_tail_segments() {
     .expect("put file");
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after commit");
     assert_eq!(status.head_seq, ChangeSeq(1));
     assert_eq!(status.current_manifest_id, None);
@@ -1737,11 +1787,11 @@ fn namespace_status_and_tick_reject_missing_namespace() {
     let namespace_id = namespace();
 
     assert_core_error_kind(
-        fs.namespace_status(&namespace_id),
+        fs.namespace_status_blocking(&namespace_id),
         ErrorCode::NamespaceNotFound,
     );
     assert_core_error_kind(
-        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        fs.maintenance_tick_namespace_blocking(&namespace_id, MaintenanceTickOptions::default()),
         ErrorCode::NamespaceNotFound,
     );
 }
@@ -1757,18 +1807,18 @@ fn namespace_status_and_tick_reject_partial_namespace() {
         .expect("build runtime");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     raw_store
         .delete(&namespace_descriptor(namespace_id.as_str()))
         .expect("delete namespace descriptor");
 
     assert_core_error_kind(
-        fs.namespace_status(&namespace_id),
+        fs.namespace_status_blocking(&namespace_id),
         ErrorCode::NamespacePartial,
     );
     assert_core_error_kind(
-        fs.maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default()),
+        fs.maintenance_tick_namespace_blocking(&namespace_id, MaintenanceTickOptions::default()),
         ErrorCode::NamespacePartial,
     );
 }
@@ -1779,9 +1829,9 @@ fn maintenance_tick_below_threshold_is_not_needed() {
     let fs = runtime(temp_dir.path(), "tick-not-needed-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1790,7 +1840,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
     .expect("put file");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -1808,9 +1858,9 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     let fs = runtime(temp_dir.path(), "tick-publish-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -1819,7 +1869,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     .expect("put file");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -1835,7 +1885,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     );
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after checkpoint");
     assert_eq!(status.current_manifest_id, Some(ManifestId(1)));
     assert_eq!(status.wal_tail_segments, 0);
@@ -1847,16 +1897,16 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     let fs = runtime(temp_dir.path(), "tick-l0-run-publish-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
         PutFileOptions::default(),
     )
     .expect("put first file");
-    fs.maintenance_tick_namespace(
+    fs.maintenance_tick_namespace_blocking(
         &namespace_id,
         MaintenanceTickOptions {
             max_wal_tail_segments: 1,
@@ -1864,7 +1914,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     )
     .expect("first maintenance tick");
 
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/second.txt",
         b"second",
@@ -1872,7 +1922,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     )
     .expect("put second file");
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -1887,7 +1937,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     );
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after l0 checkpoint");
     assert_eq!(status.current_manifest_id, Some(ManifestId(2)));
     assert_eq!(status.wal_tail_segments, 0);
@@ -1918,9 +1968,9 @@ fn maintenance_tick_counts_segments_not_commits() {
     let fs = runtime(temp_dir.path(), "tick-segment-count-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    let first_batch = fs.commit_operations_batch(
+    let first_batch = fs.commit_operations_batch_blocking(
         &namespace_id,
         vec![
             CommitRequest {
@@ -1948,13 +1998,13 @@ fn maintenance_tick_counts_segments_not_commits() {
     assert!(first_batch.iter().all(Result::is_ok));
 
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after first batch");
     assert_eq!(status.head_seq, ChangeSeq(2));
     assert_eq!(status.wal_tail_segments, 1);
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -1963,7 +2013,7 @@ fn maintenance_tick_counts_segments_not_commits() {
         .expect("maintenance tick");
     assert_eq!(tick.outcome, MaintenanceTickOutcome::NotNeeded);
 
-    fs.commit_operations(
+    fs.commit_operations_blocking(
         &namespace_id,
         CommitRequest {
             commit_id: CommitId::parse("create-c").expect("valid commit id"),
@@ -1979,7 +2029,7 @@ fn maintenance_tick_counts_segments_not_commits() {
     .expect("second segment commit");
 
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
@@ -2002,10 +2052,10 @@ fn maintenance_tick_rejects_zero_threshold() {
     let fs = runtime(temp_dir.path(), "tick-config-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     let error = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 0,
@@ -2032,9 +2082,9 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
         .build()
         .expect("build runtime");
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -2044,7 +2094,7 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
 
     raw_store.fail_head_cas();
     let tick = fs
-        .maintenance_tick_namespace(
+        .maintenance_tick_namespace_blocking(
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
@@ -2059,7 +2109,7 @@ fn maintenance_tick_treats_current_manifest_cas_loss_as_benign_race() {
         }
     );
     let status = fs
-        .namespace_status(&namespace_id)
+        .namespace_status_blocking(&namespace_id)
         .expect("status after lost race");
     assert_eq!(status.current_manifest_id, None);
     assert_eq!(status.wal_tail_segments, 1);
@@ -2071,9 +2121,9 @@ fn checkpoint_and_retention_hooks_are_available() {
     let fs = runtime(temp_dir.path(), "maintenance-test");
     let namespace_id = namespace();
 
-    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.put_file_bytes(
+    fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -2082,10 +2132,10 @@ fn checkpoint_and_retention_hooks_are_available() {
     .expect("put file");
 
     let checkpoint = fs
-        .create_checkpoint(&namespace_id)
+        .create_checkpoint_blocking(&namespace_id)
         .expect("create checkpoint");
     let retention = fs
-        .advance_retention_floor(&namespace_id)
+        .advance_retention_floor_blocking(&namespace_id)
         .expect("advance retention");
     assert_eq!(retention.retention_floor_seq, checkpoint.checkpoint_seq);
 }
@@ -2098,10 +2148,10 @@ fn separate_runtime_instances_share_object_store_state() {
     let namespace_id = namespace();
 
     writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .put_file_bytes(
+        .put_file_bytes_blocking(
             &namespace_id,
             "/docs/shared.txt",
             b"shared",
@@ -2109,11 +2159,11 @@ fn separate_runtime_instances_share_object_store_state() {
         )
         .expect("put file");
 
-    let namespaces = reader.list_namespaces().expect("list namespaces");
+    let namespaces = reader.list_namespaces_blocking().expect("list namespaces");
     assert_eq!(namespaces.len(), 1);
     assert_eq!(namespaces[0].namespace_id, namespace_id);
     let file = reader
-        .read_file_bytes(&namespace_id, "/docs/shared.txt")
+        .read_file_bytes_blocking(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");
     assert_eq!(file.bytes, b"shared");
 }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -223,6 +223,59 @@ fn filesystem_operations_match_core_semantics() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_runtime_methods_are_the_engine_boundary() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "async-runtime-test");
+    let namespace_id = namespace();
+
+    fs.create_namespace_async(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.put_file_bytes_async(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+
+    let async_stat = fs
+        .stat_path_async(&namespace_id, "/docs/hello.txt")
+        .await
+        .expect("async stat");
+
+    let sync_fs = fs.clone();
+    let sync_namespace_id = namespace_id.clone();
+    let sync_stat = std::thread::spawn(move || {
+        sync_fs
+            .stat_path(&sync_namespace_id, "/docs/hello.txt")
+            .expect("sync facade stat from non-tokio thread")
+    })
+    .join()
+    .expect("join sync facade thread");
+
+    assert_eq!(async_stat, sync_stat);
+    let stats = fs.runtime_cache_stats();
+    assert!(stats.async_engine_calls >= 3);
+    assert!(stats.sync_facade_calls >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sync_runtime_facade_refuses_inside_tokio() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "nested-runtime-test");
+
+    match fs.list_namespaces() {
+        Err(RuntimeError::CannotBlockInsideAsyncRuntime) => {}
+        Err(error) => panic!("expected nested runtime error, got {error:?}"),
+        Ok(_) => panic!("expected nested runtime error"),
+    }
+
+    assert_eq!(fs.runtime_cache_stats().block_inside_tokio_errors, 1);
+}
+
 #[test]
 fn runtime_cache_reuses_verified_basis_for_repeated_reads() {
     let temp_dir = tempdir().expect("tempdir");
@@ -673,7 +726,11 @@ fn runtime_publish_cache_disabled_replays_for_adjacent_batches() {
         raw_store.wal_get_count() > 0,
         "cache-disabled publish path should still cold-load from WAL"
     );
-    assert_eq!(fs.runtime_cache_stats(), Default::default());
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.warm_basis_cache_hits, 0);
+    assert_eq!(stats.warm_basis_cache_misses, 0);
+    assert_eq!(stats.publish_warm_basis_hits, 0);
+    assert_eq!(stats.publish_warm_basis_misses, 0);
 }
 
 #[test]

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -12,12 +12,16 @@ use loon_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use loonfs::{
-    ChangeSeq, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CopyOptions,
+    AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadResponse,
+    ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest, CommitResponse,
+    CompleteUploadRequest, CompleteUploadResponse, CopyOptions, CreateCheckpointResponse,
     CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ErrorCode, Fs, FsConfig, InodeId,
-    MaintenanceTickOptions, MaintenanceTickOutcome, ManifestId, MoveOptions, NamespaceId,
-    NamespaceMutationCandidate, PathMutationIntent, PutFileBehavior, PutFileOptions,
-    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
+    MutationResult, NamespaceId, NamespaceMutationCandidate, NamespaceStatus, PathMutationIntent,
+    PutFileBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
+    TraceMode, TraceStoreKind, UploadContentResponse,
 };
+use std::future::Future;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -36,6 +40,297 @@ fn runtime(root: &Path, writer_id: &str) -> Fs {
 
 fn namespace() -> NamespaceId {
     NamespaceId::parse("demo").expect("valid namespace id")
+}
+
+fn block_on<T>(future: impl Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(future)
+}
+
+trait FsTestExt {
+    fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> loonfs::Result<loonfs::NamespaceSummary>;
+    fn fork_namespace(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> loonfs::Result<loonfs::NamespaceSummary>;
+    fn list_namespaces(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>>;
+    fn namespace_status(&self, namespace_id: &NamespaceId) -> loonfs::Result<NamespaceStatus>;
+    fn maintenance_tick_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> loonfs::Result<MaintenanceTickResult>;
+    fn stat_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativePathEntry>;
+    fn list_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<Vec<AuthoritativePathEntry>>;
+    fn read_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativeFileBytes>;
+    fn put_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn create_dir(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn delete_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn move_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn copy_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> loonfs::Result<MutationResult>;
+    fn begin_upload(&self, namespace_id: &NamespaceId) -> loonfs::Result<BeginUploadResponse>;
+    fn upload_content(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> loonfs::Result<UploadContentResponse>;
+    fn complete_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> loonfs::Result<CompleteUploadResponse>;
+    fn commit_operations(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> loonfs::Result<CommitResponse>;
+    fn commit_operations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<CommitRequest>,
+    ) -> Vec<loonfs::Result<CommitResponse>>;
+    fn publish_namespace_mutations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<loonfs::Result<CommitResponse>>;
+    fn list_changes_after(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> loonfs::Result<ChangesResponse>;
+    fn create_checkpoint(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<CreateCheckpointResponse>;
+    fn advance_retention_floor(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<AdvanceRetentionResponse>;
+}
+
+impl FsTestExt for Fs {
+    fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> loonfs::Result<loonfs::NamespaceSummary> {
+        block_on(self.create_namespace_async(namespace_id, options))
+    }
+
+    fn fork_namespace(
+        &self,
+        source: &NamespaceId,
+        target: &NamespaceId,
+    ) -> loonfs::Result<loonfs::NamespaceSummary> {
+        block_on(self.fork_namespace_async(source, target))
+    }
+
+    fn list_namespaces(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>> {
+        block_on(self.list_namespaces_async())
+    }
+
+    fn namespace_status(&self, namespace_id: &NamespaceId) -> loonfs::Result<NamespaceStatus> {
+        block_on(self.namespace_status_async(namespace_id))
+    }
+
+    fn maintenance_tick_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+    ) -> loonfs::Result<MaintenanceTickResult> {
+        block_on(self.maintenance_tick_namespace_async(namespace_id, options))
+    }
+
+    fn stat_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativePathEntry> {
+        block_on(self.stat_path_async(namespace_id, absolute_path))
+    }
+
+    fn list_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
+        block_on(self.list_path_async(namespace_id, absolute_path))
+    }
+
+    fn read_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativeFileBytes> {
+        block_on(self.read_file_bytes_async(namespace_id, absolute_path))
+    }
+
+    fn put_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.put_file_bytes_async(namespace_id, absolute_path, bytes, options))
+    }
+
+    fn create_dir(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: CreateDirOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.create_dir_async(namespace_id, absolute_path, options))
+    }
+
+    fn delete_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: DeleteOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.delete_path_async(namespace_id, absolute_path, options))
+    }
+
+    fn move_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: MoveOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.move_path_async(namespace_id, from_path, to_path, options))
+    }
+
+    fn copy_path(
+        &self,
+        namespace_id: &NamespaceId,
+        from_path: &str,
+        to_path: &str,
+        options: CopyOptions,
+    ) -> loonfs::Result<MutationResult> {
+        block_on(self.copy_path_async(namespace_id, from_path, to_path, options))
+    }
+
+    fn begin_upload(&self, namespace_id: &NamespaceId) -> loonfs::Result<BeginUploadResponse> {
+        block_on(self.begin_upload_async(namespace_id))
+    }
+
+    fn upload_content(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        bytes: &[u8],
+    ) -> loonfs::Result<UploadContentResponse> {
+        block_on(self.upload_content_async(namespace_id, upload_id, bytes))
+    }
+
+    fn complete_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &str,
+        request: &CompleteUploadRequest,
+    ) -> loonfs::Result<CompleteUploadResponse> {
+        block_on(self.complete_upload_async(namespace_id, upload_id, request))
+    }
+
+    fn commit_operations(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+    ) -> loonfs::Result<CommitResponse> {
+        block_on(self.commit_operations_async(namespace_id, request))
+    }
+
+    fn commit_operations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        requests: Vec<CommitRequest>,
+    ) -> Vec<loonfs::Result<CommitResponse>> {
+        block_on(self.commit_operations_batch_async(namespace_id, requests))
+    }
+
+    fn publish_namespace_mutations_batch(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+    ) -> Vec<loonfs::Result<CommitResponse>> {
+        block_on(self.publish_namespace_mutations_batch_async(namespace_id, candidates))
+    }
+
+    fn list_changes_after(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+    ) -> loonfs::Result<ChangesResponse> {
+        block_on(self.list_changes_after_async(namespace_id, after_seq))
+    }
+
+    fn create_checkpoint(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<CreateCheckpointResponse> {
+        block_on(self.create_checkpoint_async(namespace_id))
+    }
+
+    fn advance_retention_floor(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<AdvanceRetentionResponse> {
+        block_on(self.advance_retention_floor_async(namespace_id))
+    }
 }
 
 fn assert_config_error(result: loonfs::Result<Fs>, expected: &str) {
@@ -246,34 +541,10 @@ async fn async_runtime_methods_are_the_engine_boundary() {
         .await
         .expect("async stat");
 
-    let sync_fs = fs.clone();
-    let sync_namespace_id = namespace_id.clone();
-    let sync_stat = std::thread::spawn(move || {
-        sync_fs
-            .stat_path(&sync_namespace_id, "/docs/hello.txt")
-            .expect("sync facade stat from non-tokio thread")
-    })
-    .join()
-    .expect("join sync facade thread");
-
-    assert_eq!(async_stat, sync_stat);
+    assert_eq!(async_stat.absolute_path, "/docs/hello.txt");
+    assert_eq!(async_stat.size_bytes, Some(5));
     let stats = fs.runtime_cache_stats();
     assert!(stats.async_engine_calls >= 3);
-    assert!(stats.sync_facade_calls >= 1);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn sync_runtime_facade_refuses_inside_tokio() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "nested-runtime-test");
-
-    match fs.list_namespaces() {
-        Err(RuntimeError::CannotBlockInsideAsyncRuntime) => {}
-        Err(error) => panic!("expected nested runtime error, got {error:?}"),
-        Ok(_) => panic!("expected nested runtime error"),
-    }
-
-    assert_eq!(fs.runtime_cache_stats().block_inside_tokio_errors, 1);
 }
 
 #[test]


### PR DESCRIPTION
Makes the loonfs runtime API async-first and moves the remaining blocking boundary into embedded CLI mode.
