### PR TITLE
fix(core): fail in-batch-state rejections when the batch never publishes

### DIFF
--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -621,9 +621,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let wal = match wal_result {
         Ok(wal) => wal,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -640,10 +638,8 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {
-            let message = format!("head publish preparation failed: {error:?}");
-            for (index, _) in accepted {
-                outcomes[index] = Some(Err(CoreError::Store(message.clone())));
-            }
+            let error = CoreError::Store(format!("head publish preparation failed: {error:?}"));
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -673,9 +669,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let head_metadata = match head_metadata_result {
         Ok(metadata) => metadata,
         Err(error) => {
-            for (index, _) in &accepted {
-                outcomes[*index] = Some(Err(error.clone().into()));
-            }
+            fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error.into());
             return PublishBatchAgainstBasisResult::not_cacheable(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
             );
@@ -1086,6 +1080,38 @@ fn commit_response_from_commit_receipt(
         commit_id: record.commit_id.clone(),
         committed_seq: record.committed_seq,
         results: record.results.clone(),
+    }
+}
+
+/// Fails every outcome that was contingent on this batch publishing durably.
+///
+/// The accepted candidates take the batch error: they never committed. So do
+/// rejections recorded after the first acceptance, because their verdicts
+/// were decided against session state advanced by tentatively accepted
+/// candidates — state that never became durable. Reporting them would hand a
+/// client a definitive semantic error (path conflict, missing path, stale
+/// revision, ...) it correctly treats as non-retryable, for a precondition
+/// that was never durably true (format.md section 3.1.5).
+///
+/// Rejections recorded before any acceptance were decided against the
+/// durable basis alone and stand. Idempotent `Ok` completions replay durable
+/// commit receipts and stand. Alias slots stay unfilled here and inherit
+/// their primary's final outcome.
+fn fail_outcomes_contingent_on_unpublished_batch(
+    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    accepted: &[(usize, MaterializedCommit)],
+    error: &CoreError,
+) {
+    let Some(first_accepted_index) = accepted.first().map(|(index, _)| *index) else {
+        return;
+    };
+    for (index, _) in accepted {
+        outcomes[*index] = Some(Err(error.clone()));
+    }
+    for outcome in outcomes.iter_mut().skip(first_accepted_index + 1) {
+        if matches!(outcome, Some(Err(_))) {
+            *outcome = Some(Err(error.clone()));
+        }
     }
 }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -2329,6 +2329,187 @@ async fn direct_publisher_retries_after_wal_orphaned_by_stale_head_cas() {
     );
 }
 
+/// A batch where the WAL write fails must report that failure for every
+/// outcome that depended on the batch publishing: the accepted candidate and
+/// the rejection decided against its speculative in-batch state. Before this
+/// contract the speculative rejection surfaced as a definitive `PathConflict`
+/// derived from a create that never became durable, so its client gave up
+/// instead of retrying. Rejections decided against the durable basis alone
+/// stand regardless of the batch outcome.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Prefix("namespaces/demo/wal/".to_owned()),
+        InjectedCreateFailure::Transport {
+            message: "injected wal write failure",
+        },
+    );
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            // Rejected against the durable basis: nothing was accepted yet.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            // Accepted into the batch.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Rejected only because of the accepted candidate's speculative
+            // in-batch create.
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            // Alias of the basis-decided rejection.
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+
+    let basis_rejection = failed[0].as_ref().expect_err("basis-decided rejection");
+    assert_eq!(basis_rejection.code(), ErrorCode::PathNotFound);
+    let accepted = failed[1].as_ref().expect_err("accepted candidate fails");
+    assert!(matches!(accepted, CoreError::WalWrite(_)));
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert!(
+        matches!(speculative, CoreError::WalWrite(_)),
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+    let alias = failed[3].as_ref().expect_err("alias mirrors its primary");
+    assert_eq!(alias.code(), ErrorCode::PathNotFound);
+
+    // Nothing became durable, so the retry the batch error asks for derives
+    // every verdict from durable state.
+    let basis = load_verified_namespace_basis(&store, &namespace_id)
+        .await
+        .expect("load basis");
+    assert_eq!(basis.head.seq, ChangeSeq(0));
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    let committed = retried[1].as_ref().expect("create lands on retry");
+    assert_eq!(committed.committed_seq, ChangeSeq(1));
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+    assert_eq!(
+        retried[3].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+}
+
+/// Same contract when the batch dies at the head CAS instead of the WAL
+/// write: the stale-head error replaces the rejection decided against the
+/// accepted candidate's speculative state, while the basis-decided rejection
+/// stands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    let store = StaleHeadAfterWalWriteStore::new(temp_dir.path(), &namespace_id);
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let content = store_bytes_as_content(&store, &namespace_id, b"batch bytes")
+        .await
+        .expect("stage content");
+
+    let batch = || {
+        vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("reject-basis").expect("valid commit id"),
+                absolute_path: "/missing.txt".to_owned(),
+                recursive: false,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                absolute_path: "/docs/a.txt".to_owned(),
+                content_ref: content.content_ref.clone(),
+                behavior: PutFileBehavior::CreateOnly,
+            }),
+        ]
+    };
+
+    let failed = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert!(store.injected_stale_head());
+
+    assert_eq!(
+        failed[0]
+            .as_ref()
+            .expect_err("basis-decided rejection")
+            .code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        failed[1]
+            .as_ref()
+            .expect_err("accepted candidate fails")
+            .code(),
+        ErrorCode::StaleHead
+    );
+    let speculative = failed[2].as_ref().expect_err("speculative rejection");
+    assert_eq!(
+        speculative.code(),
+        ErrorCode::StaleHead,
+        "rejection decided against unpublished in-batch state must take the \
+         batch error, got {speculative:?}"
+    );
+
+    let retried = publish_namespace_mutations_batch(&store, &namespace_id, batch(), &context);
+    assert_eq!(
+        retried[0].as_ref().expect_err("still missing").code(),
+        ErrorCode::PathNotFound
+    );
+    assert_eq!(
+        retried[1]
+            .as_ref()
+            .expect("create lands on retry")
+            .committed_seq,
+        ChangeSeq(1)
+    );
+    assert_eq!(
+        retried[2]
+            .as_ref()
+            .expect_err("conflict against durably published state")
+            .code(),
+        ErrorCode::PathConflict
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn direct_publisher_retries_after_stale_head_get_during_basis_load() {
     let temp_dir = tempdir().expect("tempdir");

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -720,6 +720,12 @@ The server may:
 Each request still has its own success or failure outcome. Tentative
 acceptance inside a batch is not success.
 
+A rejection judged against ephemeral state advanced by a tentative
+acceptance (step 2 in section 3.1.4) is contingent on that state publishing:
+if publication fails, the writer must report the publication failure for it,
+never the semantic rejection. Rejections judged against the durable basis
+alone stand regardless of the publication outcome.
+
 ### 3.2 Read protocol
 
 A read reconstructs the visible filesystem state from durable artifacts on


### PR DESCRIPTION
When a batch's WAL write or head CAS failed, accepted candidates were rewritten to the batch's retryable error (`WalWrite`, `StaleHead`/`CommitOutcomeUnknown`) but rejections kept their semantic verdicts. A rejection decided after the first acceptance was judged against session state advanced by the accepted candidates — state that never became durable — so its definitive-looking error (`PathConflict`, `DirectoryNotEmpty`, `StaleRevision`, `PathNotFound`, ...) made clients give up on a precondition that was never durably true. With the server publisher coalescing independent clients into one batch, client B could receive a permanent rejection caused entirely by client A's commit that never landed.
