### PR TITLE
refactor(api): prune empty options and add engine settings

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -2,9 +2,7 @@ use crate::cache::{MetadataTableCache, WalTailProjectionCache};
 use crate::context::MutationContext;
 use crate::error::Result as CoreResult;
 use crate::namespace::{bootstrap, delete, fork, BootstrapNamespaceError};
-use crate::options::{
-    BootstrapOptions, CommitOptions, DeleteNamespaceOptions, ForkOptions, WriteOptions,
-};
+use crate::options::{BootstrapOptions, DeleteNamespaceOptions, Settings, WriteOptions};
 use crate::path::query::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
 use crate::publisher::NamespaceMutationCandidate;
 use loonfs_api::generated_id;
@@ -25,8 +23,6 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
-
-const DEFAULT_LEASE_DURATION_MS: u64 = 5_000;
 
 fn default_page_limit() -> EffectiveLimit {
     EffectiveLimit::new(NonZeroU32::new(DEFAULT_PAGE_LIMIT).unwrap_or(NonZeroU32::MIN))
@@ -94,9 +90,7 @@ pub struct NamespaceEngine<S> {
     writer_id: String,
     writer_session_id: String,
     writer_version: String,
-    lease_duration_ms: u64,
-    write_options: WriteOptions,
-    commit_options: CommitOptions,
+    settings: Settings,
 }
 
 impl<S: ObjectStore> NamespaceEngine<S> {
@@ -110,9 +104,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             writer_id: None,
             writer_session_id: None,
             writer_version: default_writer_version(),
-            lease_duration_ms: DEFAULT_LEASE_DURATION_MS,
-            write_options: WriteOptions::default(),
-            commit_options: CommitOptions::default(),
+            settings: Settings::default(),
         }
     }
 
@@ -136,19 +128,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         &self.writer_version
     }
 
-    /// Returns the lease duration used by write operations.
-    pub fn lease_duration_ms(&self) -> u64 {
-        self.lease_duration_ms
-    }
-
-    /// Returns the default write options configured on the builder.
-    pub fn write_options(&self) -> &WriteOptions {
-        &self.write_options
-    }
-
-    /// Returns the default explicit-commit options configured on the builder.
-    pub fn commit_options(&self) -> &CommitOptions {
-        &self.commit_options
+    /// Returns the user-tweakable settings configured on the builder.
+    pub fn settings(&self) -> Settings {
+        self.settings
     }
 
     /// Consumes the engine and returns the underlying object store.
@@ -175,11 +157,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// Creates a new namespace at the current head of this namespace.
     ///
     /// The fork shares immutable file bytes but gets its own metadata history.
-    pub async fn fork_namespace(
-        &self,
-        target: &NamespaceId,
-        _options: ForkOptions,
-    ) -> CoreResult<NamespaceSummary> {
+    pub async fn fork_namespace(&self, target: &NamespaceId) -> CoreResult<NamespaceSummary> {
         fork::fork_namespace(
             &self.store,
             &self.namespace_id,
@@ -555,10 +533,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             bytes.as_ref(),
             options.put_behavior,
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -579,10 +554,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             content_ref,
             options.put_behavior,
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -598,10 +570,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.namespace_id,
             path.as_ref(),
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -612,10 +581,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         path: impl AsRef<str>,
         options: WriteOptions,
     ) -> CoreResult<MutationResult> {
-        let commit_id = options
-            .commit_id
-            .as_ref()
-            .map(|commit_id| commit_id.as_str());
+        let commit_id = options.commit_id.as_ref();
         if options.delete_behavior == DeleteDirectoryBehavior::Recursive {
             crate::path::write::ops::delete_path(
                 &self.store,
@@ -650,10 +616,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             source.as_ref(),
             dest.as_ref(),
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -671,10 +634,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             source.as_ref(),
             dest.as_ref(),
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -692,10 +652,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             path.as_ref(),
             source_revision_no,
             &self.mutation_context(),
-            options
-                .commit_id
-                .as_ref()
-                .map(|commit_id| commit_id.as_str()),
+            options.commit_id.as_ref(),
         )
         .await
     }
@@ -704,11 +661,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ///
     /// This is the lower-level surface used by clients that need their own
     /// commit ids, preconditions, and operation lists.
-    pub async fn commit_operations(
-        &self,
-        request: CommitRequest,
-        _options: CommitOptions,
-    ) -> CoreResult<CommitResponse> {
+    pub async fn commit_operations(&self, request: CommitRequest) -> CoreResult<CommitResponse> {
         crate::protocol::commit_operations(
             &self.store,
             &self.namespace_id,
@@ -722,7 +675,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     pub async fn commit_operations_batch(
         &self,
         requests: Vec<CommitRequest>,
-        _options: CommitOptions,
     ) -> Vec<CoreResult<CommitResponse>> {
         crate::protocol::commit_operations_batch(
             &self.store,
@@ -861,7 +813,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             writer_session_id: self.writer_session_id.clone(),
             writer_version: self.writer_version.clone(),
             now_ms: current_time_ms(),
-            lease_duration_ms: self.lease_duration_ms,
+            lease_duration_ms: self.settings.writer_lease_duration_ms(),
         }
     }
 }
@@ -877,9 +829,7 @@ pub struct NamespaceEngineBuilder<S> {
     writer_id: Option<String>,
     writer_session_id: Option<String>,
     writer_version: String,
-    lease_duration_ms: u64,
-    write_options: WriteOptions,
-    commit_options: CommitOptions,
+    settings: Settings,
 }
 
 impl<S: ObjectStore> NamespaceEngineBuilder<S> {
@@ -907,21 +857,9 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
         self
     }
 
-    /// Sets how long this writer's namespace lease should remain valid.
-    pub fn lease_duration_ms(mut self, lease_duration_ms: u64) -> Self {
-        self.lease_duration_ms = lease_duration_ms;
-        self
-    }
-
-    /// Sets default write options stored on the engine.
-    pub fn write_options(mut self, options: WriteOptions) -> Self {
-        self.write_options = options;
-        self
-    }
-
-    /// Sets default explicit-commit options stored on the engine.
-    pub fn commit_options(mut self, options: CommitOptions) -> Self {
-        self.commit_options = options;
+    /// Sets user-tweakable engine settings.
+    pub fn settings(mut self, settings: Settings) -> Self {
+        self.settings = settings;
         self
     }
 
@@ -948,9 +886,7 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
                 .writer_session_id
                 .unwrap_or_else(|| generated_id("wrs")),
             writer_version: self.writer_version,
-            lease_duration_ms: self.lease_duration_ms,
-            write_options: self.write_options,
-            commit_options: self.commit_options,
+            settings: self.settings,
         })
     }
 }
@@ -989,6 +925,7 @@ fn current_time_ms() -> u64 {
 mod tests {
     use super::*;
     use loonfs_objectstore::fs::LocalFsStore;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     #[test]
@@ -1006,9 +943,27 @@ mod tests {
         assert_eq!(engine.namespace_id(), &namespace_id);
         assert_eq!(engine.writer_id(), "writer-a");
         assert!(!engine.writer_version().is_empty());
-        assert_eq!(engine.lease_duration_ms(), DEFAULT_LEASE_DURATION_MS);
-        assert_eq!(engine.write_options(), &WriteOptions::default());
-        assert_eq!(engine.commit_options(), &CommitOptions::default());
+        assert_eq!(engine.settings(), Settings::default());
+    }
+
+    #[test]
+    fn namespace_engine_builder_accepts_settings() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let settings = Settings {
+            writer_lease_duration: Duration::from_secs(30),
+        };
+
+        let engine = NamespaceEngine::builder(store)
+            .namespace(namespace_id)
+            .writer("writer-a")
+            .settings(settings)
+            .build()
+            .expect("engine builds");
+
+        assert_eq!(engine.settings(), settings);
+        assert_eq!(engine.mutation_context().lease_duration_ms, 30_000);
     }
 
     #[test]

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -87,6 +87,4 @@ pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
 };
 pub use namespace::BootstrapNamespaceError;
-pub use options::{
-    BootstrapOptions, CommitOptions, DeleteNamespaceOptions, ForkOptions, WriteOptions,
-};
+pub use options::{BootstrapOptions, DeleteNamespaceOptions, Settings, WriteOptions};

--- a/crates/loonfs-core/src/options.rs
+++ b/crates/loonfs-core/src/options.rs
@@ -1,4 +1,26 @@
 use loonfs_api::{CommitId, DeleteDirectoryBehavior, PutBehavior};
+use std::time::Duration;
+
+/// User-tweakable namespace engine settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Settings {
+    /// How long this writer's namespace lease should remain valid.
+    pub writer_lease_duration: Duration,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            writer_lease_duration: Duration::from_millis(5_000),
+        }
+    }
+}
+
+impl Settings {
+    pub(crate) fn writer_lease_duration_ms(self) -> u64 {
+        u64::try_from(self.writer_lease_duration.as_millis()).unwrap_or(u64::MAX)
+    }
+}
 
 /// Options for namespace bootstrap.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -6,13 +28,6 @@ pub struct BootstrapOptions {
     /// If true, creating an already-existing namespace is treated as success.
     pub allow_existing: bool,
 }
-
-/// Options for namespace fork.
-///
-/// This is currently empty, but kept as the public shape for future fork
-/// controls.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ForkOptions {}
 
 /// Options for namespace deletion.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -44,10 +59,3 @@ impl Default for WriteOptions {
         }
     }
 }
-
-/// Options for explicit commit submission.
-///
-/// This is currently empty because the commit request carries the important
-/// choices: commit id, preconditions, operations, and message.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct CommitOptions {}

--- a/crates/loonfs-core/src/path/write/executor.rs
+++ b/crates/loonfs-core/src/path/write/executor.rs
@@ -5,13 +5,8 @@ use crate::publisher::{DirectObjectStorePublisher, PublishOptions};
 use loonfs_api::{CommitId, MutationResult, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
-pub(super) fn normalized_commit_id(commit_id: Option<&str>) -> Result<CommitId, CoreError> {
-    commit_id
-        .filter(|value| !value.trim().is_empty())
-        .map(CommitId::parse)
-        .transpose()
-        .map(|commit_id| commit_id.unwrap_or_else(CommitId::generate))
-        .map_err(CoreError::from)
+pub(super) fn normalized_commit_id(commit_id: Option<&CommitId>) -> CommitId {
+    commit_id.cloned().unwrap_or_else(CommitId::generate)
 }
 
 pub(super) async fn submit_path_intent<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -4,7 +4,7 @@ use super::intent::PathMutationIntent;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use loonfs_api::{
-    v0::MoveBehavior, ContentRef, DeleteDirectoryBehavior, MutationResult, NamespaceId,
+    v0::MoveBehavior, CommitId, ContentRef, DeleteDirectoryBehavior, MutationResult, NamespaceId,
     PutBehavior, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
@@ -16,7 +16,7 @@ pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     behavior: PutBehavior,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
     let content_ref =
         store_file_bytes_before_metadata_publish(store, namespace_id, absolute_path, bytes).await?;
@@ -39,7 +39,7 @@ pub(crate) async fn write_file_bytes<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     bytes: &[u8],
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
     put_file_bytes(
         store,
@@ -58,9 +58,9 @@ pub(crate) async fn create_dir_path<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,
@@ -80,9 +80,9 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
     content_ref: ContentRef,
     behavior: PutBehavior,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,
@@ -102,7 +102,7 @@ pub(crate) async fn delete_path<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
     delete_path_with_behavior(
         store,
@@ -120,7 +120,7 @@ pub(crate) async fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
     delete_path_with_behavior(
         store,
@@ -139,9 +139,9 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     behavior: DeleteDirectoryBehavior,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,
@@ -161,9 +161,9 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
     from_path: &str,
     to_path: &str,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,
@@ -184,9 +184,9 @@ pub(crate) async fn copy_file_path<S: ObjectStore + ?Sized>(
     from_path: &str,
     to_path: &str,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,
@@ -206,9 +206,9 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     source_revision_no: RevisionNo,
     context: &MutationContext,
-    commit_id: Option<&str>,
+    commit_id: Option<&CommitId>,
 ) -> Result<MutationResult, CoreError> {
-    let commit_id = normalized_commit_id(commit_id)?;
+    let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -989,6 +989,7 @@ mod tests {
     #[tokio::test]
     async fn move_path_plan_contains_binding_and_target_absence_preconditions() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let seed_commit_id = CommitId::parse("seed-file").expect("valid commit id");
         put_file_bytes(
             &store,
             &namespace_id,
@@ -996,7 +997,7 @@ mod tests {
             b"hello",
             PutBehavior::NoReplace,
             &context,
-            Some("seed-file"),
+            Some(&seed_commit_id),
         )
         .await
         .expect("seed file");
@@ -1088,6 +1089,7 @@ mod tests {
     #[tokio::test]
     async fn copy_file_plan_validates_source_revision_and_target_absence() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let seed_commit_id = CommitId::parse("seed-copy-source").expect("valid commit id");
         put_file_bytes(
             &store,
             &namespace_id,
@@ -1095,7 +1097,7 @@ mod tests {
             b"hello",
             PutBehavior::NoReplace,
             &context,
-            Some("seed-copy-source"),
+            Some(&seed_commit_id),
         )
         .await
         .expect("seed file");
@@ -1139,6 +1141,7 @@ mod tests {
     #[tokio::test]
     async fn tombstoned_ancestor_blocks_descendant_planning() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let seed_commit_id = CommitId::parse("seed-dead-tree").expect("valid commit id");
         put_file_bytes(
             &store,
             &namespace_id,
@@ -1146,16 +1149,17 @@ mod tests {
             b"hello",
             PutBehavior::NoReplace,
             &context,
-            Some("seed-dead-tree"),
+            Some(&seed_commit_id),
         )
         .await
         .expect("seed file");
+        let delete_commit_id = CommitId::parse("delete-dead-tree").expect("valid commit id");
         delete_path(
             &store,
             &namespace_id,
             "/dead",
             &context,
-            Some("delete-dead-tree"),
+            Some(&delete_commit_id),
         )
         .await
         .expect("delete tree");

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -68,10 +68,12 @@ mod tests {
     use crate::engine::NamespaceEngine;
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::options::Settings;
     use crate::publisher::{publish_namespace_mutations_batch, NamespaceMutationCandidate};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, PutBehavior};
     use loonfs_objectstore::fs::LocalFsStore;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     fn test_context() -> MutationContext {
@@ -122,7 +124,9 @@ mod tests {
             .namespace(namespace_id.clone())
             .writer(context.writer_id.clone())
             .writer_version(context.writer_version.clone())
-            .lease_duration_ms(context.lease_duration_ms)
+            .settings(Settings {
+                writer_lease_duration: Duration::from_millis(context.lease_duration_ms),
+            })
             .build()
             .expect("test engine")
     }

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -1550,17 +1550,6 @@ fn fail_outcomes_contingent_on_unpublished_batch(
     }
 }
 
-fn finish_batch_outcomes(
-    outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>>,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
-    outcomes
-        .into_iter()
-        .map(|outcome| {
-            outcome.unwrap_or_else(|| Err(CoreError::Store("missing batch outcome".to_owned())))
-        })
-        .collect()
-}
-
 fn finish_batch_outcomes_with_aliases(
     mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>>,
     aliases: &[(usize, usize)],
@@ -1572,7 +1561,12 @@ fn finish_batch_outcomes_with_aliases(
             .unwrap_or_else(|| Err(CoreError::Store("missing primary batch outcome".to_owned())));
         outcomes[*alias_index] = Some(primary_outcome);
     }
-    finish_batch_outcomes(outcomes)
+    outcomes
+        .into_iter()
+        .map(|outcome| {
+            outcome.unwrap_or_else(|| Err(CoreError::Store("missing batch outcome".to_owned())))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -39,7 +39,7 @@ use loonfs_core::publish::{
 };
 use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapOptions, Error as CoreError, ErrorCode,
-    ForkOptions, MutationContext, NamespaceEngine, WriteOptions,
+    MutationContext, NamespaceEngine, Settings, WriteOptions,
 };
 use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{
@@ -54,6 +54,7 @@ use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
+use std::time::Duration;
 use tempfile::tempdir;
 
 #[derive(Debug, Clone)]
@@ -79,7 +80,9 @@ fn namespace_engine<'a, S: ObjectStore + ?Sized>(
         .writer(context.writer_id.clone())
         .writer_session_id(context.writer_session_id.clone())
         .writer_version(context.writer_version.clone())
-        .lease_duration_ms(context.lease_duration_ms)
+        .settings(Settings {
+            writer_lease_duration: Duration::from_millis(context.lease_duration_ms),
+        })
         .build()
         .expect("test context should build namespace engine")
 }
@@ -102,10 +105,7 @@ fn fork_namespace<S: ObjectStore + ?Sized>(
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<loonfs_api::NamespaceSummary, CoreError> {
-    block_on(
-        namespace_engine(store, source_namespace_id, context)
-            .fork_namespace(new_namespace_id, ForkOptions::default()),
-    )
+    block_on(namespace_engine(store, source_namespace_id, context).fork_namespace(new_namespace_id))
 }
 
 fn load_namespace_descriptor_state<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1764,7 +1764,7 @@ mod tests {
     };
     use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
     use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-    use loonfs_core::{BootstrapOptions, MutationContext, NamespaceEngine, WriteOptions};
+    use loonfs_core::{BootstrapOptions, MutationContext, NamespaceEngine, Settings, WriteOptions};
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::namespace_head;
     use loonfs_objectstore::{
@@ -1773,7 +1773,7 @@ mod tests {
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tempfile::tempdir;
 
     #[derive(Debug)]
@@ -2294,7 +2294,9 @@ mod tests {
             .writer(context.writer_id.clone())
             .writer_session_id(context.writer_session_id.clone())
             .writer_version(context.writer_version.clone())
-            .lease_duration_ms(context.lease_duration_ms)
+            .settings(Settings {
+                writer_lease_duration: Duration::from_millis(context.lease_duration_ms),
+            })
             .build()
             .expect("test context should build namespace engine")
     }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -249,7 +249,7 @@ impl Fs {
     ) -> Result<NamespaceSummary> {
         let result = self
             .namespace_engine(source)
-            .fork_namespace(target, loonfs_core::ForkOptions::default())
+            .fork_namespace(target)
             .await
             .map_err(RuntimeError::from);
         if should_invalidate_after_result(&result) {
@@ -1174,7 +1174,11 @@ impl Fs {
             .writer(self.inner.config.writer_id.clone())
             .writer_session_id(self.inner.writer_session_id.clone())
             .writer_version(self.inner.config.writer_version.clone())
-            .lease_duration_ms(self.inner.config.lease_duration_ms)
+            .settings(loonfs_core::Settings {
+                writer_lease_duration: std::time::Duration::from_millis(
+                    self.inner.config.lease_duration_ms,
+                ),
+            })
             .build()
             .expect("validated runtime config should build namespace engine")
     }


### PR DESCRIPTION
Prunes empty options and adds explicit engine settings.
