### PR TITLE
refactor(api): remove namespace listing

### DIFF
--- a/crates/loonfs-api/src/capability.rs
+++ b/crates/loonfs-api/src/capability.rs
@@ -10,8 +10,6 @@ pub const PROFILE_CORE_V0: &str = "core/v0";
 /// The optional maintenance plane.
 pub const PROFILE_ADMIN_V0: &str = "admin/v0";
 
-/// Gates namespace enumeration.
-pub const FEATURE_NAMESPACES_LIST: &str = "core.namespaces.list";
 /// Gates namespace creation.
 pub const FEATURE_NAMESPACES_CREATE: &str = "core.namespaces.create";
 /// Gates namespace forking.
@@ -120,7 +118,7 @@ mod tests {
             protocol_version: PROTOCOL_VERSION.to_owned(),
             profiles: vec![PROFILE_CORE_V0.to_owned(), PROFILE_ADMIN_V0.to_owned()],
             features: BTreeMap::from([
-                (FEATURE_NAMESPACES_LIST.to_owned(), true),
+                (FEATURE_NAMESPACES_CREATE.to_owned(), true),
                 (FEATURE_NAMESPACES_DELETE.to_owned(), false),
             ]),
             limits: BTreeMap::new(),
@@ -132,7 +130,7 @@ mod tests {
         let document = document();
         assert!(document.has_profile(PROFILE_CORE_V0));
         assert!(!document.has_profile("query/v0"));
-        assert!(document.supports(FEATURE_NAMESPACES_LIST));
+        assert!(document.supports(FEATURE_NAMESPACES_CREATE));
         // Advertised-false and absent keys are both unsupported.
         assert!(!document.supports(FEATURE_NAMESPACES_DELETE));
         assert!(!document.supports(FEATURE_NAMESPACES_FORK));
@@ -155,7 +153,7 @@ mod tests {
         document.retain_well_formed();
         assert!(document.validate().is_ok());
         assert!(!document.features.contains_key("query.index.fulltext"));
-        assert!(document.features.contains_key(FEATURE_NAMESPACES_LIST));
+        assert!(document.features.contains_key(FEATURE_NAMESPACES_CREATE));
     }
 
     #[test]

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -46,23 +46,12 @@ pub struct ForkNamespaceRequest {
     pub new_namespace_id: String,
 }
 
-/// Short namespace listing entry.
+/// Short namespace identifier returned by namespace create/fork operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct NamespaceSummary {
     /// Durable namespace id.
     pub namespace_id: NamespaceId,
-}
-
-/// Response for namespace listing.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct ListNamespacesResponse {
-    /// Complete namespaces visible to the store for this page.
-    pub namespaces: Vec<NamespaceSummary>,
-    /// Cursor for the next page, if more namespaces remain.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
 }
 
 /// Status summary for one namespace.

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -39,8 +39,8 @@ pub mod wire {
 
 pub use capability::{
     CapabilityDocument, CapabilityDocumentError, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST,
-    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT,
+    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use content::{ContentRef, ContentRefKind};
 pub use digest::sha256_digest;
@@ -49,8 +49,8 @@ pub use http::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteNamespaceResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
     FilesystemOperationResponse, FilesystemPutBehavior, ForkNamespaceRequest,
-    ListFileRevisionsResponse, ListNamespacesResponse, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, RestoreFileRevisionRequest,
+    ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
+    RestoreFileRevisionRequest,
 };
 pub use ids::{
     generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,
@@ -62,10 +62,9 @@ pub use ids::{
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
 pub use pagination::{
-    decode_directory_cursor, decode_file_revisions_cursor, decode_namespaces_cursor,
-    encode_directory_cursor, encode_file_revisions_cursor, encode_namespaces_cursor,
-    DirectoryPageCursor, EffectiveLimit, FileRevisionsPageCursor, LimitError, NamespacesPageCursor,
-    Page, PageCursorError, PageRequest, PaginationPolicy, PaginationPolicyError,
+    decode_directory_cursor, decode_file_revisions_cursor, encode_directory_cursor,
+    encode_file_revisions_cursor, DirectoryPageCursor, EffectiveLimit, FileRevisionsPageCursor,
+    LimitError, Page, PageCursorError, PageRequest, PaginationPolicy, PaginationPolicyError,
     DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
     PAGE_CURSOR_VERSION,
 };

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -1,4 +1,4 @@
-use crate::{ChangeSeq, InodeId, NameKey, NamespaceId, RevisionNo};
+use crate::{ChangeSeq, InodeId, NameKey, RevisionNo};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
@@ -176,13 +176,6 @@ pub struct Page<T, C> {
     pub next_cursor: Option<C>,
 }
 
-/// Cursor for namespace listing.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NamespacesPageCursor {
-    /// Last namespace id returned to the client.
-    pub last_namespace_id: NamespaceId,
-}
-
 /// Cursor for one directory listing snapshot.
 ///
 /// Directory pagination advances in canonical `name_key` order.
@@ -224,10 +217,6 @@ pub struct FileRevisionsPageCursor {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum EncodedPageCursor {
-    Namespaces {
-        v: u8,
-        last_namespace_id: NamespaceId,
-    },
     Directory {
         v: u8,
         head_seq: ChangeSeq,
@@ -247,15 +236,12 @@ enum EncodedPageCursor {
 impl EncodedPageCursor {
     fn version(&self) -> u8 {
         match self {
-            Self::Namespaces { v, .. }
-            | Self::Directory { v, .. }
-            | Self::FileRevisions { v, .. } => *v,
+            Self::Directory { v, .. } | Self::FileRevisions { v, .. } => *v,
         }
     }
 
     fn kind(&self) -> &'static str {
         match self {
-            Self::Namespaces { .. } => "namespaces",
             Self::Directory { .. } => "directory",
             Self::FileRevisions { .. } => "file_revisions",
         }
@@ -271,27 +257,6 @@ impl EncodedPageCursor {
                 actual,
             })
         }
-    }
-}
-
-/// Encodes a namespace-list cursor as an opaque string for clients.
-pub fn encode_namespaces_cursor(cursor: &NamespacesPageCursor) -> Result<String, PageCursorError> {
-    encode_cursor(&EncodedPageCursor::Namespaces {
-        v: PAGE_CURSOR_VERSION,
-        last_namespace_id: cursor.last_namespace_id.clone(),
-    })
-}
-
-/// Decodes a namespace-list cursor returned by [`encode_namespaces_cursor`].
-pub fn decode_namespaces_cursor(value: &str) -> Result<NamespacesPageCursor, PageCursorError> {
-    match decode_cursor(value)? {
-        EncodedPageCursor::Namespaces {
-            last_namespace_id, ..
-        } => Ok(NamespacesPageCursor { last_namespace_id }),
-        other => Err(PageCursorError::WrongKind {
-            expected: "namespaces",
-            actual: other.kind(),
-        }),
     }
 }
 
@@ -388,15 +353,15 @@ pub enum PageCursorError {
     /// The cursor JSON did not match a supported cursor shape.
     #[error("invalid page cursor JSON: {0}")]
     InvalidJson(String),
-    /// The cursor format version is not supported by this build.
-    #[error("unsupported page cursor version `{actual}`; expected `{expected}`")]
-    UnsupportedVersion { expected: u8, actual: u8 },
-    /// The cursor was well-formed but belongs to another endpoint.
-    #[error("page cursor is for `{actual}` but `{expected}` was required")]
+    /// The cursor was valid, but for a different paginated endpoint.
+    #[error("page cursor kind `{actual}` cannot be used as `{expected}` cursor")]
     WrongKind {
         expected: &'static str,
         actual: &'static str,
     },
+    /// The cursor format version is not supported by this build.
+    #[error("unsupported page cursor version `{actual}`; expected `{expected}`")]
+    UnsupportedVersion { expected: u8, actual: u8 },
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
@@ -490,18 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn namespace_cursor_round_trips() {
-        let cursor = NamespacesPageCursor {
-            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-        };
-
-        let encoded = encode_namespaces_cursor(&cursor).expect("encode cursor");
-        let decoded = decode_namespaces_cursor(&encoded).expect("decode cursor");
-
-        assert_eq!(decoded, cursor);
-    }
-
-    #[test]
     fn directory_cursor_round_trips() {
         let cursor = DirectoryPageCursor {
             head_seq: ChangeSeq(11),
@@ -533,16 +486,20 @@ mod tests {
 
     #[test]
     fn cursor_kind_must_match_decoder() {
-        let cursor = NamespacesPageCursor {
-            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+        let cursor = FileRevisionsPageCursor {
+            head_seq: ChangeSeq(11),
+            inode_id: InodeId(7),
+            last_revision_no: RevisionNo(5),
+            last_committed_seq: ChangeSeq(10),
+            last_revision_delta_index: 3,
         };
-        let encoded = encode_namespaces_cursor(&cursor).expect("encode cursor");
+        let encoded = encode_file_revisions_cursor(&cursor).expect("encode cursor");
 
         assert_eq!(
             decode_directory_cursor(&encoded),
             Err(PageCursorError::WrongKind {
                 expected: "directory",
-                actual: "namespaces",
+                actual: "file_revisions",
             })
         );
     }
@@ -550,21 +507,23 @@ mod tests {
     #[test]
     fn malformed_cursor_is_invalid_encoding() {
         assert_eq!(
-            decode_namespaces_cursor("not-hex"),
+            decode_directory_cursor("not-hex"),
             Err(PageCursorError::InvalidEncoding)
         );
     }
 
     #[test]
     fn unsupported_cursor_version_is_rejected() {
-        let encoded = encode_cursor(&EncodedPageCursor::Namespaces {
+        let encoded = encode_cursor(&EncodedPageCursor::Directory {
             v: PAGE_CURSOR_VERSION + 1,
-            last_namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            head_seq: ChangeSeq(11),
+            dir_inode_id: InodeId(7),
+            last_name_key: NameKey::parse("plan.md").expect("name key"),
         })
         .expect("encode cursor");
 
         assert_eq!(
-            decode_namespaces_cursor(&encoded),
+            decode_directory_cursor(&encoded),
             Err(PageCursorError::UnsupportedVersion {
                 expected: PAGE_CURSOR_VERSION,
                 actual: PAGE_CURSOR_VERSION + 1,

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -56,9 +56,6 @@ Namespace management
   loon namespace create [--profile <name>] <namespace>
     Create a namespace in a profile
 
-  loon namespace list [--profile <name>]
-    List namespaces for a profile
-
   loon use [--profile <name>] <namespace>
     Set the default namespace for a profile
 

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -202,7 +202,6 @@ pub(crate) enum NamespaceCommand {
     Create(NamespaceCreateArgs),
     Delete(NamespaceDeleteArgs),
     Fork(NamespaceForkArgs),
-    List(NamespaceListArgs),
 }
 
 #[derive(Debug, Args)]
@@ -231,12 +230,6 @@ pub(crate) struct NamespaceForkArgs {
     pub profile: ProfileSelectorArgs,
     pub source: String,
     pub new_namespace_id: String,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct NamespaceListArgs {
-    #[command(flatten)]
-    pub profile: ProfileSelectorArgs,
 }
 
 #[derive(Debug, Args)]
@@ -349,7 +342,6 @@ pub(crate) enum CommandKind {
     NamespaceCreate,
     NamespaceDelete,
     NamespaceFork,
-    NamespaceList,
     NamespaceUse,
     Current,
     FilesystemLs,
@@ -381,7 +373,6 @@ impl CommandKind {
             CommandKind::NamespaceCreate => "namespace_create",
             CommandKind::NamespaceDelete => "namespace_delete",
             CommandKind::NamespaceFork => "namespace_fork",
-            CommandKind::NamespaceList => "namespace_list",
             CommandKind::NamespaceUse => "namespace_use",
             CommandKind::Current => "current",
             CommandKind::FilesystemLs => "filesystem_ls",
@@ -422,7 +413,6 @@ impl Cli {
                 NamespaceCommand::Create(_) => CommandKind::NamespaceCreate,
                 NamespaceCommand::Delete(_) => CommandKind::NamespaceDelete,
                 NamespaceCommand::Fork(_) => CommandKind::NamespaceFork,
-                NamespaceCommand::List(_) => CommandKind::NamespaceList,
             },
             Command::Use(_) => CommandKind::NamespaceUse,
             Command::Current(_) => CommandKind::Current,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -29,7 +29,6 @@ pub(crate) trait Backend {
         source: &str,
         new_namespace_id: &str,
     ) -> Result<NamespaceSummary, CliError>;
-    fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError>;
     fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError>;
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError>;
     fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError>;
@@ -101,10 +100,6 @@ impl Backend for RemoteBackend {
         self.client
             .fork_namespace(source, new_namespace_id)
             .map_err(map_client_error)
-    }
-
-    fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
-        self.client.list_namespaces().map_err(map_client_error)
     }
 
     fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError> {
@@ -274,10 +269,6 @@ impl Backend for EmbeddedBackend {
             self.fs
                 .fork_namespace(&source_namespace_id, &new_namespace_id),
         )
-    }
-
-    fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, CliError> {
-        self.block_on(self.fs.list_namespaces())
     }
 
     fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError> {

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -2,7 +2,7 @@ use super::context::{fail, validate_namespace_id};
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
-    NamespaceForkArgs, NamespaceListArgs, NamespaceUseArgs,
+    NamespaceForkArgs, NamespaceUseArgs,
 };
 use crate::config::save_config;
 use crate::error::CliError;
@@ -20,7 +20,6 @@ pub(crate) fn run_namespace_command(
         NamespaceCommand::Create(args) => run_namespace_create(kind, args),
         NamespaceCommand::Delete(args) => run_namespace_delete(kind, args),
         NamespaceCommand::Fork(args) => run_namespace_fork(kind, args),
-        NamespaceCommand::List(args) => run_namespace_list(kind, args),
     }
 }
 
@@ -169,35 +168,6 @@ fn run_namespace_fork(
         profile: Some(resolved.profile_name),
         mode: Some(mode),
         data: CommandData::NamespaceSummary(namespace),
-    })
-}
-
-fn run_namespace_list(
-    kind: CommandKind,
-    args: NamespaceListArgs,
-) -> Result<CommandOutput, CommandFailure> {
-    let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile)
-        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
-    let mode = resolved.target.mode_str().to_owned();
-    let namespaces = resolved
-        .target
-        .backend()
-        .list_namespaces()
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(resolved.profile_name),
-        mode: Some(mode),
-        data: CommandData::NamespaceList { namespaces },
     })
 }
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -41,9 +41,6 @@ pub(crate) enum CommandData {
     },
     NamespaceSummary(NamespaceSummary),
     NamespaceDeleted(DeleteNamespaceResponse),
-    NamespaceList {
-        namespaces: Vec<NamespaceSummary>,
-    },
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,
     },

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -145,13 +145,6 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             "deleted {} (head_seq {})",
             response.namespace_id, response.head_seq.0
         ),
-        CommandData::NamespaceList { namespaces } => {
-            let mut lines = vec!["NAMESPACE_ID".to_owned()];
-            for namespace in namespaces {
-                lines.push(namespace.namespace_id.to_string());
-            }
-            lines.join("\n")
-        }
         CommandData::PathEntries { entries } => entries
             .iter()
             .map(|entry| {
@@ -245,8 +238,6 @@ mod tests {
     use crate::error::CliError;
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
-    use loonfs_api::{NamespaceId, NamespaceSummary};
-
     #[test]
     fn human_profile_list_snapshot() {
         let output = CommandOutput {
@@ -267,39 +258,6 @@ mod tests {
                         store_kind: None,
                     },
                 ],
-            },
-        };
-        assert_snapshot!(human_success(&output));
-    }
-
-    #[test]
-    fn human_namespace_list_snapshot() {
-        let output = CommandOutput {
-            kind: CommandKind::NamespaceList,
-            profile: Some("default".to_owned()),
-            mode: Some("remote".to_owned()),
-            data: CommandData::NamespaceList {
-                namespaces: vec![
-                    NamespaceSummary {
-                        namespace_id: NamespaceId::parse("alpha").expect("valid namespace id"),
-                    },
-                    NamespaceSummary {
-                        namespace_id: NamespaceId::parse("prod").expect("valid namespace id"),
-                    },
-                ],
-            },
-        };
-        assert_snapshot!(human_success(&output));
-    }
-
-    #[test]
-    fn human_namespace_list_empty_snapshot() {
-        let output = CommandOutput {
-            kind: CommandKind::NamespaceList,
-            profile: Some("default".to_owned()),
-            mode: Some("remote".to_owned()),
-            data: CommandData::NamespaceList {
-                namespaces: Vec::new(),
             },
         };
         assert_snapshot!(human_success(&output));

--- a/crates/loonfs-cli/src/snapshots/loonfs_cli__render__tests__human_namespace_list_empty_snapshot.snap
+++ b/crates/loonfs-cli/src/snapshots/loonfs_cli__render__tests__human_namespace_list_empty_snapshot.snap
@@ -1,5 +1,0 @@
----
-source: crates/loonfs-cli/src/render.rs
-expression: human_success(&output)
----
-NAMESPACE_ID

--- a/crates/loonfs-cli/src/snapshots/loonfs_cli__render__tests__human_namespace_list_snapshot.snap
+++ b/crates/loonfs-cli/src/snapshots/loonfs_cli__render__tests__human_namespace_list_snapshot.snap
@@ -1,7 +1,0 @@
----
-source: crates/loonfs-cli/src/render.rs
-expression: human_success(&output)
----
-NAMESPACE_ID
-alpha
-prod

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -269,9 +269,9 @@ fn init_creates_embedded_profile_and_current_reports_namespace_unset() {
     assert!(json_data(&current)["namespace"].is_null());
 
     assert_success(&harness.run(&["namespace", "create", "demo"]));
-    let list = harness.run(&["--json", "namespace", "list"]);
-    assert_success(&list);
-    assert_eq!(json_data(&list)["namespaces"].as_array().unwrap().len(), 1);
+    let use_namespace = harness.run(&["--json", "use", "demo"]);
+    assert_success(&use_namespace);
+    assert_eq!(json_data(&use_namespace)["namespace"], "demo");
 }
 
 #[test]
@@ -340,7 +340,7 @@ fn removing_default_profile_requires_explicit_reselection() {
     assert_failure(&current);
     assert_eq!(json_error(&current)["code"], "no_default_profile");
 
-    let namespace = harness.run(&["--json", "namespace", "list"]);
+    let namespace = harness.run(&["--json", "namespace", "create", "new-ns"]);
     assert_failure(&namespace);
     assert_eq!(json_error(&namespace)["code"], "no_default_profile");
 
@@ -723,13 +723,9 @@ fn external_remote_profile_executes_through_http() {
     let use_namespace = harness.run(&["--json", "use", "demo"]);
     assert_success(&use_namespace);
 
-    let list = harness.run(&["--json", "namespace", "list"]);
-    assert_success(&list);
-    let list_data = json_data(&list);
-    let namespaces = list_data["namespaces"].as_array().unwrap();
-    assert_eq!(namespaces.len(), 2);
-    assert_eq!(namespaces[0]["namespace_id"], "clone");
-    assert_eq!(namespaces[1]["namespace_id"], "demo");
+    let use_clone = harness.run(&["--json", "use", "clone"]);
+    assert_success(&use_clone);
+    assert_eq!(json_data(&use_clone)["namespace"], "clone");
 }
 
 #[test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -17,9 +17,9 @@ use loonfs_api::{
     ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CommitId, ContentRef,
     CreateNamespaceRequest, DeleteNamespaceResponse, FilesystemOperation,
     FilesystemOperationRequest, FilesystemOperationResponse, FilesystemPutBehavior,
-    ForkNamespaceRequest, InodeId, ListFileRevisionsResponse, ListNamespacesResponse,
-    ListPathEntriesResponse, MutationResult, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, RestoreFileRevisionRequest, RevisionNo,
+    ForkNamespaceRequest, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -181,29 +181,6 @@ impl Client {
                 namespace_id: namespace_id.as_str().to_owned(),
             }),
         )
-    }
-
-    pub fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>, ClientError> {
-        let mut namespaces = Vec::new();
-        let mut cursor = None;
-        loop {
-            let page = self.list_namespaces_page(None, cursor.as_deref())?;
-            namespaces.extend(page.namespaces);
-            cursor = page.next_cursor;
-            if cursor.is_none() {
-                return Ok(namespaces);
-            }
-        }
-    }
-
-    pub fn list_namespaces_page(
-        &self,
-        limit: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<ListNamespacesResponse, ClientError> {
-        let mut url = format!("{}/v0/namespaces", self.base_url);
-        append_optional_pagination_query(&mut url, false, limit, cursor);
-        self.request_json::<(), ListNamespacesResponse>(self.agent.get(&url), None)
     }
 
     pub fn namespace_status(

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::cache::{MetadataTableCache, WalTailProjectionCache};
 use crate::context::MutationContext;
 use crate::error::Result as CoreResult;
-use crate::namespace::{bootstrap, catalog, delete, fork, BootstrapNamespaceError};
+use crate::namespace::{bootstrap, delete, fork, BootstrapNamespaceError};
 use crate::options::{
     BootstrapOptions, CommitOptions, DeleteNamespaceOptions, ForkOptions, ReadOptions, ReadSource,
     WriteOptions,
@@ -16,7 +16,7 @@ use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     ContentRef, CreateCheckpointResponse, DirectoryPageCursor, FileRevision,
     FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, MutationResult, NamespaceId,
-    NamespaceSummary, NamespacesPageCursor, Page, PageRequest, RevisionNo, DEFAULT_PAGE_LIMIT,
+    NamespaceSummary, Page, PageRequest, RevisionNo, DEFAULT_PAGE_LIMIT,
 };
 use loonfs_objectstore::ObjectStore;
 use std::num::NonZeroU32;
@@ -180,19 +180,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.mutation_context(),
         )
         .await
-    }
-
-    /// Lists complete namespaces visible in the object store.
-    pub async fn list_namespaces(&self) -> CoreResult<Vec<NamespaceSummary>> {
-        catalog::list_namespaces(&self.store).await
-    }
-
-    /// Lists one page of complete namespaces visible in the object store.
-    pub async fn list_namespaces_page(
-        &self,
-        request: PageRequest<NamespacesPageCursor>,
-    ) -> CoreResult<Page<NamespaceSummary, NamespacesPageCursor>> {
-        catalog::list_namespaces_page(&self.store, request).await
     }
 
     /// Resolves one absolute path to the authoritative entry at the current head.

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -84,7 +84,7 @@ pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuil
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
 };
-pub use namespace::{list_namespaces, list_namespaces_page, BootstrapNamespaceError};
+pub use namespace::BootstrapNamespaceError;
 pub use options::{
     BootstrapOptions, CommitOptions, DeleteNamespaceOptions, ForkOptions, ReadOptions, ReadSource,
     WriteOptions,

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -1,17 +1,10 @@
-use crate::error::CoreError;
-use crate::namespace::control::read_head_object;
 use crate::namespace::control::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
 use loonfs_api::wire::control::NamespaceDescriptorState;
-use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::{
-    ContentStoreId, NamespaceId, NamespaceIdValidationError, NamespaceSummary,
-    NamespacesPageCursor, Page, PageRequest,
-};
+use loonfs_api::{ContentStoreId, NamespaceId, NamespaceIdValidationError};
 use loonfs_objectstore::keys::{namespace_descriptor, namespace_head, namespace_lease};
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeSet;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -84,104 +77,6 @@ pub(crate) async fn load_namespace_content_store_id<S: ObjectStore + ?Sized>(
     Ok(load_namespace_catalog_entry(store, expected_namespace)
         .await?
         .content_store_id)
-}
-
-pub(crate) async fn list_namespaces<S: ObjectStore + ?Sized>(
-    store: &S,
-) -> Result<Vec<NamespaceSummary>, CoreError> {
-    let keys = store
-        .list_prefix("namespaces/")
-        .await
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    let mut names = BTreeSet::new();
-    for key in keys {
-        let Some(rest) = key.strip_prefix("namespaces/") else {
-            continue;
-        };
-        let Some((namespace, leaf)) = rest.split_once('/') else {
-            continue;
-        };
-        if leaf != "descriptor.json" {
-            continue;
-        };
-        let namespace_id = NamespaceId::parse(namespace)?;
-        load_namespace_descriptor(store, &namespace_id).await?;
-        // Deleted namespaces keep their descriptor forever as the id-reuse
-        // tombstone; the head's lifecycle state is what excludes them here.
-        let head = read_head_object(store, &namespace_id)
-            .await
-            .map_err(|error| CoreError::MetadataProjection(error.into()))?;
-        if head.envelope.state.state == NamespaceState::Deleted {
-            continue;
-        }
-        names.insert(namespace_id);
-    }
-    Ok(names
-        .into_iter()
-        .map(|namespace_id| NamespaceSummary { namespace_id })
-        .collect())
-}
-
-pub(crate) async fn list_namespaces_page<S: ObjectStore + ?Sized>(
-    store: &S,
-    request: PageRequest<NamespacesPageCursor>,
-) -> Result<Page<NamespaceSummary, NamespacesPageCursor>, CoreError> {
-    let start_after = request.cursor.map(|cursor| cursor.last_namespace_id);
-    let keys = store
-        .list_prefix("namespaces/")
-        .await
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    let mut items = Vec::with_capacity(request.limit.limit_plus_one());
-    for key in keys {
-        let Some(namespace_id) = namespace_id_from_descriptor_key(&key)? else {
-            continue;
-        };
-        if start_after
-            .as_ref()
-            .map(|last| namespace_id.as_str() <= last.as_str())
-            .unwrap_or(false)
-        {
-            continue;
-        }
-        load_namespace_descriptor(store, &namespace_id).await?;
-        let head = read_head_object(store, &namespace_id)
-            .await
-            .map_err(|error| CoreError::MetadataProjection(error.into()))?;
-        if head.envelope.state.state == NamespaceState::Deleted {
-            continue;
-        }
-        items.push(NamespaceSummary { namespace_id });
-        if items.len() == request.limit.limit_plus_one() {
-            break;
-        }
-    }
-
-    let has_more = items.len() > request.limit.as_usize();
-    if has_more {
-        items.truncate(request.limit.as_usize());
-    }
-    let next_cursor = has_more.then(|| NamespacesPageCursor {
-        last_namespace_id: items
-            .last()
-            .expect("non-zero page limit with more results must return an item")
-            .namespace_id
-            .clone(),
-    });
-
-    Ok(Page { items, next_cursor })
-}
-
-fn namespace_id_from_descriptor_key(key: &str) -> Result<Option<NamespaceId>, CoreError> {
-    let Some(rest) = key.strip_prefix("namespaces/") else {
-        return Ok(None);
-    };
-    let Some((namespace, leaf)) = rest.split_once('/') else {
-        return Ok(None);
-    };
-    if leaf != "descriptor.json" {
-        return Ok(None);
-    }
-    Ok(Some(NamespaceId::parse(namespace)?))
 }
 
 pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/namespace/mod.rs
+++ b/crates/loonfs-core/src/namespace/mod.rs
@@ -14,24 +14,8 @@ pub(crate) mod status;
 
 pub use bootstrap::BootstrapNamespaceError;
 pub use loonfs_api::wire::control::{HeadState, HeadStateEnvelope, LeaseState, LeaseStateEnvelope};
-use loonfs_api::{FenceToken, NamespaceSummary, NamespacesPageCursor, Page, PageRequest};
-use loonfs_objectstore::ObjectStore;
+use loonfs_api::FenceToken;
 use thiserror::Error;
-
-/// Lists complete namespaces in the object store.
-pub async fn list_namespaces<S: ObjectStore + ?Sized>(
-    store: &S,
-) -> crate::Result<Vec<NamespaceSummary>> {
-    catalog::list_namespaces(store).await
-}
-
-/// Lists one page of complete namespaces in namespace id order.
-pub async fn list_namespaces_page<S: ObjectStore + ?Sized>(
-    store: &S,
-    request: PageRequest<NamespacesPageCursor>,
-) -> crate::Result<Page<NamespaceSummary, NamespacesPageCursor>> {
-    catalog::list_namespaces_page(store, request).await
-}
 
 /// Returns true when the head and lease agree on the active writer fence.
 pub fn head_and_lease_fence_tokens_agree(head: &HeadState, lease: &LeaseState) -> bool {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -116,12 +116,6 @@ fn fork_namespace<S: ObjectStore + ?Sized>(
     )
 }
 
-fn list_namespaces<S: ObjectStore + ?Sized>(
-    store: &S,
-) -> Result<Vec<loonfs_api::NamespaceSummary>, CoreError> {
-    block_on(loonfs_core::namespace::list_namespaces(store))
-}
-
 fn load_namespace_descriptor_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -1124,7 +1118,7 @@ async fn restore_revision_overflow_is_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn namespace_creation_writes_descriptors_and_listing_uses_completion_marker() {
+async fn namespace_creation_writes_descriptors_and_rejects_partial_recreation() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -1201,9 +1195,6 @@ async fn namespace_creation_writes_descriptors_and_listing_uses_completion_marke
         )
         .await
         .expect("write partial namespace key");
-    let listed = list_namespaces(&store).expect("list namespaces");
-    assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].namespace_id.as_str(), "demo");
 
     let partial_error = bootstrap_namespace(
         &store,
@@ -2557,10 +2548,6 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         fork.expect_err("fork of deleted source").code(),
         ErrorCode::NamespaceDeleted
     );
-    let listed = list_namespaces(&store).expect("list namespaces");
-    assert!(listed
-        .iter()
-        .all(|summary| summary.namespace_id != namespace_id));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2602,9 +2589,6 @@ async fn fork_clone_survives_source_delete() {
         .expect("clone head survives source delete");
     assert_eq!(clone_head.state.seq, ChangeSeq(1));
     resolve_path(&store, &clone, "/shared.txt").expect("clone reads forked file");
-    let listed = list_namespaces(&store).expect("list namespaces");
-    assert!(listed.iter().any(|summary| summary.namespace_id == clone));
-    assert!(listed.iter().all(|summary| summary.namespace_id != source));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3787,13 +3771,13 @@ async fn fork_source_gc_pin_failure_leaves_target_namespace_absent() {
             .is_empty(),
         "target manifest must not be written before source retention is pinned"
     );
-    assert_eq!(
-        list_namespaces(&store)
-            .expect("list namespaces")
-            .into_iter()
-            .map(|summary| summary.namespace_id)
-            .collect::<Vec<_>>(),
-        vec![source_namespace_id]
+    assert!(
+        store
+            .head(&namespace_descriptor(source_namespace_id.as_str()))
+            .await
+            .expect("head source descriptor")
+            .is_some(),
+        "source descriptor should remain published"
     );
 }
 
@@ -3845,13 +3829,13 @@ async fn fork_target_manifest_failure_leaves_target_namespace_absent() {
             .is_empty(),
         "target manifest should not exist after injected manifest write failure"
     );
-    assert_eq!(
-        list_namespaces(&store)
-            .expect("list namespaces")
-            .into_iter()
-            .map(|summary| summary.namespace_id)
-            .collect::<Vec<_>>(),
-        vec![source_namespace_id]
+    assert!(
+        store
+            .head(&namespace_descriptor(source_namespace_id.as_str()))
+            .await
+            .expect("head source descriptor")
+            .is_some(),
+        "source descriptor should remain published"
     );
 }
 
@@ -4000,13 +3984,21 @@ async fn fork_target_control_conflict_rechecks_complete_namespace() {
     let error = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
         .expect_err("target head conflict should re-check complete namespace");
     assert_eq!(error.code(), ErrorCode::NamespaceExists);
-    assert_eq!(
-        list_namespaces(&store)
-            .expect("list namespaces")
-            .into_iter()
-            .map(|summary| summary.namespace_id)
-            .collect::<Vec<_>>(),
-        vec![clone_namespace_id, source_namespace_id]
+    assert!(
+        store
+            .head(&namespace_descriptor(source_namespace_id.as_str()))
+            .await
+            .expect("head source descriptor")
+            .is_some(),
+        "source descriptor should remain published"
+    );
+    assert!(
+        store
+            .head(&namespace_descriptor(clone_namespace_id.as_str()))
+            .await
+            .expect("head clone descriptor")
+            .is_some(),
+        "clone descriptor should be present for the simulated complete target"
     );
 }
 

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -14,8 +14,7 @@ use loonfs::{
     TraceStoreKind,
 };
 use loonfs_api::{
-    decode_directory_cursor, decode_file_revisions_cursor, decode_namespaces_cursor,
-    encode_namespaces_cursor,
+    decode_directory_cursor, decode_file_revisions_cursor,
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,
         CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
@@ -25,9 +24,9 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
     CreateNamespaceRequest, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
     FilesystemOperationRequest, FilesystemOperationResponse, FilesystemPutBehavior,
-    ForkNamespaceRequest, InodeId, LimitError, ListFileRevisionsResponse, ListNamespacesResponse,
-    NamespaceId, NamespaceIdValidationError, NamespacesPageCursor, PageCursorError, PageRequest,
-    PaginationPolicy, RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
+    ForkNamespaceRequest, InodeId, LimitError, ListFileRevisionsResponse, NamespaceId,
+    NamespaceIdValidationError, PageCursorError, PageRequest, PaginationPolicy,
+    RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
 };
 use loonfs_core::content::{
     mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
@@ -60,14 +59,14 @@ struct PathQuery {
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct PageQuery {
+struct PathPageQuery {
+    path: String,
     limit: Option<String>,
     cursor: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct PathPageQuery {
-    path: String,
+struct PageQuery {
     limit: Option<String>,
     cursor: Option<String>,
 }
@@ -128,10 +127,7 @@ fn app_with_fs(
     Router::new()
         .route("/health", get(health))
         .route("/v0/config", get(config_handler))
-        .route(
-            "/v0/namespaces",
-            post(create_namespace).get(list_namespaces_handler),
-        )
+        .route("/v0/namespaces", post(create_namespace))
         .route(
             "/v0/namespaces/:namespace",
             get(namespace_status_handler).delete(delete_namespace_handler),
@@ -387,50 +383,6 @@ async fn create_namespace(
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(summary))
-}
-
-#[cfg_attr(
-    feature = "openapi",
-    utoipa::path(
-        get,
-        path = "/v0/namespaces",
-        tag = "namespaces",
-        summary = "List namespaces",
-        params(
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
-            ("cursor" = Option<String>, Query, description = "Opaque namespace-list page cursor")
-        ),
-        responses(
-            (status = 200, description = "Namespace page", body = ListNamespacesResponse),
-            (status = 400, description = "Invalid limit or cursor", body = ApiError),
-            (status = 401, description = "Unauthorized", body = ApiError)
-        )
-    )
-)]
-async fn list_namespaces_handler(
-    State(state): State<AppState>,
-    Query(query): Query<PageQuery>,
-    headers: HeaderMap,
-) -> Result<Json<ListNamespacesResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
-    let page = state
-        .fs
-        .list_namespaces_page(PageRequest {
-            limit: resolve_page_limit(query.limit)?,
-            cursor: decode_namespaces_page_cursor(query.cursor)?,
-        })
-        .await
-        .map_err(ApiResponseError::runtime)?;
-    let next_cursor = page
-        .next_cursor
-        .as_ref()
-        .map(encode_namespaces_cursor)
-        .transpose()
-        .map_err(page_cursor_response_error)?;
-    Ok(Json(ListNamespacesResponse {
-        namespaces: page.items,
-        next_cursor,
-    }))
 }
 
 #[cfg_attr(
@@ -1365,7 +1317,6 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         health,
         config_handler,
         create_namespace,
-        list_namespaces_handler,
         namespace_status_handler,
         delete_namespace_handler,
         fork_namespace_handler,
@@ -1391,7 +1342,6 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         CreateNamespaceRequest,
         ForkNamespaceRequest,
         loonfs_api::NamespaceSummary,
-        ListNamespacesResponse,
         loonfs_api::NamespaceStatusResponse,
         loonfs_api::DeleteNamespaceResponse,
         FilesystemPutBehavior,
@@ -1514,16 +1464,6 @@ fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
             &format!("invalid limit `{value}`: {error}"),
         )
     })
-}
-
-fn decode_namespaces_page_cursor(
-    cursor: Option<String>,
-) -> Result<Option<NamespacesPageCursor>, ApiResponseError> {
-    cursor
-        .as_deref()
-        .map(decode_namespaces_cursor)
-        .transpose()
-        .map_err(page_cursor_response_error)
 }
 
 fn decode_directory_page_cursor(

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -13,9 +13,8 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    FilesystemPutBehavior, InodeId, InodeKind, ListNamespacesResponse, ListPathEntriesResponse,
-    ManifestId, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT,
-    LIMIT_PAGINATION_MAX,
+    FilesystemPutBehavior, InodeId, InodeKind, ListPathEntriesResponse, ManifestId, RevisionNo,
+    DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs_objectstore::keys::{namespace_lease, namespace_manifest};
@@ -83,8 +82,8 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         assert_eq!(response.namespace_id.as_str(), "doomed");
         assert_eq!(response.head_seq, ChangeSeq(1));
 
-        // Terminal: status is 410, reads fail, the namespace leaves the
-        // list, repeat deletes report deleted, and the id is retired.
+        // Terminal: status is 410, reads fail, repeat deletes report
+        // deleted, and the id is retired.
         let status = harness
             .client
             .namespace_status("doomed")
@@ -104,10 +103,6 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
             ClientError::Api { code, .. } => assert_eq!(code, "namespace_deleted"),
             other => panic!("expected namespace_deleted, got {other:?}"),
         }
-        let namespaces = harness.client.list_namespaces().expect("list");
-        assert!(namespaces
-            .iter()
-            .all(|namespace| namespace.namespace_id.as_str() != "doomed"));
         let again = harness
             .client
             .delete_namespace("doomed", None)
@@ -151,7 +146,7 @@ async fn config_endpoint_advertises_capabilities() {
         assert_eq!(capabilities.protocol_version, "v0");
         assert!(capabilities.has_profile("core/v0"));
         assert!(capabilities.has_profile("admin/v0"));
-        assert!(capabilities.supports("core.namespaces.list"));
+        assert!(!capabilities.supports("core.namespaces.list"));
         assert!(capabilities.supports("core.namespaces.create"));
         assert!(capabilities.supports("core.namespaces.fork"));
         assert!(capabilities.supports("core.namespaces.delete"));
@@ -170,107 +165,6 @@ async fn config_endpoint_advertises_capabilities() {
     })
     .await
     .expect("blocking task");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_paginates_namespaces_and_rejects_bad_namespace_cursors() {
-    let temp_dir = tempdir().expect("tempdir");
-    let harness = start_server(test_config(
-        temp_dir.path().join("store"),
-        "loonfs-server-test",
-        "http-namespace-pagination",
-        60_000,
-    ))
-    .await;
-
-    tokio::task::spawn_blocking(move || {
-        for namespace in ["alpha", "bravo", "charlie", "pages"] {
-            harness
-                .client
-                .create_namespace(namespace)
-                .expect("create namespace");
-        }
-
-        let first_page = harness
-            .client
-            .list_namespaces_page(Some(2), None)
-            .expect("first namespace page");
-        assert_eq!(
-            namespace_ids(&first_page),
-            vec!["alpha".to_owned(), "bravo".to_owned()]
-        );
-        let cursor = first_page.next_cursor.expect("namespace cursor");
-
-        let second_page = harness
-            .client
-            .list_namespaces_page(Some(2), Some(&cursor))
-            .expect("second namespace page");
-        assert_eq!(
-            namespace_ids(&second_page),
-            vec!["charlie".to_owned(), "pages".to_owned()]
-        );
-        assert_eq!(second_page.next_cursor, None);
-
-        let bad_limit = harness
-            .client
-            .list_namespaces_page(Some(0), None)
-            .expect_err("zero limit rejected");
-        match bad_limit {
-            ClientError::Api { status, code, .. } => {
-                assert_eq!(status, 400);
-                assert_eq!(code, "invalid_config");
-            }
-            other => panic!("expected invalid_config, got {other:?}"),
-        }
-        let over_limit = harness
-            .client
-            .list_namespaces_page(Some(DEFAULT_MAX_PAGE_LIMIT + 1), None)
-            .expect_err("oversized limit rejected");
-        match over_limit {
-            ClientError::Api { status, code, .. } => {
-                assert_eq!(status, 400);
-                assert_eq!(code, "invalid_config");
-            }
-            other => panic!("expected invalid_config, got {other:?}"),
-        }
-        let nonnumeric_limit: Result<ListNamespacesResponse, ApiError> = get_json(
-            &format!("{}/v0/namespaces?limit=not-a-number", harness.server_url),
-            "test-token",
-        );
-        let error = nonnumeric_limit.expect_err("nonnumeric limit rejected");
-        assert_eq!(error.code, "invalid_config");
-        assert!(error.message.contains("invalid limit"));
-
-        let dir = NamespacePath::parse("pages:/docs").expect("docs path");
-        harness.client.create_dir(&dir).expect("create docs dir");
-        for name in ["a.txt", "b.txt"] {
-            let path = NamespacePath::parse(&format!("pages:/docs/{name}")).expect("file path");
-            harness
-                .client
-                .write_file_bytes(&path, name.as_bytes())
-                .expect("write file");
-        }
-        let directory_page = harness
-            .client
-            .list_path_page(&dir, Some(1), None)
-            .expect("directory page");
-        let wrong_cursor = directory_page.next_cursor.expect("directory cursor");
-        let wrong_kind = harness
-            .client
-            .list_namespaces_page(Some(1), Some(&wrong_cursor))
-            .expect_err("directory cursor rejected by namespace endpoint");
-        match wrong_kind {
-            ClientError::Api { status, code, .. } => {
-                assert_eq!(status, 400);
-                assert_eq!(code, "invalid_cursor");
-            }
-            other => panic!("expected invalid_cursor, got {other:?}"),
-        }
-    })
-    .await
-    .expect("join blocking task");
-
-    harness.server.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -418,6 +312,43 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
                 assert_eq!(code, "namespace_not_found");
             }
             other => panic!("expected API error for missing namespace, got {other:?}"),
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_namespace_listing_route_is_not_exposed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-no-namespace-list",
+        60_000,
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create demo");
+
+        let response = ureq::get(&format!("{}/v0/namespaces", harness.server_url))
+            .set("authorization", "Bearer test-token")
+            .call();
+        match response {
+            Err(ureq::Error::Status(status, _)) => {
+                assert!(
+                    status == 404 || status == 405,
+                    "GET /v0/namespaces should be missing or method-not-allowed, got {status}"
+                );
+            }
+            Ok(_) => panic!("GET /v0/namespaces must not return a namespace list"),
+            Err(error) => panic!("unexpected transport error: {error}"),
         }
     })
     .await
@@ -1628,14 +1559,6 @@ fn test_config(
             key_prefix: Some(key_prefix.to_owned()),
         },
     }
-}
-
-fn namespace_ids(response: &ListNamespacesResponse) -> Vec<String> {
-    response
-        .namespaces
-        .iter()
-        .map(|namespace| namespace.namespace_id.as_str().to_owned())
-        .collect()
 }
 
 fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -34,7 +34,6 @@ fn openapi_documents_current_server_paths() {
         ("/health", "get"),
         ("/v0/config", "get"),
         ("/v0/namespaces", "post"),
-        ("/v0/namespaces", "get"),
         ("/v0/namespaces/{namespace}", "get"),
         ("/v0/namespaces/{namespace}", "delete"),
         ("/v0/namespaces/{namespace}/forks", "post"),
@@ -73,7 +72,6 @@ fn openapi_documents_current_server_paths() {
     }
 
     assert!(!paths.contains_key("/openapi.json"));
-    assert_query_params(paths, "/v0/namespaces", "get", &["limit", "cursor"]);
     assert_query_params(
         paths,
         "/v0/namespaces/{namespace}/filesystem/list",

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -24,10 +24,10 @@ use crate::{
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
     encode_directory_cursor, encode_file_revisions_cursor, AbsolutePath, CapabilityDocument,
-    DirectoryPageCursor, EffectiveLimit, FileRevision, FileRevisionsPageCursor,
-    NamespacesPageCursor, Page, PageRequest, PaginationPolicy, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST,
-    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    DirectoryPageCursor, EffectiveLimit, FileRevision, FileRevisionsPageCursor, Page, PageRequest,
+    PaginationPolicy, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
     load_namespace_head_summary, MetadataTableCache, WalTailProjectionCache,
@@ -295,7 +295,6 @@ impl Fs {
             protocol_version: PROTOCOL_VERSION.to_owned(),
             profiles: vec![PROFILE_CORE_V0.to_owned(), PROFILE_ADMIN_V0.to_owned()],
             features: BTreeMap::from([
-                (FEATURE_NAMESPACES_LIST.to_owned(), true),
                 (FEATURE_NAMESPACES_CREATE.to_owned(), true),
                 (FEATURE_NAMESPACES_FORK.to_owned(), true),
                 (FEATURE_NAMESPACES_DELETE.to_owned(), true),
@@ -303,19 +302,6 @@ impl Fs {
             ]),
             limits: PaginationPolicy::default().capability_limits(),
         }
-    }
-
-    /// Lists complete namespaces visible in the object store.
-    pub async fn list_namespaces(&self) -> Result<Vec<NamespaceSummary>> {
-        Ok(loonfs_core::list_namespaces(self.store()).await?)
-    }
-
-    /// Lists one page of complete namespaces in namespace id order.
-    pub async fn list_namespaces_page(
-        &self,
-        request: PageRequest<NamespacesPageCursor>,
-    ) -> Result<Page<NamespaceSummary, NamespacesPageCursor>> {
-        Ok(loonfs_core::list_namespaces_page(self.store(), request).await?)
     }
 
     /// Summarizes a namespace's current head: manifest, latest checkpoint,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -28,10 +28,9 @@ pub use loonfs_api::{
     DeleteNamespaceResponse, DirectoryPageCursor, DisplayName, EffectiveLimit, FileRevision,
     FileRevisionsPageCursor, FilesystemOperationResponse, InodeId, InodeKind,
     ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult, NameKey,
-    NamePolicy, NamespaceId, NamespaceSummary, NamespacesPageCursor, Page, PageRequest,
-    PaginationPolicy, RevisionNo, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
-    FEATURE_NAMESPACES_FORK, FEATURE_NAMESPACES_LIST, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
-    PROFILE_CORE_V0, PROTOCOL_VERSION,
+    NamePolicy, NamespaceId, NamespaceSummary, Page, PageRequest, PaginationPolicy, RevisionNo,
+    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -8,12 +8,12 @@ use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadResponse,
     ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
-    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
-    DeleteOptions, DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind,
-    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
-    MutationResult, NamespaceId, NamespaceStatus, NamespacesPageCursor, PageRequest,
-    PaginationPolicy, PutFileBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError,
-    SharedObjectStore, TraceMode, TraceStoreKind, UploadContentResponse,
+    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteOptions,
+    DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, MaintenanceTickOptions,
+    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
+    NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutFileBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    UploadContentResponse,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::fs::LocalFsStore;
@@ -86,7 +86,6 @@ trait FsTestExt {
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> loonfs::Result<loonfs::NamespaceSummary>;
-    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>>;
     fn namespace_status_blocking(
         &self,
         namespace_id: &NamespaceId,
@@ -200,10 +199,6 @@ impl FsTestExt for Fs {
         target: &NamespaceId,
     ) -> loonfs::Result<loonfs::NamespaceSummary> {
         block_on(self.fork_namespace(source, target))
-    }
-
-    fn list_namespaces_blocking(&self) -> loonfs::Result<Vec<loonfs::NamespaceSummary>> {
-        block_on(self.list_namespaces())
     }
 
     fn namespace_status_blocking(
@@ -964,101 +959,6 @@ fn delete_options_select_recursive_behavior() {
         error,
         RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
     ));
-}
-
-#[test]
-fn namespace_pages_resume_by_namespace_id_and_omit_deleted_namespaces() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "namespace-page-test");
-    for namespace in ["alpha", "beta", "charlie", "delta"] {
-        fs.create_namespace_blocking(
-            &NamespaceId::parse(namespace).expect("valid namespace id"),
-            CreateNamespaceOptions::default(),
-        )
-        .expect("create namespace");
-    }
-    block_on(fs.delete_namespace(
-        &NamespaceId::parse("beta").expect("valid namespace id"),
-        DeleteNamespaceOptions::default(),
-    ))
-    .expect("delete beta");
-
-    let limit = page_limit(2);
-    let first = block_on(fs.list_namespaces_page(PageRequest {
-        limit,
-        cursor: None,
-    }))
-    .expect("first namespace page");
-    assert_eq!(
-        first
-            .items
-            .iter()
-            .map(|summary| summary.namespace_id.as_str())
-            .collect::<Vec<_>>(),
-        vec!["alpha", "charlie"]
-    );
-    let second = block_on(fs.list_namespaces_page(PageRequest {
-        limit,
-        cursor: first.next_cursor,
-    }))
-    .expect("second namespace page");
-    assert_eq!(
-        second
-            .items
-            .iter()
-            .map(|summary| summary.namespace_id.as_str())
-            .collect::<Vec<_>>(),
-        vec!["delta"]
-    );
-    assert!(second.next_cursor.is_none());
-
-    let full = fs.list_namespaces_blocking().expect("full namespace list");
-    assert_eq!(
-        full.iter()
-            .map(|summary| summary.namespace_id.as_str())
-            .collect::<Vec<_>>(),
-        vec!["alpha", "charlie", "delta"]
-    );
-}
-
-#[test]
-fn namespace_pages_do_not_read_skipped_namespace_heads() {
-    let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(HeadCasFailureStore::new(temp_dir.path(), "ns-000"));
-    let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("namespace-page-read-count")
-        .build()
-        .expect("build runtime");
-
-    for index in 0..20 {
-        let namespace_id =
-            NamespaceId::parse(format!("ns-{index:03}")).expect("valid namespace id");
-        fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
-            .expect("create namespace");
-    }
-
-    raw_store.reset_control_get_counts();
-    let page = block_on(fs.list_namespaces_page(PageRequest {
-        limit: page_limit(2),
-        cursor: Some(NamespacesPageCursor {
-            last_namespace_id: NamespaceId::parse("ns-009").expect("valid namespace id"),
-        }),
-    }))
-    .expect("list namespace page");
-
-    assert_eq!(
-        page.items
-            .iter()
-            .map(|summary| summary.namespace_id.as_str())
-            .collect::<Vec<_>>(),
-        vec!["ns-010", "ns-011"]
-    );
-    assert_eq!(
-        raw_store.head_get_count(),
-        0,
-        "page should not read namespace heads before the cursor"
-    );
 }
 
 #[test]
@@ -2359,9 +2259,6 @@ fn separate_runtime_instances_share_object_store_state() {
         )
         .expect("put file");
 
-    let namespaces = reader.list_namespaces_blocking().expect("list namespaces");
-    assert_eq!(namespaces.len(), 1);
-    assert_eq!(namespaces[0].namespace_id, namespace_id);
     let file = reader
         .read_file_bytes_blocking(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -35,10 +35,9 @@ Notes:
   `admin/v0` (maintenance is manually triggerable). A minimal server that
   wraps the embedded engine over HTTP advertises the same two profiles and is
   fully conformant.
-- A hosted server may disable individual features per tenant (for example,
-  `core.namespaces.list` for tenancy isolation) and typically hides
-  `admin/v0` because maintenance runs automatically. Both choices are fully
-  conformant.
+- A hosted server may disable individual features per tenant and typically
+  hides `admin/v0` because maintenance runs automatically. Both choices are
+  fully conformant.
 - Profiles version independently (`core/v0` could coexist with a future
   `admin/v1`). The plane name — the segment before the slash — is the stable
   identity that feature keys reference.
@@ -71,7 +70,6 @@ therefore identical for both backends.
   "protocol_version": "v0",
   "profiles": ["core/v0", "admin/v0"],
   "features": {
-    "core.namespaces.list": true,
     "core.namespaces.create": true,
     "core.namespaces.fork": true,
     "core.namespaces.delete": true,
@@ -118,7 +116,6 @@ hoc.
 
 | Feature key | Gates | Notes |
 | --- | --- | --- |
-| `core.namespaces.list` | Enumerating namespaces (`GET /v0/namespaces`, `loon namespace list`). | Deniable for tenancy reasons; a deployment that disables it still resolves namespaces by id. |
 | `core.namespaces.create` | Creating namespaces (`POST /v0/namespaces`). | |
 | `core.namespaces.fork` | Forking namespaces (`POST /v0/namespaces/{ns}/forks`). | |
 | `core.namespaces.delete` | Deleting namespaces (`DELETE /v0/namespaces/{ns}`). | Terminal, and the id is permanently retired. Deletion does not reclaim storage in v0. A deployment may still advertise `false` and answer `not_supported`. |
@@ -126,6 +123,9 @@ hoc.
 
 `admin/v0` currently has required ops only and no feature keys. `query.*` and
 `acl.*` keys are unregistered until their planes materialize.
+
+Namespace listing is intentionally not supported in v0. Callers must address
+namespaces by id until LoonFS has a scalable namespace catalog/index design.
 
 ### 2.3 Namespace-level features
 
@@ -305,7 +305,6 @@ A representative v0 binding is shown below.
 | --- | --- |
 | Read deployment capabilities | `GET /v0/config` |
 | Create a namespace | `POST /v0/namespaces` |
-| List namespaces | `GET /v0/namespaces?limit=100&cursor=...` |
 | Read one namespace's status | `GET /v0/namespaces/{ns}` |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt` |
 | List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...` |
@@ -453,22 +452,7 @@ code `namespace_not_found`.
 }
 ```
 
-### 6.3 `GET /v0/namespaces`
-
-Namespace pagination advances in namespace id order. Responses include
-`next_cursor` only when another page is available.
-
-```json
-{
-  "namespaces": [
-    { "namespace_id": "demo" },
-    { "namespace_id": "logs" }
-  ],
-  "next_cursor": "7b2e2e2e7d"
-}
-```
-
-### 6.4 `DELETE /v0/namespaces/{ns}`
+### 6.3 `DELETE /v0/namespaces/{ns}`
 
 Deletion is a fenced, terminal head transition (`format.md`, "Tombstones and
 deletion"). It linearizes at the head swap: commits acknowledged before it

--- a/docs/specs/glossary.md
+++ b/docs/specs/glossary.md
@@ -30,6 +30,6 @@
 | **Operation id** | Optional commit metadata used to correlate multiple commits that belong to one higher-level workflow. |
 | **Control object** | A server-side control-plane object used to preserve authoritative state across multiple requests, such as a pinned read snapshot, a resumable upload, or a stable destination binding. |
 | **Profile** | An all-or-nothing API conformance unit covering one functional plane (for example `core/v0`). A deployment advertises a profile only when every required op in it is implemented. |
-| **Feature** | A named optional capability inside an advertised profile, keyed `plane.area.name` (for example `core.namespaces.list`). |
+| **Feature** | A named optional capability inside an advertised profile, keyed `plane.area.name` (for example `core.uploads.direct_put`). |
 | **Capability document** | The self-description a deployment returns from `GET /v0/config` (or exposes as a constant when embedded): protocol version, advertised profiles, features, and advisory limits. |
 | **Namespace features map** | The `features` map in a namespace manifest recording capabilities materialized on that namespace's data, such as derived indexes. |

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -220,65 +220,6 @@
       }
     },
     "/v0/namespaces": {
-      "get": {
-        "tags": [
-          "namespaces"
-        ],
-        "summary": "List namespaces",
-        "operationId": "list_namespaces_handler",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum page size",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "description": "Opaque namespace-list page cursor",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Namespace page",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListNamespacesResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid limit or cursor",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            }
-          }
-        }
-      },
       "post": {
         "tags": [
           "namespaces"
@@ -3407,29 +3348,6 @@
           }
         }
       },
-      "ListNamespacesResponse": {
-        "type": "object",
-        "description": "Response for namespace listing.",
-        "required": [
-          "namespaces"
-        ],
-        "properties": {
-          "namespaces": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NamespaceSummary"
-            },
-            "description": "Complete namespaces visible to the store for this page."
-          },
-          "next_cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Cursor for the next page, if more namespaces remain."
-          }
-        }
-      },
       "ListPathEntriesResponse": {
         "type": "object",
         "description": "One directory listing and the namespace head it was answered at.\n\nThe envelope names the listing target and head so an empty directory\nstill tells the caller which state it observed, and so the response can\ngrow without reshaping `entries`.",
@@ -3532,7 +3450,7 @@
       },
       "NamespaceSummary": {
         "type": "object",
-        "description": "Short namespace listing entry.",
+        "description": "Short namespace identifier returned by namespace create/fork operations.",
         "required": [
           "namespace_id"
         ],


### PR DESCRIPTION
Removes namespace listing until we can support a scalable implementation. Relying on S3 listing is brittle and does not scale. We would most likely need to use a durable catalog to support this at scale. 