### PR TITLE
feat(api): add pagination policy and cursor primitives

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -49,6 +49,7 @@ pub enum ErrorCode {
     InvalidUploadId,
     InvalidInodeId,
     InvalidRevisionNo,
+    InvalidCursor,
     InvalidConfig,
     Unauthorized,
     PermissionDenied,
@@ -83,13 +84,14 @@ pub enum ErrorCode {
 
 impl ErrorCode {
     /// Every registered code, in registry order.
-    pub const ALL: [ErrorCode; 36] = [
+    pub const ALL: [ErrorCode; 37] = [
         ErrorCode::InvalidPath,
         ErrorCode::InvalidNamespaceId,
         ErrorCode::InvalidCommitId,
         ErrorCode::InvalidUploadId,
         ErrorCode::InvalidInodeId,
         ErrorCode::InvalidRevisionNo,
+        ErrorCode::InvalidCursor,
         ErrorCode::InvalidConfig,
         ErrorCode::Unauthorized,
         ErrorCode::PermissionDenied,
@@ -130,6 +132,7 @@ impl ErrorCode {
             | ErrorCode::InvalidUploadId
             | ErrorCode::InvalidInodeId
             | ErrorCode::InvalidRevisionNo
+            | ErrorCode::InvalidCursor
             | ErrorCode::InvalidConfig
             | ErrorCode::UnsupportedRenameMode
             | ErrorCode::InvalidUploadContent => ErrorKind::InvalidRequest,
@@ -169,6 +172,7 @@ impl ErrorCode {
             ErrorCode::InvalidUploadId => "invalid_upload_id",
             ErrorCode::InvalidInodeId => "invalid_inode_id",
             ErrorCode::InvalidRevisionNo => "invalid_revision_no",
+            ErrorCode::InvalidCursor => "invalid_cursor",
             ErrorCode::InvalidConfig => "invalid_config",
             ErrorCode::Unauthorized => "unauthorized",
             ErrorCode::PermissionDenied => "permission_denied",

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -53,8 +53,11 @@ pub struct NamespaceSummary {
 /// Response for namespace listing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListNamespacesResponse {
-    /// Complete namespaces visible to the store.
+    /// Complete namespaces visible to the store for this page.
     pub namespaces: Vec<NamespaceSummary>,
+    /// Cursor for the next page, if more namespaces remain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Status summary for one namespace.

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -17,6 +17,7 @@ mod http;
 mod ids;
 mod manifest;
 mod name_policy;
+mod pagination;
 mod path;
 mod server;
 pub mod v0;
@@ -60,6 +61,13 @@ pub use ids::{
     NameKeyValidationError, NamespaceId, NamespaceIdValidationError, RevisionNo,
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
+pub use pagination::{
+    decode_directory_cursor, decode_namespaces_cursor, encode_directory_cursor,
+    encode_namespaces_cursor, DirectoryPageCursor, EffectiveLimit, LimitError,
+    NamespacesPageCursor, Page, PageCursorError, PageRequest, PaginationPolicy,
+    PaginationPolicyError, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT,
+    LIMIT_PAGINATION_MAX, PAGE_CURSOR_VERSION,
+};
 pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
 pub use server::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -70,9 +70,8 @@ impl PaginationPolicy {
 
     /// Creates a policy from raw integers.
     pub fn from_values(default_limit: u32, max_limit: u32) -> Result<Self, PaginationPolicyError> {
-        let default_limit = NonZeroU32::new(default_limit).ok_or(
-            PaginationPolicyError::ZeroDefaultLimit,
-        )?;
+        let default_limit =
+            NonZeroU32::new(default_limit).ok_or(PaginationPolicyError::ZeroDefaultLimit)?;
         let max_limit = NonZeroU32::new(max_limit).ok_or(PaginationPolicyError::ZeroMaxLimit)?;
         Self::new(default_limit, max_limit)
     }

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -1,0 +1,493 @@
+use crate::{ChangeSeq, InodeId, NameKey, NamespaceId};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::num::NonZeroU32;
+use thiserror::Error;
+
+/// Advisory capability key for the default page size applied when callers omit `limit`.
+pub const LIMIT_PAGINATION_DEFAULT: &str = "pagination.default_limit";
+/// Advisory capability key for the largest page size accepted by a deployment.
+pub const LIMIT_PAGINATION_MAX: &str = "pagination.max_limit";
+
+/// Default page size for endpoints that can return unbounded result sets.
+pub const DEFAULT_PAGE_LIMIT: u32 = 1_000;
+/// Default maximum accepted page size.
+pub const DEFAULT_MAX_PAGE_LIMIT: u32 = 1_000;
+
+/// Wire cursor format version.
+pub const PAGE_CURSOR_VERSION: u8 = 1;
+
+/// A validated page size selected from a caller request and a policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EffectiveLimit(NonZeroU32);
+
+impl EffectiveLimit {
+    /// Creates an effective limit from a non-zero value.
+    pub fn new(value: NonZeroU32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric page size.
+    pub fn get(self) -> u32 {
+        self.0.get()
+    }
+
+    /// Returns the page size as a `usize` for vector reservations and counters.
+    pub fn as_usize(self) -> usize {
+        self.0.get() as usize
+    }
+
+    /// Returns the number of items an engine should try to read to detect a next page.
+    pub fn limit_plus_one(self) -> usize {
+        self.as_usize().saturating_add(1)
+    }
+}
+
+/// Deployment or namespace policy for paginated endpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaginationPolicy {
+    default_limit: NonZeroU32,
+    max_limit: NonZeroU32,
+}
+
+impl PaginationPolicy {
+    /// Creates a policy, requiring the default to be no larger than the max.
+    pub fn new(
+        default_limit: NonZeroU32,
+        max_limit: NonZeroU32,
+    ) -> Result<Self, PaginationPolicyError> {
+        if default_limit > max_limit {
+            return Err(PaginationPolicyError::DefaultExceedsMax {
+                default_limit: default_limit.get(),
+                max_limit: max_limit.get(),
+            });
+        }
+        Ok(Self {
+            default_limit,
+            max_limit,
+        })
+    }
+
+    /// Creates a policy from raw integers.
+    pub fn from_values(default_limit: u32, max_limit: u32) -> Result<Self, PaginationPolicyError> {
+        let default_limit = NonZeroU32::new(default_limit).ok_or(
+            PaginationPolicyError::ZeroDefaultLimit,
+        )?;
+        let max_limit = NonZeroU32::new(max_limit).ok_or(PaginationPolicyError::ZeroMaxLimit)?;
+        Self::new(default_limit, max_limit)
+    }
+
+    /// Returns the page size applied when callers omit `limit`.
+    pub fn default_limit(self) -> NonZeroU32 {
+        self.default_limit
+    }
+
+    /// Returns the largest accepted caller-supplied `limit`.
+    pub fn max_limit(self) -> NonZeroU32 {
+        self.max_limit
+    }
+
+    /// Resolves a caller-supplied limit into the enforced page size.
+    pub fn resolve_limit(self, requested: Option<u32>) -> Result<EffectiveLimit, LimitError> {
+        match requested {
+            None => Ok(EffectiveLimit(self.default_limit)),
+            Some(0) => Err(LimitError::Zero),
+            Some(value) if value > self.max_limit.get() => Err(LimitError::ExceedsMax {
+                requested: value,
+                max_limit: self.max_limit.get(),
+            }),
+            Some(value) => NonZeroU32::new(value)
+                .map(EffectiveLimit)
+                .ok_or(LimitError::Zero),
+        }
+    }
+
+    /// Returns the advisory capability-document limits for this policy.
+    pub fn capability_limits(self) -> BTreeMap<String, u64> {
+        BTreeMap::from([
+            (
+                LIMIT_PAGINATION_DEFAULT.to_owned(),
+                u64::from(self.default_limit.get()),
+            ),
+            (
+                LIMIT_PAGINATION_MAX.to_owned(),
+                u64::from(self.max_limit.get()),
+            ),
+        ])
+    }
+}
+
+impl Default for PaginationPolicy {
+    fn default() -> Self {
+        let default_limit = hard_coded_nonzero(DEFAULT_PAGE_LIMIT);
+        let max_limit = hard_coded_nonzero(DEFAULT_MAX_PAGE_LIMIT);
+        Self {
+            default_limit,
+            max_limit,
+        }
+    }
+}
+
+/// Invalid pagination policy configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PaginationPolicyError {
+    /// The configured default limit was zero.
+    #[error("pagination default limit must be greater than zero")]
+    ZeroDefaultLimit,
+    /// The configured max limit was zero.
+    #[error("pagination max limit must be greater than zero")]
+    ZeroMaxLimit,
+    /// The configured default limit exceeded the configured max.
+    #[error("pagination default limit `{default_limit}` exceeds max limit `{max_limit}`")]
+    DefaultExceedsMax { default_limit: u32, max_limit: u32 },
+}
+
+/// Invalid caller-supplied page size.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LimitError {
+    /// The caller supplied `limit=0`.
+    #[error("limit must be greater than zero")]
+    Zero,
+    /// The caller supplied a limit larger than the active policy allows.
+    #[error("limit `{requested}` exceeds max limit `{max_limit}`")]
+    ExceedsMax { requested: u32, max_limit: u32 },
+}
+
+/// Request envelope for engine-level page methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageRequest<C> {
+    /// Enforced page size.
+    pub limit: EffectiveLimit,
+    /// Optional decoded endpoint cursor.
+    pub cursor: Option<C>,
+}
+
+/// Result envelope for engine-level page methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Page<T, C> {
+    /// Returned items.
+    pub items: Vec<T>,
+    /// Cursor for the next page, if another page is available.
+    pub next_cursor: Option<C>,
+}
+
+/// Cursor for namespace listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespacesPageCursor {
+    /// Last namespace id returned to the client.
+    pub last_namespace_id: NamespaceId,
+}
+
+/// Cursor for one directory listing snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectoryPageCursor {
+    /// Namespace being listed.
+    pub namespace_id: NamespaceId,
+    /// Canonical absolute path of the listed directory.
+    pub absolute_path: String,
+    /// Directory inode resolved at `head_seq`.
+    pub dir_inode_id: InodeId,
+    /// Snapshot sequence captured by the first page.
+    pub head_seq: ChangeSeq,
+    /// Last name key returned to the client.
+    pub last_name_key: NameKey,
+    /// Last child inode id returned to the client.
+    pub last_child_inode_id: InodeId,
+    /// Bind sequence for the last returned direntry.
+    pub last_bind_seq: ChangeSeq,
+    /// Bind delta index for the last returned direntry.
+    pub last_bind_delta_index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum EncodedPageCursor {
+    Namespaces {
+        v: u8,
+        last_namespace_id: NamespaceId,
+    },
+    Directory {
+        v: u8,
+        namespace_id: NamespaceId,
+        absolute_path: String,
+        dir_inode_id: InodeId,
+        head_seq: ChangeSeq,
+        last_name_key: NameKey,
+        last_child_inode_id: InodeId,
+        last_bind_seq: ChangeSeq,
+        last_bind_delta_index: u32,
+    },
+}
+
+impl EncodedPageCursor {
+    fn version(&self) -> u8 {
+        match self {
+            Self::Namespaces { v, .. } | Self::Directory { v, .. } => *v,
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Namespaces { .. } => "namespaces",
+            Self::Directory { .. } => "directory",
+        }
+    }
+
+    fn validate_version(&self) -> Result<(), PageCursorError> {
+        let actual = self.version();
+        if actual == PAGE_CURSOR_VERSION {
+            Ok(())
+        } else {
+            Err(PageCursorError::UnsupportedVersion {
+                expected: PAGE_CURSOR_VERSION,
+                actual,
+            })
+        }
+    }
+}
+
+/// Encodes a namespace-list cursor as an opaque string for clients.
+pub fn encode_namespaces_cursor(cursor: &NamespacesPageCursor) -> Result<String, PageCursorError> {
+    encode_cursor(&EncodedPageCursor::Namespaces {
+        v: PAGE_CURSOR_VERSION,
+        last_namespace_id: cursor.last_namespace_id.clone(),
+    })
+}
+
+/// Decodes a namespace-list cursor returned by [`encode_namespaces_cursor`].
+pub fn decode_namespaces_cursor(value: &str) -> Result<NamespacesPageCursor, PageCursorError> {
+    match decode_cursor(value)? {
+        EncodedPageCursor::Namespaces {
+            last_namespace_id, ..
+        } => Ok(NamespacesPageCursor { last_namespace_id }),
+        other => Err(PageCursorError::WrongKind {
+            expected: "namespaces",
+            actual: other.kind(),
+        }),
+    }
+}
+
+/// Encodes a directory-list cursor as an opaque string for clients.
+pub fn encode_directory_cursor(cursor: &DirectoryPageCursor) -> Result<String, PageCursorError> {
+    encode_cursor(&EncodedPageCursor::Directory {
+        v: PAGE_CURSOR_VERSION,
+        namespace_id: cursor.namespace_id.clone(),
+        absolute_path: cursor.absolute_path.clone(),
+        dir_inode_id: cursor.dir_inode_id,
+        head_seq: cursor.head_seq,
+        last_name_key: cursor.last_name_key.clone(),
+        last_child_inode_id: cursor.last_child_inode_id,
+        last_bind_seq: cursor.last_bind_seq,
+        last_bind_delta_index: cursor.last_bind_delta_index,
+    })
+}
+
+/// Decodes a directory-list cursor returned by [`encode_directory_cursor`].
+pub fn decode_directory_cursor(value: &str) -> Result<DirectoryPageCursor, PageCursorError> {
+    match decode_cursor(value)? {
+        EncodedPageCursor::Directory {
+            namespace_id,
+            absolute_path,
+            dir_inode_id,
+            head_seq,
+            last_name_key,
+            last_child_inode_id,
+            last_bind_seq,
+            last_bind_delta_index,
+            ..
+        } => Ok(DirectoryPageCursor {
+            namespace_id,
+            absolute_path,
+            dir_inode_id,
+            head_seq,
+            last_name_key,
+            last_child_inode_id,
+            last_bind_seq,
+            last_bind_delta_index,
+        }),
+        other => Err(PageCursorError::WrongKind {
+            expected: "directory",
+            actual: other.kind(),
+        }),
+    }
+}
+
+fn encode_cursor(cursor: &EncodedPageCursor) -> Result<String, PageCursorError> {
+    let bytes = serde_json::to_vec(cursor)
+        .map_err(|error| PageCursorError::InvalidJson(error.to_string()))?;
+    Ok(hex_encode(&bytes))
+}
+
+fn decode_cursor(value: &str) -> Result<EncodedPageCursor, PageCursorError> {
+    let bytes = hex_decode(value)?;
+    let cursor: EncodedPageCursor = serde_json::from_slice(&bytes)
+        .map_err(|error| PageCursorError::InvalidJson(error.to_string()))?;
+    cursor.validate_version()?;
+    Ok(cursor)
+}
+
+/// Invalid opaque page cursor.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PageCursorError {
+    /// The cursor was not hex-encoded JSON.
+    #[error("invalid page cursor encoding")]
+    InvalidEncoding,
+    /// The cursor JSON did not match a supported cursor shape.
+    #[error("invalid page cursor JSON: {0}")]
+    InvalidJson(String),
+    /// The cursor format version is not supported by this build.
+    #[error("unsupported page cursor version `{actual}`; expected `{expected}`")]
+    UnsupportedVersion { expected: u8, actual: u8 },
+    /// The cursor was well-formed but belongs to another endpoint.
+    #[error("page cursor is for `{actual}` but `{expected}` was required")]
+    WrongKind {
+        expected: &'static str,
+        actual: &'static str,
+    },
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>, PageCursorError> {
+    if value.len() % 2 != 0 {
+        return Err(PageCursorError::InvalidEncoding);
+    }
+    let mut decoded = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().chunks_exact(2) {
+        let high = hex_value(pair[0])?;
+        let low = hex_value(pair[1])?;
+        decoded.push((high << 4) | low);
+    }
+    Ok(decoded)
+}
+
+fn hex_value(byte: u8) -> Result<u8, PageCursorError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        _ => Err(PageCursorError::InvalidEncoding),
+    }
+}
+
+fn hard_coded_nonzero(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => unreachable!("hard-coded pagination limits must be non-zero"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_resolves_omitted_limit_to_default() {
+        let policy = PaginationPolicy::default();
+        let limit = policy.resolve_limit(None).expect("default limit");
+
+        assert_eq!(limit.get(), DEFAULT_PAGE_LIMIT);
+        assert_eq!(limit.limit_plus_one(), 1_001);
+    }
+
+    #[test]
+    fn policy_rejects_invalid_limits() {
+        let policy = PaginationPolicy::default();
+
+        assert_eq!(policy.resolve_limit(Some(0)), Err(LimitError::Zero));
+        assert_eq!(
+            policy.resolve_limit(Some(DEFAULT_MAX_PAGE_LIMIT + 1)),
+            Err(LimitError::ExceedsMax {
+                requested: DEFAULT_MAX_PAGE_LIMIT + 1,
+                max_limit: DEFAULT_MAX_PAGE_LIMIT,
+            })
+        );
+    }
+
+    #[test]
+    fn policy_rejects_default_above_max() {
+        assert_eq!(
+            PaginationPolicy::from_values(10, 5),
+            Err(PaginationPolicyError::DefaultExceedsMax {
+                default_limit: 10,
+                max_limit: 5,
+            })
+        );
+    }
+
+    #[test]
+    fn policy_exports_capability_limits() {
+        let limits = PaginationPolicy::default().capability_limits();
+
+        assert_eq!(
+            limits.get(LIMIT_PAGINATION_DEFAULT),
+            Some(&u64::from(DEFAULT_PAGE_LIMIT))
+        );
+        assert_eq!(
+            limits.get(LIMIT_PAGINATION_MAX),
+            Some(&u64::from(DEFAULT_MAX_PAGE_LIMIT))
+        );
+    }
+
+    #[test]
+    fn namespace_cursor_round_trips() {
+        let cursor = NamespacesPageCursor {
+            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+        };
+
+        let encoded = encode_namespaces_cursor(&cursor).expect("encode cursor");
+        let decoded = decode_namespaces_cursor(&encoded).expect("decode cursor");
+
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn directory_cursor_round_trips() {
+        let cursor = DirectoryPageCursor {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: "/docs".to_owned(),
+            dir_inode_id: InodeId(7),
+            head_seq: ChangeSeq(11),
+            last_name_key: NameKey::parse("plan.md").expect("name key"),
+            last_child_inode_id: InodeId(9),
+            last_bind_seq: ChangeSeq(10),
+            last_bind_delta_index: 2,
+        };
+
+        let encoded = encode_directory_cursor(&cursor).expect("encode cursor");
+        let decoded = decode_directory_cursor(&encoded).expect("decode cursor");
+
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn cursor_kind_must_match_decoder() {
+        let cursor = NamespacesPageCursor {
+            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+        };
+        let encoded = encode_namespaces_cursor(&cursor).expect("encode cursor");
+
+        assert_eq!(
+            decode_directory_cursor(&encoded),
+            Err(PageCursorError::WrongKind {
+                expected: "directory",
+                actual: "namespaces",
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_cursor_is_invalid_encoding() {
+        assert_eq!(
+            decode_namespaces_cursor("not-hex"),
+            Err(PageCursorError::InvalidEncoding)
+        );
+    }
+}

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -152,7 +152,10 @@ pub enum LimitError {
     ExceedsMax { requested: u32, max_limit: u32 },
 }
 
-/// Request envelope for engine-level page methods.
+/// Typed request envelope for internal runtime/core page methods.
+///
+/// This is not a direct wire response type. HTTP handlers parse public query
+/// fields into this shape after validating `limit` and decoding `cursor`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PageRequest<C> {
     /// Enforced page size.
@@ -161,7 +164,10 @@ pub struct PageRequest<C> {
     pub cursor: Option<C>,
 }
 
-/// Result envelope for engine-level page methods.
+/// Typed result envelope for internal runtime/core page methods.
+///
+/// This is not a direct wire response type. HTTP handlers encode
+/// `next_cursor` into the public response envelope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Page<T, C> {
     /// Returned items.
@@ -178,24 +184,22 @@ pub struct NamespacesPageCursor {
 }
 
 /// Cursor for one directory listing snapshot.
+///
+/// Directory pagination advances in canonical `name_key` order.
+///
+/// The cursor intentionally contains only the snapshot (`head_seq`), listed
+/// directory identity (`dir_inode_id`), and resume position (`last_name_key`).
+/// HTTP clients must pass the URL namespace and `path` on every page.
+/// Runtime/server code resolves that path at `head_seq` and rejects the cursor
+/// unless it names `dir_inode_id`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectoryPageCursor {
-    /// Namespace being listed.
-    pub namespace_id: NamespaceId,
-    /// Canonical absolute path of the listed directory.
-    pub absolute_path: String,
-    /// Directory inode resolved at `head_seq`.
-    pub dir_inode_id: InodeId,
     /// Snapshot sequence captured by the first page.
     pub head_seq: ChangeSeq,
-    /// Last name key returned to the client.
+    /// Directory inode resolved at `head_seq`.
+    pub dir_inode_id: InodeId,
+    /// Last canonical name key returned to the client.
     pub last_name_key: NameKey,
-    /// Last child inode id returned to the client.
-    pub last_child_inode_id: InodeId,
-    /// Bind sequence for the last returned direntry.
-    pub last_bind_seq: ChangeSeq,
-    /// Bind delta index for the last returned direntry.
-    pub last_bind_delta_index: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -207,14 +211,9 @@ enum EncodedPageCursor {
     },
     Directory {
         v: u8,
-        namespace_id: NamespaceId,
-        absolute_path: String,
-        dir_inode_id: InodeId,
         head_seq: ChangeSeq,
+        dir_inode_id: InodeId,
         last_name_key: NameKey,
-        last_child_inode_id: InodeId,
-        last_bind_seq: ChangeSeq,
-        last_bind_delta_index: u32,
     },
 }
 
@@ -270,14 +269,9 @@ pub fn decode_namespaces_cursor(value: &str) -> Result<NamespacesPageCursor, Pag
 pub fn encode_directory_cursor(cursor: &DirectoryPageCursor) -> Result<String, PageCursorError> {
     encode_cursor(&EncodedPageCursor::Directory {
         v: PAGE_CURSOR_VERSION,
-        namespace_id: cursor.namespace_id.clone(),
-        absolute_path: cursor.absolute_path.clone(),
-        dir_inode_id: cursor.dir_inode_id,
         head_seq: cursor.head_seq,
+        dir_inode_id: cursor.dir_inode_id,
         last_name_key: cursor.last_name_key.clone(),
-        last_child_inode_id: cursor.last_child_inode_id,
-        last_bind_seq: cursor.last_bind_seq,
-        last_bind_delta_index: cursor.last_bind_delta_index,
     })
 }
 
@@ -285,24 +279,14 @@ pub fn encode_directory_cursor(cursor: &DirectoryPageCursor) -> Result<String, P
 pub fn decode_directory_cursor(value: &str) -> Result<DirectoryPageCursor, PageCursorError> {
     match decode_cursor(value)? {
         EncodedPageCursor::Directory {
-            namespace_id,
-            absolute_path,
-            dir_inode_id,
             head_seq,
+            dir_inode_id,
             last_name_key,
-            last_child_inode_id,
-            last_bind_seq,
-            last_bind_delta_index,
             ..
         } => Ok(DirectoryPageCursor {
-            namespace_id,
-            absolute_path,
-            dir_inode_id,
             head_seq,
+            dir_inode_id,
             last_name_key,
-            last_child_inode_id,
-            last_bind_seq,
-            last_bind_delta_index,
         }),
         other => Err(PageCursorError::WrongKind {
             expected: "directory",
@@ -450,14 +434,9 @@ mod tests {
     #[test]
     fn directory_cursor_round_trips() {
         let cursor = DirectoryPageCursor {
-            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: "/docs".to_owned(),
-            dir_inode_id: InodeId(7),
             head_seq: ChangeSeq(11),
+            dir_inode_id: InodeId(7),
             last_name_key: NameKey::parse("plan.md").expect("name key"),
-            last_child_inode_id: InodeId(9),
-            last_bind_seq: ChangeSeq(10),
-            last_bind_delta_index: 2,
         };
 
         let encoded = encode_directory_cursor(&cursor).expect("encode cursor");
@@ -487,6 +466,23 @@ mod tests {
         assert_eq!(
             decode_namespaces_cursor("not-hex"),
             Err(PageCursorError::InvalidEncoding)
+        );
+    }
+
+    #[test]
+    fn unsupported_cursor_version_is_rejected() {
+        let encoded = encode_cursor(&EncodedPageCursor::Namespaces {
+            v: PAGE_CURSOR_VERSION + 1,
+            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+        })
+        .expect("encode cursor");
+
+        assert_eq!(
+            decode_namespaces_cursor(&encoded),
+            Err(PageCursorError::UnsupportedVersion {
+                expected: PAGE_CURSOR_VERSION,
+                actual: PAGE_CURSOR_VERSION + 1,
+            })
         );
     }
 }

--- a/crates/loonfs-api/src/server.rs
+++ b/crates/loonfs-api/src/server.rs
@@ -33,7 +33,7 @@ pub struct AuthoritativePathEntry {
 ///
 /// The envelope names the listing target and head so an empty directory
 /// still tells the caller which state it observed, and so the response can
-/// grow (for example, pagination cursors) without reshaping `entries`.
+/// grow without reshaping `entries`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListPathEntriesResponse {
     /// Namespace that was read.
@@ -42,8 +42,14 @@ pub struct ListPathEntriesResponse {
     pub absolute_path: String,
     /// Namespace head sequence this listing was read from.
     pub head_seq: ChangeSeq,
-    /// Directory entries in display-name order.
+    /// Directory entries for this page.
+    ///
+    /// Paged APIs return entries in canonical name-key order. Higher-level
+    /// full-list convenience methods may sort drained results for display.
     pub entries: Vec<AuthoritativePathEntry>,
+    /// Cursor for the next page, if more entries remain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// File bytes plus the metadata entry they came from.

--- a/crates/loonfs-api/src/server.rs
+++ b/crates/loonfs-api/src/server.rs
@@ -44,8 +44,8 @@ pub struct ListPathEntriesResponse {
     pub head_seq: ChangeSeq,
     /// Directory entries for this page.
     ///
-    /// Paged APIs return entries in canonical name-key order. Higher-level
-    /// full-list convenience methods may sort drained results for display.
+    /// Entries are returned in canonical name-key order. Higher-level display
+    /// surfaces may sort entries separately for presentation.
     pub entries: Vec<AuthoritativePathEntry>,
     /// Cursor for the next page, if more entries remain.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loonfs-api/src/v0.rs
+++ b/crates/loonfs-api/src/v0.rs
@@ -326,6 +326,8 @@ pub struct ChangesResponse {
     pub namespace_id: NamespaceId,
     pub after_seq: ChangeSeq,
     pub through_seq: ChangeSeq,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_after_seq: Option<ChangeSeq>,
     pub changes: Vec<CommittedChange>,
 }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -488,11 +488,23 @@ impl Client {
         namespace: &str,
         after_seq: ChangeSeq,
     ) -> Result<ChangesResponse, ClientError> {
+        self.list_changes_page(namespace, after_seq, None)
+    }
+
+    pub fn list_changes_page(
+        &self,
+        namespace: &str,
+        after_seq: ChangeSeq,
+        limit: Option<u32>,
+    ) -> Result<ChangesResponse, ClientError> {
         let namespace = namespace_url_segment(namespace)?;
-        let url = format!(
+        let mut url = format!(
             "{}/v0/namespaces/{namespace}/changes?after_seq={}",
             self.base_url, after_seq.0
         );
+        if let Some(limit) = limit {
+            url.push_str(&format!("&limit={limit}"));
+        }
         self.request_json::<(), ChangesResponse>(self.agent.get(&url), None)
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -184,10 +184,26 @@ impl Client {
     }
 
     pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, ClientError> {
-        let url = format!("{}/v0/namespaces", self.base_url);
-        Ok(self
-            .request_json::<(), ListNamespacesResponse>(self.agent.get(&url), None)?
-            .namespaces)
+        let mut namespaces = Vec::new();
+        let mut cursor = None;
+        loop {
+            let page = self.list_namespaces_page(None, cursor.as_deref())?;
+            namespaces.extend(page.namespaces);
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                return Ok(namespaces);
+            }
+        }
+    }
+
+    pub fn list_namespaces_page(
+        &self,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListNamespacesResponse, ClientError> {
+        let mut url = format!("{}/v0/namespaces", self.base_url);
+        append_optional_pagination_query(&mut url, false, limit, cursor);
+        self.request_json::<(), ListNamespacesResponse>(self.agent.get(&url), None)
     }
 
     pub fn namespace_status(
@@ -235,13 +251,46 @@ impl Client {
     }
 
     pub fn list_path(&self, spec: &NamespacePath) -> Result<ListPathEntriesResponse, ClientError> {
+        let mut entries = Vec::new();
+        let mut envelope = None;
+        let mut cursor = None;
+        loop {
+            let page = self.list_path_page(spec, None, cursor.as_deref())?;
+            let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
+                namespace_id: page.namespace_id.clone(),
+                absolute_path: page.absolute_path.clone(),
+                head_seq: page.head_seq,
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+            entries.extend(page.entries);
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                entries.sort_by(|left, right| {
+                    left.display_name
+                        .cmp(&right.display_name)
+                        .then(left.inode_id.0.cmp(&right.inode_id.0))
+                });
+                envelope_ref.entries = entries;
+                return Ok(envelope.expect("first page initializes response envelope"));
+            }
+        }
+    }
+
+    pub fn list_path_page(
+        &self,
+        spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListPathEntriesResponse, ClientError> {
         let namespace = namespace_url_segment(&spec.namespace)?;
-        let url = format!(
+        let mut url = format!(
             "{}/v0/namespaces/{}/filesystem/list?path={}",
             self.base_url,
             namespace,
             urlencoding::encode(&spec.absolute_path)
         );
+        append_optional_pagination_query(&mut url, true, limit, cursor);
         self.request_json::<(), ListPathEntriesResponse>(self.agent.get(&url), None)
     }
 
@@ -896,6 +945,29 @@ fn namespace_url_segment(namespace: &str) -> Result<&str, ClientError> {
 
 fn invalid_namespace_id_error(error: loonfs_api::NamespaceIdValidationError) -> ClientError {
     ClientError::InvalidNamespacePath(error.to_string())
+}
+
+fn append_optional_pagination_query(
+    url: &mut String,
+    has_query: bool,
+    limit: Option<u32>,
+    cursor: Option<&str>,
+) {
+    let mut has_query = has_query;
+    if let Some(limit) = limit {
+        append_query_param(url, &mut has_query, "limit", &limit.to_string());
+    }
+    if let Some(cursor) = cursor {
+        append_query_param(url, &mut has_query, "cursor", cursor);
+    }
+}
+
+fn append_query_param(url: &mut String, has_query: &mut bool, name: &str, value: &str) {
+    url.push(if *has_query { '&' } else { '?' });
+    *has_query = true;
+    url.push_str(name);
+    url.push('=');
+    url.push_str(&urlencoding::encode(value));
 }
 
 fn parse_commit_id(commit_id: &str) -> Result<CommitId, ClientError> {

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -13,8 +13,9 @@ use loonfs_api::v0::{
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
-    ContentRef, CreateCheckpointResponse, InodeId, ListFileRevisionsResponse, MutationResult,
-    NamespaceId, NamespaceSummary, RevisionNo,
+    ContentRef, CreateCheckpointResponse, DirectoryPageCursor, InodeId, ListFileRevisionsResponse,
+    MutationResult, NamespaceId, NamespaceSummary, NamespacesPageCursor, Page, PageRequest,
+    RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -166,6 +167,14 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         catalog::list_namespaces(&self.store).await
     }
 
+    /// Lists one page of complete namespaces visible in the object store.
+    pub async fn list_namespaces_page(
+        &self,
+        request: PageRequest<NamespacesPageCursor>,
+    ) -> CoreResult<Page<NamespaceSummary, NamespacesPageCursor>> {
+        catalog::list_namespaces_page(&self.store, request).await
+    }
+
     /// Resolves one absolute path to the authoritative entry at the current head.
     pub async fn resolve_path(
         &self,
@@ -242,6 +251,48 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         }
         let basis = self.basis_for_read_options(options).await?;
         crate::path::query::list_path_from_basis(&basis, path)
+    }
+
+    /// Lists one page of children for a directory path.
+    pub async fn list_path_page(
+        &self,
+        path: impl AsRef<str>,
+        options: ReadOptions,
+        request: PageRequest<DirectoryPageCursor>,
+    ) -> CoreResult<Page<AuthoritativePathEntry, DirectoryPageCursor>> {
+        let path = path.as_ref();
+        match options.source() {
+            ReadSource::PreferMaterialized => {
+                if let Some(entries) = crate::path::query::list_path_page_from_materialized_tables(
+                    &self.store,
+                    &self.namespace_id,
+                    path,
+                    request.clone(),
+                )
+                .await?
+                {
+                    return Ok(entries);
+                }
+            }
+            ReadSource::MaterializedTablesAtHead { head, table_cache } => {
+                if let Some(entries) =
+                    crate::path::query::list_path_page_from_materialized_tables_at_head_with_cache(
+                        &self.store,
+                        &self.namespace_id,
+                        head,
+                        path,
+                        table_cache.as_deref(),
+                        request.clone(),
+                    )
+                    .await?
+                {
+                    return Ok(entries);
+                }
+            }
+            ReadSource::FullBasis | ReadSource::VerifiedBasis(_) => {}
+        }
+        let basis = self.basis_for_read_options(options).await?;
+        crate::path::query::list_path_page_from_basis(&basis, path, request)
     }
 
     /// Reads the current bytes for a file path.

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -11,18 +11,24 @@ use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, UploadContentResponse,
 };
+use loonfs_api::EffectiveLimit;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     ContentRef, CreateCheckpointResponse, DirectoryPageCursor, InodeId, ListFileRevisionsResponse,
     MutationResult, NamespaceId, NamespaceSummary, NamespacesPageCursor, Page, PageRequest,
-    RevisionNo,
+    RevisionNo, DEFAULT_PAGE_LIMIT,
 };
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
+
+fn default_page_limit() -> EffectiveLimit {
+    EffectiveLimit::new(NonZeroU32::new(DEFAULT_PAGE_LIMIT).unwrap_or(NonZeroU32::MIN))
+}
 
 /// Internal target used by server integrations before they mint a presigned URL.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -576,7 +582,17 @@ impl<S: ObjectStore> NamespaceEngine<S> {
 
     /// Reads committed changes after `after_seq`.
     pub async fn list_changes_after(&self, after_seq: ChangeSeq) -> CoreResult<ChangesResponse> {
-        crate::protocol::list_changes_after(&self.store, &self.namespace_id, after_seq).await
+        self.list_changes_after_with_limit(after_seq, default_page_limit())
+            .await
+    }
+
+    /// Reads up to `limit` committed changes after `after_seq`.
+    pub async fn list_changes_after_with_limit(
+        &self,
+        after_seq: ChangeSeq,
+        limit: EffectiveLimit,
+    ) -> CoreResult<ChangesResponse> {
+        crate::protocol::list_changes_after(&self.store, &self.namespace_id, after_seq, limit).await
     }
 
     /// Starts a durable upload session for this namespace.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -87,6 +87,8 @@ pub enum CoreError {
     UploadContentConflict { upload_id: String },
     #[error("invalid upload content: {0}")]
     InvalidUploadContent(String),
+    #[error("invalid cursor: {0}")]
+    InvalidCursor(String),
     #[error(
         "change feed cursor `{after_seq:?}` is older than retention floor `{retention_floor_seq:?}`"
     )]
@@ -193,6 +195,7 @@ impl CoreError {
             CoreError::UploadAlreadyCompleted { .. } => ErrorCode::UploadAlreadyCompleted,
             CoreError::UploadContentConflict { .. } => ErrorCode::UploadContentConflict,
             CoreError::InvalidUploadContent(_) => ErrorCode::InvalidUploadContent,
+            CoreError::InvalidCursor(_) => ErrorCode::InvalidCursor,
             CoreError::RebootstrapRequired { .. } => ErrorCode::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
             | CoreError::ExpectedDirectory { .. }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -84,7 +84,7 @@ pub use context::MutationContext;
 pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{Error, ErrorCode, ErrorKind, Result};
-pub use namespace::{list_namespaces, BootstrapNamespaceError};
+pub use namespace::{list_namespaces, list_namespaces_page, BootstrapNamespaceError};
 pub use options::{
     BootstrapOptions, CommitOptions, DeleteNamespaceOptions, ForkOptions, ReadOptions, ReadSource,
     WriteOptions,

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -3,13 +3,14 @@ use super::{
     SubtreeTombstoneRecord,
 };
 use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::Bound;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct MetadataIndexes {
     indexed_seq: ChangeSeq,
     inode_by_id: HashMap<InodeId, InodeRecord>,
-    active_child_by_parent_name: HashMap<(InodeId, String), DirentryBindRecord>,
+    active_child_by_parent_name: BTreeMap<(InodeId, String), DirentryBindRecord>,
     /// Latest bind ever recorded per (parent, name), kept even after the
     /// binding is unbound. Tombstone-ancestry checks need to see dead
     /// bindings, which the active map deliberately drops.
@@ -27,7 +28,7 @@ impl Default for MetadataIndexes {
         Self {
             indexed_seq: ChangeSeq(0),
             inode_by_id: HashMap::new(),
-            active_child_by_parent_name: HashMap::new(),
+            active_child_by_parent_name: BTreeMap::new(),
             latest_bind_by_parent_name: HashMap::new(),
             active_parent_by_child: HashMap::new(),
             unbound_binding_keys: HashSet::new(),
@@ -133,11 +134,24 @@ impl MetadataIndexes {
     }
 
     pub(super) fn active_children(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
-        self.active_child_by_parent_name
-            .values()
-            .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+        self.active_children_after_name_key(parent_inode_id, None)
             .cloned()
             .collect()
+    }
+
+    pub(super) fn active_children_after_name_key<'a>(
+        &'a self,
+        parent_inode_id: InodeId,
+        start_after_name_key: Option<&str>,
+    ) -> impl Iterator<Item = &'a DirentryBindRecord> + 'a {
+        let lower_bound = match start_after_name_key {
+            Some(name_key) => Bound::Excluded((parent_inode_id, name_key.to_owned())),
+            None => Bound::Excluded((parent_inode_id, String::new())),
+        };
+        self.active_child_by_parent_name
+            .range((lower_bound, Bound::Unbounded))
+            .take_while(move |((candidate_parent, _), _)| *candidate_parent == parent_inode_id)
+            .map(|(_, record)| record)
     }
 
     pub(super) fn active_parent_for_child(
@@ -376,7 +390,7 @@ fn remove_active_parent_if_same(
 }
 
 fn remove_active_child_if_same(
-    active_child_by_parent_name: &mut HashMap<(InodeId, String), DirentryBindRecord>,
+    active_child_by_parent_name: &mut BTreeMap<(InodeId, String), DirentryBindRecord>,
     record: &DirentryBindRecord,
 ) {
     let key = (record.parent_inode_id, record.name_key.clone());

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -807,6 +807,72 @@ impl MetadataState {
         children
     }
 
+    pub fn visible_children_page_by_name_key(
+        &self,
+        parent_inode_id: InodeId,
+        base_seq: ChangeSeq,
+        start_after_name_key: Option<&str>,
+        limit: usize,
+    ) -> Vec<DirentryBindRecord> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        if base_seq >= self.indexed_seq() {
+            return self.visible_children_page_by_name_key_at_head(
+                parent_inode_id,
+                start_after_name_key,
+                limit,
+            );
+        }
+
+        let mut children = self.visible_children(parent_inode_id, base_seq);
+        children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
+        children
+            .into_iter()
+            .filter(|child| {
+                start_after_name_key
+                    .map(|last_name_key| child.name_key.as_str() > last_name_key)
+                    .unwrap_or(true)
+            })
+            .take(limit)
+            .collect()
+    }
+
+    pub fn visible_children_page_by_name_key_at_head(
+        &self,
+        parent_inode_id: InodeId,
+        start_after_name_key: Option<&str>,
+        limit: usize,
+    ) -> Vec<DirentryBindRecord> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
+            return Vec::new();
+        };
+        if parent.inode_kind != InodeKind::Dir {
+            return Vec::new();
+        }
+
+        let mut children = Vec::with_capacity(limit);
+        for direntry in self
+            .indexes
+            .active_children_after_name_key(parent_inode_id, start_after_name_key)
+        {
+            if self
+                .visible_inode_at_head(direntry.child_inode_id)
+                .is_none()
+            {
+                continue;
+            }
+            children.push(direntry.clone());
+            if children.len() == limit {
+                break;
+            }
+        }
+        children
+    }
+
     pub fn visible_children_at_head(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
         let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
             return Vec::new();

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -32,6 +32,8 @@ use thiserror::Error;
 pub struct VerifiedNamespaceBasis {
     pub namespace_descriptor: NamespaceDescriptorState,
     pub content_store_id: ContentStoreId,
+    /// Oldest namespace sequence this basis can answer snapshot reads for.
+    pub snapshot_floor_seq: ChangeSeq,
     pub head: HeadState,
     pub head_etag: String,
     pub lease: LeaseState,
@@ -67,6 +69,7 @@ impl VerifiedNamespaceBasis {
             + self.namespace_descriptor.namespace_id.as_str().len()
             + self.namespace_descriptor.content_store_id.as_str().len()
             + self.content_store_id.as_str().len()
+            + size_of::<ChangeSeq>()
             + self.head.namespace_id.as_str().len()
             + self.head_etag.len()
             + wal_tip_decoded_bytes(self.head.visible_wal_tip.as_ref())
@@ -281,6 +284,7 @@ async fn load_verified_namespace_basis_at_head_with_catalog<S: ObjectStore + ?Si
     Ok(VerifiedNamespaceBasis {
         namespace_descriptor: catalog_entry.namespace_descriptor,
         content_store_id: catalog_entry.content_store_id,
+        snapshot_floor_seq: initial_head.seq,
         head,
         head_etag,
         lease: loaded_lease.envelope.state,

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -5,7 +5,10 @@ use crate::namespace::control::{
 };
 use loonfs_api::wire::control::NamespaceDescriptorState;
 use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::{ContentStoreId, NamespaceId, NamespaceIdValidationError, NamespaceSummary};
+use loonfs_api::{
+    ContentStoreId, NamespaceId, NamespaceIdValidationError, NamespaceSummary,
+    NamespacesPageCursor, Page, PageRequest,
+};
 use loonfs_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
@@ -117,6 +120,40 @@ pub(crate) async fn list_namespaces<S: ObjectStore + ?Sized>(
         .into_iter()
         .map(|namespace_id| NamespaceSummary { namespace_id })
         .collect())
+}
+
+pub(crate) async fn list_namespaces_page<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: PageRequest<NamespacesPageCursor>,
+) -> Result<Page<NamespaceSummary, NamespacesPageCursor>, CoreError> {
+    let mut namespaces = list_namespaces(store).await?;
+    namespaces.sort_by(|left, right| left.namespace_id.as_str().cmp(right.namespace_id.as_str()));
+
+    let start_after = request.cursor.map(|cursor| cursor.last_namespace_id);
+    let mut items = namespaces
+        .into_iter()
+        .filter(|summary| {
+            start_after
+                .as_ref()
+                .map(|last| summary.namespace_id.as_str() > last.as_str())
+                .unwrap_or(true)
+        })
+        .take(request.limit.limit_plus_one())
+        .collect::<Vec<_>>();
+
+    let has_more = items.len() > request.limit.as_usize();
+    if has_more {
+        items.truncate(request.limit.as_usize());
+    }
+    let next_cursor = has_more.then(|| NamespacesPageCursor {
+        last_namespace_id: items
+            .last()
+            .expect("non-zero page limit with more results must return an item")
+            .namespace_id
+            .clone(),
+    });
+
+    Ok(Page { items, next_cursor })
 }
 
 pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -126,20 +126,35 @@ pub(crate) async fn list_namespaces_page<S: ObjectStore + ?Sized>(
     store: &S,
     request: PageRequest<NamespacesPageCursor>,
 ) -> Result<Page<NamespaceSummary, NamespacesPageCursor>, CoreError> {
-    let mut namespaces = list_namespaces(store).await?;
-    namespaces.sort_by(|left, right| left.namespace_id.as_str().cmp(right.namespace_id.as_str()));
-
     let start_after = request.cursor.map(|cursor| cursor.last_namespace_id);
-    let mut items = namespaces
-        .into_iter()
-        .filter(|summary| {
-            start_after
-                .as_ref()
-                .map(|last| summary.namespace_id.as_str() > last.as_str())
-                .unwrap_or(true)
-        })
-        .take(request.limit.limit_plus_one())
-        .collect::<Vec<_>>();
+    let keys = store
+        .list_prefix("namespaces/")
+        .await
+        .map_err(|err| CoreError::Store(err.to_string()))?;
+    let mut items = Vec::with_capacity(request.limit.limit_plus_one());
+    for key in keys {
+        let Some(namespace_id) = namespace_id_from_descriptor_key(&key)? else {
+            continue;
+        };
+        if start_after
+            .as_ref()
+            .map(|last| namespace_id.as_str() <= last.as_str())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        load_namespace_descriptor(store, &namespace_id).await?;
+        let head = read_head_object(store, &namespace_id)
+            .await
+            .map_err(|error| CoreError::Basis(error.into()))?;
+        if head.envelope.state.state == NamespaceState::Deleted {
+            continue;
+        }
+        items.push(NamespaceSummary { namespace_id });
+        if items.len() == request.limit.limit_plus_one() {
+            break;
+        }
+    }
 
     let has_more = items.len() > request.limit.as_usize();
     if has_more {
@@ -154,6 +169,19 @@ pub(crate) async fn list_namespaces_page<S: ObjectStore + ?Sized>(
     });
 
     Ok(Page { items, next_cursor })
+}
+
+fn namespace_id_from_descriptor_key(key: &str) -> Result<Option<NamespaceId>, CoreError> {
+    let Some(rest) = key.strip_prefix("namespaces/") else {
+        return Ok(None);
+    };
+    let Some((namespace, leaf)) = rest.split_once('/') else {
+        return Ok(None);
+    };
+    if leaf != "descriptor.json" {
+        return Ok(None);
+    }
+    Ok(Some(NamespaceId::parse(namespace)?))
 }
 
 pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/mod.rs
+++ b/crates/loonfs-core/src/namespace/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod lease;
 
 pub use bootstrap::BootstrapNamespaceError;
 pub use loonfs_api::wire::control::{HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope};
-use loonfs_api::{FenceToken, NamespaceSummary};
+use loonfs_api::{FenceToken, NamespaceSummary, NamespacesPageCursor, Page, PageRequest};
 use loonfs_objectstore::ObjectStore;
 use thiserror::Error;
 
@@ -23,6 +23,14 @@ pub async fn list_namespaces<S: ObjectStore + ?Sized>(
     store: &S,
 ) -> crate::Result<Vec<NamespaceSummary>> {
     catalog::list_namespaces(store).await
+}
+
+/// Lists one page of complete namespaces in namespace id order.
+pub async fn list_namespaces_page<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: PageRequest<NamespacesPageCursor>,
+) -> crate::Result<Page<NamespaceSummary, NamespacesPageCursor>> {
+    catalog::list_namespaces_page(store, request).await
 }
 
 /// Returns true when the head and lease agree on the active writer fence.

--- a/crates/loonfs-core/src/path/query.rs
+++ b/crates/loonfs-core/src/path/query.rs
@@ -1,8 +1,9 @@
 pub(crate) use super::read::{
     list_file_revisions_for_inode_from_basis, list_file_revisions_from_basis, list_path_from_basis,
     list_path_from_materialized_tables, list_path_from_materialized_tables_at_head_with_cache,
-    read_file_bytes_from_basis, read_file_revision_bytes_for_inode_from_basis,
-    read_file_revision_bytes_from_basis, resolve_path_from_basis,
-    resolve_path_from_materialized_tables,
+    list_path_page_from_basis, list_path_page_from_materialized_tables,
+    list_path_page_from_materialized_tables_at_head_with_cache, read_file_bytes_from_basis,
+    read_file_revision_bytes_for_inode_from_basis, read_file_revision_bytes_from_basis,
+    resolve_path_from_basis, resolve_path_from_materialized_tables,
     resolve_path_from_materialized_tables_at_head_with_cache,
 };

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -118,10 +118,16 @@ pub(crate) fn list_path_page_from_basis(
         });
     }
 
-    let mut children = basis
-        .metadata_state
-        .visible_children(resolved.inode_id, page_head_seq);
-    children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
+    let start_after = request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.last_name_key.as_str());
+    let children = basis.metadata_state.visible_children_page_by_name_key(
+        resolved.inode_id,
+        page_head_seq,
+        start_after,
+        request.limit.limit_plus_one(),
+    );
     page_directory_children(
         &basis.head.namespace_id,
         page_head_seq,
@@ -185,19 +191,7 @@ fn page_directory_children(
     children: Vec<DirentryBindRecord>,
     request: PageRequest<DirectoryPageCursor>,
 ) -> Result<Page<AuthoritativePathEntry, DirectoryPageCursor>, CoreError> {
-    let start_after = request
-        .cursor
-        .as_ref()
-        .map(|cursor| cursor.last_name_key.as_str());
-    let mut children = children
-        .into_iter()
-        .filter(|child| {
-            start_after
-                .map(|last_name_key| child.name_key.as_str() > last_name_key)
-                .unwrap_or(true)
-        })
-        .take(request.limit.limit_plus_one())
-        .collect::<Vec<_>>();
+    let mut children = children;
     let has_more = children.len() > request.limit.as_usize();
     if has_more {
         children.truncate(request.limit.as_usize());

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -1,9 +1,12 @@
 use super::resolver::build_authoritative_path_entry;
 use crate::error::CoreError;
-use crate::metadata::ResolvedVisiblePath;
+use crate::metadata::{DirentryBindRecord, ResolvedVisiblePath};
 use crate::namespace::basis::VerifiedNamespaceBasis;
 use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
-use loonfs_api::{AbsolutePath, AuthoritativePathEntry, DisplayName, InodeKind};
+use loonfs_api::{
+    AbsolutePath, AuthoritativePathEntry, ChangeSeq, DirectoryPageCursor, DisplayName, InodeKind,
+    NameKey, Page, PageRequest,
+};
 
 #[tracing::instrument(
     level = "info",
@@ -63,4 +66,181 @@ pub(crate) fn list_path_from_basis(
             )
         })
         .collect()
+}
+
+#[tracing::instrument(
+    level = "info",
+    name = "loon.phase",
+    err,
+    skip_all,
+    fields(phase = "walk_path")
+)]
+pub(crate) fn list_path_page_from_basis(
+    basis: &VerifiedNamespaceBasis,
+    absolute_path: &str,
+    request: PageRequest<DirectoryPageCursor>,
+) -> Result<Page<AuthoritativePathEntry, DirectoryPageCursor>, CoreError> {
+    let page_head_seq = page_head_seq(
+        basis.head.seq,
+        basis.snapshot_floor_seq.max(basis.head.retention_floor_seq),
+        request.cursor.as_ref(),
+    )?;
+    let absolute_path = parse_absolute_path_for_core(absolute_path)?;
+    let resolved = basis.metadata_state.resolve_visible_path(
+        &absolute_path,
+        basis.head.name_policy,
+        page_head_seq,
+    )?;
+    if let Some(cursor) = request.cursor.as_ref() {
+        validate_directory_cursor(cursor, &resolved)?;
+    }
+
+    if resolved.inode_kind == InodeKind::File {
+        if request.cursor.is_some() {
+            return Err(invalid_cursor(
+                "directory cursor cannot resume a file listing",
+            ));
+        }
+        return Ok(Page {
+            items: vec![build_authoritative_path_entry(
+                &basis.head.namespace_id,
+                page_head_seq,
+                &basis.metadata_state,
+                &resolved,
+            )?],
+            next_cursor: None,
+        });
+    }
+    if resolved.inode_kind != InodeKind::Dir {
+        return Err(CoreError::ExpectedDirectory {
+            path: resolved.absolute_path,
+            kind: resolved.inode_kind,
+        });
+    }
+
+    let mut children = basis
+        .metadata_state
+        .visible_children(resolved.inode_id, page_head_seq);
+    children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
+    page_directory_children(
+        &basis.head.namespace_id,
+        page_head_seq,
+        &basis.metadata_state,
+        &resolved,
+        children,
+        request,
+    )
+}
+
+pub(super) fn page_head_seq(
+    current_head_seq: ChangeSeq,
+    snapshot_floor_seq: ChangeSeq,
+    cursor: Option<&DirectoryPageCursor>,
+) -> Result<ChangeSeq, CoreError> {
+    let Some(cursor) = cursor else {
+        return Ok(current_head_seq);
+    };
+    if cursor.head_seq > current_head_seq {
+        return Err(invalid_cursor(format!(
+            "cursor snapshot `{}` is ahead of current head `{}`",
+            cursor.head_seq.0, current_head_seq.0
+        )));
+    }
+    if cursor.head_seq < snapshot_floor_seq {
+        return Err(invalid_cursor(format!(
+            "cursor snapshot `{}` is older than available snapshot floor `{}`",
+            cursor.head_seq.0, snapshot_floor_seq.0
+        )));
+    }
+    Ok(cursor.head_seq)
+}
+
+pub(super) fn validate_directory_cursor(
+    cursor: &DirectoryPageCursor,
+    resolved: &ResolvedVisiblePath,
+) -> Result<(), CoreError> {
+    if resolved.inode_kind != InodeKind::Dir {
+        return Err(invalid_cursor(
+            "directory cursor resolved to a non-directory path",
+        ));
+    }
+    if resolved.inode_id != cursor.dir_inode_id {
+        return Err(invalid_cursor(format!(
+            "cursor directory inode `{}` does not match requested path inode `{}`",
+            cursor.dir_inode_id.0, resolved.inode_id.0
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn invalid_cursor(message: impl Into<String>) -> CoreError {
+    CoreError::InvalidCursor(message.into())
+}
+
+fn page_directory_children(
+    namespace_id: &loonfs_api::NamespaceId,
+    page_head_seq: ChangeSeq,
+    metadata_state: &crate::metadata::MetadataState,
+    resolved: &ResolvedVisiblePath,
+    children: Vec<DirentryBindRecord>,
+    request: PageRequest<DirectoryPageCursor>,
+) -> Result<Page<AuthoritativePathEntry, DirectoryPageCursor>, CoreError> {
+    let start_after = request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.last_name_key.as_str());
+    let mut children = children
+        .into_iter()
+        .filter(|child| {
+            start_after
+                .map(|last_name_key| child.name_key.as_str() > last_name_key)
+                .unwrap_or(true)
+        })
+        .take(request.limit.limit_plus_one())
+        .collect::<Vec<_>>();
+    let has_more = children.len() > request.limit.as_usize();
+    if has_more {
+        children.truncate(request.limit.as_usize());
+    }
+
+    let next_cursor = if has_more {
+        let last = children
+            .last()
+            .expect("non-zero page limit with more children must return an item");
+        Some(DirectoryPageCursor {
+            head_seq: page_head_seq,
+            dir_inode_id: resolved.inode_id,
+            last_name_key: NameKey::try_new(last.name_key.clone()).map_err(|error| {
+                CoreError::NamespaceCorrupt(format!("invalid stored name_key: {error}"))
+            })?,
+        })
+    } else {
+        None
+    };
+
+    let items = children
+        .into_iter()
+        .map(|direntry| {
+            let child = metadata_state
+                .visible_inode(direntry.child_inode_id, page_head_seq)
+                .expect("visible child listing should resolve inode");
+            let child_path = AbsolutePath::parse(&resolved.absolute_path)
+                .map_err(map_path_error_to_core)?
+                .join(&DisplayName::parse(&direntry.display_name).map_err(map_path_error_to_core)?);
+            build_authoritative_path_entry(
+                namespace_id,
+                page_head_seq,
+                metadata_state,
+                &ResolvedVisiblePath {
+                    absolute_path: child_path.as_str().to_owned(),
+                    inode_id: direntry.child_inode_id,
+                    inode_kind: child.inode_kind,
+                    parent_inode_id: Some(direntry.parent_inode_id),
+                    display_name: direntry.display_name,
+                },
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Page { items, next_cursor })
 }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -1,4 +1,8 @@
-use super::{manifest_index, row_decode::unbind_matches_binding};
+use super::{
+    listing::{invalid_cursor, page_head_seq, validate_directory_cursor},
+    manifest_index,
+    row_decode::unbind_matches_binding,
+};
 use crate::checkpoint::{
     load_verified_manifest_tables_with_cache, manifest_basis_head, MetadataTableCache,
     VerifiedMetadataTables,
@@ -17,7 +21,8 @@ use crate::wal::{
 };
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{
-    AbsolutePath, AuthoritativePathEntry, DisplayName, InodeId, InodeKind, NameKey, NamespaceId,
+    AbsolutePath, AuthoritativePathEntry, DirectoryPageCursor, DisplayName, InodeId, InodeKind,
+    NameKey, NamespaceId, Page, PageRequest,
 };
 use loonfs_objectstore::ObjectStore;
 
@@ -76,6 +81,39 @@ pub(crate) async fn list_path_from_materialized_tables_at_head_with_cache<
     Ok(Some(view.list_path(absolute_path).await?))
 }
 
+pub(crate) async fn list_path_page_from_materialized_tables_at_head_with_cache<
+    S: ObjectStore + ?Sized,
+>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    head: &HeadState,
+    absolute_path: &str,
+    table_cache: Option<&MetadataTableCache>,
+    request: PageRequest<DirectoryPageCursor>,
+) -> Result<Option<Page<AuthoritativePathEntry, DirectoryPageCursor>>, CoreError> {
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != head.seq)
+        .unwrap_or(false)
+    {
+        return Err(invalid_cursor(
+            "cursor snapshot does not match the requested materialized head",
+        ));
+    }
+    let Some(view) = MaterializedLatestView::load_at_head_with_cache(
+        store,
+        namespace_id,
+        head.clone(),
+        table_cache,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(view.list_path_page(absolute_path, request).await?))
+}
+
 pub(crate) async fn list_path_from_materialized_tables<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -85,6 +123,26 @@ pub(crate) async fn list_path_from_materialized_tables<S: ObjectStore + ?Sized>(
         return Ok(None);
     };
     Ok(Some(view.list_path(absolute_path).await?))
+}
+
+pub(crate) async fn list_path_page_from_materialized_tables<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    request: PageRequest<DirectoryPageCursor>,
+) -> Result<Option<Page<AuthoritativePathEntry, DirectoryPageCursor>>, CoreError> {
+    let Some(view) = MaterializedLatestView::load(store, namespace_id).await? else {
+        return Ok(None);
+    };
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != view.head.seq)
+        .unwrap_or(false)
+    {
+        return Ok(None);
+    }
+    Ok(Some(view.list_path_page(absolute_path, request).await?))
 }
 
 struct MaterializedLatestView<'a, S: ObjectStore + ?Sized> {
@@ -220,6 +278,115 @@ impl<'a, S: ObjectStore + ?Sized> MaterializedLatestView<'a, S> {
             );
         }
         Ok(entries)
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.phase",
+        err,
+        skip_all,
+        fields(phase = "walk_path")
+    )]
+    async fn list_path_page(
+        &self,
+        absolute_path: &str,
+        request: PageRequest<DirectoryPageCursor>,
+    ) -> Result<Page<AuthoritativePathEntry, DirectoryPageCursor>, CoreError> {
+        let page_head_seq = page_head_seq(
+            self.head.seq,
+            self.head.retention_floor_seq,
+            request.cursor.as_ref(),
+        )?;
+        if page_head_seq != self.head.seq {
+            return Err(invalid_cursor(
+                "materialized listing can only page at its loaded head",
+            ));
+        }
+
+        let absolute_path = parse_absolute_path_for_core(absolute_path)?;
+        let resolved = self.resolve_visible_path(&absolute_path).await?;
+        if let Some(cursor) = request.cursor.as_ref() {
+            validate_directory_cursor(cursor, &resolved)?;
+        }
+
+        if resolved.inode_kind == InodeKind::File {
+            if request.cursor.is_some() {
+                return Err(invalid_cursor(
+                    "directory cursor cannot resume a file listing",
+                ));
+            }
+            return Ok(Page {
+                items: vec![self.build_authoritative_path_entry(&resolved).await?],
+                next_cursor: None,
+            });
+        }
+        if resolved.inode_kind != InodeKind::Dir {
+            return Err(CoreError::ExpectedDirectory {
+                path: resolved.absolute_path,
+                kind: resolved.inode_kind,
+            });
+        }
+
+        let mut children = self.visible_children(resolved.inode_id).await?;
+        children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
+        let start_after = request
+            .cursor
+            .as_ref()
+            .map(|cursor| cursor.last_name_key.as_str());
+        let mut children = children
+            .into_iter()
+            .filter(|child| {
+                start_after
+                    .map(|last_name_key| child.name_key.as_str() > last_name_key)
+                    .unwrap_or(true)
+            })
+            .take(request.limit.limit_plus_one())
+            .collect::<Vec<_>>();
+        let has_more = children.len() > request.limit.as_usize();
+        if has_more {
+            children.truncate(request.limit.as_usize());
+        }
+
+        let next_cursor = if has_more {
+            let last = children
+                .last()
+                .expect("non-zero page limit with more children must return an item");
+            Some(DirectoryPageCursor {
+                head_seq: page_head_seq,
+                dir_inode_id: resolved.inode_id,
+                last_name_key: NameKey::try_new(last.name_key.clone()).map_err(|error| {
+                    CoreError::NamespaceCorrupt(format!("invalid stored name_key: {error}"))
+                })?,
+            })
+        } else {
+            None
+        };
+
+        let mut entries = Vec::with_capacity(children.len());
+        for direntry in children {
+            let child = self
+                .visible_inode(direntry.child_inode_id)
+                .await?
+                .expect("visible child listing should resolve inode");
+            let child_path = AbsolutePath::parse(&resolved.absolute_path)
+                .map_err(map_path_error_to_core)?
+                .join(&DisplayName::parse(&direntry.display_name).map_err(map_path_error_to_core)?);
+            entries.push(
+                self.build_authoritative_path_entry(&ResolvedVisiblePath {
+                    absolute_path: child_path.as_str().to_owned(),
+                    inode_id: direntry.child_inode_id,
+                    inode_kind: child.inode_kind,
+                    parent_inode_id: Some(direntry.parent_inode_id),
+                    display_name: direntry.display_name,
+                })
+                .await?,
+            );
+        }
+
+        Ok(Page {
+            items: entries,
+            next_cursor,
+        })
     }
 
     async fn resolve_visible_path(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -327,21 +327,17 @@ impl<'a, S: ObjectStore + ?Sized> MaterializedLatestView<'a, S> {
             });
         }
 
-        let mut children = self.visible_children(resolved.inode_id).await?;
-        children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
         let start_after = request
             .cursor
             .as_ref()
             .map(|cursor| cursor.last_name_key.as_str());
-        let mut children = children
-            .into_iter()
-            .filter(|child| {
-                start_after
-                    .map(|last_name_key| child.name_key.as_str() > last_name_key)
-                    .unwrap_or(true)
-            })
-            .take(request.limit.limit_plus_one())
-            .collect::<Vec<_>>();
+        let mut children = self
+            .visible_children_page_by_name_key(
+                resolved.inode_id,
+                start_after,
+                request.limit.limit_plus_one(),
+            )
+            .await?;
         let has_more = children.len() > request.limit.as_usize();
         if has_more {
             children.truncate(request.limit.as_usize());
@@ -533,6 +529,61 @@ impl<'a, S: ObjectStore + ?Sized> MaterializedLatestView<'a, S> {
                 .cmp(&right.display_name)
                 .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
         });
+        Ok(children)
+    }
+
+    async fn visible_children_page_by_name_key(
+        &self,
+        parent_inode_id: InodeId,
+        start_after_name_key: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<DirentryBindRecord>, CoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let Some(parent) = self.visible_inode(parent_inode_id).await? else {
+            return Ok(Vec::new());
+        };
+        if parent.inode_kind != InodeKind::Dir {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates = self.direntry_binds_for_parent(parent_inode_id).await?;
+        candidates.extend(
+            self.wal_tail_rows
+                .direntry_binds()
+                .iter()
+                .filter(|direntry| direntry.parent_inode_id == parent_inode_id)
+                .cloned(),
+        );
+        candidates.sort_by(|left, right| left.name_key.cmp(&right.name_key));
+
+        let mut seen_name_keys = std::collections::BTreeSet::new();
+        let mut children = Vec::with_capacity(limit);
+        for candidate in candidates {
+            if start_after_name_key
+                .map(|last_name_key| candidate.name_key.as_str() <= last_name_key)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if !seen_name_keys.insert(candidate.name_key.clone()) {
+                continue;
+            }
+            let Some(active) = self
+                .visible_child(parent_inode_id, &candidate.name_key)
+                .await?
+            else {
+                continue;
+            };
+            if self.visible_inode(active.child_inode_id).await?.is_none() {
+                continue;
+            }
+            children.push(active);
+            if children.len() == limit {
+                break;
+            }
+        }
         Ok(children)
     }
 

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -6,9 +6,11 @@ mod resolver;
 mod revision_reader;
 mod row_decode;
 
-pub(crate) use listing::list_path_from_basis;
+pub(crate) use listing::{list_path_from_basis, list_path_page_from_basis};
 pub(crate) use materialized_view::{
     list_path_from_materialized_tables, list_path_from_materialized_tables_at_head_with_cache,
+    list_path_page_from_materialized_tables,
+    list_path_page_from_materialized_tables_at_head_with_cache,
     resolve_path_from_materialized_tables,
     resolve_path_from_materialized_tables_at_head_with_cache,
 };

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -787,6 +787,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_basis<S: ObjectSto
     let promoted_basis = head_metadata.etag.map(|head_etag| VerifiedNamespaceBasis {
         namespace_descriptor: basis.namespace_descriptor.clone(),
         content_store_id: basis.content_store_id.clone(),
+        snapshot_floor_seq: basis.snapshot_floor_seq,
         head: head_publish.resulting_head.clone(),
         head_etag,
         lease: basis.lease.clone(),

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -41,7 +41,7 @@ use loonfs_api::wire::control::{
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta};
 use loonfs_api::{
     generate_upload_id, validate_upload_id, ChangeSeq, CommitId, ContentRef, ContentRefKind,
-    ContentStoreId, NameKey, NamespaceId,
+    ContentStoreId, EffectiveLimit, NameKey, NamespaceId,
 };
 use loonfs_objectstore::keys::{content_blob, namespace_descriptor, upload_session};
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
@@ -964,6 +964,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     after_seq: ChangeSeq,
+    limit: EffectiveLimit,
 ) -> Result<ChangesResponse, CoreError> {
     let basis = load_verified_namespace_basis(store, namespace_id).await?;
     if after_seq < basis.head.retention_floor_seq {
@@ -977,6 +978,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
             namespace_id: namespace_id.clone(),
             after_seq,
             through_seq: basis.head.seq,
+            next_after_seq: None,
             changes: Vec::new(),
         });
     }
@@ -993,12 +995,15 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     )
     .await
     .map_err(|error| CoreError::Basis(BasisLoadError::WalChainLoad(error)))?;
-    let mut changes = Vec::new();
-    for segment in wal_chain.segments() {
+    let mut changes = Vec::with_capacity(limit.as_usize());
+    let mut through_seq = basis.head.seq;
+    let mut next_after_seq = None;
+    'segments: for segment in wal_chain.segments() {
         for record in segment.records() {
             if record.seq > after_seq {
+                let seq = record.seq;
                 changes.push(CommittedChange {
-                    seq: record.seq,
+                    seq,
                     commit_id: record.commit_id.clone(),
                     message: record.message.clone(),
                     annotations: record.annotations.clone(),
@@ -1009,6 +1014,13 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
                         .map(commit_delta_from_wal)
                         .collect::<Result<Vec<_>, _>>()?,
                 });
+                if changes.len() == limit.as_usize() {
+                    through_seq = seq;
+                    if seq < basis.head.seq {
+                        next_after_seq = Some(seq);
+                    }
+                    break 'segments;
+                }
             }
         }
     }
@@ -1016,7 +1028,8 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     Ok(ChangesResponse {
         namespace_id: namespace_id.clone(),
         after_seq,
-        through_seq: basis.head.seq,
+        through_seq,
+        next_after_seq,
         changes,
     })
 }

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -456,6 +456,7 @@ mod tests {
                 content_store_id: content_store_id.clone(),
             },
             content_store_id,
+            snapshot_floor_seq: ChangeSeq(0),
             head: head.clone(),
             head_etag: "etag-a".to_owned(),
             lease: original_lease.clone(),

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -14,6 +14,7 @@ use loonfs::{
     TraceStoreKind,
 };
 use loonfs_api::{
+    decode_directory_cursor, decode_namespaces_cursor, encode_namespaces_cursor,
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,
         CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
@@ -21,9 +22,10 @@ use loonfs_api::{
         UploadContentResponse, UploadMode, ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
-    CreateNamespaceRequest, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, FilesystemPutBehavior, ForkNamespaceRequest, InodeId,
+    CreateNamespaceRequest, DirectoryPageCursor, FilesystemOperation, FilesystemOperationRequest,
+    FilesystemOperationResponse, FilesystemPutBehavior, ForkNamespaceRequest, InodeId, LimitError,
     ListFileRevisionsResponse, ListNamespacesResponse, NamespaceId, NamespaceIdValidationError,
+    NamespacesPageCursor, PageCursorError, PageRequest, PaginationPolicy,
     RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
 };
 use loonfs_core::content::{
@@ -54,6 +56,19 @@ struct AppState {
 #[derive(Debug, serde::Deserialize)]
 struct PathQuery {
     path: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PageQuery {
+    limit: Option<u32>,
+    cursor: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PathPageQuery {
+    path: String,
+    limit: Option<u32>,
+    cursor: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -312,17 +327,27 @@ async fn create_namespace(
 
 async fn list_namespaces_handler(
     State(state): State<AppState>,
+    Query(query): Query<PageQuery>,
     headers: HeaderMap,
 ) -> Result<Json<ListNamespacesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let namespaces = state
+    let page = state
         .fs
-        .list_namespaces()
+        .list_namespaces_page(PageRequest {
+            limit: resolve_page_limit(query.limit)?,
+            cursor: decode_namespaces_page_cursor(query.cursor)?,
+        })
         .await
         .map_err(ApiResponseError::runtime)?;
+    let next_cursor = page
+        .next_cursor
+        .as_ref()
+        .map(encode_namespaces_cursor)
+        .transpose()
+        .map_err(page_cursor_response_error)?;
     Ok(Json(ListNamespacesResponse {
-        namespaces,
-        next_cursor: None,
+        namespaces: page.items,
+        next_cursor,
     }))
 }
 
@@ -347,14 +372,21 @@ async fn list_entries(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Query(query): Query<PathQuery>,
+    Query(query): Query<PathPageQuery>,
 ) -> Result<Json<loonfs_api::ListPathEntriesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let listing = state
         .fs
-        .list_path_entries(&namespace_id, &path)
+        .list_path_entries_page(
+            &namespace_id,
+            &path,
+            PageRequest {
+                limit: resolve_page_limit(query.limit)?,
+                cursor: decode_directory_page_cursor(query.cursor)?,
+            },
+        )
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(listing))
@@ -915,6 +947,48 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
             &format!("invalid revision_no `{value}`: {err}"),
         )
     })
+}
+
+fn resolve_page_limit(limit: Option<u32>) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
+    PaginationPolicy::default()
+        .resolve_limit(limit)
+        .map_err(limit_response_error)
+}
+
+fn decode_namespaces_page_cursor(
+    cursor: Option<String>,
+) -> Result<Option<NamespacesPageCursor>, ApiResponseError> {
+    cursor
+        .as_deref()
+        .map(decode_namespaces_cursor)
+        .transpose()
+        .map_err(page_cursor_response_error)
+}
+
+fn decode_directory_page_cursor(
+    cursor: Option<String>,
+) -> Result<Option<DirectoryPageCursor>, ApiResponseError> {
+    cursor
+        .as_deref()
+        .map(decode_directory_cursor)
+        .transpose()
+        .map_err(page_cursor_response_error)
+}
+
+fn limit_response_error(error: LimitError) -> ApiResponseError {
+    ApiResponseError::new(
+        StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidConfig,
+        &error.to_string(),
+    )
+}
+
+fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
+    ApiResponseError::new(
+        StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidCursor,
+        &error.to_string(),
+    )
 }
 
 struct ApiResponseError {

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -60,14 +60,14 @@ struct PathQuery {
 
 #[derive(Debug, serde::Deserialize)]
 struct PageQuery {
-    limit: Option<u32>,
+    limit: Option<String>,
     cursor: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 struct PathPageQuery {
     path: String,
-    limit: Option<u32>,
+    limit: Option<String>,
     cursor: Option<String>,
 }
 
@@ -949,10 +949,23 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
     })
 }
 
-fn resolve_page_limit(limit: Option<u32>) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
+fn resolve_page_limit(
+    limit: Option<String>,
+) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
+    let requested = limit.as_deref().map(parse_page_limit).transpose()?;
     PaginationPolicy::default()
-        .resolve_limit(limit)
+        .resolve_limit(requested)
         .map_err(limit_response_error)
+}
+
+fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
+    value.parse::<u32>().map_err(|error| {
+        ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidConfig,
+            &format!("invalid limit `{value}`: {error}"),
+        )
+    })
 }
 
 fn decode_namespaces_page_cursor(

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -320,7 +320,10 @@ async fn list_namespaces_handler(
         .list_namespaces()
         .await
         .map_err(ApiResponseError::runtime)?;
-    Ok(Json(ListNamespacesResponse { namespaces }))
+    Ok(Json(ListNamespacesResponse {
+        namespaces,
+        next_cursor: None,
+    }))
 }
 
 async fn fork_namespace_handler(
@@ -1038,6 +1041,7 @@ fn status_for_core_error_code(code: ErrorCode) -> StatusCode {
         | ErrorCode::InvalidUploadId
         | ErrorCode::InvalidInodeId
         | ErrorCode::InvalidRevisionNo
+        | ErrorCode::InvalidCursor
         | ErrorCode::InvalidConfig
         | ErrorCode::UnsupportedRenameMode
         | ErrorCode::InvalidUploadContent => StatusCode::BAD_REQUEST,

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -80,6 +80,7 @@ struct ContentQuery {
 #[derive(Debug, serde::Deserialize)]
 struct ChangesQuery {
     after_seq: u64,
+    limit: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -861,9 +862,10 @@ async fn list_changes_handler(
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let after_seq = loonfs_api::ChangeSeq(query.after_seq);
+    let limit = resolve_page_limit(query.limit)?;
     let response = state
         .fs
-        .list_changes_after(&namespace_id, after_seq)
+        .list_changes_after_with_limit(&namespace_id, after_seq, limit)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -233,6 +233,13 @@ async fn http_paginates_namespaces_and_rejects_bad_namespace_cursors() {
             }
             other => panic!("expected invalid_config, got {other:?}"),
         }
+        let nonnumeric_limit: Result<ListNamespacesResponse, ApiError> = get_json(
+            &format!("{}/v0/namespaces?limit=not-a-number", harness.server_url),
+            "test-token",
+        );
+        let error = nonnumeric_limit.expect_err("nonnumeric limit rejected");
+        assert_eq!(error.code, "invalid_config");
+        assert!(error.message.contains("invalid limit"));
 
         let dir = NamespacePath::parse("pages:/docs").expect("docs path");
         harness.client.create_dir(&dir).expect("create docs dir");
@@ -337,6 +344,17 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
         .expect("raw first directory page");
         assert_eq!(raw_first_page.entries.len(), 1);
         assert!(raw_first_page.next_cursor.is_some());
+
+        let nonnumeric_limit: Result<ListPathEntriesResponse, ApiError> = get_json(
+            &format!(
+                "{}/v0/namespaces/demo/filesystem/list?path=/docs&limit=not-a-number",
+                harness.server_url
+            ),
+            "test-token",
+        );
+        let error = nonnumeric_limit.expect_err("nonnumeric limit rejected");
+        assert_eq!(error.code, "invalid_config");
+        assert!(error.message.contains("invalid limit"));
     })
     .await
     .expect("join blocking task");

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -13,7 +13,9 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    FilesystemPutBehavior, InodeId, InodeKind, ManifestId, RevisionNo,
+    FilesystemPutBehavior, InodeId, InodeKind, ListNamespacesResponse, ListPathEntriesResponse,
+    ManifestId, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT,
+    LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs_objectstore::keys::{namespace_lease, namespace_manifest};
@@ -154,12 +156,192 @@ async fn config_endpoint_advertises_capabilities() {
         assert!(capabilities.supports("core.namespaces.fork"));
         assert!(capabilities.supports("core.namespaces.delete"));
         assert!(!capabilities.supports("core.uploads.direct_put"));
+        assert_eq!(
+            capabilities.limits.get(LIMIT_PAGINATION_DEFAULT),
+            Some(&u64::from(DEFAULT_PAGE_LIMIT))
+        );
+        assert_eq!(
+            capabilities.limits.get(LIMIT_PAGINATION_MAX),
+            Some(&u64::from(DEFAULT_MAX_PAGE_LIMIT))
+        );
 
         let cached = harness.client.capabilities().expect("cached capabilities");
         assert_eq!(cached, capabilities);
     })
     .await
     .expect("blocking task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_paginates_namespaces_and_rejects_bad_namespace_cursors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-namespace-pagination",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        for namespace in ["alpha", "bravo", "charlie", "pages"] {
+            harness
+                .client
+                .create_namespace(namespace)
+                .expect("create namespace");
+        }
+
+        let first_page = harness
+            .client
+            .list_namespaces_page(Some(2), None)
+            .expect("first namespace page");
+        assert_eq!(
+            namespace_ids(&first_page),
+            vec!["alpha".to_owned(), "bravo".to_owned()]
+        );
+        let cursor = first_page.next_cursor.expect("namespace cursor");
+
+        let second_page = harness
+            .client
+            .list_namespaces_page(Some(2), Some(&cursor))
+            .expect("second namespace page");
+        assert_eq!(
+            namespace_ids(&second_page),
+            vec!["charlie".to_owned(), "pages".to_owned()]
+        );
+        assert_eq!(second_page.next_cursor, None);
+
+        let bad_limit = harness
+            .client
+            .list_namespaces_page(Some(0), None)
+            .expect_err("zero limit rejected");
+        match bad_limit {
+            ClientError::Api { status, code, .. } => {
+                assert_eq!(status, 400);
+                assert_eq!(code, "invalid_config");
+            }
+            other => panic!("expected invalid_config, got {other:?}"),
+        }
+        let over_limit = harness
+            .client
+            .list_namespaces_page(Some(DEFAULT_MAX_PAGE_LIMIT + 1), None)
+            .expect_err("oversized limit rejected");
+        match over_limit {
+            ClientError::Api { status, code, .. } => {
+                assert_eq!(status, 400);
+                assert_eq!(code, "invalid_config");
+            }
+            other => panic!("expected invalid_config, got {other:?}"),
+        }
+
+        let dir = NamespacePath::parse("pages:/docs").expect("docs path");
+        harness.client.create_dir(&dir).expect("create docs dir");
+        for name in ["a.txt", "b.txt"] {
+            let path = NamespacePath::parse(&format!("pages:/docs/{name}")).expect("file path");
+            harness
+                .client
+                .write_file_bytes(&path, name.as_bytes())
+                .expect("write file");
+        }
+        let directory_page = harness
+            .client
+            .list_path_page(&dir, Some(1), None)
+            .expect("directory page");
+        let wrong_cursor = directory_page.next_cursor.expect("directory cursor");
+        let wrong_kind = harness
+            .client
+            .list_namespaces_page(Some(1), Some(&wrong_cursor))
+            .expect_err("directory cursor rejected by namespace endpoint");
+        match wrong_kind {
+            ClientError::Api { status, code, .. } => {
+                assert_eq!(status, 400);
+                assert_eq!(code, "invalid_cursor");
+            }
+            other => panic!("expected invalid_cursor, got {other:?}"),
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-directory-pagination",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create namespace");
+        let docs = NamespacePath::parse("demo:/docs").expect("docs path");
+        let other = NamespacePath::parse("demo:/other").expect("other path");
+        harness.client.create_dir(&docs).expect("create docs dir");
+        harness.client.create_dir(&other).expect("create other dir");
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
+            harness
+                .client
+                .write_file_bytes(&path, name.as_bytes())
+                .expect("write file");
+        }
+
+        let first_page = harness
+            .client
+            .list_path_page(&docs, Some(2), None)
+            .expect("first directory page");
+        assert_eq!(entry_names(&first_page), vec!["a.txt", "b.txt"]);
+        let cursor = first_page.next_cursor.clone().expect("directory cursor");
+
+        let second_page = harness
+            .client
+            .list_path_page(&docs, Some(2), Some(&cursor))
+            .expect("second directory page");
+        assert_eq!(entry_names(&second_page), vec!["c.txt"]);
+        assert_eq!(second_page.next_cursor, None);
+
+        let full_listing = harness
+            .client
+            .list_path(&docs)
+            .expect("full directory list");
+        assert_eq!(entry_names(&full_listing), vec!["a.txt", "b.txt", "c.txt"]);
+        assert_eq!(full_listing.next_cursor, None);
+
+        let mismatch = harness
+            .client
+            .list_path_page(&other, Some(2), Some(&cursor))
+            .expect_err("directory cursor must match listed path");
+        match mismatch {
+            ClientError::Api { status, code, .. } => {
+                assert_eq!(status, 400);
+                assert_eq!(code, "invalid_cursor");
+            }
+            other => panic!("expected invalid_cursor, got {other:?}"),
+        }
+
+        let raw_first_page: ListPathEntriesResponse = get_json(
+            &format!(
+                "{}/v0/namespaces/demo/filesystem/list?path=/docs&limit=1",
+                harness.server_url
+            ),
+            "test-token",
+        )
+        .expect("raw first directory page");
+        assert_eq!(raw_first_page.entries.len(), 1);
+        assert!(raw_first_page.next_cursor.is_some());
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1400,6 +1582,46 @@ fn test_config(
             root: store_root.display().to_string(),
             key_prefix: Some(key_prefix.to_owned()),
         },
+    }
+}
+
+fn namespace_ids(response: &ListNamespacesResponse) -> Vec<String> {
+    response
+        .namespaces
+        .iter()
+        .map(|namespace| namespace.namespace_id.as_str().to_owned())
+        .collect()
+}
+
+fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {
+    response
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.as_str())
+        .collect()
+}
+
+fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Result<T, ApiError> {
+    let request = ureq::get(url).set("authorization", &format!("Bearer {auth_token}"));
+    match request.call() {
+        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| ApiError {
+            code: "invalid_json".to_owned(),
+            feature: None,
+            message: err.to_string(),
+        }),
+        Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
+            response.into_reader(),
+        )
+        .unwrap_or_else(|err| ApiError {
+            code: "invalid_json".to_owned(),
+            feature: None,
+            message: err.to_string(),
+        })),
+        Err(ureq::Error::Transport(error)) => Err(ApiError {
+            code: "transport".to_owned(),
+            feature: None,
+            message: error.to_string(),
+        }),
     }
 }
 

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -979,6 +979,35 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             CommitId::parse("req-restore-restore").expect("valid commit id")
         );
         assert_eq!(changes.changes[2].ops, restore.results);
+
+        let first_page = harness
+            .client
+            .list_changes_page(namespace, ChangeSeq(0), Some(2))
+            .expect("list first changes page");
+        assert_eq!(first_page.after_seq, ChangeSeq(0));
+        assert_eq!(first_page.through_seq, ChangeSeq(2));
+        assert_eq!(first_page.next_after_seq, Some(ChangeSeq(2)));
+        assert_eq!(first_page.changes.len(), 2);
+
+        let second_page = harness
+            .client
+            .list_changes_page(
+                namespace,
+                first_page.next_after_seq.expect("next page"),
+                Some(2),
+            )
+            .expect("list second changes page");
+        assert_eq!(second_page.after_seq, ChangeSeq(2));
+        assert_eq!(second_page.through_seq, ChangeSeq(3));
+        assert_eq!(second_page.next_after_seq, None);
+        assert_eq!(
+            second_page
+                .changes
+                .iter()
+                .map(|change| change.seq)
+                .collect::<Vec<_>>(),
+            vec![ChangeSeq(3)]
+        );
     })
     .await
     .expect("join blocking task");

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -25,9 +25,10 @@ use crate::{
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
-    AbsolutePath, CapabilityDocument, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
-    FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
-    PROFILE_CORE_V0, PROTOCOL_VERSION,
+    encode_directory_cursor, AbsolutePath, CapabilityDocument, DirectoryPageCursor, EffectiveLimit,
+    NamespacesPageCursor, Page, PageRequest, PaginationPolicy, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST,
+    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{load_namespace_head_summary, MetadataTableCache};
 use loonfs_core::{MutationContext, NamespaceEngine};
@@ -299,7 +300,27 @@ impl Fs {
 
     /// Lists complete namespaces visible in the object store.
     pub async fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
-        Ok(loonfs_core::list_namespaces(self.store()).await?)
+        let limit = default_page_limit();
+        let mut cursor = None;
+        let mut namespaces = Vec::new();
+        loop {
+            let page = self
+                .list_namespaces_page(PageRequest { limit, cursor })
+                .await?;
+            namespaces.extend(page.items);
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                return Ok(namespaces);
+            }
+        }
+    }
+
+    /// Lists one page of complete namespaces in namespace id order.
+    pub async fn list_namespaces_page(
+        &self,
+        request: PageRequest<NamespacesPageCursor>,
+    ) -> Result<Page<NamespaceSummary, NamespacesPageCursor>> {
+        Ok(loonfs_core::list_namespaces_page(self.store(), request).await?)
     }
 
     /// Summarizes a namespace's current head: manifest, latest checkpoint,
@@ -472,45 +493,118 @@ impl Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<ListPathEntriesResponse> {
+        let limit = default_page_limit();
+        let mut cursor = None;
+        let mut entries = Vec::new();
+        let mut envelope = None;
+        loop {
+            let (page, next_cursor) = self
+                .list_path_entries_page_typed(
+                    namespace_id,
+                    absolute_path,
+                    PageRequest { limit, cursor },
+                )
+                .await?;
+            let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
+                namespace_id: page.namespace_id.clone(),
+                absolute_path: page.absolute_path.clone(),
+                head_seq: page.head_seq,
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+            entries.extend(page.entries);
+            cursor = next_cursor;
+            if cursor.is_none() {
+                entries.sort_by(|left, right| {
+                    left.display_name
+                        .cmp(&right.display_name)
+                        .then(left.inode_id.0.cmp(&right.inode_id.0))
+                });
+                envelope_ref.entries = entries;
+                return Ok(envelope.expect("first page initializes response envelope"));
+            }
+        }
+    }
+
+    /// Lists one page of a directory together with the head the page was read from.
+    pub async fn list_path_entries_page(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<DirectoryPageCursor>,
+    ) -> Result<ListPathEntriesResponse> {
+        let (mut response, next_cursor) = self
+            .list_path_entries_page_typed(namespace_id, absolute_path, request)
+            .await?;
+        response.next_cursor = next_cursor
+            .as_ref()
+            .map(encode_directory_cursor)
+            .transpose()
+            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        Ok(response)
+    }
+
+    async fn list_path_entries_page_typed(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<DirectoryPageCursor>,
+    ) -> Result<(ListPathEntriesResponse, Option<DirectoryPageCursor>)> {
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
         let head = self.head_for_metadata_read(namespace_id).await?;
         let engine = self.namespace_engine(namespace_id);
-        let head_seq = head.state.seq;
-        let entries = if head.state.current_manifest_id.is_some() {
-            let entries = engine
-                .list_path(
-                    absolute_path,
+        let request_head_seq = request.cursor.as_ref().map(|cursor| cursor.head_seq);
+        let use_materialized = head.state.current_manifest_id.is_some()
+            && request
+                .cursor
+                .as_ref()
+                .map(|cursor| cursor.head_seq == head.state.seq)
+                .unwrap_or(true);
+        let page = if use_materialized {
+            let page = engine
+                .list_path_page(
+                    listed_path.as_str(),
                     loonfs_core::ReadOptions::materialized_tables_at_head(
                         head.state.clone(),
                         Some(Arc::clone(&self.inner.metadata_table_cache)),
                     ),
+                    request,
                 )
                 .await?;
             self.inner
                 .cache_stats
                 .record_metadata_read_source(MetadataReadSource::MaterializedTables);
-            entries
+            page
         } else {
             let basis = self.basis_for_read_at_head(namespace_id, &head).await?;
-            let entries = engine
-                .list_path(
-                    absolute_path,
+            let page = engine
+                .list_path_page(
+                    listed_path.as_str(),
                     loonfs_core::ReadOptions::verified_basis(Arc::clone(&basis)),
+                    request,
                 )
                 .await?;
             self.inner
                 .cache_stats
                 .record_metadata_read_source(MetadataReadSource::FullBasisFallback);
-            entries
+            page
         };
-        Ok(ListPathEntriesResponse {
+        let head_seq = page
+            .items
+            .first()
+            .map(|entry| entry.head_seq)
+            .or(request_head_seq)
+            .unwrap_or(head.state.seq);
+        let next_cursor = page.next_cursor;
+        let response = ListPathEntriesResponse {
             namespace_id: namespace_id.clone(),
             absolute_path: listed_path.as_str().to_owned(),
             head_seq,
-            entries,
+            entries: page.items,
             next_cursor: None,
-        })
+        };
+        Ok((response, next_cursor))
     }
 
     /// Reads a file's current content plus the metadata entry it came from.
@@ -1119,6 +1213,12 @@ fn validate_runtime_mutation_path(absolute_path: &str) -> Result<()> {
         return Err(RuntimeError::Core(CoreError::RootMutationForbidden));
     }
     Ok(())
+}
+
+fn default_page_limit() -> EffectiveLimit {
+    PaginationPolicy::default()
+        .resolve_limit(None)
+        .expect("default pagination policy must resolve its default limit")
 }
 
 #[cfg(test)]

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -509,6 +509,7 @@ impl Fs {
             absolute_path: listed_path.as_str().to_owned(),
             head_seq,
             entries,
+            next_cursor: None,
         })
     }
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -1097,9 +1097,23 @@ impl Fs {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> Result<ChangesResponse> {
+        let limit = PaginationPolicy::default()
+            .resolve_limit(None)
+            .map_err(|error| RuntimeError::Config(error.to_string()))?;
+        self.list_changes_after_with_limit(namespace_id, after_seq, limit)
+            .await
+    }
+
+    /// Reads up to `limit` committed changes after the `after_seq` cursor.
+    pub async fn list_changes_after_with_limit(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+        limit: EffectiveLimit,
+    ) -> Result<ChangesResponse> {
         Ok(self
             .namespace_engine(namespace_id)
-            .list_changes_after(after_seq)
+            .list_changes_after_with_limit(after_seq, limit)
             .await?)
     }
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -475,7 +475,8 @@ impl Fs {
     /// Lists a directory together with the head the listing was read from.
     ///
     /// The envelope and every entry come from one consistent head, so an
-    /// empty directory still reports which state answered the question.
+    /// empty directory still reports which state answered the question. Entries
+    /// are returned in canonical name-key order, matching paged listings.
     pub async fn list_path_entries(
         &self,
         namespace_id: &NamespaceId,
@@ -503,11 +504,6 @@ impl Fs {
             entries.extend(page.entries);
             cursor = next_cursor;
             if cursor.is_none() {
-                entries.sort_by(|left, right| {
-                    left.display_name
-                        .cmp(&right.display_name)
-                        .then(left.inode_id.0.cmp(&right.inode_id.0))
-                });
                 envelope_ref.entries = entries;
                 return Ok(envelope.expect("first page initializes response envelope"));
             }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -294,7 +294,7 @@ impl Fs {
                 (FEATURE_NAMESPACES_DELETE.to_owned(), true),
                 (FEATURE_UPLOADS_DIRECT_PUT.to_owned(), false),
             ]),
-            limits: BTreeMap::new(),
+            limits: PaginationPolicy::default().capability_limits(),
         }
     }
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -300,19 +300,7 @@ impl Fs {
 
     /// Lists complete namespaces visible in the object store.
     pub async fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
-        let limit = default_page_limit();
-        let mut cursor = None;
-        let mut namespaces = Vec::new();
-        loop {
-            let page = self
-                .list_namespaces_page(PageRequest { limit, cursor })
-                .await?;
-            namespaces.extend(page.items);
-            cursor = page.next_cursor;
-            if cursor.is_none() {
-                return Ok(namespaces);
-            }
-        }
+        Ok(loonfs_core::list_namespaces(self.store()).await?)
     }
 
     /// Lists one page of complete namespaces in namespace id order.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -25,11 +25,13 @@ pub use loonfs_api::v0::{
 pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
     ChangeSeq, CommitId, ContentRef, ContentRefKind, CreateCheckpointResponse,
-    DeleteNamespaceResponse, DisplayName, FileRevision, FilesystemOperationResponse, InodeId,
-    InodeKind, ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult,
-    NameKey, NamePolicy, NamespaceId, NamespaceSummary, RevisionNo, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST,
-    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    DeleteNamespaceResponse, DirectoryPageCursor, DisplayName, EffectiveLimit, FileRevision,
+    FilesystemOperationResponse, InodeId, InodeKind, ListFileRevisionsResponse,
+    ListPathEntriesResponse, ManifestId, MutationResult, NameKey, NamePolicy, NamespaceId,
+    NamespaceSummary, NamespacesPageCursor, Page, PageRequest, PaginationPolicy, RevisionNo,
+    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_NAMESPACES_LIST, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -9,10 +9,11 @@ use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadResponse,
     ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
-    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ErrorCode,
-    Fs, FsConfig, InodeId, MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult,
-    ManifestId, MoveOptions, MutationResult, NamespaceId, NamespaceStatus, PutFileBehavior,
-    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
+    DeleteOptions, DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, MaintenanceTickOptions,
+    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
+    NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutFileBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
     UploadContentResponse,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
@@ -52,6 +53,24 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
         .build()
         .expect("test runtime")
         .block_on(future)
+}
+
+fn page_limit(limit: u32) -> loonfs::EffectiveLimit {
+    PaginationPolicy::from_values(limit, limit)
+        .expect("valid pagination policy")
+        .resolve_limit(Some(limit))
+        .expect("valid page limit")
+}
+
+fn decode_directory_page_cursor(value: &str) -> DirectoryPageCursor {
+    loonfs_api::decode_directory_cursor(value).expect("decode directory cursor")
+}
+
+fn display_names(entries: &[AuthoritativePathEntry]) -> Vec<&str> {
+    entries
+        .iter()
+        .map(|entry| entry.display_name.as_str())
+        .collect()
 }
 
 trait FsTestExt {
@@ -1244,6 +1263,254 @@ fn delete_options_select_recursive_behavior() {
         error,
         RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
     ));
+}
+
+#[test]
+fn namespace_pages_resume_by_namespace_id_and_omit_deleted_namespaces() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "namespace-page-test");
+    for namespace in ["alpha", "beta", "charlie", "delta"] {
+        fs.create_namespace_blocking(
+            &NamespaceId::parse(namespace).expect("valid namespace id"),
+            CreateNamespaceOptions::default(),
+        )
+        .expect("create namespace");
+    }
+    block_on(fs.delete_namespace(
+        &NamespaceId::parse("beta").expect("valid namespace id"),
+        DeleteNamespaceOptions::default(),
+    ))
+    .expect("delete beta");
+
+    let limit = page_limit(2);
+    let first = block_on(fs.list_namespaces_page(PageRequest {
+        limit,
+        cursor: None,
+    }))
+    .expect("first namespace page");
+    assert_eq!(
+        first
+            .items
+            .iter()
+            .map(|summary| summary.namespace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "charlie"]
+    );
+    let second = block_on(fs.list_namespaces_page(PageRequest {
+        limit,
+        cursor: first.next_cursor,
+    }))
+    .expect("second namespace page");
+    assert_eq!(
+        second
+            .items
+            .iter()
+            .map(|summary| summary.namespace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["delta"]
+    );
+    assert!(second.next_cursor.is_none());
+
+    let full = fs.list_namespaces_blocking().expect("full namespace list");
+    assert_eq!(
+        full.iter()
+            .map(|summary| summary.namespace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "charlie", "delta"]
+    );
+}
+
+#[test]
+fn directory_pages_use_canonical_name_key_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "directory-page-order-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in [
+        "/docs/Zebra.txt",
+        "/docs/apple.txt",
+        "/docs/B.txt",
+        "/docs/a.txt",
+    ] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
+
+    let limit = page_limit(2);
+    let first = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit,
+            cursor: None,
+        },
+    ))
+    .expect("first directory page");
+    assert_eq!(display_names(&first.entries), vec!["a.txt", "apple.txt"]);
+
+    let cursor = decode_directory_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+    let second = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit,
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second directory page");
+    assert_eq!(display_names(&second.entries), vec!["B.txt", "Zebra.txt"]);
+    assert!(second.next_cursor.is_none());
+}
+
+#[test]
+fn directory_cursor_pages_read_original_snapshot_after_later_writes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "directory-page-snapshot-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    let limit = page_limit(2);
+    let first = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit,
+            cursor: None,
+        },
+    ))
+    .expect("first directory page");
+    assert_eq!(display_names(&first.entries), vec!["a.txt", "b.txt"]);
+    let cursor = decode_directory_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/z.txt",
+        b"newer",
+        PutFileOptions::default(),
+    )
+    .expect("put later file");
+
+    let second = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit,
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second directory page");
+    assert_eq!(display_names(&second.entries), vec!["c.txt"]);
+    assert!(second.next_cursor.is_none());
+}
+
+#[test]
+fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "directory-page-floor-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    let first = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+    ))
+    .expect("first directory page");
+    let cursor = decode_directory_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/z.txt",
+        b"newer",
+        PutFileOptions::default(),
+    )
+    .expect("put later file");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint newer snapshot");
+
+    assert_core_error_kind(
+        block_on(fs.list_path_entries_page(
+            &namespace_id,
+            "/docs",
+            PageRequest {
+                limit: page_limit(2),
+                cursor: Some(cursor),
+            },
+        )),
+        ErrorCode::InvalidCursor,
+    );
+}
+
+#[test]
+fn directory_cursor_rejects_path_inode_mismatch() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "directory-page-mismatch-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    let first = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(1),
+            cursor: None,
+        },
+    ))
+    .expect("first directory page");
+    let cursor = decode_directory_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+
+    assert_core_error_kind(
+        block_on(fs.list_path_entries_page(
+            &namespace_id,
+            "/",
+            PageRequest {
+                limit: page_limit(1),
+                cursor: Some(cursor),
+            },
+        )),
+        ErrorCode::InvalidCursor,
+    );
 }
 
 #[test]

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -12,9 +12,9 @@ use loonfs::{
     CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
     DeleteOptions, DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, MaintenanceTickOptions,
     MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
-    NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutFileBehavior, PutFileOptions,
-    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
-    UploadContentResponse,
+    NamespaceId, NamespaceStatus, NamespacesPageCursor, PageRequest, PaginationPolicy,
+    PutFileBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
+    TraceMode, TraceStoreKind, UploadContentResponse,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_core::cache::load_verified_namespace_basis;
@@ -1317,6 +1317,46 @@ fn namespace_pages_resume_by_namespace_id_and_omit_deleted_namespaces() {
             .map(|summary| summary.namespace_id.as_str())
             .collect::<Vec<_>>(),
         vec!["alpha", "charlie", "delta"]
+    );
+}
+
+#[test]
+fn namespace_pages_do_not_read_skipped_namespace_heads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(HeadCasFailureStore::new(temp_dir.path(), "ns-000"));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = Fs::builder(object_store)
+        .writer_id("namespace-page-read-count")
+        .build()
+        .expect("build runtime");
+
+    for index in 0..20 {
+        let namespace_id =
+            NamespaceId::parse(format!("ns-{index:03}")).expect("valid namespace id");
+        fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+            .expect("create namespace");
+    }
+
+    raw_store.reset_control_get_counts();
+    let page = block_on(fs.list_namespaces_page(PageRequest {
+        limit: page_limit(2),
+        cursor: Some(NamespacesPageCursor {
+            last_namespace_id: NamespaceId::parse("ns-009").expect("valid namespace id"),
+        }),
+    }))
+    .expect("list namespace page");
+
+    assert_eq!(
+        page.items
+            .iter()
+            .map(|summary| summary.namespace_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["ns-010", "ns-011"]
+    );
+    assert_eq!(
+        raw_store.head_get_count(),
+        0,
+        "page should not read namespace heads before the cursor"
     );
 }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1408,6 +1408,12 @@ fn directory_pages_use_canonical_name_key_order() {
     .expect("second directory page");
     assert_eq!(display_names(&second.entries), vec!["B.txt", "Zebra.txt"]);
     assert!(second.next_cursor.is_none());
+
+    let full = block_on(fs.list_path_entries(&namespace_id, "/docs")).expect("full listing");
+    assert_eq!(
+        display_names(&full.entries),
+        vec!["a.txt", "apple.txt", "B.txt", "Zebra.txt"]
+    );
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -522,10 +522,10 @@ an empty directory still reports which state it observed and the response can
 grow without reshaping `entries`. Entries are full path entries with the same
 shape as `stat` (directory entries leave the file-only fields out).
 
-Paged directory listing advances in canonical `name_key` order. The `path`
-query parameter is required on every page; the cursor pins the snapshot and
-resume position, but the request path remains the authority for what is being
-listed. Responses include `next_cursor` only when another page is available.
+Directory listing advances in canonical `name_key` order. The `path` query parameter is
+required on every page; the cursor pins the snapshot and resume position, but
+the request path remains the authority for what is being listed. Responses
+include `next_cursor` only when another page is available.
 
 ```json
 {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -77,7 +77,10 @@ therefore identical for both backends.
     "core.namespaces.delete": true,
     "core.uploads.direct_put": false
   },
-  "limits": {}
+  "limits": {
+    "pagination.default_limit": 1000,
+    "pagination.max_limit": 1000
+  }
 }
 ```
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -100,6 +100,13 @@ Rules:
 - Limits are advisory; the authoritative outcome is the server's response to
   the actual request.
 
+Registered limit keys:
+
+| Limit key | Meaning |
+| --- | --- |
+| `pagination.default_limit` | Default page size applied when a paged request omits `limit`. |
+| `pagination.max_limit` | Largest accepted page size for paged requests. |
+
 ### 2.2 Feature registry
 
 Every feature key is defined here, alongside the ops it gates. This registry
@@ -167,6 +174,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `invalid_upload_id` | 400 | The upload id violates the generated-id grammar. |
 | `invalid_inode_id` | 400 | The inode id path parameter is not a valid integer id. |
 | `invalid_revision_no` | 400 | The revision number parameter is not a valid integer. |
+| `invalid_cursor` | 400 | The pagination cursor is malformed, unsupported, expired, wrong-kind, or no longer matches the requested resource. |
 | `invalid_config` | 400 | The request or server configuration is invalid. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
 | `permission_denied` | 403 | Authenticated, but not allowed to perform this operation. |
@@ -290,9 +298,10 @@ A representative v0 binding is shown below.
 | --- | --- |
 | Read deployment capabilities | `GET /v0/config` |
 | Create a namespace | `POST /v0/namespaces` |
+| List namespaces | `GET /v0/namespaces?limit=100&cursor=...` |
 | Read one namespace's status | `GET /v0/namespaces/{ns}` |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt` |
-| List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs` |
+| List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...` |
 | List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
 | Read prior file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` |
@@ -437,6 +446,21 @@ code `namespace_not_found`.
 }
 ```
 
+### 6.3 `GET /v0/namespaces`
+
+Namespace pagination advances in namespace id order. Responses include
+`next_cursor` only when another page is available.
+
+```json
+{
+  "namespaces": [
+    { "namespace_id": "demo" },
+    { "namespace_id": "logs" }
+  ],
+  "next_cursor": "7b2e2e2e7d"
+}
+```
+
 ### 6.4 `DELETE /v0/namespaces/{ns}`
 
 Deletion is a fenced, terminal head transition (`format.md`, "Tombstones and
@@ -490,9 +514,13 @@ the durable naming rules (`format.md`, "Durable naming conventions").
 
 The envelope names the listed path and the head the listing was read from, so
 an empty directory still reports which state it observed and the response can
-grow (for example, pagination cursors) without reshaping `entries`. Entries
-are full path entries with the same shape as `stat` (directory entries leave
-the file-only fields out).
+grow without reshaping `entries`. Entries are full path entries with the same
+shape as `stat` (directory entries leave the file-only fields out).
+
+Paged directory listing advances in canonical `name_key` order. The `path`
+query parameter is required on every page; the cursor pins the snapshot and
+resume position, but the request path remains the authority for what is being
+listed. Responses include `next_cursor` only when another page is available.
 
 ```json
 {
@@ -525,7 +553,8 @@ the file-only fields out).
       "parent_inode_id": 7,
       "display_name": "slides"
     }
-  ]
+  ],
+  "next_cursor": "7b2e2e2e7d"
 }
 ```
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -280,7 +280,9 @@ Annotations may be used to correlate multiple logical commits that belong to
 one higher-level workflow, for example with fields such as `operation_id`,
 `operation_kind`, or `operation_part`.
 
-The change feed returns ordered committed changes after an explicit cursor. If
+The change feed returns ordered committed changes after an explicit cursor.
+Callers may bound a response with `limit`; a truncated page returns
+`next_after_seq`, which should be used as the next request's `after_seq`. If
 the requested cursor is older than the retention floor, the caller must
 re-bootstrap instead of expecting older incremental history to remain
 available.
@@ -315,7 +317,7 @@ A representative v0 binding is shown below.
 | Upload full staged content | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
 | Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
 | Submit an explicit commit request | `POST /v0/namespaces/{ns}/commits` |
-| Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123` |
+| Read committed changes | `GET /v0/namespaces/{ns}/changes?after_seq=123&limit=100` |
 | Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
 | Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
 | Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoint` |
@@ -768,7 +770,7 @@ Representative response:
 {
   "namespace_id": "demo",
   "after_seq": 418,
-  "through_seq": 420,
+  "through_seq": 419,
   "changes": [
     {
       "seq": 419,
@@ -805,6 +807,10 @@ Representative response:
   ]
 }
 ```
+
+If `limit` truncates the page before the namespace head, the response includes
+`next_after_seq` set to the last returned change seq. The client resumes with
+`after_seq={next_after_seq}`.
 
 ### 6.11 `POST /forks`
 


### PR DESCRIPTION
- add reusable pagination policy and effective limit primitives
- add namespace and directory cursors
- export pagination primitives from loonfs-api