### PR TITLE
feat(objectstore): add native GCP GCS provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1677,6 +1678,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4.5", features = ["derive"] }
 http = "1"
 futures = "0.3"
 fs4 = "0.13"
-object_store = { version = "=0.12.4", default-features = false, features = ["aws"] }
+object_store = { version = "=0.12.4", default-features = false, features = ["aws", "gcp"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }

--- a/configs/loonfs-server.gcp-gcs.example.toml
+++ b/configs/loonfs-server.gcp-gcs.example.toml
@@ -1,0 +1,12 @@
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server-gcp"
+writer_version = "loonfs-server/0.1.0"
+lease_duration_ms = 60000
+
+[store]
+kind = "gcp-gcs"
+bucket = "your-bucket"
+# Optional; omit both to use the ambient Google credential chain.
+service_account_key_path = "/path/to/service-account.json"
+key_prefix = "loon-demo"

--- a/configs/loonfs-server.gcp-gcs.example.toml
+++ b/configs/loonfs-server.gcp-gcs.example.toml
@@ -7,6 +7,5 @@ lease_duration_ms = 60000
 [store]
 kind = "gcp-gcs"
 bucket = "your-bucket"
-# Optional; omit both to use the ambient Google credential chain.
 service_account_key_path = "/path/to/service-account.json"
 key_prefix = "loon-demo"

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -67,6 +67,8 @@ pub(crate) struct InitArgs {
     #[arg(long)]
     pub account_id: Option<String>,
     #[arg(long)]
+    pub service_account_key_path: Option<String>,
+    #[arg(long)]
     pub key_prefix: Option<String>,
     #[arg(long)]
     pub force_path_style: bool,
@@ -114,6 +116,8 @@ pub(crate) struct ProfileCreateArgs {
     #[arg(long)]
     pub account_id: Option<String>,
     #[arg(long)]
+    pub service_account_key_path: Option<String>,
+    #[arg(long)]
     pub server_url: Option<String>,
     #[arg(long)]
     pub auth_token: Option<String>,
@@ -140,6 +144,8 @@ pub(crate) struct ProfileUpdateArgs {
     pub session_token: Option<String>,
     #[arg(long)]
     pub account_id: Option<String>,
+    #[arg(long)]
+    pub service_account_key_path: Option<String>,
     #[arg(long)]
     pub server_url: Option<String>,
     #[arg(long)]

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -632,6 +632,7 @@ fn trace_store_kind(store: &StoreConfig) -> TraceStoreKind {
         StoreConfig::LocalFs { .. } => TraceStoreKind::LocalFs,
         StoreConfig::AwsS3 { .. } => TraceStoreKind::S3,
         StoreConfig::CloudflareR2 { .. } => TraceStoreKind::R2,
+        StoreConfig::GcpGcs { .. } => TraceStoreKind::Gcs,
     }
 }
 

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -168,6 +168,11 @@ fn build_embedded_profile(
             reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "local-fs")?;
             reject_create_flag("session-token", spec.session_token.is_some(), "local-fs")?;
             reject_create_flag("account-id", spec.account_id.is_some(), "local-fs")?;
+            reject_create_flag(
+                "service-account-key-path",
+                spec.service_account_key_path.is_some(),
+                "local-fs",
+            )?;
             reject_create_flag("force-path-style", spec.force_path_style, "local-fs")?;
             StoreConfig::LocalFs {
                 root: require_or_prompt(spec.root.as_ref(), "root", runtime)?,
@@ -177,6 +182,11 @@ fn build_embedded_profile(
         "aws-s3" => {
             reject_create_flag("root", spec.root.is_some(), "aws-s3")?;
             reject_create_flag("account-id", spec.account_id.is_some(), "aws-s3")?;
+            reject_create_flag(
+                "service-account-key-path",
+                spec.service_account_key_path.is_some(),
+                "aws-s3",
+            )?;
             StoreConfig::AwsS3 {
                 bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
                 region: require_or_prompt_region(spec.region.as_ref(), runtime)?,
@@ -209,6 +219,11 @@ fn build_embedded_profile(
                 "cloudflare-r2",
             )?;
             reject_create_flag("force-path-style", spec.force_path_style, "cloudflare-r2")?;
+            reject_create_flag(
+                "service-account-key-path",
+                spec.service_account_key_path.is_some(),
+                "cloudflare-r2",
+            )?;
             StoreConfig::CloudflareR2 {
                 bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
                 account_id: require_or_prompt(spec.account_id.as_ref(), "account-id", runtime)?,
@@ -245,8 +260,11 @@ fn build_embedded_profile(
             reject_create_flag("force-path-style", spec.force_path_style, "gcp-gcs")?;
             StoreConfig::GcpGcs {
                 bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
-                service_account_key_path: spec.service_account_key_path,
-                application_credentials_path: None,
+                service_account_key_path: require_or_prompt(
+                    spec.service_account_key_path.as_ref(),
+                    "service-account-key-path",
+                    runtime,
+                )?,
                 key_prefix: spec.key_prefix,
             }
         }
@@ -281,6 +299,11 @@ fn build_remote_profile(
     reject_create_flag("session-token", spec.session_token.is_some(), "remote")?;
     reject_create_flag("force-path-style", spec.force_path_style, "remote")?;
     reject_create_flag("account-id", spec.account_id.is_some(), "remote")?;
+    reject_create_flag(
+        "service-account-key-path",
+        spec.service_account_key_path.is_some(),
+        "remote",
+    )?;
 
     Ok(ProfileConfig::Remote {
         server_url: require_or_prompt(spec.server_url.as_ref(), "server url", runtime)?,
@@ -341,15 +364,30 @@ pub(super) fn apply_update_flags(
                     reject_flag("endpoint-url", &args.endpoint_url, "local-fs")?;
                     reject_flag("session-token", &args.session_token, "local-fs")?;
                     reject_flag("account-id", &args.account_id, "local-fs")?;
+                    reject_flag(
+                        "service-account-key-path",
+                        &args.service_account_key_path,
+                        "local-fs",
+                    )?;
                 }
                 StoreConfig::AwsS3 { .. } => {
                     reject_flag("root", &args.root, "aws-s3")?;
                     reject_flag("account-id", &args.account_id, "aws-s3")?;
+                    reject_flag(
+                        "service-account-key-path",
+                        &args.service_account_key_path,
+                        "aws-s3",
+                    )?;
                 }
                 StoreConfig::CloudflareR2 { .. } => {
                     reject_flag("root", &args.root, "cloudflare-r2")?;
                     reject_flag("region", &args.region, "cloudflare-r2")?;
                     reject_flag("session-token", &args.session_token, "cloudflare-r2")?;
+                    reject_flag(
+                        "service-account-key-path",
+                        &args.service_account_key_path,
+                        "cloudflare-r2",
+                    )?;
                 }
                 StoreConfig::GcpGcs { .. } => {
                     reject_flag("root", &args.root, "gcp-gcs")?;
@@ -372,6 +410,11 @@ pub(super) fn apply_update_flags(
             reject_flag("session-token", &args.session_token, "remote")?;
             reject_flag("account-id", &args.account_id, "remote")?;
             reject_flag("key-prefix", &args.key_prefix, "remote")?;
+            reject_flag(
+                "service-account-key-path",
+                &args.service_account_key_path,
+                "remote",
+            )?;
         }
     }
 
@@ -425,15 +468,13 @@ pub(super) fn apply_update_flags(
                 StoreConfig::GcpGcs {
                     bucket,
                     service_account_key_path,
-                    application_credentials_path,
                     key_prefix,
                 } => StoreConfig::GcpGcs {
                     bucket: args.bucket.clone().unwrap_or(bucket),
                     service_account_key_path: args
                         .service_account_key_path
                         .clone()
-                        .or(service_account_key_path),
-                    application_credentials_path,
+                        .unwrap_or(service_account_key_path),
                     key_prefix: args.key_prefix.clone().or(key_prefix),
                 },
             };
@@ -530,17 +571,12 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                 StoreConfig::GcpGcs {
                     bucket,
                     service_account_key_path,
-                    application_credentials_path,
                     key_prefix,
                 } => StoreConfig::GcpGcs {
                     bucket: prompt::prompt_line_default("bucket name", &bucket)?,
-                    service_account_key_path: prompt::prompt_optional(
+                    service_account_key_path: prompt::prompt_line_default(
                         "service account key path",
-                        service_account_key_path.as_deref(),
-                    )?,
-                    application_credentials_path: prompt::prompt_optional(
-                        "application credentials path",
-                        application_credentials_path.as_deref(),
+                        &service_account_key_path,
                     )?,
                     key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
                 },

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -50,6 +50,7 @@ pub(super) struct CreateProfileSpec {
     session_token: Option<String>,
     force_path_style: bool,
     account_id: Option<String>,
+    service_account_key_path: Option<String>,
     server_url: Option<String>,
     auth_token: Option<String>,
 }
@@ -68,6 +69,7 @@ pub(super) fn create_profile_spec_from_init(args: InitArgs) -> CreateProfileSpec
         session_token: args.session_token,
         force_path_style: args.force_path_style,
         account_id: args.account_id,
+        service_account_key_path: args.service_account_key_path,
         server_url: args.server_url,
         auth_token: args.auth_token,
     }
@@ -87,6 +89,7 @@ pub(super) fn create_profile_spec_from_create(args: ProfileCreateArgs) -> Create
         session_token: args.session_token,
         force_path_style: args.force_path_style,
         account_id: args.account_id,
+        service_account_key_path: args.service_account_key_path,
         server_url: args.server_url,
         auth_token: args.auth_token,
     }
@@ -128,22 +131,26 @@ fn build_embedded_profile(
         Some("local-fs") => "local-fs",
         Some("aws-s3") => "aws-s3",
         Some("cloudflare-r2") => "cloudflare-r2",
+        Some("gcp-gcs") => "gcp-gcs",
         Some(other) => {
             return Err(CliError::invalid_input(format!(
-                "unknown store kind: `{other}` (expected local-fs, aws-s3, or cloudflare-r2)"
-            )))
+            "unknown store kind: `{other}` (expected local-fs, aws-s3, cloudflare-r2, or gcp-gcs)"
+        )))
         }
         None if runtime.interactive => {
-            return prompt::prompt_choice("store kind", &["aws-s3", "cloudflare-r2", "local-fs"])
-                .and_then(|choice| {
-                    build_embedded_profile(
-                        CreateProfileSpec {
-                            store_kind: Some(choice),
-                            ..spec
-                        },
-                        runtime,
-                    )
-                });
+            return prompt::prompt_choice(
+                "store kind",
+                &["aws-s3", "cloudflare-r2", "gcp-gcs", "local-fs"],
+            )
+            .and_then(|choice| {
+                build_embedded_profile(
+                    CreateProfileSpec {
+                        store_kind: Some(choice),
+                        ..spec
+                    },
+                    runtime,
+                )
+            });
         }
         None => return Err(CliError::non_interactive_input_required("store-kind")),
     };
@@ -220,6 +227,26 @@ fn build_embedded_profile(
                     "secret-access-key",
                     runtime,
                 )?,
+                key_prefix: spec.key_prefix,
+            }
+        }
+        "gcp-gcs" => {
+            reject_create_flag("root", spec.root.is_some(), "gcp-gcs")?;
+            reject_create_flag("region", spec.region.is_some(), "gcp-gcs")?;
+            reject_create_flag("access-key-id", spec.access_key_id.is_some(), "gcp-gcs")?;
+            reject_create_flag(
+                "secret-access-key",
+                spec.secret_access_key.is_some(),
+                "gcp-gcs",
+            )?;
+            reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "gcp-gcs")?;
+            reject_create_flag("session-token", spec.session_token.is_some(), "gcp-gcs")?;
+            reject_create_flag("account-id", spec.account_id.is_some(), "gcp-gcs")?;
+            reject_create_flag("force-path-style", spec.force_path_style, "gcp-gcs")?;
+            StoreConfig::GcpGcs {
+                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+                service_account_key_path: spec.service_account_key_path,
+                application_credentials_path: None,
                 key_prefix: spec.key_prefix,
             }
         }
@@ -324,6 +351,15 @@ pub(super) fn apply_update_flags(
                     reject_flag("region", &args.region, "cloudflare-r2")?;
                     reject_flag("session-token", &args.session_token, "cloudflare-r2")?;
                 }
+                StoreConfig::GcpGcs { .. } => {
+                    reject_flag("root", &args.root, "gcp-gcs")?;
+                    reject_flag("region", &args.region, "gcp-gcs")?;
+                    reject_flag("access-key-id", &args.access_key_id, "gcp-gcs")?;
+                    reject_flag("secret-access-key", &args.secret_access_key, "gcp-gcs")?;
+                    reject_flag("endpoint-url", &args.endpoint_url, "gcp-gcs")?;
+                    reject_flag("session-token", &args.session_token, "gcp-gcs")?;
+                    reject_flag("account-id", &args.account_id, "gcp-gcs")?;
+                }
             }
         }
         ProfileConfig::Remote { .. } => {
@@ -384,6 +420,20 @@ pub(super) fn apply_update_flags(
                     endpoint_url: args.endpoint_url.clone().unwrap_or(endpoint_url),
                     access_key_id: args.access_key_id.clone().unwrap_or(access_key_id),
                     secret_access_key: args.secret_access_key.clone().unwrap_or(secret_access_key),
+                    key_prefix: args.key_prefix.clone().or(key_prefix),
+                },
+                StoreConfig::GcpGcs {
+                    bucket,
+                    service_account_key_path,
+                    application_credentials_path,
+                    key_prefix,
+                } => StoreConfig::GcpGcs {
+                    bucket: args.bucket.clone().unwrap_or(bucket),
+                    service_account_key_path: args
+                        .service_account_key_path
+                        .clone()
+                        .or(service_account_key_path),
+                    application_credentials_path,
                     key_prefix: args.key_prefix.clone().or(key_prefix),
                 },
             };
@@ -474,6 +524,23 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                     secret_access_key: prompt::prompt_line_default(
                         "secret access key",
                         &secret_access_key,
+                    )?,
+                    key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
+                },
+                StoreConfig::GcpGcs {
+                    bucket,
+                    service_account_key_path,
+                    application_credentials_path,
+                    key_prefix,
+                } => StoreConfig::GcpGcs {
+                    bucket: prompt::prompt_line_default("bucket name", &bucket)?,
+                    service_account_key_path: prompt::prompt_optional(
+                        "service account key path",
+                        service_account_key_path.as_deref(),
+                    )?,
+                    application_credentials_path: prompt::prompt_optional(
+                        "application credentials path",
+                        application_credentials_path.as_deref(),
                     )?,
                     key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
                 },

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -80,10 +80,7 @@ pub(crate) enum StoreConfig {
     },
     GcpGcs {
         bucket: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        service_account_key_path: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        application_credentials_path: Option<String>,
+        service_account_key_path: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key_prefix: Option<String>,
     },
@@ -273,12 +270,10 @@ impl StoreConfig {
             StoreConfig::GcpGcs {
                 bucket,
                 service_account_key_path,
-                application_credentials_path,
                 key_prefix,
             } => ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
                 bucket: bucket.clone(),
                 service_account_key_path: service_account_key_path.clone(),
-                application_credentials_path: application_credentials_path.clone(),
                 key_prefix: key_prefix.clone(),
             })
             .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
@@ -322,8 +317,16 @@ impl StoreConfig {
                     secret_access_key,
                 )
             }
-            StoreConfig::GcpGcs { bucket, .. } => {
-                require_non_empty(&store_field(profile_name, "bucket"), bucket)
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                ..
+            } => {
+                require_non_empty(&store_field(profile_name, "bucket"), bucket)?;
+                require_non_empty(
+                    &store_field(profile_name, "service_account_key_path"),
+                    service_account_key_path,
+                )
             }
         }
     }

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -1,6 +1,7 @@
 use crate::error::CliError;
 use http::Uri;
 use loonfs_api::NamespaceId;
+use loonfs_objectstore::gcs::GcsStoreConfig;
 use loonfs_objectstore::r2::R2StoreConfig;
 use loonfs_objectstore::s3::AwsS3StoreConfig;
 use loonfs_objectstore::ConfiguredObjectStore;
@@ -74,6 +75,15 @@ pub(crate) enum StoreConfig {
         endpoint_url: String,
         access_key_id: String,
         secret_access_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+    },
+    GcpGcs {
+        bucket: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        service_account_key_path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        application_credentials_path: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key_prefix: Option<String>,
     },
@@ -214,6 +224,7 @@ impl StoreConfig {
             StoreConfig::LocalFs { .. } => "local-fs",
             StoreConfig::AwsS3 { .. } => "aws-s3",
             StoreConfig::CloudflareR2 { .. } => "cloudflare-r2",
+            StoreConfig::GcpGcs { .. } => "gcp-gcs",
         }
     }
 
@@ -259,6 +270,18 @@ impl StoreConfig {
                 key_prefix: key_prefix.clone(),
             })
             .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                application_credentials_path,
+                key_prefix,
+            } => ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
+                bucket: bucket.clone(),
+                service_account_key_path: service_account_key_path.clone(),
+                application_credentials_path: application_credentials_path.clone(),
+                key_prefix: key_prefix.clone(),
+            })
+            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
         }
     }
 
@@ -299,6 +322,9 @@ impl StoreConfig {
                     secret_access_key,
                 )
             }
+            StoreConfig::GcpGcs { bucket, .. } => {
+                require_non_empty(&store_field(profile_name, "bucket"), bucket)
+            }
         }
     }
 
@@ -336,6 +362,7 @@ impl StoreConfig {
                 secret_access_key: "REDACTED".to_owned(),
                 key_prefix: key_prefix.clone(),
             },
+            StoreConfig::GcpGcs { .. } => self.clone(),
         }
     }
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -221,6 +221,8 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    const FAKE_GCS_SERVICE_ACCOUNT_KEY: &str = r#"{"private_key":"private_key","private_key_id":"private_key_id","client_email":"client_email","disable_oauth":true}"#;
+
     #[tokio::test]
     async fn configured_local_fs_scopes_optional_key_prefix() {
         let temp_dir = unique_temp_dir("configured-store-local");
@@ -278,10 +280,11 @@ mod tests {
         .expect("construct r2 store");
         assert_eq!(r2.kind(), ConfiguredObjectStoreKind::CloudflareR2);
 
+        let gcs_service_account_key_path =
+            fake_gcs_service_account_key_file("configured-store-gcs-kind");
         let gcs = ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
             bucket: "bucket".to_owned(),
-            service_account_key_path: None,
-            application_credentials_path: None,
+            service_account_key_path: gcs_service_account_key_path.display().to_string(),
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct gcs store");
@@ -310,6 +313,12 @@ mod tests {
             .as_nanos();
         let path = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}"));
         fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn fake_gcs_service_account_key_file(label: &str) -> PathBuf {
+        let path = unique_temp_dir(label).join("service-account.json");
+        fs::write(&path, FAKE_GCS_SERVICE_ACCOUNT_KEY).expect("write fake service account key");
         path
     }
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -1,5 +1,6 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::fs::LocalFsStore;
+use crate::gcs::{GcsStore, GcsStoreConfig};
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
@@ -16,6 +17,7 @@ pub enum ConfiguredObjectStoreKind {
     LocalFs,
     AwsS3,
     CloudflareR2,
+    GcpGcs,
 }
 
 #[derive(Debug)]
@@ -32,6 +34,7 @@ enum ConfiguredObjectStoreInner {
     },
     AwsS3(AwsS3Store),
     CloudflareR2(R2Store),
+    GcpGcs(GcsStore),
 }
 
 impl ConfiguredObjectStore {
@@ -64,6 +67,14 @@ impl ConfiguredObjectStore {
         })
     }
 
+    pub fn gcp_gcs(config: GcsStoreConfig) -> Result<Self, ObjectStoreError> {
+        let store = GcsStore::new(config)?;
+        Ok(Self {
+            kind: ConfiguredObjectStoreKind::GcpGcs,
+            inner: ConfiguredObjectStoreInner::GcpGcs(store),
+        })
+    }
+
     pub fn kind(&self) -> ConfiguredObjectStoreKind {
         self.kind
     }
@@ -80,6 +91,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.head(key).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.head(key).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.head(key).await,
         }
     }
 
@@ -95,6 +107,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.head_with_checksum(key).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.head_with_checksum(key).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.head_with_checksum(key).await,
         }
     }
 
@@ -107,6 +120,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.get_with_metadata(key).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.get_with_metadata(key).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.get_with_metadata(key).await,
         }
     }
 
@@ -123,6 +137,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.get(key, range).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.get(key, range).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.get(key, range).await,
         }
     }
 
@@ -140,6 +155,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.put(key, bytes, mode).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.put(key, bytes, mode).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.put(key, bytes, mode).await,
         }
     }
 
@@ -152,6 +168,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.delete(key).await,
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.delete(key).await,
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.delete(key).await,
         }
     }
 
@@ -184,6 +201,7 @@ impl ObjectStore for ConfiguredObjectStore {
             }
             ConfiguredObjectStoreInner::AwsS3(store) => store.list_prefix_stream(prefix),
             ConfiguredObjectStoreInner::CloudflareR2(store) => store.list_prefix_stream(prefix),
+            ConfiguredObjectStoreInner::GcpGcs(store) => store.list_prefix_stream(prefix),
         }
     }
 }
@@ -192,6 +210,7 @@ impl ObjectStore for ConfiguredObjectStore {
 mod tests {
     use super::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
     use crate::fs::LocalFsStore;
+    use crate::gcs::GcsStoreConfig;
     use crate::keys::namespace_head;
     use crate::r2::R2StoreConfig;
     use crate::s3::AwsS3StoreConfig;
@@ -258,6 +277,15 @@ mod tests {
         })
         .expect("construct r2 store");
         assert_eq!(r2.kind(), ConfiguredObjectStoreKind::CloudflareR2);
+
+        let gcs = ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
+            bucket: "bucket".to_owned(),
+            service_account_key_path: None,
+            application_credentials_path: None,
+            key_prefix: Some("tenant-a".to_owned()),
+        })
+        .expect("construct gcs store");
+        assert_eq!(gcs.kind(), ConfiguredObjectStoreKind::GcpGcs);
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,0 +1,127 @@
+use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcsStoreConfig {
+    pub bucket: String,
+    /// Service account key file. When absent, falls back to
+    /// `application_credentials_path`, then the ambient Google credential
+    /// chain (environment, application default credentials, metadata server).
+    pub service_account_key_path: Option<String>,
+    pub application_credentials_path: Option<String>,
+    pub key_prefix: Option<String>,
+}
+
+/// Google Cloud Storage through its native API.
+///
+/// GCS conditions writes on object generations, not ETags, and silently
+/// ignores HTTP `If-Match`/`If-None-Match` on its S3-interoperability
+/// surface — conformance proved interop overwrites instead of failing
+/// preconditions. The native API is therefore the only correct backend, and
+/// this adapter hands out the generation as the opaque compare token.
+#[derive(Debug)]
+pub struct GcsStore {
+    inner: ProviderObjectStore,
+}
+
+impl GcsStore {
+    pub fn new(config: GcsStoreConfig) -> Result<Self, ObjectStoreError> {
+        if config.bucket.trim().is_empty() {
+            return Err(ObjectStoreError::Transport(
+                "bucket must not be empty".to_owned(),
+            ));
+        }
+
+        let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(config.bucket);
+        if let Some(path) = config.service_account_key_path {
+            builder = builder.with_service_account_path(path);
+        }
+        if let Some(path) = config.application_credentials_path {
+            builder = builder.with_application_credentials(path);
+        }
+
+        let provider = builder
+            .build()
+            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+        let inner = ProviderObjectStore::new(
+            Arc::new(provider),
+            ProviderObjectStoreConfig {
+                key_prefix: config.key_prefix,
+                sha256_checksum_metadata: false,
+            },
+        )?;
+
+        Ok(Self { inner })
+    }
+
+    fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {
+        ObjectMetadata {
+            etag: metadata.version.clone(),
+            ..metadata
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GcsStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        Ok(self
+            .inner
+            .head(key)
+            .await?
+            .map(Self::generation_as_compare_token))
+    }
+
+    async fn head_with_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        Ok(self
+            .inner
+            .get_with_metadata(key)
+            .await?
+            .map(|body| ObjectBody {
+                metadata: Self::generation_as_compare_token(body.metadata),
+                bytes: body.bytes,
+            }))
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        Ok(Self::generation_as_compare_token(
+            self.inner.put(key, bytes, mode).await?,
+        ))
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -65,6 +65,13 @@ impl GcsStore {
             ..metadata
         }
     }
+
+    fn require_generation_compare_token(expected_etag: &str) -> Result<(), ObjectStoreError> {
+        expected_etag
+            .parse::<u64>()
+            .map(|_| ())
+            .map_err(|_| ObjectStoreError::PreconditionFailed)
+    }
 }
 
 #[async_trait]
@@ -109,6 +116,10 @@ impl ObjectStore for GcsStore {
         bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.validate_key(key)?;
+        if let PutMode::CompareAndSwap { expected_etag } = &mode {
+            Self::require_generation_compare_token(expected_etag)?;
+        }
         Ok(Self::generation_as_compare_token(
             self.inner.put(key, bytes, mode).await?,
         ))
@@ -123,5 +134,39 @@ impl ObjectStore for GcsStore {
         prefix: &str,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         self.inner.list_prefix_stream(prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GcsStore, GcsStoreConfig};
+    use crate::{ObjectStore, ObjectStoreError};
+    use bytes::Bytes;
+
+    #[test]
+    fn generation_compare_tokens_must_be_numeric() {
+        assert!(GcsStore::require_generation_compare_token("1729").is_ok());
+        assert!(matches!(
+            GcsStore::require_generation_compare_token("not-a-generation"),
+            Err(ObjectStoreError::PreconditionFailed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_keys_are_rejected_before_generation_tokens() {
+        let store = GcsStore::new(GcsStoreConfig {
+            bucket: "bucket".to_owned(),
+            service_account_key_path: None,
+            application_credentials_path: None,
+            key_prefix: None,
+        })
+        .expect("construct gcs store");
+
+        assert!(matches!(
+            store
+                .compare_and_swap("../escape", "not-a-generation", Bytes::from_static(b"oops"))
+                .await,
+            Err(ObjectStoreError::InvalidKey(_))
+        ));
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -145,15 +145,6 @@ mod tests {
 
     const FAKE_SERVICE_ACCOUNT_KEY: &str = r#"{"private_key":"private_key","private_key_id":"private_key_id","client_email":"client_email","disable_oauth":true}"#;
 
-    #[test]
-    fn generation_compare_tokens_must_be_numeric() {
-        assert!(GcsStore::require_generation_compare_token("1729").is_ok());
-        assert!(matches!(
-            GcsStore::require_generation_compare_token("not-a-generation"),
-            Err(ObjectStoreError::PreconditionFailed)
-        ));
-    }
-
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
         let service_account_key_path = fake_service_account_key_file("gcs-invalid-key");

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -9,11 +9,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GcsStoreConfig {
     pub bucket: String,
-    /// Service account key file. When absent, falls back to
-    /// `application_credentials_path`, then the ambient Google credential
-    /// chain (environment, application default credentials, metadata server).
-    pub service_account_key_path: Option<String>,
-    pub application_credentials_path: Option<String>,
+    pub service_account_key_path: String,
     pub key_prefix: Option<String>,
 }
 
@@ -36,14 +32,15 @@ impl GcsStore {
                 "bucket must not be empty".to_owned(),
             ));
         }
+        if config.service_account_key_path.trim().is_empty() {
+            return Err(ObjectStoreError::Transport(
+                "service account key path must not be empty".to_owned(),
+            ));
+        }
 
-        let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(config.bucket);
-        if let Some(path) = config.service_account_key_path {
-            builder = builder.with_service_account_path(path);
-        }
-        if let Some(path) = config.application_credentials_path {
-            builder = builder.with_application_credentials(path);
-        }
+        let builder = GoogleCloudStorageBuilder::new()
+            .with_bucket_name(config.bucket)
+            .with_service_account_path(config.service_account_key_path);
 
         let provider = builder
             .build()
@@ -142,6 +139,11 @@ mod tests {
     use super::{GcsStore, GcsStoreConfig};
     use crate::{ObjectStore, ObjectStoreError};
     use bytes::Bytes;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const FAKE_SERVICE_ACCOUNT_KEY: &str = r#"{"private_key":"private_key","private_key_id":"private_key_id","client_email":"client_email","disable_oauth":true}"#;
 
     #[test]
     fn generation_compare_tokens_must_be_numeric() {
@@ -154,10 +156,10 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
+        let service_account_key_path = fake_service_account_key_file("gcs-invalid-key");
         let store = GcsStore::new(GcsStoreConfig {
             bucket: "bucket".to_owned(),
-            service_account_key_path: None,
-            application_credentials_path: None,
+            service_account_key_path: service_account_key_path.display().to_string(),
             key_prefix: None,
         })
         .expect("construct gcs store");
@@ -168,5 +170,34 @@ mod tests {
                 .await,
             Err(ObjectStoreError::InvalidKey(_))
         ));
+    }
+
+    #[test]
+    fn service_account_key_path_is_required() {
+        assert!(matches!(
+            GcsStore::new(GcsStoreConfig {
+                bucket: "bucket".to_owned(),
+                service_account_key_path: " ".to_owned(),
+                key_prefix: None,
+            }),
+            Err(ObjectStoreError::Transport(_))
+        ));
+    }
+
+    fn fake_service_account_key_file(label: &str) -> PathBuf {
+        let path = unique_temp_dir(label).join("service-account.json");
+        fs::write(&path, FAKE_SERVICE_ACCOUNT_KEY).expect("write fake service account key");
+        path
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
     }
 }

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -3,12 +3,13 @@
 //! LoonFS assumes only the narrow provider contract the format spec names —
 //! create-if-absent, compare-and-swap, read-after-write visibility, prefix
 //! listing — and this crate owns that boundary: the [`ObjectStore`] trait,
-//! provider adapters for S3, Cloudflare R2, and the local filesystem, the
-//! durable key layout in [`keys`] and [`layout`], and the conformance
-//! [`probes`] that keep provider assumptions honest.
+//! provider adapters for S3, Cloudflare R2, Google Cloud Storage, and the
+//! local filesystem, the durable key layout in [`keys`] and [`layout`], and
+//! the conformance [`probes`] that keep provider assumptions honest.
 
 mod configured;
 pub mod fs;
+pub mod gcs;
 pub mod keys;
 mod keyspace;
 pub mod layout;

--- a/crates/loonfs-objectstore/src/provider.rs
+++ b/crates/loonfs-objectstore/src/provider.rs
@@ -101,3 +101,25 @@ pub const CLOUDFLARE_R2: ProviderProfile = ProviderProfile {
         multipart_upload: Expectation::ExpectedYes,
     },
 };
+
+pub const GCP_GCS: ProviderProfile = ProviderProfile {
+    name: "gcp-gcs",
+    active_contract: ActiveContractProfile {
+        create_if_absent: Expectation::VerifyByConformance,
+        compare_and_swap_small_object: Expectation::VerifyByConformance,
+        opaque_compare_token_for_cas: Expectation::VerifyByConformance,
+        full_object_read_identity: Expectation::VerifyByConformance,
+        overwrite: Expectation::VerifyByConformance,
+        delete_idempotent: Expectation::VerifyByConformance,
+        head_reflects_latest_write_and_delete: Expectation::VerifyByConformance,
+        strong_list_after_write: Expectation::ExpectedYes,
+        strong_list_after_delete: Expectation::ExpectedYes,
+        range_read: Expectation::ExpectedYes,
+        scoped_key_prefixing: Expectation::ExpectedYes,
+        traversal_rejection: Expectation::ExpectedYes,
+        sorted_list_prefix: Expectation::ExpectedYes,
+    },
+    future_capabilities: FutureCapabilityProfile {
+        multipart_upload: Expectation::ExpectedYes,
+    },
+};

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -246,9 +246,13 @@ fn map_put_mode(mode: PutMode) -> provider_store::PutMode {
         PutMode::Overwrite => provider_store::PutMode::Overwrite,
         PutMode::CreateIfAbsent => provider_store::PutMode::Create,
         PutMode::CompareAndSwap { expected_etag } => {
+            // The compare token is opaque and provider-issued: S3-family
+            // backends condition on `e_tag`, GCS conditions on `version`
+            // (its generation). Populate both so each backend reads the
+            // field it understands.
             provider_store::PutMode::Update(UpdateVersion {
-                e_tag: Some(expected_etag),
-                version: None,
+                e_tag: Some(expected_etag.clone()),
+                version: Some(expected_etag),
             })
         }
     }

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -54,6 +54,10 @@ impl ProviderObjectStore {
         Path::parse(scoped).map_err(|err| ObjectStoreError::InvalidKey(err.to_string()))
     }
 
+    pub(crate) fn validate_key(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.to_path(key).map(|_| ())
+    }
+
     fn list_path(&self, prefix: &str) -> Result<Option<Path>, ObjectStoreError> {
         let scoped = scope_list_prefix(self.key_prefix.as_deref(), prefix)?;
         if scoped.is_empty() {
@@ -187,6 +191,7 @@ impl ObjectStore for ProviderObjectStore {
         let path = self.to_path(key)?;
         let checksum_sha256 = self.sha256_checksum_metadata.then(|| sha256_digest(&bytes));
         let size_bytes = bytes.len() as u64;
+        let compare_and_swap = matches!(mode, PutMode::CompareAndSwap { .. });
         let options = PutOptions {
             mode: map_put_mode(mode),
             ..Default::default()
@@ -198,6 +203,9 @@ impl ObjectStore for ProviderObjectStore {
             .await
         {
             Ok(result) => Ok(Self::from_put_result(result, size_bytes, checksum_sha256)),
+            Err(err) if compare_and_swap && provider_not_found(&err) => {
+                Err(ObjectStoreError::PreconditionFailed)
+            }
             Err(err) => Err(map_provider_error(err)),
         }
     }
@@ -354,6 +362,16 @@ mod tests {
         assert!(matches!(
             store
                 .compare_and_swap(key, "stale", Bytes::from_static(b"two"))
+                .await,
+            Err(ObjectStoreError::PreconditionFailed)
+        ));
+        assert!(matches!(
+            store
+                .compare_and_swap(
+                    "namespaces/demo/control/missing-head.json",
+                    "missing",
+                    Bytes::from_static(b"two")
+                )
                 .await,
             Err(ObjectStoreError::PreconditionFailed)
         ));

--- a/crates/loonfs-objectstore/src/r2.rs
+++ b/crates/loonfs-objectstore/src/r2.rs
@@ -38,7 +38,11 @@ impl R2Store {
                 secret_access_key: config.secret_access_key,
                 session_token: None,
                 key_prefix: config.key_prefix,
-                force_path_style: false,
+                // The configured endpoint is the bucket-less account host;
+                // path style makes the client append the bucket. Virtual
+                // hosting would use the endpoint verbatim and address keys
+                // as buckets.
+                force_path_style: true,
                 sha256_checksum_metadata: false,
             })?,
         })

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -363,7 +363,6 @@ async fn gcp_gcs_real_provider_conformance() {
     let store = GcsStore::new(GcsStoreConfig {
         bucket: config.bucket,
         service_account_key_path: config.service_account_key_path,
-        application_credentials_path: config.application_credentials_path,
         key_prefix: Some(config.prefix),
     })
     .expect("create GCP GCS object store");

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -3,20 +3,22 @@ mod provider_env;
 use bytes::Bytes;
 use loonfs_api::ManifestId;
 use loonfs_objectstore::fs::LocalFsStore;
+use loonfs_objectstore::gcs::{GcsStore, GcsStoreConfig};
 use loonfs_objectstore::keys::{
     content_blob, content_store_descriptor, derived_progress, metadata_sst, namespace_descriptor,
     namespace_head, namespace_lease, namespace_manifest, wal_segment, DerivedWorkClass,
 };
 use loonfs_objectstore::probes::run_contract_probes;
-use loonfs_objectstore::provider::{Expectation, AWS_S3, CLOUDFLARE_R2, LOCAL_FS};
+use loonfs_objectstore::provider::{Expectation, AWS_S3, CLOUDFLARE_R2, GCP_GCS, LOCAL_FS};
 use loonfs_objectstore::r2::{R2Store, R2StoreConfig};
 use loonfs_objectstore::s3::{AwsS3Store, AwsS3StoreConfig};
 use loonfs_objectstore::ObjectStoreError;
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use provider_env::{
     provider_env_example_contents, AwsS3ConformanceConfig, CloudflareR2ConformanceConfig,
-    AWS_S3_OPTIONAL_VARS, AWS_S3_REQUIRED_VARS, CLOUDFLARE_R2_OPTIONAL_VARS,
-    CLOUDFLARE_R2_REQUIRED_VARS,
+    GcpGcsConformanceConfig, AWS_S3_OPTIONAL_VARS, AWS_S3_REQUIRED_VARS,
+    CLOUDFLARE_R2_OPTIONAL_VARS, CLOUDFLARE_R2_REQUIRED_VARS, GCP_GCS_OPTIONAL_VARS,
+    GCP_GCS_REQUIRED_VARS,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -27,6 +29,7 @@ fn provider_profiles_exist() {
     assert_eq!(LOCAL_FS.name, "local-fs");
     assert_eq!(AWS_S3.name, "aws-s3");
     assert_eq!(CLOUDFLARE_R2.name, "cloudflare-r2");
+    assert_eq!(GCP_GCS.name, "gcp-gcs");
     assert_eq!(
         LOCAL_FS.active_contract.opaque_compare_token_for_cas,
         Expectation::VerifyByConformance
@@ -125,6 +128,40 @@ fn provider_profiles_exist() {
         Expectation::ExpectedYes
     );
     assert_eq!(
+        GCP_GCS.active_contract.opaque_compare_token_for_cas,
+        Expectation::VerifyByConformance
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.full_object_read_identity,
+        Expectation::VerifyByConformance
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.overwrite,
+        Expectation::VerifyByConformance
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.delete_idempotent,
+        Expectation::VerifyByConformance
+    );
+    assert_eq!(
+        GCP_GCS
+            .active_contract
+            .head_reflects_latest_write_and_delete,
+        Expectation::VerifyByConformance
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.scoped_key_prefixing,
+        Expectation::ExpectedYes
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.traversal_rejection,
+        Expectation::ExpectedYes
+    );
+    assert_eq!(
+        GCP_GCS.active_contract.sorted_list_prefix,
+        Expectation::ExpectedYes
+    );
+    assert_eq!(
         LOCAL_FS.future_capabilities.multipart_upload,
         Expectation::ExpectedNo
     );
@@ -134,6 +171,10 @@ fn provider_profiles_exist() {
     );
     assert_eq!(
         CLOUDFLARE_R2.future_capabilities.multipart_upload,
+        Expectation::ExpectedYes
+    );
+    assert_eq!(
+        GCP_GCS.future_capabilities.multipart_upload,
         Expectation::ExpectedYes
     );
 }
@@ -195,6 +236,8 @@ fn provider_env_example_covers_real_provider_contract() {
         .chain(AWS_S3_OPTIONAL_VARS.iter())
         .chain(CLOUDFLARE_R2_REQUIRED_VARS.iter())
         .chain(CLOUDFLARE_R2_OPTIONAL_VARS.iter())
+        .chain(GCP_GCS_REQUIRED_VARS.iter())
+        .chain(GCP_GCS_OPTIONAL_VARS.iter())
     {
         assert!(
             example.contains(name),
@@ -309,6 +352,21 @@ async fn cloudflare_r2_real_provider_conformance() {
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
+    assert_provider_conformance(&store).await;
+}
+
+#[tokio::test]
+#[ignore = "requires real GCP GCS credentials"]
+async fn gcp_gcs_real_provider_conformance() {
+    let config = GcpGcsConformanceConfig::from_env()
+        .expect("load GCP GCS real-provider conformance environment");
+    let store = GcsStore::new(GcsStoreConfig {
+        bucket: config.bucket,
+        service_account_key_path: config.service_account_key_path,
+        application_credentials_path: config.application_credentials_path,
+        key_prefix: Some(config.prefix),
+    })
+    .expect("create GCP GCS object store");
     assert_provider_conformance(&store).await;
 }
 

--- a/crates/loonfs-objectstore/tests/provider-conformance.env.example
+++ b/crates/loonfs-objectstore/tests/provider-conformance.env.example
@@ -20,3 +20,10 @@ LOON_TEST_R2_ENDPOINT=https://0123456789abcdef0123456789abcdef.r2.cloudflarestor
 LOON_TEST_R2_ACCESS_KEY_ID=example-r2-access-key-id
 LOON_TEST_R2_SECRET_ACCESS_KEY=example-r2-secret-access-key-not-real
 LOON_TEST_R2_PREFIX=conformance/r2/manual
+
+# GCP GCS (native API; leave both credential paths unset to use the
+# ambient Google credential chain)
+LOON_TEST_GCS_BUCKET=example-loonfs-gcs-bucket
+LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH=/path/to/service-account.json
+LOON_TEST_GCS_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json
+LOON_TEST_GCS_PREFIX=conformance/gcp-gcs/manual

--- a/crates/loonfs-objectstore/tests/provider-conformance.env.example
+++ b/crates/loonfs-objectstore/tests/provider-conformance.env.example
@@ -21,9 +21,7 @@ LOON_TEST_R2_ACCESS_KEY_ID=example-r2-access-key-id
 LOON_TEST_R2_SECRET_ACCESS_KEY=example-r2-secret-access-key-not-real
 LOON_TEST_R2_PREFIX=conformance/r2/manual
 
-# GCP GCS (native API; leave both credential paths unset to use the
-# ambient Google credential chain)
+# GCP GCS 
 LOON_TEST_GCS_BUCKET=example-loonfs-gcs-bucket
 LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH=/path/to/service-account.json
-LOON_TEST_GCS_APPLICATION_CREDENTIALS=/path/to/application_default_credentials.json
 LOON_TEST_GCS_PREFIX=conformance/gcp-gcs/manual

--- a/crates/loonfs-objectstore/tests/provider_env.rs
+++ b/crates/loonfs-objectstore/tests/provider_env.rs
@@ -32,6 +32,14 @@ pub(crate) const CLOUDFLARE_R2_REQUIRED_VARS: &[&str] = &[
 
 pub(crate) const CLOUDFLARE_R2_OPTIONAL_VARS: &[&str] = &["LOON_TEST_R2_PREFIX"];
 
+pub(crate) const GCP_GCS_REQUIRED_VARS: &[&str] = &["LOON_TEST_GCS_BUCKET"];
+
+pub(crate) const GCP_GCS_OPTIONAL_VARS: &[&str] = &[
+    "LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH",
+    "LOON_TEST_GCS_APPLICATION_CREDENTIALS",
+    "LOON_TEST_GCS_PREFIX",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AwsS3ConformanceConfig {
     pub bucket: String,
@@ -50,6 +58,14 @@ pub(crate) struct CloudflareR2ConformanceConfig {
     pub endpoint: String,
     pub access_key_id: String,
     pub secret_access_key: String,
+    pub prefix: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GcpGcsConformanceConfig {
+    pub bucket: String,
+    pub service_account_key_path: Option<String>,
+    pub application_credentials_path: Option<String>,
     pub prefix: String,
 }
 
@@ -84,6 +100,18 @@ impl CloudflareR2ConformanceConfig {
             access_key_id: required_env("LOON_TEST_R2_ACCESS_KEY_ID")?,
             secret_access_key: required_env("LOON_TEST_R2_SECRET_ACCESS_KEY")?,
             prefix: optional_env("LOON_TEST_R2_PREFIX").unwrap_or_else(|| default_prefix("r2")),
+        })
+    }
+}
+
+impl GcpGcsConformanceConfig {
+    pub(crate) fn from_env() -> Result<Self, ProviderEnvError> {
+        Ok(Self {
+            bucket: required_env("LOON_TEST_GCS_BUCKET")?,
+            service_account_key_path: optional_env("LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH"),
+            application_credentials_path: optional_env("LOON_TEST_GCS_APPLICATION_CREDENTIALS"),
+            prefix: optional_env("LOON_TEST_GCS_PREFIX")
+                .unwrap_or_else(|| default_prefix("gcp-gcs")),
         })
     }
 }

--- a/crates/loonfs-objectstore/tests/provider_env.rs
+++ b/crates/loonfs-objectstore/tests/provider_env.rs
@@ -32,13 +32,12 @@ pub(crate) const CLOUDFLARE_R2_REQUIRED_VARS: &[&str] = &[
 
 pub(crate) const CLOUDFLARE_R2_OPTIONAL_VARS: &[&str] = &["LOON_TEST_R2_PREFIX"];
 
-pub(crate) const GCP_GCS_REQUIRED_VARS: &[&str] = &["LOON_TEST_GCS_BUCKET"];
-
-pub(crate) const GCP_GCS_OPTIONAL_VARS: &[&str] = &[
+pub(crate) const GCP_GCS_REQUIRED_VARS: &[&str] = &[
+    "LOON_TEST_GCS_BUCKET",
     "LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH",
-    "LOON_TEST_GCS_APPLICATION_CREDENTIALS",
-    "LOON_TEST_GCS_PREFIX",
 ];
+
+pub(crate) const GCP_GCS_OPTIONAL_VARS: &[&str] = &["LOON_TEST_GCS_PREFIX"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AwsS3ConformanceConfig {
@@ -64,8 +63,7 @@ pub(crate) struct CloudflareR2ConformanceConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GcpGcsConformanceConfig {
     pub bucket: String,
-    pub service_account_key_path: Option<String>,
-    pub application_credentials_path: Option<String>,
+    pub service_account_key_path: String,
     pub prefix: String,
 }
 
@@ -108,8 +106,7 @@ impl GcpGcsConformanceConfig {
     pub(crate) fn from_env() -> Result<Self, ProviderEnvError> {
         Ok(Self {
             bucket: required_env("LOON_TEST_GCS_BUCKET")?,
-            service_account_key_path: optional_env("LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH"),
-            application_credentials_path: optional_env("LOON_TEST_GCS_APPLICATION_CREDENTIALS"),
+            service_account_key_path: required_env("LOON_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH")?,
             prefix: optional_env("LOON_TEST_GCS_PREFIX")
                 .unwrap_or_else(|| default_prefix("gcp-gcs")),
         })

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -61,8 +61,7 @@ pub enum StoreConfig {
     },
     GcpGcs {
         bucket: String,
-        service_account_key_path: Option<String>,
-        application_credentials_path: Option<String>,
+        service_account_key_path: String,
         key_prefix: Option<String>,
     },
 }
@@ -164,12 +163,10 @@ impl ServerConfig {
             StoreConfig::GcpGcs {
                 bucket,
                 service_account_key_path,
-                application_credentials_path,
                 key_prefix,
             } => ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
                 bucket: bucket.clone(),
                 service_account_key_path: service_account_key_path.clone(),
-                application_credentials_path: application_credentials_path.clone(),
                 key_prefix: key_prefix.clone(),
             })
             .map_err(|err| ServerConfigError::InvalidField {
@@ -233,8 +230,13 @@ impl ServerConfig {
                 require_non_empty("store.secret_access_key", secret_access_key)?;
                 validate_absolute_http_url("store.endpoint_url", endpoint_url)?;
             }
-            StoreConfig::GcpGcs { bucket, .. } => {
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                ..
+            } => {
                 require_non_empty("store.bucket", bucket)?;
+                require_non_empty("store.service_account_key_path", service_account_key_path)?;
             }
         }
 
@@ -503,6 +505,7 @@ lease_duration_ms = 60000
 [store]
 kind = "gcp-gcs"
 bucket = " "
+service_account_key_path = "/tmp/service-account.json"
 key_prefix = "demo"
 "#,
         );

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1,5 +1,6 @@
 use http::Uri;
 use loonfs::RuntimeCacheConfig;
+use loonfs_objectstore::gcs::GcsStoreConfig;
 use loonfs_objectstore::r2::R2StoreConfig;
 use loonfs_objectstore::s3::AwsS3StoreConfig;
 use loonfs_objectstore::ConfiguredObjectStore;
@@ -56,6 +57,12 @@ pub enum StoreConfig {
         endpoint_url: String,
         access_key_id: String,
         secret_access_key: String,
+        key_prefix: Option<String>,
+    },
+    GcpGcs {
+        bucket: String,
+        service_account_key_path: Option<String>,
+        application_credentials_path: Option<String>,
         key_prefix: Option<String>,
     },
 }
@@ -154,6 +161,21 @@ impl ServerConfig {
                 field: "store.key_prefix",
                 reason: err.to_string(),
             }),
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                application_credentials_path,
+                key_prefix,
+            } => ConfiguredObjectStore::gcp_gcs(GcsStoreConfig {
+                bucket: bucket.clone(),
+                service_account_key_path: service_account_key_path.clone(),
+                application_credentials_path: application_credentials_path.clone(),
+                key_prefix: key_prefix.clone(),
+            })
+            .map_err(|err| ServerConfigError::InvalidField {
+                field: "store.key_prefix",
+                reason: err.to_string(),
+            }),
         }
     }
 
@@ -210,6 +232,9 @@ impl ServerConfig {
                 require_non_empty("store.access_key_id", access_key_id)?;
                 require_non_empty("store.secret_access_key", secret_access_key)?;
                 validate_absolute_http_url("store.endpoint_url", endpoint_url)?;
+            }
+            StoreConfig::GcpGcs { bucket, .. } => {
+                require_non_empty("store.bucket", bucket)?;
             }
         }
 
@@ -463,6 +488,28 @@ key_prefix = "demo"
 
         assert_invalid_field(aws_error, "store.endpoint_url");
         assert_invalid_field(r2_error, "store.endpoint_url");
+    }
+
+    #[test]
+    fn load_rejects_blank_gcs_bucket() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+lease_duration_ms = 60000
+
+[store]
+kind = "gcp-gcs"
+bucket = " "
+key_prefix = "demo"
+"#,
+        );
+
+        let error = load_server_config(&path).expect_err("blank gcs bucket");
+
+        assert_missing_field(error, "store.bucket");
     }
 
     #[test]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -213,6 +213,7 @@ fn trace_store_kind(store: &StoreConfig) -> TraceStoreKind {
         StoreConfig::LocalFs { .. } => TraceStoreKind::LocalFs,
         StoreConfig::AwsS3 { .. } => TraceStoreKind::S3,
         StoreConfig::CloudflareR2 { .. } => TraceStoreKind::R2,
+        StoreConfig::GcpGcs { .. } => TraceStoreKind::Gcs,
     }
 }
 

--- a/crates/loonfs/src/trace.rs
+++ b/crates/loonfs/src/trace.rs
@@ -28,6 +28,8 @@ pub enum TraceStoreKind {
     S3,
     /// Cloudflare R2.
     R2,
+    /// Google Cloud Storage.
+    Gcs,
     /// Backend not identified by the caller.
     Unknown,
 }
@@ -39,6 +41,7 @@ impl TraceStoreKind {
             Self::LocalFs => "local_fs",
             Self::S3 => "s3",
             Self::R2 => "r2",
+            Self::Gcs => "gcs",
             Self::Unknown => "unknown",
         }
     }
@@ -84,6 +87,7 @@ mod tests {
         assert_eq!(TraceStoreKind::LocalFs.as_str(), "local_fs");
         assert_eq!(TraceStoreKind::S3.as_str(), "s3");
         assert_eq!(TraceStoreKind::R2.as_str(), "r2");
+        assert_eq!(TraceStoreKind::Gcs.as_str(), "gcs");
         assert_eq!(TraceStoreKind::Unknown.as_str(), "unknown");
         assert_eq!(CachePath::WarmReuse.as_str(), "warm_reuse");
         assert_eq!(CachePath::EtagProbe.as_str(), "etag_probe");


### PR DESCRIPTION
- add native GCP GCS object-store provider wiring
- add CLI/server config support and example config
- extend provider conformance env support

Comparison vs. S3:

Metric | S3 | GCS | GCS vs S3
-- | -- | -- | --
Dataset build | 3m58s | 4m28s | +12.6% slower
Cold open | 718 ms | 775 ms | +7.9% slower
Cold first stat | 1.397s | 1.716s | +22.9% slower
Cold first full list | 272.261s | 239.194s | -12.1% faster
Warm full list | 237.354s | 241.728s | +1.8% slower
Warm stat | 1.017s | 1.256s | +23.5% slower
Warm read | 2.071s | 2.539s | +22.6% slower
Warm write | 2.650s | 3.270s | +23.4% slower
Compaction | 9.665s | 12.145s | +25.7% slower
Total incl. cleanup | 13m32s | 13m48s | +2.0% slower

Results are expected, GCS is better at throughput than latency. I could add large-file comparisons to test that later. 