### PR TITLE
refactor(runtime): remove foreground wal tail limit

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -78,7 +78,6 @@ pub enum ErrorCode {
     UploadContentConflict,
     InvalidUploadContent,
     RebootstrapRequired,
-    MetadataTailTooLong,
     BootstrapFailed,
     NamespaceCorrupt,
     ServerError,
@@ -86,7 +85,7 @@ pub enum ErrorCode {
 
 impl ErrorCode {
     /// Every registered code, in registry order.
-    pub const ALL: [ErrorCode; 39] = [
+    pub const ALL: [ErrorCode; 38] = [
         ErrorCode::InvalidPath,
         ErrorCode::InvalidNamespaceId,
         ErrorCode::InvalidCommitId,
@@ -122,7 +121,6 @@ impl ErrorCode {
         ErrorCode::UploadContentConflict,
         ErrorCode::InvalidUploadContent,
         ErrorCode::RebootstrapRequired,
-        ErrorCode::MetadataTailTooLong,
         ErrorCode::BootstrapFailed,
         ErrorCode::NamespaceCorrupt,
         ErrorCode::ServerError,
@@ -152,8 +150,7 @@ impl ErrorCode {
             ErrorCode::StaleRevision => ErrorKind::PreconditionFailed,
             ErrorCode::CommitQueueFull
             | ErrorCode::CheckpointUnavailable
-            | ErrorCode::MaintenanceRequired
-            | ErrorCode::MetadataTailTooLong => ErrorKind::Unavailable,
+            | ErrorCode::MaintenanceRequired => ErrorKind::Unavailable,
             ErrorCode::CommitOutcomeUnknown => ErrorKind::OutcomeUnknown,
             ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
             ErrorCode::ServerError | ErrorCode::BootstrapFailed => ErrorKind::Internal,
@@ -208,7 +205,6 @@ impl ErrorCode {
             ErrorCode::UploadContentConflict => "upload_content_conflict",
             ErrorCode::InvalidUploadContent => "invalid_upload_content",
             ErrorCode::RebootstrapRequired => "rebootstrap_required",
-            ErrorCode::MetadataTailTooLong => "metadata_tail_too_long",
             ErrorCode::BootstrapFailed => "bootstrap_failed",
             ErrorCode::NamespaceCorrupt => "namespace_corrupt",
             ErrorCode::ServerError => "server_error",

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -135,6 +135,16 @@ pub enum ManifestLoadError {
         family: MetadataTableFamily,
         row_kind: String,
     },
+    #[error(
+        "namespace manifest `{object_key}` has duplicate revision rows in `{family:?}` for key `{row_key}`"
+    )]
+    DuplicateRevisionRow {
+        object_key: String,
+        family: MetadataTableFamily,
+        row_key: String,
+    },
+    #[error("namespace manifest `{object_key}` revision index does not match canonical revisions")]
+    RevisionIndexMismatch { object_key: String },
     #[error("metadata rows do not reproduce authoritative metadata")]
     MetadataMismatch,
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -25,7 +25,7 @@ use loonfs_api::wire::manifest::{
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_sst, namespace_manifest};
 use loonfs_objectstore::ObjectStore;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Mutex;
 use tracing::Instrument;
 
@@ -278,6 +278,8 @@ where
     let ordered_tables = ordered_manifest_tables(context.manifest_object_key, tables)?;
     let mut direntry_bind_rows = Vec::new();
     let mut direntry_child_bind_rows = Vec::new();
+    let mut revision_rows = Vec::new();
+    let mut revision_by_inode_desc_rows = Vec::new();
     for table in ordered_tables {
         let mut descriptors = Vec::with_capacity(table.segments.len());
         for descriptor in &table.segments {
@@ -310,6 +312,12 @@ where
                 MetadataTableFamily::DirentryChildBinds => {
                     direntry_child_bind_rows.extend(rows.iter().cloned());
                 }
+                MetadataTableFamily::Revisions => {
+                    revision_rows.extend(rows.iter().cloned());
+                }
+                MetadataTableFamily::RevisionsByInodeDesc => {
+                    revision_by_inode_desc_rows.extend(rows.iter().cloned());
+                }
                 _ => {}
             }
             append_rows_to_metadata(metadata_state, table.family, &descriptor.object_key, &rows)?;
@@ -320,6 +328,11 @@ where
         context.manifest_object_key,
         direntry_bind_rows,
         direntry_child_bind_rows,
+    )?;
+    validate_revision_by_inode_desc_index(
+        context.manifest_object_key,
+        revision_rows,
+        revision_by_inode_desc_rows,
     )
 }
 
@@ -627,4 +640,55 @@ pub(super) fn validate_direntry_child_bind_index(
     }
 
     Ok(())
+}
+
+pub(super) fn validate_revision_by_inode_desc_index(
+    object_key: &str,
+    mut revision_rows: Vec<MetadataRow>,
+    mut revision_by_inode_desc_rows: Vec<MetadataRow>,
+) -> Result<(), ManifestLoadError> {
+    validate_revision_rows_have_unique_keys(
+        object_key,
+        MetadataTableFamily::Revisions,
+        &revision_rows,
+    )?;
+    validate_revision_rows_have_unique_keys(
+        object_key,
+        MetadataTableFamily::RevisionsByInodeDesc,
+        &revision_by_inode_desc_rows,
+    )?;
+
+    revision_rows.sort_by_key(revision_logical_key);
+    revision_by_inode_desc_rows.sort_by_key(revision_logical_key);
+
+    if revision_rows != revision_by_inode_desc_rows {
+        return Err(ManifestLoadError::RevisionIndexMismatch {
+            object_key: object_key.to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_revision_rows_have_unique_keys(
+    object_key: &str,
+    family: MetadataTableFamily,
+    rows: &[MetadataRow],
+) -> Result<(), ManifestLoadError> {
+    let mut seen = BTreeSet::new();
+    for row in rows {
+        let row_key = revision_logical_key(row);
+        if !seen.insert(row_key.clone()) {
+            return Err(ManifestLoadError::DuplicateRevisionRow {
+                object_key: object_key.to_owned(),
+                family,
+                row_key,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn revision_logical_key(row: &MetadataRow) -> String {
+    row.row_key_for_family(MetadataTableFamily::Revisions)
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -1499,6 +1499,316 @@ fn assert_child_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
     }
 }
 
+#[tokio::test]
+async fn manifest_rejects_missing_revision_desc_index() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let manifest = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_verified_manifest_materialization(&store, &namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let mut manifest = materialized.manifest;
+    let manifest_id = manifest.payload.manifest_id;
+    manifest.payload.metadata_files.retain(|metadata_file| {
+        metadata_file.family != ApiMetadataTableFamily::RevisionsByInodeDesc
+    });
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_missing_row() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/other.txt",
+        b"other\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write other");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    revision_index_rows.pop().expect("revision index row");
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_extra_row() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    let extra_row = revision_index_rows
+        .first()
+        .expect("revision index row")
+        .clone();
+    revision_index_rows.push(match extra_row {
+        MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            revision_delta_index,
+            content_ref,
+        } => MetadataRow::Revision {
+            inode_id,
+            revision_no: loonfs_api::RevisionNo(revision_no.0 + 100),
+            committed_seq,
+            revision_delta_index,
+            content_ref,
+        },
+        other => other,
+    });
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_changed_content_ref() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    let first = revision_index_rows.first_mut().expect("revision index row");
+    if let MetadataRow::Revision { content_ref, .. } = first {
+        content_ref.digest =
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+    }
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_duplicate_rows() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    revision_index_rows.push(
+        revision_index_rows
+            .first()
+            .expect("revision index row")
+            .clone(),
+    );
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    match load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await {
+        Err(ManifestLoadError::DuplicateRevisionRow { family, .. }) => {
+            assert_eq!(family, ApiMetadataTableFamily::RevisionsByInodeDesc);
+        }
+        other => panic!("expected duplicate revision row, got {other:?}"),
+    }
+}
+
+async fn revision_index_test_materialization(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> (ManifestId, NamespaceManifestEnvelope, Vec<MetadataRow>) {
+    let manifest = create_checkpoint(store, namespace_id, context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_verified_manifest_materialization(store, namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let revision_index_rows = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+    );
+    assert!(!revision_index_rows.is_empty());
+    (
+        materialized.manifest.payload.manifest_id,
+        materialized.manifest,
+        revision_index_rows,
+    )
+}
+
+async fn rewrite_revision_index_segment(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    manifest: &mut NamespaceManifestEnvelope,
+    mut rows: Vec<MetadataRow>,
+    writer_version: &str,
+) {
+    rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataTableFamily::RevisionsByInodeDesc));
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::RevisionsByInodeDesc
+        })
+        .expect("revision index metadata file");
+    rewrite_manifest_segment(
+        store,
+        namespace_id,
+        manifest.payload.head_seq,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+        descriptor,
+        rows,
+        writer_version,
+    )
+    .await;
+}
+
+async fn overwrite_manifest(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    manifest: NamespaceManifestEnvelope,
+) {
+    let manifest_key = namespace_manifest(namespace_id.as_str(), manifest.payload.manifest_id);
+    let updated_manifest =
+        NamespaceManifestEnvelope::from_payload(manifest.writer_version, manifest.payload)
+            .expect("updated manifest");
+    let manifest_bytes =
+        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    store
+        .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
+        .await
+        .expect("overwrite manifest");
+}
+
+fn assert_revision_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
+    match result {
+        Err(ManifestLoadError::RevisionIndexMismatch { .. }) => {}
+        Err(other) => panic!("expected revision index mismatch, got {other:?}"),
+        Ok(_) => panic!("expected revision index mismatch"),
+    }
+}
+
 fn base_run(manifest: &NamespaceManifestEnvelope) -> MetadataRunManifest {
     runs_from_metadata_files(&manifest.payload)
         .into_iter()

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -34,13 +34,11 @@ fn manifest_plus_tail_cache_context<'a>(
     head_etag: &'a str,
     table_cache: &'a Option<Arc<MetadataTableCache>>,
     tail_cache: &'a Option<Arc<WalTailProjectionCache>>,
-    max_wal_tail_segments: u64,
 ) -> crate::path::query::ManifestPlusTailCacheContext<'a> {
     crate::path::query::ManifestPlusTailCacheContext::new(
         Some(head_etag),
         table_cache.as_deref(),
         tail_cache.as_deref(),
-        max_wal_tail_segments,
     )
 }
 
@@ -203,14 +201,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::resolve_path_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -244,14 +237,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_path_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -287,14 +275,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_path_page_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -332,14 +315,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::read_file_bytes_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -373,14 +351,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_file_revisions_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -416,14 +389,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_file_revisions_page_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -457,14 +425,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_file_revisions_for_inode_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -499,14 +462,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::list_file_revisions_for_inode_page_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -543,14 +501,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::read_file_revision_bytes_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,
@@ -586,14 +539,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             } => {
-                let cache_context = manifest_plus_tail_cache_context(
-                    head_etag.as_str(),
-                    table_cache,
-                    tail_cache,
-                    *max_wal_tail_segments,
-                );
+                let cache_context =
+                    manifest_plus_tail_cache_context(head_etag.as_str(), table_cache, tail_cache);
                 crate::path::query::read_file_revision_bytes_for_inode_from_manifest_plus_tail_at_head_with_cache(
                     &self.store,
                     &self.namespace_id,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -130,17 +130,6 @@ pub enum CoreError {
 pub enum MetadataViewError {
     #[error("namespace `{namespace_id}` head has no current manifest")]
     MissingManifest { namespace_id: NamespaceId },
-    #[error(
-        "metadata WAL tail after manifest `{manifest_id:?}` is too long: {wal_tail_segments} segments exceeds max {max_wal_tail_segments}"
-    )]
-    TailTooLong {
-        namespace_id: NamespaceId,
-        manifest_id: ManifestId,
-        manifest_head_seq: ChangeSeq,
-        head_seq: ChangeSeq,
-        wal_tail_segments: u64,
-        max_wal_tail_segments: u64,
-    },
     #[error("metadata view for namespace `{namespace_id}` requires maintenance: {reason}")]
     MaintenanceRequired {
         namespace_id: NamespaceId,
@@ -325,7 +314,6 @@ impl CoreError {
 fn classify_metadata_view_error(error: &MetadataViewError) -> ErrorCode {
     match error {
         MetadataViewError::MissingManifest { .. } => ErrorCode::NamespaceCorrupt,
-        MetadataViewError::TailTooLong { .. } => ErrorCode::MetadataTailTooLong,
         MetadataViewError::MaintenanceRequired { .. } => ErrorCode::MaintenanceRequired,
         MetadataViewError::SnapshotUnavailable { .. }
         | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::InvalidCursor,
@@ -568,17 +556,6 @@ mod tests {
                     namespace_id: namespace_id.clone(),
                 },
                 ErrorCode::NamespaceCorrupt,
-            ),
-            (
-                MetadataViewError::TailTooLong {
-                    namespace_id: namespace_id.clone(),
-                    manifest_id,
-                    manifest_head_seq: ChangeSeq(1),
-                    head_seq,
-                    wal_tail_segments: 33,
-                    max_wal_tail_segments: 32,
-                },
-                ErrorCode::MetadataTailTooLong,
             ),
             (
                 MetadataViewError::MaintenanceRequired {

--- a/crates/loonfs-core/src/options.rs
+++ b/crates/loonfs-core/src/options.rs
@@ -48,7 +48,6 @@ impl ReadOptions {
         head_etag: String,
         table_cache: Option<Arc<MetadataTableCache>>,
         tail_cache: Option<Arc<WalTailProjectionCache>>,
-        max_wal_tail_segments: u64,
     ) -> Self {
         Self {
             source: ReadSource::ManifestPlusTailAtHead {
@@ -56,7 +55,6 @@ impl ReadOptions {
                 head_etag,
                 table_cache,
                 tail_cache,
-                max_wal_tail_segments,
             },
         }
     }
@@ -76,7 +74,7 @@ impl Default for ReadOptions {
 /// Source used by [`ReadOptions`].
 #[derive(Debug, Clone)]
 pub enum ReadSource {
-    /// Use the current manifest and bounded WAL tail.
+    /// Use the current manifest and visible WAL tail.
     ManifestPlusTail,
     /// Use manifest-plus-tail for a specific already-loaded head.
     ManifestPlusTailAtHead {
@@ -88,8 +86,6 @@ pub enum ReadSource {
         table_cache: Option<Arc<MetadataTableCache>>,
         /// Optional WAL-tail projection cache.
         tail_cache: Option<Arc<WalTailProjectionCache>>,
-        /// Maximum visible WAL tail segments this read may project.
-        max_wal_tail_segments: u64,
     },
 }
 

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -29,14 +29,11 @@ use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
 use tracing::Instrument;
 
-const DEFAULT_MAX_READ_WAL_TAIL_SEGMENTS: u64 = 32;
-
 #[derive(Clone, Copy)]
 pub(crate) struct ManifestPlusTailCacheContext<'a> {
     head_etag: Option<&'a str>,
     table_cache: Option<&'a MetadataTableCache>,
     tail_cache: Option<&'a WalTailProjectionCache>,
-    max_wal_tail_segments: u64,
 }
 
 impl<'a> ManifestPlusTailCacheContext<'a> {
@@ -44,13 +41,11 @@ impl<'a> ManifestPlusTailCacheContext<'a> {
         head_etag: Option<&'a str>,
         table_cache: Option<&'a MetadataTableCache>,
         tail_cache: Option<&'a WalTailProjectionCache>,
-        max_wal_tail_segments: u64,
     ) -> Self {
         Self {
             head_etag,
             table_cache,
             tail_cache,
-            max_wal_tail_segments,
         }
     }
 
@@ -59,7 +54,6 @@ impl<'a> ManifestPlusTailCacheContext<'a> {
             head_etag: None,
             table_cache: None,
             tail_cache: None,
-            max_wal_tail_segments: DEFAULT_MAX_READ_WAL_TAIL_SEGMENTS,
         }
     }
 }
@@ -536,18 +530,6 @@ impl<'a, S: ObjectStore + ?Sized> ManifestPlusTailView<'a, S> {
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
         })?;
-        let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
-        if wal_tail_segments > cache_context.max_wal_tail_segments {
-            return Err(MetadataViewError::TailTooLong {
-                namespace_id: namespace_id.clone(),
-                manifest_id,
-                manifest_head_seq: manifest_head.seq,
-                head_seq: head.seq,
-                wal_tail_segments,
-                max_wal_tail_segments: cache_context.max_wal_tail_segments,
-            }
-            .into());
-        }
         let replayed = {
             let _span =
                 tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -145,7 +145,6 @@ struct InBatchRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PublishTailOptions {
-    pub(crate) max_wal_tail_segments: u64,
     pub(crate) max_tail_rows: usize,
     pub(crate) max_tail_decoded_bytes: Option<usize>,
 }
@@ -153,7 +152,6 @@ pub(crate) struct PublishTailOptions {
 impl Default for PublishTailOptions {
     fn default() -> Self {
         Self {
-            max_wal_tail_segments: 32,
             max_tail_rows: 1_000_000,
             max_tail_decoded_bytes: Some(256 * 1024 * 1024),
         }
@@ -191,8 +189,7 @@ impl PublishTailProjection {
     }
 
     pub(crate) fn within_limits(&self, options: &PublishTailOptions) -> bool {
-        self.wal_tail_segments <= options.max_wal_tail_segments
-            && self.tail_state.row_count() <= options.max_tail_rows
+        self.tail_state.row_count() <= options.max_tail_rows
             && options
                 .max_tail_decoded_bytes
                 .map(|max| self.tail_state.decoded_bytes() <= max)
@@ -714,7 +711,6 @@ pub(crate) async fn load_publish_manifest_plus_tail_view<'a, S: ObjectStore + ?S
             manifest_id,
             &manifest_head,
             manifest_payload_checksum,
-            options,
         )
         .await?
     };
@@ -744,7 +740,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     manifest_id: ManifestId,
     manifest_head: &HeadState,
     manifest_payload_checksum: String,
-    options: &PublishTailOptions,
 ) -> Result<PublishTailProjection, CoreError> {
     let wal_chain = load_validated_wal_chain(
         store,
@@ -761,17 +756,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
     let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
-    if wal_tail_segments > options.max_wal_tail_segments {
-        return Err(MetadataViewError::TailTooLong {
-            namespace_id: namespace_id.clone(),
-            manifest_id,
-            manifest_head_seq: manifest_head.seq,
-            head_seq: head.seq,
-            wal_tail_segments,
-            max_wal_tail_segments: options.max_wal_tail_segments,
-        }
-        .into());
-    }
     let replayed = replay_validated_wal_tail_with_metadata(
         manifest_head,
         &MetadataState::default(),
@@ -791,17 +775,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         wal_tail_segments,
         tail_state: replayed.resulting_metadata_state,
     };
-    if !projection.within_limits(options) {
-        return Err(MetadataViewError::TailTooLong {
-            namespace_id: namespace_id.clone(),
-            manifest_id,
-            manifest_head_seq: manifest_head.seq,
-            head_seq: head.seq,
-            wal_tail_segments,
-            max_wal_tail_segments: options.max_wal_tail_segments,
-        }
-        .into());
-    }
     Ok(projection)
 }
 

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -167,17 +167,15 @@ impl NamespaceCommitEngine {
         }
     }
 
-    pub async fn publish_batch_with_tail_limits<S: ObjectStore + ?Sized>(
+    pub async fn publish_batch_with_tail_cache_limits<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
         candidates: Vec<NamespaceMutationCandidate>,
         context: &MutationContext,
-        max_wal_tail_segments: u64,
         max_tail_rows: usize,
         max_tail_decoded_bytes: Option<usize>,
     ) -> NamespaceCommitEnginePublishResult {
         let options = PublishTailOptions {
-            max_wal_tail_segments,
             max_tail_rows,
             max_tail_decoded_bytes,
         };

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -534,7 +534,7 @@ fn resolve_path_with_read_source<S: ObjectStore + ?Sized>(
     Ok(MetadataRead {
         value: block_on(engine.resolve_path(
             absolute_path,
-            ReadOptions::manifest_plus_tail_at_head(head.state, head.identity.etag, None, None, 32),
+            ReadOptions::manifest_plus_tail_at_head(head.state, head.identity.etag, None, None),
         ))?,
         source: MetadataReadSource::ManifestPlusTail,
     })
@@ -552,7 +552,7 @@ fn list_path_with_read_source<S: ObjectStore + ?Sized>(
     Ok(MetadataRead {
         value: block_on(engine.list_path(
             absolute_path,
-            ReadOptions::manifest_plus_tail_at_head(head.state, head.identity.etag, None, None, 32),
+            ReadOptions::manifest_plus_tail_at_head(head.state, head.identity.etag, None, None),
         ))?,
         source: MetadataReadSource::ManifestPlusTail,
     })

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -32,7 +32,6 @@ pub struct RuntimeCacheConfigOverrides {
     pub max_cached_namespaces: Option<usize>,
     pub max_cached_wal_tail_projection_rows: Option<usize>,
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
-    pub max_read_wal_tail_segments: Option<u64>,
     pub metadata_table_cache_enabled: Option<bool>,
     pub metadata_table_cache_max_blocks: Option<usize>,
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
@@ -206,9 +205,6 @@ impl ServerConfig {
             .max_cached_wal_tail_projection_decoded_bytes
         {
             config.max_cached_wal_tail_projection_decoded_bytes = Some(value);
-        }
-        if let Some(value) = self.runtime_cache.max_read_wal_tail_segments {
-            config.max_read_wal_tail_segments = value;
         }
         if let Some(value) = self.runtime_cache.metadata_table_cache_enabled {
             config.metadata_table_cache.enabled = value;
@@ -821,7 +817,6 @@ control_cache_enabled = false
 max_cached_namespaces = 2
 max_cached_wal_tail_projection_rows = 10
 max_cached_wal_tail_projection_decoded_bytes = 4096
-max_read_wal_tail_segments = 4
 
 [store]
 kind = "local-fs"
@@ -840,7 +835,6 @@ root = "/tmp/loonfs-server"
             config.max_cached_wal_tail_projection_decoded_bytes,
             Some(4096)
         );
-        assert_eq!(config.max_read_wal_tail_segments, 4);
     }
 
     #[test]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1652,8 +1652,7 @@ fn status_for_core_error_code(code: ErrorCode) -> StatusCode {
         ErrorCode::CommitQueueFull
         | ErrorCode::CommitOutcomeUnknown
         | ErrorCode::CheckpointUnavailable
-        | ErrorCode::MaintenanceRequired
-        | ErrorCode::MetadataTailTooLong => StatusCode::SERVICE_UNAVAILABLE,
+        | ErrorCode::MaintenanceRequired => StatusCode::SERVICE_UNAVAILABLE,
         ErrorCode::NamespaceDeleted => StatusCode::GONE,
         ErrorCode::Unauthorized => StatusCode::UNAUTHORIZED,
         ErrorCode::PermissionDenied => StatusCode::FORBIDDEN,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -381,7 +381,6 @@ impl Fs {
             head.identity.etag.clone(),
             Some(Arc::clone(&self.inner.metadata_table_cache)),
             tail_cache,
-            cache_config.max_read_wal_tail_segments,
         )
     }
 

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -60,8 +60,6 @@ pub struct RuntimeCacheConfig {
     pub max_cached_wal_tail_projection_rows: usize,
     /// Approximate decoded-byte budget for cached WAL-tail projections.
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
-    /// Maximum WAL tail segments a foreground read may project.
-    pub max_read_wal_tail_segments: u64,
     /// Cache settings for decoded metadata tables.
     pub metadata_table_cache: MetadataTableCacheConfig,
 }
@@ -75,7 +73,6 @@ impl RuntimeCacheConfig {
             max_cached_namespaces: 0,
             max_cached_wal_tail_projection_rows: 0,
             max_cached_wal_tail_projection_decoded_bytes: Some(0),
-            max_read_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
             metadata_table_cache: MetadataTableCacheConfig {
                 enabled: false,
                 max_blocks: 0,
@@ -95,7 +92,6 @@ impl Default for RuntimeCacheConfig {
             max_cached_wal_tail_projection_decoded_bytes: Some(
                 DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES,
             ),
-            max_read_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
             metadata_table_cache: MetadataTableCacheConfig::default(),
         }
     }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -1026,11 +1026,10 @@ impl Fs {
                 let cache_config = &self.inner.config.runtime_cache;
                 let mut engine = engine.lock().await;
                 engine
-                    .publish_batch_with_tail_limits(
+                    .publish_batch_with_tail_cache_limits(
                         &store,
                         candidates,
                         &context,
-                        cache_config.max_read_wal_tail_segments,
                         cache_config.max_cached_wal_tail_projection_rows,
                         cache_config.max_cached_wal_tail_projection_decoded_bytes,
                     )

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -649,7 +649,7 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 }
 
 #[test]
-fn runtime_publish_rejects_wal_tail_over_configured_bound() {
+fn runtime_publish_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let raw_store = Arc::new(HeadCasFailureStore::new(
@@ -658,15 +658,11 @@ fn runtime_publish_rejects_wal_tail_over_configured_bound() {
     ));
     let object_store: SharedObjectStore = raw_store.clone();
     let setup = Fs::builder(object_store.clone())
-        .writer_id("publish-tail-limit")
+        .writer_id("publish-tail")
         .build()
         .expect("build setup runtime");
     let measured = Fs::builder(object_store)
-        .writer_id("publish-tail-limit")
-        .runtime_cache(RuntimeCacheConfig {
-            max_read_wal_tail_segments: 1,
-            ..RuntimeCacheConfig::default()
-        })
+        .writer_id("publish-tail")
         .build()
         .expect("build measured runtime");
 
@@ -680,10 +676,13 @@ fn runtime_publish_rejects_wal_tail_over_configured_bound() {
         .create_dir_blocking(&namespace_id, "/seed-b", CreateDirOptions::default())
         .expect("seed second WAL segment");
 
-    assert_core_error_kind(
-        measured.create_dir_blocking(&namespace_id, "/should-fail", CreateDirOptions::default()),
-        ErrorCode::MetadataTailTooLong,
-    );
+    measured
+        .create_dir_blocking(
+            &namespace_id,
+            "/should-succeed",
+            CreateDirOptions::default(),
+        )
+        .expect("publish projects the visible WAL tail without a segment limit");
 }
 
 #[test]
@@ -854,15 +853,11 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
 }
 
 #[test]
-fn runtime_read_rejects_wal_tail_over_configured_bound() {
+fn runtime_read_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace();
     let fs = Fs::builder(store(temp_dir.path()))
-        .writer_id("tail-too-long-test")
-        .runtime_cache(RuntimeCacheConfig {
-            max_read_wal_tail_segments: 0,
-            ..RuntimeCacheConfig::default()
-        })
+        .writer_id("tail-read-test")
         .build()
         .expect("build runtime");
 
@@ -870,11 +865,11 @@ fn runtime_read_rejects_wal_tail_over_configured_bound() {
         .expect("create namespace");
     fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
         .expect("create docs");
+    fs.create_dir_blocking(&namespace_id, "/more", CreateDirOptions::default())
+        .expect("create another WAL segment");
 
-    assert_core_error_kind(
-        fs.stat_path_blocking(&namespace_id, "/docs"),
-        ErrorCode::MetadataTailTooLong,
-    );
+    fs.stat_path_blocking(&namespace_id, "/docs")
+        .expect("read projects the visible WAL tail without a segment limit");
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -206,7 +206,6 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
 | `checkpoint_unavailable` | 503 | Required checkpoint state is not yet available; retry. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
-| `metadata_tail_too_long` | 503 | The WAL tail after the current manifest is too long to serve directly; run checkpoint maintenance and retry. |
 | `bootstrap_failed` | 500 | Namespace bootstrap failed internally. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1183,6 +1183,12 @@ The namespace manifest may reference one or more immutable metadata runs. Runs
 are not a second source of truth; they are rebuildable metadata rows used to
 keep normal basis reconstruction from replaying an unbounded WAL tail.
 
+For file revisions, a valid manifest includes the canonical `revisions` table
+and the `revisions_by_inode_desc` index table. The index table must contain
+exactly the same revision rows as the canonical table, keyed for newest-first
+inode revision scans. Readers treat a missing, extra, duplicate, or changed
+revision index row as namespace corruption.
+
 ### 6.2 Compaction
 
 Compaction rewrites metadata runs (and, in the future, content layouts) into


### PR DESCRIPTION
Removes the foreground WAL-tail segment limit so reads and writes continue projecting the visible tail. Maintenance still controls checkpoint timing. This might be added later, but should be thoughtfully considered alongside other limits and behaviors. 
