### PR TITLE
feat(server): generate static openapi spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-test-
       - run: cargo test --all
+      - run: cargo test -p loonfs-server --features openapi openapi
 
   dist:
     name: dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-casefold",
  "unicode-normalization",
+ "utoipa",
  "uuid",
  "zstd",
 ]
@@ -1205,6 +1206,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "utoipa",
 ]
 
 [[package]]
@@ -2385,6 +2387,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ureq = { version = "2.10", features = ["json"] }
+utoipa = { version = "5.5", features = ["macros"] }
 urlencoding = "2"
 unicode-casefold = "0.2"
 unicode-normalization = "0.1"

--- a/crates/loonfs-api/Cargo.toml
+++ b/crates/loonfs-api/Cargo.toml
@@ -16,8 +16,12 @@ sha2.workspace = true
 thiserror.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true
+utoipa = { workspace = true, optional = true }
 uuid.workspace = true
 zstd.workspace = true
+
+[features]
+openapi = ["dep:utoipa"]
 
 [lints]
 workspace = true

--- a/crates/loonfs-api/src/capability.rs
+++ b/crates/loonfs-api/src/capability.rs
@@ -32,6 +32,7 @@ pub const FEATURE_UPLOADS_DIRECT_PUT: &str = "core.uploads.direct_put";
 /// [`supports`]: CapabilityDocument::supports
 /// [`has_profile`]: CapabilityDocument::has_profile
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CapabilityDocument {
     /// The protocol generation, currently `v0`.
     pub protocol_version: String,

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -62,8 +62,10 @@ impl<'de> Deserialize<'de> for ContentRefKind {
 /// A `ContentRef` is safe to publish only after the referenced bytes are
 /// durable in the namespace's content store.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ContentRef {
     /// Content strategy used by the referenced object.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub kind: ContentRefKind,
     /// Digest string, currently `sha256:<64 lowercase hex>`.
     pub digest: String,

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// HTTP error body used by LoonFS APIs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ApiError {
     /// Stable machine-readable reason from the [`ErrorCode`] registry.
     ///
@@ -31,6 +32,7 @@ impl ApiError {
 
 /// Request to create a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateNamespaceRequest {
     /// Durable namespace id to create.
     pub namespace_id: String,
@@ -38,6 +40,7 @@ pub struct CreateNamespaceRequest {
 
 /// Request to fork a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ForkNamespaceRequest {
     /// Durable namespace id for the fork target.
     pub new_namespace_id: String,
@@ -45,6 +48,7 @@ pub struct ForkNamespaceRequest {
 
 /// Short namespace listing entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct NamespaceSummary {
     /// Durable namespace id.
     pub namespace_id: NamespaceId,
@@ -52,6 +56,7 @@ pub struct NamespaceSummary {
 
 /// Response for namespace listing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListNamespacesResponse {
     /// Complete namespaces visible to the store for this page.
     pub namespaces: Vec<NamespaceSummary>,
@@ -65,6 +70,7 @@ pub struct ListNamespacesResponse {
 /// This is the point-lookup answer to "does this namespace exist, and where
 /// is its head?" — cheaper than listing all namespaces when only one matters.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct NamespaceStatusResponse {
     /// Namespace being inspected.
     pub namespace_id: NamespaceId,
@@ -84,6 +90,7 @@ pub struct NamespaceStatusResponse {
 
 /// Result of deleting a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DeleteNamespaceResponse {
     /// Namespace whose history ended.
     pub namespace_id: NamespaceId,
@@ -94,6 +101,7 @@ pub struct DeleteNamespaceResponse {
 
 /// Result of a namespace-visible mutation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MutationResult {
     /// Namespace that changed.
     pub namespace_id: NamespaceId,
@@ -103,6 +111,7 @@ pub struct MutationResult {
 
 /// Put behavior for path-oriented file writes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum FilesystemPutBehavior {
     /// Fail if the path already exists.
@@ -113,6 +122,7 @@ pub enum FilesystemPutBehavior {
 
 /// One path-oriented filesystem operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum FilesystemOperation {
     /// Create one directory.
@@ -143,6 +153,7 @@ pub enum FilesystemOperation {
 
 /// Request wrapper for one path-oriented operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FilesystemOperationRequest {
     /// Caller-supplied idempotency key for this operation.
     pub commit_id: CommitId,
@@ -155,6 +166,7 @@ pub struct FilesystemOperationRequest {
 
 /// Response for one path-oriented operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FilesystemOperationResponse {
     /// Namespace that changed.
     pub namespace_id: NamespaceId,
@@ -164,6 +176,7 @@ pub struct FilesystemOperationResponse {
 
 /// One immutable file revision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FileRevision {
     /// File inode that owns this revision.
     pub inode_id: InodeId,
@@ -177,6 +190,7 @@ pub struct FileRevision {
 
 /// Response for listing file revisions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListFileRevisionsResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
@@ -190,6 +204,7 @@ pub struct ListFileRevisionsResponse {
 
 /// Request to restore a file revision by inode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RestoreFileRevisionRequest {
     /// Caller-supplied idempotency key.
     pub commit_id: CommitId,
@@ -199,6 +214,7 @@ pub struct RestoreFileRevisionRequest {
 
 /// Result of creating or reusing a checkpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateCheckpointResponse {
     /// Namespace that was checkpointed.
     pub namespace_id: NamespaceId,
@@ -216,6 +232,7 @@ pub struct CreateCheckpointResponse {
 
 /// Result of advancing the retention floor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AdvanceRetentionResponse {
     /// Namespace whose retention floor changed.
     pub namespace_id: NamespaceId,

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -11,18 +11,24 @@ const SERVER_GENERATED_ID_BODY_LEN: usize = 32;
 /// A namespace is one filesystem history. This id is not a display name and
 /// should not be reused after destruction.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = String))]
 pub struct NamespaceId(String);
 
 /// Durable id for an immutable content store.
 ///
 /// Content stores own file bytes. Namespaces point at content stores.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = String))]
 pub struct ContentStoreId(String);
 
 /// Client-supplied idempotency key for one logical commit.
 ///
 /// Reuse the same `CommitId` when retrying the same request.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = String))]
 pub struct CommitId(String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -584,16 +590,22 @@ impl<'de> Deserialize<'de> for NameKey {
 ///
 /// Inodes are stable across renames.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = u64))]
 pub struct InodeId(pub u64);
 
 /// Monotonically increasing file revision counter within one file inode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = u64))]
 pub struct RevisionNo(pub u64);
 
 /// Monotonically increasing namespace commit sequence number.
 ///
 /// This is the global visibility order for a namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = u64))]
 pub struct ChangeSeq(pub u64);
 
 /// Monotonically increasing namespace manifest identity.
@@ -603,10 +615,14 @@ pub struct ChangeSeq(pub u64);
 /// later manifest ids can advance for checkpoint metadata, compaction, or
 /// fork/index metadata without a new namespace commit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = u64))]
 pub struct ManifestId(pub u64);
 
 /// Fencing token for write-lease concurrency control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = u64))]
 pub struct FenceToken(pub u64);
 
 /// Name-policy-derived directory entry key.
@@ -614,10 +630,13 @@ pub struct FenceToken(pub u64);
 /// Use this for exact name preconditions. Keep user-facing spelling in
 /// `DisplayName`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = String))]
 pub struct NameKey(String);
 
 /// Filesystem item kind.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum InodeKind {
     /// File with revision history.

--- a/crates/loonfs-api/src/server.rs
+++ b/crates/loonfs-api/src/server.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// This is the result shape for stat/list style reads. File entries include
 /// revision and content summary fields; directory entries leave those empty.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuthoritativePathEntry {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
@@ -35,6 +36,7 @@ pub struct AuthoritativePathEntry {
 /// still tells the caller which state it observed, and so the response can
 /// grow without reshaping `entries`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListPathEntriesResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
@@ -54,6 +56,7 @@ pub struct ListPathEntriesResponse {
 
 /// File bytes plus the metadata entry they came from.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuthoritativeFileBytes {
     /// Authoritative metadata for the file that was read.
     pub entry: AuthoritativePathEntry,

--- a/crates/loonfs-api/src/v0.rs
+++ b/crates/loonfs-api/src/v0.rs
@@ -10,6 +10,7 @@ pub type CommitAnnotations = BTreeMap<String, Value>;
 
 /// Rename behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum RenameMode {
     /// Move only if the destination name is absent.
@@ -26,6 +27,7 @@ pub fn default_rename_mode() -> RenameMode {
 
 /// Upload transport mode.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum UploadMode {
     /// The service receives bytes and writes content to object storage.
@@ -43,6 +45,7 @@ impl UploadMode {
 
 /// Request for starting an upload session.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct BeginUploadRequest {
     /// Requested upload transport. Absent keeps the existing service-proxied path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -54,6 +57,7 @@ pub struct BeginUploadRequest {
 
 /// Client-facing direct transfer capability.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ObjectTransferAccess {
     /// Short-lived URL plus required headers for one object-store write.
@@ -72,6 +76,7 @@ pub enum ObjectTransferAccess {
 
 /// Presigned direct_put upload details. The raw object key is intentionally not public.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DirectPutUpload {
     pub content_ref: ContentRef,
     pub access: ObjectTransferAccess,
@@ -79,6 +84,7 @@ pub struct DirectPutUpload {
 
 /// Stateless proof that a LoonFS server already validated a content ref.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ValidatedContentToken {
     pub content_ref: ContentRef,
     /// Opaque, server-signed token. Clients must not parse it.
@@ -87,6 +93,7 @@ pub struct ValidatedContentToken {
 
 /// Response for starting an upload session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct BeginUploadResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -97,6 +104,7 @@ pub struct BeginUploadResponse {
 
 /// Response after uploading bytes into a session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UploadContentResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -105,12 +113,14 @@ pub struct UploadContentResponse {
 
 /// Request to complete an upload with the expected content ref.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CompleteUploadRequest {
     pub content_ref: ContentRef,
 }
 
 /// Response after an upload session is completed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CompleteUploadResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: String,
@@ -124,6 +134,7 @@ pub struct CompleteUploadResponse {
 /// Use this lower-level shape when you need one commit id, optional
 /// preconditions, and multiple ordered operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitRequest {
     /// Client idempotency key for this logical commit.
     pub commit_id: CommitId,
@@ -137,11 +148,13 @@ pub struct CommitRequest {
     pub message: Option<String>,
     /// Optional structured metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub annotations: Option<CommitAnnotations>,
 }
 
 /// Response for a committed explicit request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitResponse {
     pub namespace_id: NamespaceId,
     pub commit_id: CommitId,
@@ -151,6 +164,7 @@ pub struct CommitResponse {
 
 /// Semantic operation inside a commit request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum CommitOp {
     /// Create a directory under a parent inode.
@@ -192,6 +206,7 @@ pub enum CommitOp {
 
 /// Race check evaluated before a commit is accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CommitPrecondition {
     /// File inode is still at this revision.
@@ -220,6 +235,7 @@ pub enum CommitPrecondition {
 
 /// Per-operation result returned after a commit succeeds.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum CommitOpResult {
     CreateDir {
@@ -264,6 +280,7 @@ pub enum CommitOpResult {
 /// Most clients should use semantic operation results. Sync and projection
 /// clients can apply deltas directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "delta", rename_all = "snake_case")]
 pub enum CommitDelta {
     CreateInode {
@@ -305,6 +322,7 @@ pub enum CommitDelta {
 
 /// One committed change in namespace order.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommittedChange {
     /// Namespace sequence for this logical commit.
     pub seq: ChangeSeq,
@@ -313,6 +331,7 @@ pub struct CommittedChange {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub annotations: Option<CommitAnnotations>,
     /// Semantic operation results.
     pub ops: Vec<CommitOpResult>,
@@ -322,6 +341,7 @@ pub struct CommittedChange {
 
 /// Change-feed response after a cursor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChangesResponse {
     pub namespace_id: NamespaceId,
     pub after_seq: ChangeSeq,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -945,7 +945,7 @@ key_prefix = "{key_prefix}"
                 .spawn()
                 .expect("spawn loonfs-server");
             let server_url = server_url_from_config(&server_config_path);
-            if wait_for_healthz_ready(&server_url) {
+            if wait_for_health_ready(&server_url) {
                 return ExternalServer { child, server_url };
             }
 
@@ -1027,10 +1027,10 @@ fn server_url_from_config(path: &Path) -> String {
     format!("http://{bind}")
 }
 
-fn wait_for_healthz_ready(server_url: &str) -> bool {
+fn wait_for_health_ready(server_url: &str) -> bool {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
-        if ureq::get(&format!("{server_url}/healthz")).call().is_ok() {
+        if ureq::get(&format!("{server_url}/health")).call().is_ok() {
             return true;
         }
         thread::sleep(Duration::from_millis(100));

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -373,8 +373,8 @@ impl Client {
         self.request_bytes(&url)
     }
 
-    pub fn healthz(&self) -> Result<(), ClientError> {
-        let url = format!("{}/healthz", self.base_url);
+    pub fn health(&self) -> Result<(), ClientError> {
+        let url = format!("{}/health", self.base_url);
         let request = self.authenticated(self.agent.get(&url));
         request.call().map_err(|err| self.map_error(err))?;
         Ok(())

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 name = "loonfs-server"
 path = "src/main.rs"
 
+[[bin]]
+name = "loonfs-openapi"
+path = "src/bin/loonfs-openapi.rs"
+required-features = ["openapi"]
+
 [dependencies]
 axum.workspace = true
 bytes.workspace = true
@@ -27,6 +32,7 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-trait.workspace = true
@@ -34,6 +40,9 @@ futures.workspace = true
 loonfs-client = { path = "../loonfs-client" }
 tempfile.workspace = true
 ureq.workspace = true
+
+[features]
+openapi = ["dep:utoipa", "loonfs-api/openapi"]
 
 [lints]
 workspace = true

--- a/crates/loonfs-server/src/bin/loonfs-openapi.rs
+++ b/crates/loonfs-server/src/bin/loonfs-openapi.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("docs/specs/openapi.json"));
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut json = loonfs_server::openapi_json_pretty()?;
+    json.push('\n');
+    std::fs::write(path, json)?;
+    Ok(())
+}

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -125,7 +125,7 @@ fn app_with_fs(
         transfer_issuer,
     };
     Router::new()
-        .route("/healthz", get(healthz))
+        .route("/health", get(health))
         .route("/v0/config", get(config_handler))
         .route(
             "/v0/namespaces",
@@ -279,14 +279,14 @@ pub async fn serve(config: ServerConfig) -> Result<(), String> {
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/healthz",
+        path = "/health",
         tag = "health",
         summary = "Check health",
         security(()),
         responses((status = 200, description = "Server health check", body = String))
     )
 )]
-async fn healthz() -> &'static str {
+async fn health() -> &'static str {
     "ok"
 }
 
@@ -1341,7 +1341,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         description = "Static OpenAPI document for the LoonFS v0 HTTP API."
     ),
     paths(
-        healthz,
+        health,
         config_handler,
         create_namespace,
         list_namespaces_handler,

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -281,6 +281,7 @@ pub async fn serve(config: ServerConfig) -> Result<(), String> {
         get,
         path = "/healthz",
         tag = "health",
+        summary = "Check health",
         security(()),
         responses((status = 200, description = "Server health check", body = String))
     )
@@ -295,6 +296,7 @@ async fn healthz() -> &'static str {
         get,
         path = "/v0/config",
         tag = "config",
+        summary = "Get config",
         responses(
             (status = 200, description = "Capability document", body = loonfs_api::CapabilityDocument),
             (status = 401, description = "Unauthorized", body = ApiError)
@@ -320,6 +322,7 @@ async fn config_handler(
         delete,
         path = "/v0/namespaces/{namespace}",
         tag = "namespaces",
+        summary = "Delete namespace",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("expected_head_seq" = Option<u64>, Query, description = "Delete only if the namespace head is still at this sequence")
@@ -359,6 +362,7 @@ async fn delete_namespace_handler(
         post,
         path = "/v0/namespaces",
         tag = "namespaces",
+        summary = "Create namespace",
         request_body = CreateNamespaceRequest,
         responses(
             (status = 200, description = "Namespace created", body = loonfs_api::NamespaceSummary),
@@ -390,6 +394,7 @@ async fn create_namespace(
         get,
         path = "/v0/namespaces",
         tag = "namespaces",
+        summary = "List namespaces",
         params(
             ("limit" = Option<String>, Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque namespace-list page cursor")
@@ -433,6 +438,7 @@ async fn list_namespaces_handler(
         post,
         path = "/v0/namespaces/{namespace}/forks",
         tag = "namespaces",
+        summary = "Fork namespace",
         params(("namespace" = String, Path, description = "Source namespace id")),
         request_body = ForkNamespaceRequest,
         responses(
@@ -468,6 +474,7 @@ async fn fork_namespace_handler(
         get,
         path = "/v0/namespaces/{namespace}/filesystem/list",
         tag = "filesystem",
+        summary = "List directory",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path"),
@@ -513,6 +520,7 @@ async fn list_entries(
         get,
         path = "/v0/namespaces/{namespace}",
         tag = "namespaces",
+        summary = "Get namespace status",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Namespace status", body = loonfs_api::NamespaceStatusResponse),
@@ -551,6 +559,7 @@ async fn namespace_status_handler(
         get,
         path = "/v0/namespaces/{namespace}/filesystem/stat",
         tag = "filesystem",
+        summary = "Stat path",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path")
@@ -587,6 +596,7 @@ async fn stat_entry(
         get,
         path = "/v0/namespaces/{namespace}/filesystem/content",
         tag = "filesystem",
+        summary = "Read file",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path"),
@@ -634,6 +644,7 @@ async fn get_content(
         get,
         path = "/v0/namespaces/{namespace}/filesystem/revisions",
         tag = "filesystem",
+        summary = "List file revisions",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path")
@@ -670,6 +681,7 @@ async fn list_path_revisions(
         get,
         path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions",
         tag = "inodes",
+        summary = "List inode revisions",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("inode_id" = String, Path, description = "File inode id")
@@ -705,6 +717,7 @@ async fn list_inode_revisions(
         get,
         path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{revision_no}/content",
         tag = "inodes",
+        summary = "Read inode revision",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("inode_id" = String, Path, description = "File inode id"),
@@ -742,6 +755,7 @@ async fn get_inode_revision_content(
         post,
         path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{source_revision_no}/restore",
         tag = "inodes",
+        summary = "Restore inode revision",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("inode_id" = String, Path, description = "File inode id"),
@@ -796,6 +810,7 @@ async fn restore_inode_revision(
         post,
         path = "/v0/namespaces/{namespace}/filesystem/operations",
         tag = "filesystem",
+        summary = "Run filesystem operation",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = FilesystemOperationRequest,
         responses(
@@ -930,6 +945,7 @@ async fn filesystem_operation(
         post,
         path = "/v0/namespaces/{namespace}/uploads",
         tag = "uploads",
+        summary = "Begin upload",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = BeginUploadRequest,
         responses(
@@ -1087,6 +1103,7 @@ fn current_unix_ms() -> Result<u64, ApiResponseError> {
         put,
         path = "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
         tag = "uploads",
+        summary = "Upload content",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
@@ -1125,6 +1142,7 @@ async fn upload_content_handler(
         post,
         path = "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
         tag = "uploads",
+        summary = "Complete upload",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
@@ -1171,6 +1189,7 @@ async fn complete_upload_handler(
         post,
         path = "/v0/namespaces/{namespace}/commits",
         tag = "commits",
+        summary = "Commit operations",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = ApiCommitRequest,
         responses(
@@ -1206,6 +1225,7 @@ async fn commit_operations_handler(
         get,
         path = "/v0/namespaces/{namespace}/changes",
         tag = "commits",
+        summary = "List changes",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("after_seq" = u64, Query, description = "Return committed changes after this sequence")
@@ -1243,6 +1263,7 @@ async fn list_changes_handler(
         post,
         path = "/v0/admin/namespaces/{namespace}/checkpoint",
         tag = "admin",
+        summary = "Create checkpoint",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Checkpoint created or reused", body = CreateCheckpointResponse),
@@ -1275,6 +1296,7 @@ async fn create_checkpoint_handler(
         post,
         path = "/v0/admin/namespaces/{namespace}/retention/advance",
         tag = "admin",
+        summary = "Advance retention",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Retention floor advanced", body = AdvanceRetentionResponse),

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1228,11 +1228,12 @@ async fn commit_operations_handler(
         summary = "List changes",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
-            ("after_seq" = u64, Query, description = "Return committed changes after this sequence")
+            ("after_seq" = u64, Query, description = "Return committed changes after this sequence"),
+            ("limit" = Option<String>, Query, description = "Maximum page size")
         ),
         responses(
             (status = 200, description = "Committed changes", body = ChangesResponse),
-            (status = 400, description = "Invalid change cursor", body = ApiError),
+            (status = 400, description = "Invalid change cursor or limit", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError)

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -275,10 +275,32 @@ pub async fn serve(config: ServerConfig) -> Result<(), String> {
         .map_err(|err| err.to_string())
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/healthz",
+        tag = "health",
+        security(()),
+        responses((status = 200, description = "Server health check", body = String))
+    )
+)]
 async fn healthz() -> &'static str {
     "ok"
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/config",
+        tag = "config",
+        responses(
+            (status = 200, description = "Capability document", body = loonfs_api::CapabilityDocument),
+            (status = 401, description = "Unauthorized", body = ApiError)
+        )
+    )
+)]
 async fn config_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -292,6 +314,26 @@ async fn config_handler(
     Ok(Json(capabilities))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        delete,
+        path = "/v0/namespaces/{namespace}",
+        tag = "namespaces",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("expected_head_seq" = Option<u64>, Query, description = "Delete only if the namespace head is still at this sequence")
+        ),
+        responses(
+            (status = 200, description = "Namespace deleted", body = loonfs_api::DeleteNamespaceResponse),
+            (status = 400, description = "Invalid request", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Delete conflict", body = ApiError),
+            (status = 410, description = "Namespace already deleted", body = ApiError)
+        )
+    )
+)]
 async fn delete_namespace_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -311,6 +353,22 @@ async fn delete_namespace_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces",
+        tag = "namespaces",
+        request_body = CreateNamespaceRequest,
+        responses(
+            (status = 200, description = "Namespace created", body = loonfs_api::NamespaceSummary),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 409, description = "Namespace already exists or is partial", body = ApiError),
+            (status = 410, description = "Namespace id was deleted and retired", body = ApiError)
+        )
+    )
+)]
 async fn create_namespace(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -326,6 +384,23 @@ async fn create_namespace(
     Ok(Json(summary))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces",
+        tag = "namespaces",
+        params(
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque namespace-list page cursor")
+        ),
+        responses(
+            (status = 200, description = "Namespace page", body = ListNamespacesResponse),
+            (status = 400, description = "Invalid limit or cursor", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError)
+        )
+    )
+)]
 async fn list_namespaces_handler(
     State(state): State<AppState>,
     Query(query): Query<PageQuery>,
@@ -352,6 +427,24 @@ async fn list_namespaces_handler(
     }))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/forks",
+        tag = "namespaces",
+        params(("namespace" = String, Path, description = "Source namespace id")),
+        request_body = ForkNamespaceRequest,
+        responses(
+            (status = 200, description = "Namespace forked", body = loonfs_api::NamespaceSummary),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Source namespace not found", body = ApiError),
+            (status = 409, description = "Fork conflict", body = ApiError),
+            (status = 410, description = "Source namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn fork_namespace_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -369,6 +462,27 @@ async fn fork_namespace_handler(
     Ok(Json(summary))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/filesystem/list",
+        tag = "filesystem",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("path" = String, Query, description = "Absolute filesystem path"),
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque directory-list page cursor")
+        ),
+        responses(
+            (status = 200, description = "Directory listing page", body = loonfs_api::ListPathEntriesResponse),
+            (status = 400, description = "Invalid path, limit, or cursor", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or path not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn list_entries(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -393,6 +507,22 @@ async fn list_entries(
     Ok(Json(listing))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}",
+        tag = "namespaces",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Namespace status", body = loonfs_api::NamespaceStatusResponse),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn namespace_status_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -415,6 +545,25 @@ async fn namespace_status_handler(
     }))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/filesystem/stat",
+        tag = "filesystem",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("path" = String, Query, description = "Absolute filesystem path")
+        ),
+        responses(
+            (status = 200, description = "Authoritative path entry", body = loonfs_api::AuthoritativePathEntry),
+            (status = 400, description = "Invalid path", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or path not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn stat_entry(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -432,6 +581,26 @@ async fn stat_entry(
     Ok(Json(entry))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/filesystem/content",
+        tag = "filesystem",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("path" = String, Query, description = "Absolute file path"),
+            ("revision_no" = Option<String>, Query, description = "Optional prior revision number")
+        ),
+        responses(
+            (status = 200, description = "File bytes", body = Vec<u8>, content_type = "application/octet-stream"),
+            (status = 400, description = "Invalid path or revision", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace, path, or revision not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn get_content(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -459,6 +628,25 @@ async fn get_content(
     Ok((StatusCode::OK, file.bytes).into_response())
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/filesystem/revisions",
+        tag = "filesystem",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("path" = String, Query, description = "Absolute file path")
+        ),
+        responses(
+            (status = 200, description = "File revisions", body = ListFileRevisionsResponse),
+            (status = 400, description = "Invalid path", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or path not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn list_path_revisions(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -476,6 +664,25 @@ async fn list_path_revisions(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions",
+        tag = "inodes",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("inode_id" = String, Path, description = "File inode id")
+        ),
+        responses(
+            (status = 200, description = "File revisions", body = ListFileRevisionsResponse),
+            (status = 400, description = "Invalid inode id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or inode not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn list_inode_revisions(
     State(state): State<AppState>,
     AxumPath((namespace, inode_id)): AxumPath<(String, String)>,
@@ -492,6 +699,26 @@ async fn list_inode_revisions(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{revision_no}/content",
+        tag = "inodes",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("inode_id" = String, Path, description = "File inode id"),
+            ("revision_no" = String, Path, description = "File revision number")
+        ),
+        responses(
+            (status = 200, description = "Revision bytes", body = Vec<u8>, content_type = "application/octet-stream"),
+            (status = 400, description = "Invalid inode id or revision", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace, inode, or revision not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn get_inode_revision_content(
     State(state): State<AppState>,
     AxumPath((namespace, inode_id, revision_no)): AxumPath<(String, String, String)>,
@@ -509,6 +736,28 @@ async fn get_inode_revision_content(
     Ok((StatusCode::OK, bytes).into_response())
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{source_revision_no}/restore",
+        tag = "inodes",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("inode_id" = String, Path, description = "File inode id"),
+            ("source_revision_no" = String, Path, description = "Revision number to restore")
+        ),
+        request_body = RestoreFileRevisionRequest,
+        responses(
+            (status = 200, description = "Restore commit response", body = ApiCommitResponse),
+            (status = 400, description = "Invalid inode id, revision, or request", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace, inode, or revision not found", body = ApiError),
+            (status = 409, description = "Commit conflict", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn restore_inode_revision(
     State(state): State<AppState>,
     AxumPath((namespace, inode_id, source_revision_no)): AxumPath<(String, String, String)>,
@@ -541,6 +790,25 @@ async fn restore_inode_revision(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/filesystem/operations",
+        tag = "filesystem",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        request_body = FilesystemOperationRequest,
+        responses(
+            (status = 200, description = "Filesystem operation committed", body = FilesystemOperationResponse),
+            (status = 400, description = "Invalid operation", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or path not found", body = ApiError),
+            (status = 409, description = "Operation conflict", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 503, description = "Commit unavailable", body = ApiError)
+        )
+    )
+)]
 async fn filesystem_operation(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -656,6 +924,24 @@ async fn filesystem_operation(
     Ok(Json(result))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/uploads",
+        tag = "uploads",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        request_body = BeginUploadRequest,
+        responses(
+            (status = 200, description = "Upload session started", body = BeginUploadResponse),
+            (status = 400, description = "Invalid upload request", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 501, description = "Requested upload mode is unsupported", body = ApiError)
+        )
+    )
+)]
 async fn begin_upload_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -795,6 +1081,27 @@ fn current_unix_ms() -> Result<u64, ApiResponseError> {
     })
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        put,
+        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+        tag = "uploads",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("upload_id" = String, Path, description = "Upload session id")
+        ),
+        request_body(content = Vec<u8>, content_type = "application/octet-stream"),
+        responses(
+            (status = 200, description = "Upload content accepted", body = UploadContentResponse),
+            (status = 400, description = "Invalid upload content", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or upload not found", body = ApiError),
+            (status = 409, description = "Upload content conflict", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn upload_content_handler(
     State(state): State<AppState>,
     AxumPath((namespace, upload_id)): AxumPath<(String, String)>,
@@ -812,6 +1119,27 @@ async fn upload_content_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+        tag = "uploads",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("upload_id" = String, Path, description = "Upload session id")
+        ),
+        request_body = CompleteUploadRequest,
+        responses(
+            (status = 200, description = "Upload completed", body = CompleteUploadResponse),
+            (status = 400, description = "Invalid completion request", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or upload not found", body = ApiError),
+            (status = 409, description = "Upload completion conflict", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn complete_upload_handler(
     State(state): State<AppState>,
     AxumPath((namespace, upload_id)): AxumPath<(String, String)>,
@@ -837,6 +1165,25 @@ async fn complete_upload_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace}/commits",
+        tag = "commits",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        request_body = ApiCommitRequest,
+        responses(
+            (status = 200, description = "Commit accepted", body = ApiCommitResponse),
+            (status = 400, description = "Invalid commit request", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Commit conflict", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 503, description = "Commit unavailable", body = ApiError)
+        )
+    )
+)]
 async fn commit_operations_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -853,6 +1200,25 @@ async fn commit_operations_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace}/changes",
+        tag = "commits",
+        params(
+            ("namespace" = String, Path, description = "Namespace id"),
+            ("after_seq" = u64, Query, description = "Return committed changes after this sequence")
+        ),
+        responses(
+            (status = 200, description = "Committed changes", body = ChangesResponse),
+            (status = 400, description = "Invalid change cursor", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn list_changes_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -871,6 +1237,23 @@ async fn list_changes_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/checkpoint",
+        tag = "admin",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Checkpoint created or reused", body = CreateCheckpointResponse),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 503, description = "Checkpoint unavailable", body = ApiError)
+        )
+    )
+)]
 async fn create_checkpoint_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -886,6 +1269,22 @@ async fn create_checkpoint_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/retention/advance",
+        tag = "admin",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Retention floor advanced", body = AdvanceRetentionResponse),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
 async fn advance_retention_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
@@ -900,6 +1299,110 @@ async fn advance_retention_handler(
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
 }
+
+#[cfg(feature = "openapi")]
+pub fn openapi_document() -> utoipa::openapi::OpenApi {
+    <LoonfsOpenApi as utoipa::OpenApi>::openapi()
+}
+
+#[cfg(feature = "openapi")]
+pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&openapi_document())
+}
+
+#[cfg(feature = "openapi")]
+#[derive(utoipa::OpenApi)]
+#[openapi(
+    info(
+        title = "LoonFS HTTP API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Static OpenAPI document for the LoonFS v0 HTTP API."
+    ),
+    paths(
+        healthz,
+        config_handler,
+        create_namespace,
+        list_namespaces_handler,
+        namespace_status_handler,
+        delete_namespace_handler,
+        fork_namespace_handler,
+        list_entries,
+        stat_entry,
+        get_content,
+        list_path_revisions,
+        filesystem_operation,
+        list_inode_revisions,
+        get_inode_revision_content,
+        restore_inode_revision,
+        begin_upload_handler,
+        upload_content_handler,
+        complete_upload_handler,
+        commit_operations_handler,
+        list_changes_handler,
+        create_checkpoint_handler,
+        advance_retention_handler
+    ),
+    components(schemas(
+        loonfs_api::CapabilityDocument,
+        ApiError,
+        CreateNamespaceRequest,
+        ForkNamespaceRequest,
+        loonfs_api::NamespaceSummary,
+        ListNamespacesResponse,
+        loonfs_api::NamespaceStatusResponse,
+        loonfs_api::DeleteNamespaceResponse,
+        FilesystemPutBehavior,
+        FilesystemOperation,
+        FilesystemOperationRequest,
+        FilesystemOperationResponse,
+        loonfs_api::FileRevision,
+        ListFileRevisionsResponse,
+        RestoreFileRevisionRequest,
+        CreateCheckpointResponse,
+        AdvanceRetentionResponse,
+        ContentRef,
+        loonfs_api::NamespaceId,
+        loonfs_api::ContentStoreId,
+        loonfs_api::CommitId,
+        InodeId,
+        RevisionNo,
+        ChangeSeq,
+        loonfs_api::ManifestId,
+        loonfs_api::NameKey,
+        loonfs_api::InodeKind,
+        loonfs_api::AuthoritativePathEntry,
+        loonfs_api::ListPathEntriesResponse,
+        BeginUploadRequest,
+        BeginUploadResponse,
+        UploadContentResponse,
+        CompleteUploadRequest,
+        CompleteUploadResponse,
+        DirectPutUpload,
+        ObjectTransferAccess,
+        UploadMode,
+        ValidatedContentToken,
+        ApiCommitRequest,
+        ApiCommitResponse,
+        loonfs_api::v0::RenameMode,
+        loonfs_api::v0::CommitOp,
+        loonfs_api::v0::CommitPrecondition,
+        loonfs_api::v0::CommitOpResult,
+        loonfs_api::v0::CommitDelta,
+        loonfs_api::v0::CommittedChange,
+        ChangesResponse
+    )),
+    tags(
+        (name = "health", description = "Server health"),
+        (name = "config", description = "Capability discovery"),
+        (name = "namespaces", description = "Namespace lifecycle and status"),
+        (name = "filesystem", description = "Path-oriented filesystem APIs"),
+        (name = "inodes", description = "Inode revision APIs"),
+        (name = "uploads", description = "Upload session APIs"),
+        (name = "commits", description = "Commit and change-feed APIs"),
+        (name = "admin", description = "Administrative maintenance APIs")
+    )
+)]
+struct LoonfsOpenApi;
 
 fn authorize(config: &ServerConfig, headers: &HeaderMap) -> Result<(), ApiResponseError> {
     let Some(expected) = &config.auth_token else {

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -14,4 +14,6 @@ pub use config::{
     load_server_config, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
 };
 pub use http::{app, serve};
+#[cfg(feature = "openapi")]
+pub use http::{openapi_document, openapi_json_pretty};
 pub use trace::{init_tracing_from_env, TraceInitError};

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -31,7 +31,7 @@ fn openapi_documents_current_server_paths() {
         .expect("openapi paths object");
 
     for (path, method) in [
-        ("/healthz", "get"),
+        ("/health", "get"),
         ("/v0/config", "get"),
         ("/v0/namespaces", "post"),
         ("/v0/namespaces", "get"),

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -1,0 +1,121 @@
+#![cfg(feature = "openapi")]
+#![allow(clippy::panic)]
+
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+const OPENAPI_JSON_PATH: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/specs/openapi.json");
+
+#[test]
+fn openapi_static_file_is_current() {
+    let mut generated = loonfs_server::openapi_json_pretty().expect("generate openapi json");
+    generated.push('\n');
+    let committed = std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json");
+
+    assert_eq!(
+        generated, committed,
+        "docs/specs/openapi.json is stale; rerun `cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- docs/specs/openapi.json`"
+    );
+}
+
+#[test]
+fn openapi_documents_current_server_paths() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("openapi paths object");
+
+    for (path, method) in [
+        ("/healthz", "get"),
+        ("/v0/config", "get"),
+        ("/v0/namespaces", "post"),
+        ("/v0/namespaces", "get"),
+        ("/v0/namespaces/{namespace}", "get"),
+        ("/v0/namespaces/{namespace}", "delete"),
+        ("/v0/namespaces/{namespace}/forks", "post"),
+        ("/v0/namespaces/{namespace}/filesystem/list", "get"),
+        ("/v0/namespaces/{namespace}/filesystem/stat", "get"),
+        ("/v0/namespaces/{namespace}/filesystem/content", "get"),
+        ("/v0/namespaces/{namespace}/filesystem/revisions", "get"),
+        ("/v0/namespaces/{namespace}/filesystem/operations", "post"),
+        (
+            "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions",
+            "get",
+        ),
+        (
+            "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{revision_no}/content",
+            "get",
+        ),
+        (
+            "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{source_revision_no}/restore",
+            "post",
+        ),
+        ("/v0/namespaces/{namespace}/uploads", "post"),
+        (
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            "put",
+        ),
+        (
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+            "post",
+        ),
+        ("/v0/namespaces/{namespace}/commits", "post"),
+        ("/v0/namespaces/{namespace}/changes", "get"),
+        ("/v0/admin/namespaces/{namespace}/checkpoint", "post"),
+        ("/v0/admin/namespaces/{namespace}/retention/advance", "post"),
+    ] {
+        assert_path_method(paths, path, method);
+    }
+
+    assert!(!paths.contains_key("/openapi.json"));
+    assert_query_params(paths, "/v0/namespaces", "get", &["limit", "cursor"]);
+    assert_query_params(
+        paths,
+        "/v0/namespaces/{namespace}/filesystem/list",
+        "get",
+        &["path", "limit", "cursor"],
+    );
+}
+
+fn assert_path_method(paths: &serde_json::Map<String, Value>, path: &str, method: &str) {
+    let path_item = paths
+        .get(path)
+        .unwrap_or_else(|| panic!("missing OpenAPI path `{path}`"));
+    assert!(
+        path_item.get(method).is_some(),
+        "missing OpenAPI method `{method}` for `{path}`"
+    );
+}
+
+fn assert_query_params(
+    paths: &serde_json::Map<String, Value>,
+    path: &str,
+    method: &str,
+    expected: &[&str],
+) {
+    let operation = paths
+        .get(path)
+        .and_then(|path_item| path_item.get(method))
+        .unwrap_or_else(|| panic!("missing OpenAPI operation `{method} {path}`"));
+    let params = operation
+        .get("parameters")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("missing parameters for `{method} {path}`"));
+    let query_names = params
+        .iter()
+        .filter(|param| param.get("in").and_then(Value::as_str) == Some("query"))
+        .filter_map(|param| param.get("name").and_then(Value::as_str))
+        .collect::<BTreeSet<_>>();
+
+    for name in expected {
+        assert!(
+            query_names.contains(name),
+            "missing query parameter `{name}` for `{method} {path}`"
+        );
+    }
+}

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -80,6 +80,12 @@ fn openapi_documents_current_server_paths() {
         "get",
         &["path", "limit", "cursor"],
     );
+    assert_query_params(
+        paths,
+        "/v0/namespaces/{namespace}/changes",
+        "get",
+        &["after_seq", "limit"],
+    );
 }
 
 fn assert_path_method(paths: &serde_json::Map<String, Value>, path: &str, method: &str) {

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -30,6 +30,7 @@ The specification lives in this folder:
 | `glossary.md` | Orientation | Shared vocabulary for every other document. |
 | `architecture.md` | Orientation | How the durable pieces and the runtime fit together. |
 | `object-storage-providers.md` | Non-normative reference | Provider limits and performance data points that inform the design. |
+| `openapi.json` | Generated reference | Static OpenAPI document for the current v0 HTTP API. |
 
 When something new needs a home: if other implementations must understand it to read or write a store correctly, it belongs in `format.md`. If it is an operation clients call, it belongs in `api.md`. How an implementation organizes its internal work — queues, schedulers, caches — is not specified at all.
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -15,6 +15,7 @@
         "tags": [
           "health"
         ],
+        "summary": "Check health",
         "operationId": "healthz",
         "responses": {
           "200": {
@@ -38,6 +39,7 @@
         "tags": [
           "admin"
         ],
+        "summary": "Create checkpoint",
         "operationId": "create_checkpoint_handler",
         "parameters": [
           {
@@ -119,6 +121,7 @@
         "tags": [
           "admin"
         ],
+        "summary": "Advance retention",
         "operationId": "advance_retention_handler",
         "parameters": [
           {
@@ -190,6 +193,7 @@
         "tags": [
           "config"
         ],
+        "summary": "Get config",
         "operationId": "config_handler",
         "responses": {
           "200": {
@@ -220,6 +224,7 @@
         "tags": [
           "namespaces"
         ],
+        "summary": "List namespaces",
         "operationId": "list_namespaces_handler",
         "parameters": [
           {
@@ -278,6 +283,7 @@
         "tags": [
           "namespaces"
         ],
+        "summary": "Create namespace",
         "operationId": "create_namespace",
         "requestBody": {
           "content": {
@@ -348,6 +354,7 @@
         "tags": [
           "namespaces"
         ],
+        "summary": "Get namespace status",
         "operationId": "namespace_status_handler",
         "parameters": [
           {
@@ -417,6 +424,7 @@
         "tags": [
           "namespaces"
         ],
+        "summary": "Delete namespace",
         "operationId": "delete_namespace_handler",
         "parameters": [
           {
@@ -509,6 +517,7 @@
         "tags": [
           "commits"
         ],
+        "summary": "List changes",
         "operationId": "list_changes_handler",
         "parameters": [
           {
@@ -591,6 +600,7 @@
         "tags": [
           "commits"
         ],
+        "summary": "Commit operations",
         "operationId": "commit_operations_handler",
         "parameters": [
           {
@@ -692,6 +702,7 @@
         "tags": [
           "filesystem"
         ],
+        "summary": "Read file",
         "operationId": "get_content",
         "parameters": [
           {
@@ -786,6 +797,7 @@
         "tags": [
           "filesystem"
         ],
+        "summary": "List directory",
         "operationId": "list_entries",
         "parameters": [
           {
@@ -884,6 +896,7 @@
         "tags": [
           "filesystem"
         ],
+        "summary": "Run filesystem operation",
         "operationId": "filesystem_operation",
         "parameters": [
           {
@@ -985,6 +998,7 @@
         "tags": [
           "filesystem"
         ],
+        "summary": "List file revisions",
         "operationId": "list_path_revisions",
         "parameters": [
           {
@@ -1065,6 +1079,7 @@
         "tags": [
           "filesystem"
         ],
+        "summary": "Stat path",
         "operationId": "stat_entry",
         "parameters": [
           {
@@ -1145,6 +1160,7 @@
         "tags": [
           "namespaces"
         ],
+        "summary": "Fork namespace",
         "operationId": "fork_namespace_handler",
         "parameters": [
           {
@@ -1236,6 +1252,7 @@
         "tags": [
           "inodes"
         ],
+        "summary": "List inode revisions",
         "operationId": "list_inode_revisions",
         "parameters": [
           {
@@ -1316,6 +1333,7 @@
         "tags": [
           "inodes"
         ],
+        "summary": "Read inode revision",
         "operationId": "get_inode_revision_content",
         "parameters": [
           {
@@ -1410,6 +1428,7 @@
         "tags": [
           "inodes"
         ],
+        "summary": "Restore inode revision",
         "operationId": "restore_inode_revision",
         "parameters": [
           {
@@ -1519,6 +1538,7 @@
         "tags": [
           "uploads"
         ],
+        "summary": "Begin upload",
         "operationId": "begin_upload_handler",
         "parameters": [
           {
@@ -1610,6 +1630,7 @@
         "tags": [
           "uploads"
         ],
+        "summary": "Complete upload",
         "operationId": "complete_upload_handler",
         "parameters": [
           {
@@ -1710,6 +1731,7 @@
         "tags": [
           "uploads"
         ],
+        "summary": "Upload content",
         "operationId": "upload_content_handler",
         "parameters": [
           {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -10,13 +10,13 @@
     "version": "0.1.1"
   },
   "paths": {
-    "/healthz": {
+    "/health": {
       "get": {
         "tags": [
           "health"
         ],
         "summary": "Check health",
-        "operationId": "healthz",
+        "operationId": "health",
         "responses": {
           "200": {
             "description": "Server health check",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1,0 +1,3623 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "LoonFS HTTP API",
+    "description": "Static OpenAPI document for the LoonFS v0 HTTP API.",
+    "license": {
+      "name": "Apache-2.0",
+      "identifier": "Apache-2.0"
+    },
+    "version": "0.1.1"
+  },
+  "paths": {
+    "/healthz": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "operationId": "healthz",
+        "responses": {
+          "200": {
+            "description": "Server health check",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/v0/admin/namespaces/{namespace}/checkpoint": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "create_checkpoint_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Checkpoint created or reused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCheckpointResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Checkpoint unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/admin/namespaces/{namespace}/retention/advance": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "advance_retention_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retention floor advanced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvanceRetentionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/config": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "operationId": "config_handler",
+        "responses": {
+          "200": {
+            "description": "Capability document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CapabilityDocument"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces": {
+      "get": {
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "list_namespaces_handler",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque namespace-list page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Namespace page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListNamespacesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid limit or cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "create_namespace",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNamespaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Namespace created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamespaceSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Namespace already exists or is partial",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace id was deleted and retired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}": {
+      "get": {
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "namespace_status_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Namespace status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamespaceStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "delete_namespace_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expected_head_seq",
+            "in": "query",
+            "description": "Delete only if the namespace head is still at this sequence",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteNamespaceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Delete conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace already deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/changes": {
+      "get": {
+        "tags": [
+          "commits"
+        ],
+        "operationId": "list_changes_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "after_seq",
+            "in": "query",
+            "description": "Return committed changes after this sequence",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Committed changes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid change cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/commits": {
+      "post": {
+        "tags": [
+          "commits"
+        ],
+        "operationId": "commit_operations_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Commit accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid commit request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Commit conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Commit unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/filesystem/content": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "operationId": "get_content",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute file path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "revision_no",
+            "in": "query",
+            "description": "Optional prior revision number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File bytes",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path or revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, path, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/filesystem/list": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "operationId": "list_entries",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute filesystem path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque directory-list page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Directory listing page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPathEntriesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path, limit, or cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/filesystem/operations": {
+      "post": {
+        "tags": [
+          "filesystem"
+        ],
+        "operationId": "filesystem_operation",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilesystemOperationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Filesystem operation committed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesystemOperationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Operation conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Commit unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/filesystem/revisions": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "operationId": "list_path_revisions",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute file path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File revisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFileRevisionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/filesystem/stat": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "operationId": "stat_entry",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Absolute filesystem path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authoritative path entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthoritativePathEntry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or path not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/forks": {
+      "post": {
+        "tags": [
+          "namespaces"
+        ],
+        "operationId": "fork_namespace_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Source namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForkNamespaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Namespace forked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamespaceSummary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Source namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Fork conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Source namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions": {
+      "get": {
+        "tags": [
+          "inodes"
+        ],
+        "operationId": "list_inode_revisions",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File revisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFileRevisionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or inode not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{revision_no}/content": {
+      "get": {
+        "tags": [
+          "inodes"
+        ],
+        "operationId": "get_inode_revision_content",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "revision_no",
+            "in": "path",
+            "description": "File revision number",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revision bytes",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id or revision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, inode, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/inodes/{inode_id}/revisions/{source_revision_no}/restore": {
+      "post": {
+        "tags": [
+          "inodes"
+        ],
+        "operationId": "restore_inode_revision",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source_revision_no",
+            "in": "path",
+            "description": "Revision number to restore",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestoreFileRevisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Restore commit response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id, revision, or request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, inode, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Commit conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/uploads": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "operationId": "begin_upload_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeginUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload session started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeginUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Requested upload mode is unsupported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/uploads/{upload_id}/complete": {
+      "post": {
+        "tags": [
+          "uploads"
+        ],
+        "operationId": "complete_upload_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid completion request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Upload completion conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace}/uploads/{upload_id}/content": {
+      "put": {
+        "tags": [
+          "uploads"
+        ],
+        "operationId": "upload_content_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "upload_id",
+            "in": "path",
+            "description": "Upload session id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Upload content accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid upload content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or upload not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Upload content conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AdvanceRetentionResponse": {
+        "type": "object",
+        "description": "Result of advancing the retention floor.",
+        "required": [
+          "namespace_id",
+          "retention_floor_seq"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace whose retention floor changed."
+          },
+          "retention_floor_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "New minimum sequence for incremental replay."
+          }
+        }
+      },
+      "ApiError": {
+        "type": "object",
+        "description": "HTTP error body used by LoonFS APIs.",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable reason from the [`ErrorCode`] registry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use [`ApiError::error_code`] for\ntyped access."
+          },
+          "feature": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          }
+        }
+      },
+      "AuthoritativePathEntry": {
+        "type": "object",
+        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. File entries include\nrevision and content summary fields; directory entries leave those empty.",
+        "required": [
+          "namespace_id",
+          "absolute_path",
+          "inode_id",
+          "inode_kind",
+          "head_seq",
+          "display_name"
+        ],
+        "properties": {
+          "absolute_path": {
+            "type": "string",
+            "description": "Absolute path as rendered from stored display names."
+          },
+          "content_ref": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ContentRef",
+                "description": "Current content reference, for files."
+              }
+            ]
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Stored display name for this path component."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this answer was read from."
+          },
+          "inode_id": {
+            "$ref": "#/components/schemas/InodeId",
+            "description": "Stable inode identity for this item."
+          },
+          "inode_kind": {
+            "$ref": "#/components/schemas/InodeKind",
+            "description": "Whether the item is a file or directory."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "parent_inode_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InodeId",
+                "description": "Parent directory inode, or `None` for the root."
+              }
+            ]
+          },
+          "revision_no": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RevisionNo",
+                "description": "Current file revision number, for files."
+              }
+            ]
+          },
+          "size_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Current file size in bytes, for files.",
+            "minimum": 0
+          }
+        }
+      },
+      "BeginUploadRequest": {
+        "type": "object",
+        "description": "Request for starting an upload session.",
+        "properties": {
+          "content_ref": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ContentRef",
+                "description": "Required for `direct_put`; the server signs exactly this content object."
+              }
+            ]
+          },
+          "mode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UploadMode",
+                "description": "Requested upload transport. Absent keeps the existing service-proxied path."
+              }
+            ]
+          }
+        }
+      },
+      "BeginUploadResponse": {
+        "type": "object",
+        "description": "Response for starting an upload session.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "mode"
+        ],
+        "properties": {
+          "direct_put": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DirectPutUpload"
+              }
+            ]
+          },
+          "mode": {
+            "$ref": "#/components/schemas/UploadMode"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId"
+          },
+          "upload_id": {
+            "type": "string"
+          }
+        }
+      },
+      "CapabilityDocument": {
+        "type": "object",
+        "description": "A deployment's self-description (API spec, \"Capability discovery\").\n\nA remote client fetches this from `GET /v0/config` and caches it; an\nembedded engine exposes the same document as a constant. SDK gating logic\nis therefore identical for both backends: check [`supports`] or\n[`has_profile`], and treat a `not_supported` error as authoritative when\nthe two disagree.\n\n[`supports`]: CapabilityDocument::supports\n[`has_profile`]: CapabilityDocument::has_profile",
+        "required": [
+          "protocol_version",
+          "profiles"
+        ],
+        "properties": {
+          "features": {
+            "type": "object",
+            "description": "Named features and whether this deployment supports them. An absent\nkey means unsupported.",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "limits": {
+            "type": "object",
+            "description": "Advisory numeric limits clients may use to pre-validate requests.",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Advertised profiles, each `plane/version`. All-or-nothing: every\nrequired op of an advertised profile is implemented."
+          },
+          "protocol_version": {
+            "type": "string",
+            "description": "The protocol generation, currently `v0`."
+          }
+        }
+      },
+      "ChangeSeq": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Monotonically increasing namespace commit sequence number.\n\nThis is the global visibility order for a namespace.",
+        "minimum": 0
+      },
+      "ChangesResponse": {
+        "type": "object",
+        "description": "Change-feed response after a cursor.",
+        "required": [
+          "namespace_id",
+          "after_seq",
+          "through_seq",
+          "changes"
+        ],
+        "properties": {
+          "after_seq": {
+            "$ref": "#/components/schemas/ChangeSeq"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommittedChange"
+            }
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId"
+          },
+          "through_seq": {
+            "$ref": "#/components/schemas/ChangeSeq"
+          }
+        }
+      },
+      "CommitDelta": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "semantic_op_index",
+              "delta_index",
+              "inode_id",
+              "inode_kind",
+              "delta"
+            ],
+            "properties": {
+              "delta": {
+                "type": "string",
+                "enum": [
+                  "create_inode"
+                ]
+              },
+              "delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "inode_kind": {
+                "$ref": "#/components/schemas/InodeKind"
+              },
+              "semantic_op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "semantic_op_index",
+              "delta_index",
+              "parent_inode",
+              "name_key",
+              "display_name",
+              "child_inode",
+              "delta"
+            ],
+            "properties": {
+              "child_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "delta": {
+                "type": "string",
+                "enum": [
+                  "bind_direntry"
+                ]
+              },
+              "delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "name_key": {
+                "$ref": "#/components/schemas/NameKey"
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "semantic_op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "semantic_op_index",
+              "delta_index",
+              "parent_inode",
+              "name_key",
+              "child_inode",
+              "bind_seq",
+              "bind_delta_index",
+              "delta"
+            ],
+            "properties": {
+              "bind_delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "bind_seq": {
+                "$ref": "#/components/schemas/ChangeSeq"
+              },
+              "child_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "delta": {
+                "type": "string",
+                "enum": [
+                  "unbind_direntry"
+                ]
+              },
+              "delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "name_key": {
+                "$ref": "#/components/schemas/NameKey"
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "semantic_op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "semantic_op_index",
+              "delta_index",
+              "inode_id",
+              "revision_no",
+              "content_ref",
+              "delta"
+            ],
+            "properties": {
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "delta": {
+                "type": "string",
+                "enum": [
+                  "append_file_revision"
+                ]
+              },
+              "delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              },
+              "semantic_op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "semantic_op_index",
+              "delta_index",
+              "root_inode",
+              "delta"
+            ],
+            "properties": {
+              "delta": {
+                "type": "string",
+                "enum": [
+                  "tombstone_subtree"
+                ]
+              },
+              "delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "root_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "semantic_op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          }
+        ],
+        "description": "Durable metadata fact exposed through the change feed.\n\nMost clients should use semantic operation results. Sync and projection\nclients can apply deltas directly."
+      },
+      "CommitId": {
+        "type": "string",
+        "description": "Client-supplied idempotency key for one logical commit.\n\nReuse the same `CommitId` when retrying the same request."
+      },
+      "CommitOp": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Create a directory under a parent inode.",
+            "required": [
+              "parent_inode",
+              "display_name",
+              "op"
+            ],
+            "properties": {
+              "display_name": {
+                "type": "string"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "create_dir"
+                ]
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Create a file under a parent inode.",
+            "required": [
+              "parent_inode",
+              "display_name",
+              "content_ref",
+              "op"
+            ],
+            "properties": {
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "create_file"
+                ]
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Append a new revision to an existing file.",
+            "required": [
+              "inode_id",
+              "base_revision_no",
+              "content_ref",
+              "op"
+            ],
+            "properties": {
+              "base_revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              },
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "replace_file"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Restore a prior revision as a new current revision.",
+            "required": [
+              "inode_id",
+              "source_revision_no",
+              "base_revision_no",
+              "op"
+            ],
+            "properties": {
+              "base_revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "restore_revision"
+                ]
+              },
+              "source_revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Delete a file inode.",
+            "required": [
+              "inode_id",
+              "op"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "delete_file"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Rename or move an inode.",
+            "required": [
+              "inode_id",
+              "new_parent_inode",
+              "new_display_name",
+              "op"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "mode": {
+                "$ref": "#/components/schemas/RenameMode"
+              },
+              "new_display_name": {
+                "type": "string"
+              },
+              "new_parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "rename"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Delete a directory subtree.",
+            "required": [
+              "root_inode",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "delete_subtree"
+                ]
+              },
+              "root_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              }
+            }
+          }
+        ],
+        "description": "Semantic operation inside a commit request."
+      },
+      "CommitOpResult": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "op"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "create_dir"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "revision_no",
+              "content_ref",
+              "op"
+            ],
+            "properties": {
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "create_file"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "revision_no",
+              "content_ref",
+              "op"
+            ],
+            "properties": {
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "replace_file"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "source_revision_no",
+              "revision_no",
+              "content_ref",
+              "op"
+            ],
+            "properties": {
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "restore_revision"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              },
+              "source_revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "op"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "delete_file"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "inode_id",
+              "op"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "rename"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "op_index",
+              "root_inode",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "delete_subtree"
+                ]
+              },
+              "op_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "root_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              }
+            }
+          }
+        ],
+        "description": "Per-operation result returned after a commit succeeds."
+      },
+      "CommitPrecondition": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "File inode is still at this revision.",
+            "required": [
+              "inode_id",
+              "revision_no",
+              "type"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "inode_revision_is"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Inode ancestors have not been subtree-deleted.",
+            "required": [
+              "inode_id",
+              "type"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ancestors_not_subtree_deleted"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Directory child name is still absent.",
+            "required": [
+              "parent_inode",
+              "name_key",
+              "type"
+            ],
+            "properties": {
+              "name_key": {
+                "$ref": "#/components/schemas/NameKey"
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "child_name_absent"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Directory binding is still exactly the binding the caller saw.",
+            "required": [
+              "parent_inode",
+              "name_key",
+              "child_inode",
+              "bind_seq",
+              "bind_delta_index",
+              "type"
+            ],
+            "properties": {
+              "bind_delta_index": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "bind_seq": {
+                "$ref": "#/components/schemas/ChangeSeq"
+              },
+              "child_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "name_key": {
+                "$ref": "#/components/schemas/NameKey"
+              },
+              "parent_inode": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "binding_is"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Directory is still empty.",
+            "required": [
+              "inode_id",
+              "type"
+            ],
+            "properties": {
+              "inode_id": {
+                "$ref": "#/components/schemas/InodeId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "directory_empty"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Race check evaluated before a commit is accepted."
+      },
+      "CommitRequest": {
+        "type": "object",
+        "description": "Explicit semantic commit request.\n\nUse this lower-level shape when you need one commit id, optional\npreconditions, and multiple ordered operations.",
+        "required": [
+          "commit_id",
+          "ops"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Optional structured metadata."
+          },
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Client idempotency key for this logical commit."
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable note."
+          },
+          "ops": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitOp"
+            },
+            "description": "Ordered semantic operations."
+          },
+          "preconditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitPrecondition"
+            },
+            "description": "Optional race checks evaluated before mutation."
+          }
+        }
+      },
+      "CommitResponse": {
+        "type": "object",
+        "description": "Response for a committed explicit request.",
+        "required": [
+          "namespace_id",
+          "commit_id",
+          "committed_seq",
+          "results"
+        ],
+        "properties": {
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId"
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitOpResult"
+            }
+          }
+        }
+      },
+      "CommittedChange": {
+        "type": "object",
+        "description": "One committed change in namespace order.",
+        "required": [
+          "seq",
+          "commit_id",
+          "ops",
+          "deltas"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object"
+          },
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Client idempotency key for this logical commit."
+          },
+          "deltas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitDelta"
+            },
+            "description": "Materialized metadata deltas."
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ops": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitOpResult"
+            },
+            "description": "Semantic operation results."
+          },
+          "seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace sequence for this logical commit."
+          }
+        }
+      },
+      "CompleteUploadRequest": {
+        "type": "object",
+        "description": "Request to complete an upload with the expected content ref.",
+        "required": [
+          "content_ref"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef"
+          }
+        }
+      },
+      "CompleteUploadResponse": {
+        "type": "object",
+        "description": "Response after an upload session is completed.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "content_ref"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId"
+          },
+          "upload_id": {
+            "type": "string"
+          },
+          "validated_content_token": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ContentRef": {
+        "type": "object",
+        "description": "Pointer to immutable file content.\n\nA `ContentRef` is safe to publish only after the referenced bytes are\ndurable in the namespace's content store.",
+        "required": [
+          "kind",
+          "digest",
+          "size_bytes"
+        ],
+        "properties": {
+          "digest": {
+            "type": "string",
+            "description": "Digest string, currently `sha256:<64 lowercase hex>`."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Content strategy used by the referenced object."
+          },
+          "size_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Complete byte length of the referenced file content.",
+            "minimum": 0
+          }
+        }
+      },
+      "ContentStoreId": {
+        "type": "string",
+        "description": "Durable id for an immutable content store.\n\nContent stores own file bytes. Namespaces point at content stores."
+      },
+      "CreateCheckpointResponse": {
+        "type": "object",
+        "description": "Result of creating or reusing a checkpoint.",
+        "required": [
+          "namespace_id",
+          "checkpoint_id",
+          "checkpoint_seq",
+          "manifest_id"
+        ],
+        "properties": {
+          "checkpoint_id": {
+            "type": "string",
+            "description": "Durable checkpoint id."
+          },
+          "checkpoint_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence covered by the checkpoint."
+          },
+          "current_manifest_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ManifestId",
+                "description": "Head's current manifest pointer after the operation."
+              }
+            ]
+          },
+          "latest_checkpoint_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Latest checkpoint id recorded on the head after the operation."
+          },
+          "manifest_id": {
+            "$ref": "#/components/schemas/ManifestId",
+            "description": "Manifest pinned by the checkpoint."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was checkpointed."
+          }
+        }
+      },
+      "CreateNamespaceRequest": {
+        "type": "object",
+        "description": "Request to create a namespace.",
+        "required": [
+          "namespace_id"
+        ],
+        "properties": {
+          "namespace_id": {
+            "type": "string",
+            "description": "Durable namespace id to create."
+          }
+        }
+      },
+      "DeleteNamespaceResponse": {
+        "type": "object",
+        "description": "Result of deleting a namespace.",
+        "required": [
+          "namespace_id",
+          "head_seq"
+        ],
+        "properties": {
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "The head's last committed sequence; the delete linearized\nimmediately after it, so this is where history ended."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace whose history ended."
+          }
+        }
+      },
+      "DirectPutUpload": {
+        "type": "object",
+        "description": "Presigned direct_put upload details. The raw object key is intentionally not public.",
+        "required": [
+          "content_ref",
+          "access"
+        ],
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/ObjectTransferAccess"
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef"
+          }
+        }
+      },
+      "FileRevision": {
+        "type": "object",
+        "description": "One immutable file revision.",
+        "required": [
+          "inode_id",
+          "revision_no",
+          "committed_seq",
+          "content_ref"
+        ],
+        "properties": {
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace sequence that created this revision."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Content stored for this revision."
+          },
+          "inode_id": {
+            "$ref": "#/components/schemas/InodeId",
+            "description": "File inode that owns this revision."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision number within the file inode."
+          }
+        }
+      },
+      "FilesystemOperation": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Create one directory.",
+            "required": [
+              "path",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "create_dir"
+                ]
+              },
+              "path": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Create or replace one file with an already-durable content ref.",
+            "required": [
+              "path",
+              "content_ref",
+              "behavior",
+              "op"
+            ],
+            "properties": {
+              "behavior": {
+                "$ref": "#/components/schemas/FilesystemPutBehavior"
+              },
+              "content_ref": {
+                "$ref": "#/components/schemas/ContentRef"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "put_file"
+                ]
+              },
+              "path": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Delete one path.",
+            "required": [
+              "path",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "delete_path"
+                ]
+              },
+              "path": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Move one path to another path.",
+            "required": [
+              "from_path",
+              "to_path",
+              "op"
+            ],
+            "properties": {
+              "from_path": {
+                "type": "string"
+              },
+              "mode": {
+                "$ref": "#/components/schemas/RenameMode"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "move_path"
+                ]
+              },
+              "to_path": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Copy one file path to another path.",
+            "required": [
+              "from_path",
+              "to_path",
+              "op"
+            ],
+            "properties": {
+              "from_path": {
+                "type": "string"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "copy_path"
+                ]
+              },
+              "to_path": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Restore an older revision as the current revision for a path.",
+            "required": [
+              "path",
+              "source_revision_no",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "restore_revision"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "source_revision_no": {
+                "$ref": "#/components/schemas/RevisionNo"
+              }
+            }
+          }
+        ],
+        "description": "One path-oriented filesystem operation."
+      },
+      "FilesystemOperationRequest": {
+        "type": "object",
+        "description": "Request wrapper for one path-oriented operation.",
+        "required": [
+          "commit_id",
+          "operation"
+        ],
+        "properties": {
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Caller-supplied idempotency key for this operation."
+          },
+          "content_tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidatedContentToken"
+            },
+            "description": "Proofs for any new external content refs introduced by this operation."
+          },
+          "operation": {
+            "$ref": "#/components/schemas/FilesystemOperation",
+            "description": "Operation to apply."
+          }
+        }
+      },
+      "FilesystemOperationResponse": {
+        "type": "object",
+        "description": "Response for one path-oriented operation.",
+        "required": [
+          "namespace_id",
+          "committed_seq"
+        ],
+        "properties": {
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence where the operation became visible."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that changed."
+          }
+        }
+      },
+      "FilesystemPutBehavior": {
+        "type": "string",
+        "description": "Put behavior for path-oriented file writes.",
+        "enum": [
+          "create_only",
+          "replace_existing"
+        ]
+      },
+      "ForkNamespaceRequest": {
+        "type": "object",
+        "description": "Request to fork a namespace.",
+        "required": [
+          "new_namespace_id"
+        ],
+        "properties": {
+          "new_namespace_id": {
+            "type": "string",
+            "description": "Durable namespace id for the fork target."
+          }
+        }
+      },
+      "InodeId": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Numeric identity of a file or directory within a namespace.\n\nInodes are stable across renames.",
+        "minimum": 0
+      },
+      "InodeKind": {
+        "type": "string",
+        "description": "Filesystem item kind.",
+        "enum": [
+          "file",
+          "dir"
+        ]
+      },
+      "ListFileRevisionsResponse": {
+        "type": "object",
+        "description": "Response for listing file revisions.",
+        "required": [
+          "namespace_id",
+          "inode_id",
+          "head_seq",
+          "revisions"
+        ],
+        "properties": {
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence used for the read."
+          },
+          "inode_id": {
+            "$ref": "#/components/schemas/InodeId",
+            "description": "File inode whose revisions were returned."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "revisions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileRevision"
+            },
+            "description": "Retained revisions in order."
+          }
+        }
+      },
+      "ListNamespacesResponse": {
+        "type": "object",
+        "description": "Response for namespace listing.",
+        "required": [
+          "namespaces"
+        ],
+        "properties": {
+          "namespaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NamespaceSummary"
+            },
+            "description": "Complete namespaces visible to the store for this page."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor for the next page, if more namespaces remain."
+          }
+        }
+      },
+      "ListPathEntriesResponse": {
+        "type": "object",
+        "description": "One directory listing and the namespace head it was answered at.\n\nThe envelope names the listing target and head so an empty directory\nstill tells the caller which state it observed, and so the response can\ngrow without reshaping `entries`.",
+        "required": [
+          "namespace_id",
+          "absolute_path",
+          "head_seq",
+          "entries"
+        ],
+        "properties": {
+          "absolute_path": {
+            "type": "string",
+            "description": "Absolute path of the listed directory."
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuthoritativePathEntry"
+            },
+            "description": "Directory entries for this page.\n\nPaged APIs return entries in canonical name-key order. Higher-level\nfull-list convenience methods may sort drained results for display."
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace head sequence this listing was read from."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Cursor for the next page, if more entries remain."
+          }
+        }
+      },
+      "ManifestId": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Monotonically increasing namespace manifest identity.\n\nThis is the durable file-set version identity for namespace manifests.\nInitial/fork manifests may be seeded from the current head sequence, but\nlater manifest ids can advance for checkpoint metadata, compaction, or\nfork/index metadata without a new namespace commit.",
+        "minimum": 0
+      },
+      "NameKey": {
+        "type": "string",
+        "description": "Name-policy-derived directory entry key.\n\nUse this for exact name preconditions. Keep user-facing spelling in\n`DisplayName`."
+      },
+      "NamespaceId": {
+        "type": "string",
+        "description": "Durable id for one namespace.\n\nA namespace is one filesystem history. This id is not a display name and\nshould not be reused after destruction."
+      },
+      "NamespaceStatusResponse": {
+        "type": "object",
+        "description": "Status summary for one namespace.\n\nThis is the point-lookup answer to \"does this namespace exist, and where\nis its head?\" — cheaper than listing all namespaces when only one matters.",
+        "required": [
+          "namespace_id",
+          "head_seq",
+          "wal_tail_segments",
+          "retention_floor_seq"
+        ],
+        "properties": {
+          "current_manifest_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ManifestId",
+                "description": "Current manifest pointer recorded by the head."
+              }
+            ]
+          },
+          "head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Current visible namespace sequence."
+          },
+          "latest_checkpoint_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Latest checkpoint recorded by the head."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace being inspected."
+          },
+          "retention_floor_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Oldest sequence still promised for incremental replay."
+          },
+          "wal_tail_segments": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of visible WAL segments after the manifest basis.",
+            "minimum": 0
+          }
+        }
+      },
+      "NamespaceSummary": {
+        "type": "object",
+        "description": "Short namespace listing entry.",
+        "required": [
+          "namespace_id"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Durable namespace id."
+          }
+        }
+      },
+      "ObjectTransferAccess": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Short-lived URL plus required headers for one object-store write.",
+            "required": [
+              "method",
+              "url",
+              "expires_at_ms",
+              "kind"
+            ],
+            "properties": {
+              "expires_at_ms": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Expiration timestamp in Unix milliseconds.",
+                "minimum": 0
+              },
+              "headers": {
+                "type": "object",
+                "description": "Headers that are covered by the signature and must be sent.",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "presigned_url"
+                ]
+              },
+              "method": {
+                "type": "string",
+                "description": "HTTP method the client must use."
+              },
+              "url": {
+                "type": "string",
+                "description": "Full presigned URL."
+              }
+            }
+          }
+        ],
+        "description": "Client-facing direct transfer capability."
+      },
+      "RenameMode": {
+        "type": "string",
+        "description": "Rename behavior.",
+        "enum": [
+          "no_replace",
+          "replace_existing",
+          "exchange"
+        ]
+      },
+      "RestoreFileRevisionRequest": {
+        "type": "object",
+        "description": "Request to restore a file revision by inode.",
+        "required": [
+          "commit_id",
+          "base_revision_no"
+        ],
+        "properties": {
+          "base_revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Current revision the caller expects to replace."
+          },
+          "commit_id": {
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Caller-supplied idempotency key."
+          }
+        }
+      },
+      "RevisionNo": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Monotonically increasing file revision counter within one file inode.",
+        "minimum": 0
+      },
+      "UploadContentResponse": {
+        "type": "object",
+        "description": "Response after uploading bytes into a session.",
+        "required": [
+          "namespace_id",
+          "upload_id",
+          "content_ref"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef"
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId"
+          },
+          "upload_id": {
+            "type": "string"
+          }
+        }
+      },
+      "UploadMode": {
+        "type": "string",
+        "description": "Upload transport mode.",
+        "enum": [
+          "service_proxied",
+          "direct_put"
+        ]
+      },
+      "ValidatedContentToken": {
+        "type": "object",
+        "description": "Stateless proof that a LoonFS server already validated a content ref.",
+        "required": [
+          "content_ref",
+          "token"
+        ],
+        "properties": {
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef"
+          },
+          "token": {
+            "type": "string",
+            "description": "Opaque, server-signed token. Clients must not parse it."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "health",
+      "description": "Server health"
+    },
+    {
+      "name": "config",
+      "description": "Capability discovery"
+    },
+    {
+      "name": "namespaces",
+      "description": "Namespace lifecycle and status"
+    },
+    {
+      "name": "filesystem",
+      "description": "Path-oriented filesystem APIs"
+    },
+    {
+      "name": "inodes",
+      "description": "Inode revision APIs"
+    },
+    {
+      "name": "uploads",
+      "description": "Upload session APIs"
+    },
+    {
+      "name": "commits",
+      "description": "Commit and change-feed APIs"
+    },
+    {
+      "name": "admin",
+      "description": "Administrative maintenance APIs"
+    }
+  ]
+}

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -539,6 +539,15 @@
               "format": "int64",
               "minimum": 0
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -553,7 +562,7 @@
             }
           },
           "400": {
-            "description": "Invalid change cursor",
+            "description": "Invalid change cursor or limit",
             "content": {
               "application/json": {
                 "schema": {
@@ -2087,6 +2096,16 @@
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId"
           },
+          "next_after_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq"
+              }
+            ]
+          },
           "through_seq": {
             "$ref": "#/components/schemas/ChangeSeq"
           }
@@ -3387,7 +3406,7 @@
             "items": {
               "$ref": "#/components/schemas/AuthoritativePathEntry"
             },
-            "description": "Directory entries for this page.\n\nPaged APIs return entries in canonical name-key order. Higher-level\nfull-list convenience methods may sort drained results for display."
+            "description": "Directory entries for this page.\n\nEntries are returned in canonical name-key order. Higher-level display\nsurfaces may sort entries separately for presentation."
           },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",


### PR DESCRIPTION
adds static openapi generation and checks in `docs/specs/openapi.json`.
