### PR TITLE
refactor(core): centralize control update helpers

### DIFF
--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -1,0 +1,421 @@
+use crate::error::CoreError;
+use crate::namespace::control::{read_head_object, ControlObjectLoadError, LoadedHeadObject};
+use bytes::Bytes;
+use loonfs_api::wire::control::{
+    decode_control_object, encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope,
+    UploadSessionEnvelope, UploadSessionState,
+};
+use loonfs_api::{validate_upload_id, NamespaceId};
+use loonfs_objectstore::keys::upload_session;
+use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
+use std::future::Future;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HeadUpdate<T> {
+    Noop(T),
+    Replace { next: Box<HeadState>, outcome: T },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UploadSessionUpdate<T> {
+    Noop(T),
+    Replace {
+        next: Box<UploadSessionState>,
+        outcome: T,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum ControlUpdateError {
+    #[error(transparent)]
+    LoadHead(ControlObjectLoadError),
+    #[error("missing etag for `{object_key}`")]
+    MissingEtag { object_key: String },
+    #[error("control object codec error: {0}")]
+    Codec(String),
+    #[error("control object store error: {0}")]
+    Store(String),
+    #[error("control object update retries exhausted after {attempts} attempts")]
+    RetryExhausted { attempts: usize },
+}
+
+pub(crate) async fn update_head<S, T, E, F>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    writer_version: &str,
+    max_attempts: usize,
+    mut update: F,
+) -> Result<T, E>
+where
+    S: ObjectStore + ?Sized,
+    E: From<ControlUpdateError>,
+    F: FnMut(&LoadedHeadObject) -> Result<HeadUpdate<T>, E>,
+{
+    for _attempt in 0..max_attempts {
+        let loaded = read_head_object(store, namespace_id)
+            .await
+            .map_err(|error| E::from(ControlUpdateError::LoadHead(error)))?;
+        let expected_etag = required_etag(&loaded.metadata, &loaded.object_key).map_err(E::from)?;
+
+        match update(&loaded)? {
+            HeadUpdate::Noop(outcome) => return Ok(outcome),
+            HeadUpdate::Replace { next, outcome } => {
+                let encoded = encode_head(writer_version, *next).map_err(E::from)?;
+                match store
+                    .compare_and_swap(&loaded.object_key, expected_etag, Bytes::from(encoded))
+                    .await
+                {
+                    Ok(_) => return Ok(outcome),
+                    Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+                        continue;
+                    }
+                    Err(error) => {
+                        return Err(E::from(ControlUpdateError::Store(error.to_string())))
+                    }
+                }
+            }
+        }
+    }
+
+    Err(E::from(ControlUpdateError::RetryExhausted {
+        attempts: max_attempts,
+    }))
+}
+
+pub(crate) async fn update_upload_session<S, T, F, Fut>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &str,
+    writer_version: &str,
+    max_attempts: usize,
+    mut update: F,
+) -> Result<T, CoreError>
+where
+    S: ObjectStore + ?Sized,
+    F: FnMut(UploadSessionState) -> Fut,
+    Fut: Future<Output = Result<UploadSessionUpdate<T>, CoreError>>,
+{
+    for _attempt in 0..max_attempts {
+        let loaded = read_upload_session_object(store, namespace_id, upload_id).await?;
+        let expected_etag = required_etag_core(&loaded.metadata, &loaded.object_key)?;
+
+        match update(loaded.envelope.state).await? {
+            UploadSessionUpdate::Noop(outcome) => return Ok(outcome),
+            UploadSessionUpdate::Replace { next, outcome } => {
+                let envelope = UploadSessionEnvelope::from_state(
+                    ControlObjectKind::UploadSession,
+                    writer_version,
+                    *next,
+                )
+                .map_err(|err| CoreError::Store(err.to_string()))?;
+                let encoded = encode_control_object(&envelope)
+                    .map_err(|err| CoreError::Store(err.to_string()))?;
+                match store
+                    .compare_and_swap(&loaded.object_key, expected_etag, Bytes::from(encoded))
+                    .await
+                {
+                    Ok(_) => return Ok(outcome),
+                    Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+                        continue;
+                    }
+                    Err(error) => return Err(CoreError::Store(error.to_string())),
+                }
+            }
+        }
+    }
+
+    Err(CoreError::Store(
+        "upload session compare-and-swap retry exhausted".to_owned(),
+    ))
+}
+
+fn encode_head(writer_version: &str, next: HeadState) -> Result<Vec<u8>, ControlUpdateError> {
+    let envelope =
+        HeadStateEnvelope::from_state(ControlObjectKind::NamespaceHead, writer_version, next)
+            .map_err(|err| ControlUpdateError::Codec(err.to_string()))?;
+    encode_control_object(&envelope).map_err(|err| ControlUpdateError::Codec(err.to_string()))
+}
+
+fn required_etag<'a>(
+    metadata: &'a ObjectMetadata,
+    object_key: &str,
+) -> Result<&'a str, ControlUpdateError> {
+    metadata
+        .etag
+        .as_deref()
+        .ok_or_else(|| ControlUpdateError::MissingEtag {
+            object_key: object_key.to_owned(),
+        })
+}
+
+fn required_etag_core<'a>(
+    metadata: &'a ObjectMetadata,
+    object_key: &str,
+) -> Result<&'a str, CoreError> {
+    metadata
+        .etag
+        .as_deref()
+        .ok_or_else(|| CoreError::Store(format!("missing control object etag for `{object_key}`")))
+}
+
+#[derive(Debug, Clone)]
+struct LoadedUploadSessionObject {
+    object_key: String,
+    metadata: ObjectMetadata,
+    envelope: UploadSessionEnvelope,
+}
+
+async fn read_upload_session_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &str,
+) -> Result<LoadedUploadSessionObject, CoreError> {
+    NamespaceId::parse(namespace_id.as_str()).map_err(CoreError::from)?;
+    validate_upload_id(upload_id).map_err(CoreError::InvalidUploadId)?;
+    let object_key = upload_session(namespace_id.as_str(), upload_id);
+    let body = store
+        .get_with_metadata(&object_key)
+        .await
+        .map_err(|err| CoreError::Store(err.to_string()))?
+        .ok_or_else(|| CoreError::UploadNotFound {
+            upload_id: upload_id.to_owned(),
+        })?;
+    let envelope: UploadSessionEnvelope =
+        decode_control_object(&body.bytes, ControlObjectKind::UploadSession).map_err(|err| {
+            CoreError::Store(format!("invalid upload session `{object_key}`: {err}"))
+        })?;
+    if envelope.state.namespace_id != *namespace_id {
+        return Err(CoreError::Store(format!(
+            "upload session namespace mismatch for `{object_key}`"
+        )));
+    }
+    if envelope.state.upload_id != upload_id {
+        return Err(CoreError::Store(format!(
+            "upload session id mismatch for `{object_key}`"
+        )));
+    }
+
+    Ok(LoadedUploadSessionObject {
+        object_key,
+        metadata: body.metadata,
+        envelope,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+    use loonfs_api::wire::control::{ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::NamespaceId;
+    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::keys::namespace_head;
+    use loonfs_objectstore::{ByteRange, ObjectBody, PutMode};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    const WRITER_VERSION: &str = "writer/0.1.0";
+
+    async fn write_initial_head(store: &LocalFsStore, namespace_id: &NamespaceId) {
+        let envelope = HeadStateEnvelope::from_state(
+            ControlObjectKind::NamespaceHead,
+            WRITER_VERSION,
+            HeadState::initial(namespace_id.clone()),
+        )
+        .expect("head envelope");
+        let bytes = encode_control_object(&envelope).expect("head bytes");
+        store
+            .put_if_absent(&namespace_head(namespace_id.as_str()), Bytes::from(bytes))
+            .await
+            .expect("write head");
+    }
+
+    #[tokio::test]
+    async fn update_head_noop_returns_without_writing() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        write_initial_head(&store, &namespace_id).await;
+        let before = store
+            .head(&namespace_head(namespace_id.as_str()))
+            .await
+            .expect("head")
+            .expect("head exists")
+            .etag;
+
+        let outcome = update_head(&store, &namespace_id, WRITER_VERSION, 3, |_loaded| {
+            Ok::<_, ControlUpdateError>(HeadUpdate::Noop("unchanged"))
+        })
+        .await
+        .expect("noop update");
+
+        let after = store
+            .head(&namespace_head(namespace_id.as_str()))
+            .await
+            .expect("head")
+            .expect("head exists")
+            .etag;
+        assert_eq!(outcome, "unchanged");
+        assert_eq!(after, before);
+    }
+
+    #[tokio::test]
+    async fn update_head_retries_cas_conflict_and_succeeds() {
+        let temp_dir = tempdir().expect("tempdir");
+        let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        write_initial_head(&inner, &namespace_id).await;
+        let store = ConflictOnceStore {
+            inner,
+            remaining_conflicts: AtomicUsize::new(1),
+        };
+
+        let outcome = update_head(&store, &namespace_id, WRITER_VERSION, 3, |loaded| {
+            let mut next = loaded.envelope.state.clone();
+            next.seq.0 += 1;
+            Ok::<_, ControlUpdateError>(HeadUpdate::Replace {
+                next: Box::new(next),
+                outcome: "updated",
+            })
+        })
+        .await
+        .expect("retry update");
+
+        assert_eq!(outcome, "updated");
+        assert_eq!(store.remaining_conflicts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn update_head_missing_etag_fails_without_retry() {
+        let temp_dir = tempdir().expect("tempdir");
+        let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        write_initial_head(&inner, &namespace_id).await;
+        let store = MissingEtagStore { inner };
+
+        let closure_called = AtomicBool::new(false);
+        let error = update_head(&store, &namespace_id, WRITER_VERSION, 3, |_loaded| {
+            closure_called.store(true, Ordering::SeqCst);
+            Ok::<_, ControlUpdateError>(HeadUpdate::Noop(()))
+        })
+        .await
+        .expect_err("missing etag should fail");
+
+        assert!(matches!(error, ControlUpdateError::MissingEtag { .. }));
+        assert!(!closure_called.load(Ordering::SeqCst));
+    }
+
+    #[derive(Debug)]
+    struct ConflictOnceStore {
+        inner: LocalFsStore,
+        remaining_conflicts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ObjectStore for ConflictOnceStore {
+        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Bytes>, ObjectStoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: Bytes,
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn compare_and_swap(
+            &self,
+            key: &str,
+            expected_etag: &str,
+            bytes: Bytes,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
+                self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
+                return Err(ObjectStoreError::PreconditionFailed);
+            }
+            self.inner.compare_and_swap(key, expected_etag, bytes).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            prefix: &str,
+        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    #[derive(Debug)]
+    struct MissingEtagStore {
+        inner: LocalFsStore,
+    }
+
+    #[async_trait]
+    impl ObjectStore for MissingEtagStore {
+        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+            let Some(mut body) = self.inner.get_with_metadata(key).await? else {
+                return Ok(None);
+            };
+            body.metadata.etag = None;
+            Ok(Some(body))
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Bytes>, ObjectStoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: Bytes,
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            _prefix: &str,
+        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+            Box::pin(stream::empty())
+        }
+    }
+}

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -33,6 +33,7 @@ mod checkpoint;
 pub mod commit;
 pub mod content;
 mod context;
+mod control_update;
 mod engine;
 mod error;
 mod invariants;

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -1,12 +1,9 @@
 use crate::context::MutationContext;
-use crate::namespace::control::{read_head_object, ControlObjectLoadError};
-use bytes::Bytes;
-use loonfs_api::wire::control::{
-    encode_control_object, AcquiredWriter, ControlObjectKind, HeadState, HeadStateEnvelope,
-    WriterLease,
-};
+use crate::control_update::{update_head, ControlUpdateError, HeadUpdate};
+use crate::namespace::control::ControlObjectLoadError;
+use loonfs_api::wire::control::{AcquiredWriter, HeadState, WriterLease};
 use loonfs_api::{NamespaceId, WriterEpoch};
-use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -54,74 +51,47 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         return Err(WriterEpochAcquireError::ZeroLeaseDuration);
     }
 
-    for _attempt in 0..MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS {
-        let loaded_head = read_head_object(store, namespace_id)
-            .await
-            .map_err(WriterEpochAcquireError::LoadHead)?;
-        let head_etag = loaded_head.metadata.etag.clone().ok_or_else(|| {
-            WriterEpochAcquireError::MissingHeadEtag {
-                object_key: loaded_head.object_key.clone(),
-            }
-        })?;
-        let head = loaded_head.envelope.state;
-
-        if let Some(active_lease) = head
-            .writer_lease
-            .as_ref()
-            .filter(|lease| lease.is_valid_at(params.now_ms))
-        {
-            if active_lease.writer_id != params.writer_id {
-                return Err(WriterEpochAcquireError::HeldByOtherWriter {
-                    writer_id: active_lease.writer_id.clone(),
-                    lease_expires_at_ms: active_lease.lease_expires_at_ms,
-                });
-            }
-
-            if active_lease.writer_session_id == params.writer_session_id {
-                if !lease_needs_renewal(active_lease.lease_expires_at_ms, params) {
-                    return Ok(acquired_writer_from_lease(head.writer_epoch, active_lease));
+    update_head(
+        store,
+        namespace_id,
+        &params.writer_version,
+        MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS,
+        |loaded_head| {
+            let head = &loaded_head.envelope.state;
+            if let Some(active_lease) = head
+                .writer_lease
+                .as_ref()
+                .filter(|lease| lease.is_valid_at(params.now_ms))
+            {
+                if active_lease.writer_id != params.writer_id {
+                    return Err(WriterEpochAcquireError::HeldByOtherWriter {
+                        writer_id: active_lease.writer_id.clone(),
+                        lease_expires_at_ms: active_lease.lease_expires_at_ms,
+                    });
                 }
-                let next_head = head_with_writer_lease(&head, head.writer_epoch, params);
-                match compare_and_swap_head(
-                    store,
-                    &loaded_head.object_key,
-                    &head_etag,
-                    &params.writer_version,
-                    next_head,
-                )
-                .await
-                {
-                    Ok(()) => return Ok(acquired_writer(head.writer_epoch, params)),
-                    Err(CasOutcome::Retryable) => continue,
-                    Err(CasOutcome::Fatal(message)) => {
-                        return Err(WriterEpochAcquireError::HeadWrite(message));
+
+                if active_lease.writer_session_id == params.writer_session_id {
+                    if !lease_needs_renewal(active_lease.lease_expires_at_ms, params) {
+                        return Ok(HeadUpdate::Noop(acquired_writer_from_lease(
+                            head.writer_epoch,
+                            active_lease,
+                        )));
                     }
+                    return Ok(HeadUpdate::Replace {
+                        next: Box::new(head_with_writer_lease(head, head.writer_epoch, params)),
+                        outcome: acquired_writer(head.writer_epoch, params),
+                    });
                 }
             }
-        }
 
-        let next_epoch = next_writer_epoch(head.writer_epoch)?;
-        let next_head = head_with_writer_lease(&head, next_epoch, params);
-        match compare_and_swap_head(
-            store,
-            &loaded_head.object_key,
-            &head_etag,
-            &params.writer_version,
-            next_head,
-        )
-        .await
-        {
-            Ok(()) => return Ok(acquired_writer(next_epoch, params)),
-            Err(CasOutcome::Retryable) => continue,
-            Err(CasOutcome::Fatal(message)) => {
-                return Err(WriterEpochAcquireError::HeadWrite(message));
-            }
-        }
-    }
-
-    Err(WriterEpochAcquireError::RetryExhausted {
-        attempts: MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS,
-    })
+            let next_epoch = next_writer_epoch(head.writer_epoch)?;
+            Ok(HeadUpdate::Replace {
+                next: Box::new(head_with_writer_lease(head, next_epoch, params)),
+                outcome: acquired_writer(next_epoch, params),
+            })
+        },
+    )
+    .await
 }
 
 fn next_writer_epoch(active: WriterEpoch) -> Result<WriterEpoch, WriterEpochAcquireError> {
@@ -180,35 +150,16 @@ fn lease_needs_renewal(lease_expires_at_ms: u64, params: &MutationContext) -> bo
     lease_expires_at_ms <= params.now_ms.saturating_add(renew_after_ms)
 }
 
-async fn compare_and_swap_head<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_etag: &str,
-    writer_version: &str,
-    next_head: HeadState,
-) -> Result<(), CasOutcome> {
-    let envelope =
-        HeadStateEnvelope::from_state(ControlObjectKind::NamespaceHead, writer_version, next_head)
-            .map_err(|err| CasOutcome::Fatal(err.to_string()))?;
-    let bytes =
-        encode_control_object(&envelope).map_err(|err| CasOutcome::Fatal(err.to_string()))?;
-    store
-        .compare_and_swap(object_key, expected_etag, Bytes::from(bytes))
-        .await
-        .map(|_| ())
-        .map_err(map_cas_error)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum CasOutcome {
-    Retryable,
-    Fatal(String),
-}
-
-fn map_cas_error(err: ObjectStoreError) -> CasOutcome {
-    match err {
-        ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict => CasOutcome::Retryable,
-        other => CasOutcome::Fatal(other.to_string()),
+impl From<ControlUpdateError> for WriterEpochAcquireError {
+    fn from(value: ControlUpdateError) -> Self {
+        match value {
+            ControlUpdateError::LoadHead(error) => Self::LoadHead(error),
+            ControlUpdateError::MissingEtag { object_key } => Self::MissingHeadEtag { object_key },
+            ControlUpdateError::Codec(message) | ControlUpdateError::Store(message) => {
+                Self::HeadWrite(message)
+            }
+            ControlUpdateError::RetryExhausted { attempts } => Self::RetryExhausted { attempts },
+        }
     }
 }
 
@@ -222,13 +173,19 @@ mod tests {
     use crate::options::DeleteNamespaceOptions;
     use crate::protocol::commit_operations;
     use async_trait::async_trait;
+    use bytes::Bytes;
     use futures::stream::BoxStream;
     use loonfs_api::v0::{CommitOp as ApiCommitOp, CommitRequest as ApiCommitRequest};
-    use loonfs_api::wire::control::{decode_control_object, NamespaceState};
+    use loonfs_api::wire::control::{
+        decode_control_object, encode_control_object, ControlObjectKind, HeadStateEnvelope,
+        NamespaceState,
+    };
     use loonfs_api::{ChangeSeq, CommitId, InodeId, NamespaceId};
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::namespace_head;
-    use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, PutMode};
+    use loonfs_objectstore::{
+        ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
 

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -10,6 +10,7 @@ use crate::commit::{
 };
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
+use crate::control_update::{update_upload_session, UploadSessionUpdate};
 use crate::engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError};
@@ -40,18 +41,18 @@ use loonfs_api::v0::{
     CompleteUploadRequest, CompleteUploadResponse, UploadContentResponse, UploadMode,
 };
 use loonfs_api::wire::control::{
-    decode_control_object, encode_control_object, AcquiredWriter, CompletedUpload,
-    ControlObjectKind, HeadState, NamespaceState, UploadSessionEnvelope, UploadSessionState,
+    encode_control_object, AcquiredWriter, CompletedUpload, ControlObjectKind, HeadState,
+    NamespaceState, UploadSessionEnvelope, UploadSessionState,
 };
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
 use loonfs_api::{
-    generate_upload_id, validate_upload_id, ChangeSeq, CommitId, ContentRef, ContentRefKind,
-    ContentStoreId, EffectiveLimit, ManifestId, NameKey, NamespaceId,
+    generate_upload_id, ChangeSeq, CommitId, ContentRef, ContentRefKind, ContentStoreId,
+    EffectiveLimit, ManifestId, NameKey, NamespaceId,
 };
 use loonfs_objectstore::keys::{
     content_blob, namespace_descriptor, namespace_head, upload_session,
 };
-use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
+use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 use tracing::Instrument;
 
@@ -127,13 +128,6 @@ impl<S: ObjectStore + ?Sized> PublishManifestPlusTailView<'_, S> {
     ) -> Result<Option<CommitReceiptRecord>, CoreError> {
         self.metadata_view().find_commit_receipt(commit_id).await
     }
-}
-
-#[derive(Debug, Clone)]
-struct LoadedUploadSessionObject {
-    object_key: String,
-    metadata: ObjectMetadata,
-    envelope: UploadSessionEnvelope,
 }
 
 #[derive(Debug, Clone)]
@@ -378,70 +372,54 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
         .map_err(|err| CoreError::Store(err.to_string()))?;
 
-    for _attempt in 0..UPLOAD_SESSION_RETRY_LIMIT {
-        let loaded = read_upload_session_object(store, namespace_id, upload_id).await?;
-        if loaded.envelope.state.completed.is_some() {
-            return Err(CoreError::UploadAlreadyCompleted {
-                upload_id: upload_id.to_owned(),
-            });
-        }
-        if loaded.envelope.state.mode == UploadMode::DirectPut {
-            return Err(CoreError::InvalidUploadContent(
-                "direct_put sessions must be completed after using the presigned URL".to_owned(),
-            ));
-        }
+    update_upload_session(
+        store,
+        namespace_id,
+        upload_id,
+        &context.writer_version,
+        UPLOAD_SESSION_RETRY_LIMIT,
+        |mut state| {
+            let content_ref = content_ref.clone();
+            let object_key = object_key.clone();
+            let namespace_id = namespace_id.clone();
+            let upload_id = upload_id.to_owned();
+            async move {
+                if state.completed.is_some() {
+                    return Err(CoreError::UploadAlreadyCompleted { upload_id });
+                }
+                if state.mode == UploadMode::DirectPut {
+                    return Err(CoreError::InvalidUploadContent(
+                        "direct_put sessions must be completed after using the presigned URL"
+                            .to_owned(),
+                    ));
+                }
 
-        if let Some(existing) = &loaded.envelope.state.staged_content_ref {
-            if existing == &content_ref {
-                return Ok(UploadContentResponse {
-                    namespace_id: namespace_id.clone(),
-                    upload_id: upload_id.to_owned(),
-                    content_ref,
-                });
+                if let Some(existing) = &state.staged_content_ref {
+                    if existing == &content_ref {
+                        return Ok(UploadSessionUpdate::Noop(UploadContentResponse {
+                            namespace_id,
+                            upload_id,
+                            content_ref,
+                        }));
+                    }
+                    return Err(CoreError::UploadContentConflict { upload_id });
+                }
+
+                write_immutable_object(store, &object_key, bytes).await?;
+                state.staged_content_ref = Some(content_ref.clone());
+
+                Ok(UploadSessionUpdate::Replace {
+                    next: Box::new(state),
+                    outcome: UploadContentResponse {
+                        namespace_id,
+                        upload_id,
+                        content_ref,
+                    },
+                })
             }
-            return Err(CoreError::UploadContentConflict {
-                upload_id: upload_id.to_owned(),
-            });
-        }
-
-        write_immutable_object(store, &object_key, bytes).await?;
-
-        let mut next_state = loaded.envelope.state.clone();
-        next_state.staged_content_ref = Some(content_ref.clone());
-
-        let envelope = UploadSessionEnvelope::from_state(
-            ControlObjectKind::UploadSession,
-            &context.writer_version,
-            next_state,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
-        let expected_etag = loaded
-            .metadata
-            .etag
-            .as_deref()
-            .ok_or_else(|| CoreError::Store("missing upload session etag".to_owned()))?;
-
-        match store
-            .compare_and_swap(&loaded.object_key, expected_etag, Bytes::from(encoded))
-            .await
-        {
-            Ok(_) => {
-                return Ok(UploadContentResponse {
-                    namespace_id: namespace_id.clone(),
-                    upload_id: upload_id.to_owned(),
-                    content_ref,
-                });
-            }
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(err) => return Err(CoreError::Store(err.to_string())),
-        }
-    }
-
-    Err(CoreError::Store(
-        "upload session compare-and-swap retry exhausted".to_owned(),
-    ))
+        },
+    )
+    .await
 }
 
 pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
@@ -451,88 +429,76 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     request: &CompleteUploadRequest,
     context: &MutationContext,
 ) -> Result<CompleteUploadResponse, CoreError> {
-    for _attempt in 0..UPLOAD_SESSION_RETRY_LIMIT {
-        let loaded = read_upload_session_object(store, namespace_id, upload_id).await?;
-        if let Some(completed) = &loaded.envelope.state.completed {
-            if completed.content_ref == request.content_ref {
-                return Ok(CompleteUploadResponse {
-                    namespace_id: namespace_id.clone(),
-                    upload_id: upload_id.to_owned(),
-                    content_ref: completed.content_ref.clone(),
-                    validated_content_token: None,
-                });
-            }
-            return Err(CoreError::UploadAlreadyCompleted {
-                upload_id: upload_id.to_owned(),
-            });
-        }
+    update_upload_session(
+        store,
+        namespace_id,
+        upload_id,
+        &context.writer_version,
+        UPLOAD_SESSION_RETRY_LIMIT,
+        |mut state| {
+            let namespace_id = namespace_id.clone();
+            let upload_id = upload_id.to_owned();
+            let request = request.clone();
+            async move {
+                if let Some(completed) = &state.completed {
+                    if completed.content_ref == request.content_ref {
+                        return Ok(UploadSessionUpdate::Noop(CompleteUploadResponse {
+                            namespace_id,
+                            upload_id,
+                            content_ref: completed.content_ref.clone(),
+                            validated_content_token: None,
+                        }));
+                    }
+                    return Err(CoreError::UploadAlreadyCompleted { upload_id });
+                }
 
-        let staged_content_ref = match loaded.envelope.state.staged_content_ref.clone() {
-            Some(content_ref) => content_ref,
-            None => stage_direct_put_content_ref(store, namespace_id, &loaded, request).await?,
-        };
-        if staged_content_ref != request.content_ref {
-            return Err(CoreError::InvalidUploadContent(
-                "completed content ref does not match staged content".to_owned(),
-            ));
-        }
+                let staged_content_ref = match state.staged_content_ref.clone() {
+                    Some(content_ref) => content_ref,
+                    None => {
+                        stage_direct_put_content_ref(store, &namespace_id, &state, &request).await?
+                    }
+                };
+                if staged_content_ref != request.content_ref {
+                    return Err(CoreError::InvalidUploadContent(
+                        "completed content ref does not match staged content".to_owned(),
+                    ));
+                }
 
-        let mut next_state = loaded.envelope.state.clone();
-        if next_state.staged_content_ref.is_none() {
-            next_state.staged_content_ref = Some(staged_content_ref);
-        }
-        next_state.completed = Some(CompletedUpload {
-            content_ref: request.content_ref.clone(),
-        });
-        let envelope = UploadSessionEnvelope::from_state(
-            ControlObjectKind::UploadSession,
-            &context.writer_version,
-            next_state,
-        )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
-        let expected_etag = loaded
-            .metadata
-            .etag
-            .as_deref()
-            .ok_or_else(|| CoreError::Store("missing upload session etag".to_owned()))?;
-
-        match store
-            .compare_and_swap(&loaded.object_key, expected_etag, Bytes::from(encoded))
-            .await
-        {
-            Ok(_) => {
-                return Ok(CompleteUploadResponse {
-                    namespace_id: namespace_id.clone(),
-                    upload_id: upload_id.to_owned(),
+                if state.staged_content_ref.is_none() {
+                    state.staged_content_ref = Some(staged_content_ref);
+                }
+                state.completed = Some(CompletedUpload {
                     content_ref: request.content_ref.clone(),
-                    validated_content_token: None,
                 });
-            }
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(err) => return Err(CoreError::Store(err.to_string())),
-        }
-    }
 
-    Err(CoreError::Store(
-        "upload session compare-and-swap retry exhausted".to_owned(),
-    ))
+                Ok(UploadSessionUpdate::Replace {
+                    next: Box::new(state),
+                    outcome: CompleteUploadResponse {
+                        namespace_id,
+                        upload_id,
+                        content_ref: request.content_ref.clone(),
+                        validated_content_token: None,
+                    },
+                })
+            }
+        },
+    )
+    .await
 }
 
 async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    loaded: &LoadedUploadSessionObject,
+    state: &UploadSessionState,
     request: &CompleteUploadRequest,
 ) -> Result<ContentRef, CoreError> {
-    if loaded.envelope.state.mode != UploadMode::DirectPut {
+    if state.mode != UploadMode::DirectPut {
         return Err(CoreError::InvalidUploadContent(
             "upload content has not been staged".to_owned(),
         ));
     }
 
-    let Some(expected) = &loaded.envelope.state.direct_put_content_ref else {
+    let Some(expected) = &state.direct_put_content_ref else {
         return Err(CoreError::InvalidUploadContent(
             "direct_put session is missing its target content ref".to_owned(),
         ));
@@ -1539,50 +1505,6 @@ fn candidate_content_admissions(candidate: &NamespaceMutationCandidate) -> &[Con
         NamespaceMutationCandidate::PathWithContentAdmission { admissions, .. } => admissions,
         NamespaceMutationCandidate::Commit(_) | NamespaceMutationCandidate::Path(_) => &[],
     }
-}
-
-async fn read_upload_session_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    upload_id: &str,
-) -> Result<LoadedUploadSessionObject, CoreError> {
-    NamespaceId::parse(namespace_id.as_str()).map_err(CoreError::from)?;
-    validate_upload_id(upload_id).map_err(CoreError::InvalidUploadId)?;
-    let object_key = upload_session(namespace_id.as_str(), upload_id);
-    let metadata = store
-        .head(&object_key)
-        .await
-        .map_err(|err| CoreError::Store(err.to_string()))?
-        .ok_or_else(|| CoreError::UploadNotFound {
-            upload_id: upload_id.to_owned(),
-        })?;
-    let encoded = store
-        .get(&object_key, None)
-        .await
-        .map_err(|err| CoreError::Store(err.to_string()))?
-        .ok_or_else(|| CoreError::UploadNotFound {
-            upload_id: upload_id.to_owned(),
-        })?;
-    let envelope: UploadSessionEnvelope =
-        decode_control_object(&encoded, ControlObjectKind::UploadSession).map_err(|err| {
-            CoreError::Store(format!("invalid upload session `{object_key}`: {err}"))
-        })?;
-    if envelope.state.namespace_id != *namespace_id {
-        return Err(CoreError::Store(format!(
-            "upload session namespace mismatch for `{object_key}`"
-        )));
-    }
-    if envelope.state.upload_id != upload_id {
-        return Err(CoreError::Store(format!(
-            "upload session id mismatch for `{object_key}`"
-        )));
-    }
-
-    Ok(LoadedUploadSessionObject {
-        object_key,
-        metadata,
-        envelope,
-    })
 }
 
 fn commit_response_from_commit_receipt(


### PR DESCRIPTION
Centralizes common control-object ETag/CAS retry helpers and moves writer epoch plus upload session updates onto them.