### PR TITLE
refactor(core): plan publish batches through one planning session

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -181,6 +181,18 @@ pub fn validate_upload_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValid
     validate_generated_id("upl", value.as_ref())
 }
 
+/// Start seq encoded in a WAL segment id's 20-digit position prefix.
+///
+/// Returns `None` when the value does not follow the generated id shape, so
+/// listings can skip foreign objects instead of failing. Like the name
+/// itself, the parsed position is an inspection and reclamation hint only —
+/// recovery authority is the head and chain.
+pub fn wal_segment_id_start_seq(segment_id: &str) -> Option<ChangeSeq> {
+    validate_wal_segment_id(segment_id).ok()?;
+    let (position, _) = segment_id.split_once('-')?;
+    position.parse().ok().map(ChangeSeq)
+}
+
 pub fn validate_wal_segment_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValidationError> {
     let value = value.as_ref();
     let Some((position, suffix)) = value.split_once('-') else {

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -55,9 +55,9 @@ pub use ids::{
     generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,
     generate_wal_segment_id, generated_id, validate_checkpoint_id, validate_gc_pin_id,
     validate_generated_id, validate_metadata_table_id, validate_upload_id, validate_wal_segment_id,
-    ChangeSeq, CommitId, CommitIdValidationError, ContentStoreId, FenceToken,
-    GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey, NameKeyValidationError,
-    NamespaceId, NamespaceIdValidationError, RevisionNo,
+    wal_segment_id_start_seq, ChangeSeq, CommitId, CommitIdValidationError, ContentStoreId,
+    FenceToken, GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey,
+    NameKeyValidationError, NamespaceId, NamespaceIdValidationError, RevisionNo,
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
 pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -41,6 +41,22 @@ pub(crate) async fn load_verified_manifest_materialization<S: ObjectStore + ?Siz
         })
 }
 
+/// Loads and validates only the manifest envelope, without fetching its
+/// metadata tables. Enough for callers that need manifest framing such as
+/// the materialized basis seq, not the rows.
+pub(crate) async fn load_namespace_manifest_envelope<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    manifest_id: ManifestId,
+) -> Result<NamespaceManifestEnvelope, ManifestLoadError> {
+    let manifest_key = namespace_manifest(namespace_id.as_str(), manifest_id);
+    load_namespace_manifest_envelope_if_present(store, namespace_id, manifest_id, &manifest_key)
+        .await?
+        .ok_or(ManifestLoadError::MissingManifest {
+            object_key: manifest_key,
+        })
+}
+
 pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     table_cache: Option<&'a MetadataTableCache>,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -37,8 +37,8 @@ pub use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::load::{
-    load_verified_manifest_materialization, load_verified_manifest_tables_with_cache,
-    manifest_basis_head,
+    load_namespace_manifest_envelope, load_verified_manifest_materialization,
+    load_verified_manifest_tables_with_cache, manifest_basis_head,
 };
 pub(crate) use self::publish::write_namespace_manifest;
 pub(crate) use self::retention::advance_retention_floor;

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -10,6 +10,10 @@ pub(super) struct MetadataIndexes {
     indexed_seq: ChangeSeq,
     inode_by_id: HashMap<InodeId, InodeRecord>,
     active_child_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
+    /// Latest bind ever recorded per (parent, name), kept even after the
+    /// binding is unbound. Tombstone-ancestry checks need to see dead
+    /// bindings, which the active map deliberately drops.
+    latest_bind_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
     active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
     unbound_binding_keys: HashSet<BindingKey>,
     tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
@@ -24,6 +28,7 @@ impl Default for MetadataIndexes {
             indexed_seq: ChangeSeq(0),
             inode_by_id: HashMap::new(),
             active_child_by_parent_name: HashMap::new(),
+            latest_bind_by_parent_name: HashMap::new(),
             active_parent_by_child: HashMap::new(),
             unbound_binding_keys: HashSet::new(),
             tombstone_by_root: HashMap::new(),
@@ -82,6 +87,7 @@ impl MetadataIndexes {
                 .active_parent_by_child
                 .insert(bind.child_inode_id, bind.clone());
         }
+        indexes.latest_bind_by_parent_name = latest_by_parent_name;
 
         for revision in revisions {
             indexes.record_revision(revision);
@@ -112,6 +118,16 @@ impl MetadataIndexes {
         name_key: &str,
     ) -> Option<DirentryBindRecord> {
         self.active_child_by_parent_name
+            .get(&(parent_inode_id, name_key.to_owned()))
+            .cloned()
+    }
+
+    pub(super) fn latest_bind(
+        &self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Option<DirentryBindRecord> {
+        self.latest_bind_by_parent_name
             .get(&(parent_inode_id, name_key.to_owned()))
             .cloned()
     }
@@ -169,6 +185,11 @@ impl MetadataIndexes {
     pub(super) fn record_bind(&mut self, record: &DirentryBindRecord) {
         self.indexed_seq = self.indexed_seq.max(record.bind_seq);
         let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+        replace_if_newer_bind(
+            &mut self.latest_bind_by_parent_name,
+            parent_name_key.clone(),
+            record.clone(),
+        );
 
         if let Some(previous_child_at_name) =
             self.active_child_by_parent_name.remove(&parent_name_key)

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -197,6 +197,13 @@ impl MetadataState {
         state
     }
 
+    /// Highest sequence carried by any indexed record.
+    ///
+    /// No record carries a larger seq, so a query at `base_seq >=
+    /// indexed_seq()` passes every `seq <= base_seq` filter and is equivalent
+    /// to an at-head query. The seq-gated read methods below rely on this to
+    /// route to the indexes; only queries strictly below `indexed_seq()` need
+    /// the historical scans.
     pub fn indexed_seq(&self) -> ChangeSeq {
         self.indexes.indexed_seq()
     }
@@ -461,7 +468,7 @@ impl MetadataState {
     }
 
     pub fn inode_at_seq(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.inode_at_head(inode_id);
         }
         self.inode_at_seq_scan(inode_id, base_seq)
@@ -483,7 +490,7 @@ impl MetadataState {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<RevisionRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.latest_revision_at_head(inode_id);
         }
         self.latest_revision_head_at_seq_scan(inode_id, base_seq)
@@ -517,7 +524,7 @@ impl MetadataState {
         revision_no: RevisionNo,
         base_seq: ChangeSeq,
     ) -> Option<RevisionRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.revision_at_head(inode_id, revision_no);
         }
         self.revision_at_seq_scan(inode_id, revision_no, base_seq)
@@ -548,12 +555,17 @@ impl MetadataState {
             .cloned()
     }
 
+    /// Latest bind for `(parent, name)` at or before `base_seq`, regardless
+    /// of whether it has since been unbound.
     pub fn bound_child_at_seq(
         &self,
         parent_inode_id: InodeId,
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
+        if base_seq >= self.indexed_seq() {
+            return self.indexes.latest_bind(parent_inode_id, name_key);
+        }
         self.bound_child_at_seq_scan(parent_inode_id, name_key, base_seq)
     }
 
@@ -579,7 +591,7 @@ impl MetadataState {
         child_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.current_parent_binding_for_child_at_head(child_inode_id);
         }
         let direntry = self.latest_parent_binding_for_child_at_seq(child_inode_id, base_seq)?;
@@ -601,7 +613,7 @@ impl MetadataState {
         root_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<SubtreeTombstoneRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.active_subtree_tombstone_at_head(root_inode_id);
         }
         self.active_subtree_tombstone_scan(root_inode_id, base_seq)
@@ -633,7 +645,7 @@ impl MetadataState {
         inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Option<SubtreeTombstoneRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.covering_subtree_tombstone_at_head(inode_id);
         }
 
@@ -682,7 +694,7 @@ impl MetadataState {
     }
 
     pub fn visible_inode(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.visible_inode_at_head(inode_id);
         }
 
@@ -721,7 +733,7 @@ impl MetadataState {
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.visible_child_at_head(parent_inode_id, name_key);
         }
 
@@ -755,7 +767,7 @@ impl MetadataState {
         parent_inode_id: InodeId,
         base_seq: ChangeSeq,
     ) -> Vec<DirentryBindRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.visible_children_at_head(parent_inode_id);
         }
 
@@ -895,7 +907,7 @@ impl MetadataState {
         name_key: &str,
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.indexes.active_child(parent_inode_id, name_key);
         }
 
@@ -936,7 +948,7 @@ impl MetadataState {
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
     ) -> bool {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.is_direntry_unbound_at_head(direntry);
         }
         self.is_direntry_unbound_at_seq_scan(direntry, base_seq)
@@ -967,7 +979,7 @@ impl MetadataState {
         new_parent_inode: InodeId,
         base_seq: ChangeSeq,
     ) -> bool {
-        if base_seq == self.indexed_seq() {
+        if base_seq >= self.indexed_seq() {
             return self.would_create_directory_cycle_at_head(inode_id, new_parent_inode);
         }
 
@@ -1672,6 +1684,197 @@ mod tests {
                 .expect("receipt after decode")
                 .semantic_commit_fingerprint,
             "fingerprint"
+        );
+    }
+
+    /// Binding churn under one parent:
+    /// - seq 1: child 2 bound at `contested`, child 4 bound at `deleted`
+    /// - seq 2: child 2 renamed to `renamed-away`, child 4 unbound for good
+    /// - seq 3: child 3 takes over `contested`
+    ///
+    /// At head this leaves `contested` rebound, `renamed-away` active, and
+    /// `deleted` with only a dead binding.
+    fn churned_binding_state() -> MetadataState {
+        let mut state = MetadataState::default();
+        state
+            .apply_committed_wal_deltas_mut(
+                ChangeSeq(0),
+                &[WalDelta::CreateInode {
+                    delta_index: 0,
+                    inode_id: InodeId(1),
+                    inode_kind: InodeKind::Dir,
+                }],
+            )
+            .expect("seed root");
+        state
+            .apply_committed_wal_deltas_mut(
+                ChangeSeq(1),
+                &[
+                    WalDelta::CreateInode {
+                        delta_index: 0,
+                        inode_id: InodeId(2),
+                        inode_kind: InodeKind::Dir,
+                    },
+                    WalDelta::BindDirentry {
+                        delta_index: 1,
+                        parent_inode: InodeId(1),
+                        name_key: "contested".to_owned(),
+                        display_name: "contested".to_owned(),
+                        child_inode: InodeId(2),
+                    },
+                    WalDelta::CreateInode {
+                        delta_index: 2,
+                        inode_id: InodeId(4),
+                        inode_kind: InodeKind::Dir,
+                    },
+                    WalDelta::BindDirentry {
+                        delta_index: 3,
+                        parent_inode: InodeId(1),
+                        name_key: "deleted".to_owned(),
+                        display_name: "deleted".to_owned(),
+                        child_inode: InodeId(4),
+                    },
+                ],
+            )
+            .expect("bind children 2 and 4");
+        state
+            .apply_committed_wal_deltas_mut(
+                ChangeSeq(2),
+                &[
+                    WalDelta::UnbindDirentry {
+                        delta_index: 0,
+                        parent_inode: InodeId(1),
+                        name_key: "contested".to_owned(),
+                        child_inode: InodeId(2),
+                        bind_seq: ChangeSeq(1),
+                        bind_delta_index: 1,
+                    },
+                    WalDelta::BindDirentry {
+                        delta_index: 1,
+                        parent_inode: InodeId(1),
+                        name_key: "renamed-away".to_owned(),
+                        display_name: "renamed-away".to_owned(),
+                        child_inode: InodeId(2),
+                    },
+                    WalDelta::UnbindDirentry {
+                        delta_index: 2,
+                        parent_inode: InodeId(1),
+                        name_key: "deleted".to_owned(),
+                        child_inode: InodeId(4),
+                        bind_seq: ChangeSeq(1),
+                        bind_delta_index: 3,
+                    },
+                ],
+            )
+            .expect("rename child 2, unbind child 4");
+        state
+            .apply_committed_wal_deltas_mut(
+                ChangeSeq(3),
+                &[
+                    WalDelta::CreateInode {
+                        delta_index: 0,
+                        inode_id: InodeId(3),
+                        inode_kind: InodeKind::Dir,
+                    },
+                    WalDelta::BindDirentry {
+                        delta_index: 1,
+                        parent_inode: InodeId(1),
+                        name_key: "contested".to_owned(),
+                        display_name: "contested".to_owned(),
+                        child_inode: InodeId(3),
+                    },
+                ],
+            )
+            .expect("bind child 3");
+        state
+    }
+
+    /// Rebuilds the churned state from its rows, so the `from_rows` index
+    /// construction path is pinned against the incremental one.
+    fn churned_binding_state_rebuilt() -> MetadataState {
+        let incremental = churned_binding_state();
+        MetadataState::from_rows(
+            incremental.inodes().to_vec(),
+            incremental.direntry_binds().to_vec(),
+            incremental.direntry_unbinds().to_vec(),
+            incremental.revisions().to_vec(),
+            incremental.subtree_tombstones().to_vec(),
+            incremental.commit_receipts().to_vec(),
+        )
+    }
+
+    #[test]
+    fn bound_child_at_head_sees_latest_bind_including_dead_bindings() {
+        let state = churned_binding_state();
+        let head = state.indexed_seq();
+        assert_eq!(head, ChangeSeq(3));
+
+        // The latest bind at the contested name is child 3.
+        let head_bind = state
+            .bound_child_at_seq(InodeId(1), "contested", head)
+            .expect("bind at head");
+        assert_eq!(head_bind.child_inode_id, InodeId(3));
+        assert_eq!(head_bind.bind_seq, ChangeSeq(3));
+
+        // The deleted name still answers with its dead binding: the bind is
+        // unbound but tombstone-ancestry walks must see it.
+        let dead_bind = state
+            .bound_child_at_seq(InodeId(1), "deleted", head)
+            .expect("dead binding visible at head");
+        assert_eq!(dead_bind.child_inode_id, InodeId(4));
+        assert!(state.is_direntry_unbound_at_seq(&dead_bind, head));
+        assert!(state.visible_child(InodeId(1), "deleted", head).is_none());
+    }
+
+    #[test]
+    fn bound_child_below_indexed_seq_still_scans_history() {
+        let state = churned_binding_state();
+
+        // At seq 2 the contested name's latest bind is still child 2's
+        // (unbound) binding; the rebind at seq 3 is not visible yet.
+        let historical = state
+            .bound_child_at_seq(InodeId(1), "contested", ChangeSeq(2))
+            .expect("historical bind");
+        assert_eq!(historical.child_inode_id, InodeId(2));
+        assert_eq!(historical.bind_seq, ChangeSeq(1));
+    }
+
+    #[test]
+    fn incremental_and_rebuilt_indexes_agree_on_latest_binds() {
+        let incremental = churned_binding_state();
+        let rebuilt = churned_binding_state_rebuilt();
+
+        for name_key in ["contested", "renamed-away", "deleted", "never-bound"] {
+            assert_eq!(
+                rebuilt.bound_child_at_seq(InodeId(1), name_key, ChangeSeq(3)),
+                incremental.bound_child_at_seq(InodeId(1), name_key, ChangeSeq(3)),
+                "latest bind for `{name_key}` diverges between construction paths"
+            );
+        }
+    }
+
+    /// Queries above `indexed_seq()` are at-head queries: commit validation
+    /// probes the basis at the next assigned seq and must hit the indexes.
+    #[test]
+    fn queries_above_indexed_seq_match_at_head_results() {
+        let state = churned_binding_state();
+        let beyond_head = ChangeSeq(state.indexed_seq().0 + 1);
+
+        assert_eq!(
+            state.bound_child_at_seq(InodeId(1), "contested", beyond_head),
+            state.indexes.latest_bind(InodeId(1), "contested"),
+        );
+        assert_eq!(
+            state.visible_child(InodeId(1), "contested", beyond_head),
+            state.visible_child_at_head(InodeId(1), "contested"),
+        );
+        assert_eq!(
+            state.current_parent_binding_for_child(InodeId(2), beyond_head),
+            state.current_parent_binding_for_child_at_head(InodeId(2)),
+        );
+        assert_eq!(
+            state.visible_inode(InodeId(3), beyond_head),
+            state.visible_inode_at_head(InodeId(3)),
         );
     }
 }

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -1,5 +1,6 @@
 use crate::checkpoint::{
-    load_verified_manifest_materialization, manifest_basis_head, ManifestLoadError,
+    load_namespace_manifest_envelope, load_verified_manifest_materialization, manifest_basis_head,
+    ManifestLoadError,
 };
 use crate::error::CoreError;
 use crate::metadata::MetadataState;
@@ -14,9 +15,9 @@ use crate::wal::{
     WalChainLoadRequest, WalReplayError,
 };
 use loonfs_api::wire::control::{HeadState, LeaseState, NamespaceDescriptorState, NamespaceState};
-use loonfs_api::{ChangeSeq, ContentStoreId, ManifestId, NamespaceId};
+use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ContentStoreId, ManifestId, NamespaceId};
 use loonfs_objectstore::{
-    keys::{namespace_descriptor, namespace_head},
+    keys::{namespace_descriptor, namespace_head, wal_segment_id_from_key, wal_segment_prefix},
     ObjectStore,
 };
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,11 @@ pub struct NamespaceHeadSummary {
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
     pub latest_checkpoint_id: Option<String>,
+    /// WAL segment objects positioned past the materialized manifest basis.
+    ///
+    /// Derived from position-ordered object names, not from walking the
+    /// chain: an inspection count for maintenance gating and operators, not
+    /// a validated chain length.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
@@ -345,29 +351,19 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     }
     let head = loaded_head.envelope.state;
     let manifest_basis_seq = if let Some(manifest_id) = head.current_manifest_id {
-        load_verified_manifest_materialization(store, expected_namespace, manifest_id)
+        load_namespace_manifest_envelope(store, expected_namespace, manifest_id)
             .await
             .map_err(|error| CoreError::Basis(BasisLoadError::ManifestLoad(error)))?
-            .manifest
             .payload
             .head_seq
     } else {
         ChangeSeq(0)
     };
-    let wal_chain = load_validated_wal_chain(
-        store,
-        WalChainLoadRequest {
-            namespace_id: expected_namespace,
-            chain_base_seq: manifest_basis_seq,
-            head_seq: head.seq,
-            visible_tip: head.visible_wal_tip.clone(),
-            stop_after_seq: None,
-        },
-    )
-    .await
-    .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;
-    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
-        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))?;
+    let wal_tail_segments = if head.visible_wal_tip.is_some() {
+        count_wal_tail_segments_by_position(store, expected_namespace, manifest_basis_seq).await?
+    } else {
+        0
+    };
     Ok(NamespaceHeadSummary {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
@@ -376,6 +372,33 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         wal_tail_segments,
         retention_floor_seq: head.retention_floor_seq,
     })
+}
+
+/// Counts WAL tail segments from their position-ordered object names.
+///
+/// Status is an inspection surface, so the count comes from one listing
+/// instead of loading and validating segment bodies: segment file names
+/// carry their `start_seq`, and every chain segment past the materialized
+/// manifest basis starts above it. Objects that lost a head race are counted
+/// until reclamation removes them, which can only over-trigger maintenance,
+/// never starve it. Recovery authority stays with the head and chain.
+async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    manifest_basis_seq: ChangeSeq,
+) -> Result<u64, CoreError> {
+    let keys = store
+        .list_prefix(&wal_segment_prefix(namespace_id.as_str()))
+        .await
+        .map_err(|error| CoreError::Store(format!("list WAL tail segments: {error}")))?;
+    let tail_segments = keys
+        .iter()
+        .filter_map(|key| wal_segment_id_from_key(key))
+        .filter_map(wal_segment_id_start_seq)
+        .filter(|start_seq| *start_seq > manifest_basis_seq)
+        .count();
+    u64::try_from(tail_segments)
+        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))
 }
 
 #[tracing::instrument(
@@ -568,5 +591,61 @@ mod tests {
             error,
             BasisLoadError::HeadChangedDuringLoad { object_key, .. } if object_key == head_key
         ));
+    }
+
+    #[tokio::test]
+    async fn head_summary_counts_only_position_named_wal_segments() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let namespace_id = NamespaceId::parse("primary").expect("valid namespace id");
+        let engine = NamespaceEngine::builder(Arc::clone(&store))
+            .namespace(namespace_id.clone())
+            .writer("writer-a")
+            .build()
+            .expect("engine");
+        engine
+            .bootstrap_namespace(BootstrapOptions::default())
+            .await
+            .expect("bootstrap");
+        engine
+            .create_dir("/docs", WriteOptions::default())
+            .await
+            .expect("first commit");
+        engine
+            .create_dir("/more", WriteOptions::default())
+            .await
+            .expect("second commit");
+
+        // Foreign objects in the WAL prefix are skipped: a non-segment
+        // suffix, and a current-suffix name without a position prefix.
+        let prefix = loonfs_objectstore::keys::wal_segment_prefix(namespace_id.as_str());
+        for stray in ["random.tmp", "seg_legacy.wal.zst"] {
+            store
+                .put_if_absent(&format!("{prefix}{stray}"), Bytes::from_static(b"x"))
+                .await
+                .expect("plant stray object");
+        }
+
+        let summary = load_namespace_head_summary(store.as_ref(), &namespace_id)
+            .await
+            .expect("summary with strays");
+        assert_eq!(summary.wal_tail_segments, 2);
+
+        // A position-named object that lost a head race still counts:
+        // status is an inspection surface and may only over-trigger
+        // maintenance, never starve it.
+        let orphan_key = loonfs_objectstore::keys::wal_segment(
+            namespace_id.as_str(),
+            &loonfs_api::generate_wal_segment_id(ChangeSeq(9)),
+        );
+        store
+            .put_if_absent(&orphan_key, Bytes::from_static(b"x"))
+            .await
+            .expect("plant orphan segment");
+
+        let summary = load_namespace_head_summary(store.as_ref(), &namespace_id)
+            .await
+            .expect("summary with orphan");
+        assert_eq!(summary.wal_tail_segments, 3);
     }
 }

--- a/crates/loonfs-core/src/path/write/mod.rs
+++ b/crates/loonfs-core/src/path/write/mod.rs
@@ -4,8 +4,10 @@ mod content_write;
 mod executor;
 mod intent;
 pub(crate) mod planner;
+mod session;
 
 pub use intent::{PathMutationIntent, PutFileBehavior};
 pub(crate) use planner::{
     path_intent_fingerprint_for_path_intent, PathPlanner, PlannedPathMutation,
 };
+pub(crate) use session::PublishPlanningSession;

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -8,7 +8,6 @@ use crate::path::helpers::{
 };
 use crate::path::tombstone::reject_tombstoned_path_ancestor;
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     v0::{
         CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
@@ -359,18 +358,9 @@ fn plan_put_file_content_ref(
     );
 
     let mut ops = Vec::new();
-    let mut working = view.metadata_state.clone();
     let mut next_inode_id = view.head.next_inode_id;
-    let mut op_index = 0u32;
-    let final_parent_inode = ensure_parent_directories(
-        &absolute_path,
-        view.head.seq,
-        view.head.name_policy,
-        &mut working,
-        &mut ops,
-        &mut next_inode_id,
-        &mut op_index,
-    )?;
+    let final_parent_inode =
+        ensure_parent_directories(&absolute_path, view, &mut ops, &mut next_inode_id)?;
     let final_name = final_component(&absolute_path)?;
     let mut preconditions = Vec::new();
 
@@ -690,14 +680,19 @@ fn plan_restore_revision(
     })
 }
 
+/// Resolves the parent chain of `absolute_path`, planning `CreateDir` ops for
+/// missing ancestors.
+///
+/// Planned directories receive speculative inode ids allocated in op order
+/// from `next_inode_id`; commit validation re-derives the same ids because it
+/// allocates from the same head counter in the same order. Once one ancestor
+/// is missing, every deeper component is missing too (a planned directory has
+/// no children), so the walk never needs to materialize planned state.
 fn ensure_parent_directories(
     absolute_path: &AbsolutePath,
-    committed_seq: ChangeSeq,
-    name_policy: loonfs_api::NamePolicy,
-    working: &mut MetadataState,
+    view: &PathPlanningView<'_>,
     ops: &mut Vec<ApiCommitOp>,
     next_inode_id: &mut InodeId,
-    op_index: &mut u32,
 ) -> Result<InodeId, CoreError> {
     let components = absolute_path.components();
     if components.len() <= 1 {
@@ -705,21 +700,28 @@ fn ensure_parent_directories(
     }
 
     let mut current_inode = InodeId(1);
+    let mut creating_missing_ancestors = false;
     for component in &components[..components.len() - 1] {
         let display_name = component.to_display_name();
-        let name_key = NameKey::for_display_name(name_policy, &display_name);
-        if let Some(child) = working.visible_child(current_inode, name_key.as_str(), committed_seq)
-        {
-            let inode = working
-                .visible_inode(child.child_inode_id, committed_seq)
-                .ok_or_else(|| CoreError::MissingPath(component.as_str().to_owned()))?;
-            if inode.inode_kind != InodeKind::Dir {
-                return Err(CoreError::NonDirectoryPathComponent(
-                    component.as_str().to_owned(),
-                ));
+        let name_key = NameKey::for_display_name(view.head.name_policy, &display_name);
+        if !creating_missing_ancestors {
+            if let Some(child) =
+                view.metadata_state
+                    .visible_child(current_inode, name_key.as_str(), view.head.seq)
+            {
+                let inode = view
+                    .metadata_state
+                    .visible_inode(child.child_inode_id, view.head.seq)
+                    .ok_or_else(|| CoreError::MissingPath(component.as_str().to_owned()))?;
+                if inode.inode_kind != InodeKind::Dir {
+                    return Err(CoreError::NonDirectoryPathComponent(
+                        component.as_str().to_owned(),
+                    ));
+                }
+                current_inode = child.child_inode_id;
+                continue;
             }
-            current_inode = child.child_inode_id;
-            continue;
+            creating_missing_ancestors = true;
         }
 
         ops.push(ApiCommitOp::CreateDir {
@@ -728,26 +730,6 @@ fn ensure_parent_directories(
         });
         let allocated = *next_inode_id;
         *next_inode_id = InodeId(next_inode_id.0.saturating_add(1));
-        let delta_index = op_index.saturating_mul(2);
-        let applied = working.apply_committed_wal_deltas(
-            committed_seq,
-            &[
-                WalDelta::CreateInode {
-                    delta_index,
-                    inode_id: allocated,
-                    inode_kind: InodeKind::Dir,
-                },
-                WalDelta::BindDirentry {
-                    delta_index: delta_index.saturating_add(1),
-                    parent_inode: current_inode,
-                    name_key: name_key.as_str().to_owned(),
-                    display_name: display_name.as_str().to_owned(),
-                    child_inode: allocated,
-                },
-            ],
-        )?;
-        *working = applied.metadata_state;
-        *op_index = op_index.saturating_add(1);
         current_inode = allocated;
     }
     Ok(current_inode)

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -1,0 +1,220 @@
+use super::intent::PathMutationIntent;
+use super::planner::{plan_path_mutation_against_state, PlannedPathMutation};
+use crate::commit::CommitPlan;
+use crate::error::CoreError;
+use crate::metadata::{MetadataApplyError, MetadataState};
+use crate::namespace::basis::VerifiedNamespaceBasis;
+use loonfs_api::wire::control::HeadState;
+use loonfs_api::wire::wal::WalCommitPayload;
+use loonfs_api::NamespaceId;
+
+/// Working view of one publish attempt against a verified basis.
+///
+/// The session owns the batch's evolving head and metadata state: it is
+/// derived from the basis once per publish attempt, every path mutation is
+/// planned against it, every accepted commit is applied back into it, and it
+/// is either promoted into the next cached basis or discarded with the
+/// attempt. Keeping head and state behind one seam guarantees planner reads
+/// always observe the same sequence the indexes are built at.
+pub(crate) struct PublishPlanningSession {
+    head: HeadState,
+    metadata_state: MetadataState,
+}
+
+impl PublishPlanningSession {
+    pub(crate) fn new(basis: &VerifiedNamespaceBasis) -> Self {
+        Self {
+            head: basis.head.clone(),
+            metadata_state: basis.metadata_state.clone(),
+        }
+    }
+
+    pub(crate) fn head(&self) -> &HeadState {
+        &self.head
+    }
+
+    pub(crate) fn metadata_state(&self) -> &MetadataState {
+        &self.metadata_state
+    }
+
+    pub(crate) fn plan_path_mutation(
+        &self,
+        namespace_id: &NamespaceId,
+        intent: &PathMutationIntent,
+    ) -> Result<PlannedPathMutation, CoreError> {
+        plan_path_mutation_against_state(namespace_id, intent, &self.head, &self.metadata_state)
+    }
+
+    /// Folds an accepted commit into the session so later candidates in the
+    /// same batch plan and validate against it.
+    pub(crate) fn apply_accepted_commit(
+        &mut self,
+        preview: &WalCommitPayload,
+        plan: &CommitPlan,
+    ) -> Result<(), MetadataApplyError> {
+        self.metadata_state
+            .apply_committed_wal_record_mut(preview)?;
+        self.head.seq = plan.assigned_seq;
+        self.head.next_inode_id = plan.resulting_next_inode_id;
+        Ok(())
+    }
+
+    pub(crate) fn into_metadata_state(self) -> MetadataState {
+        self.metadata_state
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::intent::PutFileBehavior;
+    use super::*;
+    use crate::context::MutationContext;
+    use crate::error::ErrorCode;
+    use crate::namespace::basis::load_verified_namespace_basis;
+    use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::publisher::{publish_namespace_mutations_batch, NamespaceMutationCandidate};
+    use crate::storage::content::store_bytes_as_content;
+    use loonfs_api::CommitId;
+    use loonfs_objectstore::fs::LocalFsStore;
+    use tempfile::tempdir;
+
+    fn test_context() -> MutationContext {
+        MutationContext {
+            writer_id: "writer".to_owned(),
+            writer_version: "test".to_owned(),
+            now_ms: 1,
+            lease_duration_ms: 60_000,
+        }
+    }
+
+    async fn setup_namespace() -> (
+        tempfile::TempDir,
+        LocalFsStore,
+        NamespaceId,
+        MutationContext,
+    ) {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let context = test_context();
+        bootstrap_namespace(&store, &namespace_id, &context, false)
+            .await
+            .expect("bootstrap");
+        (temp_dir, store, namespace_id, context)
+    }
+
+    fn put_file_candidate(
+        commit_id: &str,
+        absolute_path: &str,
+        content_ref: loonfs_api::ContentRef,
+    ) -> NamespaceMutationCandidate {
+        NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+            absolute_path: absolute_path.to_owned(),
+            content_ref,
+            behavior: PutFileBehavior::CreateOnly,
+        })
+    }
+
+    /// The first candidate implicitly creates `/wide`; the second must plan
+    /// against the session state that already contains it, or its own
+    /// duplicate `CreateDir` would fail child-name-absent validation.
+    #[tokio::test]
+    async fn batch_creates_under_one_new_parent_share_session_state() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let staged = store_bytes_as_content(&store, &namespace_id, b"hello")
+            .await
+            .expect("stage");
+
+        let results = publish_namespace_mutations_batch(
+            &store,
+            &namespace_id,
+            vec![
+                put_file_candidate("create-wide-a", "/wide/a.txt", staged.content_ref.clone()),
+                put_file_candidate("create-wide-b", "/wide/b.txt", staged.content_ref.clone()),
+            ],
+            &context,
+        )
+        .await;
+
+        let first = results[0].as_ref().expect("first create succeeds");
+        let second = results[1].as_ref().expect("second create succeeds");
+        assert!(second.committed_seq > first.committed_seq);
+
+        let basis = load_verified_namespace_basis(&store, &namespace_id)
+            .await
+            .expect("basis");
+        for path in ["/wide/a.txt", "/wide/b.txt"] {
+            let absolute_path = loonfs_api::AbsolutePath::parse(path).expect("path");
+            basis
+                .metadata_state
+                .resolve_visible_path(&absolute_path, basis.head.name_policy, basis.head.seq)
+                .expect("published file is visible");
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_create_only_put_in_one_batch_is_destination_exists() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let staged = store_bytes_as_content(&store, &namespace_id, b"hello")
+            .await
+            .expect("stage");
+
+        let results = publish_namespace_mutations_batch(
+            &store,
+            &namespace_id,
+            vec![
+                put_file_candidate("create-a-first", "/docs/a.txt", staged.content_ref.clone()),
+                put_file_candidate("create-a-second", "/docs/a.txt", staged.content_ref.clone()),
+            ],
+            &context,
+        )
+        .await;
+
+        results[0].as_ref().expect("first create succeeds");
+        let error = results[1].as_ref().expect_err("duplicate create rejected");
+        assert_eq!(error.code(), ErrorCode::PathConflict);
+        assert!(matches!(error, CoreError::DestinationExists(_)));
+    }
+
+    #[tokio::test]
+    async fn create_then_delete_in_one_batch_respects_candidate_order() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let staged = store_bytes_as_content(&store, &namespace_id, b"hello")
+            .await
+            .expect("stage");
+
+        let results = publish_namespace_mutations_batch(
+            &store,
+            &namespace_id,
+            vec![
+                put_file_candidate(
+                    "create-doomed",
+                    "/docs/doomed.txt",
+                    staged.content_ref.clone(),
+                ),
+                NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                    commit_id: CommitId::parse("delete-doomed").expect("valid commit id"),
+                    absolute_path: "/docs/doomed.txt".to_owned(),
+                    recursive: false,
+                }),
+            ],
+            &context,
+        )
+        .await;
+
+        results[0].as_ref().expect("create succeeds");
+        results[1]
+            .as_ref()
+            .expect("delete sees the create from the same batch");
+
+        let basis = load_verified_namespace_basis(&store, &namespace_id)
+            .await
+            .expect("basis");
+        let absolute_path = loonfs_api::AbsolutePath::parse("/docs/doomed.txt").expect("path");
+        basis
+            .metadata_state
+            .resolve_visible_path(&absolute_path, basis.head.name_policy, basis.head.seq)
+            .expect_err("deleted file is no longer visible");
+    }
+}

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -20,7 +20,7 @@ use crate::namespace::control::{
     load_namespace_head_control, load_namespace_lease_control,
 };
 use crate::namespace::lease::acquire_or_renew_namespace_lease;
-use crate::path::write::{path_intent_fingerprint_for_path_intent, PathPlanner};
+use crate::path::write::{path_intent_fingerprint_for_path_intent, PublishPlanningSession};
 use crate::publisher::NamespaceMutationCandidate;
 use crate::storage::content::{write_immutable_object, ContentValidationTracker};
 use crate::wal::{load_validated_wal_chain, prepare_wal_segment, WalChainLoadRequest};
@@ -31,7 +31,7 @@ use loonfs_api::v0::{
     CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, CompletedUpload, ControlObjectKind, HeadState,
+    decode_control_object, encode_control_object, CompletedUpload, ControlObjectKind,
     UploadSessionEnvelope, UploadSessionState,
 };
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta};
@@ -461,8 +461,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     }
     let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
         (0..candidates.len()).map(|_| None).collect();
-    let mut current_head = basis.head.clone();
-    let mut current_metadata_state = basis.metadata_state.clone();
+    let mut session = PublishPlanningSession::new(basis);
     let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
     let mut in_batch_requests: HashMap<CommitId, InBatchRequest> = HashMap::new();
     let mut aliases: Vec<(usize, usize)> = Vec::new();
@@ -479,11 +478,9 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
             let candidate_request = {
                 let _span = tracing::info_span!("loon.phase", phase = "prepare_commit").entered();
                 prepare_candidate_request(
-                    store,
                     namespace_id,
                     basis,
-                    &current_head,
-                    &current_metadata_state,
+                    &session,
                     candidate,
                     context,
                     index,
@@ -496,10 +493,10 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
                 continue;
             };
             let validation = CommitValidationContext {
-                head: current_head.clone(),
+                head: session.head().clone(),
                 lease: basis.lease.clone(),
                 now_ms: context.now_ms,
-                metadata_state: &current_metadata_state,
+                metadata_state: session.metadata_state(),
             };
             let request = candidate_request.request;
             let resolved_restore_content_refs = resolve_restore_content_refs(&request, &validation);
@@ -565,14 +562,10 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
             let applied = {
                 let _span = tracing::info_span!("loon.phase", phase = "apply_committed_wal_record")
                     .entered();
-                current_metadata_state.apply_committed_wal_record_mut(&preview)
+                session.apply_accepted_commit(&preview, &plan)
             };
             match applied {
-                Ok(_) => {
-                    current_head.seq = plan.assigned_seq;
-                    current_head.next_inode_id = plan.resulting_next_inode_id;
-                    accepted.push((index, materialized));
-                }
+                Ok(()) => accepted.push((index, materialized)),
                 Err(error) => outcomes[index] = Some(Err(error.into())),
             }
         }
@@ -695,7 +688,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
         head: head_publish.resulting_head.clone(),
         head_etag,
         lease: basis.lease.clone(),
-        metadata_state: current_metadata_state,
+        metadata_state: session.into_metadata_state(),
     });
 
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
@@ -714,12 +707,10 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
 }
 
 #[allow(clippy::too_many_arguments)]
-fn prepare_candidate_request<S: ObjectStore + ?Sized>(
-    store: &S,
+fn prepare_candidate_request(
     namespace_id: &NamespaceId,
     basis: &VerifiedNamespaceBasis,
-    current_head: &HeadState,
-    current_metadata_state: &MetadataState,
+    session: &PublishPlanningSession,
     candidate: &NamespaceMutationCandidate,
     context: &MutationContext,
     index: usize,
@@ -798,12 +789,7 @@ fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             ) {
                 return None;
             }
-            let planned = match PathPlanner::new(store).plan_against_state(
-                namespace_id,
-                intent,
-                current_head,
-                current_metadata_state,
-            ) {
+            let planned = match session.plan_path_mutation(namespace_id, intent) {
                 Ok(value) => value,
                 Err(error) => {
                     outcomes[index] = Some(Err(error));

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -621,9 +621,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let wal = match wal_result {
         Ok(wal) => wal,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -640,10 +638,8 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {
-            let message = format!("head publish preparation failed: {error:?}");
-            for (index, _) in accepted {
-                outcomes[index] = Some(Err(CoreError::Store(message.clone())));
-            }
+            let error = CoreError::Store(format!("head publish preparation failed: {error:?}"));
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -673,9 +669,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_metadata = match head_metadata_result {
         Ok(metadata) => metadata,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone().into()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error.into());
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -1086,6 +1080,38 @@ fn commit_response_from_commit_receipt(
         commit_id: record.commit_id.clone(),
         committed_seq: record.committed_seq,
         results: record.results.clone(),
+    }
+}
+
+/// Fails every outcome that was contingent on this batch publishing durably.
+///
+/// The accepted candidates take the batch error: they never committed. So do
+/// rejections recorded after the first acceptance, because their verdicts
+/// were decided against session state advanced by tentatively accepted
+/// candidates — state that never became durable. Reporting them would hand a
+/// client a definitive semantic error (path conflict, missing path, stale
+/// revision, ...) it correctly treats as non-retryable, for a precondition
+/// that was never durably true (format.md section 3.1.5).
+///
+/// Rejections recorded before any acceptance were decided against the
+/// durable basis alone and stand. Idempotent `Ok` completions replay durable
+/// commit receipts and stand. Alias slots stay unfilled here and inherit
+/// their primary's final outcome.
+fn fail_outcomes_contingent_on_unpublished_batch(
+    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    accepted: &[(usize, MaterializedCommit)],
+    error: &CoreError,
+) {
+    let Some(first_accepted_index) = accepted.first().map(|(index, _)| *index) else {
+        return;
+    };
+    for (index, _) in accepted {
+        outcomes[*index] = Some(Err(error.clone()));
+    }
+    for outcome in outcomes.iter_mut().skip(first_accepted_index + 1) {
+        if matches!(outcome, Some(Err(_))) {
+            *outcome = Some(Err(error.clone()));
+        }
     }
 }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -2329,6 +2329,187 @@ async fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     );
 }
 
+/// A batch where the WAL write fails must report that failure for every
+/// outcome that depended on the batch publishing: the accepted candidate and
+/// the rejection decided against its speculative in-batch state. Before this
+/// contract the speculative rejection surfaced as a definitive `PathConflict`
+/// derived from a create that never became durable, so its client gave up
+/// instead of retrying. Rejections decided against the durable basis alone
+/// stand regardless of the batch outcome.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Prefix("namespaces/demo/wal/".to_owned()),
+        InjectedCreateFailure::Transport {
+            message: "injected wal write failure",
+        },
+    );
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            // Rejected against the durable basis: nothing was accepted yet.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            // Accepted into the batch.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Rejected only because of the accepted candidate's speculative
+            // in-batch create.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Alias of the basis-decided rejection.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+
+    let basis_rejection = failed[0].as_ref().expect_err("basis-decided rejection");
+    assert_eq!(basis_rejection.code(), ErrorCode::PathNotFound);
+    let accepted = failed[1].as_ref().expect_err("accepted candidate fails");
+    assert!(matches!(accepted, CoreError::WalWrite(_)));
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert!(
+        matches!(speculative, CoreError::WalWrite(_)),
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+    let alias = failed[3].as_ref().expect_err("alias mirrors its primary");
+    assert_eq!(alias.code(), ErrorCode::PathNotFound);
+
+    // Nothing became durable, so the retry the batch error asks for derives
+    // every verdict from durable state.
+    let basis = load_verified_namespace_basis(&store, &namespace_id)
+        .await
+        .expect("load basis");
+    assert_eq!(basis.head.seq, ChangeSeq(0));
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    let committed = retried[1].as_ref().expect("create lands on retry");
+    assert_eq!(committed.committed_seq, ChangeSeq(1));
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+    assert_eq!(
+        retried[3].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+}
+
+/// Same contract when the batch dies at the head CAS instead of the WAL
+/// write: the stale-head error replaces the rejection decided against the
+/// accepted candidate's speculative state, while the basis-decided rejection
+/// stands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = StaleHeadAfterWalWriteStore::new(temp_dir.path(), &namespace_id);
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert!(store.injected_stale_head());
+
+    assert_eq!(
+        failed[0]
+            .as_ref()
+            .expect_err("basis-decided rejection")
+            .code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        failed[1]
+            .as_ref()
+            .expect_err("accepted candidate fails")
+            .code(),
+        ErrorCode::StaleHead
+    );
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert_eq!(
+        speculative.code(),
+        ErrorCode::StaleHead,
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        retried[1]
+            .as_ref()
+            .expect("create lands on retry")
+            .committed_seq,
+        ChangeSeq(1)
+    );
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn direct_publisher_retries_after_stale_head_get_during_basis_load() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -66,6 +66,14 @@ pub fn wal_segment(namespace: &str, segment_id: &str) -> String {
         .into_string()
 }
 
+pub fn wal_segment_prefix(namespace: &str) -> String {
+    ObjectLayout::new().wal_segment_prefix(namespace)
+}
+
+pub fn wal_segment_id_from_key(key: &str) -> Option<&str> {
+    ObjectLayout::new().wal_segment_id_from_key(key)
+}
+
 pub fn content_store_descriptor(content_store: &str) -> String {
     ObjectLayout::new()
         .content_store_descriptor(content_store)
@@ -144,7 +152,8 @@ mod tests {
         conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
         derived_progress, metadata_sst, namespace_descriptor, namespace_fork_state, namespace_head,
         namespace_lease, namespace_manifest, sha256_hex_from_digest, upload_session,
-        upload_session_prefix, wal_segment, DerivedWorkClass,
+        upload_session_prefix, wal_segment, wal_segment_id_from_key, wal_segment_prefix,
+        DerivedWorkClass,
     };
     use loonfs_api::ManifestId;
 
@@ -170,6 +179,20 @@ mod tests {
         assert_eq!(
             wal_segment("ns-1", "seg_00000000000000000000000000000001"),
             "namespaces/ns-1/wal/seg_00000000000000000000000000000001.wal.zst"
+        );
+        assert_eq!(wal_segment_prefix("ns-1"), "namespaces/ns-1/wal/");
+        assert!(wal_segment("ns-1", "00000000000000000042-0123456789abcdef")
+            .starts_with(&wal_segment_prefix("ns-1")));
+        assert_eq!(
+            wal_segment_id_from_key(&wal_segment(
+                "ns-1",
+                "00000000000000000042-0123456789abcdef"
+            )),
+            Some("00000000000000000042-0123456789abcdef")
+        );
+        assert_eq!(
+            wal_segment_id_from_key("namespaces/ns-1/wal/random.tmp"),
+            None
         );
         assert_eq!(
             namespace_manifest("ns-1", ManifestId(400)),

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -158,6 +158,23 @@ impl ObjectLayout {
         )))
     }
 
+    /// Listing prefix that contains every WAL segment of `namespace`.
+    ///
+    /// Segment file names start with the segment's 20-digit `start_seq`, so
+    /// a listing under this prefix orders by history position.
+    pub fn wal_segment_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/wal/")
+    }
+
+    /// Extracts the WAL segment id from a listed object key.
+    ///
+    /// Returns `None` for keys that are not current-format WAL segments, so
+    /// listings can skip boundary markers and foreign objects.
+    pub fn wal_segment_id_from_key<'a>(&self, key: &'a str) -> Option<&'a str> {
+        let (_, file_name) = key.rsplit_once('/')?;
+        file_name.strip_suffix(".wal.zst")
+    }
+
     pub fn content_store_descriptor(&self, content_store: &str) -> ContentStoreDescriptorKey {
         ContentStoreDescriptorKey(ObjectKey::new(format!(
             "content-stores/{content_store}/descriptor.json"

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -720,6 +720,12 @@ The server may:
 Each request still has its own success or failure outcome. Tentative
 acceptance inside a batch is not success.
 
+A rejection judged against ephemeral state advanced by a tentative
+acceptance (step 2 in section 3.1.4) is contingent on that state publishing:
+if publication fails, the writer must report the publication failure for it,
+never the semantic rejection. Rejections judged against the durable basis
+alone stand regardless of the publication outcome.
+
 ### 3.2 Read protocol
 
 A read reconstructs the visible filesystem state from durable artifacts on


### PR DESCRIPTION
Routes publish batch planning through a single planning session. This and the subsequent PR fixed a hot spot for same-directory updates (our benchmark ran 20k updates in the same directory):


State | First batch | Last batch (19k children) | Total for 20k
-- | -- | -- | --
before this PR | 393ms | 13,203ms | 145.1s
after this PR | 73ms | 83ms | 1.5s

