### PR TITLE
feat(core): drop dead rows below the retention floor at base rebuild

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -545,10 +545,10 @@ pub(super) fn retained_checkpoint_records(
 /// unbound bindings, and spent unbind markers at or below the retention
 /// floor. Tombstone and inode rows are always retained until
 /// reachability-based dropping is designed.
-fn drop_rows_below_retention_floor(
+pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
-) {
+) -> Result<(), CoreError> {
     // The latest revision at or below the floor is what the floor itself
     // observes; every older one is superseded at every retained sequence.
     let mut latest_revision_at_floor = BTreeMap::new();
@@ -598,6 +598,9 @@ fn drop_rows_below_retention_floor(
     // At the floor only the latest non-unbound bind per (parent, name) slot
     // is visible; an unbind marker at or below the floor has finished its
     // work once every bind it covered is gone.
+    // Unbind identity here omits child_inode_id (the read path also matches
+    // it); the 4-tuple is already unique for writer-produced rows, so the
+    // predicates agree on every legal history.
     let mut unbound_at_floor = BTreeSet::new();
     for row in rows_by_family
         .get(&MetadataTableFamily::DirentryUnbinds)
@@ -648,6 +651,41 @@ fn drop_rows_below_retention_floor(
             }
         }
     }
+    // Load-bearing writer invariant: a bind is only ever superseded by an
+    // operation that also unbinds it, so every non-latest bind at or below
+    // the floor must have a matching unbind at or below the floor. The drop
+    // is only visibility-preserving under that rule; refuse to compact state
+    // that violates it.
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryBinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq
+                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
+                    != Some(&(*bind_seq, *bind_delta_index))
+                && !unbound_at_floor.contains(&(
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ))
+            {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "bind at seq {bind_seq:?} delta {bind_delta_index} for parent {parent_inode_id:?} is superseded at or below the retention floor without an unbind; refusing to drop rows"
+                )));
+            }
+        }
+    }
+
     let retain_bind = |row: &MetadataRow| match row {
         MetadataRow::DirentryBind {
             parent_inode_id,
@@ -682,6 +720,7 @@ fn drop_rows_below_retention_floor(
             _ => true,
         });
     }
+    Ok(())
 }
 
 async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
@@ -753,7 +792,7 @@ async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
     )
     .map_err(index_error)?;
 
-    drop_rows_below_retention_floor(&mut rows_by_family, projection.head.retention_floor_seq);
+    drop_rows_below_retention_floor(&mut rows_by_family, projection.head.retention_floor_seq)?;
 
     build_manifest_tables_from_rows(
         store,

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -40,7 +40,7 @@ use loonfs_api::{
 };
 use loonfs_objectstore::keys::namespace_manifest;
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::Instrument;
 
 #[cfg(test)]
@@ -540,6 +540,150 @@ pub(super) fn retained_checkpoint_records(
     checkpoints
 }
 
+/// Drops rows that no retained sequence can observe (format spec,
+/// "Compaction"). Conservative subset: superseded revisions, superseded or
+/// unbound bindings, and spent unbind markers at or below the retention
+/// floor. Tombstone and inode rows are always retained until
+/// reachability-based dropping is designed.
+fn drop_rows_below_retention_floor(
+    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    retention_floor_seq: ChangeSeq,
+) {
+    // The latest revision at or below the floor is what the floor itself
+    // observes; every older one is superseded at every retained sequence.
+    let mut latest_revision_at_floor = BTreeMap::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::Revisions)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            ..
+        } = row
+        {
+            if *committed_seq <= retention_floor_seq {
+                let latest = latest_revision_at_floor
+                    .entry(*inode_id)
+                    .or_insert(*revision_no);
+                if *revision_no > *latest {
+                    *latest = *revision_no;
+                }
+            }
+        }
+    }
+    let retain_revision = |row: &MetadataRow| match row {
+        MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            ..
+        } => {
+            *committed_seq > retention_floor_seq
+                || latest_revision_at_floor.get(inode_id) == Some(revision_no)
+        }
+        _ => true,
+    };
+    for family in [
+        MetadataTableFamily::Revisions,
+        MetadataTableFamily::RevisionsByInodeDesc,
+    ] {
+        if let Some(rows) = rows_by_family.get_mut(&family) {
+            rows.retain(retain_revision);
+        }
+    }
+
+    // At the floor only the latest non-unbound bind per (parent, name) slot
+    // is visible; an unbind marker at or below the floor has finished its
+    // work once every bind it covered is gone.
+    let mut unbound_at_floor = BTreeSet::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryUnbinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryUnbind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            unbind_seq,
+            ..
+        } = row
+        {
+            if *unbind_seq <= retention_floor_seq {
+                unbound_at_floor.insert((
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ));
+            }
+        }
+    }
+    let mut latest_bind_at_floor = BTreeMap::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryBinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq {
+                let candidate = (*bind_seq, *bind_delta_index);
+                let latest = latest_bind_at_floor
+                    .entry((*parent_inode_id, name_key.clone()))
+                    .or_insert(candidate);
+                if candidate > *latest {
+                    *latest = candidate;
+                }
+            }
+        }
+    }
+    let retain_bind = |row: &MetadataRow| match row {
+        MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } => {
+            *bind_seq > retention_floor_seq
+                || (latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
+                    == Some(&(*bind_seq, *bind_delta_index))
+                    && !unbound_at_floor.contains(&(
+                        *parent_inode_id,
+                        name_key.clone(),
+                        *bind_seq,
+                        *bind_delta_index,
+                    )))
+        }
+        _ => true,
+    };
+    for family in [
+        MetadataTableFamily::DirentryBinds,
+        MetadataTableFamily::DirentryChildBinds,
+    ] {
+        if let Some(rows) = rows_by_family.get_mut(&family) {
+            rows.retain(retain_bind);
+        }
+    }
+    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
+        rows.retain(|row| match row {
+            MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq > retention_floor_seq,
+            _ => true,
+        });
+    }
+}
+
 async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -608,6 +752,8 @@ async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
             .unwrap_or_default(),
     )
     .map_err(index_error)?;
+
+    drop_rows_below_retention_floor(&mut rows_by_family, projection.head.retention_floor_seq);
 
     build_manifest_tables_from_rows(
         store,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -33,7 +33,7 @@ use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::control::read_head_object;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
-use crate::path::write::ops::{move_path, put_file_bytes, write_file_bytes};
+use crate::path::write::ops::{delete_path, move_path, put_file_bytes, write_file_bytes};
 use crate::protocol::list_changes_after;
 use crate::MutationContext;
 use async_trait::async_trait;
@@ -744,6 +744,155 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
         row,
         MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == ChangeSeq(2)
     )));
+}
+
+#[tokio::test]
+async fn base_rebuild_drops_revisions_superseded_below_floor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"one\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write one");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"two\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write two");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance floor");
+
+    let mut last_manifest_id = None;
+    for round in 0..9u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        last_manifest_id = Some(checkpoint.manifest_id);
+    }
+
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        last_manifest_id.expect("manifest id"),
+    )
+    .await
+    .expect("load manifest");
+    let revisions = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::Revisions,
+    );
+    let digest_one = loonfs_api::sha256_digest(b"one\n");
+    let digest_two = loonfs_api::sha256_digest(b"two\n");
+    assert!(!revisions.iter().any(|row| matches!(
+        row,
+        MetadataRow::Revision { content_ref, .. } if content_ref.digest == digest_one
+    )));
+    assert!(revisions.iter().any(|row| matches!(
+        row,
+        MetadataRow::Revision { content_ref, .. } if content_ref.digest == digest_two
+    )));
+}
+
+#[tokio::test]
+async fn base_rebuild_drops_bindings_unbound_below_floor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/tmp.txt",
+        b"scratch\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write tmp");
+    delete_path(&store, &namespace_id, "/docs/tmp.txt", &context, None)
+        .await
+        .expect("delete tmp");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance floor");
+
+    let mut last_manifest_id = None;
+    for round in 0..9u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        last_manifest_id = Some(checkpoint.manifest_id);
+    }
+
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        last_manifest_id.expect("manifest id"),
+    )
+    .await
+    .expect("load manifest");
+    let binds = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::DirentryBinds,
+    );
+    assert!(!binds.iter().any(|row| matches!(
+        row,
+        MetadataRow::DirentryBind { display_name, .. } if display_name == "tmp.txt"
+    )));
+    let unbinds = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::DirentryUnbinds,
+    );
+    assert!(
+        unbinds.is_empty(),
+        "spent unbind markers survived: {unbinds:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -10,8 +10,8 @@ use super::build::{
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::create::{
     build_namespace_manifest_from_metadata_state, checkpoint_record_by_id, create_checkpoint,
-    create_checkpoint_with_policy, load_checkpoint_projection_metadata_state,
-    retained_checkpoint_records, ManifestMetadataSource,
+    create_checkpoint_with_policy, drop_rows_below_retention_floor,
+    load_checkpoint_projection_metadata_state, retained_checkpoint_records, ManifestMetadataSource,
 };
 use super::error::ManifestLoadError;
 use super::load::{
@@ -33,7 +33,9 @@ use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::control::read_head_object;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
-use crate::path::write::ops::{delete_path, move_path, put_file_bytes, write_file_bytes};
+use crate::path::write::ops::{
+    delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,
+};
 use crate::protocol::list_changes_after;
 use crate::MutationContext;
 use async_trait::async_trait;
@@ -48,7 +50,7 @@ use loonfs_api::wire::manifest::{
 };
 use loonfs_api::{
     validate_checkpoint_id, ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId,
-    NamespaceId, PutBehavior,
+    NamespaceId, PutBehavior, RevisionNo,
 };
 use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{metadata_sst, namespace_head, namespace_manifest, wal_segment};
@@ -744,6 +746,187 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
         row,
         MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq == ChangeSeq(2)
     )));
+}
+
+#[test]
+fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
+    use std::collections::BTreeMap;
+    let bind = |seq: u64, delta: u32| MetadataRow::DirentryBind {
+        parent_inode_id: InodeId(1),
+        name_key: "docs".to_owned(),
+        display_name: "docs".to_owned(),
+        child_inode_id: InodeId(2),
+        bind_seq: ChangeSeq(seq),
+        bind_delta_index: delta,
+    };
+    let unbind = |bind_seq: u64, delta: u32, unbind_seq: u64| MetadataRow::DirentryUnbind {
+        parent_inode_id: InodeId(1),
+        name_key: "docs".to_owned(),
+        child_inode_id: InodeId(2),
+        bind_seq: ChangeSeq(bind_seq),
+        bind_delta_index: delta,
+        unbind_seq: ChangeSeq(unbind_seq),
+        unbind_delta_index: 0,
+    };
+    let mut rows = BTreeMap::new();
+    // bind at seq 1 is visible at the floor (1); the rename that supersedes
+    // it happens above the floor, so bind, unbind, and replacement all stay.
+    rows.insert(
+        ApiMetadataTableFamily::DirentryBinds,
+        vec![bind(1, 0), bind(2, 1)],
+    );
+    rows.insert(
+        ApiMetadataTableFamily::DirentryChildBinds,
+        vec![bind(1, 0), bind(2, 1)],
+    );
+    rows.insert(
+        ApiMetadataTableFamily::DirentryUnbinds,
+        vec![unbind(1, 0, 2)],
+    );
+
+    drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+
+    assert_eq!(rows[&ApiMetadataTableFamily::DirentryBinds].len(), 2);
+    assert_eq!(rows[&ApiMetadataTableFamily::DirentryChildBinds].len(), 2);
+    assert_eq!(rows[&ApiMetadataTableFamily::DirentryUnbinds].len(), 1);
+}
+
+#[test]
+fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
+    use std::collections::BTreeMap;
+    let bind = |delta: u32| MetadataRow::DirentryBind {
+        parent_inode_id: InodeId(1),
+        name_key: "docs".to_owned(),
+        display_name: "docs".to_owned(),
+        child_inode_id: InodeId(2),
+        bind_seq: ChangeSeq(1),
+        bind_delta_index: delta,
+    };
+    let unbind = MetadataRow::DirentryUnbind {
+        parent_inode_id: InodeId(1),
+        name_key: "docs".to_owned(),
+        child_inode_id: InodeId(2),
+        bind_seq: ChangeSeq(1),
+        bind_delta_index: 0,
+        unbind_seq: ChangeSeq(1),
+        unbind_delta_index: 1,
+    };
+    let mut rows = BTreeMap::new();
+    rows.insert(
+        ApiMetadataTableFamily::DirentryBinds,
+        vec![bind(0), bind(2)],
+    );
+    rows.insert(
+        ApiMetadataTableFamily::DirentryChildBinds,
+        vec![bind(0), bind(2)],
+    );
+    rows.insert(ApiMetadataTableFamily::DirentryUnbinds, vec![unbind]);
+
+    drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+
+    // Only the delta-2 rebind (the slot's latest) survives; the superseded
+    // delta-0 bind and its spent unbind marker are gone from both families.
+    for family in [
+        ApiMetadataTableFamily::DirentryBinds,
+        ApiMetadataTableFamily::DirentryChildBinds,
+    ] {
+        let kept = &rows[&family];
+        assert_eq!(kept.len(), 1);
+        assert!(matches!(
+            kept[0],
+            MetadataRow::DirentryBind {
+                bind_delta_index: 2,
+                ..
+            }
+        ));
+    }
+    assert!(rows[&ApiMetadataTableFamily::DirentryUnbinds].is_empty());
+}
+
+#[test]
+fn drop_pass_refuses_superseded_bind_without_unbind() {
+    use std::collections::BTreeMap;
+    let bind = |delta: u32| MetadataRow::DirentryBind {
+        parent_inode_id: InodeId(1),
+        name_key: "docs".to_owned(),
+        display_name: "docs".to_owned(),
+        child_inode_id: InodeId(2),
+        bind_seq: ChangeSeq(1),
+        bind_delta_index: delta,
+    };
+    let mut rows = BTreeMap::new();
+    rows.insert(
+        ApiMetadataTableFamily::DirentryBinds,
+        vec![bind(0), bind(1)],
+    );
+
+    let error = drop_rows_below_retention_floor(&mut rows, ChangeSeq(1))
+        .expect_err("superseded live bind must refuse the drop");
+    assert!(matches!(error, CoreError::NamespaceCorrupt(_)));
+}
+
+#[tokio::test]
+async fn restore_below_the_floor_fails_with_revision_not_found() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"one\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write one");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        b"two\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write two");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance floor");
+    for round in 0..9u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write");
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+    }
+
+    let error = restore_file_revision(
+        &store,
+        &namespace_id,
+        "/docs/a.txt",
+        RevisionNo(1),
+        &context,
+        None,
+    )
+    .await
+    .expect_err("restoring a reclaimed revision must fail cleanly");
+    assert_eq!(error.code(), crate::error::ErrorCode::RevisionNotFound);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -270,6 +270,13 @@ fn publish_child_name_absent_precondition<S: ObjectStore + ?Sized>(
     }
 }
 
+/// Rejects planning through a *visible* path component covered by a subtree
+/// tombstone. The walk observes only visible bindings, so its answer cannot
+/// change when compaction drops rows no retained sequence observes: a deleted
+/// (unbound) name simply ends the walk, and recreating it plans as a fresh
+/// subtree. A visible-but-covered component cannot arise from legal writer
+/// histories; hitting one means corrupt state, and failing the plan is the
+/// safe answer.
 async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
     view: &PublishPathPlanningView<'_, '_, '_, S>,
     absolute_path: &AbsolutePath,
@@ -282,7 +289,7 @@ async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
         let name_key = NameKey::for_display_name(view.head.name_policy, &display_name);
         let Some(bound_child) = view
             .metadata_state
-            .bound_child(current_inode, name_key.as_str())
+            .visible_child(current_inode, name_key.as_str())
             .await?
         else {
             return Ok(());
@@ -300,20 +307,6 @@ async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
                 root_inode: tombstone.root_inode_id,
                 tombstone_seq: tombstone.tombstone_seq,
             });
-        }
-        let Some(latest_binding) = view
-            .metadata_state
-            .current_parent_binding_for_child(bound_child.child_inode_id)
-            .await?
-        else {
-            return Ok(());
-        };
-        if latest_binding.parent_inode_id != bound_child.parent_inode_id
-            || latest_binding.name_key != bound_child.name_key
-            || latest_binding.bind_seq != bound_child.bind_seq
-            || latest_binding.bind_delta_index != bound_child.bind_delta_index
-        {
-            return Ok(());
         }
         current_inode = bound_child.child_inode_id;
         current_path = visible_path;
@@ -1139,7 +1132,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tombstoned_ancestor_blocks_descendant_planning() {
+    async fn recreate_after_delete_succeeds_at_the_same_path() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        put_file_bytes(
+            &store,
+            &namespace_id,
+            "/docs/tmp.txt",
+            b"first",
+            PutBehavior::NoReplace,
+            &context,
+            Some(&CommitId::parse("recreate-seed").expect("valid commit id")),
+        )
+        .await
+        .expect("seed file");
+        delete_path(
+            &store,
+            &namespace_id,
+            "/docs/tmp.txt",
+            &context,
+            Some(&CommitId::parse("recreate-delete").expect("valid commit id")),
+        )
+        .await
+        .expect("delete file");
+
+        // The tombstone covers the dead inode, not the name: the name is
+        // reusable immediately, with or without an intervening rebuild.
+        put_file_bytes(
+            &store,
+            &namespace_id,
+            "/docs/tmp.txt",
+            b"second",
+            PutBehavior::NoReplace,
+            &context,
+            Some(&CommitId::parse("recreate-put").expect("valid commit id")),
+        )
+        .await
+        .expect("recreate at the deleted path");
+    }
+
+    #[tokio::test]
+    async fn deleted_subtree_names_replan_as_fresh_state() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
         let seed_commit_id = CommitId::parse("seed-dead-tree").expect("valid commit id");
         put_file_bytes(
@@ -1166,7 +1198,10 @@ mod tests {
         let staged = store_bytes_as_content(&store, &namespace_id, b"new")
             .await
             .expect("stage");
-        let error = try_plan_against_current_state(
+        // The deleted name is invisible, so planning under it starts a
+        // fresh subtree instead of conflicting with the dead one — the same
+        // answer callers get after compaction drops the dead rows.
+        try_plan_against_current_state(
             &store,
             &namespace_id,
             &PathMutationIntent::PutFile {
@@ -1177,8 +1212,6 @@ mod tests {
             },
         )
         .await
-        .expect_err("tombstoned ancestor");
-
-        assert_eq!(error.code(), ErrorCode::TombstoneConflict);
+        .expect("recreating a deleted subtree plans as fresh state");
     }
 }

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -4369,7 +4369,7 @@ async fn move_path_directory_cycle_is_would_cycle() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn write_and_move_under_tombstoned_ancestor_are_tombstone_conflicts() {
+async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -4401,27 +4401,31 @@ async fn write_and_move_under_tombstoned_ancestor_are_tombstone_conflicts() {
     )
     .expect("delete docs");
 
-    let put_error = write_file_bytes(
+    // Deleting `/docs` unbinds the name: it is reusable immediately, and
+    // writes and moves under it create a fresh subtree rather than
+    // conflicting with the dead one. The old subtree stays dead — its
+    // previous child is not resurrected by the recreation.
+    write_file_bytes(
         &store,
         &namespace_id(),
         "/docs/new.txt",
         b"new",
         &context,
-        Some("put-under-tombstone"),
+        Some("put-under-recreated"),
     )
-    .expect_err("put tombstone conflict");
-    assert_eq!(put_error.code(), ErrorCode::TombstoneConflict);
+    .expect("put recreates the subtree");
+    let old_child = resolve_path(&store, &namespace_id(), "/docs/old.txt");
+    assert!(old_child.is_err(), "dead subtree child must stay invisible");
 
-    let move_error = move_path(
+    move_path(
         &store,
         &namespace_id(),
         "/tmp/source.txt",
         "/docs/source.txt",
         &context,
-        Some("move-under-tombstone"),
+        Some("move-under-recreated"),
     )
-    .expect_err("move tombstone conflict");
-    assert_eq!(move_error.code(), ErrorCode::TombstoneConflict);
+    .expect("move lands in the recreated subtree");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -2096,7 +2096,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn http_put_and_move_under_tombstoned_ancestor_return_tombstone_conflict() {
+    async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let now_ms = now_ms();
@@ -2136,22 +2136,27 @@ mod tests {
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
+            // The deleted name is invisible and immediately reusable; the
+            // dead subtree's children stay dead.
             let put_target = NamespacePath::parse("demo:/docs/new.txt").expect("put target");
+            harness
+                .client
+                .write_file_bytes(&put_target, b"new")
+                .expect("put recreates the subtree");
+            let old_child = NamespacePath::parse("demo:/docs/old.txt").expect("old child");
             assert_api_error(
-                harness.client.write_file_bytes(&put_target, b"new"),
-                409,
-                "tombstone_conflict",
+                harness.client.stat_path(&old_child),
+                404,
+                "path_not_found",
                 None,
             );
 
             let from = NamespacePath::parse("demo:/tmp/source.txt").expect("from");
             let to = NamespacePath::parse("demo:/docs/source.txt").expect("to");
-            assert_api_error(
-                harness.client.move_path(&from, &to),
-                409,
-                "tombstone_conflict",
-                None,
-            );
+            harness
+                .client
+                .move_path(&from, &to)
+                .expect("move lands in the recreated subtree");
         })
         .await
         .expect("join blocking task");

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1216,7 +1216,8 @@ A base rebuild drops rows that no retained sequence can observe: revisions
 superseded at or below the retention floor, bindings superseded or unbound at
 or below the floor, spent unbind markers, and commit receipts below the
 floor. The floor is the single retention policy: history below it — including
-file revision history — is reclaimed. Tombstone and inode rows are always
+file revision history — is reclaimed, except where a named checkpoint record
+still pins an older manifest that can serve it. Tombstone and inode rows are always
 retained for now; reachability-based dropping for them is future work.
 
 Invariants:

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1212,6 +1212,13 @@ rows.
 Compaction rewrites metadata runs (and, in the future, content layouts) into
 more efficient physical shapes.
 
+A base rebuild drops rows that no retained sequence can observe: revisions
+superseded at or below the retention floor, bindings superseded or unbound at
+or below the floor, spent unbind markers, and commit receipts below the
+floor. The floor is the single retention policy: history below it — including
+file revision history — is reclaimed. Tombstone and inode rows are always
+retained for now; reachability-based dropping for them is future work.
+
 Invariants:
 
 - Compaction MUST NOT change logical content: the visible metadata state at


### PR DESCRIPTION
Base rebuilds copied every row ever written, so metadata tables grew with total history rather than live state — spec 6.2 permitted dropping but nothing exercised it. The rebuild now drops what no retained sequence can observe: revisions superseded at or below the floor, bindings superseded or unbound at or below it, and spent unbind markers. The floor is the single retention knob, so sub-floor file revision history is reclaimed with everything else. Deliberately conservative: tombstone and inode rows are always kept — dropping them interacts with restore preconditions and inode reachability, which deserves its own design pass (noted in the spec).