### PR TITLE
refactor(api): add strict checkpoint id type

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -3,7 +3,8 @@ use crate::envelope::EnvelopeProbe;
 use crate::v0::UploadMode;
 use crate::WriterEpoch;
 use crate::{
-    ChangeSeq, CommitId, ContentRef, ContentStoreId, InodeId, ManifestId, NamePolicy, NamespaceId,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentStoreId, InodeId, ManifestId, NamePolicy,
+    NamespaceId,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -84,7 +85,7 @@ pub struct NamespaceForkState {
     pub namespace_id: NamespaceId,
     pub source_namespace_id: NamespaceId,
     pub fork_seq: ChangeSeq,
-    pub source_checkpoint_id: String,
+    pub source_checkpoint_id: CheckpointId,
     pub source_manifest_id: ManifestId,
     pub source_head_seq: ChangeSeq,
     pub created_at_ms: u64,
@@ -98,7 +99,7 @@ pub struct NamespaceGcPinState {
     pub pin_id: String,
     pub source_namespace_id: NamespaceId,
     pub target_namespace_id: NamespaceId,
-    pub source_checkpoint_id: String,
+    pub source_checkpoint_id: CheckpointId,
     pub source_manifest_id: ManifestId,
     pub source_head_seq: ChangeSeq,
     pub created_at_ms: u64,
@@ -185,7 +186,7 @@ pub struct HeadState {
     /// Reads do not use this as authority; checkpoints pin manifests for
     /// retention, forks, stable reads, and restore workflows.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub latest_checkpoint_id: Option<String>,
+    pub latest_checkpoint_id: Option<CheckpointId>,
     pub retention_floor_seq: ChangeSeq,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_wal_tip: Option<WalSegmentPointer>,

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -1,6 +1,7 @@
 use crate::{
     v0::{MoveBehavior, ValidatedContentToken},
-    ChangeSeq, CommitId, ContentRef, ErrorCode, InodeId, ManifestId, NamespaceId, RevisionNo,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, ErrorCode, InodeId, ManifestId, NamespaceId,
+    RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -70,7 +71,7 @@ pub struct NamespaceStatusResponse {
     pub current_manifest_id: Option<ManifestId>,
     /// Latest checkpoint recorded by the head.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub latest_checkpoint_id: Option<String>,
+    pub latest_checkpoint_id: Option<CheckpointId>,
     /// Number of visible WAL segments after the manifest basis.
     pub wal_tail_segments: u64,
     /// Oldest sequence still promised for incremental replay.
@@ -235,7 +236,7 @@ pub struct CreateCheckpointResponse {
     /// Namespace that was checkpointed.
     pub namespace_id: NamespaceId,
     /// Durable checkpoint id.
-    pub checkpoint_id: String,
+    pub checkpoint_id: CheckpointId,
     /// Sequence covered by the checkpoint.
     pub checkpoint_seq: ChangeSeq,
     /// Manifest pinned by the checkpoint.
@@ -243,7 +244,7 @@ pub struct CreateCheckpointResponse {
     /// Head's current manifest pointer after the operation.
     pub current_manifest_id: Option<ManifestId>,
     /// Latest checkpoint id recorded on the head after the operation.
-    pub latest_checkpoint_id: Option<String>,
+    pub latest_checkpoint_id: Option<CheckpointId>,
 }
 
 /// Result of advancing the retention floor.

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -31,6 +31,14 @@ pub struct ContentStoreId(String);
 #[cfg_attr(feature = "openapi", schema(value_type = String))]
 pub struct CommitId(String);
 
+/// Durable checkpoint identifier.
+///
+/// A checkpoint is a durable bookmark to a namespace manifest version.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(value_type = String))]
+pub struct CheckpointId(String);
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid namespace_id {value:?}: {reason}")]
 pub struct NamespaceIdValidationError {
@@ -179,8 +187,8 @@ pub fn generate_gc_pin_id() -> String {
     generated_id("pin")
 }
 
-pub fn generate_checkpoint_id() -> String {
-    generated_id("chk")
+pub fn generate_checkpoint_id() -> CheckpointId {
+    CheckpointId::generate()
 }
 
 pub fn validate_upload_id(value: impl AsRef<str>) -> Result<(), GeneratedIdValidationError> {
@@ -385,6 +393,32 @@ impl ContentStoreId {
     }
 }
 
+impl CheckpointId {
+    /// Generates a valid random checkpoint id.
+    pub fn generate() -> Self {
+        Self(generated_id("chk"))
+    }
+
+    /// Parses and validates a checkpoint id.
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, GeneratedIdValidationError> {
+        let value = value.as_ref();
+        validate_checkpoint_id(value)?;
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Builds a checkpoint id from an owned string after validation.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, GeneratedIdValidationError> {
+        let value = value.into();
+        validate_checkpoint_id(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the serialized checkpoint id.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl NameKey {
     /// Parses and validates a stored name key.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, NameKeyValidationError> {
@@ -462,6 +496,22 @@ impl TryFrom<String> for CommitId {
     }
 }
 
+impl TryFrom<&str> for CheckpointId {
+    type Error = GeneratedIdValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for CheckpointId {
+    type Error = GeneratedIdValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
 impl AsRef<str> for NamespaceId {
     fn as_ref(&self) -> &str {
         self.as_str()
@@ -475,6 +525,12 @@ impl AsRef<str> for ContentStoreId {
 }
 
 impl AsRef<str> for CommitId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for CheckpointId {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
@@ -499,6 +555,12 @@ impl Borrow<str> for ContentStoreId {
 }
 
 impl Borrow<str> for CommitId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for CheckpointId {
     fn borrow(&self) -> &str {
         self.as_str()
     }
@@ -529,6 +591,15 @@ impl Serialize for ContentStoreId {
 }
 
 impl Serialize for CommitId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl Serialize for CheckpointId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -573,6 +644,16 @@ impl<'de> Deserialize<'de> for ContentStoreId {
     {
         let value = String::deserialize(deserializer)?;
         ContentStoreId::try_new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for CheckpointId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        CheckpointId::try_new(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -663,6 +744,12 @@ impl fmt::Display for CommitId {
     }
 }
 
+impl fmt::Display for CheckpointId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 impl fmt::Display for NameKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
@@ -693,7 +780,7 @@ mod tests {
         generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,
         generate_wal_segment_id, validate_checkpoint_id, validate_gc_pin_id,
         validate_metadata_table_id, validate_upload_id, validate_wal_segment_id, ChangeSeq,
-        CommitId, ContentStoreId, NameKey, NamespaceId,
+        CheckpointId, CommitId, ContentStoreId, NameKey, NamespaceId,
     };
     use std::collections::BTreeSet;
 
@@ -764,10 +851,17 @@ mod tests {
                 .as_str(),
             "cs_00000000000000000000000000000001"
         );
+        assert_eq!(
+            CheckpointId::try_from("chk_00000000000000000000000000000001")
+                .expect("valid checkpoint id")
+                .as_str(),
+            "chk_00000000000000000000000000000001"
+        );
 
         assert!(NamespaceId::try_from("invalid/name").is_err());
         assert!(CommitId::try_from("invalid/name").is_err());
         assert!(ContentStoreId::try_from("cs_0000000000000000000000000000000g").is_err());
+        assert!(CheckpointId::try_from("chk_0000000000000000000000000000000g").is_err());
     }
 
     #[test]
@@ -785,6 +879,13 @@ mod tests {
             content_store_id.as_str(),
             "cs_00000000000000000000000000000001"
         );
+        let checkpoint_id: CheckpointId =
+            serde_json::from_str(r#""chk_00000000000000000000000000000001""#)
+                .expect("valid checkpoint id json");
+        assert_eq!(
+            checkpoint_id.as_str(),
+            "chk_00000000000000000000000000000001"
+        );
 
         let namespace_error = serde_json::from_str::<NamespaceId>(r#""invalid/name""#)
             .expect_err("invalid namespace id json");
@@ -796,6 +897,10 @@ mod tests {
             serde_json::from_str::<ContentStoreId>(r#""cs_0000000000000000000000000000000g""#)
                 .expect_err("invalid content store id json");
         assert!(content_store_error.to_string().contains("generated id"));
+        let checkpoint_error =
+            serde_json::from_str::<CheckpointId>(r#""chk_0000000000000000000000000000000g""#)
+                .expect_err("invalid checkpoint id json");
+        assert!(checkpoint_error.to_string().contains("generated id"));
     }
 
     #[test]
@@ -853,12 +958,12 @@ mod tests {
         assert!(wal_segment_id.starts_with("00000000000000000412-"));
         assert_generated_id_shape(&metadata_table_id, "tbl");
         assert_generated_id_shape(&gc_pin_id, "pin");
-        assert_generated_id_shape(&checkpoint_id, "chk");
+        assert_generated_id_shape(checkpoint_id.as_str(), "chk");
         assert!(validate_upload_id(&upload_id).is_ok());
         assert!(validate_wal_segment_id(&wal_segment_id).is_ok());
         assert!(validate_metadata_table_id(&metadata_table_id).is_ok());
         assert!(validate_gc_pin_id(&gc_pin_id).is_ok());
-        assert!(validate_checkpoint_id(&checkpoint_id).is_ok());
+        assert!(validate_checkpoint_id(checkpoint_id.as_str()).is_ok());
     }
 
     #[test]

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -56,9 +56,9 @@ pub use ids::{
     generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,
     generate_wal_segment_id, generated_id, validate_checkpoint_id, validate_gc_pin_id,
     validate_generated_id, validate_metadata_table_id, validate_upload_id, validate_wal_segment_id,
-    wal_segment_id_start_seq, ChangeSeq, CommitId, CommitIdValidationError, ContentStoreId,
-    GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey, NameKeyValidationError,
-    NamespaceId, NamespaceIdValidationError, RevisionNo, WriterEpoch,
+    wal_segment_id_start_seq, ChangeSeq, CheckpointId, CommitId, CommitIdValidationError,
+    ContentStoreId, GeneratedIdValidationError, InodeId, InodeKind, ManifestId, NameKey,
+    NameKeyValidationError, NamespaceId, NamespaceIdValidationError, RevisionNo, WriterEpoch,
 };
 pub use name_policy::{name_key_for_display_name, NamePolicy};
 pub use pagination::{

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -2,8 +2,8 @@ use crate::digest::sha256_digest;
 use crate::envelope::EnvelopeProbe;
 use crate::WriterEpoch;
 use crate::{
-    ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, ManifestId, NamePolicy, NamespaceId,
-    RevisionNo,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, InodeKind, ManifestId, NamePolicy,
+    NamespaceId, RevisionNo,
 };
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
@@ -90,14 +90,14 @@ pub struct MetadataFileRef {
 pub struct NamespaceManifestFork {
     pub source_namespace_id: NamespaceId,
     pub fork_seq: ChangeSeq,
-    pub source_checkpoint_id: String,
+    pub source_checkpoint_id: CheckpointId,
     pub source_manifest_id: ManifestId,
     pub source_head_seq: ChangeSeq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceCheckpointRecord {
-    pub checkpoint_id: String,
+    pub checkpoint_id: CheckpointId,
     pub manifest_id: ManifestId,
     pub head_seq: ChangeSeq,
     pub head_commit_id: CommitId,
@@ -638,7 +638,10 @@ mod tests {
         MetadataSegmentKey, MetadataTableFamily, NamespaceCheckpointRecord,
         NamespaceManifestEnvelope, NamespaceManifestFork, NamespaceManifestPayload,
     };
-    use crate::{ChangeSeq, CommitId, InodeId, ManifestId, NamePolicy, NamespaceId, WriterEpoch};
+    use crate::{
+        ChangeSeq, CheckpointId, CommitId, InodeId, ManifestId, NamePolicy, NamespaceId,
+        WriterEpoch,
+    };
     use std::collections::BTreeMap;
 
     #[test]
@@ -660,7 +663,8 @@ mod tests {
                 verified: true,
                 fork: None,
                 checkpoints: vec![NamespaceCheckpointRecord {
-                    checkpoint_id: "chk_00000000000000000000000000000001".to_owned(),
+                    checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000001")
+                        .expect("checkpoint id"),
                     manifest_id: ManifestId(10),
                     head_seq: ChangeSeq(10),
                     head_commit_id: CommitId::parse("c_00000000000000000000000000000001")
@@ -689,7 +693,7 @@ mod tests {
         assert_eq!(decoded.payload.checkpoints.len(), 1);
         assert_eq!(
             decoded.payload.checkpoints[0].checkpoint_id,
-            "chk_00000000000000000000000000000001"
+            CheckpointId::parse("chk_00000000000000000000000000000001").expect("checkpoint id")
         );
         assert_eq!(decoded.payload.metadata_files.len(), 1);
         assert_eq!(decoded.payload.metadata_files[0].run_seq, ChangeSeq(10));
@@ -715,7 +719,10 @@ mod tests {
                 fork: Some(NamespaceManifestFork {
                     source_namespace_id: NamespaceId::parse("source").expect("valid namespace id"),
                     fork_seq: ChangeSeq(12),
-                    source_checkpoint_id: "chk_00000000000000000000000000000002".to_owned(),
+                    source_checkpoint_id: CheckpointId::parse(
+                        "chk_00000000000000000000000000000002",
+                    )
+                    .expect("checkpoint id"),
                     source_manifest_id: ManifestId(10),
                     source_head_seq: ChangeSeq(12),
                 }),

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -37,8 +37,8 @@ use loonfs_api::wire::wal::{
     WalCommitDelta, WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
 };
 use loonfs_api::{
-    sha256_digest, v0::UploadMode, ChangeSeq, CommitId, ContentRef, ContentStoreId, InodeId,
-    InodeKind, ManifestId, NamePolicy, NamespaceId, RevisionNo, WriterEpoch,
+    sha256_digest, v0::UploadMode, ChangeSeq, CheckpointId, CommitId, ContentRef, ContentStoreId,
+    InodeId, InodeKind, ManifestId, NamePolicy, NamespaceId, RevisionNo, WriterEpoch,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -108,6 +108,10 @@ fn namespace_id() -> NamespaceId {
 
 fn commit_id() -> CommitId {
     CommitId::parse("c_00000000000000000000000000000042").expect("valid commit id")
+}
+
+fn checkpoint_id(value: &str) -> CheckpointId {
+    CheckpointId::parse(value).expect("valid checkpoint id")
 }
 
 fn sample_content_ref() -> ContentRef {
@@ -287,12 +291,12 @@ fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
             fork: Some(NamespaceManifestFork {
                 source_namespace_id: NamespaceId::parse("source").expect("valid namespace id"),
                 fork_seq: ChangeSeq(2),
-                source_checkpoint_id: "chk_00000000000000000000000000000001".to_owned(),
+                source_checkpoint_id: checkpoint_id("chk_00000000000000000000000000000001"),
                 source_manifest_id: ManifestId(1),
                 source_head_seq: ChangeSeq(2),
             }),
             checkpoints: vec![NamespaceCheckpointRecord {
-                checkpoint_id: "chk_00000000000000000000000000000002".to_owned(),
+                checkpoint_id: checkpoint_id("chk_00000000000000000000000000000002"),
                 manifest_id: ManifestId(2),
                 head_seq: ChangeSeq(2),
                 head_commit_id: commit_id(),
@@ -339,7 +343,7 @@ fn sample_head_state() -> HeadState {
         next_inode_id: InodeId(10),
         name_policy: NamePolicy::default(),
         current_manifest_id: Some(ManifestId(2)),
-        latest_checkpoint_id: Some("chk_00000000000000000000000000000002".to_owned()),
+        latest_checkpoint_id: Some(checkpoint_id("chk_00000000000000000000000000000002")),
         retention_floor_seq: ChangeSeq(0),
         visible_wal_tip: Some(sample_wal_pointer()),
         state: NamespaceState::Active,
@@ -469,7 +473,7 @@ fn control_objects_match_golden_bytes() {
             namespace_id: NamespaceId::parse("clone").expect("valid namespace id"),
             source_namespace_id: namespace_id(),
             fork_seq: ChangeSeq(2),
-            source_checkpoint_id: "chk_00000000000000000000000000000002".to_owned(),
+            source_checkpoint_id: checkpoint_id("chk_00000000000000000000000000000002"),
             source_manifest_id: ManifestId(2),
             source_head_seq: ChangeSeq(2),
             created_at_ms: 1_000,
@@ -482,7 +486,7 @@ fn control_objects_match_golden_bytes() {
             pin_id: "pin_0123456789abcdef0123456789abcdef".to_owned(),
             source_namespace_id: namespace_id(),
             target_namespace_id: NamespaceId::parse("clone").expect("valid namespace id"),
-            source_checkpoint_id: "chk_00000000000000000000000000000002".to_owned(),
+            source_checkpoint_id: checkpoint_id("chk_00000000000000000000000000000002"),
             source_manifest_id: ManifestId(2),
             source_head_seq: ChangeSeq(2),
             created_at_ms: 1_000,

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -693,11 +693,11 @@ pub(super) fn checkpoint_record_for_manifest(
 
 pub(super) fn checkpoint_record_by_id<'a>(
     manifest: &'a NamespaceManifestEnvelope,
-    checkpoint_id: &str,
+    checkpoint_id: &loonfs_api::CheckpointId,
 ) -> Option<&'a NamespaceCheckpointRecord> {
     manifest
         .payload
         .checkpoints
         .iter()
-        .find(|checkpoint| checkpoint.checkpoint_id == checkpoint_id)
+        .find(|checkpoint| &checkpoint.checkpoint_id == checkpoint_id)
 }

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -12,7 +12,7 @@ use loonfs_api::wire::control::{
     encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope,
 };
 use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
-use loonfs_api::{ManifestId, NamespaceId};
+use loonfs_api::{CheckpointId, ManifestId, NamespaceId};
 use loonfs_objectstore::keys::namespace_manifest;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 
@@ -102,7 +102,7 @@ pub(super) async fn publish_current_manifest_id<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     manifest_id: ManifestId,
-    checkpoint_id: &str,
+    checkpoint_id: &CheckpointId,
     writer_version: &str,
 ) -> Result<ManifestPublicationOutcome, CoreError> {
     for _attempt in 0..HEAD_CAS_RETRY_LIMIT {
@@ -148,7 +148,7 @@ pub(super) async fn publish_current_manifest_id<S: ObjectStore + ?Sized>(
             next_inode_id: current_head.next_inode_id,
             name_policy: current_head.name_policy,
             current_manifest_id: Some(manifest_id),
-            latest_checkpoint_id: Some(checkpoint_id.to_owned()),
+            latest_checkpoint_id: Some(checkpoint_id.clone()),
             retention_floor_seq: current_head.retention_floor_seq,
             visible_wal_tip: current_head.visible_wal_tip.clone(),
             state: current_head.state,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -44,7 +44,8 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestPayload,
 };
 use loonfs_api::{
-    validate_checkpoint_id, ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, PutBehavior,
+    validate_checkpoint_id, ChangeSeq, CheckpointId, CommitId, InodeId, ManifestId, NamespaceId,
+    PutBehavior,
 };
 use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{metadata_sst, namespace_head, namespace_manifest};
@@ -2223,7 +2224,7 @@ async fn create_checkpoint_adds_record_when_current_manifest_exists_without_it()
         &store,
         &namespace_id,
         ManifestId(1),
-        "chk_00000000000000000000000000000099",
+        &CheckpointId::parse("chk_00000000000000000000000000000099").expect("checkpoint id"),
         &context.writer_version,
     )
     .await
@@ -2433,12 +2434,13 @@ async fn current_manifest_advance_without_checkpoint_record_is_not_success() {
         .expect("later checkpoint");
     assert!(later_checkpoint.manifest_id > ManifestId(materialization_before.head.seq.0));
 
-    let checkpoint_id = "chk_00000000000000000000000000000099";
+    let checkpoint_id =
+        CheckpointId::parse("chk_00000000000000000000000000000099").expect("checkpoint id");
     let outcome = publish_current_manifest_id(
         &store,
         &namespace_id,
         ManifestId(materialization_before.head.seq.0),
-        checkpoint_id,
+        &checkpoint_id,
         &context.writer_version,
     )
     .await
@@ -2470,7 +2472,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         &store,
         &namespace_id,
         ManifestId(1),
-        "chk_00000000000000000000000000000000",
+        &CheckpointId::parse("chk_00000000000000000000000000000000").expect("checkpoint id"),
         &context.writer_version,
     )
     .await

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -174,7 +174,7 @@ mod tests {
     }
     use loonfs_api::wire::control::WriterLease;
     use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload};
-    use loonfs_api::{CommitId, InodeId, ManifestId, NamespaceId, WriterEpoch};
+    use loonfs_api::{CheckpointId, CommitId, InodeId, ManifestId, NamespaceId, WriterEpoch};
 
     fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
         HeadState {
@@ -191,7 +191,9 @@ mod tests {
             next_inode_id: InodeId(10),
             name_policy: loonfs_api::NamePolicy::default(),
             current_manifest_id: Some(ManifestId(0)),
-            latest_checkpoint_id: Some("chk_00000000000000000000000000000000".to_owned()),
+            latest_checkpoint_id: Some(
+                CheckpointId::parse("chk_00000000000000000000000000000000").expect("checkpoint id"),
+            ),
             retention_floor_seq: ChangeSeq(0),
             visible_wal_tip: None,
             state: Default::default(),

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -22,7 +22,8 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestPayload,
 };
 use loonfs_api::{
-    generate_checkpoint_id, sha256_digest, ManifestId, NamespaceId, NamespaceSummary, WriterEpoch,
+    generate_checkpoint_id, sha256_digest, CheckpointId, ManifestId, NamespaceId, NamespaceSummary,
+    WriterEpoch,
 };
 use loonfs_objectstore::keys::{
     gc_pin, namespace_descriptor, namespace_fork_state, namespace_head,
@@ -236,13 +237,13 @@ async fn write_source_gc_pin<S: ObjectStore + ?Sized>(
 
 fn checkpoint_record_by_id<'a>(
     manifest: &'a NamespaceManifestEnvelope,
-    checkpoint_id: &str,
+    checkpoint_id: &CheckpointId,
 ) -> Result<&'a NamespaceCheckpointRecord, CoreError> {
     manifest
         .payload
         .checkpoints
         .iter()
-        .find(|checkpoint| checkpoint.checkpoint_id == checkpoint_id)
+        .find(|checkpoint| &checkpoint.checkpoint_id == checkpoint_id)
         .ok_or_else(|| {
             CoreError::NamespaceCorrupt(format!(
                 "manifest {:?} does not contain checkpoint `{checkpoint_id}`",
@@ -254,7 +255,7 @@ fn checkpoint_record_by_id<'a>(
 fn deterministic_gc_pin_id(
     source_namespace_id: &NamespaceId,
     target_namespace_id: &NamespaceId,
-    source_checkpoint_id: &str,
+    source_checkpoint_id: &CheckpointId,
     source_manifest_id: ManifestId,
     source_head_seq: loonfs_api::ChangeSeq,
 ) -> String {
@@ -367,8 +368,8 @@ mod tests {
         NamespaceCheckpointRecord, NamespaceManifestEnvelope, NamespaceManifestPayload,
     };
     use loonfs_api::{
-        validate_gc_pin_id, ChangeSeq, CommitId, InodeId, ManifestId, NamePolicy, NamespaceId,
-        WriterEpoch,
+        validate_gc_pin_id, ChangeSeq, CheckpointId, CommitId, InodeId, ManifestId, NamePolicy,
+        NamespaceId, WriterEpoch,
     };
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::gc_pin;
@@ -380,17 +381,19 @@ mod tests {
     async fn gc_pin_id_is_deterministic_for_same_source_target_checkpoint_manifest() {
         let source = NamespaceId::parse("source").expect("source namespace");
         let target = NamespaceId::parse("target").expect("target namespace");
+        let checkpoint_id =
+            CheckpointId::parse("chk_00000000000000000000000000000001").expect("checkpoint id");
         let first = deterministic_gc_pin_id(
             &source,
             &target,
-            "chk_00000000000000000000000000000001",
+            &checkpoint_id,
             ManifestId(42),
             ChangeSeq(7),
         );
         let second = deterministic_gc_pin_id(
             &source,
             &target,
-            "chk_00000000000000000000000000000001",
+            &checkpoint_id,
             ManifestId(42),
             ChangeSeq(7),
         );
@@ -407,9 +410,11 @@ mod tests {
             ChangeSeq(7),
             "c_00000000000000000000000000000007",
         );
+        let checkpoint_id =
+            CheckpointId::parse("chk_00000000000000000000000000000001").expect("checkpoint id");
 
-        let checkpoint = checkpoint_record_by_id(&manifest, "chk_00000000000000000000000000000001")
-            .expect("checkpoint record");
+        let checkpoint =
+            checkpoint_record_by_id(&manifest, &checkpoint_id).expect("checkpoint record");
 
         assert_eq!(checkpoint.manifest_id, ManifestId(42));
         assert_eq!(checkpoint.head_seq, ChangeSeq(7));
@@ -472,7 +477,8 @@ mod tests {
     ) -> NamespaceGcPinStateEnvelope {
         let source = NamespaceId::parse(source_namespace_id).expect("source namespace");
         let target = NamespaceId::parse(target_namespace_id).expect("target namespace");
-        let checkpoint_id = "chk_00000000000000000000000000000001";
+        let checkpoint_id =
+            CheckpointId::parse("chk_00000000000000000000000000000001").expect("checkpoint id");
         let source_manifest_id = ManifestId(42);
         let source_head_seq = ChangeSeq(7);
         NamespaceGcPinStateEnvelope::from_state(
@@ -482,13 +488,13 @@ mod tests {
                 pin_id: deterministic_gc_pin_id(
                     &source,
                     &target,
-                    checkpoint_id,
+                    &checkpoint_id,
                     source_manifest_id,
                     source_head_seq,
                 ),
                 source_namespace_id: source,
                 target_namespace_id: target,
-                source_checkpoint_id: checkpoint_id.to_owned(),
+                source_checkpoint_id: checkpoint_id,
                 source_manifest_id,
                 source_head_seq,
                 created_at_ms,
@@ -505,6 +511,7 @@ mod tests {
     ) -> NamespaceManifestEnvelope {
         let namespace_id = NamespaceId::parse("source").expect("source namespace");
         let commit_id = CommitId::parse(head_commit_id).expect("commit id");
+        let checkpoint_id = CheckpointId::parse(checkpoint_id).expect("checkpoint id");
         NamespaceManifestEnvelope::from_payload(
             "test-writer/0.1.0",
             NamespaceManifestPayload {
@@ -521,7 +528,7 @@ mod tests {
                 verified: true,
                 fork: None,
                 checkpoints: vec![NamespaceCheckpointRecord {
-                    checkpoint_id: checkpoint_id.to_owned(),
+                    checkpoint_id,
                     manifest_id,
                     head_seq,
                     head_commit_id: commit_id,

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -6,7 +6,7 @@ use crate::namespace::catalog::{
 };
 use crate::namespace::control::{read_head_object, ControlObjectLoadError};
 use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ManifestId, NamespaceId};
+use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, CheckpointId, ManifestId, NamespaceId};
 use loonfs_objectstore::{
     keys::{namespace_descriptor, namespace_head, wal_segment_id_from_key, wal_segment_prefix},
     ObjectStore,
@@ -19,7 +19,7 @@ pub struct NamespaceHeadSummary {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
-    pub latest_checkpoint_id: Option<String>,
+    pub latest_checkpoint_id: Option<CheckpointId>,
     /// WAL segment objects positioned past the loaded manifest.
     ///
     /// Derived from position-ordered object names, not from walking the

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -22,7 +22,7 @@ use loonfs_api::{
         NamespaceManifestEnvelope,
     },
     wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
-    AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
+    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind,
     DeleteDirectoryBehavior, DirectoryPageCursor, EffectiveLimit, InodeId, InodeKind, ManifestId,
     NameKey, NamespaceId, Page, PageRequest, PutBehavior, RevisionNo, WriterEpoch,
 };
@@ -3417,7 +3417,11 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     assert_eq!(fork_state.state.namespace_id, clone_namespace_id);
     assert_eq!(fork_state.state.source_namespace_id, source_namespace_id);
     assert_eq!(fork_state.state.fork_seq, ChangeSeq(1));
-    assert!(fork_state.state.source_checkpoint_id.starts_with("chk_"));
+    assert!(fork_state
+        .state
+        .source_checkpoint_id
+        .as_str()
+        .starts_with("chk_"));
     assert_eq!(fork_state.state.source_manifest_id, ManifestId(1));
     assert_eq!(fork_state.state.source_head_seq, ChangeSeq(1));
     assert!(fork_state.state.created_at_ms > 0);
@@ -4998,7 +5002,9 @@ fn validation_context(
         next_inode_id,
         name_policy: loonfs_api::NamePolicy::default(),
         current_manifest_id: Some(ManifestId(0)),
-        latest_checkpoint_id: Some("chk_00000000000000000000000000000000".to_owned()),
+        latest_checkpoint_id: Some(
+            CheckpointId::parse("chk_00000000000000000000000000000000").expect("checkpoint id"),
+        ),
         retention_floor_seq: ChangeSeq(0),
         visible_wal_tip: None,
         state: Default::default(),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -24,7 +24,7 @@ pub use loonfs_api::v0::{
 };
 pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
-    ChangeSeq, CommitId, ContentRef, ContentRefKind, CreateCheckpointResponse,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointResponse,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DirectoryPageCursor, DisplayName,
     EffectiveLimit, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse, InodeId,
     InodeKind, ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult,

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -2,8 +2,8 @@
 
 use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
-    ChangeSeq, CommitId, DeleteDirectoryBehavior, ManifestId, MoveBehavior, NamespaceId,
-    PutBehavior,
+    ChangeSeq, CheckpointId, CommitId, DeleteDirectoryBehavior, ManifestId, MoveBehavior,
+    NamespaceId, PutBehavior,
 };
 
 /// Current maintenance-related namespace status.
@@ -16,7 +16,7 @@ pub struct NamespaceStatus {
     /// Current manifest pointer recorded by the head.
     pub current_manifest_id: Option<ManifestId>,
     /// Latest checkpoint recorded by the head.
-    pub latest_checkpoint_id: Option<String>,
+    pub latest_checkpoint_id: Option<CheckpointId>,
     /// Number of visible WAL segments after the manifest materialization.
     pub wal_tail_segments: u64,
     /// Oldest sequence still promised for incremental replay.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2109,6 +2109,10 @@
           }
         }
       },
+      "CheckpointId": {
+        "type": "string",
+        "description": "Durable checkpoint identifier.\n\nA checkpoint is a durable bookmark to a namespace manifest version."
+      },
       "CommitDelta": {
         "oneOf": [
           {
@@ -2795,7 +2799,7 @@
         ],
         "properties": {
           "checkpoint_id": {
-            "type": "string",
+            "$ref": "#/components/schemas/CheckpointId",
             "description": "Durable checkpoint id."
           },
           "checkpoint_seq": {
@@ -2814,11 +2818,15 @@
             ]
           },
           "latest_checkpoint_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Latest checkpoint id recorded on the head after the operation."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CheckpointId",
+                "description": "Latest checkpoint id recorded on the head after the operation."
+              }
+            ]
           },
           "manifest_id": {
             "$ref": "#/components/schemas/ManifestId",
@@ -3258,11 +3266,15 @@
             "description": "Current visible namespace sequence."
           },
           "latest_checkpoint_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Latest checkpoint recorded by the head."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CheckpointId",
+                "description": "Latest checkpoint recorded by the head."
+              }
+            ]
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",


### PR DESCRIPTION
Adds a strict CheckpointId type and wires checkpoint, fork, and GC pin metadata through it.