### PR TITLE
fix(server,core): retry unknown head outcomes

### DIFF
--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -1,4 +1,6 @@
-use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
+use crate::commit::{
+    core_commit_fingerprint_for_v0_request, CommitHeadPublishError, SemanticMutationIdentity,
+};
 use crate::context::MutationContext;
 use crate::error::{CoreError, ErrorCode};
 use crate::namespace::basis::{
@@ -213,7 +215,7 @@ impl NamespaceCommitEngine {
             &basis,
         )
         .await;
-        if should_retry_reused_warm_rejection(basis_reuse_event, &published) {
+        if should_retry_reused_warm_stale_head(basis_reuse_event, &published) {
             self.invalidate();
             let cold_basis = match load_verified_namespace_basis(store, &self.namespace_id).await {
                 Ok(value) => value,
@@ -304,16 +306,23 @@ impl NamespaceCommitEngine {
     }
 }
 
-fn should_retry_reused_warm_rejection(
+/// A reused warm basis is only probed for freshness before the publish, so a
+/// racing writer can still advance the head between the probe and our
+/// compare-and-swap. That stale-head loss says nothing about the candidates
+/// themselves; retrying them once against a cold-loaded basis keeps the warm
+/// cache transparent to callers. Rejections decided against an etag-matched
+/// basis are as authoritative as a cold load and stand without a retry.
+fn should_retry_reused_warm_stale_head(
     basis_reuse_event: BasisReuseEvent,
     published: &crate::protocol::PublishBatchAgainstBasisResult,
 ) -> bool {
     basis_reuse_event == BasisReuseEvent::ReusedAfterHeadEtagMatch
-        && matches!(
-            published.basis_promotion,
-            crate::protocol::BasisPromotion::Unchanged(_)
-        )
-        && published.results.iter().any(Result::is_err)
+        && published.results.iter().any(|result| {
+            matches!(
+                result,
+                Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+            )
+        })
 }
 
 fn repeated_error(count: usize, error: CoreError) -> Vec<Result<ApiCommitResponse, CoreError>> {

--- a/crates/loonfs-server/src/publisher.rs
+++ b/crates/loonfs-server/src/publisher.rs
@@ -463,7 +463,7 @@ impl NamespacePublisher {
                     .into_iter()
                     .map(|result| result.map_err(runtime_error_to_core))
                     .collect();
-                if !results.iter().any(is_head_publish_stale) {
+                if !results.iter().any(is_retryable_head_publish) {
                     break;
                 }
                 if attempt + 1 == HEAD_CAS_RETRY_LIMIT {
@@ -722,10 +722,16 @@ impl Drop for PublishAbortGuard {
     }
 }
 
-fn is_head_publish_stale(result: &CommitResult) -> bool {
+/// Retrying with the same commit ids is safe: candidates that actually
+/// committed replay their durable receipts. So an unknown head outcome is
+/// retried like a stale head, resolving it into a definite answer instead of
+/// handing `commit_outcome_unknown` to every waiter.
+fn is_retryable_head_publish(result: &CommitResult) -> bool {
     matches!(
         result,
-        Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+        Err(CoreError::HeadPublish(
+            CommitHeadPublishError::StaleHead | CommitHeadPublishError::OutcomeUnknown(_)
+        ))
     )
 }
 
@@ -811,6 +817,7 @@ mod tests {
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };
     use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Condvar;
     use tempfile::tempdir;
 
@@ -1056,6 +1063,80 @@ mod tests {
                 .expect("head CAS gate task");
             }
             self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            prefix: &str,
+        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    /// Applies head CAS writes but reports a transport failure for the next
+    /// one: the commit lands durably while the acknowledgement is lost.
+    #[derive(Debug)]
+    struct LostHeadCasAckStore {
+        inner: LocalFsStore,
+        head_key: String,
+        lose_next_head_cas_ack: AtomicBool,
+    }
+
+    impl LostHeadCasAckStore {
+        fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+            Self {
+                inner: LocalFsStore::new(root.as_ref()).expect("store"),
+                head_key: namespace_head(namespace_id.as_str()),
+                lose_next_head_cas_ack: AtomicBool::new(false),
+            }
+        }
+
+        fn lose_next_head_cas_ack(&self) {
+            self.lose_next_head_cas_ack.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for LostHeadCasAckStore {
+        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Bytes>, ObjectStoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: Bytes,
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            let lose_ack = key == self.head_key
+                && matches!(mode, PutMode::CompareAndSwap { .. })
+                && self.lose_next_head_cas_ack.swap(false, Ordering::SeqCst);
+            let metadata = self.inner.put(key, bytes, mode).await?;
+            if lose_ack {
+                return Err(ObjectStoreError::Transport(
+                    "injected lost head CAS acknowledgement".to_owned(),
+                ));
+            }
+            Ok(metadata)
         }
 
         async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
@@ -1381,6 +1462,33 @@ mod tests {
                 ChangeSeq(index as u64 + 1)
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publisher_resolves_unknown_head_outcome_by_replaying_receipt() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let store = Arc::new(LostHeadCasAckStore::new(temp_dir.path(), &namespace_id));
+        let shared = store.clone() as SharedStore;
+        let config = test_config(temp_dir.path());
+        let fs = test_fs(shared, &config);
+        create_namespace(&fs, &namespace_id).await;
+        let publisher = NamespacePublisher::new(namespace_id.clone(), fs);
+
+        // The commit lands but the CAS acknowledgement is lost. The publisher
+        // retries with the same commit id and replays the durable receipt
+        // instead of reporting `commit_outcome_unknown` to the waiter.
+        store.lose_next_head_cas_ack();
+        let response = recv_commit(
+            admit_commit(
+                &publisher,
+                &namespace_id,
+                create_dir_request("unknown-ack", "unknown-ack"),
+            ),
+            "unknown-ack",
+        )
+        .await;
+        assert_eq!(response.committed_seq, ChangeSeq(1));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1049,6 +1049,8 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
     ));
 
     raw_store.fail_head_cas();
+    // The warm-reused attempt loses its head CAS, retries once from a cold
+    // basis, and loses again: a persistent stale head is surfaced as such.
     let stale = fs
         .publish_namespace_mutations_batch_blocking(
             &namespace_id,
@@ -1072,10 +1074,100 @@ fn runtime_publish_stale_head_invalidates_warm_basis() {
     );
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.publish_warm_basis_hits, 1);
+    assert_eq!(stats.publish_warm_basis_hits, 0);
+    assert_eq!(stats.publish_warm_basis_misses, 3);
+    assert_eq!(stats.publish_warm_basis_invalidations, 1);
+    assert_eq!(stats.publish_warm_basis_advances, 2);
+}
+
+#[test]
+fn runtime_publish_retries_warm_stale_head_race_from_cold_basis() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("publish-warm-race-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
+        &namespace_id,
+        vec![create_dir_candidate("race-prime", "/docs")],
+    ));
+
+    // A racing writer can advance the head between the warm-reuse etag probe
+    // and our CAS; the engine must absorb that loss with one cold retry
+    // instead of surfacing a stale-head error for a transient cache race.
+    raw_store.fail_next_head_cas();
+    raw_store.reset_wal_get_count();
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
+        &namespace_id,
+        vec![create_dir_candidate("race-child", "/docs/child")],
+    ));
+    assert!(
+        raw_store.wal_get_count() > 0,
+        "stale-head retry should replan from a cold-loaded basis"
+    );
+    fs.stat_path_blocking(&namespace_id, "/docs/child")
+        .expect("retried publish is visible");
+
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_hits, 0);
     assert_eq!(stats.publish_warm_basis_misses, 2);
     assert_eq!(stats.publish_warm_basis_invalidations, 1);
     assert_eq!(stats.publish_warm_basis_advances, 2);
+}
+
+#[test]
+fn runtime_publish_warm_rejection_stands_without_cold_retry() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace();
+    let raw_store = Arc::new(HeadCasFailureStore::new(
+        temp_dir.path(),
+        namespace_id.as_str(),
+    ));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("publish-warm-reject-test")
+        .build()
+        .expect("build runtime");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    assert_single_publish_ok(fs.publish_namespace_mutations_batch_blocking(
+        &namespace_id,
+        vec![create_dir_candidate("reject-prime", "/docs")],
+    ));
+
+    // A rejection decided against an etag-matched warm basis is as
+    // authoritative as a cold load: it must not trigger a cold replay.
+    raw_store.reset_wal_get_count();
+    let rejected = fs
+        .publish_namespace_mutations_batch_blocking(
+            &namespace_id,
+            vec![delete_candidate("reject-missing", "/missing")],
+        )
+        .into_iter()
+        .next()
+        .expect("one result");
+    assert_core_error_kind(rejected, ErrorCode::PathNotFound);
+    assert_eq!(
+        raw_store.wal_get_count(),
+        0,
+        "legitimate warm rejection should not cold-load the WAL"
+    );
+
+    let stats = fs.runtime_cache_stats();
+    assert_eq!(stats.publish_warm_basis_hits, 1);
+    assert_eq!(stats.publish_warm_basis_misses, 1);
+    assert_eq!(stats.publish_warm_basis_invalidations, 0);
+    assert_eq!(stats.publish_warm_basis_advances, 1);
 }
 
 #[test]
@@ -2216,6 +2308,7 @@ struct HeadCasFailureStore {
     wal_prefix: String,
     manifest_prefix: String,
     fail_head_cas: AtomicBool,
+    fail_next_head_cas: AtomicBool,
     wal_get_count: AtomicUsize,
     manifest_get_count: AtomicUsize,
     head_get_count: AtomicUsize,
@@ -2229,6 +2322,7 @@ impl HeadCasFailureStore {
             wal_prefix: format!("namespaces/{namespace}/wal/"),
             manifest_prefix: format!("namespaces/{namespace}/manifest/"),
             fail_head_cas: AtomicBool::new(false),
+            fail_next_head_cas: AtomicBool::new(false),
             wal_get_count: AtomicUsize::new(0),
             manifest_get_count: AtomicUsize::new(0),
             head_get_count: AtomicUsize::new(0),
@@ -2241,6 +2335,10 @@ impl HeadCasFailureStore {
 
     fn allow_head_cas(&self) {
         self.fail_head_cas.store(false, Ordering::SeqCst);
+    }
+
+    fn fail_next_head_cas(&self) {
+        self.fail_next_head_cas.store(true, Ordering::SeqCst);
     }
 
     fn reset_wal_get_count(&self) {
@@ -2310,7 +2408,8 @@ impl ObjectStore for HeadCasFailureStore {
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         if key == self.head_key
             && matches!(&mode, PutMode::CompareAndSwap { .. })
-            && self.fail_head_cas.load(Ordering::SeqCst)
+            && (self.fail_head_cas.load(Ordering::SeqCst)
+                || self.fail_next_head_cas.swap(false, Ordering::SeqCst))
         {
             return Err(ObjectStoreError::PreconditionFailed);
         }


### PR DESCRIPTION
Retries unknown head-publish outcomes through the batch publisher and re-aims warm-basis retry state.