### PR TITLE
fix(core): verify checkpoint material at floor advance and base rebuild

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -8,7 +8,8 @@ use super::build::{
 use super::error::ManifestLoadError;
 use super::load::{
     head_from_manifest, load_namespace_manifest_envelope_if_present,
-    load_verified_manifest_tables_with_cache,
+    load_verified_manifest_tables_with_cache, validate_direntry_child_bind_index,
+    validate_revision_by_inode_desc_index,
 };
 use super::publish::{
     publish_current_manifest_id, write_namespace_manifest, ManifestPublicationOutcome,
@@ -530,6 +531,41 @@ async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
         rows.sort_by_key(|row| row.row_key_for_family(family));
         rows_by_family.insert(family, rows);
     }
+
+    // The base rebuild is the one production point that holds every row of
+    // every family, so cross-check the index families against their
+    // canonical tables before compacting them forward (format spec,
+    // "Manifest publication and checkpoint verification").
+    let source_manifest_key = namespace_manifest(
+        namespace_id.as_str(),
+        projection.manifest_tables.manifest().payload.manifest_id,
+    );
+    let index_error =
+        |error| CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error));
+    validate_direntry_child_bind_index(
+        &source_manifest_key,
+        rows_by_family
+            .get(&MetadataTableFamily::DirentryBinds)
+            .cloned()
+            .unwrap_or_default(),
+        rows_by_family
+            .get(&MetadataTableFamily::DirentryChildBinds)
+            .cloned()
+            .unwrap_or_default(),
+    )
+    .map_err(index_error)?;
+    validate_revision_by_inode_desc_index(
+        &source_manifest_key,
+        rows_by_family
+            .get(&MetadataTableFamily::Revisions)
+            .cloned()
+            .unwrap_or_default(),
+        rows_by_family
+            .get(&MetadataTableFamily::RevisionsByInodeDesc)
+            .cloned()
+            .unwrap_or_default(),
+    )
+    .map_err(index_error)?;
 
     build_manifest_tables_from_rows(
         store,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -39,7 +39,6 @@ use loonfs_api::wire::manifest::{
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_sst, namespace_manifest};
 use loonfs_objectstore::ObjectStore;
-#[cfg(test)]
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -734,7 +733,6 @@ pub(super) fn append_rows_to_metadata(
     Ok(())
 }
 
-#[cfg(test)]
 pub(super) fn validate_direntry_child_bind_index(
     object_key: &str,
     mut direntry_bind_rows: Vec<MetadataRow>,
@@ -756,7 +754,6 @@ pub(super) fn validate_direntry_child_bind_index(
     Ok(())
 }
 
-#[cfg(test)]
 pub(super) fn validate_revision_by_inode_desc_index(
     object_key: &str,
     mut revision_rows: Vec<MetadataRow>,
@@ -785,7 +782,6 @@ pub(super) fn validate_revision_by_inode_desc_index(
     Ok(())
 }
 
-#[cfg(test)]
 fn validate_revision_rows_have_unique_keys(
     object_key: &str,
     family: MetadataTableFamily,
@@ -805,7 +801,6 @@ fn validate_revision_rows_have_unique_keys(
     Ok(())
 }
 
-#[cfg(test)]
 fn revision_logical_key(row: &MetadataRow) -> String {
     row.row_key_for_family(MetadataTableFamily::Revisions)
 }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -11,6 +11,8 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
+const MAX_RETENTION_PROBE_IO: usize = 8;
+
 pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -39,24 +41,44 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
     let target_floor = manifest_tables.manifest().payload.head_seq;
+    if loaded_head.envelope.state.retention_floor_seq >= target_floor {
+        // Already advanced; skip the existence probes on the idempotent
+        // re-invocation path.
+        return Ok(AdvanceRetentionResponse {
+            namespace_id: namespace_id.clone(),
+            retention_floor_seq: loaded_head.envelope.state.retention_floor_seq,
+        });
+    }
 
     // Advancing the floor surrenders the WAL replay promise below the
     // target, so every metadata segment the target manifest references must
-    // still exist before that promise is given up. Corruption discovered
-    // later is caught by read-path checksums; disappearance must be caught
-    // here, while replay can still rebuild the state.
-    for metadata_file in &manifest_tables.manifest().payload.metadata_files {
-        let present = store
-            .head(&metadata_file.object_key)
-            .await
-            .map_err(|error| CoreError::Store(error.to_string()))?
-            .is_some();
-        if !present {
-            return Err(CoreError::CheckpointUnavailable(format!(
-                "retention floor cannot advance: missing metadata segment `{}`",
-                metadata_file.object_key
-            )));
-        }
+    // still exist before that promise is given up. This probe is advisory
+    // defense-in-depth: the atomic guarantee belongs to the deleter — GC
+    // must never remove an object reachable from the current manifest or a
+    // retained checkpoint or pin (format spec, "Garbage collection").
+    // Corruption discovered later is caught by read-path checksums.
+    for metadata_files in manifest_tables
+        .manifest()
+        .payload
+        .metadata_files
+        .chunks(MAX_RETENTION_PROBE_IO)
+    {
+        let probes = metadata_files.iter().map(|metadata_file| async move {
+            let present = store
+                .head(&metadata_file.object_key)
+                .await
+                .map_err(|error| CoreError::Store(error.to_string()))?
+                .is_some();
+            if present {
+                Ok(())
+            } else {
+                Err(CoreError::CheckpointUnavailable(format!(
+                    "retention floor cannot advance: missing metadata segment `{}`",
+                    metadata_file.object_key
+                )))
+            }
+        });
+        futures::future::try_join_all(probes).await?;
     }
 
     update_head(

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -40,6 +40,25 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         })?;
     let target_floor = manifest_tables.manifest().payload.head_seq;
 
+    // Advancing the floor surrenders the WAL replay promise below the
+    // target, so every metadata segment the target manifest references must
+    // still exist before that promise is given up. Corruption discovered
+    // later is caught by read-path checksums; disappearance must be caught
+    // here, while replay can still rebuild the state.
+    for metadata_file in &manifest_tables.manifest().payload.metadata_files {
+        let present = store
+            .head(&metadata_file.object_key)
+            .await
+            .map_err(|error| CoreError::Store(error.to_string()))?
+            .is_some();
+        if !present {
+            return Err(CoreError::CheckpointUnavailable(format!(
+                "retention floor cannot advance: missing metadata segment `{}`",
+                metadata_file.object_key
+            )));
+        }
+    }
+
     update_head(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -525,6 +525,126 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
 }
 
 #[tokio::test]
+async fn retention_floor_does_not_advance_past_missing_metadata_segment() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_id)
+            .await
+            .expect("load manifest");
+    let missing_key = materialized
+        .manifest
+        .payload
+        .metadata_files
+        .first()
+        .expect("metadata file")
+        .object_key
+        .clone();
+    store.delete(&missing_key).await.expect("delete segment");
+
+    let error = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect_err("floor must not advance past missing segment");
+    assert!(
+        matches!(error, CoreError::CheckpointUnavailable(_)),
+        "unexpected error: {error:?}"
+    );
+    let head = read_head_object(&store, &namespace_id)
+        .await
+        .expect("read head")
+        .envelope
+        .state;
+    assert_eq!(head.retention_floor_seq, ChangeSeq(0));
+}
+
+#[tokio::test]
+async fn base_rebuild_rejects_divergent_revision_index() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+
+    // Count-neutral divergence: same row count, different content, so only
+    // row-level index equality can catch it.
+    let (_, mut manifest, mut revision_index_rows) =
+        revision_index_test_materialization(&store, &namespace_id, &context).await;
+    let first = revision_index_rows.first_mut().expect("revision index row");
+    if let MetadataRow::Revision { content_ref, .. } = first {
+        content_ref.digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111".to_owned();
+    }
+    rewrite_revision_index_segment(
+        &store,
+        &namespace_id,
+        &mut manifest,
+        revision_index_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    // L0 appends never re-read the base run; the base rebuild that folds
+    // every run back together is the production point that must reject it.
+    let mut rebuild_error = None;
+    for round in 0..12u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        match create_checkpoint(&store, &namespace_id, &context).await {
+            Ok(_) => {}
+            Err(error) => {
+                rebuild_error = Some(error);
+                break;
+            }
+        }
+    }
+    match rebuild_error.expect("base rebuild should reject the divergent index") {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::RevisionIndexMismatch { .. },
+        )) => {}
+        other => panic!("expected revision index mismatch, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn manifest_load_rejects_unequal_index_descriptor_counts() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -204,7 +204,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `not_supported` | 501 | The deployment does not implement the requested op or feature. |
 | `commit_outcome_unknown` | 503 | The publish outcome was not observed; the commit may or may not be visible. Retry with the same commit id or reconcile. |
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
-| `checkpoint_unavailable` | 503 | Required checkpoint state is not yet available; retry. |
+| `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, changed during the operation, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `bootstrap_failed` | 500 | Namespace bootstrap failed internally. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -983,9 +983,11 @@ checkpoint instead of replaying from an obsolete cursor.
 The retention floor may advance only after the system has enough verified
 material to keep replay safe at or after that point: advancement verifies
 that every metadata segment referenced by the target manifest still exists
-before the floor moves. Corruption discovered after advancement is caught by
-read-path checksum validation; a segment that disappeared must block the
-floor while replay can still rebuild the lost state.
+before the floor moves. The probe is advisory — the atomic guarantee is the
+garbage collector's obligation to never remove reachable objects ("Garbage
+collection") — but a segment that already disappeared must block the floor
+while replay can still rebuild the lost state. Corruption discovered after
+advancement is caught by read-path checksum validation.
 
 Creating a checkpoint pins the current durable namespace file-set version. If
 there is no manifest for the current head, the implementation first writes one
@@ -1195,9 +1197,10 @@ and the `revisions_by_inode_desc` index table. The index table must contain
 exactly the same revision rows as the canonical table, keyed for newest-first
 inode revision scans. Readers treat a missing, extra, duplicate, or changed
 revision index row as namespace corruption. Segment reads enforce per-segment
-checksums, key ranges, and per-run row-count equality between canonical and
-index families; full row-level index equality is enforced at every base
-rebuild, the production point that materializes all rows.
+checksums and key ranges; manifest-table loads enforce per-run row-count
+equality between canonical and index families; full row-level index equality
+is enforced at every base rebuild, the production point that materializes all
+rows.
 
 ### 6.2 Compaction
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -981,7 +981,11 @@ Clients older than the retention floor must re-bootstrap from a fresh
 checkpoint instead of replaying from an obsolete cursor.
 
 The retention floor may advance only after the system has enough verified
-material to keep replay safe at or after that point.
+material to keep replay safe at or after that point: advancement verifies
+that every metadata segment referenced by the target manifest still exists
+before the floor moves. Corruption discovered after advancement is caught by
+read-path checksum validation; a segment that disappeared must block the
+floor while replay can still rebuild the lost state.
 
 Creating a checkpoint pins the current durable namespace file-set version. If
 there is no manifest for the current head, the implementation first writes one
@@ -1190,7 +1194,10 @@ For file revisions, a valid manifest includes the canonical `revisions` table
 and the `revisions_by_inode_desc` index table. The index table must contain
 exactly the same revision rows as the canonical table, keyed for newest-first
 inode revision scans. Readers treat a missing, extra, duplicate, or changed
-revision index row as namespace corruption.
+revision index row as namespace corruption. Segment reads enforce per-segment
+checksums, key ranges, and per-run row-count equality between canonical and
+index families; full row-level index equality is enforced at every base
+rebuild, the production point that materializes all rows.
 
 ### 6.2 Compaction
 


### PR DESCRIPTION
Advancing the retention floor makes sub-floor WAL GC-eligible, but advancement only parsed the target manifest — a metadata segment lost after checkpoint publication would surrender the replay promise that could still have rebuilt it. Floor advancement now existence-probes every referenced segment first and refuses to move past a missing one. The base rebuild — the one production point that materializes every row of every family — now cross-checks the index families against their canonical tables, giving the spec's index-corruption rule a production enforcement point instead of a test-only one. Spec wording updated to promise exactly what is enforced.