### PR TITLE
fix(manifest): require verified revision index rows

### DIFF
--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -135,6 +135,16 @@ pub enum ManifestLoadError {
         family: MetadataTableFamily,
         row_kind: String,
     },
+    #[error(
+        "namespace manifest `{object_key}` has duplicate revision rows in `{family:?}` for key `{row_key}`"
+    )]
+    DuplicateRevisionRow {
+        object_key: String,
+        family: MetadataTableFamily,
+        row_key: String,
+    },
+    #[error("namespace manifest `{object_key}` revision index does not match canonical revisions")]
+    RevisionIndexMismatch { object_key: String },
     #[error("metadata rows do not reproduce authoritative metadata")]
     MetadataMismatch,
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -25,7 +25,7 @@ use loonfs_api::wire::manifest::{
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_sst, namespace_manifest};
 use loonfs_objectstore::ObjectStore;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Mutex;
 use tracing::Instrument;
 
@@ -278,6 +278,8 @@ where
     let ordered_tables = ordered_manifest_tables(context.manifest_object_key, tables)?;
     let mut direntry_bind_rows = Vec::new();
     let mut direntry_child_bind_rows = Vec::new();
+    let mut revision_rows = Vec::new();
+    let mut revision_by_inode_desc_rows = Vec::new();
     for table in ordered_tables {
         let mut descriptors = Vec::with_capacity(table.segments.len());
         for descriptor in &table.segments {
@@ -310,6 +312,12 @@ where
                 MetadataTableFamily::DirentryChildBinds => {
                     direntry_child_bind_rows.extend(rows.iter().cloned());
                 }
+                MetadataTableFamily::Revisions => {
+                    revision_rows.extend(rows.iter().cloned());
+                }
+                MetadataTableFamily::RevisionsByInodeDesc => {
+                    revision_by_inode_desc_rows.extend(rows.iter().cloned());
+                }
                 _ => {}
             }
             append_rows_to_metadata(metadata_state, table.family, &descriptor.object_key, &rows)?;
@@ -320,6 +328,11 @@ where
         context.manifest_object_key,
         direntry_bind_rows,
         direntry_child_bind_rows,
+    )?;
+    validate_revision_by_inode_desc_index(
+        context.manifest_object_key,
+        revision_rows,
+        revision_by_inode_desc_rows,
     )
 }
 
@@ -627,4 +640,55 @@ pub(super) fn validate_direntry_child_bind_index(
     }
 
     Ok(())
+}
+
+pub(super) fn validate_revision_by_inode_desc_index(
+    object_key: &str,
+    mut revision_rows: Vec<MetadataRow>,
+    mut revision_by_inode_desc_rows: Vec<MetadataRow>,
+) -> Result<(), ManifestLoadError> {
+    validate_revision_rows_have_unique_keys(
+        object_key,
+        MetadataTableFamily::Revisions,
+        &revision_rows,
+    )?;
+    validate_revision_rows_have_unique_keys(
+        object_key,
+        MetadataTableFamily::RevisionsByInodeDesc,
+        &revision_by_inode_desc_rows,
+    )?;
+
+    revision_rows.sort_by_key(revision_logical_key);
+    revision_by_inode_desc_rows.sort_by_key(revision_logical_key);
+
+    if revision_rows != revision_by_inode_desc_rows {
+        return Err(ManifestLoadError::RevisionIndexMismatch {
+            object_key: object_key.to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_revision_rows_have_unique_keys(
+    object_key: &str,
+    family: MetadataTableFamily,
+    rows: &[MetadataRow],
+) -> Result<(), ManifestLoadError> {
+    let mut seen = BTreeSet::new();
+    for row in rows {
+        let row_key = revision_logical_key(row);
+        if !seen.insert(row_key.clone()) {
+            return Err(ManifestLoadError::DuplicateRevisionRow {
+                object_key: object_key.to_owned(),
+                family,
+                row_key,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn revision_logical_key(row: &MetadataRow) -> String {
+    row.row_key_for_family(MetadataTableFamily::Revisions)
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -1499,6 +1499,316 @@ fn assert_child_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
     }
 }
 
+#[tokio::test]
+async fn manifest_rejects_missing_revision_desc_index() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let manifest = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_verified_manifest_materialization(&store, &namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let mut manifest = materialized.manifest;
+    let manifest_id = manifest.payload.manifest_id;
+    manifest.payload.metadata_files.retain(|metadata_file| {
+        metadata_file.family != ApiMetadataTableFamily::RevisionsByInodeDesc
+    });
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_missing_row() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/other.txt",
+        b"other\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write other");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    revision_index_rows.pop().expect("revision index row");
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_extra_row() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    let extra_row = revision_index_rows
+        .first()
+        .expect("revision index row")
+        .clone();
+    revision_index_rows.push(match extra_row {
+        MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            revision_delta_index,
+            content_ref,
+        } => MetadataRow::Revision {
+            inode_id,
+            revision_no: loonfs_api::RevisionNo(revision_no.0 + 100),
+            committed_seq,
+            revision_delta_index,
+            content_ref,
+        },
+        other => other,
+    });
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_changed_content_ref() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    let first = revision_index_rows.first_mut().expect("revision index row");
+    if let MetadataRow::Revision { content_ref, .. } = first {
+        content_ref.digest =
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+    }
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    assert_revision_index_mismatch(
+        load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await,
+    );
+}
+
+#[tokio::test]
+async fn manifest_rejects_revision_desc_index_duplicate_rows() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    let (manifest_id, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    revision_index_rows.push(
+        revision_index_rows
+            .first()
+            .expect("revision index row")
+            .clone(),
+    );
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    match load_verified_manifest_materialization(&store, &namespace_id, manifest_id).await {
+        Err(ManifestLoadError::DuplicateRevisionRow { family, .. }) => {
+            assert_eq!(family, ApiMetadataTableFamily::RevisionsByInodeDesc);
+        }
+        other => panic!("expected duplicate revision row, got {other:?}"),
+    }
+}
+
+async fn revision_index_test_materialization(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> (ManifestId, NamespaceManifestEnvelope, Vec<MetadataRow>) {
+    let manifest = create_checkpoint(store, namespace_id, context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_verified_manifest_materialization(store, namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let revision_index_rows = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+    );
+    assert!(!revision_index_rows.is_empty());
+    (
+        materialized.manifest.payload.manifest_id,
+        materialized.manifest,
+        revision_index_rows,
+    )
+}
+
+async fn rewrite_revision_index_segment(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    manifest: &mut NamespaceManifestEnvelope,
+    mut rows: Vec<MetadataRow>,
+    writer_version: &str,
+) {
+    rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataTableFamily::RevisionsByInodeDesc));
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::RevisionsByInodeDesc
+        })
+        .expect("revision index metadata file");
+    rewrite_manifest_segment(
+        store,
+        namespace_id,
+        manifest.payload.head_seq,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+        descriptor,
+        rows,
+        writer_version,
+    )
+    .await;
+}
+
+async fn overwrite_manifest(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    manifest: NamespaceManifestEnvelope,
+) {
+    let manifest_key = namespace_manifest(namespace_id.as_str(), manifest.payload.manifest_id);
+    let updated_manifest =
+        NamespaceManifestEnvelope::from_payload(manifest.writer_version, manifest.payload)
+            .expect("updated manifest");
+    let manifest_bytes =
+        encode_namespace_manifest_json(&updated_manifest).expect("encode updated manifest");
+    store
+        .put_overwrite(&manifest_key, Bytes::from(manifest_bytes))
+        .await
+        .expect("overwrite manifest");
+}
+
+fn assert_revision_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
+    match result {
+        Err(ManifestLoadError::RevisionIndexMismatch { .. }) => {}
+        Err(other) => panic!("expected revision index mismatch, got {other:?}"),
+        Ok(_) => panic!("expected revision index mismatch"),
+    }
+}
+
 fn base_run(manifest: &NamespaceManifestEnvelope) -> MetadataRunManifest {
     runs_from_metadata_files(&manifest.payload)
         .into_iter()

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1183,6 +1183,12 @@ The namespace manifest may reference one or more immutable metadata runs. Runs
 are not a second source of truth; they are rebuildable metadata rows used to
 keep normal basis reconstruction from replaying an unbounded WAL tail.
 
+For file revisions, a valid manifest includes the canonical `revisions` table
+and the `revisions_by_inode_desc` index table. The index table must contain
+exactly the same revision rows as the canonical table, keyed for newest-first
+inode revision scans. Readers treat a missing, extra, duplicate, or changed
+revision index row as namespace corruption.
+
 ### 6.2 Compaction
 
 Compaction rewrites metadata runs (and, in the future, content layouts) into


### PR DESCRIPTION
Requires verified manifests to include index references so reads (specifically about file revisions) can rely on those  indexes vs. growing work unbounded as revisions increase.