### PR TITLE
feat(core): bound checkpoint records and receipts to what retention needs

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -444,6 +444,7 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
     if let Some(checkpoint) = checkpoint_to_add {
         checkpoints.push(checkpoint);
     }
+    let checkpoints = retained_checkpoint_records(checkpoints);
 
     let (base_seq, metadata_files) = if is_bootstrap_seed_manifest(&previous_manifest.payload) {
         let run_tables = build_base_manifest_tables_from_projection(
@@ -510,6 +511,35 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
     .map_err(|err| CoreError::Store(err.to_string()))
 }
 
+/// Unnamed checkpoint records are maintenance bookkeeping; a manifest keeps
+/// only the newest few so correctly-operated maintenance cannot pin storage
+/// forever. Named records persist until explicitly removed, and fork sources
+/// stay protected by their GC pins independently of any record (format spec,
+/// "Retention management").
+const RETAINED_UNNAMED_CHECKPOINT_RECORDS: usize = 4;
+
+pub(super) fn retained_checkpoint_records(
+    mut checkpoints: Vec<NamespaceCheckpointRecord>,
+) -> Vec<NamespaceCheckpointRecord> {
+    let unnamed = checkpoints
+        .iter()
+        .filter(|record| record.name.is_none())
+        .count();
+    let mut drop_remaining = unnamed.saturating_sub(RETAINED_UNNAMED_CHECKPOINT_RECORDS);
+    if drop_remaining == 0 {
+        return checkpoints;
+    }
+    // Records are appended oldest-first, so retention drops from the front.
+    checkpoints.retain(|record| {
+        if record.name.is_some() || drop_remaining == 0 {
+            return true;
+        }
+        drop_remaining -= 1;
+        false
+    });
+    checkpoints
+}
+
 async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -528,6 +558,18 @@ async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
                 CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
             })?;
         rows.extend(manifest_rows_for_family(&projection.tail_state, family));
+        if family == MetadataTableFamily::CommitReceipts {
+            // The idempotency horizon is the retention floor: a commit
+            // retried from below it re-bootstraps like any sub-floor cursor,
+            // so its receipt no longer needs to be carried forward.
+            let retention_floor_seq = projection.head.retention_floor_seq;
+            rows.retain(|row| match row {
+                MetadataRow::CommitReceipt { committed_seq, .. } => {
+                    *committed_seq >= retention_floor_seq
+                }
+                _ => true,
+            });
+        }
         rows.sort_by_key(|row| row.row_key_for_family(family));
         rows_by_family.insert(family, rows);
     }
@@ -625,6 +667,7 @@ pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
     if let Some(checkpoint) = checkpoint_to_add {
         checkpoints.push(checkpoint);
     }
+    let checkpoints = retained_checkpoint_records(checkpoints);
 
     let (base_seq, metadata_files) = match previous_manifest {
         Some(previous) if is_bootstrap_seed_manifest(&previous.manifest.payload) => {

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -515,7 +515,7 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
 /// only the newest few so correctly-operated maintenance cannot pin storage
 /// forever. Named records persist until explicitly removed, and fork sources
 /// stay protected by their GC pins independently of any record (format spec,
-/// "Retention management").
+/// "Compaction").
 const RETAINED_UNNAMED_CHECKPOINT_RECORDS: usize = 4;
 
 pub(super) fn retained_checkpoint_records(

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -600,6 +600,22 @@ fn record_retention_keeps_named_and_newest_unnamed_records() {
 
     let kept_seqs: Vec<u64> = kept.iter().map(|r| r.head_seq.0).collect();
     assert_eq!(kept_seqs, vec![1, 4, 5, 6, 7]);
+
+    // A named record interleaved mid-vec is skipped, not counted or dropped.
+    let records = vec![
+        record(1, None),
+        record(2, None),
+        record(3, Some("mid")),
+        record(4, None),
+        record(5, None),
+        record(6, None),
+        record(7, None),
+    ];
+
+    let kept = retained_checkpoint_records(records);
+
+    let kept_seqs: Vec<u64> = kept.iter().map(|r| r.head_seq.0).collect();
+    assert_eq!(kept_seqs, vec![3, 4, 5, 6, 7]);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -11,7 +11,7 @@ use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::create::{
     build_namespace_manifest_from_metadata_state, checkpoint_record_by_id, create_checkpoint,
     create_checkpoint_with_policy, load_checkpoint_projection_metadata_state,
-    ManifestMetadataSource,
+    retained_checkpoint_records, ManifestMetadataSource,
 };
 use super::error::ManifestLoadError;
 use super::load::{
@@ -43,8 +43,8 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::{
     encode_metadata_sst_envelope_zstd, encode_namespace_manifest_json, MetadataFileRef,
     MetadataPage, MetadataRow, MetadataSegmentKey, MetadataSstEnvelope, MetadataSstPayload,
-    MetadataTableFamily as ApiMetadataTableFamily, NamespaceManifestEnvelope,
-    NamespaceManifestPayload,
+    MetadataTableFamily as ApiMetadataTableFamily, NamespaceCheckpointRecord,
+    NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
     validate_checkpoint_id, ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId,
@@ -573,6 +573,161 @@ async fn retention_floor_does_not_advance_past_missing_metadata_segment() {
         .envelope
         .state;
     assert_eq!(head.retention_floor_seq, ChangeSeq(0));
+}
+
+#[test]
+fn record_retention_keeps_named_and_newest_unnamed_records() {
+    let record = |seq: u64, name: Option<&str>| NamespaceCheckpointRecord {
+        checkpoint_id: CheckpointId::parse(format!("chk_{seq:032x}")).expect("checkpoint id"),
+        manifest_id: ManifestId(seq),
+        head_seq: ChangeSeq(seq),
+        head_commit_id: CommitId::parse("c_00000000000000000000000000000001").expect("commit id"),
+        created_at_ms: seq,
+        expires_at_ms: None,
+        name: name.map(str::to_owned),
+    };
+    let records = vec![
+        record(1, Some("release")),
+        record(2, None),
+        record(3, None),
+        record(4, None),
+        record(5, None),
+        record(6, None),
+        record(7, None),
+    ];
+
+    let kept = retained_checkpoint_records(records);
+
+    let kept_seqs: Vec<u64> = kept.iter().map(|r| r.head_seq.0).collect();
+    assert_eq!(kept_seqs, vec![1, 4, 5, 6, 7]);
+}
+
+#[tokio::test]
+async fn manifest_publication_retains_only_newest_unnamed_checkpoint_records() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    let mut checkpoint_ids = Vec::new();
+    let mut last_manifest_id = None;
+    for round in 0..6u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        checkpoint_ids.push(checkpoint.checkpoint_id.clone());
+        last_manifest_id = Some(checkpoint.manifest_id);
+    }
+
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        last_manifest_id.expect("manifest id"),
+    )
+    .await
+    .expect("load manifest");
+    let records = &materialized.manifest.payload.checkpoints;
+    assert_eq!(records.len(), 4);
+    let expected: Vec<_> = checkpoint_ids[checkpoint_ids.len() - 4..].to_vec();
+    let actual: Vec<_> = records
+        .iter()
+        .map(|record| record.checkpoint_id.clone())
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/one.txt",
+        b"one\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write one");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/two.txt",
+        b"two\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write two");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let advanced = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance floor");
+    assert_eq!(advanced.retention_floor_seq, ChangeSeq(2));
+
+    let mut last_manifest_id = None;
+    for round in 0..9u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        last_manifest_id = Some(checkpoint.manifest_id);
+    }
+
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        last_manifest_id.expect("manifest id"),
+    )
+    .await
+    .expect("load manifest");
+    let receipts = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::CommitReceipts,
+    );
+    assert!(!receipts.is_empty());
+    for row in &receipts {
+        if let MetadataRow::CommitReceipt { committed_seq, .. } = row {
+            assert!(
+                *committed_seq >= ChangeSeq(2),
+                "receipt below floor survived: {committed_seq:?}"
+            );
+        }
+    }
+    assert!(receipts.iter().any(|row| matches!(
+        row,
+        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == ChangeSeq(2)
+    )));
 }
 
 #[tokio::test]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1254,7 +1254,7 @@ async fn list_changes_handler(
         path = "/v0/admin/namespaces/{namespace}/checkpoint",
         tag = "admin",
         summary = "Create checkpoint",
-        description = "Pins the current namespace view with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
+        description = "Records a checkpoint of the current namespace view. Unnamed checkpoints are maintenance bookkeeping: a manifest retains only the four newest, so this is not a durable pin with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Checkpoint created or reused", body = CreateCheckpointResponse),

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -881,7 +881,7 @@ normalized absolute paths, and the intent's semantic parameters).
 
 The idempotency horizon is the retention floor. Commit receipts below the
 floor are dropped when metadata runs are rebuilt, so a commit retried from
-below the floor is treated as new — the same re-bootstrap contract the change
+below the floor may be treated as new — the same re-bootstrap contract the change
 feed gives sub-floor cursors.
 
 A reused `commit_id` with an equal fingerprint replays the originally

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -879,6 +879,11 @@ Path-level mutations fingerprint the same way with domain
 `loonfs.path.intent.semantic.v0` over the normalized path intent (intent kind,
 normalized absolute paths, and the intent's semantic parameters).
 
+The idempotency horizon is the retention floor. Commit receipts below the
+floor are dropped when metadata runs are rebuilt, so a commit retried from
+below the floor is treated as new — the same re-bootstrap contract the change
+feed gives sub-floor cursors.
+
 A reused `commit_id` with an equal fingerprint replays the originally
 committed response; an unequal fingerprint is rejected as
 `commit_id_reuse_conflict`. Reference values are pinned by tests in
@@ -1215,6 +1220,12 @@ Invariants:
   path; readers never observe a partially compacted state.
 - Compacted inputs MUST remain available until no retained manifest version,
   checkpoint record, or fork GC pin references them.
+
+Unnamed checkpoint records are maintenance bookkeeping. A manifest carries at
+most the four newest unnamed records; publishing a new manifest drops older
+unnamed records. Named checkpoint records persist until explicitly removed.
+Fork sources are protected by their GC pins independently of any checkpoint
+record, so record retention never affects fork safety.
 
 ### 6.3 Retention management
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -41,7 +41,7 @@
           "admin"
         ],
         "summary": "Create checkpoint",
-        "description": "Pins the current namespace view with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
+        "description": "Records a checkpoint of the current namespace view. Unnamed checkpoints are maintenance bookkeeping: a manifest retains only the four newest, so this is not a durable pin with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
         "operationId": "create_checkpoint_handler",
         "parameters": [
           {


### PR DESCRIPTION
Checkpoint records were immortal: every manifest cloned all prior records forward, so correctly-operated maintenance pinned a full metadata copy roughly every eighth tick, forever — even a perfect GC would reclaim nothing. Manifests now keep only the four newest unnamed records (maintenance bookkeeping); named records persist until removed, and fork sources remain protected by their GC pins independently of records. Commit receipts get the same treatment: the idempotency horizon is now the retention floor — receipts below it drop at base rebuild, matching the re-bootstrap contract the change feed already gives sub-floor cursors. Spec updated accordingly.