### PR TITLE
refactor(core): remove stack leftovers and tighten index checks

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -299,20 +299,20 @@ fn validate_manifest_table_descriptors(
             }
         }
 
-        if direntry_bind_rows > 0 && direntry_child_bind_rows == 0 {
+        if direntry_bind_rows != direntry_child_bind_rows {
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: manifest_object_key.to_owned(),
                 message: format!(
-                    "metadata run {:?} has direntry binds without direntry child-bind index descriptors",
+                    "metadata run {:?} has {direntry_bind_rows} direntry bind rows but {direntry_child_bind_rows} child-bind index rows",
                     run.run_seq
                 ),
             });
         }
-        if revision_rows > 0 && revision_by_inode_desc_rows == 0 {
+        if revision_rows != revision_by_inode_desc_rows {
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: manifest_object_key.to_owned(),
                 message: format!(
-                    "metadata run {:?} has revisions without revision-by-inode index descriptors",
+                    "metadata run {:?} has {revision_rows} revision rows but {revision_by_inode_desc_rows} revision index rows",
                     run.run_seq
                 ),
             });

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -3,7 +3,7 @@
 use super::load::load_verified_manifest_tables;
 use super::publish::HEAD_CAS_RETRY_LIMIT;
 use crate::context::MutationContext;
-use crate::control_update::{update_head, ControlUpdateError, HeadUpdate};
+use crate::control_update::{update_head, HeadUpdate};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError};
 use crate::namespace::control::read_head_object;
@@ -17,9 +17,10 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<AdvanceRetentionResponse, CoreError> {
     // Derive the target floor from the currently published manifest before
-    // entering the head update. If a newer manifest lands while the CAS
-    // below retries, publishing this floor is still safe: floors only move
-    // forward and the newer manifest covers at least this much history.
+    // entering the head update. The closure refuses to publish if the
+    // current manifest changes mid-update: manifest ids do not order
+    // coverage, so a newer id is no promise of newer history. The caller
+    // retries and re-derives from whatever manifest won.
     let loaded_head = read_head_object(store, namespace_id)
         .await
         .map_err(|error| {
@@ -53,6 +54,15 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
                 }));
             }
 
+            // The floor above was derived from `current_manifest_id`. Only
+            // publish it while that manifest is still current; any change
+            // aborts so the caller re-derives against the winner.
+            if head.current_manifest_id != Some(current_manifest_id) {
+                return Err(CoreError::CheckpointUnavailable(format!(
+                    "current manifest changed during retention advance (floor was derived from {current_manifest_id:?}); retry"
+                )));
+            }
+
             // Maintenance head update.
             //
             // Advancing retention_floor_seq is a metadata-retention decision. It
@@ -83,10 +93,4 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         },
     )
     .await
-    .map_err(|error: ControlUpdateError| match error {
-        ControlUpdateError::LoadHead(error) => {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        }
-        other => CoreError::Store(other.to_string()),
-    })
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -31,6 +31,7 @@ use super::runs::{
 use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
+use crate::namespace::control::read_head_object;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::ops::{move_path, put_file_bytes, write_file_bytes};
 use crate::protocol::list_changes_after;
@@ -502,6 +503,13 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
         .await
         .expect("advance retention");
 
+    let head_after = read_head_object(&store, &namespace_id)
+        .await
+        .expect("read head")
+        .envelope
+        .state;
+    assert_eq!(head_after.seq, ChangeSeq(2));
+
     let changes = list_changes_after(
         &store,
         &namespace_id,
@@ -514,6 +522,139 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
     assert_eq!(changes.through_seq, ChangeSeq(2));
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(changes.changes[0].seq, ChangeSeq(2));
+}
+
+#[tokio::test]
+async fn retention_advance_aborts_when_current_manifest_changes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let plain = LocalFsStore::new(temp_dir.path()).expect("store");
+    bootstrap_namespace(&plain, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &plain,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&plain, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    // Lose the floor CAS once while a competing maintenance actor installs a
+    // different current manifest; the retry must abort instead of publishing
+    // a floor derived from the replaced manifest.
+    let store = ManifestSwapOnCasConflictStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+        namespace_id: namespace_id.clone(),
+        remaining_conflicts: std::sync::atomic::AtomicUsize::new(1),
+    };
+    let error = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect_err("floor derived from a replaced manifest must not publish");
+    assert!(
+        matches!(error, CoreError::CheckpointUnavailable(_)),
+        "unexpected error: {error:?}"
+    );
+    let head = read_head_object(&store.inner, &namespace_id)
+        .await
+        .expect("read head")
+        .envelope
+        .state;
+    assert_eq!(head.retention_floor_seq, ChangeSeq(0));
+}
+
+#[derive(Debug)]
+struct ManifestSwapOnCasConflictStore {
+    inner: LocalFsStore,
+    namespace_id: NamespaceId,
+    remaining_conflicts: std::sync::atomic::AtomicUsize,
+}
+
+impl ManifestSwapOnCasConflictStore {
+    async fn install_competing_manifest_id(&self) {
+        let loaded = read_head_object(&self.inner, &self.namespace_id)
+            .await
+            .expect("read head for swap");
+        let mut head = loaded.envelope.state;
+        head.current_manifest_id = head.current_manifest_id.map(|id| ManifestId(id.0 + 1));
+        let envelope = loonfs_api::wire::control::HeadStateEnvelope::from_state(
+            loonfs_api::wire::control::ControlObjectKind::NamespaceHead,
+            "test-writer/0.1.0",
+            head,
+        )
+        .expect("head envelope");
+        let bytes =
+            loonfs_api::wire::control::encode_control_object(&envelope).expect("head bytes");
+        self.inner
+            .put(
+                &namespace_head(self.namespace_id.as_str()),
+                Bytes::from(bytes),
+                PutMode::Overwrite,
+            )
+            .await
+            .expect("install competing head");
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ManifestSwapOnCasConflictStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        use std::sync::atomic::Ordering;
+        if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
+            self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
+            self.install_competing_manifest_id().await;
+            return Err(ObjectStoreError::PreconditionFailed);
+        }
+        self.inner.compare_and_swap(key, expected_etag, bytes).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -16,7 +16,7 @@ use super::create::{
 use super::error::ManifestLoadError;
 use super::load::{
     head_from_manifest, load_manifest_materialization_for_inspection,
-    load_manifest_metadata_state_for_inspection_from_manifest,
+    load_manifest_metadata_state_for_inspection_from_manifest, load_verified_manifest_tables,
 };
 use super::publish::{
     publish_current_manifest_id, write_namespace_manifest, ManifestPublicationOutcome,
@@ -522,6 +522,52 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
     assert_eq!(changes.through_seq, ChangeSeq(2));
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(changes.changes[0].seq, ChangeSeq(2));
+}
+
+#[tokio::test]
+async fn manifest_load_rejects_unequal_index_descriptor_counts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    // Tamper only the descriptor's row_count for the revision index family;
+    // the per-run count-equality check must reject the manifest at load.
+    let mut manifest =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_id)
+            .await
+            .expect("load manifest")
+            .manifest;
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|file| file.family == ApiMetadataTableFamily::RevisionsByInodeDesc)
+        .expect("revision index descriptor");
+    descriptor.row_count += 1;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    match load_verified_manifest_tables(&store, &namespace_id, checkpoint.manifest_id).await {
+        Err(ManifestLoadError::RunManifestMismatch { .. }) => {}
+        Err(other) => panic!("expected run manifest mismatch, got {other:?}"),
+        Ok(_) => panic!("tampered descriptor counts must not load"),
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -7,9 +7,7 @@ use loonfs_api::wire::manifest::{
     MetadataFileRef, MetadataPage, MetadataRow, MetadataSstEnvelope, MetadataTableFamily,
     NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
-use loonfs_api::{
-    validate_checkpoint_id, validate_metadata_table_id, ChangeSeq, ManifestId, NamespaceId,
-};
+use loonfs_api::{validate_metadata_table_id, ChangeSeq, ManifestId, NamespaceId};
 
 pub(super) fn validate_namespace_manifest(
     namespace_id: &NamespaceId,
@@ -52,12 +50,6 @@ pub(super) fn validate_manifest_checkpoint_records(
 ) -> Result<(), ManifestLoadError> {
     let mut seen_checkpoint_ids = Vec::new();
     for checkpoint in &payload.checkpoints {
-        validate_checkpoint_id(&checkpoint.checkpoint_id).map_err(|error| {
-            ManifestLoadError::RunManifestMismatch {
-                object_key: object_key.to_owned(),
-                message: error.to_string(),
-            }
-        })?;
         if seen_checkpoint_ids.contains(&checkpoint.checkpoint_id.as_str()) {
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: object_key.to_owned(),

--- a/crates/loonfs-core/src/commit/validate.rs
+++ b/crates/loonfs-core/src/commit/validate.rs
@@ -105,7 +105,6 @@ pub async fn build_commit_plan(
     let shape = compute_commit_shape(request, context)?;
     let validated_metadata = validate_metadata_preconditions(
         request,
-        &context.head,
         context.metadata_state,
         shape.assigned_seq,
         &shape.allocated_inode_ids,
@@ -289,7 +288,6 @@ fn compute_commit_shape_from_head(
 
 async fn validate_metadata_preconditions(
     request: &CommitRequest,
-    head: &HeadState,
     metadata_state: &MetadataState,
     committed_seq: ChangeSeq,
     allocated_inode_ids: &[InodeId],
@@ -302,7 +300,6 @@ async fn validate_metadata_preconditions(
     let mut next_delta_index = 0u32;
 
     let metadata_view = InMemoryMetadataView::in_memory(
-        head,
         metadata_state,
         Some(overlay_rows.rows()),
         committed_seq,
@@ -311,7 +308,6 @@ async fn validate_metadata_preconditions(
     validate_publish_explicit_preconditions(
         &request.preconditions,
         &metadata_view,
-        committed_seq,
         checked_invariants,
     )
     .await
@@ -321,7 +317,6 @@ async fn validate_metadata_preconditions(
         let op_index =
             u32::try_from(op_index).map_err(|_| CommitValidationError::OpIndexOverflow)?;
         let metadata_view = InMemoryMetadataView::in_memory(
-            head,
             metadata_state,
             Some(overlay_rows.rows()),
             committed_seq,
@@ -336,7 +331,6 @@ async fn validate_metadata_preconditions(
                     &metadata_view,
                     *parent_inode,
                     display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await
@@ -344,7 +338,6 @@ async fn validate_metadata_preconditions(
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_view,
                     *parent_inode,
-                    committed_seq,
                     checked_invariants,
                     true,
                 )
@@ -372,7 +365,6 @@ async fn validate_metadata_preconditions(
                     &metadata_view,
                     *parent_inode,
                     display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await
@@ -380,7 +372,6 @@ async fn validate_metadata_preconditions(
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_view,
                     *parent_inode,
-                    committed_seq,
                     checked_invariants,
                     true,
                 )
@@ -406,19 +397,13 @@ async fn validate_metadata_preconditions(
                 base_revision_no,
                 content_ref,
             } => {
-                validate_publish_inode_revision_is(
-                    &metadata_view,
-                    *inode_id,
-                    *base_revision_no,
-                    committed_seq,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
+                validate_publish_inode_revision_is(&metadata_view, *inode_id, *base_revision_no)
+                    .await
+                    .map_err(commit_validation_from_core)?;
                 let revision_no = next_revision_no(*inode_id, *base_revision_no, true)?;
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_view,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                     false,
                 )
@@ -437,31 +422,20 @@ async fn validate_metadata_preconditions(
                 source_revision_no,
                 base_revision_no,
             } => {
-                validate_publish_restore_target(
-                    &metadata_view,
-                    *inode_id,
-                    *base_revision_no,
-                    committed_seq,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
+                validate_publish_restore_target(&metadata_view, *inode_id, *base_revision_no)
+                    .await
+                    .map_err(commit_validation_from_core)?;
                 let source_revision = validate_publish_restore_source_revision(
                     &metadata_view,
                     *inode_id,
                     *source_revision_no,
-                    committed_seq,
                 )
                 .await
                 .map_err(commit_validation_from_core)?;
                 let revision_no = next_revision_no(*inode_id, *base_revision_no, false)?;
-                validate_publish_restore_not_covered(
-                    &metadata_view,
-                    *inode_id,
-                    committed_seq,
-                    checked_invariants,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
+                validate_publish_restore_not_covered(&metadata_view, *inode_id, checked_invariants)
+                    .await
+                    .map_err(commit_validation_from_core)?;
                 ValidatedOp::RestoreRevision {
                     op_index,
                     inode_id: *inode_id,
@@ -472,20 +446,16 @@ async fn validate_metadata_preconditions(
                 }
             }
             CommitOp::DeleteFile { inode_id } => {
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_view,
-                    *inode_id,
-                    committed_seq,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
-                validate_publish_delete_file_target(&metadata_view, *inode_id, committed_seq)
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_view, *inode_id)
+                        .await
+                        .map_err(commit_validation_from_core)?;
+                validate_publish_delete_file_target(&metadata_view, *inode_id)
                     .await
                     .map_err(commit_validation_from_core)?;
                 validate_publish_delete_file_not_covered(
                     &metadata_view,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await
@@ -509,21 +479,17 @@ async fn validate_metadata_preconditions(
                         behavior: *behavior,
                     });
                 }
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_view,
-                    *inode_id,
-                    committed_seq,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
-                validate_publish_rename_source(&metadata_view, *inode_id, committed_seq)
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_view, *inode_id)
+                        .await
+                        .map_err(commit_validation_from_core)?;
+                validate_publish_rename_source(&metadata_view, *inode_id)
                     .await
                     .map_err(commit_validation_from_core)?;
                 let new_name_key = validate_publish_rename_target_name_absent(
                     &metadata_view,
                     *new_parent_inode,
                     new_display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await
@@ -532,14 +498,12 @@ async fn validate_metadata_preconditions(
                     &metadata_view,
                     *inode_id,
                     *new_parent_inode,
-                    committed_seq,
                 )
                 .await
                 .map_err(commit_validation_from_core)?;
                 validate_publish_rename_inode_not_covered(
                     &metadata_view,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await
@@ -547,7 +511,6 @@ async fn validate_metadata_preconditions(
                 validate_publish_rename_target_parent_not_covered(
                     &metadata_view,
                     *new_parent_inode,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await
@@ -564,20 +527,16 @@ async fn validate_metadata_preconditions(
                 }
             }
             CommitOp::DeleteSubtree { root_inode } => {
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_view,
-                    *root_inode,
-                    committed_seq,
-                )
-                .await
-                .map_err(commit_validation_from_core)?;
-                validate_publish_delete_subtree_root(&metadata_view, *root_inode, committed_seq)
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_view, *root_inode)
+                        .await
+                        .map_err(commit_validation_from_core)?;
+                validate_publish_delete_subtree_root(&metadata_view, *root_inode)
                     .await
                     .map_err(commit_validation_from_core)?;
                 validate_publish_delete_subtree_not_covered(
                     &metadata_view,
                     *root_inode,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await
@@ -616,7 +575,6 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
     validate_publish_explicit_preconditions(
         &request.preconditions,
         &metadata_state,
-        committed_seq,
         checked_invariants,
     )
     .await?;
@@ -635,14 +593,12 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                     &metadata_state,
                     *parent_inode,
                     display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await?;
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_state,
                     *parent_inode,
-                    committed_seq,
                     checked_invariants,
                     true,
                 )
@@ -669,14 +625,12 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                     &metadata_state,
                     *parent_inode,
                     display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await?;
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_state,
                     *parent_inode,
-                    committed_seq,
                     checked_invariants,
                     true,
                 )
@@ -701,18 +655,12 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                 base_revision_no,
                 content_ref,
             } => {
-                validate_publish_inode_revision_is(
-                    &metadata_state,
-                    *inode_id,
-                    *base_revision_no,
-                    committed_seq,
-                )
-                .await?;
+                validate_publish_inode_revision_is(&metadata_state, *inode_id, *base_revision_no)
+                    .await?;
                 let revision_no = next_revision_no(*inode_id, *base_revision_no, true)?;
                 validate_publish_ancestors_not_subtree_deleted(
                     &metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                     false,
                 )
@@ -730,25 +678,18 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                 source_revision_no,
                 base_revision_no,
             } => {
-                validate_publish_restore_target(
-                    &metadata_state,
-                    *inode_id,
-                    *base_revision_no,
-                    committed_seq,
-                )
-                .await?;
+                validate_publish_restore_target(&metadata_state, *inode_id, *base_revision_no)
+                    .await?;
                 let source_revision = validate_publish_restore_source_revision(
                     &metadata_state,
                     *inode_id,
                     *source_revision_no,
-                    committed_seq,
                 )
                 .await?;
                 let revision_no = next_revision_no(*inode_id, *base_revision_no, false)?;
                 validate_publish_restore_not_covered(
                     &metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await?;
@@ -762,18 +703,13 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                 }
             }
             CommitOp::DeleteFile { inode_id } => {
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_state,
-                    *inode_id,
-                    committed_seq,
-                )
-                .await?;
-                validate_publish_delete_file_target(&metadata_state, *inode_id, committed_seq)
-                    .await?;
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_state, *inode_id)
+                        .await?;
+                validate_publish_delete_file_target(&metadata_state, *inode_id).await?;
                 validate_publish_delete_file_not_covered(
                     &metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await?;
@@ -797,18 +733,14 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                     }
                     .into());
                 }
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_state,
-                    *inode_id,
-                    committed_seq,
-                )
-                .await?;
-                validate_publish_rename_source(&metadata_state, *inode_id, committed_seq).await?;
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_state, *inode_id)
+                        .await?;
+                validate_publish_rename_source(&metadata_state, *inode_id).await?;
                 let new_name_key = validate_publish_rename_target_name_absent(
                     &metadata_state,
                     *new_parent_inode,
                     new_display_name,
-                    committed_seq,
                     name_policy,
                 )
                 .await?;
@@ -816,20 +748,17 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                     &metadata_state,
                     *inode_id,
                     *new_parent_inode,
-                    committed_seq,
                 )
                 .await?;
                 validate_publish_rename_inode_not_covered(
                     &metadata_state,
                     *inode_id,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await?;
                 validate_publish_rename_target_parent_not_covered(
                     &metadata_state,
                     *new_parent_inode,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await?;
@@ -845,18 +774,13 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                 }
             }
             CommitOp::DeleteSubtree { root_inode } => {
-                let source_binding = resolve_publish_current_binding_for_mutation(
-                    &metadata_state,
-                    *root_inode,
-                    committed_seq,
-                )
-                .await?;
-                validate_publish_delete_subtree_root(&metadata_state, *root_inode, committed_seq)
-                    .await?;
+                let source_binding =
+                    resolve_publish_current_binding_for_mutation(&metadata_state, *root_inode)
+                        .await?;
+                validate_publish_delete_subtree_root(&metadata_state, *root_inode).await?;
                 validate_publish_delete_subtree_not_covered(
                     &metadata_state,
                     *root_inode,
-                    committed_seq,
                     checked_invariants,
                 )
                 .await?;
@@ -921,7 +845,6 @@ fn commit_validation_from_core(error: CoreError) -> CommitValidationError {
 async fn validate_publish_explicit_preconditions<S: ObjectStore + ?Sized>(
     preconditions: &[Precondition],
     metadata_state: &MetadataView<'_, '_, S>,
-    base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     for precondition in preconditions {
@@ -930,19 +853,12 @@ async fn validate_publish_explicit_preconditions<S: ObjectStore + ?Sized>(
                 inode_id,
                 revision_no,
             } => {
-                validate_publish_inode_revision_is(
-                    metadata_state,
-                    *inode_id,
-                    *revision_no,
-                    base_seq,
-                )
-                .await?;
+                validate_publish_inode_revision_is(metadata_state, *inode_id, *revision_no).await?;
             }
             Precondition::AncestorsNotSubtreeDeleted { inode_id } => {
                 validate_publish_ancestors_not_subtree_deleted(
                     metadata_state,
                     *inode_id,
-                    base_seq,
                     checked_invariants,
                     false,
                 )
@@ -956,7 +872,6 @@ async fn validate_publish_explicit_preconditions<S: ObjectStore + ?Sized>(
                     metadata_state,
                     *parent_inode,
                     name_key,
-                    base_seq,
                 )
                 .await?;
             }
@@ -974,13 +889,11 @@ async fn validate_publish_explicit_preconditions<S: ObjectStore + ?Sized>(
                     *child_inode,
                     *bind_seq,
                     *bind_delta_index,
-                    base_seq,
                 )
                 .await?;
             }
             Precondition::DirectoryEmpty { inode_id } => {
-                validate_publish_directory_empty_precondition(metadata_state, *inode_id, base_seq)
-                    .await?;
+                validate_publish_directory_empty_precondition(metadata_state, *inode_id).await?;
             }
         }
     }
@@ -992,7 +905,6 @@ async fn validate_publish_child_name_absent_precondition<S: ObjectStore + ?Sized
     metadata_state: &MetadataView<'_, '_, S>,
     parent_inode: InodeId,
     name_key: &str,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode)
@@ -1021,7 +933,6 @@ async fn validate_publish_child_name_absent_precondition<S: ObjectStore + ?Sized
 async fn resolve_publish_current_binding_for_mutation<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<ResolvedBinding, CoreError> {
     let binding = metadata_state
         .current_parent_binding_for_child(inode_id)
@@ -1045,7 +956,6 @@ async fn validate_publish_binding_is_precondition<S: ObjectStore + ?Sized>(
     child_inode: InodeId,
     bind_seq: ChangeSeq,
     bind_delta_index: u32,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let parent = metadata_state
         .inode_at_seq(parent_inode)
@@ -1085,7 +995,6 @@ async fn validate_publish_binding_is_precondition<S: ObjectStore + ?Sized>(
 async fn validate_publish_directory_empty_precondition<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .visible_inode(inode_id)
@@ -1112,7 +1021,6 @@ async fn validate_publish_child_name_absent<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     parent_inode: InodeId,
     display_name: &str,
-    _base_seq: ChangeSeq,
     name_policy: NamePolicy,
 ) -> Result<String, CoreError> {
     validate_display_name(display_name)?;
@@ -1148,7 +1056,6 @@ async fn validate_publish_inode_revision_is<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
     expected_revision_no: RevisionNo,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .inode_at_seq(inode_id)
@@ -1182,7 +1089,6 @@ async fn validate_publish_restore_target<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
     expected_revision_no: RevisionNo,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .inode_at_seq(inode_id)
@@ -1216,7 +1122,6 @@ async fn validate_publish_restore_source_revision<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
     source_revision_no: RevisionNo,
-    _base_seq: ChangeSeq,
 ) -> Result<RevisionRecord, CoreError> {
     metadata_state
         .revision_at_head(inode_id, source_revision_no)
@@ -1233,7 +1138,6 @@ async fn validate_publish_restore_source_revision<S: ObjectStore + ?Sized>(
 async fn validate_publish_ancestors_not_subtree_deleted<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
     is_create: bool,
 ) -> Result<(), CoreError> {
@@ -1265,7 +1169,6 @@ async fn validate_publish_ancestors_not_subtree_deleted<S: ObjectStore + ?Sized>
 async fn validate_publish_restore_not_covered<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id).await? {
@@ -1289,7 +1192,6 @@ async fn validate_publish_restore_not_covered<S: ObjectStore + ?Sized>(
 async fn validate_publish_delete_subtree_root<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     root_inode: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .inode_at_seq(root_inode)
@@ -1309,7 +1211,6 @@ async fn validate_publish_delete_subtree_root<S: ObjectStore + ?Sized>(
 async fn validate_publish_delete_file_target<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .inode_at_seq(inode_id)
@@ -1329,7 +1230,6 @@ async fn validate_publish_delete_file_target<S: ObjectStore + ?Sized>(
 async fn validate_publish_delete_file_not_covered<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id).await? {
@@ -1351,7 +1251,6 @@ async fn validate_publish_delete_file_not_covered<S: ObjectStore + ?Sized>(
 async fn validate_publish_delete_subtree_not_covered<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     root_inode: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     if let Some(tombstone) = metadata_state
@@ -1376,7 +1275,6 @@ async fn validate_publish_delete_subtree_not_covered<S: ObjectStore + ?Sized>(
 async fn validate_publish_rename_source<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     metadata_state
         .inode_at_seq(inode_id)
@@ -1397,7 +1295,6 @@ async fn validate_publish_rename_target_name_absent<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     parent_inode: InodeId,
     display_name: &str,
-    _base_seq: ChangeSeq,
     name_policy: NamePolicy,
 ) -> Result<String, CoreError> {
     validate_display_name(display_name)?;
@@ -1433,7 +1330,6 @@ async fn validate_publish_rename_does_not_cycle<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
     new_parent_inode: InodeId,
-    _base_seq: ChangeSeq,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
         .inode_at_seq(inode_id)
@@ -1459,7 +1355,6 @@ async fn validate_publish_rename_does_not_cycle<S: ObjectStore + ?Sized>(
 async fn validate_publish_rename_inode_not_covered<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     inode_id: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id).await? {
@@ -1481,7 +1376,6 @@ async fn validate_publish_rename_inode_not_covered<S: ObjectStore + ?Sized>(
 async fn validate_publish_rename_target_parent_not_covered<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataView<'_, '_, S>,
     parent_inode: InodeId,
-    _base_seq: ChangeSeq,
     checked_invariants: &mut Vec<InvariantId>,
 ) -> Result<(), CoreError> {
     if let Some(tombstone) = metadata_state

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -40,6 +40,12 @@ pub(crate) enum ControlUpdateError {
     RetryExhausted { attempts: usize },
 }
 
+/// Reads the head, lets `update` decide `Noop` or `Replace`, and publishes a
+/// replacement by compare-and-swap on the loaded etag, retrying the whole
+/// read-decide-swap cycle on CAS conflict. Closure errors propagate
+/// immediately without retrying — that is the fencing hook: a closure that
+/// observes a disqualifying head (newer writer, changed manifest) must error,
+/// never clobber.
 pub(crate) async fn update_head<S, T, E, F>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -397,6 +397,18 @@ fn classify_durable_content_error(error: &DurableContentValidationError) -> Erro
     }
 }
 
+impl From<crate::control_update::ControlUpdateError> for CoreError {
+    fn from(value: crate::control_update::ControlUpdateError) -> Self {
+        use crate::control_update::ControlUpdateError;
+        match value {
+            ControlUpdateError::LoadHead(error) => {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+            }
+            other => CoreError::Store(other.to_string()),
+        }
+    }
+}
+
 fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> ErrorCode {
     match error {
         WriterEpochAcquireError::LoadHead(error) => classify_control_object_load_error(error),

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -82,13 +82,6 @@ define_invariant_ids! {
     (SubtreeTombstoneBlocksDescendantMutation, "subtree_tombstone_blocks_descendant_mutation"),
 
     // Namespace core metadata apply invariants.
-    (CreateDirWritesInodeAndDirentryRows, "create_dir_writes_inode_and_direntry_rows"),
-    (CreateFileWritesInodeDirentryAndInitialRevision, "create_file_writes_inode_direntry_and_initial_revision"),
-    (ReplaceFileAppendsNewRevisionHead, "replace_file_appends_new_revision_head"),
-    (RestoreCreatesNewRevisionHead, "restore_creates_new_revision_head"),
-    (DeleteFileWritesTombstoneRow, "delete_file_writes_tombstone_row"),
-    (RenameAppendsNewDirentryBinding, "rename_appends_new_direntry_binding"),
-    (DeleteSubtreeWritesTombstoneRow, "delete_subtree_writes_tombstone_row"),
 
     // Namespace core WAL replay invariants.
     (WalPayloadChecksumMatchesPayload, "wal_payload_checksum_matches_payload"),
@@ -100,39 +93,14 @@ define_invariant_ids! {
     (WalReplayAppliesMetadataRows, "wal_replay_applies_metadata_rows"),
 
     // Namespace core manifest replay invariants.
-    (NamespaceManifestChecksumMatchesPayload, "namespace_manifest_checksum_matches_payload"),
-    (NamespaceManifestKeyMatchesId, "namespace_manifest_key_matches_id"),
-    (NamespaceManifestMustBeVerified, "namespace_manifest_must_be_verified"),
-    (ManifestReplayRequiresAllManifestSegments, "manifest_replay_requires_all_manifest_segments"),
-    (MetadataFileRefMatchesPayload, "manifest_segment_descriptor_matches_payload"),
-    (MetadataSstRowsRestoreManifestMetadata, "manifest_segment_rows_restore_manifest_metadata"),
-    (CheckpointPlusWalTailReproducesHead, "checkpoint_plus_wal_tail_reproduces_head"),
-    (CheckpointPlusWalTailReproducesMetadata, "checkpoint_plus_wal_tail_reproduces_metadata"),
 
     // Background work progress invariants.
-    (ProgressObjectChecksumMatchesPayload, "progress_object_checksum_matches_payload"),
-    (ProgressObjectKeyMatchesNamespaceAndWorkClass, "progress_object_key_matches_namespace_and_work_class"),
-    (ProgressThroughSeqAdvancesMonotonically, "progress_through_seq_advances_monotonically"),
 
     // Background work queue shard object invariants.
 
     // Background work queue mutation invariants.
-    (LostEnqueueRepairEnqueuesWhenHeadOutpacesProgress, "lost_enqueue_repair_enqueues_when_head_outpaces_progress"),
-    (ManifestRepairDedupeKeyIsNamespaceScoped, "manifest_repair_dedupe_key_is_namespace_scoped"),
-    (ManifestRepairClaimedJobGetsFollowUp, "manifest_repair_claimed_job_gets_follow_up"),
-    (BrokerLeaseTakeoverIncrementsEpoch, "broker_lease_takeover_increments_epoch"),
-    (ActiveBrokerLeaseRequiredForShardMutation, "active_broker_lease_required_for_shard_mutation"),
-    (ClaimTimeoutAllowsSteal, "claim_timeout_allows_steal"),
-    (WorkerHeartbeatRequiresMatchingClaimToken, "worker_heartbeat_requires_matching_claim_token"),
-    (StaleClaimTokenCannotComplete, "stale_claim_token_cannot_complete"),
-    (StolenJobCompletesOnce, "stolen_job_completes_once"),
 
     // Background work checkpoint head publish invariants.
-    (CheckpointPublishRequiresVerifiedManifest, "checkpoint_publish_requires_verified_manifest"),
-    (CurrentManifestIdAdvancesMonotonically, "current_manifest_id_advances_monotonically"),
-    (RetentionFloorSeqAdvancesMonotonically, "retention_floor_seq_advances_monotonically"),
-    (RetentionFloorSeqRequiresCheckpointCoverage, "retention_floor_seq_requires_checkpoint_coverage"),
-    (RetentionFloorSeqRespectsPolicyGate, "retention_floor_seq_respects_policy_gate"),
 
     // Content object file invariants.
     (WholeFileContentRefKindIsSupported, "whole_file_content_ref_kind_is_supported"),
@@ -141,112 +109,18 @@ define_invariant_ids! {
     (WholeFileContentDigestMatchesRef, "whole_file_content_digest_matches_ref"),
 
     // Manifest object immutable invariants.
-    (MetadataSstPayloadChecksumMatchesPayload, "manifest_segment_payload_checksum_matches_payload"),
-    (MetadataSegmentKeyMatchesFamilyAndIndex, "manifest_segment_key_matches_family_and_index"),
-    (VerifiedNamespaceManifestRequiresDurableSegments, "verified_namespace_manifest_requires_durable_segments"),
-    (NamespaceManifestPreservesHeadSummary, "namespace_manifest_preserves_head_summary"),
-    (NamespaceManifestPreservesMetadata, "namespace_manifest_preserves_metadata"),
 
     // Client transfer download invariants.
-    (DownloadTransferByteRangeAdvancesMonotonically, "download_transfer_byte_range_advances_monotonically"),
-    (DownloadTransferResetRecordsDurableIssue, "download_transfer_reset_records_durable_issue"),
-    (DownloadCompletionClearsTransferLedger, "download_completion_clears_transfer_ledger"),
-    (DownloadMaterializationUpdatesLocalStateAndSyncAnchor, "download_materialization_updates_local_state_and_sync_anchor"),
 
     // Client transfer inode upload invariants.
-    (InodeUploadContentProgressAdvancesMonotonically, "inode_upload_content_progress_advances_monotonically"),
-    (InodeUploadDispatchWaitsForStagedContent, "inode_upload_dispatch_waits_for_staged_content"),
-    (InodeUploadRetryReusesPendingInodeMutation, "inode_upload_retry_reuses_pending_inode_mutation"),
-    (InodeUploadCompletionClearsTransferLedger, "inode_upload_completion_clears_transfer_ledger"),
-    (InodeUploadTransferResetRecordsDurableIssue, "inode_upload_transfer_reset_records_durable_issue"),
 
     // Client transfer local-only upload invariants.
-    (LocalOnlyUploadContentProgressAdvancesMonotonically, "local_only_upload_content_progress_advances_monotonically"),
-    (LocalOnlyUploadDispatchWaitsForStagedContent, "local_only_upload_dispatch_waits_for_staged_content"),
-    (LocalOnlyUploadRetryReusesPendingClientMutation, "local_only_upload_retry_reuses_pending_client_mutation"),
-    (LocalOnlyUploadCompletionClearsTempTransferLedger, "local_only_upload_completion_clears_temp_transfer_ledger"),
-    (LocalOnlyUploadBindClearsTempIssueAndTransferLedger, "local_only_upload_bind_clears_temp_issue_and_transfer_ledger"),
-    (LocalOnlyUploadTransferResetRecordsDurableIssue, "local_only_upload_transfer_reset_records_durable_issue"),
 
     // Client reconciliation invariants.
-    (SameInodeConflictPreservesLoserArtifact, "same_inode_conflict_preserves_loser_artifact"),
-    (SameInodeConflictKeepsCanonicalPath, "same_inode_conflict_keeps_canonical_path"),
-    (DeleteVsEditConflictPreservesLoserArtifact, "delete_vs_edit_conflict_preserves_loser_artifact"),
-    (DeleteVsEditConflictRemovesCanonicalPath, "delete_vs_edit_conflict_removes_canonical_path"),
-    (RenameVsEditConflictPreservesLoserArtifact, "rename_vs_edit_conflict_preserves_loser_artifact"),
-    (RenameVsEditConflictConvergesRemoteWinner, "rename_vs_edit_conflict_converges_remote_winner"),
-    (PathBindingCollisionPreservesLoserArtifact, "path_binding_collision_preserves_loser_artifact"),
-    (PathBindingCollisionKeepsWinnerCanonicalPath, "path_binding_collision_keeps_winner_canonical_path"),
-    (SubtreeDeleteConflictPreservesLoserArtifact, "subtree_delete_conflict_preserves_loser_artifact"),
-    (SubtreeDeleteConflictPreservesFullSubtreeEntries, "subtree_delete_conflict_preserves_full_subtree_entries"),
-    (SubtreeDeleteConflictRemovesCanonicalPath, "subtree_delete_conflict_removes_canonical_path"),
-    (SubtreeDeleteConflictClearsPreservedTempRows, "subtree_delete_conflict_clears_preserved_temp_rows"),
-    (SubtreeRenameConflictPreservesLoserArtifact, "subtree_rename_conflict_preserves_loser_artifact"),
-    (SubtreeRenameConflictRevertsBoundDescendantsToWinnerState, "subtree_rename_conflict_reverts_bound_descendants_to_winner_state"),
-    (SubtreeRenameConflictKeepsWinnerCanonicalPath, "subtree_rename_conflict_keeps_winner_canonical_path"),
-    (SubtreeRenameConflictClearsPreservedTempRows, "subtree_rename_conflict_clears_preserved_temp_rows"),
-    (StablePathsDefaultDoesNotMaterializeVisibleSibling, "stable_paths_default_does_not_materialize_visible_sibling"),
-    (StablePathsDefaultDoesNotMaterializeVisibleSiblingTree, "stable_paths_default_does_not_materialize_visible_sibling_tree"),
-    (RemoteObservationConvergenceClearsDirtyAndPlannedAction, "remote_observation_convergence_clears_dirty_and_planned_action"),
-    (RemoteObservationConvergenceClearsPendingInodeMutation, "remote_observation_convergence_clears_pending_inode_mutation"),
-    (RemoteObservationConvergenceAdvancesSyncAnchor, "remote_observation_convergence_advances_sync_anchor"),
-    (RemoteObservationLateBindEstablishesRemoteLocalAndAnchor, "remote_observation_late_bind_establishes_remote_local_and_anchor"),
-    (RemoteObservationLateBindClearsTempLocalState, "remote_observation_late_bind_clears_temp_local_state"),
-    (RemoteObservationLateBindClearsTempTransferAndIssueRows, "remote_observation_late_bind_clears_temp_transfer_and_issue_rows"),
-    (RemoteObservationLateBindRetainsPendingClientMutationUntilResponse, "remote_observation_late_bind_retains_pending_client_mutation_until_response"),
-    (RemoteObservationAmbiguousBindRecordsDurableIssue, "remote_observation_ambiguous_bind_records_durable_issue"),
-    (RemoteObservationAmbiguousBindAvoidsPartialMigration, "remote_observation_ambiguous_bind_avoids_partial_migration"),
-    (RemoteObservationActiveUploadPreservesTransferAndPendingInodeMutation, "remote_observation_active_upload_preserves_transfer_and_pending_inode_mutation"),
-    (RemoteObservationActiveDownloadPreservesTransferLedger, "remote_observation_active_download_preserves_transfer_ledger"),
-    (RemoteOnlyMaterializationWaitsForParentMaterialization, "remote_only_materialization_waits_for_parent_materialization"),
-    (RemoteOnlyDirectoryMaterializationUpdatesLocalStateAndSyncAnchor, "remote_only_directory_materialization_updates_local_state_and_sync_anchor"),
-    (RemoteOnlyDirectoryMaterializationClearsPlannedAction, "remote_only_directory_materialization_clears_planned_action"),
-    (RemoteOnlyDirectoryMaterializationFailureRecordsDurableIssue, "remote_only_directory_materialization_failure_records_durable_issue"),
-    (RemoteDeletePlansApplyRemoteDelete, "remote_delete_plans_apply_remote_delete"),
-    (ApplyRemoteDeletePreservesRemoteTombstone, "apply_remote_delete_preserves_remote_tombstone"),
-    (ApplyRemoteDeleteClearsLocalStateAndSyncAnchor, "apply_remote_delete_clears_local_state_and_sync_anchor"),
-    (ApplyRemoteDeleteClearsPlannedAction, "apply_remote_delete_clears_planned_action"),
-    (ApplyRemoteDeleteFailureRecordsDurableIssue, "apply_remote_delete_failure_records_durable_issue"),
-    (RemoteSubtreeDeletePlansApplyRemoteSubtreeDelete, "remote_subtree_delete_plans_apply_remote_subtree_delete"),
-    (ApplyRemoteSubtreeDeletePreservesRootRemoteTombstone, "apply_remote_subtree_delete_preserves_root_remote_tombstone"),
-    (ApplyRemoteSubtreeDeleteClearsDescendantRemoteRows, "apply_remote_subtree_delete_clears_descendant_remote_rows"),
-    (ApplyRemoteSubtreeDeleteClearsRemoteOnlyDescendants, "apply_remote_subtree_delete_clears_remote_only_descendants"),
-    (ApplyRemoteSubtreeDeleteClearsLocalStateAndSyncAnchorForSubtree, "apply_remote_subtree_delete_clears_local_state_and_sync_anchor_for_subtree"),
-    (ApplyRemoteSubtreeDeleteClearsSubtreePlannedActions, "apply_remote_subtree_delete_clears_subtree_planned_actions"),
-    (ApplyRemoteSubtreeDeleteFailureRecordsDurableIssue, "apply_remote_subtree_delete_failure_records_durable_issue"),
-    (RemoteSubtreePathChangePlansApplyRemoteSubtreeRename, "remote_subtree_path_change_plans_apply_remote_subtree_rename"),
-    (MaterializedTargetParentUnblocksApplyRemoteSubtreeRename, "materialized_target_parent_unblocks_apply_remote_subtree_rename"),
-    (ApplyRemoteSubtreeRenameUpdatesRootLocalStateAndSyncAnchor, "apply_remote_subtree_rename_updates_root_local_state_and_sync_anchor"),
-    (ApplyRemoteSubtreeRenamePreservesDescendantDurableState, "apply_remote_subtree_rename_preserves_descendant_durable_state"),
-    (ApplyRemoteSubtreeRenamePreservesRemoteOnlyDescendants, "apply_remote_subtree_rename_preserves_remote_only_descendants"),
-    (ApplyRemoteSubtreeRenameClearsRootPlannedAction, "apply_remote_subtree_rename_clears_root_planned_action"),
-    (ApplyRemoteSubtreeRenameFailureRecordsDurableIssue, "apply_remote_subtree_rename_failure_records_durable_issue"),
-    (RemotePathChangePlansApplyRemoteRename, "remote_path_change_plans_apply_remote_rename"),
-    (MaterializedTargetParentUnblocksApplyRemoteRename, "materialized_target_parent_unblocks_apply_remote_rename"),
-    (ApplyRemoteRenameUpdatesLocalStateAndSyncAnchor, "apply_remote_rename_updates_local_state_and_sync_anchor"),
-    (ApplyRemoteRenameClearsPlannedAction, "apply_remote_rename_clears_planned_action"),
-    (ApplyRemoteRenameFailureRecordsDurableIssue, "apply_remote_rename_failure_records_durable_issue"),
 
     // Simulation interleaving invariants.
-    (ClientRetryReusesPendingRequestAfterDelayedResponse, "client_retry_reuses_pending_request_after_delayed_response"),
-    (DuplicateResponseIsIdempotent, "duplicate_response_is_idempotent"),
-    (LateRemoteObservationDoesNotDuplicateWinnerApply, "late_remote_observation_does_not_duplicate_winner_apply"),
-    (ResponseAfterNewerObservationIsIdempotent, "response_after_newer_observation_is_idempotent"),
-    (SimTraceOrderIsSeedStable, "sim_trace_order_is_seed_stable"),
-    (StaleWriterPublishRemainsFencedAfterHandover, "stale_writer_publish_remains_fenced_after_handover"),
-    (StaleWriterFenceSurvivesInflightClientRequest, "stale_writer_fence_survives_inflight_client_request"),
-    (CheckpointPublishWaitsForRequiredProgressUnderInterleaving, "checkpoint_publish_waits_for_required_progress_under_interleaving"),
-    (CheckpointPublishPreservesMonotonicHeadSummaryUnderInterleaving, "checkpoint_publish_preserves_monotonic_head_summary_under_interleaving"),
-    (RepairLostEnqueueTracksLatestVisibleHeadSeq, "repair_lost_enqueue_tracks_latest_visible_head_seq"),
-    (CheckpointPublishUsesLatestVisibleHeadAfterClientServerAdvance, "checkpoint_publish_uses_latest_visible_head_after_client_server_advance"),
-    (RepairLostEnqueueTracksLatestVisibleHeadAfterClientServerAdvance, "repair_lost_enqueue_tracks_latest_visible_head_after_client_server_advance"),
-    (QueueSimTraceOrderIsSeedStable, "queue_sim_trace_order_is_seed_stable"),
-    (BackgroundSimTraceOrderIsSeedStable, "background_sim_trace_order_is_seed_stable"),
-    (UnifiedNamespaceSimTraceOrderIsSeedStable, "unified_namespace_sim_trace_order_is_seed_stable"),
 
     // Production invariant report IDs that were previously only in the flat catalogue.
-    (NoOrphanedLiveEntry, "no_orphaned_live_entry"),
-    (VisibleRevisionPointsToDurableContent, "visible_revision_points_to_durable_content"),
 
     // Normalized WAL delta apply invariants.
     (CreateInodeWritesInodeRow, "create_inode_writes_inode_row"),

--- a/crates/loonfs-core/src/invariants.rs
+++ b/crates/loonfs-core/src/invariants.rs
@@ -1,3 +1,10 @@
+//! Registry of invariant identifiers recorded by validation and replay.
+//!
+//! An id exists here iff some production code pushes it into a
+//! `checked_invariants` ledger. Wire names are stable strings, so re-adding
+//! an id later is purely additive; do not reserve ids for machinery that
+//! does not exist yet.
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
@@ -81,8 +88,6 @@ define_invariant_ids! {
     (RestoreRevisionRequiresDurableContent, "restore_revision_requires_durable_content"),
     (SubtreeTombstoneBlocksDescendantMutation, "subtree_tombstone_blocks_descendant_mutation"),
 
-    // Namespace core metadata apply invariants.
-
     // Namespace core WAL replay invariants.
     (WalPayloadChecksumMatchesPayload, "wal_payload_checksum_matches_payload"),
     (WalKeyMatchesSegmentSeqRange, "wal_key_matches_segment_seq_range"),
@@ -92,35 +97,11 @@ define_invariant_ids! {
     (WalTailSeqIsContiguous, "wal_tail_seq_is_contiguous"),
     (WalReplayAppliesMetadataRows, "wal_replay_applies_metadata_rows"),
 
-    // Namespace core manifest replay invariants.
-
-    // Background work progress invariants.
-
-    // Background work queue shard object invariants.
-
-    // Background work queue mutation invariants.
-
-    // Background work checkpoint head publish invariants.
-
     // Content object file invariants.
     (WholeFileContentRefKindIsSupported, "whole_file_content_ref_kind_is_supported"),
     (WholeFileContentObjectKeyMatchesDigest, "whole_file_content_object_key_matches_digest"),
     (WholeFileContentSizeMatchesRef, "whole_file_content_size_matches_ref"),
     (WholeFileContentDigestMatchesRef, "whole_file_content_digest_matches_ref"),
-
-    // Manifest object immutable invariants.
-
-    // Client transfer download invariants.
-
-    // Client transfer inode upload invariants.
-
-    // Client transfer local-only upload invariants.
-
-    // Client reconciliation invariants.
-
-    // Simulation interleaving invariants.
-
-    // Production invariant report IDs that were previously only in the flat catalogue.
 
     // Normalized WAL delta apply invariants.
     (CreateInodeWritesInodeRow, "create_inode_writes_inode_row"),

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -21,8 +21,7 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 const DIRECTORY_PAGE_RAW_SCAN_LIMIT: usize = 64;
 
 #[derive(Clone, Copy)]
-pub(crate) struct MetadataSnapshot<'a> {
-    head: &'a HeadState,
+pub(crate) struct MetadataSnapshot {
     visible_seq: ChangeSeq,
     name_policy: NamePolicy,
 }
@@ -35,7 +34,7 @@ pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
 }
 
 pub(crate) struct MetadataView<'a, 'store, S: ObjectStore + ?Sized> {
-    snapshot: MetadataSnapshot<'a>,
+    snapshot: MetadataSnapshot,
     sources: MetadataSourceStack<'a, 'store, S>,
 }
 
@@ -111,7 +110,6 @@ impl ObjectStore for InMemoryMetadataViewStore {
 
 impl<'a> InMemoryMetadataView<'a> {
     pub(crate) fn in_memory(
-        head: &'a HeadState,
         base: &'a MetadataState,
         overlay: Option<&'a MetadataState>,
         visible_seq: ChangeSeq,
@@ -119,7 +117,6 @@ impl<'a> InMemoryMetadataView<'a> {
     ) -> Self {
         Self {
             snapshot: MetadataSnapshot {
-                head,
                 visible_seq,
                 name_policy,
             },
@@ -141,7 +138,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     ) -> Self {
         Self {
             snapshot: MetadataSnapshot {
-                head,
                 visible_seq: head.seq,
                 name_policy: head.name_policy,
             },
@@ -162,7 +158,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     ) -> MetadataView<'view, 'store, S> {
         MetadataView {
             snapshot: MetadataSnapshot {
-                head: self.snapshot.head,
                 visible_seq,
                 name_policy,
             },

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -117,6 +117,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
         &context.writer_version,
         fork_target_manifest_payload(
             new_namespace_id,
+            target_manifest_id,
             &target_checkpoint_id,
             source_namespace_id,
             source_manifest,
@@ -177,6 +178,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
 /// capabilities the source declared for those tables.
 fn fork_target_manifest_payload(
     new_namespace_id: &NamespaceId,
+    target_manifest_id: ManifestId,
     target_checkpoint_id: &CheckpointId,
     source_namespace_id: &NamespaceId,
     source_manifest: &NamespaceManifestEnvelope,
@@ -184,7 +186,6 @@ fn fork_target_manifest_payload(
     created_at_ms: u64,
 ) -> NamespaceManifestPayload {
     let fork_seq = source_checkpoint.head_seq;
-    let target_manifest_id = ManifestId(fork_seq.0);
     NamespaceManifestPayload {
         namespace_id: new_namespace_id.clone(),
         manifest_id: target_manifest_id,
@@ -568,6 +569,7 @@ mod tests {
 
         let target = fork_target_manifest_payload(
             &NamespaceId::parse("target").expect("target namespace"),
+            ManifestId(7),
             &target_checkpoint_id,
             &NamespaceId::parse("source").expect("source namespace"),
             &source,

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -115,37 +115,14 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     let descriptor_key = namespace_descriptor(new_namespace_id.as_str());
     let target_manifest = NamespaceManifestEnvelope::from_payload(
         &context.writer_version,
-        NamespaceManifestPayload {
-            namespace_id: new_namespace_id.clone(),
-            manifest_id: target_manifest_id,
-            head_seq: fork_seq,
-            head_commit_id: source_head_commit_id.clone(),
-            base_seq: source_manifest.payload.base_seq,
-            writer_epoch: WriterEpoch(0),
-            next_inode_id: source_manifest.payload.next_inode_id,
-            name_policy: source_manifest.payload.name_policy,
-            retention_floor_seq: fork_seq,
-            initialized: true,
-            verified: true,
-            fork: Some(NamespaceManifestFork {
-                source_namespace_id: source_namespace_id.clone(),
-                fork_seq,
-                source_checkpoint_id: source_checkpoint_id.clone(),
-                source_manifest_id,
-                source_head_seq,
-            }),
-            checkpoints: vec![NamespaceCheckpointRecord {
-                checkpoint_id: target_checkpoint_id.clone(),
-                manifest_id: target_manifest_id,
-                head_seq: fork_seq,
-                head_commit_id: source_head_commit_id.clone(),
-                created_at_ms: context.now_ms,
-                expires_at_ms: None,
-                name: None,
-            }],
-            features: source_manifest.payload.features.clone(),
-            metadata_files: source_manifest.payload.metadata_files.clone(),
-        },
+        fork_target_manifest_payload(
+            new_namespace_id,
+            &target_checkpoint_id,
+            source_namespace_id,
+            source_manifest,
+            source_checkpoint,
+            context.now_ms,
+        ),
     )
     .map_err(|err| CoreError::Store(err.to_string()))?;
     let gc_pin_envelope = NamespaceGcPinStateEnvelope::from_state(
@@ -192,6 +169,53 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     Ok(NamespaceSummary {
         namespace_id: new_namespace_id.clone(),
     })
+}
+
+/// Builds the fork target's manifest payload from the pinned source
+/// checkpoint. The target adopts the source's feature declarations and
+/// metadata file references verbatim: it must be readable under exactly the
+/// capabilities the source declared for those tables.
+fn fork_target_manifest_payload(
+    new_namespace_id: &NamespaceId,
+    target_checkpoint_id: &CheckpointId,
+    source_namespace_id: &NamespaceId,
+    source_manifest: &NamespaceManifestEnvelope,
+    source_checkpoint: &NamespaceCheckpointRecord,
+    created_at_ms: u64,
+) -> NamespaceManifestPayload {
+    let fork_seq = source_checkpoint.head_seq;
+    let target_manifest_id = ManifestId(fork_seq.0);
+    NamespaceManifestPayload {
+        namespace_id: new_namespace_id.clone(),
+        manifest_id: target_manifest_id,
+        head_seq: fork_seq,
+        head_commit_id: source_checkpoint.head_commit_id.clone(),
+        base_seq: source_manifest.payload.base_seq,
+        writer_epoch: WriterEpoch(0),
+        next_inode_id: source_manifest.payload.next_inode_id,
+        name_policy: source_manifest.payload.name_policy,
+        retention_floor_seq: fork_seq,
+        initialized: true,
+        verified: true,
+        fork: Some(NamespaceManifestFork {
+            source_namespace_id: source_namespace_id.clone(),
+            fork_seq,
+            source_checkpoint_id: source_checkpoint.checkpoint_id.clone(),
+            source_manifest_id: source_checkpoint.manifest_id,
+            source_head_seq: source_checkpoint.head_seq,
+        }),
+        checkpoints: vec![NamespaceCheckpointRecord {
+            checkpoint_id: target_checkpoint_id.clone(),
+            manifest_id: target_manifest_id,
+            head_seq: fork_seq,
+            head_commit_id: source_checkpoint.head_commit_id.clone(),
+            created_at_ms,
+            expires_at_ms: None,
+            name: None,
+        }],
+        features: source_manifest.payload.features.clone(),
+        metadata_files: source_manifest.payload.metadata_files.clone(),
+    }
 }
 
 async fn write_source_gc_pin<S: ObjectStore + ?Sized>(
@@ -332,7 +356,10 @@ fn map_namespace_initialization_error_to_core(error: NamespaceInitializationErro
 
 #[cfg(test)]
 mod tests {
-    use super::{checkpoint_record_by_id, deterministic_gc_pin_id, write_source_gc_pin};
+    use super::{
+        checkpoint_record_by_id, deterministic_gc_pin_id, fork_target_manifest_payload,
+        write_source_gc_pin,
+    };
     use crate::error::CoreError;
     use bytes::Bytes;
     use loonfs_api::wire::control::{
@@ -515,5 +542,47 @@ mod tests {
             },
         )
         .expect("manifest")
+    }
+
+    #[test]
+    fn fork_target_manifest_preserves_source_features_and_tables() {
+        let base = namespace_manifest_with_checkpoint(
+            "chk_00000000000000000000000000000002",
+            ManifestId(7),
+            ChangeSeq(7),
+            "c_00000000000000000000000000000009",
+        );
+        let mut payload = base.payload.clone();
+        payload
+            .features
+            .insert("core.test-capability".to_owned(), serde_json::json!(true));
+        let source = NamespaceManifestEnvelope::from_payload("test-writer/0.1.0", payload)
+            .expect("source manifest");
+        let source_checkpoint = source
+            .payload
+            .checkpoints
+            .first()
+            .expect("checkpoint record");
+        let target_checkpoint_id =
+            CheckpointId::parse("chk_00000000000000000000000000000003").expect("checkpoint id");
+
+        let target = fork_target_manifest_payload(
+            &NamespaceId::parse("target").expect("target namespace"),
+            &target_checkpoint_id,
+            &NamespaceId::parse("source").expect("source namespace"),
+            &source,
+            source_checkpoint,
+            2_000,
+        );
+
+        assert_eq!(target.features, source.payload.features);
+        assert_eq!(target.metadata_files, source.payload.metadata_files);
+        assert_eq!(target.head_seq, source_checkpoint.head_seq);
+        let fork = target.fork.expect("fork provenance");
+        assert_eq!(fork.source_checkpoint_id, source_checkpoint.checkpoint_id);
+        assert_eq!(fork.source_manifest_id, source_checkpoint.manifest_id);
+        let target_record = target.checkpoints.first().expect("target record");
+        assert_eq!(target_record.checkpoint_id, target_checkpoint_id);
+        assert_eq!(target_record.created_at_ms, 2_000);
     }
 }

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -158,7 +158,6 @@ pub(crate) struct PublishTailProjection {
     pub(crate) manifest_id: ManifestId,
     pub(crate) manifest_head_seq: ChangeSeq,
     pub(crate) manifest_payload_checksum: String,
-    pub(crate) wal_tail_segments: u64,
     pub(crate) tail_state: MetadataState,
 }
 
@@ -734,7 +733,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
-    let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
     let replayed = project_validated_wal_tail(
         manifest_head,
         &MetadataState::default(),
@@ -752,7 +750,6 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         manifest_id,
         manifest_head_seq: manifest_head.seq,
         manifest_payload_checksum,
-        wal_tail_segments,
         tail_state: replayed.resulting_metadata_state,
     };
     Ok(projection)

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -215,7 +215,6 @@ impl NamespaceCommitEngine {
         }
         projection.head_seq = resulting_head.seq;
         projection.head_etag = resulting_head_etag;
-        projection.wal_tail_segments = projection.wal_tail_segments.saturating_add(1);
         if projection.within_limits(tail_options) {
             self.publish_tail_projection = Some(projection);
         } else {

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -164,8 +164,8 @@ explicit commits — are fenced by `writer_epoch` and then linearized by the hea
 compare-and-swap that makes their WAL visible.
 
 Checkpoint and retention maintenance updates are CAS-linearized metadata
-updates. They preserve `writer_epoch` and `writer_lease`, and must not make
-uncommitted WAL visible. Maintenance may race with semantic writers; on head
+updates. They preserve `writer_epoch` and `writer_lease`, and must not change
+WAL visibility at all. Maintenance may race with semantic writers; on head
 CAS conflict it must reload the latest head and rebase or retry the metadata
 update. It must not bump `writer_epoch` unless its purpose is to intentionally
 fence writers.


### PR DESCRIPTION
Sweeps a number of leftover work: the unread wal_tail_segments projection field, a number of validator parameters and a MetadataSnapshot field that no longer carry anything, an unreachable re-validation of already-typed checkpoint ids, and invariant registry ids that no code or spec references — several of which described retention gates that do not exist and read as if they were enforced. Also tightens the per-run index descriptor check from presence-only to row-count equality with the canonical family (same trust basis, strictly stronger), and extracts the fork target manifest construction so the source-features carry-over finally has a direct test.