### PR TITLE
perf(revisions): add paged bounded revision reads

### DIFF
--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -200,6 +200,9 @@ pub struct ListFileRevisionsResponse {
     pub head_seq: ChangeSeq,
     /// Retained revisions in order.
     pub revisions: Vec<FileRevision>,
+    /// Opaque cursor for the next page, if more revisions are available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Request to restore a file revision by inode.

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -62,11 +62,12 @@ pub use ids::{
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
 pub use pagination::{
-    decode_directory_cursor, decode_namespaces_cursor, encode_directory_cursor,
-    encode_namespaces_cursor, DirectoryPageCursor, EffectiveLimit, LimitError,
-    NamespacesPageCursor, Page, PageCursorError, PageRequest, PaginationPolicy,
-    PaginationPolicyError, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT,
-    LIMIT_PAGINATION_MAX, PAGE_CURSOR_VERSION,
+    decode_directory_cursor, decode_file_revisions_cursor, decode_namespaces_cursor,
+    encode_directory_cursor, encode_file_revisions_cursor, encode_namespaces_cursor,
+    DirectoryPageCursor, EffectiveLimit, FileRevisionsPageCursor, LimitError, NamespacesPageCursor,
+    Page, PageCursorError, PageRequest, PaginationPolicy, PaginationPolicyError,
+    DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
+    PAGE_CURSOR_VERSION,
 };
 pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
 pub use server::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -56,6 +56,7 @@ pub enum MetadataTableFamily {
     DirentryChildBinds,
     DirentryUnbinds,
     Revisions,
+    RevisionsByInodeDesc,
     Tombstones,
     CommitReceipts,
 }
@@ -223,14 +224,26 @@ impl MetadataRow {
             Self::Revision {
                 inode_id,
                 revision_no,
+                committed_seq,
                 revision_delta_index,
                 ..
-            } => {
-                format!(
-                    "revision-{:020}-{:020}-{:010}",
-                    inode_id.0, revision_no.0, revision_delta_index
-                )
-            }
+            } => match family {
+                MetadataTableFamily::RevisionsByInodeDesc => {
+                    let reverse_revision_no = u64::MAX - revision_no.0;
+                    let reverse_committed_seq = u64::MAX - committed_seq.0;
+                    let reverse_delta_index = u32::MAX - revision_delta_index;
+                    format!(
+                        "revision-by-inode-desc-{:020}-{:020}-{:020}-{:010}",
+                        inode_id.0, reverse_revision_no, reverse_committed_seq, reverse_delta_index
+                    )
+                }
+                _ => {
+                    format!(
+                        "revision-{:020}-{:020}-{:010}",
+                        inode_id.0, revision_no.0, revision_delta_index
+                    )
+                }
+            },
             Self::Tombstone {
                 root_inode_id,
                 tombstone_seq,
@@ -780,6 +793,30 @@ mod tests {
         assert_eq!(
             row.row_key_for_family(MetadataTableFamily::DirentryBinds),
             "direntry-00000000000000000009-7265706f72742d32303234-00000000000000000017-0000000003"
+        );
+    }
+
+    #[test]
+    fn revision_row_key_supports_newest_first_inode_index() {
+        let row = super::MetadataRow::Revision {
+            inode_id: InodeId(42),
+            revision_no: crate::RevisionNo(7),
+            committed_seq: ChangeSeq(12),
+            revision_delta_index: 3,
+            content_ref: crate::ContentRef {
+                kind: crate::ContentRefKind::WholeFileV0,
+                digest: "sha256:abc".to_owned(),
+                size_bytes: 123,
+            },
+        };
+
+        assert_eq!(
+            row.row_key_for_family(MetadataTableFamily::Revisions),
+            "revision-00000000000000000042-00000000000000000007-0000000003"
+        );
+        assert_eq!(
+            row.row_key_for_family(MetadataTableFamily::RevisionsByInodeDesc),
+            "revision-by-inode-desc-00000000000000000042-18446744073709551608-18446744073709551603-4294967292"
         );
     }
 

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, InodeId, NameKey, NamespaceId};
+use crate::{ChangeSeq, InodeId, NameKey, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
@@ -202,6 +202,25 @@ pub struct DirectoryPageCursor {
     pub last_name_key: NameKey,
 }
 
+/// Cursor for one file revision listing snapshot.
+///
+/// Revision pagination advances in newest-first revision order for one file
+/// inode. The cursor includes the snapshot head plus the last returned row's
+/// complete ordering identity so ties stay unambiguous.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRevisionsPageCursor {
+    /// Snapshot sequence captured by the first page.
+    pub head_seq: ChangeSeq,
+    /// File inode whose revisions are being listed.
+    pub inode_id: InodeId,
+    /// Last revision number returned to the client.
+    pub last_revision_no: RevisionNo,
+    /// Namespace sequence that created the last returned revision.
+    pub last_committed_seq: ChangeSeq,
+    /// WAL delta index that created the last returned revision.
+    pub last_revision_delta_index: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum EncodedPageCursor {
@@ -215,12 +234,22 @@ enum EncodedPageCursor {
         dir_inode_id: InodeId,
         last_name_key: NameKey,
     },
+    FileRevisions {
+        v: u8,
+        head_seq: ChangeSeq,
+        inode_id: InodeId,
+        last_revision_no: RevisionNo,
+        last_committed_seq: ChangeSeq,
+        last_revision_delta_index: u32,
+    },
 }
 
 impl EncodedPageCursor {
     fn version(&self) -> u8 {
         match self {
-            Self::Namespaces { v, .. } | Self::Directory { v, .. } => *v,
+            Self::Namespaces { v, .. }
+            | Self::Directory { v, .. }
+            | Self::FileRevisions { v, .. } => *v,
         }
     }
 
@@ -228,6 +257,7 @@ impl EncodedPageCursor {
         match self {
             Self::Namespaces { .. } => "namespaces",
             Self::Directory { .. } => "directory",
+            Self::FileRevisions { .. } => "file_revisions",
         }
     }
 
@@ -290,6 +320,46 @@ pub fn decode_directory_cursor(value: &str) -> Result<DirectoryPageCursor, PageC
         }),
         other => Err(PageCursorError::WrongKind {
             expected: "directory",
+            actual: other.kind(),
+        }),
+    }
+}
+
+/// Encodes a file-revisions cursor as an opaque string for clients.
+pub fn encode_file_revisions_cursor(
+    cursor: &FileRevisionsPageCursor,
+) -> Result<String, PageCursorError> {
+    encode_cursor(&EncodedPageCursor::FileRevisions {
+        v: PAGE_CURSOR_VERSION,
+        head_seq: cursor.head_seq,
+        inode_id: cursor.inode_id,
+        last_revision_no: cursor.last_revision_no,
+        last_committed_seq: cursor.last_committed_seq,
+        last_revision_delta_index: cursor.last_revision_delta_index,
+    })
+}
+
+/// Decodes a file-revisions cursor returned by [`encode_file_revisions_cursor`].
+pub fn decode_file_revisions_cursor(
+    value: &str,
+) -> Result<FileRevisionsPageCursor, PageCursorError> {
+    match decode_cursor(value)? {
+        EncodedPageCursor::FileRevisions {
+            head_seq,
+            inode_id,
+            last_revision_no,
+            last_committed_seq,
+            last_revision_delta_index,
+            ..
+        } => Ok(FileRevisionsPageCursor {
+            head_seq,
+            inode_id,
+            last_revision_no,
+            last_committed_seq,
+            last_revision_delta_index,
+        }),
+        other => Err(PageCursorError::WrongKind {
+            expected: "file_revisions",
             actual: other.kind(),
         }),
     }
@@ -441,6 +511,22 @@ mod tests {
 
         let encoded = encode_directory_cursor(&cursor).expect("encode cursor");
         let decoded = decode_directory_cursor(&encoded).expect("decode cursor");
+
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn file_revisions_cursor_round_trips() {
+        let cursor = FileRevisionsPageCursor {
+            head_seq: ChangeSeq(11),
+            inode_id: InodeId(7),
+            last_revision_no: RevisionNo(5),
+            last_committed_seq: ChangeSeq(10),
+            last_revision_delta_index: 3,
+        };
+
+        let encoded = encode_file_revisions_cursor(&cursor).expect("encode cursor");
+        let decoded = decode_file_revisions_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
     }

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -85,8 +85,8 @@ Filesystem operations
   loon put [--profile <name>] [--namespace <name>] <local-path> [remote-path] [--force]
     Upload a local file
 
-  loon revisions [--profile <name>] [--namespace <name>] <path>
-    List file revisions
+  loon revisions [--profile <name>] [--namespace <name>] [--limit <n>] [--cursor <cursor>] <path>
+    List file revisions newest-first
 
   loon mkdir [--profile <name>] [--namespace <name>] <path>
     Create a directory

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -30,7 +30,7 @@ pub(crate) enum Command {
     Cat(FilesystemCatArgs),
     Get(FilesystemGetArgs),
     Put(FilesystemPutArgs),
-    Revisions(FilesystemPathArgs),
+    Revisions(FilesystemRevisionsArgs),
     Restore(FilesystemRestoreArgs),
     Mkdir(FilesystemPathArgs),
     Rm(FilesystemPathArgs),
@@ -251,6 +251,17 @@ pub(crate) struct FilesystemPathArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     pub path: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FilesystemRevisionsArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: String,
+    #[arg(long)]
+    pub limit: Option<u32>,
+    #[arg(long)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -7,8 +7,9 @@ use loonfs::{
     RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use loonfs_api::{
-    AuthoritativePathEntry, ChangeSeq, CommitId, ListFileRevisionsResponse, MutationResult,
-    NamespaceId, NamespaceStatusResponse, NamespaceSummary, RevisionNo,
+    AuthoritativePathEntry, ChangeSeq, CommitId, EffectiveLimit, ListFileRevisionsResponse,
+    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary, PaginationPolicy,
+    RevisionNo,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use std::future::Future;
@@ -41,6 +42,8 @@ pub(crate) trait Backend {
     fn list_file_revisions(
         &self,
         spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, CliError>;
     fn put_file_bytes(
         &self,
@@ -139,9 +142,11 @@ impl Backend for RemoteBackend {
     fn list_file_revisions(
         &self,
         spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, CliError> {
         self.client
-            .list_file_revisions(spec)
+            .list_file_revisions_page(spec, limit, cursor)
             .map_err(map_client_error)
     }
 
@@ -330,12 +335,23 @@ impl Backend for EmbeddedBackend {
     fn list_file_revisions(
         &self,
         spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, CliError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
-            self.fs
-                .list_file_revisions(&namespace_id, &spec.absolute_path),
+            self.fs.list_file_revisions_page(
+                &namespace_id,
+                &spec.absolute_path,
+                loonfs_api::PageRequest {
+                    limit: resolve_cli_page_limit(limit)?,
+                    cursor: cursor
+                        .map(loonfs_api::decode_file_revisions_cursor)
+                        .transpose()
+                        .map_err(|error| CliError::new("invalid_cursor", error.to_string()))?,
+                },
+            ),
         )
     }
 
@@ -460,6 +476,12 @@ impl Backend for EmbeddedBackend {
 
 fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
     NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))
+}
+
+fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, CliError> {
+    PaginationPolicy::default()
+        .resolve_limit(limit)
+        .map_err(|error| CliError::invalid_input(error.to_string()))
 }
 
 fn generated_commit_id() -> CommitId {

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -5,7 +5,8 @@ use super::context::{
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemLsArgs, FilesystemMoveArgs,
-    FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs, RuntimeBehavior,
+    FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs, FilesystemRevisionsArgs,
+    RuntimeBehavior,
 };
 use crate::error::CliError;
 use loonfs_api::{InodeKind, RevisionNo};
@@ -193,7 +194,7 @@ pub(crate) fn run_filesystem_get(
 
 pub(crate) fn run_filesystem_revisions(
     kind: CommandKind,
-    args: FilesystemPathArgs,
+    args: FilesystemRevisionsArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target)?;
     let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
@@ -207,7 +208,7 @@ pub(crate) fn run_filesystem_revisions(
     let response = context
         .target
         .backend()
-        .list_file_revisions(&spec)
+        .list_file_revisions(&spec, args.limit, args.cursor.as_deref())
         .map_err(|error| {
             fail(
                 kind,
@@ -224,6 +225,7 @@ pub(crate) fn run_filesystem_revisions(
         data: CommandData::FileRevisions {
             target: render_target(&context.namespace, &spec.absolute_path),
             revisions: response.revisions,
+            next_cursor: response.next_cursor,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -51,6 +51,7 @@ pub(crate) enum CommandData {
     FileRevisions {
         target: String,
         revisions: Vec<FileRevision>,
+        next_cursor: Option<String>,
     },
     FileTransfer {
         target: String,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -182,7 +182,11 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             }
             lines.join("\n")
         }
-        CommandData::FileRevisions { target, revisions } => {
+        CommandData::FileRevisions {
+            target,
+            revisions,
+            next_cursor,
+        } => {
             let mut lines = vec![
                 format!("revisions for {target}"),
                 "REVISION\tSEQ\tSIZE\tDIGEST".to_owned(),
@@ -195,6 +199,9 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     revision.content_ref.size_bytes,
                     revision.content_ref.digest
                 ));
+            }
+            if let Some(cursor) = next_cursor {
+                lines.push(format!("next_cursor: {cursor}"));
             }
             lines.join("\n")
         }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -336,13 +336,23 @@ impl Client {
         &self,
         spec: &NamespacePath,
     ) -> Result<ListFileRevisionsResponse, ClientError> {
+        self.list_file_revisions_page(spec, None, None)
+    }
+
+    pub fn list_file_revisions_page(
+        &self,
+        spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListFileRevisionsResponse, ClientError> {
         let namespace = namespace_url_segment(&spec.namespace)?;
-        let url = format!(
+        let mut url = format!(
             "{}/v0/namespaces/{}/filesystem/revisions?path={}",
             self.base_url,
             namespace,
             urlencoding::encode(&spec.absolute_path)
         );
+        append_optional_pagination_query(&mut url, true, limit, cursor);
         self.request_json::<(), ListFileRevisionsResponse>(self.agent.get(&url), None)
     }
 
@@ -351,11 +361,22 @@ impl Client {
         namespace: &str,
         inode_id: InodeId,
     ) -> Result<ListFileRevisionsResponse, ClientError> {
+        self.list_file_revisions_for_inode_page(namespace, inode_id, None, None)
+    }
+
+    pub fn list_file_revisions_for_inode_page(
+        &self,
+        namespace: &str,
+        inode_id: InodeId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListFileRevisionsResponse, ClientError> {
         let namespace = namespace_url_segment(namespace)?;
-        let url = format!(
+        let mut url = format!(
             "{}/v0/namespaces/{namespace}/inodes/{}/revisions",
             self.base_url, inode_id.0
         );
+        append_optional_pagination_query(&mut url, false, limit, cursor);
         self.request_json::<(), ListFileRevisionsResponse>(self.agent.get(&url), None)
     }
 

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -569,6 +569,7 @@ pub(super) fn append_rows_to_metadata(
                 revision_delta_index: *revision_delta_index,
                 content_ref: content_ref.clone(),
             }),
+            (MetadataTableFamily::RevisionsByInodeDesc, MetadataRow::Revision { .. }) => {}
             (
                 MetadataTableFamily::Tombstones,
                 MetadataRow::Tombstone {

--- a/crates/loonfs-core/src/checkpoint/row.rs
+++ b/crates/loonfs-core/src/checkpoint/row.rs
@@ -53,17 +53,19 @@ pub(super) fn manifest_rows_for_family(
                 unbind_delta_index: unbind.unbind_delta_index,
             })
             .collect::<Vec<_>>(),
-        MetadataTableFamily::Revisions => metadata_state
-            .revisions()
-            .iter()
-            .map(|revision| MetadataRow::Revision {
-                inode_id: revision.inode_id,
-                revision_no: revision.revision_no,
-                committed_seq: revision.committed_seq,
-                revision_delta_index: revision.revision_delta_index,
-                content_ref: revision.content_ref.clone(),
-            })
-            .collect::<Vec<_>>(),
+        MetadataTableFamily::Revisions | MetadataTableFamily::RevisionsByInodeDesc => {
+            metadata_state
+                .revisions()
+                .iter()
+                .map(|revision| MetadataRow::Revision {
+                    inode_id: revision.inode_id,
+                    revision_no: revision.revision_no,
+                    committed_seq: revision.committed_seq,
+                    revision_delta_index: revision.revision_delta_index,
+                    content_ref: revision.content_ref.clone(),
+                })
+                .collect::<Vec<_>>()
+        }
         MetadataTableFamily::Tombstones => metadata_state
             .subtree_tombstones()
             .iter()
@@ -138,6 +140,10 @@ pub(super) fn manifest_row_matches_family(row: &MetadataRow, family: MetadataTab
                 MetadataRow::DirentryUnbind { .. }
             )
             | (MetadataTableFamily::Revisions, MetadataRow::Revision { .. })
+            | (
+                MetadataTableFamily::RevisionsByInodeDesc,
+                MetadataRow::Revision { .. },
+            )
             | (
                 MetadataTableFamily::Tombstones,
                 MetadataRow::Tombstone { .. }

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -14,12 +14,13 @@ pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const MAX_CHECKPOINT_L0_RUNS: usize = DEFAULT_MAX_CHECKPOINT_L0_RUNS;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
 pub(super) const CHECKPOINT_BASE_RUN_LEVEL: u32 = 1;
-pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 7] = [
+pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 8] = [
     MetadataTableFamily::Inodes,
     MetadataTableFamily::DirentryBinds,
     MetadataTableFamily::DirentryChildBinds,
     MetadataTableFamily::DirentryUnbinds,
     MetadataTableFamily::Revisions,
+    MetadataTableFamily::RevisionsByInodeDesc,
     MetadataTableFamily::Tombstones,
     MetadataTableFamily::CommitReceipts,
 ];

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -14,9 +14,9 @@ use loonfs_api::v0::{
 use loonfs_api::EffectiveLimit;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
-    ContentRef, CreateCheckpointResponse, DirectoryPageCursor, InodeId, ListFileRevisionsResponse,
-    MutationResult, NamespaceId, NamespaceSummary, NamespacesPageCursor, Page, PageRequest,
-    RevisionNo, DEFAULT_PAGE_LIMIT,
+    ContentRef, CreateCheckpointResponse, DirectoryPageCursor, FileRevision,
+    FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, MutationResult, NamespaceId,
+    NamespaceSummary, NamespacesPageCursor, Page, PageRequest, RevisionNo, DEFAULT_PAGE_LIMIT,
 };
 use loonfs_objectstore::ObjectStore;
 use std::num::NonZeroU32;
@@ -406,6 +406,50 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         }
     }
 
+    /// Lists one page of retained revisions for the file currently visible at `path`.
+    pub async fn list_file_revisions_page(
+        &self,
+        path: impl AsRef<str>,
+        options: ReadOptions,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> CoreResult<Page<FileRevision, FileRevisionsPageCursor>> {
+        let path = path.as_ref();
+        match options.source() {
+            ReadSource::ManifestPlusTail => {
+                crate::path::query::list_file_revisions_page_from_manifest_plus_tail(
+                    &self.store,
+                    &self.namespace_id,
+                    path,
+                    request,
+                )
+                .await
+            }
+            ReadSource::ManifestPlusTailAtHead {
+                head,
+                head_etag,
+                table_cache,
+                tail_cache,
+                max_wal_tail_segments,
+            } => {
+                let cache_context = manifest_plus_tail_cache_context(
+                    head_etag.as_str(),
+                    table_cache,
+                    tail_cache,
+                    *max_wal_tail_segments,
+                );
+                crate::path::query::list_file_revisions_page_from_manifest_plus_tail_at_head_with_cache(
+                    &self.store,
+                    &self.namespace_id,
+                    head,
+                    cache_context,
+                    path,
+                    request,
+                )
+                .await
+            }
+        }
+    }
+
     /// Lists retained revisions for a file inode, independent of its current path.
     pub async fn list_file_revisions_for_inode(
         &self,
@@ -440,6 +484,49 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                     head,
                     cache_context,
                     inode_id,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Lists one page of retained revisions for a file inode.
+    pub async fn list_file_revisions_for_inode_page(
+        &self,
+        inode_id: InodeId,
+        options: ReadOptions,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> CoreResult<Page<FileRevision, FileRevisionsPageCursor>> {
+        match options.source() {
+            ReadSource::ManifestPlusTail => {
+                crate::path::query::list_file_revisions_for_inode_page_from_manifest_plus_tail(
+                    &self.store,
+                    &self.namespace_id,
+                    inode_id,
+                    request,
+                )
+                .await
+            }
+            ReadSource::ManifestPlusTailAtHead {
+                head,
+                head_etag,
+                table_cache,
+                tail_cache,
+                max_wal_tail_segments,
+            } => {
+                let cache_context = manifest_plus_tail_cache_context(
+                    head_etag.as_str(),
+                    table_cache,
+                    tail_cache,
+                    *max_wal_tail_segments,
+                );
+                crate::path::query::list_file_revisions_for_inode_page_from_manifest_plus_tail_at_head_with_cache(
+                    &self.store,
+                    &self.namespace_id,
+                    head,
+                    cache_context,
+                    inode_id,
+                    request,
                 )
                 .await
             }

--- a/crates/loonfs-core/src/path/query.rs
+++ b/crates/loonfs-core/src/path/query.rs
@@ -1,8 +1,12 @@
 pub(crate) use super::read::{
     list_file_revisions_for_inode_from_manifest_plus_tail,
     list_file_revisions_for_inode_from_manifest_plus_tail_at_head_with_cache,
+    list_file_revisions_for_inode_page_from_manifest_plus_tail,
+    list_file_revisions_for_inode_page_from_manifest_plus_tail_at_head_with_cache,
     list_file_revisions_from_manifest_plus_tail,
     list_file_revisions_from_manifest_plus_tail_at_head_with_cache,
+    list_file_revisions_page_from_manifest_plus_tail,
+    list_file_revisions_page_from_manifest_plus_tail_at_head_with_cache,
     list_path_from_manifest_plus_tail, list_path_from_manifest_plus_tail_at_head_with_cache,
     list_path_page_from_manifest_plus_tail,
     list_path_page_from_manifest_plus_tail_at_head_with_cache,

--- a/crates/loonfs-core/src/path/read/checkpoint_index.rs
+++ b/crates/loonfs-core/src/path/read/checkpoint_index.rs
@@ -11,7 +11,7 @@ use crate::metadata::{
     SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::{hex_encode_row_key_component, MetadataRow, MetadataTableFamily};
-use loonfs_api::{CommitId, InodeId};
+use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
 use loonfs_objectstore::ObjectStore;
 
 pub(super) fn manifest_error_to_core(error: ManifestLoadError) -> CoreError {
@@ -133,13 +133,63 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         .collect())
 }
 
-pub(super) async fn revisions_for_inode<S: ObjectStore + ?Sized>(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RevisionPagePosition {
+    pub(super) revision_no: RevisionNo,
+    pub(super) committed_seq: ChangeSeq,
+    pub(super) revision_delta_index: u32,
+}
+
+pub(super) async fn latest_revision_for_inode<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
-) -> Result<Vec<RevisionRecord>, CoreError> {
-    let prefix = format!("revision-{:020}-", inode_id.0);
+) -> Result<Option<RevisionRecord>, CoreError> {
+    Ok(revisions_for_inode_page_desc(tables, inode_id, None, 1)
+        .await?
+        .into_iter()
+        .next())
+}
+
+pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    inode_id: InodeId,
+    revision_no: RevisionNo,
+) -> Result<Option<RevisionRecord>, CoreError> {
+    let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
     Ok(tables
-        .scan_prefix(MetadataTableFamily::Revisions, &prefix)
+        .scan_range_page(
+            MetadataTableFamily::RevisionsByInodeDesc,
+            &exact_prefix,
+            string_prefix_upper_bound(&exact_prefix).as_deref(),
+            1,
+        )
+        .await
+        .map_err(manifest_error_to_core)?
+        .into_iter()
+        .filter_map(revision_from_manifest_row)
+        .next())
+}
+
+pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    inode_id: InodeId,
+    start_after: Option<RevisionPagePosition>,
+    limit: usize,
+) -> Result<Vec<RevisionRecord>, CoreError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let inode_prefix = revision_by_inode_desc_inode_prefix(inode_id);
+    let lower_bound = start_after
+        .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
+        .unwrap_or_else(|| inode_prefix.clone());
+    Ok(tables
+        .scan_range_page(
+            MetadataTableFamily::RevisionsByInodeDesc,
+            &lower_bound,
+            string_prefix_upper_bound(&inode_prefix).as_deref(),
+            limit,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -189,4 +239,29 @@ fn resume_after_row_key(row_key: &str) -> String {
     lower_bound.push_str(row_key);
     lower_bound.push('\0');
     lower_bound
+}
+
+fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
+    format!("revision-by-inode-desc-{:020}-", inode_id.0)
+}
+
+fn revision_by_inode_desc_exact_revision_prefix(
+    inode_id: InodeId,
+    revision_no: RevisionNo,
+) -> String {
+    format!(
+        "{}{:020}-",
+        revision_by_inode_desc_inode_prefix(inode_id),
+        u64::MAX - revision_no.0
+    )
+}
+
+fn revision_by_inode_desc_row_key(inode_id: InodeId, position: RevisionPagePosition) -> String {
+    format!(
+        "{}{:020}-{:020}-{:010}",
+        revision_by_inode_desc_inode_prefix(inode_id),
+        u64::MAX - position.revision_no.0,
+        u64::MAX - position.committed_seq.0,
+        u32::MAX - position.revision_delta_index
+    )
 }

--- a/crates/loonfs-core/src/path/read/current_view.rs
+++ b/crates/loonfs-core/src/path/read/current_view.rs
@@ -235,29 +235,13 @@ impl<'a, S: ObjectStore + ?Sized> CurrentManifestTailView<'a, S> {
         if self.visible_inode(inode_id).await?.is_none() {
             return Ok(None);
         }
-        Ok(self
-            .revisions_for_inode_at_head(inode_id)
-            .await?
+        let tail_revision = self.tail_latest_revision_for_inode(inode_id);
+        let manifest_revision =
+            manifest_index::latest_revision_for_inode(self.tables, inode_id).await?;
+        Ok(tail_revision
             .into_iter()
-            .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index)))
-    }
-
-    pub(crate) async fn revisions_for_inode_at_head(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<Vec<RevisionRecord>, CoreError> {
-        let mut revisions = self.revisions_for_inode(inode_id).await?;
-        revisions.extend(
-            self.wal_tail_rows
-                .revisions()
-                .iter()
-                .filter(|revision| revision.inode_id == inode_id)
-                .cloned(),
-        );
-        Ok(revisions
-            .into_iter()
-            .filter(|revision| revision.committed_seq <= self.head.seq)
-            .collect())
+            .chain(manifest_revision)
+            .max_by_key(revision_order_key))
     }
 
     pub(crate) async fn revision_for_inode(
@@ -275,11 +259,8 @@ impl<'a, S: ObjectStore + ?Sized> CurrentManifestTailView<'a, S> {
                 kind: inode.inode_kind,
             });
         }
-        self.revisions_for_inode_at_head(inode_id)
+        self.revision_at_head(inode_id, revision_no)
             .await?
-            .into_iter()
-            .filter(|revision| revision.revision_no == revision_no)
-            .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index))
             .ok_or(CoreError::MissingRevision {
                 inode_id,
                 revision_no,
@@ -291,12 +272,36 @@ impl<'a, S: ObjectStore + ?Sized> CurrentManifestTailView<'a, S> {
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<Option<RevisionRecord>, CoreError> {
-        Ok(self
-            .revisions_for_inode_at_head(inode_id)
-            .await?
+        let tail_revision = self.tail_revision_for_inode_no(inode_id, revision_no);
+        let manifest_revision =
+            manifest_index::revision_for_inode_no(self.tables, inode_id, revision_no).await?;
+        Ok(tail_revision
             .into_iter()
-            .filter(|revision| revision.revision_no == revision_no)
-            .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index)))
+            .chain(manifest_revision)
+            .max_by_key(revision_order_key))
+    }
+
+    pub(crate) async fn revisions_for_inode_page_desc(
+        &self,
+        inode_id: InodeId,
+        start_after: Option<manifest_index::RevisionPagePosition>,
+        limit: usize,
+    ) -> Result<Vec<RevisionRecord>, CoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut revisions = manifest_index::revisions_for_inode_page_desc(
+            self.tables,
+            inode_id,
+            start_after,
+            limit,
+        )
+        .await?;
+        revisions.extend(self.tail_revisions_for_inode_page_desc(inode_id, start_after));
+        revisions.retain(|revision| revision.committed_seq <= self.head.seq);
+        revisions.sort_by_key(|revision| std::cmp::Reverse(revision_order_key(revision)));
+        revisions.truncate(limit);
+        Ok(revisions)
     }
 
     pub(crate) async fn find_commit_receipt(
@@ -450,11 +455,54 @@ impl<'a, S: ObjectStore + ?Sized> CurrentManifestTailView<'a, S> {
         manifest_index::direntry_unbinds_for_binding(self.tables, direntry).await
     }
 
-    async fn revisions_for_inode(
+    fn tail_latest_revision_for_inode(&self, inode_id: InodeId) -> Option<RevisionRecord> {
+        self.wal_tail_rows
+            .revisions()
+            .iter()
+            .filter(|revision| {
+                revision.inode_id == inode_id && revision.committed_seq <= self.head.seq
+            })
+            .max_by_key(|revision| revision_order_key(revision))
+            .cloned()
+    }
+
+    fn tail_revision_for_inode_no(
         &self,
         inode_id: InodeId,
-    ) -> Result<Vec<RevisionRecord>, CoreError> {
-        manifest_index::revisions_for_inode(self.tables, inode_id).await
+        revision_no: RevisionNo,
+    ) -> Option<RevisionRecord> {
+        self.wal_tail_rows
+            .revisions()
+            .iter()
+            .filter(|revision| {
+                revision.inode_id == inode_id
+                    && revision.revision_no == revision_no
+                    && revision.committed_seq <= self.head.seq
+            })
+            .max_by_key(|revision| revision_order_key(revision))
+            .cloned()
+    }
+
+    fn tail_revisions_for_inode_page_desc(
+        &self,
+        inode_id: InodeId,
+        start_after: Option<manifest_index::RevisionPagePosition>,
+    ) -> Vec<RevisionRecord> {
+        let mut revisions = self
+            .wal_tail_rows
+            .revisions()
+            .iter()
+            .filter(|revision| {
+                revision.inode_id == inode_id
+                    && revision.committed_seq <= self.head.seq
+                    && start_after
+                        .map(|position| revision_is_after_position_desc(revision, position))
+                        .unwrap_or(true)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        revisions.sort_by_key(|revision| std::cmp::Reverse(revision_order_key(revision)));
+        revisions
     }
 
     async fn tombstones_for_root(
@@ -502,7 +550,6 @@ pub(crate) struct MetadataReadSessionCounters {
     pub(crate) current_parent_binding_calls: u64,
     pub(crate) covering_tombstone_calls: u64,
     pub(crate) latest_revision_calls: u64,
-    pub(crate) revision_scan_calls: u64,
     pub(crate) direntry_child_scan_calls: u64,
     pub(crate) scan_prefix_calls: u64,
     pub(crate) scan_range_page_calls: u64,
@@ -710,17 +757,22 @@ impl<'a, S: ObjectStore + ?Sized> MetadataReadSession<'a, S> {
         if let Some(cached) = self.latest_revision_head_cache.get(&inode_id).cloned() {
             return Ok(cached);
         }
-        let revision = if self.visible_inode(inode_id).await?.is_some() {
-            self.revisions_for_inode_at_head(inode_id)
-                .await?
-                .into_iter()
-                .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index))
-        } else {
-            None
-        };
+        let revision = self.base.latest_revision_head(inode_id).await?;
         self.latest_revision_head_cache
             .insert(inode_id, revision.clone());
         Ok(revision)
+    }
+
+    pub(crate) async fn revisions_for_inode_page_desc(
+        &mut self,
+        inode_id: InodeId,
+        start_after: Option<manifest_index::RevisionPagePosition>,
+        limit: usize,
+    ) -> Result<Vec<RevisionRecord>, CoreError> {
+        self.counters.scan_range_page_calls = self.counters.scan_range_page_calls.saturating_add(1);
+        self.base
+            .revisions_for_inode_page_desc(inode_id, start_after, limit)
+            .await
     }
 
     pub(crate) async fn current_parent_binding_for_child(
@@ -883,27 +935,6 @@ impl<'a, S: ObjectStore + ?Sized> MetadataReadSession<'a, S> {
         self.unbind_cache.insert(cache_key, unbound);
         Ok(unbound)
     }
-
-    async fn revisions_for_inode_at_head(
-        &mut self,
-        inode_id: InodeId,
-    ) -> Result<Vec<RevisionRecord>, CoreError> {
-        self.counters.revision_scan_calls = self.counters.revision_scan_calls.saturating_add(1);
-        self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let mut revisions = self.base.revisions_for_inode(inode_id).await?;
-        revisions.extend(
-            self.base
-                .wal_tail_rows
-                .revisions()
-                .iter()
-                .filter(|revision| revision.inode_id == inode_id)
-                .cloned(),
-        );
-        Ok(revisions
-            .into_iter()
-            .filter(|revision| revision.committed_seq <= self.base.head.seq)
-            .collect())
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -949,6 +980,26 @@ fn direntry_bind_row_key(record: &DirentryBindRecord) -> String {
         bind_delta_index: record.bind_delta_index,
     }
     .row_key_for_family(MetadataTableFamily::DirentryBinds)
+}
+
+fn revision_order_key(record: &RevisionRecord) -> (RevisionNo, loonfs_api::ChangeSeq, u32) {
+    (
+        record.revision_no,
+        record.committed_seq,
+        record.revision_delta_index,
+    )
+}
+
+fn revision_is_after_position_desc(
+    record: &RevisionRecord,
+    position: manifest_index::RevisionPagePosition,
+) -> bool {
+    revision_order_key(record)
+        < (
+            position.revision_no,
+            position.committed_seq,
+            position.revision_delta_index,
+        )
 }
 
 fn absolute_path_prefix(current: &str, component: &str) -> String {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -21,8 +21,9 @@ use crate::wal::{
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{
     AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ContentStoreId,
-    DirectoryPageCursor, DisplayName, FileRevision, InodeId, InodeKind, ListFileRevisionsResponse,
-    NameKey, NamespaceId, Page, PageRequest, RevisionNo,
+    DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind,
+    ListFileRevisionsResponse, NameKey, NamespaceId, Page, PageRequest, PaginationPolicy,
+    RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -222,6 +223,42 @@ pub(crate) async fn list_file_revisions_from_manifest_plus_tail_at_head_with_cac
     view.list_file_revisions(absolute_path).await
 }
 
+pub(crate) async fn list_file_revisions_page_from_manifest_plus_tail_at_head_with_cache<
+    S: ObjectStore + ?Sized,
+>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    head: &HeadState,
+    cache_context: ManifestPlusTailCacheContext<'_>,
+    absolute_path: &str,
+    request: PageRequest<FileRevisionsPageCursor>,
+) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != head.seq)
+        .unwrap_or(false)
+    {
+        let cursor = request
+            .cursor
+            .as_ref()
+            .expect("cursor presence checked above");
+        return Err(MetadataViewError::UnsupportedHistoricalRead {
+            requested_seq: cursor.head_seq,
+            head_seq: head.seq,
+        }
+        .into());
+    }
+    let view = ManifestPlusTailView::load_at_head_with_cache(
+        store,
+        namespace_id,
+        head.clone(),
+        cache_context,
+    )
+    .await?;
+    view.list_file_revisions_page(absolute_path, request).await
+}
+
 pub(crate) async fn list_file_revisions_from_manifest_plus_tail<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -229,6 +266,26 @@ pub(crate) async fn list_file_revisions_from_manifest_plus_tail<S: ObjectStore +
 ) -> Result<ListFileRevisionsResponse, CoreError> {
     let view = ManifestPlusTailView::load(store, namespace_id).await?;
     view.list_file_revisions(absolute_path).await
+}
+
+pub(crate) async fn list_file_revisions_page_from_manifest_plus_tail<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    request: PageRequest<FileRevisionsPageCursor>,
+) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
+    let view = ManifestPlusTailView::load(store, namespace_id).await?;
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != view.head.seq)
+        .unwrap_or(false)
+    {
+        return Err(invalid_cursor(
+            "cursor snapshot does not match the current namespace head",
+        ));
+    }
+    view.list_file_revisions_page(absolute_path, request).await
 }
 
 pub(crate) async fn list_file_revisions_for_inode_from_manifest_plus_tail_at_head_with_cache<
@@ -250,6 +307,43 @@ pub(crate) async fn list_file_revisions_for_inode_from_manifest_plus_tail_at_hea
     view.list_file_revisions_for_inode(inode_id).await
 }
 
+pub(crate) async fn list_file_revisions_for_inode_page_from_manifest_plus_tail_at_head_with_cache<
+    S: ObjectStore + ?Sized,
+>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    head: &HeadState,
+    cache_context: ManifestPlusTailCacheContext<'_>,
+    inode_id: InodeId,
+    request: PageRequest<FileRevisionsPageCursor>,
+) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != head.seq)
+        .unwrap_or(false)
+    {
+        let cursor = request
+            .cursor
+            .as_ref()
+            .expect("cursor presence checked above");
+        return Err(MetadataViewError::UnsupportedHistoricalRead {
+            requested_seq: cursor.head_seq,
+            head_seq: head.seq,
+        }
+        .into());
+    }
+    let view = ManifestPlusTailView::load_at_head_with_cache(
+        store,
+        namespace_id,
+        head.clone(),
+        cache_context,
+    )
+    .await?;
+    view.list_file_revisions_for_inode_page(inode_id, request)
+        .await
+}
+
 pub(crate) async fn list_file_revisions_for_inode_from_manifest_plus_tail<
     S: ObjectStore + ?Sized,
 >(
@@ -259,6 +353,29 @@ pub(crate) async fn list_file_revisions_for_inode_from_manifest_plus_tail<
 ) -> Result<ListFileRevisionsResponse, CoreError> {
     let view = ManifestPlusTailView::load(store, namespace_id).await?;
     view.list_file_revisions_for_inode(inode_id).await
+}
+
+pub(crate) async fn list_file_revisions_for_inode_page_from_manifest_plus_tail<
+    S: ObjectStore + ?Sized,
+>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    inode_id: InodeId,
+    request: PageRequest<FileRevisionsPageCursor>,
+) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
+    let view = ManifestPlusTailView::load(store, namespace_id).await?;
+    if request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.head_seq != view.head.seq)
+        .unwrap_or(false)
+    {
+        return Err(invalid_cursor(
+            "cursor snapshot does not match the current namespace head",
+        ));
+    }
+    view.list_file_revisions_for_inode_page(inode_id, request)
+        .await
 }
 
 pub(crate) async fn read_file_revision_bytes_from_manifest_plus_tail_at_head_with_cache<
@@ -555,10 +672,60 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
         self.list_file_revisions_for_inode(entry.inode_id).await
     }
 
+    pub(crate) async fn list_file_revisions_page(
+        &self,
+        absolute_path: &str,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
+        let entry = self.resolve_path(absolute_path).await?;
+        if entry.inode_kind != InodeKind::File {
+            return Err(CoreError::ExpectedFile {
+                path: entry.absolute_path,
+                kind: entry.inode_kind,
+            });
+        }
+        self.list_file_revisions_for_inode_page(entry.inode_id, request)
+            .await
+    }
+
     pub(crate) async fn list_file_revisions_for_inode(
         &self,
         inode_id: InodeId,
     ) -> Result<ListFileRevisionsResponse, CoreError> {
+        let limit = PaginationPolicy::default()
+            .resolve_limit(None)
+            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        let mut cursor = None;
+        let mut revisions = Vec::new();
+        loop {
+            let page = self
+                .list_file_revisions_for_inode_page(
+                    inode_id,
+                    PageRequest {
+                        limit,
+                        cursor: cursor.clone(),
+                    },
+                )
+                .await?;
+            revisions.extend(page.items);
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                return Ok(ListFileRevisionsResponse {
+                    namespace_id: self.namespace_id.clone(),
+                    inode_id,
+                    head_seq: self.head.seq,
+                    revisions,
+                    next_cursor: None,
+                });
+            }
+        }
+    }
+
+    pub(crate) async fn list_file_revisions_for_inode_page(
+        &self,
+        inode_id: InodeId,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> Result<Page<FileRevision, FileRevisionsPageCursor>, CoreError> {
         let inode = self
             .metadata_view()
             .inode_at_seq(inode_id)
@@ -570,11 +737,43 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
                 kind: inode.inode_kind,
             });
         }
+        if let Some(cursor) = request.cursor.as_ref() {
+            validate_file_revisions_cursor(cursor, self.head.seq, inode_id)?;
+        }
 
-        let mut revisions = self
+        let start_after =
+            request
+                .cursor
+                .as_ref()
+                .map(|cursor| super::manifest_index::RevisionPagePosition {
+                    revision_no: cursor.last_revision_no,
+                    committed_seq: cursor.last_committed_seq,
+                    revision_delta_index: cursor.last_revision_delta_index,
+                });
+        let mut revision_records = self
             .metadata_view()
-            .revisions_for_inode_at_head(inode_id)
-            .await?
+            .session()
+            .revisions_for_inode_page_desc(inode_id, start_after, request.limit.limit_plus_one())
+            .await?;
+        let has_more = revision_records.len() > request.limit.as_usize();
+        if has_more {
+            revision_records.truncate(request.limit.as_usize());
+        }
+        let next_cursor = if has_more {
+            let last = revision_records
+                .last()
+                .expect("non-zero page limit with more revisions must return an item");
+            Some(FileRevisionsPageCursor {
+                head_seq: self.head.seq,
+                inode_id,
+                last_revision_no: last.revision_no,
+                last_committed_seq: last.committed_seq,
+                last_revision_delta_index: last.revision_delta_index,
+            })
+        } else {
+            None
+        };
+        let revisions = revision_records
             .into_iter()
             .map(|revision| FileRevision {
                 inode_id: revision.inode_id,
@@ -582,14 +781,11 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
                 committed_seq: revision.committed_seq,
                 content_ref: revision.content_ref,
             })
-            .collect::<Vec<_>>();
-        revisions.sort_by_key(|revision| revision.revision_no);
+            .collect();
 
-        Ok(ListFileRevisionsResponse {
-            namespace_id: self.namespace_id.clone(),
-            inode_id,
-            head_seq: self.head.seq,
-            revisions,
+        Ok(Page {
+            items: revisions,
+            next_cursor,
         })
     }
 
@@ -733,7 +929,6 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
             list_page_current_parent_binding_calls = tracing::field::Empty,
             list_page_covering_tombstone_calls = tracing::field::Empty,
             list_page_latest_revision_calls = tracing::field::Empty,
-            list_page_revision_scan_calls = tracing::field::Empty,
             list_page_direntry_child_scan_calls = tracing::field::Empty,
             list_page_scan_prefix_calls = tracing::field::Empty,
             list_page_scan_range_page_calls = tracing::field::Empty,
@@ -774,10 +969,6 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
         build_span.record(
             "list_page_latest_revision_calls",
             counters.latest_revision_calls,
-        );
-        build_span.record(
-            "list_page_revision_scan_calls",
-            counters.revision_scan_calls,
         );
         build_span.record(
             "list_page_direntry_child_scan_calls",
@@ -892,4 +1083,22 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
     fn metadata_view(&self) -> CurrentManifestTailView<'_, S> {
         CurrentManifestTailView::new(&self.head, &self.tables, self.wal_tail_rows.as_ref())
     }
+}
+
+fn validate_file_revisions_cursor(
+    cursor: &FileRevisionsPageCursor,
+    head_seq: loonfs_api::ChangeSeq,
+    inode_id: InodeId,
+) -> Result<(), CoreError> {
+    if cursor.head_seq != head_seq {
+        return Err(invalid_cursor(
+            "file revisions cursor snapshot does not match the current namespace head",
+        ));
+    }
+    if cursor.inode_id != inode_id {
+        return Err(invalid_cursor(
+            "file revisions cursor inode does not match the requested file",
+        ));
+    }
+    Ok(())
 }

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -11,8 +11,12 @@ pub(crate) use materialized_view::ManifestPlusTailView;
 pub(crate) use materialized_view::{
     list_file_revisions_for_inode_from_manifest_plus_tail,
     list_file_revisions_for_inode_from_manifest_plus_tail_at_head_with_cache,
+    list_file_revisions_for_inode_page_from_manifest_plus_tail,
+    list_file_revisions_for_inode_page_from_manifest_plus_tail_at_head_with_cache,
     list_file_revisions_from_manifest_plus_tail,
     list_file_revisions_from_manifest_plus_tail_at_head_with_cache,
+    list_file_revisions_page_from_manifest_plus_tail,
+    list_file_revisions_page_from_manifest_plus_tail_at_head_with_cache,
     list_path_from_manifest_plus_tail, list_path_from_manifest_plus_tail_at_head_with_cache,
     list_path_page_from_manifest_plus_tail,
     list_path_page_from_manifest_plus_tail_at_head_with_cache,

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -2145,7 +2145,7 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
             .iter()
             .map(|revision| revision.revision_no)
             .collect::<Vec<_>>(),
-        vec![RevisionNo(1), RevisionNo(2)]
+        vec![RevisionNo(2), RevisionNo(1)]
     );
 
     let historical =
@@ -2196,7 +2196,7 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
             .iter()
             .map(|revision| revision.revision_no)
             .collect::<Vec<_>>(),
-        vec![RevisionNo(1), RevisionNo(2), RevisionNo(3)]
+        vec![RevisionNo(3), RevisionNo(2), RevisionNo(1)]
     );
 }
 

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -14,7 +14,8 @@ use loonfs::{
     TraceStoreKind,
 };
 use loonfs_api::{
-    decode_directory_cursor, decode_namespaces_cursor, encode_namespaces_cursor,
+    decode_directory_cursor, decode_file_revisions_cursor, decode_namespaces_cursor,
+    encode_namespaces_cursor,
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,
         CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
@@ -22,11 +23,11 @@ use loonfs_api::{
         UploadContentResponse, UploadMode, ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
-    CreateNamespaceRequest, DirectoryPageCursor, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, FilesystemPutBehavior, ForkNamespaceRequest, InodeId, LimitError,
-    ListFileRevisionsResponse, ListNamespacesResponse, NamespaceId, NamespaceIdValidationError,
-    NamespacesPageCursor, PageCursorError, PageRequest, PaginationPolicy,
-    RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
+    CreateNamespaceRequest, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
+    FilesystemOperationRequest, FilesystemOperationResponse, FilesystemPutBehavior,
+    ForkNamespaceRequest, InodeId, LimitError, ListFileRevisionsResponse, ListNamespacesResponse,
+    NamespaceId, NamespaceIdValidationError, NamespacesPageCursor, PageCursorError, PageRequest,
+    PaginationPolicy, RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
 };
 use loonfs_core::content::{
     mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
@@ -647,7 +648,9 @@ async fn get_content(
         summary = "List file revisions",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
-            ("path" = String, Query, description = "Absolute file path")
+            ("path" = String, Query, description = "Absolute file path"),
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
         ),
         responses(
             (status = 200, description = "File revisions", body = ListFileRevisionsResponse),
@@ -662,14 +665,21 @@ async fn list_path_revisions(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Query(query): Query<PathQuery>,
+    Query(query): Query<PathPageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let path = query.path;
     let response = state
         .fs
-        .list_file_revisions(&namespace_id, &path)
+        .list_file_revisions_page(
+            &namespace_id,
+            &path,
+            PageRequest {
+                limit: resolve_page_limit(query.limit)?,
+                cursor: decode_file_revisions_page_cursor(query.cursor)?,
+            },
+        )
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -684,7 +694,9 @@ async fn list_path_revisions(
         summary = "List inode revisions",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
-            ("inode_id" = String, Path, description = "File inode id")
+            ("inode_id" = String, Path, description = "File inode id"),
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
         ),
         responses(
             (status = 200, description = "File revisions", body = ListFileRevisionsResponse),
@@ -699,13 +711,21 @@ async fn list_inode_revisions(
     State(state): State<AppState>,
     AxumPath((namespace, inode_id)): AxumPath<(String, String)>,
     headers: HeaderMap,
+    Query(query): Query<PageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let inode_id = parse_inode_id(&inode_id)?;
     let response = state
         .fs
-        .list_file_revisions_for_inode(&namespace_id, inode_id)
+        .list_file_revisions_for_inode_page(
+            &namespace_id,
+            inode_id,
+            PageRequest {
+                limit: resolve_page_limit(query.limit)?,
+                cursor: decode_file_revisions_page_cursor(query.cursor)?,
+            },
+        )
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -1512,6 +1532,16 @@ fn decode_directory_page_cursor(
     cursor
         .as_deref()
         .map(decode_directory_cursor)
+        .transpose()
+        .map_err(page_cursor_response_error)
+}
+
+fn decode_file_revisions_page_cursor(
+    cursor: Option<String>,
+) -> Result<Option<FileRevisionsPageCursor>, ApiResponseError> {
+    cursor
+        .as_deref()
+        .map(decode_file_revisions_cursor)
         .transpose()
         .map_err(page_cursor_response_error)
 }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
-    encode_directory_cursor, AbsolutePath, CapabilityDocument, DirectoryPageCursor, EffectiveLimit,
+    encode_directory_cursor, encode_file_revisions_cursor, AbsolutePath, CapabilityDocument,
+    DirectoryPageCursor, EffectiveLimit, FileRevision, FileRevisionsPageCursor,
     NamespacesPageCursor, Page, PageRequest, PaginationPolicy, FEATURE_NAMESPACES_CREATE,
     FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST,
     FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
@@ -578,6 +579,32 @@ impl Fs {
         Ok(revisions)
     }
 
+    /// Lists one page of a file path's revision history.
+    pub async fn list_file_revisions_page(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> Result<ListFileRevisionsResponse> {
+        let head = self.head_for_metadata_read(namespace_id).await?;
+        let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
+        let page = self
+            .namespace_engine(namespace_id)
+            .list_file_revisions_page(
+                absolute_path,
+                self.manifest_plus_tail_read_options(&head),
+                request,
+            )
+            .await?;
+        self.inner.cache_stats.record_manifest_plus_tail_read();
+        Ok(file_revisions_page_response(
+            namespace_id.clone(),
+            head.state.seq,
+            page,
+            fallback_inode_id,
+        )?)
+    }
+
     /// Lists a file's revision history by inode id, independent of its
     /// current path.
     pub async fn list_file_revisions_for_inode(
@@ -592,6 +619,31 @@ impl Fs {
             .await?;
         self.inner.cache_stats.record_manifest_plus_tail_read();
         Ok(revisions)
+    }
+
+    /// Lists one page of a file inode's revision history.
+    pub async fn list_file_revisions_for_inode_page(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> Result<ListFileRevisionsResponse> {
+        let head = self.head_for_metadata_read(namespace_id).await?;
+        let page = self
+            .namespace_engine(namespace_id)
+            .list_file_revisions_for_inode_page(
+                inode_id,
+                self.manifest_plus_tail_read_options(&head),
+                request,
+            )
+            .await?;
+        self.inner.cache_stats.record_manifest_plus_tail_read();
+        Ok(file_revisions_page_response(
+            namespace_id.clone(),
+            head.state.seq,
+            page,
+            Some(inode_id),
+        )?)
     }
 
     /// Reads the content of one historical file revision by path.
@@ -1183,6 +1235,36 @@ fn default_page_limit() -> EffectiveLimit {
     PaginationPolicy::default()
         .resolve_limit(None)
         .expect("default pagination policy must resolve its default limit")
+}
+
+fn file_revisions_page_response(
+    namespace_id: NamespaceId,
+    head_seq: ChangeSeq,
+    page: Page<FileRevision, FileRevisionsPageCursor>,
+    fallback_inode_id: Option<InodeId>,
+) -> std::result::Result<ListFileRevisionsResponse, CoreError> {
+    let inode_id = page
+        .items
+        .first()
+        .map(|revision| revision.inode_id)
+        .or_else(|| page.next_cursor.as_ref().map(|cursor| cursor.inode_id))
+        .or(fallback_inode_id)
+        .ok_or_else(|| {
+            CoreError::InvalidCursor("empty revision page lacks inode identity".into())
+        })?;
+    let next_cursor = page
+        .next_cursor
+        .as_ref()
+        .map(encode_file_revisions_cursor)
+        .transpose()
+        .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+    Ok(ListFileRevisionsResponse {
+        namespace_id,
+        inode_id,
+        head_seq,
+        revisions: page.items,
+        next_cursor,
+    })
 }
 
 #[cfg(test)]

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -26,12 +26,12 @@ pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
     ChangeSeq, CommitId, ContentRef, ContentRefKind, CreateCheckpointResponse,
     DeleteNamespaceResponse, DirectoryPageCursor, DisplayName, EffectiveLimit, FileRevision,
-    FilesystemOperationResponse, InodeId, InodeKind, ListFileRevisionsResponse,
-    ListPathEntriesResponse, ManifestId, MutationResult, NameKey, NamePolicy, NamespaceId,
-    NamespaceSummary, NamespacesPageCursor, Page, PageRequest, PaginationPolicy, RevisionNo,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_NAMESPACES_LIST, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROTOCOL_VERSION,
+    FileRevisionsPageCursor, FilesystemOperationResponse, InodeId, InodeKind,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult, NameKey,
+    NamePolicy, NamespaceId, NamespaceSummary, NamespacesPageCursor, Page, PageRequest,
+    PaginationPolicy, RevisionNo, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
+    PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -64,6 +64,10 @@ fn decode_directory_page_cursor(value: &str) -> DirectoryPageCursor {
     loonfs_api::decode_directory_cursor(value).expect("decode directory cursor")
 }
 
+fn decode_file_revisions_page_cursor(value: &str) -> loonfs::FileRevisionsPageCursor {
+    loonfs_api::decode_file_revisions_cursor(value).expect("decode file revisions cursor")
+}
+
 fn display_names(entries: &[AuthoritativePathEntry]) -> Vec<&str> {
     entries
         .iter()
@@ -1110,6 +1114,88 @@ fn directory_pages_use_canonical_name_key_order() {
     assert_eq!(
         display_names(&full.entries),
         vec!["a.txt", "apple.txt", "B.txt", "Zebra.txt"]
+    );
+}
+
+#[test]
+fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "file-revision-page-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    let replace = PutFileOptions {
+        behavior: PutFileBehavior::ReplaceExisting,
+        commit_id: None,
+    };
+    fs.put_file_bytes_blocking(&namespace_id, "/doc.txt", b"v1", PutFileOptions::default())
+        .expect("put v1");
+    fs.put_file_bytes_blocking(&namespace_id, "/doc.txt", b"v2", replace.clone())
+        .expect("put v2");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint after v2");
+    fs.put_file_bytes_blocking(&namespace_id, "/doc.txt", b"v3", replace.clone())
+        .expect("put v3");
+    fs.put_file_bytes_blocking(&namespace_id, "/doc.txt", b"v4", replace)
+        .expect("put v4");
+
+    let limit = page_limit(2);
+    let first = block_on(fs.list_file_revisions_page(
+        &namespace_id,
+        "/doc.txt",
+        PageRequest {
+            limit,
+            cursor: None,
+        },
+    ))
+    .expect("first revision page");
+    assert_eq!(
+        first
+            .revisions
+            .iter()
+            .map(|revision| revision.revision_no.0)
+            .collect::<Vec<_>>(),
+        vec![4, 3]
+    );
+
+    let cursor =
+        decode_file_revisions_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+    let second = block_on(fs.list_file_revisions_page(
+        &namespace_id,
+        "/doc.txt",
+        PageRequest {
+            limit,
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second revision page");
+    assert_eq!(
+        second
+            .revisions
+            .iter()
+            .map(|revision| revision.revision_no.0)
+            .collect::<Vec<_>>(),
+        vec![2, 1]
+    );
+    assert!(second.next_cursor.is_none());
+
+    let inode_page = block_on(fs.list_file_revisions_for_inode_page(
+        &namespace_id,
+        first.inode_id,
+        PageRequest {
+            limit,
+            cursor: None,
+        },
+    ))
+    .expect("inode revision page");
+    assert_eq!(
+        inode_page
+            .revisions
+            .iter()
+            .map(|revision| revision.revision_no.0)
+            .collect::<Vec<_>>(),
+        vec![4, 3]
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -309,10 +309,10 @@ A representative v0 binding is shown below.
 | Read one namespace's status | `GET /v0/namespaces/{ns}` |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt` |
 | List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...` |
-| List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt` |
+| List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt&limit=100&cursor=...` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
 | Read prior file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` |
-| List file revisions by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions` |
+| List file revisions by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?limit=100&cursor=...` |
 | Read prior file content by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content` |
 | Apply path-oriented operations | `POST /v0/namespaces/{ns}/filesystem/operations` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
@@ -569,6 +569,33 @@ include `next_cursor` only when another page is available.
 
 The response body is the authoritative file bytes. Metadata may be exposed in
 headers, but the body itself is raw content rather than JSON.
+
+Revision listing endpoints return newest revisions first and use the same
+`limit` / `cursor` pattern as directory and namespace listing. Path-based
+revision listing resolves the current path to its current inode, while inode
+revision listing is stable across later renames. Responses include
+`next_cursor` only when another page is available.
+
+```json
+{
+  "namespace_id": "demo",
+  "inode_id": 42,
+  "head_seq": 418,
+  "revisions": [
+    {
+      "inode_id": 42,
+      "revision_no": 7,
+      "committed_seq": 418,
+      "content_ref": {
+        "kind": "whole_file_v0",
+        "digest": "sha256:42d...",
+        "size_bytes": 19482
+      }
+    }
+  ],
+  "next_cursor": "7b2e2e2e7d"
+}
+```
 
 ### 6.7 `POST /filesystem/operations`
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1027,6 +1027,24 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque file-revisions page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1278,6 +1296,24 @@
             "in": "path",
             "description": "File inode id",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque file-revisions page cursor",
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -3354,6 +3390,13 @@
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace that was read."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque cursor for the next page, if more revisions are available."
           },
           "revisions": {
             "type": "array",


### PR DESCRIPTION
Adds paged file revision listing and bounded latest/specific revision lookups. This is the last remaining API that was potentially unbounded leading to runaway complexity as the worst-case grew. In this case, we needed to be resilient to documents with many revisions. 