### PR TITLE
feat(core): auto-tick maintenance and backpressure publishes on long wal tails

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -28,7 +28,7 @@ use super::runs::{
     CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
     DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT, MAX_CHECKPOINT_L0_RUNS,
 };
-use crate::error::{CoreError, MetadataProjectionLoadError};
+use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::control::read_head_object;
@@ -1076,6 +1076,52 @@ async fn base_rebuild_drops_bindings_unbound_below_floor() {
         unbinds.is_empty(),
         "spent unbind markers survived: {unbinds:?}"
     );
+}
+
+#[tokio::test]
+async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for round in 0..129u32 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write within backpressure window");
+    }
+
+    let error = write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/one-too-many.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect_err("publish past the backpressure limit must be rejected");
+    assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+
+    // Reads never gate: the change feed still serves the whole tail.
+    let changes = list_changes_after(
+        &store,
+        &namespace_id,
+        ChangeSeq(0),
+        EffectiveLimit::new(NonZeroU32::new(200).expect("nonzero")),
+    )
+    .await
+    .expect("list changes");
+    assert_eq!(changes.through_seq, ChangeSeq(129));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -1087,7 +1087,8 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
-    for round in 0..129u32 {
+    let limit = u32::try_from(crate::publisher::WAL_TAIL_BACKPRESSURE_SEGMENTS).expect("limit");
+    for round in 0..=limit {
         write_file_bytes(
             &store,
             &namespace_id,

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -158,6 +158,7 @@ pub(crate) struct PublishTailProjection {
     pub(crate) manifest_id: ManifestId,
     pub(crate) manifest_head_seq: ChangeSeq,
     pub(crate) manifest_payload_checksum: String,
+    pub(crate) wal_tail_segments: u64,
     pub(crate) tail_state: MetadataState,
 }
 
@@ -743,6 +744,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalReplay(error))
     })?;
     ensure_publish_reconstructed_head_matches(head, &replayed.resulting_head)?;
+    let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
     let projection = PublishTailProjection {
         namespace_id: namespace_id.clone(),
         head_etag: head_etag.to_owned(),
@@ -750,6 +752,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         manifest_id,
         manifest_head_seq: manifest_head.seq,
         manifest_payload_checksum,
+        wal_tail_segments,
         tail_state: replayed.resulting_metadata_state,
     };
     Ok(projection)

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -579,7 +579,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         }
     };
     let publish_tail_options = PublishTailOptions::default();
-    let publish_view = match load_publish_metadata_view(
+    let (publish_view, projection) = match load_publish_metadata_view(
         store,
         namespace_id,
         Some(acquired_writer),
@@ -592,9 +592,25 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     ))
     .await
     {
-        Ok((publish_view, _projection)) => publish_view,
+        Ok(value) => value,
         Err(error) => return (0..candidates.len()).map(|_| Err(error.clone())).collect(),
     };
+    if projection.wal_tail_segments > crate::publisher::WAL_TAIL_BACKPRESSURE_SEGMENTS {
+        // Same backpressure contract as the caching engine: the commit
+        // surface must not outrun maintenance either (format spec,
+        // "Maintenance operations").
+        let error = MetadataViewError::MaintenanceRequired {
+            namespace_id: namespace_id.clone(),
+            reason: format!(
+                "wal tail has {} segments; publishes resume once maintenance brings it back to {} or fewer",
+                projection.wal_tail_segments,
+                crate::publisher::WAL_TAIL_BACKPRESSURE_SEGMENTS
+            ),
+        };
+        return (0..candidates.len())
+            .map(|_| Err(CoreError::from(error.clone())))
+            .collect();
+    }
     publish_namespace_mutations_batch_against_publish_view(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -1,7 +1,7 @@
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
-use crate::error::{CoreError, ErrorCode};
+use crate::error::{CoreError, ErrorCode, MetadataViewError};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::planner::plan_path_mutation_against_publish_view;
 use crate::path::write::{
@@ -72,9 +72,18 @@ impl Default for PublishOptions {
     }
 }
 
+/// Publishes stop being accepted once the WAL tail is far past the default
+/// maintenance checkpoint threshold (4x at defaults). Reads never gate; this
+/// only asks writers to wait for the maintenance a deployment failed to run
+/// (format spec, "Maintenance operations").
+pub(crate) const WAL_TAIL_BACKPRESSURE_SEGMENTS: u64 = 128;
+
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
     pub results: Vec<Result<ApiCommitResponse, CoreError>>,
+    /// WAL tail length observed by this publish, for opportunistic
+    /// maintenance scheduling. Zero when no projection was loaded.
+    pub wal_tail_segments: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -120,6 +129,7 @@ impl NamespaceCommitEngine {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
+                wal_tail_segments: 0,
             };
         }
 
@@ -129,6 +139,7 @@ impl NamespaceCommitEngine {
             Err(error) => {
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, CoreError::WriterEpoch(error)),
+                    wal_tail_segments: 0,
                 };
             }
         };
@@ -147,9 +158,25 @@ impl NamespaceCommitEngine {
                 self.invalidate();
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
+                    wal_tail_segments: 0,
                 };
             }
         };
+
+        if projection.wal_tail_segments > WAL_TAIL_BACKPRESSURE_SEGMENTS {
+            let wal_tail_segments = projection.wal_tail_segments;
+            self.publish_tail_projection = Some(projection);
+            let error = MetadataViewError::MaintenanceRequired {
+                namespace_id: self.namespace_id.clone(),
+                reason: format!(
+                    "wal tail has {wal_tail_segments} segments; publishes resume once maintenance brings it back under {WAL_TAIL_BACKPRESSURE_SEGMENTS}"
+                ),
+            };
+            return NamespaceCommitEnginePublishResult {
+                results: repeated_error(candidate_count, CoreError::from(error)),
+                wal_tail_segments,
+            };
+        }
 
         let published = crate::protocol::publish_namespace_mutations_batch_against_publish_view(
             store,
@@ -159,9 +186,11 @@ impl NamespaceCommitEngine {
             &publish_view,
         )
         .await;
-        self.update_publish_tail_projection(projection, &published, tail_options);
+        let wal_tail_segments =
+            self.update_publish_tail_projection(projection, &published, tail_options);
         NamespaceCommitEnginePublishResult {
             results: published.results,
+            wal_tail_segments,
         }
     }
 
@@ -186,22 +215,26 @@ impl NamespaceCommitEngine {
         mut projection: PublishTailProjection,
         published: &crate::protocol::PublishBatchAgainstViewResult,
         tail_options: &PublishTailOptions,
-    ) {
+    ) -> u64 {
+        if !published.published_records.is_empty() {
+            projection.wal_tail_segments = projection.wal_tail_segments.saturating_add(1);
+        }
+        let wal_tail_segments = projection.wal_tail_segments;
         let Some(resulting_head) = published.resulting_head.clone() else {
             if published.can_reuse_loaded_projection {
                 self.publish_tail_projection = Some(projection);
             } else {
                 self.invalidate();
             }
-            return;
+            return wal_tail_segments;
         };
         let Some(resulting_head_etag) = published.resulting_head_etag.clone() else {
             self.invalidate();
-            return;
+            return wal_tail_segments;
         };
         if resulting_head.current_manifest_id != Some(projection.manifest_id) {
             self.invalidate();
-            return;
+            return wal_tail_segments;
         }
         for record in &published.published_records {
             if projection
@@ -210,7 +243,7 @@ impl NamespaceCommitEngine {
                 .is_err()
             {
                 self.invalidate();
-                return;
+                return wal_tail_segments;
             }
         }
         projection.head_seq = resulting_head.seq;
@@ -220,6 +253,7 @@ impl NamespaceCommitEngine {
         } else {
             self.invalidate();
         }
+        wal_tail_segments
     }
 }
 

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -55,6 +55,9 @@ pub struct RuntimeCacheConfig {
     /// Enables namespace control-object caching.
     pub control_cache_enabled: bool,
     /// Maximum namespaces retained in runtime caches.
+    /// Setting this to zero disables the commit-engine cache — a diagnostic
+    /// mode that also disables post-publish auto-maintenance, leaving only
+    /// the hard publish backpressure. Not for production use.
     pub max_cached_namespaces: usize,
     /// Maximum metadata rows retained across cached WAL-tail projections.
     pub max_cached_wal_tail_projection_rows: usize,

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -55,6 +55,7 @@ pub(crate) struct FsInner {
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
+    pub(crate) maintenance_inflight: std::sync::atomic::AtomicBool,
 }
 
 /// Lock accessors for the runtime caches.
@@ -201,6 +202,7 @@ impl Fs {
                 metadata_table_cache,
                 wal_tail_projection_cache,
                 cache_stats: RuntimeCacheStatsInner::default(),
+                maintenance_inflight: std::sync::atomic::AtomicBool::new(false),
             }),
         })
     }
@@ -1046,11 +1048,15 @@ impl Fs {
                     .collect::<Vec<_>>();
                 self.invalidate_namespace_cache_after_batch(namespace_id, &runtime_results);
             }
-            return publish
+            let wal_tail_segments = publish.wal_tail_segments;
+            let results = publish
                 .results
                 .into_iter()
                 .map(|result| result.map_err(RuntimeError::Core))
                 .collect();
+            self.maybe_auto_tick_after_publish(namespace_id, wal_tail_segments)
+                .await;
+            return results;
         }
 
         let results: Vec<_> = self
@@ -1072,6 +1078,40 @@ impl Fs {
             self.invalidate_namespace_cache_after_batch(namespace_id, &results);
         }
         results
+    }
+
+    /// Runs a maintenance tick inline after a publish that observed the WAL
+    /// tail at or past the checkpoint threshold. One publish pays for the
+    /// checkpoint instead of every reader paying for an unbounded tail; the
+    /// in-flight flag keeps concurrent publishers from stacking ticks. The
+    /// cache-disabled diagnostic mode skips this, as it tracks no tail
+    /// projection to observe.
+    async fn maybe_auto_tick_after_publish(
+        &self,
+        namespace_id: &NamespaceId,
+        wal_tail_segments: u64,
+    ) {
+        use std::sync::atomic::Ordering;
+
+        let options = MaintenanceTickOptions::default();
+        if wal_tail_segments < options.max_wal_tail_segments {
+            return;
+        }
+        if self.inner.maintenance_inflight.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let outcome = self.maintenance_tick_namespace(namespace_id, options).await;
+        self.inner
+            .maintenance_inflight
+            .store(false, Ordering::SeqCst);
+        if let Err(error) = outcome {
+            tracing::info!(
+                phase = "auto_maintenance_tick",
+                result = "error",
+                error = %error,
+                "post-publish maintenance tick failed"
+            );
+        }
     }
 
     /// Snapshots the runtime cache counters.

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -55,7 +55,10 @@ pub(crate) struct FsInner {
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
-    pub(crate) maintenance_inflight: std::sync::atomic::AtomicBool,
+    pub(crate) maintenance_inflight: std::sync::Mutex<std::collections::BTreeSet<NamespaceId>>,
+    pub(crate) maintenance_idle: std::sync::Condvar,
+    pub(crate) maintenance_worker:
+        std::sync::OnceLock<std::sync::mpsc::Sender<(NamespaceId, MaintenanceTickOptions)>>,
 }
 
 /// Lock accessors for the runtime caches.
@@ -202,7 +205,9 @@ impl Fs {
                 metadata_table_cache,
                 wal_tail_projection_cache,
                 cache_stats: RuntimeCacheStatsInner::default(),
-                maintenance_inflight: std::sync::atomic::AtomicBool::new(false),
+                maintenance_inflight: std::sync::Mutex::new(std::collections::BTreeSet::new()),
+                maintenance_idle: std::sync::Condvar::new(),
+                maintenance_worker: std::sync::OnceLock::new(),
             }),
         })
     }
@@ -1054,8 +1059,7 @@ impl Fs {
                 .into_iter()
                 .map(|result| result.map_err(RuntimeError::Core))
                 .collect();
-            self.maybe_auto_tick_after_publish(namespace_id, wal_tail_segments)
-                .await;
+            self.maybe_auto_tick_after_publish(namespace_id, wal_tail_segments);
             return results;
         }
 
@@ -1080,38 +1084,114 @@ impl Fs {
         results
     }
 
-    /// Runs a maintenance tick inline after a publish that observed the WAL
-    /// tail at or past the checkpoint threshold. One publish pays for the
-    /// checkpoint instead of every reader paying for an unbounded tail; the
-    /// in-flight flag keeps concurrent publishers from stacking ticks. The
-    /// cache-disabled diagnostic mode skips this, as it tracks no tail
-    /// projection to observe.
-    async fn maybe_auto_tick_after_publish(
-        &self,
-        namespace_id: &NamespaceId,
-        wal_tail_segments: u64,
-    ) {
-        use std::sync::atomic::Ordering;
-
+    /// Queues a maintenance tick after a publish that observed the WAL tail
+    /// at or past the checkpoint threshold. Ticks run on a dedicated worker
+    /// thread with its own runtime, so no writer (and no server batch
+    /// pipeline) ever waits behind a checkpoint or base rebuild, and the
+    /// mechanism works under any caller executor — including per-call
+    /// `block_on` embedders whose ambient runtime dies between calls. The
+    /// per-namespace in-flight marker dedupes concurrent publishers and is
+    /// cleared by the worker on every outcome, including tick panics. The
+    /// cache-disabled diagnostic mode never reaches this, as it tracks no
+    /// tail projection to observe.
+    fn maybe_auto_tick_after_publish(&self, namespace_id: &NamespaceId, wal_tail_segments: u64) {
         let options = MaintenanceTickOptions::default();
         if wal_tail_segments < options.max_wal_tail_segments {
             return;
         }
-        if self.inner.maintenance_inflight.swap(true, Ordering::SeqCst) {
-            return;
+        {
+            let mut inflight = self
+                .inner
+                .maintenance_inflight
+                .lock()
+                .expect("maintenance inflight lock");
+            if !inflight.insert(namespace_id.clone()) {
+                return;
+            }
         }
-        let outcome = self.maintenance_tick_namespace(namespace_id, options).await;
-        self.inner
+        let sender = self.maintenance_worker();
+        if sender.send((namespace_id.clone(), options)).is_err() {
+            if let Ok(mut inflight) = self.inner.maintenance_inflight.lock() {
+                inflight.remove(namespace_id);
+            }
+            self.inner.maintenance_idle.notify_all();
+        }
+    }
+
+    /// Blocks until every queued background maintenance tick has finished.
+    ///
+    /// Publishes schedule maintenance on a dedicated worker; call this to
+    /// quiesce before shutdown, or in tests that assert on post-maintenance
+    /// state.
+    pub fn wait_for_background_maintenance(&self) {
+        let mut inflight = self
+            .inner
             .maintenance_inflight
-            .store(false, Ordering::SeqCst);
-        if let Err(error) = outcome {
-            tracing::info!(
-                phase = "auto_maintenance_tick",
-                result = "error",
-                error = %error,
-                "post-publish maintenance tick failed"
-            );
+            .lock()
+            .expect("maintenance inflight lock");
+        while !inflight.is_empty() {
+            inflight = self
+                .inner
+                .maintenance_idle
+                .wait(inflight)
+                .expect("maintenance inflight lock");
         }
+    }
+
+    fn maintenance_worker(
+        &self,
+    ) -> &std::sync::mpsc::Sender<(NamespaceId, MaintenanceTickOptions)> {
+        self.inner.maintenance_worker.get_or_init(|| {
+            let (sender, receiver) =
+                std::sync::mpsc::channel::<(NamespaceId, MaintenanceTickOptions)>();
+            // The worker holds only a weak reference: dropping the last Fs
+            // drops FsInner (and this sender with it), which ends the loop
+            // and the thread.
+            let inner = Arc::downgrade(&self.inner);
+            std::thread::Builder::new()
+                .name("loonfs-maintenance".to_owned())
+                .spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("maintenance runtime");
+                    while let Ok((namespace_id, options)) = receiver.recv() {
+                        let Some(inner) = inner.upgrade() else {
+                            return;
+                        };
+                        let fs = Fs { inner };
+                        let outcome =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                runtime
+                                    .block_on(fs.maintenance_tick_namespace(&namespace_id, options))
+                            }));
+                        if let Ok(mut inflight) = fs.inner.maintenance_inflight.lock() {
+                            inflight.remove(&namespace_id);
+                        }
+                        fs.inner.maintenance_idle.notify_all();
+                        match outcome {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(error)) => {
+                                tracing::info!(
+                                    phase = "auto_maintenance_tick",
+                                    result = "error",
+                                    error = %error,
+                                    "post-publish maintenance tick failed"
+                                );
+                            }
+                            Err(_) => {
+                                tracing::info!(
+                                    phase = "auto_maintenance_tick",
+                                    result = "panic",
+                                    "post-publish maintenance tick panicked"
+                                );
+                            }
+                        }
+                    }
+                })
+                .expect("spawn maintenance worker");
+            sender
+        })
     }
 
     /// Snapshots the runtime cache counters.

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1822,6 +1822,8 @@ fn publish_auto_ticks_maintenance_once_tail_reaches_threshold() {
         .expect("put file");
     }
 
+    // The tick runs on the maintenance worker thread; quiesce, then assert.
+    fs.wait_for_background_maintenance();
     let status = fs
         .namespace_status_blocking(&namespace_id)
         .expect("status after auto tick");

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1805,6 +1805,37 @@ fn explicit_commit_appears_in_change_feed() {
 }
 
 #[test]
+fn publish_auto_ticks_maintenance_once_tail_reaches_threshold() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "auto-tick-test");
+    let namespace_id = namespace();
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    for round in 0..33u32 {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            b"body",
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    let status = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect("status after auto tick");
+    assert!(
+        status.current_manifest_id > Some(ManifestId(0)),
+        "auto tick should have published a manifest: {status:?}"
+    );
+    assert!(
+        status.wal_tail_segments < 32,
+        "auto tick should have bounded the tail: {status:?}"
+    );
+}
+
+#[test]
 fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "status-test");

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1178,11 +1178,15 @@ bump.
 Maintenance keeps read cost bounded, retention safe, and durable state clean.
 Maintenance **effects** are normative format semantics; maintenance
 **scheduling and triggering** are not. Two behaviors keep an un-administered
-deployment healthy regardless of scheduling: the reference implementation
-runs a maintenance tick inline after any publish that observes the WAL tail
-at or past the checkpoint threshold, and publishes are rejected with
-`maintenance_required` once the tail exceeds four times that threshold.
-Reads never gate on tail length. An embedded engine where an operator
+deployment's read costs bounded regardless of scheduling: the reference
+implementation schedules a background maintenance tick after any runtime
+publish that observes the WAL tail at or past the checkpoint threshold
+(32 segments at defaults), and every publish surface rejects with
+`maintenance_required` once the tail exceeds four times that threshold
+(128 at defaults). Reads never gate on tail length. Bounded reads are the
+automatic half only: the retention floor never advances on its own, so
+history retention — and the row reclamation that follows it — remains an
+explicit operator decision. An embedded engine where an operator
 triggers maintenance manually and a server that runs the same work invisibly
 are equally conformant (see `api.md` for the optional maintenance plane). The
 invariants below bind every implementation, whoever runs the work: maintenance

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1177,7 +1177,12 @@ bump.
 
 Maintenance keeps read cost bounded, retention safe, and durable state clean.
 Maintenance **effects** are normative format semantics; maintenance
-**scheduling and triggering** are not. An embedded engine where an operator
+**scheduling and triggering** are not. Two behaviors keep an un-administered
+deployment healthy regardless of scheduling: the reference implementation
+runs a maintenance tick inline after any publish that observes the WAL tail
+at or past the checkpoint threshold, and publishes are rejected with
+`maintenance_required` once the tail exceeds four times that threshold.
+Reads never gate on tail length. An embedded engine where an operator
 triggers maintenance manually and a server that runs the same work invisibly
 are equally conformant (see `api.md` for the optional maintenance plane). The
 invariants below bind every implementation, whoever runs the work: maintenance


### PR DESCRIPTION
Nothing in a default deployment ever ran maintenance: the tick had zero in-tree callers, so an un-administered namespace accumulated WAL forever and cold reads degraded linearly. Publishes now run a maintenance tick inline whenever they observe the tail at or past the checkpoint threshold (one publish pays for the checkpoint instead of every reader paying for the tail), and past four times that threshold publishes are rejected with the previously-unraisable maintenance_required code. Reads never gate, preserving the #153 decision that backpressure belongs on the write side.