### PR TITLE
perf(core): derive namespace status without materializing checkpoints

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -181,6 +181,18 @@ pub fn validate_upload_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValid
     validate_generated_id("upl", value.as_ref())
 }
 
+/// Start seq encoded in a WAL segment id's 20-digit position prefix.
+///
+/// Returns `None` when the value does not follow the generated id shape, so
+/// listings can skip foreign objects instead of failing. Like the name
+/// itself, the parsed position is an inspection and reclamation hint only —
+/// recovery authority is the head and chain.
+pub fn wal_segment_id_start_seq(segment_id: &str) -> Option<ChangeSeq> {
+    validate_wal_segment_id(segment_id).ok()?;
+    let (position, _) = segment_id.split_once('-')?;
+    position.parse().ok().map(ChangeSeq)
+}
+
 pub fn validate_wal_segment_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValidationError> {
     let value = value.as_ref();
     let Some((position, suffix)) = value.split_once('-') else {

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -55,9 +55,9 @@ pub use ids::{
     generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,
     generate_wal_segment_id, generated_id, validate_checkpoint_id, validate_gc_pin_id,
     validate_generated_id, validate_metadata_table_id, validate_upload_id, validate_wal_segment_id,
-    ChangeSeq, CommitId, CommitIdValidationError, ContentStoreId, FenceToken,
-    GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey, NameKeyValidationError,
-    NamespaceId, NamespaceIdValidationError, RevisionNo,
+    wal_segment_id_start_seq, ChangeSeq, CommitId, CommitIdValidationError, ContentStoreId,
+    FenceToken, GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey,
+    NameKeyValidationError, NamespaceId, NamespaceIdValidationError, RevisionNo,
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
 pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -41,6 +41,22 @@ pub(crate) async fn load_verified_manifest_materialization<S: ObjectStore + ?Siz
         })
 }
 
+/// Loads and validates only the manifest envelope, without fetching its
+/// metadata tables. Enough for callers that need manifest framing such as
+/// the materialized basis seq, not the rows.
+pub(crate) async fn load_namespace_manifest_envelope<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    manifest_id: ManifestId,
+) -> Result<NamespaceManifestEnvelope, ManifestLoadError> {
+    let manifest_key = namespace_manifest(namespace_id.as_str(), manifest_id);
+    load_namespace_manifest_envelope_if_present(store, namespace_id, manifest_id, &manifest_key)
+        .await?
+        .ok_or(ManifestLoadError::MissingManifest {
+            object_key: manifest_key,
+        })
+}
+
 pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     table_cache: Option<&'a MetadataTableCache>,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -37,8 +37,8 @@ pub use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::load::{
-    load_verified_manifest_materialization, load_verified_manifest_tables_with_cache,
-    manifest_basis_head,
+    load_namespace_manifest_envelope, load_verified_manifest_materialization,
+    load_verified_manifest_tables_with_cache, manifest_basis_head,
 };
 pub(crate) use self::publish::write_namespace_manifest;
 pub(crate) use self::retention::advance_retention_floor;

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -1,5 +1,6 @@
 use crate::checkpoint::{
-    load_verified_manifest_materialization, manifest_basis_head, ManifestLoadError,
+    load_namespace_manifest_envelope, load_verified_manifest_materialization, manifest_basis_head,
+    ManifestLoadError,
 };
 use crate::error::CoreError;
 use crate::metadata::MetadataState;
@@ -14,9 +15,9 @@ use crate::wal::{
     WalChainLoadRequest, WalReplayError,
 };
 use loonfs_api::wire::control::{HeadState, LeaseState, NamespaceDescriptorState, NamespaceState};
-use loonfs_api::{ChangeSeq, ContentStoreId, ManifestId, NamespaceId};
+use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ContentStoreId, ManifestId, NamespaceId};
 use loonfs_objectstore::{
-    keys::{namespace_descriptor, namespace_head},
+    keys::{namespace_descriptor, namespace_head, wal_segment_id_from_key, wal_segment_prefix},
     ObjectStore,
 };
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,11 @@ pub struct NamespaceHeadSummary {
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
     pub latest_checkpoint_id: Option<String>,
+    /// WAL segment objects positioned past the materialized manifest basis.
+    ///
+    /// Derived from position-ordered object names, not from walking the
+    /// chain: an inspection count for maintenance gating and operators, not
+    /// a validated chain length.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
@@ -345,29 +351,19 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     }
     let head = loaded_head.envelope.state;
     let manifest_basis_seq = if let Some(manifest_id) = head.current_manifest_id {
-        load_verified_manifest_materialization(store, expected_namespace, manifest_id)
+        load_namespace_manifest_envelope(store, expected_namespace, manifest_id)
             .await
             .map_err(|error| CoreError::Basis(BasisLoadError::ManifestLoad(error)))?
-            .manifest
             .payload
             .head_seq
     } else {
         ChangeSeq(0)
     };
-    let wal_chain = load_validated_wal_chain(
-        store,
-        WalChainLoadRequest {
-            namespace_id: expected_namespace,
-            chain_base_seq: manifest_basis_seq,
-            head_seq: head.seq,
-            visible_tip: head.visible_wal_tip.clone(),
-            stop_after_seq: None,
-        },
-    )
-    .await
-    .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;
-    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
-        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))?;
+    let wal_tail_segments = if head.visible_wal_tip.is_some() {
+        count_wal_tail_segments_by_position(store, expected_namespace, manifest_basis_seq).await?
+    } else {
+        0
+    };
     Ok(NamespaceHeadSummary {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
@@ -376,6 +372,33 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         wal_tail_segments,
         retention_floor_seq: head.retention_floor_seq,
     })
+}
+
+/// Counts WAL tail segments from their position-ordered object names.
+///
+/// Status is an inspection surface, so the count comes from one listing
+/// instead of loading and validating segment bodies: segment file names
+/// carry their `start_seq`, and every chain segment past the materialized
+/// manifest basis starts above it. Objects that lost a head race are counted
+/// until reclamation removes them, which can only over-trigger maintenance,
+/// never starve it. Recovery authority stays with the head and chain.
+async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    manifest_basis_seq: ChangeSeq,
+) -> Result<u64, CoreError> {
+    let keys = store
+        .list_prefix(&wal_segment_prefix(namespace_id.as_str()))
+        .await
+        .map_err(|error| CoreError::Store(format!("list WAL tail segments: {error}")))?;
+    let tail_segments = keys
+        .iter()
+        .filter_map(|key| wal_segment_id_from_key(key))
+        .filter_map(wal_segment_id_start_seq)
+        .filter(|start_seq| *start_seq > manifest_basis_seq)
+        .count();
+    u64::try_from(tail_segments)
+        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))
 }
 
 #[tracing::instrument(
@@ -568,5 +591,61 @@ mod tests {
             error,
             BasisLoadError::HeadChangedDuringLoad { object_key, .. } if object_key == head_key
         ));
+    }
+
+    #[tokio::test]
+    async fn head_summary_counts_only_position_named_wal_segments() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let namespace_id = NamespaceId::parse("primary").expect("valid namespace id");
+        let engine = NamespaceEngine::builder(Arc::clone(&store))
+            .namespace(namespace_id.clone())
+            .writer("writer-a")
+            .build()
+            .expect("engine");
+        engine
+            .bootstrap_namespace(BootstrapOptions::default())
+            .await
+            .expect("bootstrap");
+        engine
+            .create_dir("/docs", WriteOptions::default())
+            .await
+            .expect("first commit");
+        engine
+            .create_dir("/more", WriteOptions::default())
+            .await
+            .expect("second commit");
+
+        // Foreign objects in the WAL prefix are skipped: a non-segment
+        // suffix, and a current-suffix name without a position prefix.
+        let prefix = loonfs_objectstore::keys::wal_segment_prefix(namespace_id.as_str());
+        for stray in ["random.tmp", "seg_legacy.wal.zst"] {
+            store
+                .put_if_absent(&format!("{prefix}{stray}"), Bytes::from_static(b"x"))
+                .await
+                .expect("plant stray object");
+        }
+
+        let summary = load_namespace_head_summary(store.as_ref(), &namespace_id)
+            .await
+            .expect("summary with strays");
+        assert_eq!(summary.wal_tail_segments, 2);
+
+        // A position-named object that lost a head race still counts:
+        // status is an inspection surface and may only over-trigger
+        // maintenance, never starve it.
+        let orphan_key = loonfs_objectstore::keys::wal_segment(
+            namespace_id.as_str(),
+            &loonfs_api::generate_wal_segment_id(ChangeSeq(9)),
+        );
+        store
+            .put_if_absent(&orphan_key, Bytes::from_static(b"x"))
+            .await
+            .expect("plant orphan segment");
+
+        let summary = load_namespace_head_summary(store.as_ref(), &namespace_id)
+            .await
+            .expect("summary with orphan");
+        assert_eq!(summary.wal_tail_segments, 3);
     }
 }

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -621,9 +621,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let wal = match wal_result {
         Ok(wal) => wal,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -640,10 +638,8 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {
-            let message = format!("head publish preparation failed: {error:?}");
-            for (index, _) in accepted {
-                outcomes[index] = Some(Err(CoreError::Store(message.clone())));
-            }
+            let error = CoreError::Store(format!("head publish preparation failed: {error:?}"));
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -673,9 +669,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_metadata = match head_metadata_result {
         Ok(metadata) => metadata,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone().into()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error.into());
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -1086,6 +1080,38 @@ fn commit_response_from_commit_receipt(
         commit_id: record.commit_id.clone(),
         committed_seq: record.committed_seq,
         results: record.results.clone(),
+    }
+}
+
+/// Fails every outcome that was contingent on this batch publishing durably.
+///
+/// The accepted candidates take the batch error: they never committed. So do
+/// rejections recorded after the first acceptance, because their verdicts
+/// were decided against session state advanced by tentatively accepted
+/// candidates — state that never became durable. Reporting them would hand a
+/// client a definitive semantic error (path conflict, missing path, stale
+/// revision, ...) it correctly treats as non-retryable, for a precondition
+/// that was never durably true (format.md section 3.1.5).
+///
+/// Rejections recorded before any acceptance were decided against the
+/// durable basis alone and stand. Idempotent `Ok` completions replay durable
+/// commit receipts and stand. Alias slots stay unfilled here and inherit
+/// their primary's final outcome.
+fn fail_outcomes_contingent_on_unpublished_batch(
+    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    accepted: &[(usize, MaterializedCommit)],
+    error: &CoreError,
+) {
+    let Some(first_accepted_index) = accepted.first().map(|(index, _)| *index) else {
+        return;
+    };
+    for (index, _) in accepted {
+        outcomes[*index] = Some(Err(error.clone()));
+    }
+    for outcome in outcomes.iter_mut().skip(first_accepted_index + 1) {
+        if matches!(outcome, Some(Err(_))) {
+            *outcome = Some(Err(error.clone()));
+        }
     }
 }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -2329,6 +2329,187 @@ async fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     );
 }
 
+/// A batch where the WAL write fails must report that failure for every
+/// outcome that depended on the batch publishing: the accepted candidate and
+/// the rejection decided against its speculative in-batch state. Before this
+/// contract the speculative rejection surfaced as a definitive `PathConflict`
+/// derived from a create that never became durable, so its client gave up
+/// instead of retrying. Rejections decided against the durable basis alone
+/// stand regardless of the batch outcome.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Prefix("namespaces/demo/wal/".to_owned()),
+        InjectedCreateFailure::Transport {
+            message: "injected wal write failure",
+        },
+    );
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            // Rejected against the durable basis: nothing was accepted yet.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            // Accepted into the batch.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Rejected only because of the accepted candidate's speculative
+            // in-batch create.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Alias of the basis-decided rejection.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+
+    let basis_rejection = failed[0].as_ref().expect_err("basis-decided rejection");
+    assert_eq!(basis_rejection.code(), ErrorCode::PathNotFound);
+    let accepted = failed[1].as_ref().expect_err("accepted candidate fails");
+    assert!(matches!(accepted, CoreError::WalWrite(_)));
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert!(
+        matches!(speculative, CoreError::WalWrite(_)),
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+    let alias = failed[3].as_ref().expect_err("alias mirrors its primary");
+    assert_eq!(alias.code(), ErrorCode::PathNotFound);
+
+    // Nothing became durable, so the retry the batch error asks for derives
+    // every verdict from durable state.
+    let basis = load_verified_namespace_basis(&store, &namespace_id)
+        .await
+        .expect("load basis");
+    assert_eq!(basis.head.seq, ChangeSeq(0));
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    let committed = retried[1].as_ref().expect("create lands on retry");
+    assert_eq!(committed.committed_seq, ChangeSeq(1));
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+    assert_eq!(
+        retried[3].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+}
+
+/// Same contract when the batch dies at the head CAS instead of the WAL
+/// write: the stale-head error replaces the rejection decided against the
+/// accepted candidate's speculative state, while the basis-decided rejection
+/// stands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = StaleHeadAfterWalWriteStore::new(temp_dir.path(), &namespace_id);
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert!(store.injected_stale_head());
+
+    assert_eq!(
+        failed[0]
+            .as_ref()
+            .expect_err("basis-decided rejection")
+            .code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        failed[1]
+            .as_ref()
+            .expect_err("accepted candidate fails")
+            .code(),
+        ErrorCode::StaleHead
+    );
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert_eq!(
+        speculative.code(),
+        ErrorCode::StaleHead,
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        retried[1]
+            .as_ref()
+            .expect("create lands on retry")
+            .committed_seq,
+        ChangeSeq(1)
+    );
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn direct_publisher_retries_after_stale_head_get_during_basis_load() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -66,6 +66,14 @@ pub fn wal_segment(namespace: &str, segment_id: &str) -> String {
         .into_string()
 }
 
+pub fn wal_segment_prefix(namespace: &str) -> String {
+    ObjectLayout::new().wal_segment_prefix(namespace)
+}
+
+pub fn wal_segment_id_from_key(key: &str) -> Option<&str> {
+    ObjectLayout::new().wal_segment_id_from_key(key)
+}
+
 pub fn content_store_descriptor(content_store: &str) -> String {
     ObjectLayout::new()
         .content_store_descriptor(content_store)
@@ -144,7 +152,8 @@ mod tests {
         conflict_artifact, conflict_artifact_prefix, content_blob, content_store_descriptor,
         derived_progress, metadata_sst, namespace_descriptor, namespace_fork_state, namespace_head,
         namespace_lease, namespace_manifest, sha256_hex_from_digest, upload_session,
-        upload_session_prefix, wal_segment, DerivedWorkClass,
+        upload_session_prefix, wal_segment, wal_segment_id_from_key, wal_segment_prefix,
+        DerivedWorkClass,
     };
     use loonfs_api::ManifestId;
 
@@ -170,6 +179,20 @@ mod tests {
         assert_eq!(
             wal_segment("ns-1", "seg_00000000000000000000000000000001"),
             "namespaces/ns-1/wal/seg_00000000000000000000000000000001.wal.zst"
+        );
+        assert_eq!(wal_segment_prefix("ns-1"), "namespaces/ns-1/wal/");
+        assert!(wal_segment("ns-1", "00000000000000000042-0123456789abcdef")
+            .starts_with(&wal_segment_prefix("ns-1")));
+        assert_eq!(
+            wal_segment_id_from_key(&wal_segment(
+                "ns-1",
+                "00000000000000000042-0123456789abcdef"
+            )),
+            Some("00000000000000000042-0123456789abcdef")
+        );
+        assert_eq!(
+            wal_segment_id_from_key("namespaces/ns-1/wal/random.tmp"),
+            None
         );
         assert_eq!(
             namespace_manifest("ns-1", ManifestId(400)),

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -158,6 +158,23 @@ impl ObjectLayout {
         )))
     }
 
+    /// Listing prefix that contains every WAL segment of `namespace`.
+    ///
+    /// Segment file names start with the segment's 20-digit `start_seq`, so
+    /// a listing under this prefix orders by history position.
+    pub fn wal_segment_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/wal/")
+    }
+
+    /// Extracts the WAL segment id from a listed object key.
+    ///
+    /// Returns `None` for keys that are not current-format WAL segments, so
+    /// listings can skip boundary markers and foreign objects.
+    pub fn wal_segment_id_from_key<'a>(&self, key: &'a str) -> Option<&'a str> {
+        let (_, file_name) = key.rsplit_once('/')?;
+        file_name.strip_suffix(".wal.zst")
+    }
+
     pub fn content_store_descriptor(&self, content_store: &str) -> ContentStoreDescriptorKey {
         ContentStoreDescriptorKey(ObjectKey::new(format!(
             "content-stores/{content_store}/descriptor.json"

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -720,6 +720,12 @@ The server may:
 Each request still has its own success or failure outcome. Tentative
 acceptance inside a batch is not success.
 
+A rejection judged against ephemeral state advanced by a tentative
+acceptance (step 2 in section 3.1.4) is contingent on that state publishing:
+if publication fails, the writer must report the publication failure for it,
+never the semantic rejection. Rejections judged against the durable basis
+alone stand regardless of the publication outcome.
+
 ### 3.2 Read protocol
 
 A read reconstructs the visible filesystem state from durable artifacts on


### PR DESCRIPTION
Derives namespace status from lightweight control and manifest metadata instead of loading full checkpoint materializations. Another meaningful win in the benchmark. 