### PR TITLE
refactor(core): standardize metadata view naming

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -159,8 +159,8 @@ pub struct HeadState {
     pub next_inode_id: InodeId,
     #[serde(default)]
     pub name_policy: NamePolicy,
-    /// Live read/recovery pointer. If present, basis reconstruction loads this
-    /// manifest before replaying the visible WAL tail.
+    /// Live read/recovery pointer. Reads load this manifest before projecting
+    /// the visible WAL tail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_manifest_id: Option<ManifestId>,
     /// Admin/provenance convenience pointer to the latest checkpoint record.

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -72,7 +72,7 @@ pub struct NamespaceStatusResponse {
     /// Latest checkpoint recorded by the head.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_checkpoint_id: Option<CheckpointId>,
-    /// Number of visible WAL segments after the manifest basis.
+    /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
     /// Oldest sequence still promised for incremental replay.
     pub retention_floor_seq: ChangeSeq,

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -105,7 +105,7 @@ define_invariant_ids! {
     (NamespaceManifestMustBeVerified, "namespace_manifest_must_be_verified"),
     (ManifestReplayRequiresAllManifestSegments, "manifest_replay_requires_all_manifest_segments"),
     (MetadataFileRefMatchesPayload, "manifest_segment_descriptor_matches_payload"),
-    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_basis_metadata"),
+    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_manifest_metadata"),
     (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
     (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
@@ -145,7 +145,7 @@ define_invariant_ids! {
     (MetadataSegmentKeyMatchesFamilyAndIndex, "manifest_segment_key_matches_family_and_index"),
     (VerifiedNamespaceManifestRequiresDurableSegments, "verified_namespace_manifest_requires_durable_segments"),
     (NamespaceManifestPreservesHeadSummary, "namespace_manifest_preserves_head_summary"),
-    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_basis_metadata"),
+    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_metadata_view"),
 
     // Client transfer download invariants.
     (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -105,7 +105,7 @@ define_invariant_ids! {
     (NamespaceManifestMustBeVerified, "namespace_manifest_must_be_verified"),
     (ManifestReplayRequiresAllManifestSegments, "manifest_replay_requires_all_manifest_segments"),
     (MetadataFileRefMatchesPayload, "manifest_segment_descriptor_matches_payload"),
-    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_manifest_metadata"),
+    (MetadataSstRowsRestoreManifestMetadata, "manifest_segment_rows_restore_manifest_metadata"),
     (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
     (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
@@ -145,7 +145,7 @@ define_invariant_ids! {
     (MetadataSegmentKeyMatchesFamilyAndIndex, "manifest_segment_key_matches_family_and_index"),
     (VerifiedNamespaceManifestRequiresDurableSegments, "verified_namespace_manifest_requires_durable_segments"),
     (NamespaceManifestPreservesHeadSummary, "namespace_manifest_preserves_head_summary"),
-    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_metadata_view"),
+    (NamespaceManifestPreservesMetadata, "namespace_manifest_preserves_metadata"),
 
     // Client transfer download invariants.
     (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -134,7 +134,7 @@ impl<'a> InMemoryMetadataView<'a> {
 }
 
 impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
-    pub(crate) fn manifest_plus_tail(
+    pub(crate) fn from_loaded_head(
         head: &'a HeadState,
         tables: &'a VerifiedMetadataTables<'store, S>,
         wal_tail_rows: &'a MetadataState,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -702,7 +702,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     }
 
     fn metadata_view(&self) -> MetadataView<'_, '_, S> {
-        MetadataView::manifest_plus_tail(&self.head, &self.tables, self.wal_tail_rows.as_ref())
+        MetadataView::from_loaded_head(&self.head, &self.tables, self.wal_tail_rows.as_ref())
     }
 }
 

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -750,7 +750,7 @@ mod tests {
     use crate::metadata::{DirentryBindRecord, InodeRecord};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::path::write::ops::{delete_path, put_file_bytes};
-    use crate::protocol::{load_publish_manifest_plus_tail_view, PublishTailOptions};
+    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::v0::{CommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest};
     use loonfs_api::RevisionNo;
@@ -812,7 +812,7 @@ mod tests {
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
     ) -> Result<PlannedPathMutation, CoreError> {
-        let (view, _projection) = load_publish_manifest_plus_tail_view(
+        let (view, _projection) = load_publish_metadata_view(
             store,
             namespace_id,
             None,

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -103,7 +103,7 @@ impl PublishBatchAgainstViewResult {
     }
 }
 
-pub(crate) struct PublishManifestPlusTailView<'a, S: ObjectStore + ?Sized> {
+pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     content_store_id: ContentStoreId,
     head: HeadState,
     head_etag: String,
@@ -112,13 +112,13 @@ pub(crate) struct PublishManifestPlusTailView<'a, S: ObjectStore + ?Sized> {
     tail_state: MetadataState,
 }
 
-impl<S: ObjectStore + ?Sized> PublishManifestPlusTailView<'_, S> {
+impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
     pub(crate) fn head(&self) -> &HeadState {
         &self.head
     }
 
     pub(crate) fn metadata_view(&self) -> MetadataView<'_, '_, S> {
-        MetadataView::manifest_plus_tail(&self.head, &self.manifest_tables, &self.tail_state)
+        MetadataView::from_loaded_head(&self.head, &self.manifest_tables, &self.tail_state)
     }
 
     async fn find_commit_receipt(
@@ -579,7 +579,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         }
     };
     let publish_tail_options = PublishTailOptions::default();
-    let publish_view = match load_publish_manifest_plus_tail_view(
+    let publish_view = match load_publish_metadata_view(
         store,
         namespace_id,
         Some(acquired_writer),
@@ -606,13 +606,13 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     .results
 }
 
-pub(crate) async fn load_publish_manifest_plus_tail_view<'a, S: ObjectStore + ?Sized>(
+pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
     acquired_writer: Option<AcquiredWriter>,
     cached_projection: Option<&PublishTailProjection>,
     options: &PublishTailOptions,
-) -> Result<(PublishManifestPlusTailView<'a, S>, PublishTailProjection), CoreError> {
+) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection), CoreError> {
     let catalog_entry = load_namespace_catalog_entry(store, namespace_id)
         .await
         .map_err(|error| CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)))?;
@@ -678,7 +678,7 @@ pub(crate) async fn load_publish_manifest_plus_tail_view<'a, S: ObjectStore + ?S
     ensure_publish_head_etag_still_current(store, namespace_id, &head_etag).await?;
 
     Ok((
-        PublishManifestPlusTailView {
+        PublishMetadataView {
             content_store_id: catalog_entry.content_store_id,
             head,
             head_etag,
@@ -828,7 +828,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     namespace_id: &NamespaceId,
     candidates: &[NamespaceMutationCandidate],
     context: &MutationContext,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
         return PublishBatchAgainstViewResult::new(Vec::new());
@@ -1098,7 +1098,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
 #[allow(clippy::too_many_arguments)]
 async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
     session: &PublishPlanningSession,
     candidate: &NamespaceMutationCandidate,
     index: usize,
@@ -1245,7 +1245,7 @@ fn validate_commit_id(commit_id: &CommitId) -> Result<(), CoreError> {
 #[allow(clippy::too_many_arguments)]
 async fn record_primary_request_or_complete_idempotent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
     in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -8,9 +8,7 @@ use crate::path::write::{
     path_intent_fingerprint_for_path_intent, PathMutationIntent, PlannedPathMutation,
     PublishPlanningSession,
 };
-use crate::protocol::{
-    load_publish_manifest_plus_tail_view, PublishTailOptions, PublishTailProjection,
-};
+use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, MutationResult, NamespaceId};
 use loonfs_objectstore::ObjectStore;
@@ -135,7 +133,7 @@ impl NamespaceCommitEngine {
             }
         };
 
-        let (publish_view, projection) = match load_publish_manifest_plus_tail_view(
+        let (publish_view, projection) = match load_publish_metadata_view(
             store,
             &self.namespace_id,
             Some(acquired_writer),
@@ -244,7 +242,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
     ) -> Result<PlannedPathMutation, CoreError> {
-        let (view, _projection) = load_publish_manifest_plus_tail_view(
+        let (view, _projection) = load_publish_metadata_view(
             self.store,
             namespace_id,
             None,

--- a/crates/loonfs-core/tests/differential.rs
+++ b/crates/loonfs-core/tests/differential.rs
@@ -245,7 +245,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
 }
 
 fn model_bootstrap_state() -> ModelMetadataState {
-    loonfs_model::bootstrap_basis_metadata_state()
+    loonfs_model::bootstrap_metadata_state()
 }
 
 fn assert_states_match(sequences: &[Vec<WalDelta>]) {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1705,7 +1705,7 @@ async fn query_driven_reads_use_initial_manifest_with_wal_overlay() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_driven_stat_and_list_use_manifest_plus_tail_with_l0_run_and_wal_overlay() {
+async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overlay() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let context = mutation_context();

--- a/crates/loonfs-model/src/genesis.rs
+++ b/crates/loonfs-model/src/genesis.rs
@@ -1,7 +1,7 @@
 use crate::metadata::{InodeRecord, MetadataState};
 use loonfs_api::{ChangeSeq, InodeId, InodeKind};
 
-pub fn bootstrap_basis_metadata_state() -> MetadataState {
+pub fn bootstrap_metadata_state() -> MetadataState {
     MetadataState {
         inodes: vec![InodeRecord {
             inode_id: InodeId(1),

--- a/crates/loonfs-model/src/lib.rs
+++ b/crates/loonfs-model/src/lib.rs
@@ -10,4 +10,4 @@ mod genesis;
 pub mod metadata;
 pub mod wal;
 
-pub use genesis::bootstrap_basis_metadata_state;
+pub use genesis::bootstrap_metadata_state;

--- a/crates/loonfs-model/src/wal.rs
+++ b/crates/loonfs-model/src/wal.rs
@@ -16,12 +16,12 @@ pub enum WalReplayError {
 }
 
 pub fn replay_wal_tail_with_metadata(
-    basis_head: &HeadState,
-    basis_metadata_state: &MetadataState,
+    base_head: &HeadState,
+    base_metadata_state: &MetadataState,
     wal_tail: &[(ChangeSeq, Vec<WalDelta>)],
 ) -> Result<ReplayedWalTail, WalReplayError> {
-    let mut current_head = basis_head.clone();
-    let mut current_metadata_state = basis_metadata_state.clone();
+    let mut current_head = base_head.clone();
+    let mut current_metadata_state = base_metadata_state.clone();
 
     for (seq, deltas) in wal_tail {
         let applied = current_metadata_state

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -94,8 +94,8 @@ pub(crate) struct CachedControl<T> {
 /// understanding read/write warmup behavior.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuntimeCacheStats {
-    /// Metadata reads served from manifest tables plus WAL tail projection.
-    pub read_manifest_plus_tail_hits: usize,
+    /// Latest metadata reads served through the metadata-view path.
+    pub latest_metadata_view_reads: usize,
     /// WAL-tail projection cache hits.
     pub wal_tail_projection_cache_hits: usize,
     /// WAL-tail projection cache misses.
@@ -130,7 +130,7 @@ pub struct RuntimeCacheStats {
 
 #[derive(Debug, Default)]
 pub(crate) struct RuntimeCacheStatsInner {
-    read_manifest_plus_tail_hits: AtomicUsize,
+    latest_metadata_view_reads: AtomicUsize,
 }
 
 impl RuntimeCacheStatsInner {
@@ -140,7 +140,7 @@ impl RuntimeCacheStatsInner {
         wal_tail_projection_cache: WalTailProjectionCacheStats,
     ) -> RuntimeCacheStats {
         RuntimeCacheStats {
-            read_manifest_plus_tail_hits: self.read_manifest_plus_tail_hits.load(Ordering::SeqCst),
+            latest_metadata_view_reads: self.latest_metadata_view_reads.load(Ordering::SeqCst),
             wal_tail_projection_cache_hits: wal_tail_projection_cache.hits,
             wal_tail_projection_cache_misses: wal_tail_projection_cache.misses,
             wal_tail_projection_cache_inserts: wal_tail_projection_cache.inserts,
@@ -163,8 +163,8 @@ impl RuntimeCacheStatsInner {
         }
     }
 
-    pub(crate) fn record_manifest_plus_tail_read(&self) {
-        self.read_manifest_plus_tail_hits
+    pub(crate) fn record_latest_metadata_view_read(&self) {
+        self.latest_metadata_view_reads
             .fetch_add(1, Ordering::SeqCst);
     }
 }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -428,7 +428,7 @@ impl Fs {
             "cache_path",
             crate::trace::CachePath::MaterializedTables.as_str(),
         );
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(entry)
     }
 
@@ -517,7 +517,7 @@ impl Fs {
         let page = engine
             .list_path_page_with_runtime_context(listed_path.as_str(), request, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         let head_seq = page
             .items
             .first()
@@ -547,7 +547,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_with_runtime_context(absolute_path, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -563,7 +563,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_with_runtime_context(absolute_path, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(revisions)
     }
 
@@ -581,7 +581,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_page_with_runtime_context(absolute_path, request, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             head.state.seq,
@@ -603,7 +603,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_for_inode_with_runtime_context(inode_id, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(revisions)
     }
 
@@ -624,7 +624,7 @@ impl Fs {
                 &read_context,
             )
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             head.state.seq,
@@ -646,7 +646,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_revision_with_runtime_context(absolute_path, revision_no, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -663,7 +663,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_revision_for_inode_with_runtime_context(inode_id, revision_no, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1380,7 +1380,7 @@ fn stat_and_list_use_initial_manifest_without_checkpoint() {
         .expect("list root");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
 }
 
 #[test]
@@ -1413,7 +1413,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
         .expect("list materialized docs");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
     assert_eq!(raw_store.content_blob_get_count(), 0);
     assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 }
@@ -1452,7 +1452,7 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
     assert_eq!(list[0].absolute_path, "/docs/file.txt");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
 }
 
 #[test]
@@ -1482,7 +1482,7 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 
     assert!(after_first.metadata_table_cache_inserts > 0);
     assert!(after_second.metadata_table_cache_hits > after_first.metadata_table_cache_hits);
-    assert_eq!(after_second.read_manifest_plus_tail_hits, 2);
+    assert_eq!(after_second.latest_metadata_view_reads, 2);
 }
 
 #[test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -545,7 +545,7 @@ store copies are not supported in v0 unless the content is first imported into
 the destination content store. Inode identity does not cross the namespace
 boundary.
 
-### 2.9 Recovery basis
+### 2.9 Recovery view
 
 Readers reconstruct authoritative state from:
 
@@ -623,12 +623,12 @@ Content must be durable before any metadata change can reference it.
 Content staging is idempotent and has no effect on the visible tree. If the
 caller crashes mid-upload, orphaned content objects are harmless.
 
-#### 3.1.2 Basis reconstruction
+#### 3.1.2 Metadata view loading
 
-Before evaluating commit requests, the server reconstructs the current
-metadata state using the same procedure described in section 3.2.1: load the
-head, load the current manifest (if any), and replay the visible WAL segment
-chain. The server never trusts caller-supplied metadata.
+Before evaluating commit requests, the server loads the current metadata view
+using the same procedure described in section 3.2.1: load the head, load the
+current manifest, and project the visible WAL segment chain. The server never
+trusts caller-supplied metadata.
 
 #### 3.1.3 Validation and logical commits
 
@@ -711,7 +711,7 @@ acceptance inside a batch is not success.
 A rejection judged against ephemeral state advanced by a tentative
 acceptance (step 2 in section 3.1.4) is contingent on that state publishing:
 if publication fails, the writer must report the publication failure for it,
-never the semantic rejection. Rejections judged against the durable basis
+never the semantic rejection. Rejections judged against the durable metadata view
 alone stand regardless of the publication outcome.
 
 ### 3.2 Read protocol
@@ -720,7 +720,7 @@ A read reconstructs the visible filesystem state from durable artifacts on
 object storage. No server-side cache or local database is required for
 correctness; everything needed is in the object store.
 
-#### 3.2.1 Basis reconstruction
+#### 3.2.1 Metadata view loading
 
 The reader builds an in-memory metadata state from two kinds of durable
 object:
@@ -735,19 +735,17 @@ object:
    versions for retention, fork, or stable read workflows. Reads use
    `current_manifest_id`; `latest_checkpoint_id` is not recovery authority.
 4. Use the visible WAL tip named by the head to identify the visible segment
-   chain after the manifest `head_seq` (or from genesis, if no current
-   manifest exists), then replay the logical commit records in ascending
+   chain after the manifest `head_seq`, then replay the logical commit records in ascending
    `seq` order through `head.seq`. Each logical commit appends normalized rows
    to the same metadata tables.
 
-The result is a complete metadata state pinned to one `seq`.
+The result is a metadata view pinned to one `seq`.
 
 For latest path `stat` and directory `list`, an implementation may avoid
-hydrating the complete metadata state when `current_manifest_id` is present.
-The reader may query verified metadata run tables and the visible WAL tail
+hydrating a complete metadata state. The reader may query verified metadata run tables and the visible WAL tail
 overlay directly, provided it applies the same visibility rules and treats
 missing or corrupt manifest/WAL objects as hard errors. If no current manifest
-is published, latest stat/list falls back to full basis reconstruction.
+is published for a complete namespace, the namespace is corrupt.
 
 #### 3.2.2 Visibility rules
 
@@ -986,7 +984,7 @@ The fork protocol is:
    rejected as existing, and a partial target is rejected as partially
    initialized.
 2. Resolve and verify the source namespace descriptor, content-store
-   descriptor, head, checkpoint, and WAL basis.
+   descriptor, head, checkpoint, and WAL visibility chain.
 3. Create or reuse a verified source checkpoint at the current source head.
 4. Build the target head, target manifest, and descriptor using the source
    namespace's `content_store_id`.
@@ -1166,7 +1164,7 @@ visible WAL segment chain over unverified or partial manifest artifacts.
 
 The namespace manifest may reference one or more immutable metadata runs. Runs
 are not a second source of truth; they are rebuildable metadata rows used to
-keep normal basis reconstruction from replaying an unbounded WAL tail.
+keep normal metadata view loading from replaying an unbounded WAL tail.
 
 For file revisions, a valid manifest includes the canonical `revisions` table
 and the `revisions_by_inode_desc` index table. The index table must contain

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3287,7 +3287,7 @@
           "wal_tail_segments": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of visible WAL segments after the manifest basis.",
+            "description": "Number of visible WAL segments after the current manifest.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
Standardizes the remaining metadata view and recovery naming.
