### PR TITLE
refactor(wal): make replay canonical and strict

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -27,9 +27,7 @@ use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_metadata_state;
 use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::read_head_object;
-use crate::wal::{
-    load_validated_wal_chain, replay_validated_wal_tail_with_metadata, WalChainLoadRequest,
-};
+use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::control::NamespaceState;
 use loonfs_api::wire::manifest::{
@@ -298,10 +296,11 @@ async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
     })?;
     let replayed = {
         let _span = tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
-        replay_validated_wal_tail_with_metadata(
+        project_validated_wal_tail(
             &manifest_head,
             &MetadataState::default(),
-            wal_chain.segments(),
+            Some(head.writer_epoch),
+            &wal_chain,
         )
         .map_err(MetadataProjectionLoadError::WalReplay)
         .map_err(CoreError::MetadataProjection)?

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -5,7 +5,7 @@ mod view;
 
 use crate::invariants::InvariantId;
 use indexes::MetadataIndexes;
-use loonfs_api::wire::wal::{WalCommitPayload, WalDelta};
+use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey, NamePolicy,
     RevisionNo,
@@ -341,100 +341,106 @@ impl MetadataState {
         let mut checked_invariants = Vec::new();
 
         for delta in deltas {
-            match delta {
-                WalDelta::CreateInode {
-                    delta_index: _,
-                    inode_id,
-                    inode_kind,
-                } => {
-                    self.push_inode_record(InodeRecord {
-                        inode_id: *inode_id,
-                        inode_kind: inode_kind.clone(),
-                        created_seq: committed_seq,
-                    });
-                    push_unique_invariant(
-                        &mut checked_invariants,
-                        InvariantId::CreateInodeWritesInodeRow,
-                    );
-                }
-                WalDelta::BindDirentry {
-                    delta_index,
-                    parent_inode,
-                    name_key,
-                    display_name,
-                    child_inode,
-                } => {
-                    self.push_direntry_bind_record(DirentryBindRecord {
-                        parent_inode_id: *parent_inode,
-                        name_key: name_key.clone(),
-                        display_name: display_name.clone(),
-                        child_inode_id: *child_inode,
-                        bind_seq: committed_seq,
-                        bind_delta_index: *delta_index,
-                    });
-                    push_unique_invariant(
-                        &mut checked_invariants,
-                        InvariantId::BindDirentryWritesDirentryBindRow,
-                    );
-                }
-                WalDelta::UnbindDirentry {
-                    delta_index,
-                    parent_inode,
-                    name_key,
-                    child_inode,
-                    bind_seq,
-                    bind_delta_index,
-                } => {
-                    self.push_direntry_unbind_record(DirentryUnbindRecord {
-                        parent_inode_id: *parent_inode,
-                        name_key: name_key.clone(),
-                        child_inode_id: *child_inode,
-                        bind_seq: *bind_seq,
-                        bind_delta_index: *bind_delta_index,
-                        unbind_seq: committed_seq,
-                        unbind_delta_index: *delta_index,
-                    });
-                    push_unique_invariant(
-                        &mut checked_invariants,
-                        InvariantId::UnbindDirentryWritesUnbindRow,
-                    );
-                }
-                WalDelta::AppendFileRevision {
-                    delta_index,
-                    inode_id,
-                    revision_no,
-                    content_ref,
-                } => {
-                    self.push_revision_record(RevisionRecord {
-                        inode_id: *inode_id,
-                        revision_no: *revision_no,
-                        committed_seq,
-                        revision_delta_index: *delta_index,
-                        content_ref: content_ref.clone(),
-                    });
-                    push_unique_invariant(
-                        &mut checked_invariants,
-                        InvariantId::AppendFileRevisionWritesRevisionRow,
-                    );
-                }
-                WalDelta::TombstoneSubtree {
-                    delta_index,
-                    root_inode,
-                } => {
-                    self.push_subtree_tombstone_record(SubtreeTombstoneRecord {
-                        root_inode_id: *root_inode,
-                        tombstone_seq: committed_seq,
-                        tombstone_delta_index: *delta_index,
-                    });
-                    push_unique_invariant(
-                        &mut checked_invariants,
-                        InvariantId::TombstoneSubtreeWritesTombstoneRow,
-                    );
-                }
-            }
+            self.apply_committed_wal_delta_mut(committed_seq, delta, &mut checked_invariants);
         }
 
         Ok(checked_invariants)
+    }
+
+    fn apply_committed_wal_delta_mut(
+        &mut self,
+        committed_seq: ChangeSeq,
+        delta: &WalDelta,
+        checked_invariants: &mut Vec<InvariantId>,
+    ) {
+        match delta {
+            WalDelta::CreateInode {
+                delta_index: _,
+                inode_id,
+                inode_kind,
+            } => {
+                self.push_inode_record(InodeRecord {
+                    inode_id: *inode_id,
+                    inode_kind: inode_kind.clone(),
+                    created_seq: committed_seq,
+                });
+                push_unique_invariant(checked_invariants, InvariantId::CreateInodeWritesInodeRow);
+            }
+            WalDelta::BindDirentry {
+                delta_index,
+                parent_inode,
+                name_key,
+                display_name,
+                child_inode,
+            } => {
+                self.push_direntry_bind_record(DirentryBindRecord {
+                    parent_inode_id: *parent_inode,
+                    name_key: name_key.clone(),
+                    display_name: display_name.clone(),
+                    child_inode_id: *child_inode,
+                    bind_seq: committed_seq,
+                    bind_delta_index: *delta_index,
+                });
+                push_unique_invariant(
+                    checked_invariants,
+                    InvariantId::BindDirentryWritesDirentryBindRow,
+                );
+            }
+            WalDelta::UnbindDirentry {
+                delta_index,
+                parent_inode,
+                name_key,
+                child_inode,
+                bind_seq,
+                bind_delta_index,
+            } => {
+                self.push_direntry_unbind_record(DirentryUnbindRecord {
+                    parent_inode_id: *parent_inode,
+                    name_key: name_key.clone(),
+                    child_inode_id: *child_inode,
+                    bind_seq: *bind_seq,
+                    bind_delta_index: *bind_delta_index,
+                    unbind_seq: committed_seq,
+                    unbind_delta_index: *delta_index,
+                });
+                push_unique_invariant(
+                    checked_invariants,
+                    InvariantId::UnbindDirentryWritesUnbindRow,
+                );
+            }
+            WalDelta::AppendFileRevision {
+                delta_index,
+                inode_id,
+                revision_no,
+                content_ref,
+            } => {
+                self.push_revision_record(RevisionRecord {
+                    inode_id: *inode_id,
+                    revision_no: *revision_no,
+                    committed_seq,
+                    revision_delta_index: *delta_index,
+                    content_ref: content_ref.clone(),
+                });
+                push_unique_invariant(
+                    checked_invariants,
+                    InvariantId::AppendFileRevisionWritesRevisionRow,
+                );
+            }
+            WalDelta::TombstoneSubtree {
+                delta_index,
+                root_inode,
+            } => {
+                self.push_subtree_tombstone_record(SubtreeTombstoneRecord {
+                    root_inode_id: *root_inode,
+                    tombstone_seq: committed_seq,
+                    tombstone_delta_index: *delta_index,
+                });
+                push_unique_invariant(
+                    checked_invariants,
+                    InvariantId::TombstoneSubtreeWritesTombstoneRow,
+                );
+            }
+        }
     }
 
     pub fn apply_committed_wal_record(
@@ -454,17 +460,32 @@ impl MetadataState {
         &mut self,
         record: &WalCommitPayload,
     ) -> Result<Vec<InvariantId>, MetadataApplyError> {
-        let deltas = record
-            .deltas
-            .iter()
-            .map(|delta| delta.delta.clone())
-            .collect::<Vec<_>>();
-        let mut checked_invariants = self.apply_committed_wal_deltas_mut(record.seq, &deltas)?;
+        self.apply_committed_wal_record_parts_mut(
+            record.seq,
+            &record.commit_id,
+            &record.semantic_commit_fingerprint,
+            record.message.as_deref(),
+            &record.deltas,
+        )
+    }
+
+    pub(crate) fn apply_committed_wal_record_parts_mut(
+        &mut self,
+        seq: ChangeSeq,
+        commit_id: &CommitId,
+        semantic_commit_fingerprint: &str,
+        message: Option<&str>,
+        deltas: &[WalCommitDelta],
+    ) -> Result<Vec<InvariantId>, MetadataApplyError> {
+        let mut checked_invariants = Vec::new();
+        for delta in deltas {
+            self.apply_committed_wal_delta_mut(seq, &delta.delta, &mut checked_invariants);
+        }
         self.push_commit_receipt_record(CommitReceiptRecord {
-            commit_id: record.commit_id.clone(),
-            semantic_commit_fingerprint: record.semantic_commit_fingerprint.clone(),
-            committed_seq: record.seq,
-            message: record.message.clone(),
+            commit_id: commit_id.clone(),
+            semantic_commit_fingerprint: semantic_commit_fingerprint.to_owned(),
+            committed_seq: seq,
+            message: message.map(str::to_owned),
         });
         push_unique_invariant(
             &mut checked_invariants,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -13,9 +13,7 @@ use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::read_head_object;
 use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::read_durable_content_bytes;
-use crate::wal::{
-    load_validated_wal_chain, replay_validated_wal_tail_with_metadata, WalChainLoadRequest,
-};
+use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{
     AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ContentStoreId,
@@ -175,10 +173,11 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let replayed = {
             let _span =
                 tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
-            replay_validated_wal_tail_with_metadata(
+            project_validated_wal_tail(
                 &manifest_head,
                 &MetadataState::default(),
-                wal_chain.segments(),
+                Some(head.writer_epoch),
+                &wal_chain,
             )
             .map_err(|error| {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::WalReplay(error))

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -31,8 +31,7 @@ use crate::storage::content::{
     validate_durable_content_reference, write_immutable_object, ContentValidationTracker,
 };
 use crate::wal::{
-    load_validated_wal_chain, prepare_wal_segment, replay_validated_wal_tail_with_metadata,
-    WalChainLoadRequest,
+    load_validated_wal_chain, prepare_wal_segment, project_validated_wal_tail, WalChainLoadRequest,
 };
 use bytes::Bytes;
 use loonfs_api::v0::{
@@ -736,10 +735,11 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
     let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
-    let replayed = replay_validated_wal_tail_with_metadata(
+    let replayed = project_validated_wal_tail(
         manifest_head,
         &MetadataState::default(),
-        wal_chain.segments(),
+        Some(head.writer_epoch),
+        &wal_chain,
     )
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalReplay(error))

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -1,9 +1,10 @@
 use crate::invariants::InvariantId;
 use crate::metadata::MetadataApplyError;
 use loonfs_api::wire::control::{HeadState, WalSegmentPointer};
-use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope};
-use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalSegmentEnvelope};
+use loonfs_api::{ChangeSeq, CommitId, NamespaceId, WriterEpoch};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -49,6 +50,17 @@ pub(crate) struct ValidatedWalSegment {
     envelope: WalSegmentEnvelope,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct DecodedWalRecord<'a> {
+    pub(crate) namespace_id: &'a NamespaceId,
+    pub(crate) seq: ChangeSeq,
+    pub(crate) writer_epoch: WriterEpoch,
+    pub(crate) commit_id: &'a CommitId,
+    pub(crate) semantic_commit_fingerprint: &'a str,
+    pub(crate) message: Option<&'a str>,
+    pub(crate) deltas: Cow<'a, [WalCommitDelta]>,
+}
+
 impl ValidatedWalSegment {
     pub(crate) fn new(object_key: String, envelope: WalSegmentEnvelope) -> Self {
         Self {
@@ -71,6 +83,24 @@ impl ValidatedWalSegment {
 
     pub(crate) fn pointer(&self) -> WalSegmentPointer {
         self.envelope.pointer(self.object_key.clone())
+    }
+
+    pub(crate) fn decoded_records(&self) -> impl Iterator<Item = DecodedWalRecord<'_>> {
+        let namespace_id = &self.envelope.payload.namespace_id;
+        let writer_epoch = self.envelope.payload.writer_epoch;
+        self.envelope
+            .payload
+            .records
+            .iter()
+            .map(move |record| DecodedWalRecord {
+                namespace_id,
+                seq: record.seq,
+                writer_epoch,
+                commit_id: &record.commit_id,
+                semantic_commit_fingerprint: &record.semantic_commit_fingerprint,
+                message: record.message.as_deref(),
+                deltas: Cow::Borrowed(&record.deltas),
+            })
     }
 }
 
@@ -100,6 +130,16 @@ impl ValidatedWalChain {
 
     pub(crate) fn segments(&self) -> &[ValidatedWalSegment] {
         &self.segments
+    }
+
+    pub(crate) fn checked_invariants(&self) -> &[InvariantId] {
+        &self.checked_invariants
+    }
+
+    pub(crate) fn decoded_records(&self) -> impl Iterator<Item = DecodedWalRecord<'_>> {
+        self.segments
+            .iter()
+            .flat_map(ValidatedWalSegment::decoded_records)
     }
 }
 
@@ -167,6 +207,10 @@ pub enum WalReplayError {
     NonContiguousSeq {
         expected: ChangeSeq,
         actual: ChangeSeq,
+    },
+    WriterEpochMismatch {
+        expected_max: WriterEpoch,
+        actual: WriterEpoch,
     },
     EmptySegment,
     SegmentSummaryMismatch,

--- a/crates/loonfs-core/src/wal/mod.rs
+++ b/crates/loonfs-core/src/wal/mod.rs
@@ -4,11 +4,11 @@ mod replay;
 mod writer;
 
 pub(crate) use self::frame::{
-    PreparedWalSegment, ReplayedWalTail, ValidatedWalChain, ValidatedWalSegment, WalBuildError,
-    WalChainLoadError, WalChainLoadRequest, WalReplayError,
+    DecodedWalRecord, PreparedWalSegment, ReplayedWalTail, ValidatedWalChain, ValidatedWalSegment,
+    WalBuildError, WalChainLoadError, WalChainLoadRequest, WalReplayError,
 };
 pub(crate) use self::reader::load_validated_wal_chain;
-pub(crate) use self::replay::replay_validated_wal_tail_with_metadata;
+pub(crate) use self::replay::project_validated_wal_tail;
 pub(crate) use self::writer::prepare_wal_segment;
 
 #[cfg(test)]
@@ -27,6 +27,7 @@ mod tests {
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::wal_segment;
     use loonfs_objectstore::ObjectStore;
+    use std::borrow::Cow;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -143,6 +144,114 @@ mod tests {
 
         assert_eq!(chain.segments().len(), 1);
         assert_eq!(chain.segments()[0].records()[0].seq, ChangeSeq(1));
+    }
+
+    #[test]
+    fn canonical_replay_advances_head_and_applies_metadata_rows() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let commit = materialized_create_dir(
+            &namespace_id,
+            "c_wal_replay",
+            "docs",
+            ChangeSeq(0),
+            ChangeSeq(1),
+        );
+        let segment = prepare_wal_segment(
+            namespace_id.clone(),
+            WriterEpoch(1),
+            None,
+            std::slice::from_ref(&commit),
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        let mut base_head = loonfs_api::wire::control::HeadState::initial(namespace_id.clone());
+        base_head.writer_epoch = WriterEpoch(1);
+        let record = segment
+            .envelope
+            .payload
+            .records
+            .first()
+            .expect("wal record");
+
+        let replayed = replay::replay_wal_records(
+            &base_head,
+            &crate::metadata::MetadataState::default(),
+            Some(WriterEpoch(1)),
+            [DecodedWalRecord {
+                namespace_id: &namespace_id,
+                seq: record.seq,
+                writer_epoch: segment.envelope.payload.writer_epoch,
+                commit_id: &record.commit_id,
+                semantic_commit_fingerprint: &record.semantic_commit_fingerprint,
+                message: record.message.as_deref(),
+                deltas: Cow::Borrowed(&record.deltas),
+            }],
+        )
+        .expect("replay wal records");
+
+        assert_eq!(replayed.resulting_head.seq, ChangeSeq(1));
+        assert_eq!(replayed.resulting_head.head_commit_id, record.commit_id);
+        assert_eq!(replayed.resulting_head.next_inode_id, InodeId(3));
+        assert!(replayed
+            .resulting_metadata_state
+            .inode_at_head(InodeId(2))
+            .is_some());
+        assert!(replayed
+            .resulting_metadata_state
+            .find_commit_receipt(&record.commit_id)
+            .is_some());
+    }
+
+    #[test]
+    fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let commit = materialized_create_dir(
+            &namespace_id,
+            "c_wal_replay_epoch",
+            "docs",
+            ChangeSeq(0),
+            ChangeSeq(1),
+        );
+        let segment = prepare_wal_segment(
+            namespace_id.clone(),
+            WriterEpoch(2),
+            None,
+            std::slice::from_ref(&commit),
+            "test-writer",
+        )
+        .expect("prepare wal segment");
+        let mut base_head = loonfs_api::wire::control::HeadState::initial(namespace_id.clone());
+        base_head.writer_epoch = WriterEpoch(1);
+        let record = segment
+            .envelope
+            .payload
+            .records
+            .first()
+            .expect("wal record");
+
+        let error = replay::replay_wal_records(
+            &base_head,
+            &crate::metadata::MetadataState::default(),
+            Some(WriterEpoch(1)),
+            [DecodedWalRecord {
+                namespace_id: &namespace_id,
+                seq: record.seq,
+                writer_epoch: segment.envelope.payload.writer_epoch,
+                commit_id: &record.commit_id,
+                semantic_commit_fingerprint: &record.semantic_commit_fingerprint,
+                message: record.message.as_deref(),
+                deltas: Cow::Borrowed(&record.deltas),
+            }],
+        )
+        .expect_err("future writer epoch should fail");
+
+        assert_eq!(
+            error,
+            WalReplayError::WriterEpochMismatch {
+                expected_max: WriterEpoch(1),
+                actual: WriterEpoch(2),
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -1,4 +1,6 @@
-use super::replay::{extend_wal_replay_invariants, validate_decoded_replayed_wal, WalReplayError};
+use super::replay::{
+    extend_wal_replay_invariants, validate_wal_segment_for_replay, WalReplayError,
+};
 use super::{ValidatedWalChain, ValidatedWalSegment, WalChainLoadError, WalChainLoadRequest};
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{decode_wal_segment_envelope_zstd, WalSegmentEnvelope};
@@ -98,7 +100,7 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     }
     let mut checked_invariants = Vec::new();
     for segment in &reversed {
-        validate_decoded_replayed_wal(
+        validate_wal_segment_for_replay(
             request.namespace_id,
             expected_base_seq,
             segment.object_key(),

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -1,44 +1,67 @@
 pub(crate) use super::frame::WalReplayError;
-use super::{ReplayedWalTail, ValidatedWalSegment};
+use super::{DecodedWalRecord, ReplayedWalTail, ValidatedWalChain};
 use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta, WalSegmentEnvelope};
-use loonfs_api::{validate_wal_segment_id, ChangeSeq, InodeId, NamespaceId};
+use loonfs_api::{validate_wal_segment_id, ChangeSeq, InodeId, NamespaceId, WriterEpoch};
 use loonfs_objectstore::keys::wal_segment;
 
-pub(crate) fn replay_validated_wal_tail_with_metadata(
+pub(crate) fn project_validated_wal_tail(
     base_head: &HeadState,
     base_metadata_state: &MetadataState,
-    wal_tail: &[ValidatedWalSegment],
+    expected_writer_epoch: Option<WriterEpoch>,
+    wal_tail: &ValidatedWalChain,
 ) -> Result<ReplayedWalTail, WalReplayError> {
+    let mut replayed = replay_wal_records(
+        base_head,
+        base_metadata_state,
+        expected_writer_epoch,
+        wal_tail.decoded_records(),
+    )?;
+    if let Some(last_segment) = wal_tail.segments().last() {
+        replayed.resulting_head.visible_wal_tip = Some(last_segment.pointer());
+    }
+    extend_invariants(
+        &mut replayed.checked_invariants,
+        wal_tail.checked_invariants(),
+    );
+    Ok(replayed)
+}
+
+pub(crate) fn replay_wal_records<'a, I>(
+    base_head: &HeadState,
+    base_metadata_state: &MetadataState,
+    expected_writer_epoch: Option<WriterEpoch>,
+    records: I,
+) -> Result<ReplayedWalTail, WalReplayError>
+where
+    I: IntoIterator<Item = DecodedWalRecord<'a>>,
+{
     let mut current_head = base_head.clone();
     let mut current_metadata_state = base_metadata_state.clone();
     let mut checked_invariants = Vec::new();
 
-    for wal_segment in wal_tail {
-        validate_decoded_replayed_wal(
-            &current_head.namespace_id,
-            current_head.seq,
-            wal_segment.object_key(),
-            wal_segment.envelope(),
-        )?;
-        for record in wal_segment.records() {
-            current_head.seq = record.seq;
-            current_head.head_commit_id = record.commit_id.clone();
-            current_head.next_inode_id =
-                replay_next_inode_id_from_commit_deltas(current_head.next_inode_id, &record.deltas);
-            let apply_invariants = current_metadata_state
-                .apply_committed_wal_record_mut(record)
-                .map_err(WalReplayError::MetadataApply)?;
-            push_invariant(
-                &mut checked_invariants,
-                InvariantId::WalReplayAppliesMetadataRows,
-            );
-            extend_invariants(&mut checked_invariants, &apply_invariants);
-        }
-        current_head.visible_wal_tip = Some(wal_segment.pointer());
-        extend_wal_replay_invariants(&mut checked_invariants);
+    for record in records {
+        validate_replay_record(&current_head, expected_writer_epoch, &record)?;
+        current_head.seq = record.seq;
+        current_head.head_commit_id = record.commit_id.clone();
+        current_head.next_inode_id =
+            replay_next_inode_id_from_commit_deltas(current_head.next_inode_id, &record.deltas);
+        let apply_invariants = current_metadata_state
+            .apply_committed_wal_record_parts_mut(
+                record.seq,
+                record.commit_id,
+                record.semantic_commit_fingerprint,
+                record.message,
+                &record.deltas,
+            )
+            .map_err(WalReplayError::MetadataApply)?;
+        push_invariant(
+            &mut checked_invariants,
+            InvariantId::WalReplayAppliesMetadataRows,
+        );
+        extend_invariants(&mut checked_invariants, &apply_invariants);
     }
 
     Ok(ReplayedWalTail {
@@ -48,7 +71,43 @@ pub(crate) fn replay_validated_wal_tail_with_metadata(
     })
 }
 
-pub(super) fn validate_decoded_replayed_wal(
+fn validate_replay_record(
+    current_head: &HeadState,
+    expected_writer_epoch: Option<WriterEpoch>,
+    record: &DecodedWalRecord<'_>,
+) -> Result<(), WalReplayError> {
+    if record.namespace_id != &current_head.namespace_id {
+        return Err(WalReplayError::NamespaceMismatch {
+            expected: current_head.namespace_id.clone(),
+            actual: record.namespace_id.clone(),
+        });
+    }
+    let expected_seq = current_head
+        .seq
+        .0
+        .checked_add(1)
+        .map(ChangeSeq)
+        .ok_or(WalReplayError::SeqOverflow)?;
+    if record.seq != expected_seq {
+        return Err(WalReplayError::NonContiguousSeq {
+            expected: expected_seq,
+            actual: record.seq,
+        });
+    }
+    if let Some(expected_max) = expected_writer_epoch {
+        // A visible tail may contain older epochs after writer takeover; it
+        // must never contain records from an epoch beyond the current head.
+        if record.writer_epoch > expected_max {
+            return Err(WalReplayError::WriterEpochMismatch {
+                expected_max,
+                actual: record.writer_epoch,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_wal_segment_for_replay(
     expected_namespace: &NamespaceId,
     expected_base_head_seq: ChangeSeq,
     object_key: &str,


### PR DESCRIPTION
Makes WAL replay use one canonical strict path. Avoids scattered implementations
