### PR TITLE
refactor(core): centralize maintenance head updates

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -159,8 +159,8 @@ pub struct HeadState {
     pub next_inode_id: InodeId,
     #[serde(default)]
     pub name_policy: NamePolicy,
-    /// Live read/recovery pointer. If present, basis reconstruction loads this
-    /// manifest before replaying the visible WAL tail.
+    /// Live read/recovery pointer. Reads load this manifest before projecting
+    /// the visible WAL tail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_manifest_id: Option<ManifestId>,
     /// Admin/provenance convenience pointer to the latest checkpoint record.

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -72,7 +72,7 @@ pub struct NamespaceStatusResponse {
     /// Latest checkpoint recorded by the head.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_checkpoint_id: Option<CheckpointId>,
-    /// Number of visible WAL segments after the manifest basis.
+    /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
     /// Oldest sequence still promised for incremental replay.
     pub retention_floor_seq: ChangeSeq,

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -139,6 +139,13 @@ pub(super) async fn publish_current_manifest_id<S: ObjectStore + ?Sized>(
             );
         }
 
+        // Maintenance head update, not semantic writer publication.
+        //
+        // This operation does not acquire writer_epoch. It only moves the
+        // manifest/checkpoint pointer forward and is linearized by the head
+        // CAS. If the head changes concurrently, the caller reloads and
+        // retries/rebases. Operations that publish user mutations or
+        // intentionally stop writers must acquire writer_epoch first.
         let next_head = HeadState {
             namespace_id: current_head.namespace_id.clone(),
             seq: current_head.seq,

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -4,13 +4,11 @@
 use super::create::checkpoint_record_by_id;
 use super::error::ManifestLoadError;
 use super::load::{load_namespace_manifest_envelope, load_namespace_manifest_envelope_if_present};
+use crate::control_update::{update_head, ControlUpdateError, HeadUpdate};
 use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
-use crate::namespace::control::read_head_object;
 use bytes::Bytes;
-use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope,
-};
+use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
 use loonfs_api::{CheckpointId, ManifestId, NamespaceId};
 use loonfs_objectstore::keys::namespace_manifest;
@@ -105,14 +103,69 @@ pub(super) async fn publish_current_manifest_id<S: ObjectStore + ?Sized>(
     checkpoint_id: &CheckpointId,
     writer_version: &str,
 ) -> Result<ManifestPublicationOutcome, CoreError> {
-    for _attempt in 0..HEAD_CAS_RETRY_LIMIT {
-        let loaded_head = read_head_object(store, namespace_id)
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-            })?;
-        let current_head = loaded_head.envelope.state;
-        if current_head.current_manifest_id >= Some(manifest_id) {
+    enum HeadAdvance {
+        AlreadyCurrent(Box<HeadState>),
+        Published(Box<HeadState>),
+    }
+
+    let advance = update_head(
+        store,
+        namespace_id,
+        writer_version,
+        HEAD_CAS_RETRY_LIMIT,
+        |loaded| {
+            let current_head = &loaded.envelope.state;
+            if current_head.current_manifest_id >= Some(manifest_id) {
+                return Ok(HeadUpdate::Noop(HeadAdvance::AlreadyCurrent(Box::new(
+                    current_head.clone(),
+                ))));
+            }
+
+            // Maintenance head update, not semantic writer publication.
+            //
+            // This operation does not acquire writer_epoch. It only moves the
+            // manifest/checkpoint pointer forward and is linearized by the head
+            // CAS. If the head changes concurrently, the caller reloads and
+            // retries/rebases. Operations that publish user mutations or
+            // intentionally stop writers must acquire writer_epoch first.
+            let next_head = HeadState {
+                namespace_id: current_head.namespace_id.clone(),
+                seq: current_head.seq,
+                head_commit_id: current_head.head_commit_id.clone(),
+                writer_epoch: current_head.writer_epoch,
+                writer_lease: current_head.writer_lease.clone(),
+                next_inode_id: current_head.next_inode_id,
+                name_policy: current_head.name_policy,
+                current_manifest_id: Some(manifest_id),
+                latest_checkpoint_id: Some(checkpoint_id.clone()),
+                retention_floor_seq: current_head.retention_floor_seq,
+                visible_wal_tip: current_head.visible_wal_tip.clone(),
+                state: current_head.state,
+            };
+            Ok(HeadUpdate::Replace {
+                next: Box::new(next_head.clone()),
+                outcome: HeadAdvance::Published(Box::new(next_head)),
+            })
+        },
+    )
+    .await;
+
+    let advance = match advance {
+        Ok(advance) => advance,
+        Err(ControlUpdateError::RetryExhausted { .. }) => {
+            return Ok(ManifestPublicationOutcome::HeadCasRaceLost);
+        }
+        Err(ControlUpdateError::LoadHead(error)) => {
+            return Err(CoreError::MetadataProjection(
+                MetadataProjectionLoadError::LoadHead(error),
+            ));
+        }
+        Err(other) => return Err(CoreError::Store(other.to_string())),
+    };
+
+    match advance {
+        HeadAdvance::Published(next_head) => Ok(ManifestPublicationOutcome::Published(next_head)),
+        HeadAdvance::AlreadyCurrent(current_head) => {
             let current_manifest_id = current_head.current_manifest_id.ok_or_else(|| {
                 CoreError::CheckpointUnavailable(format!(
                     "namespace `{}` has no published manifest",
@@ -128,76 +181,13 @@ pub(super) async fn publish_current_manifest_id<S: ObjectStore + ?Sized>(
                         ))
                     })?;
             if checkpoint_record_by_id(&current_manifest, checkpoint_id).is_some() {
-                return Ok(ManifestPublicationOutcome::Published(Box::new(
-                    current_head,
-                )));
+                return Ok(ManifestPublicationOutcome::Published(current_head));
             }
-            return Ok(
+            Ok(
                 ManifestPublicationOutcome::CurrentManifestMissingCheckpoint {
                     current_manifest_id,
                 },
-            );
-        }
-
-        // Maintenance head update, not semantic writer publication.
-        //
-        // This operation does not acquire writer_epoch. It only moves the
-        // manifest/checkpoint pointer forward and is linearized by the head
-        // CAS. If the head changes concurrently, the caller reloads and
-        // retries/rebases. Operations that publish user mutations or
-        // intentionally stop writers must acquire writer_epoch first.
-        let next_head = HeadState {
-            namespace_id: current_head.namespace_id.clone(),
-            seq: current_head.seq,
-            head_commit_id: current_head.head_commit_id.clone(),
-            writer_epoch: current_head.writer_epoch,
-            writer_lease: current_head.writer_lease.clone(),
-            next_inode_id: current_head.next_inode_id,
-            name_policy: current_head.name_policy,
-            current_manifest_id: Some(manifest_id),
-            latest_checkpoint_id: Some(checkpoint_id.clone()),
-            retention_floor_seq: current_head.retention_floor_seq,
-            visible_wal_tip: current_head.visible_wal_tip.clone(),
-            state: current_head.state,
-        };
-        match compare_and_swap_head(
-            store,
-            &loaded_head.object_key,
-            loaded_head.metadata.etag.as_deref(),
-            writer_version,
-            &next_head,
-        )
-        .await
-        {
-            Ok(()) => return Ok(ManifestPublicationOutcome::Published(Box::new(next_head))),
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(error) => return Err(CoreError::Store(error.to_string())),
+            )
         }
     }
-
-    Ok(ManifestPublicationOutcome::HeadCasRaceLost)
-}
-
-pub(super) async fn compare_and_swap_head<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_head_etag: Option<&str>,
-    writer_version: &str,
-    next_head: &HeadState,
-) -> Result<(), ObjectStoreError> {
-    let expected_head_etag = expected_head_etag.ok_or_else(|| {
-        ObjectStoreError::Transport(format!("missing head etag for `{object_key}`"))
-    })?;
-    let envelope = HeadStateEnvelope::from_state(
-        ControlObjectKind::NamespaceHead,
-        writer_version,
-        next_head.clone(),
-    )
-    .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
-    let encoded = encode_control_object(&envelope)
-        .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
-    store
-        .compare_and_swap(object_key, expected_head_etag, Bytes::from(encoded))
-        .await
-        .map(|_| ())
 }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -1,88 +1,92 @@
 //! Retention floor advancement against the current verified manifest.
 
 use super::load::load_verified_manifest_tables;
-use super::publish::{compare_and_swap_head, HEAD_CAS_RETRY_LIMIT};
+use super::publish::HEAD_CAS_RETRY_LIMIT;
 use crate::context::MutationContext;
+use crate::control_update::{update_head, ControlUpdateError, HeadUpdate};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError};
 use crate::namespace::control::read_head_object;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
-use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use loonfs_objectstore::ObjectStore;
 
 pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<AdvanceRetentionResponse, CoreError> {
-    for _attempt in 0..HEAD_CAS_RETRY_LIMIT {
-        let loaded_head = read_head_object(store, namespace_id)
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-            })?;
-        let head = loaded_head.envelope.state;
-        let current_manifest_id =
-            head.current_manifest_id
-                .ok_or_else(|| MetadataViewError::MissingManifest {
-                    namespace_id: namespace_id.clone(),
-                })?;
-        let manifest_tables =
-            load_verified_manifest_tables(store, namespace_id, current_manifest_id)
-                .await
-                .map_err(|error| {
-                    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-                })?;
-        let target_floor = manifest_tables.manifest().payload.head_seq;
-
-        if head.retention_floor_seq >= target_floor {
-            return Ok(AdvanceRetentionResponse {
-                namespace_id: namespace_id.clone(),
-                retention_floor_seq: head.retention_floor_seq,
-            });
-        }
-
-        // Maintenance head update.
-        //
-        // Advancing retention_floor_seq is a metadata-retention decision. It
-        // preserves writer_epoch and writer_lease and is serialized by head
-        // CAS. It must not make new WAL visible and must not delete
-        // checkpoint-reachable files by itself.
-        let next_head = HeadState {
-            namespace_id: head.namespace_id.clone(),
-            seq: head.seq,
-            head_commit_id: head.head_commit_id.clone(),
-            writer_epoch: head.writer_epoch,
-            writer_lease: head.writer_lease.clone(),
-            next_inode_id: head.next_inode_id,
-            name_policy: head.name_policy,
-            current_manifest_id: head.current_manifest_id,
-            latest_checkpoint_id: head.latest_checkpoint_id.clone(),
-            retention_floor_seq: target_floor,
-            visible_wal_tip: head.visible_wal_tip.clone(),
-            state: head.state,
-        };
-        match compare_and_swap_head(
-            store,
-            &loaded_head.object_key,
-            loaded_head.metadata.etag.as_deref(),
-            &context.writer_version,
-            &next_head,
-        )
+    // Derive the target floor from the currently published manifest before
+    // entering the head update. If a newer manifest lands while the CAS
+    // below retries, publishing this floor is still safe: floors only move
+    // forward and the newer manifest covers at least this much history.
+    let loaded_head = read_head_object(store, namespace_id)
         .await
-        {
-            Ok(()) => {
-                return Ok(AdvanceRetentionResponse {
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    let current_manifest_id = loaded_head
+        .envelope
+        .state
+        .current_manifest_id
+        .ok_or_else(|| MetadataViewError::MissingManifest {
+            namespace_id: namespace_id.clone(),
+        })?;
+    let manifest_tables = load_verified_manifest_tables(store, namespace_id, current_manifest_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let target_floor = manifest_tables.manifest().payload.head_seq;
+
+    update_head(
+        store,
+        namespace_id,
+        &context.writer_version,
+        HEAD_CAS_RETRY_LIMIT,
+        |loaded| {
+            let head = &loaded.envelope.state;
+            if head.retention_floor_seq >= target_floor {
+                return Ok(HeadUpdate::Noop(AdvanceRetentionResponse {
+                    namespace_id: namespace_id.clone(),
+                    retention_floor_seq: head.retention_floor_seq,
+                }));
+            }
+
+            // Maintenance head update.
+            //
+            // Advancing retention_floor_seq is a metadata-retention decision. It
+            // preserves writer_epoch and writer_lease and is serialized by head
+            // CAS. It must not make new WAL visible and must not delete
+            // checkpoint-reachable files by itself.
+            let next_head = HeadState {
+                namespace_id: head.namespace_id.clone(),
+                seq: head.seq,
+                head_commit_id: head.head_commit_id.clone(),
+                writer_epoch: head.writer_epoch,
+                writer_lease: head.writer_lease.clone(),
+                next_inode_id: head.next_inode_id,
+                name_policy: head.name_policy,
+                current_manifest_id: head.current_manifest_id,
+                latest_checkpoint_id: head.latest_checkpoint_id.clone(),
+                retention_floor_seq: target_floor,
+                visible_wal_tip: head.visible_wal_tip.clone(),
+                state: head.state,
+            };
+            Ok(HeadUpdate::Replace {
+                next: Box::new(next_head),
+                outcome: AdvanceRetentionResponse {
                     namespace_id: namespace_id.clone(),
                     retention_floor_seq: target_floor,
-                });
-            }
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(error) => return Err(CoreError::Store(error.to_string())),
+                },
+            })
+        },
+    )
+    .await
+    .map_err(|error: ControlUpdateError| match error {
+        ControlUpdateError::LoadHead(error) => {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
         }
-    }
-
-    Err(CoreError::Store(
-        "retention floor compare-and-swap retry exhausted".to_owned(),
-    ))
+        other => CoreError::Store(other.to_string()),
+    })
 }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -42,6 +42,12 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             });
         }
 
+        // Maintenance head update.
+        //
+        // Advancing retention_floor_seq is a metadata-retention decision. It
+        // preserves writer_epoch and writer_lease and is serialized by head
+        // CAS. It must not make new WAL visible and must not delete
+        // checkpoint-reachable files by itself.
         let next_head = HeadState {
             namespace_id: head.namespace_id.clone(),
             seq: head.seq,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -31,7 +31,9 @@ use super::runs::{
 use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
+use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::ops::{move_path, put_file_bytes, write_file_bytes};
+use crate::protocol::list_changes_after;
 use crate::MutationContext;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -44,15 +46,16 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestPayload,
 };
 use loonfs_api::{
-    validate_checkpoint_id, ChangeSeq, CheckpointId, CommitId, InodeId, ManifestId, NamespaceId,
-    PutBehavior,
+    validate_checkpoint_id, ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId,
+    NamespaceId, PutBehavior,
 };
 use loonfs_objectstore::fs::LocalFsStore;
-use loonfs_objectstore::keys::{metadata_sst, namespace_head, namespace_manifest};
+use loonfs_objectstore::keys::{metadata_sst, namespace_head, namespace_manifest, wal_segment};
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU32;
 use std::sync::Mutex;
 use tempfile::tempdir;
 
@@ -383,6 +386,134 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
         .await
         .expect("manifest head")
         .is_some());
+}
+
+#[tokio::test]
+async fn checkpoint_publication_preserves_writer_identity() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    acquire_writer_epoch(&store, &namespace_id, &context)
+        .await
+        .expect("acquire writer");
+    let before = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("load before checkpoint")
+        .head;
+
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let after = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("load after checkpoint")
+        .head;
+
+    assert_eq!(after.writer_epoch, before.writer_epoch);
+    assert_eq!(after.writer_lease, before.writer_lease);
+}
+
+#[tokio::test]
+async fn retention_floor_advancement_preserves_writer_identity() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let before = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("load before retention")
+        .head;
+
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+    let after = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("load after retention")
+        .head;
+
+    assert_eq!(after.retention_floor_seq, ChangeSeq(1));
+    assert_eq!(after.writer_epoch, before.writer_epoch);
+    assert_eq!(after.writer_lease, before.writer_lease);
+}
+
+#[tokio::test]
+async fn maintenance_does_not_make_orphan_wal_visible() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/first.txt",
+        b"first\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write first");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/second.txt",
+        b"second\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write second");
+
+    let orphan_key = wal_segment(
+        namespace_id.as_str(),
+        "00000000000000000002-deadbeefdeadbeef",
+    );
+    store
+        .put_overwrite(&orphan_key, Bytes::from_static(b"not a wal envelope"))
+        .await
+        .expect("write orphan wal");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+
+    let changes = list_changes_after(
+        &store,
+        &namespace_id,
+        ChangeSeq(1),
+        EffectiveLimit::new(NonZeroU32::new(10).expect("nonzero")),
+    )
+    .await
+    .expect("list changes");
+
+    assert_eq!(changes.through_seq, ChangeSeq(2));
+    assert_eq!(changes.changes.len(), 1);
+    assert_eq!(changes.changes[0].seq, ChangeSeq(2));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -105,7 +105,7 @@ define_invariant_ids! {
     (NamespaceManifestMustBeVerified, "namespace_manifest_must_be_verified"),
     (ManifestReplayRequiresAllManifestSegments, "manifest_replay_requires_all_manifest_segments"),
     (MetadataFileRefMatchesPayload, "manifest_segment_descriptor_matches_payload"),
-    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_basis_metadata"),
+    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_manifest_metadata"),
     (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
     (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
@@ -145,7 +145,7 @@ define_invariant_ids! {
     (MetadataSegmentKeyMatchesFamilyAndIndex, "manifest_segment_key_matches_family_and_index"),
     (VerifiedNamespaceManifestRequiresDurableSegments, "verified_namespace_manifest_requires_durable_segments"),
     (NamespaceManifestPreservesHeadSummary, "namespace_manifest_preserves_head_summary"),
-    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_basis_metadata"),
+    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_metadata_view"),
 
     // Client transfer download invariants.
     (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -105,7 +105,7 @@ define_invariant_ids! {
     (NamespaceManifestMustBeVerified, "namespace_manifest_must_be_verified"),
     (ManifestReplayRequiresAllManifestSegments, "manifest_replay_requires_all_manifest_segments"),
     (MetadataFileRefMatchesPayload, "manifest_segment_descriptor_matches_payload"),
-    (MetadataSstRowsRestoreBasisMetadata, "manifest_segment_rows_restore_manifest_metadata"),
+    (MetadataSstRowsRestoreManifestMetadata, "manifest_segment_rows_restore_manifest_metadata"),
     (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
     (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
@@ -145,7 +145,7 @@ define_invariant_ids! {
     (MetadataSegmentKeyMatchesFamilyAndIndex, "manifest_segment_key_matches_family_and_index"),
     (VerifiedNamespaceManifestRequiresDurableSegments, "verified_namespace_manifest_requires_durable_segments"),
     (NamespaceManifestPreservesHeadSummary, "namespace_manifest_preserves_head_summary"),
-    (NamespaceManifestPreservesBasisMetadata, "namespace_manifest_preserves_metadata_view"),
+    (NamespaceManifestPreservesMetadata, "namespace_manifest_preserves_metadata"),
 
     // Client transfer download invariants.
     (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -134,7 +134,7 @@ impl<'a> InMemoryMetadataView<'a> {
 }
 
 impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
-    pub(crate) fn manifest_plus_tail(
+    pub(crate) fn from_loaded_head(
         head: &'a HeadState,
         tables: &'a VerifiedMetadataTables<'store, S>,
         wal_tail_rows: &'a MetadataState,

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -575,4 +575,143 @@ mod tests {
             self.inner.list_prefix_stream(prefix)
         }
     }
+
+    #[tokio::test]
+    async fn cas_conflict_then_fenced_yields_held_by_other_writer() {
+        // writer-a's lease has expired and writer-c starts a takeover. Its
+        // CAS loses to writer-b, whose fresh lease must fence writer-c out on
+        // the conflict re-read instead of being clobbered by another bump.
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+        write_head(
+            &inner,
+            &namespace_id,
+            leased_head(
+                &namespace_id,
+                "writer-a",
+                "session-a",
+                WriterEpoch(7),
+                1_000,
+            ),
+        )
+        .await;
+        let store = TakeoverOnCasConflictStore {
+            inner,
+            namespace_id: namespace_id.clone(),
+            remaining_conflicts: AtomicUsize::new(1),
+        };
+
+        let error = acquire_writer_epoch(
+            &store,
+            &namespace_id,
+            &context("writer-c", "session-c", 2_000),
+        )
+        .await
+        .expect_err("conflicting takeover must observe the winner's lease");
+
+        assert!(matches!(
+            error,
+            WriterEpochAcquireError::HeldByOtherWriter { ref writer_id, .. }
+                if writer_id == "writer-b"
+        ));
+        let head = read_head_object(&store.inner, &namespace_id)
+            .await
+            .expect("read head")
+            .envelope
+            .state;
+        assert_eq!(head.writer_epoch, WriterEpoch(8));
+        let lease = head.writer_lease.expect("active lease");
+        assert_eq!(lease.writer_id, "writer-b");
+    }
+
+    #[derive(Debug)]
+    struct TakeoverOnCasConflictStore {
+        inner: LocalFsStore,
+        namespace_id: NamespaceId,
+        remaining_conflicts: AtomicUsize,
+    }
+
+    impl TakeoverOnCasConflictStore {
+        async fn inject_winner(&self) {
+            let winner = leased_head(
+                &self.namespace_id,
+                "writer-b",
+                "session-b",
+                WriterEpoch(8),
+                99_000,
+            );
+            let envelope = HeadStateEnvelope::from_state(
+                ControlObjectKind::NamespaceHead,
+                WRITER_VERSION,
+                winner,
+            )
+            .expect("head envelope");
+            let bytes = encode_control_object(&envelope).expect("head bytes");
+            self.inner
+                .put(
+                    &namespace_head(self.namespace_id.as_str()),
+                    Bytes::from(bytes),
+                    PutMode::Overwrite,
+                )
+                .await
+                .expect("write winner head");
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for TakeoverOnCasConflictStore {
+        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> Result<Option<Bytes>, ObjectStoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: Bytes,
+            mode: PutMode,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn compare_and_swap(
+            &self,
+            key: &str,
+            expected_etag: &str,
+            bytes: Bytes,
+        ) -> Result<ObjectMetadata, ObjectStoreError> {
+            if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
+                self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
+                self.inject_winner().await;
+                return Err(ObjectStoreError::PreconditionFailed);
+            }
+            self.inner.compare_and_swap(key, expected_etag, bytes).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            prefix: &str,
+        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
 }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -702,7 +702,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     }
 
     fn metadata_view(&self) -> MetadataView<'_, '_, S> {
-        MetadataView::manifest_plus_tail(&self.head, &self.tables, self.wal_tail_rows.as_ref())
+        MetadataView::from_loaded_head(&self.head, &self.tables, self.wal_tail_rows.as_ref())
     }
 }
 

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -750,7 +750,7 @@ mod tests {
     use crate::metadata::{DirentryBindRecord, InodeRecord};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::path::write::ops::{delete_path, put_file_bytes};
-    use crate::protocol::{load_publish_manifest_plus_tail_view, PublishTailOptions};
+    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::v0::{CommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest};
     use loonfs_api::RevisionNo;
@@ -812,7 +812,7 @@ mod tests {
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
     ) -> Result<PlannedPathMutation, CoreError> {
-        let (view, _projection) = load_publish_manifest_plus_tail_view(
+        let (view, _projection) = load_publish_metadata_view(
             store,
             namespace_id,
             None,

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -103,7 +103,7 @@ impl PublishBatchAgainstViewResult {
     }
 }
 
-pub(crate) struct PublishManifestPlusTailView<'a, S: ObjectStore + ?Sized> {
+pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     content_store_id: ContentStoreId,
     head: HeadState,
     head_etag: String,
@@ -112,13 +112,13 @@ pub(crate) struct PublishManifestPlusTailView<'a, S: ObjectStore + ?Sized> {
     tail_state: MetadataState,
 }
 
-impl<S: ObjectStore + ?Sized> PublishManifestPlusTailView<'_, S> {
+impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
     pub(crate) fn head(&self) -> &HeadState {
         &self.head
     }
 
     pub(crate) fn metadata_view(&self) -> MetadataView<'_, '_, S> {
-        MetadataView::manifest_plus_tail(&self.head, &self.manifest_tables, &self.tail_state)
+        MetadataView::from_loaded_head(&self.head, &self.manifest_tables, &self.tail_state)
     }
 
     async fn find_commit_receipt(
@@ -579,7 +579,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         }
     };
     let publish_tail_options = PublishTailOptions::default();
-    let publish_view = match load_publish_manifest_plus_tail_view(
+    let publish_view = match load_publish_metadata_view(
         store,
         namespace_id,
         Some(acquired_writer),
@@ -606,13 +606,13 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     .results
 }
 
-pub(crate) async fn load_publish_manifest_plus_tail_view<'a, S: ObjectStore + ?Sized>(
+pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
     acquired_writer: Option<AcquiredWriter>,
     cached_projection: Option<&PublishTailProjection>,
     options: &PublishTailOptions,
-) -> Result<(PublishManifestPlusTailView<'a, S>, PublishTailProjection), CoreError> {
+) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection), CoreError> {
     let catalog_entry = load_namespace_catalog_entry(store, namespace_id)
         .await
         .map_err(|error| CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)))?;
@@ -678,7 +678,7 @@ pub(crate) async fn load_publish_manifest_plus_tail_view<'a, S: ObjectStore + ?S
     ensure_publish_head_etag_still_current(store, namespace_id, &head_etag).await?;
 
     Ok((
-        PublishManifestPlusTailView {
+        PublishMetadataView {
             content_store_id: catalog_entry.content_store_id,
             head,
             head_etag,
@@ -828,7 +828,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     namespace_id: &NamespaceId,
     candidates: &[NamespaceMutationCandidate],
     context: &MutationContext,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
         return PublishBatchAgainstViewResult::new(Vec::new());
@@ -1098,7 +1098,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
 #[allow(clippy::too_many_arguments)]
 async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
     session: &PublishPlanningSession,
     candidate: &NamespaceMutationCandidate,
     index: usize,
@@ -1245,7 +1245,7 @@ fn validate_commit_id(commit_id: &CommitId) -> Result<(), CoreError> {
 #[allow(clippy::too_many_arguments)]
 async fn record_primary_request_or_complete_idempotent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
-    view: &PublishManifestPlusTailView<'_, S>,
+    view: &PublishMetadataView<'_, S>,
     outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
     in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -8,9 +8,7 @@ use crate::path::write::{
     path_intent_fingerprint_for_path_intent, PathMutationIntent, PlannedPathMutation,
     PublishPlanningSession,
 };
-use crate::protocol::{
-    load_publish_manifest_plus_tail_view, PublishTailOptions, PublishTailProjection,
-};
+use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, MutationResult, NamespaceId};
 use loonfs_objectstore::ObjectStore;
@@ -135,7 +133,7 @@ impl NamespaceCommitEngine {
             }
         };
 
-        let (publish_view, projection) = match load_publish_manifest_plus_tail_view(
+        let (publish_view, projection) = match load_publish_metadata_view(
             store,
             &self.namespace_id,
             Some(acquired_writer),
@@ -244,7 +242,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
     ) -> Result<PlannedPathMutation, CoreError> {
-        let (view, _projection) = load_publish_manifest_plus_tail_view(
+        let (view, _projection) = load_publish_metadata_view(
             self.store,
             namespace_id,
             None,

--- a/crates/loonfs-core/tests/differential.rs
+++ b/crates/loonfs-core/tests/differential.rs
@@ -245,7 +245,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
 }
 
 fn model_bootstrap_state() -> ModelMetadataState {
-    loonfs_model::bootstrap_basis_metadata_state()
+    loonfs_model::bootstrap_metadata_state()
 }
 
 fn assert_states_match(sequences: &[Vec<WalDelta>]) {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1705,7 +1705,7 @@ async fn query_driven_reads_use_initial_manifest_with_wal_overlay() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn query_driven_stat_and_list_use_manifest_plus_tail_with_l0_run_and_wal_overlay() {
+async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overlay() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let context = mutation_context();

--- a/crates/loonfs-model/src/genesis.rs
+++ b/crates/loonfs-model/src/genesis.rs
@@ -1,7 +1,7 @@
 use crate::metadata::{InodeRecord, MetadataState};
 use loonfs_api::{ChangeSeq, InodeId, InodeKind};
 
-pub fn bootstrap_basis_metadata_state() -> MetadataState {
+pub fn bootstrap_metadata_state() -> MetadataState {
     MetadataState {
         inodes: vec![InodeRecord {
             inode_id: InodeId(1),

--- a/crates/loonfs-model/src/lib.rs
+++ b/crates/loonfs-model/src/lib.rs
@@ -10,4 +10,4 @@ mod genesis;
 pub mod metadata;
 pub mod wal;
 
-pub use genesis::bootstrap_basis_metadata_state;
+pub use genesis::bootstrap_metadata_state;

--- a/crates/loonfs-model/src/wal.rs
+++ b/crates/loonfs-model/src/wal.rs
@@ -16,12 +16,12 @@ pub enum WalReplayError {
 }
 
 pub fn replay_wal_tail_with_metadata(
-    basis_head: &HeadState,
-    basis_metadata_state: &MetadataState,
+    base_head: &HeadState,
+    base_metadata_state: &MetadataState,
     wal_tail: &[(ChangeSeq, Vec<WalDelta>)],
 ) -> Result<ReplayedWalTail, WalReplayError> {
-    let mut current_head = basis_head.clone();
-    let mut current_metadata_state = basis_metadata_state.clone();
+    let mut current_head = base_head.clone();
+    let mut current_metadata_state = base_metadata_state.clone();
 
     for (seq, deltas) in wal_tail {
         let applied = current_metadata_state

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -94,8 +94,8 @@ pub(crate) struct CachedControl<T> {
 /// understanding read/write warmup behavior.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuntimeCacheStats {
-    /// Metadata reads served from manifest tables plus WAL tail projection.
-    pub read_manifest_plus_tail_hits: usize,
+    /// Latest metadata reads served through the metadata-view path.
+    pub latest_metadata_view_reads: usize,
     /// WAL-tail projection cache hits.
     pub wal_tail_projection_cache_hits: usize,
     /// WAL-tail projection cache misses.
@@ -130,7 +130,7 @@ pub struct RuntimeCacheStats {
 
 #[derive(Debug, Default)]
 pub(crate) struct RuntimeCacheStatsInner {
-    read_manifest_plus_tail_hits: AtomicUsize,
+    latest_metadata_view_reads: AtomicUsize,
 }
 
 impl RuntimeCacheStatsInner {
@@ -140,7 +140,7 @@ impl RuntimeCacheStatsInner {
         wal_tail_projection_cache: WalTailProjectionCacheStats,
     ) -> RuntimeCacheStats {
         RuntimeCacheStats {
-            read_manifest_plus_tail_hits: self.read_manifest_plus_tail_hits.load(Ordering::SeqCst),
+            latest_metadata_view_reads: self.latest_metadata_view_reads.load(Ordering::SeqCst),
             wal_tail_projection_cache_hits: wal_tail_projection_cache.hits,
             wal_tail_projection_cache_misses: wal_tail_projection_cache.misses,
             wal_tail_projection_cache_inserts: wal_tail_projection_cache.inserts,
@@ -163,8 +163,8 @@ impl RuntimeCacheStatsInner {
         }
     }
 
-    pub(crate) fn record_manifest_plus_tail_read(&self) {
-        self.read_manifest_plus_tail_hits
+    pub(crate) fn record_latest_metadata_view_read(&self) {
+        self.latest_metadata_view_reads
             .fetch_add(1, Ordering::SeqCst);
     }
 }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -428,7 +428,7 @@ impl Fs {
             "cache_path",
             crate::trace::CachePath::MaterializedTables.as_str(),
         );
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(entry)
     }
 
@@ -517,7 +517,7 @@ impl Fs {
         let page = engine
             .list_path_page_with_runtime_context(listed_path.as_str(), request, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         let head_seq = page
             .items
             .first()
@@ -547,7 +547,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_with_runtime_context(absolute_path, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -563,7 +563,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_with_runtime_context(absolute_path, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(revisions)
     }
 
@@ -581,7 +581,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_page_with_runtime_context(absolute_path, request, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             head.state.seq,
@@ -603,7 +603,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .list_file_revisions_for_inode_with_runtime_context(inode_id, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(revisions)
     }
 
@@ -624,7 +624,7 @@ impl Fs {
                 &read_context,
             )
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             head.state.seq,
@@ -646,7 +646,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_revision_with_runtime_context(absolute_path, revision_no, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -663,7 +663,7 @@ impl Fs {
             .namespace_engine(namespace_id)
             .read_file_revision_for_inode_with_runtime_context(inode_id, revision_no, &read_context)
             .await?;
-        self.inner.cache_stats.record_manifest_plus_tail_read();
+        self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(read)
     }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1380,7 +1380,7 @@ fn stat_and_list_use_initial_manifest_without_checkpoint() {
         .expect("list root");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
 }
 
 #[test]
@@ -1413,7 +1413,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
         .expect("list materialized docs");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
     assert_eq!(raw_store.content_blob_get_count(), 0);
     assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 }
@@ -1452,7 +1452,7 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
     assert_eq!(list[0].absolute_path, "/docs/file.txt");
 
     let stats = fs.runtime_cache_stats();
-    assert_eq!(stats.read_manifest_plus_tail_hits, 2);
+    assert_eq!(stats.latest_metadata_view_reads, 2);
 }
 
 #[test]
@@ -1482,7 +1482,7 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 
     assert!(after_first.metadata_table_cache_inserts > 0);
     assert!(after_second.metadata_table_cache_hits > after_first.metadata_table_cache_hits);
-    assert_eq!(after_second.read_manifest_plus_tail_hits, 2);
+    assert_eq!(after_second.latest_metadata_view_reads, 2);
 }
 
 #[test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -154,7 +154,27 @@ within the relevant namespace incarnation.
 Underscores are reserved for generated opaque ID prefixes and JSON snake_case
 values. Fixed object-store path-family names should not use underscores.
 
-### 1.4 WAL segment rules
+### 1.4 Head update authority
+
+The namespace head is updated by different classes of work, and each class has
+its own authority boundary.
+
+Semantic namespace mutations — file writes, restores, renames, deletes, and
+explicit commits — are fenced by `writer_epoch` and then linearized by the head
+compare-and-swap that makes their WAL visible.
+
+Checkpoint and retention maintenance updates are CAS-linearized metadata
+updates. They preserve `writer_epoch` and `writer_lease`, and must not make
+uncommitted WAL visible. Maintenance may race with semantic writers; on head
+CAS conflict it must reload the latest head and rebase or retry the metadata
+update. It must not bump `writer_epoch` unless its purpose is to intentionally
+fence writers.
+
+Destructive namespace-admin updates that intentionally stop writers, such as
+namespace deletion, must fence writers first or publish an equivalent terminal
+state that prevents stale writers from succeeding.
+
+### 1.5 WAL segment rules
 
 The metadata log has six rules.
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -545,7 +545,7 @@ store copies are not supported in v0 unless the content is first imported into
 the destination content store. Inode identity does not cross the namespace
 boundary.
 
-### 2.9 Recovery basis
+### 2.9 Recovery view
 
 Readers reconstruct authoritative state from:
 
@@ -623,12 +623,12 @@ Content must be durable before any metadata change can reference it.
 Content staging is idempotent and has no effect on the visible tree. If the
 caller crashes mid-upload, orphaned content objects are harmless.
 
-#### 3.1.2 Basis reconstruction
+#### 3.1.2 Metadata view loading
 
-Before evaluating commit requests, the server reconstructs the current
-metadata state using the same procedure described in section 3.2.1: load the
-head, load the current manifest (if any), and replay the visible WAL segment
-chain. The server never trusts caller-supplied metadata.
+Before evaluating commit requests, the server loads the current metadata view
+using the same procedure described in section 3.2.1: load the head, load the
+current manifest, and project the visible WAL segment chain. The server never
+trusts caller-supplied metadata.
 
 #### 3.1.3 Validation and logical commits
 
@@ -711,7 +711,7 @@ acceptance inside a batch is not success.
 A rejection judged against ephemeral state advanced by a tentative
 acceptance (step 2 in section 3.1.4) is contingent on that state publishing:
 if publication fails, the writer must report the publication failure for it,
-never the semantic rejection. Rejections judged against the durable basis
+never the semantic rejection. Rejections judged against the durable metadata view
 alone stand regardless of the publication outcome.
 
 ### 3.2 Read protocol
@@ -720,7 +720,7 @@ A read reconstructs the visible filesystem state from durable artifacts on
 object storage. No server-side cache or local database is required for
 correctness; everything needed is in the object store.
 
-#### 3.2.1 Basis reconstruction
+#### 3.2.1 Metadata view loading
 
 The reader builds an in-memory metadata state from two kinds of durable
 object:
@@ -735,19 +735,17 @@ object:
    versions for retention, fork, or stable read workflows. Reads use
    `current_manifest_id`; `latest_checkpoint_id` is not recovery authority.
 4. Use the visible WAL tip named by the head to identify the visible segment
-   chain after the manifest `head_seq` (or from genesis, if no current
-   manifest exists), then replay the logical commit records in ascending
+   chain after the manifest `head_seq`, then replay the logical commit records in ascending
    `seq` order through `head.seq`. Each logical commit appends normalized rows
    to the same metadata tables.
 
-The result is a complete metadata state pinned to one `seq`.
+The result is a metadata view pinned to one `seq`.
 
 For latest path `stat` and directory `list`, an implementation may avoid
-hydrating the complete metadata state when `current_manifest_id` is present.
-The reader may query verified metadata run tables and the visible WAL tail
+hydrating a complete metadata state. The reader may query verified metadata run tables and the visible WAL tail
 overlay directly, provided it applies the same visibility rules and treats
 missing or corrupt manifest/WAL objects as hard errors. If no current manifest
-is published, latest stat/list falls back to full basis reconstruction.
+is published for a complete namespace, the namespace is corrupt.
 
 #### 3.2.2 Visibility rules
 
@@ -986,7 +984,7 @@ The fork protocol is:
    rejected as existing, and a partial target is rejected as partially
    initialized.
 2. Resolve and verify the source namespace descriptor, content-store
-   descriptor, head, checkpoint, and WAL basis.
+   descriptor, head, checkpoint, and WAL visibility chain.
 3. Create or reuse a verified source checkpoint at the current source head.
 4. Build the target head, target manifest, and descriptor using the source
    namespace's `content_store_id`.
@@ -1166,7 +1164,7 @@ visible WAL segment chain over unverified or partial manifest artifacts.
 
 The namespace manifest may reference one or more immutable metadata runs. Runs
 are not a second source of truth; they are rebuildable metadata rows used to
-keep normal basis reconstruction from replaying an unbounded WAL tail.
+keep normal metadata view loading from replaying an unbounded WAL tail.
 
 For file revisions, a valid manifest includes the canonical `revisions` table
 and the `revisions_by_inode_desc` index table. The index table must contain

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -199,7 +199,7 @@ The metadata log has six rules.
 6. Orphan WAL segments are permitted and harmless when a writer loses the head
    compare-and-swap.
 
-### 1.5 Immutable content rules
+### 1.6 Immutable content rules
 
 The content model has five rules.
 
@@ -234,7 +234,7 @@ A reader or writer resolves content through the namespace descriptor:
 File revisions and change-feed payloads store only `content_ref`; they do not
 store content-store ids or object-store paths.
 
-### 1.6 Mutable control-object rules
+### 1.7 Mutable control-object rules
 
 Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
@@ -258,7 +258,7 @@ Large immutable file data may use multipart upload or another
 provider-specific optimization. Small mutable control objects should not
 depend on those mechanisms.
 
-### 1.7 Provider conformance
+### 1.8 Provider conformance
 
 The format standardizes the required behaviors, not a brand name such as "S3
 compatible." A provider is conforming only when those behaviors are verified

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3287,7 +3287,7 @@
           "wal_tail_segments": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of visible WAL segments after the manifest basis.",
+            "description": "Number of visible WAL segments after the current manifest.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
Makes the head-update authority split explicit — semantic writers are epoch-fenced, maintenance updates preserve writer identity and rebase on CAS conflict, destructive admin operations fence first — in the format spec and at both maintenance call sites. The two remaining bespoke maintenance head CAS loops (manifest publication, retention floor advance) now route through control_update::update_head so every rebasing head update shares one retry shape, and the conflict-then-fenced acquire path gets the regression test it was missing.