### PR TITLE
refactor(api): merge the invalid_* error family and drop reserved surface

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -43,16 +43,8 @@ pub enum ErrorKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorCode {
-    InvalidPath,
-    InvalidNamespaceId,
-    InvalidCommitId,
-    InvalidUploadId,
-    InvalidInodeId,
-    InvalidRevisionNo,
-    InvalidCursor,
-    InvalidConfig,
+    InvalidRequest,
     Unauthorized,
-    PermissionDenied,
     NotSupported,
     NamespaceNotFound,
     NamespaceDeleted,
@@ -67,7 +59,6 @@ pub enum ErrorCode {
     TombstoneConflict,
     LeaseConflict,
     WouldCycle,
-    UnsupportedMoveBehavior,
     CommitIdReuseConflict,
     CommitOutcomeUnknown,
     CommitQueueFull,
@@ -76,26 +67,16 @@ pub enum ErrorCode {
     UploadNotFound,
     UploadAlreadyCompleted,
     UploadContentConflict,
-    InvalidUploadContent,
     RebootstrapRequired,
-    BootstrapFailed,
     NamespaceCorrupt,
     ServerError,
 }
 
 impl ErrorCode {
     /// Every registered code, in registry order.
-    pub const ALL: [ErrorCode; 38] = [
-        ErrorCode::InvalidPath,
-        ErrorCode::InvalidNamespaceId,
-        ErrorCode::InvalidCommitId,
-        ErrorCode::InvalidUploadId,
-        ErrorCode::InvalidInodeId,
-        ErrorCode::InvalidRevisionNo,
-        ErrorCode::InvalidCursor,
-        ErrorCode::InvalidConfig,
+    pub const ALL: [ErrorCode; 27] = [
+        ErrorCode::InvalidRequest,
         ErrorCode::Unauthorized,
-        ErrorCode::PermissionDenied,
         ErrorCode::NotSupported,
         ErrorCode::NamespaceNotFound,
         ErrorCode::NamespaceDeleted,
@@ -110,7 +91,6 @@ impl ErrorCode {
         ErrorCode::TombstoneConflict,
         ErrorCode::LeaseConflict,
         ErrorCode::WouldCycle,
-        ErrorCode::UnsupportedMoveBehavior,
         ErrorCode::CommitIdReuseConflict,
         ErrorCode::CommitOutcomeUnknown,
         ErrorCode::CommitQueueFull,
@@ -119,27 +99,15 @@ impl ErrorCode {
         ErrorCode::UploadNotFound,
         ErrorCode::UploadAlreadyCompleted,
         ErrorCode::UploadContentConflict,
-        ErrorCode::InvalidUploadContent,
         ErrorCode::RebootstrapRequired,
-        ErrorCode::BootstrapFailed,
         ErrorCode::NamespaceCorrupt,
         ErrorCode::ServerError,
     ];
 
     pub fn kind(self) -> ErrorKind {
         match self {
-            ErrorCode::InvalidPath
-            | ErrorCode::InvalidNamespaceId
-            | ErrorCode::InvalidCommitId
-            | ErrorCode::InvalidUploadId
-            | ErrorCode::InvalidInodeId
-            | ErrorCode::InvalidRevisionNo
-            | ErrorCode::InvalidCursor
-            | ErrorCode::InvalidConfig
-            | ErrorCode::UnsupportedMoveBehavior
-            | ErrorCode::InvalidUploadContent => ErrorKind::InvalidRequest,
+            ErrorCode::InvalidRequest => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
-            ErrorCode::PermissionDenied => ErrorKind::PermissionDenied,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound
             | ErrorCode::NamespaceDeleted
@@ -153,7 +121,7 @@ impl ErrorCode {
             | ErrorCode::MaintenanceRequired => ErrorKind::Unavailable,
             ErrorCode::CommitOutcomeUnknown => ErrorKind::OutcomeUnknown,
             ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
-            ErrorCode::ServerError | ErrorCode::BootstrapFailed => ErrorKind::Internal,
+            ErrorCode::ServerError => ErrorKind::Internal,
             ErrorCode::NamespacePartial
             | ErrorCode::PathConflict
             | ErrorCode::DirectoryNotEmpty
@@ -170,16 +138,8 @@ impl ErrorCode {
 
     pub fn as_str(self) -> &'static str {
         match self {
-            ErrorCode::InvalidPath => "invalid_path",
-            ErrorCode::InvalidNamespaceId => "invalid_namespace_id",
-            ErrorCode::InvalidCommitId => "invalid_commit_id",
-            ErrorCode::InvalidUploadId => "invalid_upload_id",
-            ErrorCode::InvalidInodeId => "invalid_inode_id",
-            ErrorCode::InvalidRevisionNo => "invalid_revision_no",
-            ErrorCode::InvalidCursor => "invalid_cursor",
-            ErrorCode::InvalidConfig => "invalid_config",
+            ErrorCode::InvalidRequest => "invalid_request",
             ErrorCode::Unauthorized => "unauthorized",
-            ErrorCode::PermissionDenied => "permission_denied",
             ErrorCode::NotSupported => "not_supported",
             ErrorCode::NamespaceNotFound => "namespace_not_found",
             ErrorCode::NamespaceDeleted => "namespace_deleted",
@@ -194,7 +154,6 @@ impl ErrorCode {
             ErrorCode::TombstoneConflict => "tombstone_conflict",
             ErrorCode::LeaseConflict => "lease_conflict",
             ErrorCode::WouldCycle => "would_cycle",
-            ErrorCode::UnsupportedMoveBehavior => "unsupported_move_behavior",
             ErrorCode::CommitIdReuseConflict => "commit_id_reuse_conflict",
             ErrorCode::CommitOutcomeUnknown => "commit_outcome_unknown",
             ErrorCode::CommitQueueFull => "commit_queue_full",
@@ -203,9 +162,7 @@ impl ErrorCode {
             ErrorCode::UploadNotFound => "upload_not_found",
             ErrorCode::UploadAlreadyCompleted => "upload_already_completed",
             ErrorCode::UploadContentConflict => "upload_content_conflict",
-            ErrorCode::InvalidUploadContent => "invalid_upload_content",
             ErrorCode::RebootstrapRequired => "rebootstrap_required",
-            ErrorCode::BootstrapFailed => "bootstrap_failed",
             ErrorCode::NamespaceCorrupt => "namespace_corrupt",
             ErrorCode::ServerError => "server_error",
         }

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -304,8 +304,8 @@ mod tests {
             serde_json::json!("recursive")
         );
         assert_eq!(
-            serde_json::to_value(MoveBehavior::Exchange).expect("move behavior json"),
-            serde_json::json!("exchange")
+            serde_json::to_value(MoveBehavior::NoReplace).expect("move behavior json"),
+            serde_json::json!("no_replace")
         );
     }
 

--- a/crates/loonfs-api/src/v0.rs
+++ b/crates/loonfs-api/src/v0.rs
@@ -13,10 +13,6 @@ pub enum MoveBehavior {
     /// Move only if the destination name is absent.
     #[default]
     NoReplace,
-    /// Reserved for a future version.
-    Replace,
-    /// Reserved for a future version.
-    Exchange,
 }
 
 /// Upload transport mode.

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -340,7 +340,7 @@ impl Backend for EmbeddedBackend {
                     cursor: cursor
                         .map(loonfs_api::decode_file_revisions_cursor)
                         .transpose()
-                        .map_err(|error| CliError::new("invalid_cursor", error.to_string()))?,
+                        .map_err(|error| CliError::new("invalid_request", error.to_string()))?,
                 },
             ),
         )
@@ -501,10 +501,7 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
 }
 
 fn map_core_error(error: CoreError) -> CliError {
-    if matches!(
-        error.code(),
-        ErrorCode::InvalidNamespaceId | ErrorCode::InvalidCommitId | ErrorCode::InvalidUploadId
-    ) {
+    if matches!(error.code(), ErrorCode::InvalidRequest) {
         return CliError::invalid_input(error.to_string());
     }
 
@@ -539,7 +536,7 @@ fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {
         BootstrapNamespaceError::EmptyHolderId | BootstrapNamespaceError::EmptyWriterVersion => {
             CliError::invalid_config(error.to_string())
         }
-        _ => CliError::new("bootstrap_failed", error.to_string()),
+        _ => CliError::new("server_error", error.to_string()),
     }
 }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -15,7 +15,7 @@ impl CliError {
     }
 
     pub(crate) fn invalid_config(message: impl Into<String>) -> Self {
-        Self::new("invalid_config", message)
+        Self::new("invalid_request", message)
     }
 
     pub(crate) fn invalid_input(message: impl Into<String>) -> Self {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -526,7 +526,7 @@ default_profile = ""
     let list = harness.run(&["--json", "profile", "list"]);
     assert_failure(&list);
     let error = json_error(&list);
-    assert_eq!(error["code"], "invalid_config");
+    assert_eq!(error["code"], "invalid_request");
     assert!(error["message"]
         .as_str()
         .unwrap()
@@ -546,7 +546,7 @@ default_profile = "   "
     let list = harness.run(&["--json", "profile", "list"]);
     assert_failure(&list);
     let error = json_error(&list);
-    assert_eq!(error["code"], "invalid_config");
+    assert_eq!(error["code"], "invalid_request");
     assert!(error["message"]
         .as_str()
         .unwrap()
@@ -573,7 +573,7 @@ root = ""
     let list = harness.run(&["--json", "profile", "list"]);
     assert_failure(&list);
     let error = json_error(&list);
-    assert_eq!(error["code"], "invalid_config");
+    assert_eq!(error["code"], "invalid_request");
     assert!(error["message"]
         .as_str()
         .unwrap()
@@ -602,7 +602,7 @@ root = "{}"
     let current = harness.run(&["--json", "current"]);
     assert_failure(&current);
     let error = json_error(&current);
-    assert_eq!(error["code"], "invalid_config");
+    assert_eq!(error["code"], "invalid_request");
     assert!(error["message"]
         .as_str()
         .unwrap()
@@ -675,7 +675,7 @@ fn invalid_remote_urls_are_rejected() {
         "http://",
     ]);
     assert_failure(&missing_host_http);
-    assert_eq!(json_error(&missing_host_http)["code"], "invalid_config");
+    assert_eq!(json_error(&missing_host_http)["code"], "invalid_request");
     assert!(json_error(&missing_host_http)["message"]
         .as_str()
         .unwrap()
@@ -692,7 +692,7 @@ fn invalid_remote_urls_are_rejected() {
         "https://",
     ]);
     assert_failure(&missing_host_https);
-    assert_eq!(json_error(&missing_host_https)["code"], "invalid_config");
+    assert_eq!(json_error(&missing_host_https)["code"], "invalid_request");
 }
 
 #[test]

--- a/crates/loonfs-core/src/commit/validate.rs
+++ b/crates/loonfs-core/src/commit/validate.rs
@@ -472,13 +472,8 @@ async fn validate_metadata_preconditions(
                 inode_id,
                 new_parent_inode,
                 new_display_name,
-                behavior,
+                behavior: _,
             } => {
-                if *behavior != loonfs_api::v0::MoveBehavior::NoReplace {
-                    return Err(CommitValidationError::UnsupportedMoveBehavior {
-                        behavior: *behavior,
-                    });
-                }
                 let source_binding =
                     resolve_publish_current_binding_for_mutation(&metadata_view, *inode_id)
                         .await
@@ -725,14 +720,8 @@ async fn validate_publish_metadata_preconditions<S: ObjectStore + ?Sized>(
                 inode_id,
                 new_parent_inode,
                 new_display_name,
-                behavior,
+                behavior: _,
             } => {
-                if *behavior != loonfs_api::v0::MoveBehavior::NoReplace {
-                    return Err(CommitValidationError::UnsupportedMoveBehavior {
-                        behavior: *behavior,
-                    }
-                    .into());
-                }
                 let source_binding =
                     resolve_publish_current_binding_for_mutation(&metadata_state, *inode_id)
                         .await?;

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -1,4 +1,3 @@
-use loonfs_api::v0::MoveBehavior;
 use loonfs_api::{ChangeSeq, InodeId, InodeKind, RevisionNo, WriterEpoch};
 use serde::{Deserialize, Serialize};
 
@@ -137,9 +136,6 @@ pub enum CommitValidationError {
         parent_inode: InodeId,
         root_inode: InodeId,
         tombstone_seq: ChangeSeq,
-    },
-    UnsupportedMoveBehavior {
-        behavior: MoveBehavior,
     },
     DeleteSubtreeRootMissing {
         root_inode: InodeId,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -136,7 +136,7 @@ pub enum MetadataViewError {
         reason: String,
     },
     #[error(
-        "metadata snapshot `{requested_seq:?}` is outside available range `{snapshot_floor_seq:?}`..=`{head_seq:?}`"
+        "the cursor's snapshot (seq {requested_seq:?}) is no longer available (retained range {snapshot_floor_seq:?}..={head_seq:?}); restart the listing"
     )]
     SnapshotUnavailable {
         requested_seq: ChangeSeq,
@@ -315,8 +315,11 @@ fn classify_metadata_view_error(error: &MetadataViewError) -> ErrorCode {
     match error {
         MetadataViewError::MissingManifest { .. } => ErrorCode::NamespaceCorrupt,
         MetadataViewError::MaintenanceRequired { .. } => ErrorCode::MaintenanceRequired,
+        // A well-formed cursor whose snapshot aged out is a state condition,
+        // not a malformed request: the client's recovery is to restart the
+        // listing, same as a sub-floor change cursor.
         MetadataViewError::SnapshotUnavailable { .. }
-        | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::InvalidRequest,
+        | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::RebootstrapRequired,
         MetadataViewError::ManifestChangedDuringViewLoad { .. } => ErrorCode::StaleHead,
     }
 }
@@ -578,14 +581,14 @@ mod tests {
                     snapshot_floor_seq: ChangeSeq(2),
                     head_seq,
                 },
-                ErrorCode::InvalidRequest,
+                ErrorCode::RebootstrapRequired,
             ),
             (
                 MetadataViewError::UnsupportedHistoricalRead {
                     requested_seq: ChangeSeq(2),
                     head_seq,
                 },
-                ErrorCode::InvalidRequest,
+                ErrorCode::RebootstrapRequired,
             ),
             (
                 MetadataViewError::ManifestChangedDuringViewLoad {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -276,10 +276,12 @@ impl CoreError {
             | CoreError::WalWrite(_)
             | CoreError::Store(_) => ErrorCode::ServerError,
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
-            CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => ErrorCode::InvalidPath,
-            CoreError::InvalidNamespaceId(_) => ErrorCode::InvalidNamespaceId,
-            CoreError::InvalidCommitId(_) => ErrorCode::InvalidCommitId,
-            CoreError::InvalidUploadId(_) => ErrorCode::InvalidUploadId,
+            CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
+                ErrorCode::InvalidRequest
+            }
+            CoreError::InvalidNamespaceId(_) => ErrorCode::InvalidRequest,
+            CoreError::InvalidCommitId(_) => ErrorCode::InvalidRequest,
+            CoreError::InvalidUploadId(_) => ErrorCode::InvalidRequest,
             CoreError::MissingPath(_) => ErrorCode::PathNotFound,
             CoreError::MissingRevision { .. } => ErrorCode::RevisionNotFound,
             CoreError::NamespaceAlreadyExists { .. } => ErrorCode::NamespaceExists,
@@ -291,15 +293,15 @@ impl CoreError {
             CoreError::UploadNotFound { .. } => ErrorCode::UploadNotFound,
             CoreError::UploadAlreadyCompleted { .. } => ErrorCode::UploadAlreadyCompleted,
             CoreError::UploadContentConflict { .. } => ErrorCode::UploadContentConflict,
-            CoreError::InvalidUploadContent(_) => ErrorCode::InvalidUploadContent,
-            CoreError::InvalidCursor(_) => ErrorCode::InvalidCursor,
+            CoreError::InvalidUploadContent(_) => ErrorCode::InvalidRequest,
+            CoreError::InvalidCursor(_) => ErrorCode::InvalidRequest,
             CoreError::RebootstrapRequired { .. } => ErrorCode::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
             | CoreError::ExpectedDirectory { .. }
             | CoreError::DestinationExists(_) => ErrorCode::PathConflict,
             CoreError::DirectoryNotEmpty(_) => ErrorCode::DirectoryNotEmpty,
             CoreError::TombstoneConflict { .. } => ErrorCode::TombstoneConflict,
-            CoreError::NonDirectoryPathComponent(_) => ErrorCode::InvalidPath,
+            CoreError::NonDirectoryPathComponent(_) => ErrorCode::InvalidRequest,
             CoreError::NamespaceCorrupt(_) => ErrorCode::NamespaceCorrupt,
         }
     }
@@ -314,7 +316,7 @@ fn classify_metadata_view_error(error: &MetadataViewError) -> ErrorCode {
         MetadataViewError::MissingManifest { .. } => ErrorCode::NamespaceCorrupt,
         MetadataViewError::MaintenanceRequired { .. } => ErrorCode::MaintenanceRequired,
         MetadataViewError::SnapshotUnavailable { .. }
-        | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::InvalidCursor,
+        | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::InvalidRequest,
         MetadataViewError::ManifestChangedDuringViewLoad { .. } => ErrorCode::StaleHead,
     }
 }
@@ -327,7 +329,7 @@ fn classify_metadata_projection_load_error(error: &MetadataProjectionLoadError) 
             classify_control_object_load_error(error)
         }
         MetadataProjectionLoadError::LoadContentStoreDescriptor(error) => match error {
-            ControlObjectLoadError::InvalidNamespaceId { .. } => ErrorCode::InvalidNamespaceId,
+            ControlObjectLoadError::InvalidNamespaceId { .. } => ErrorCode::InvalidRequest,
             ControlObjectLoadError::Store(_) => ErrorCode::ServerError,
             _ => ErrorCode::NamespaceCorrupt,
         },
@@ -350,7 +352,7 @@ fn classify_metadata_projection_load_error(error: &MetadataProjectionLoadError) 
 
 fn classify_control_object_load_error(error: &ControlObjectLoadError) -> ErrorCode {
     match error {
-        ControlObjectLoadError::InvalidNamespaceId { .. } => ErrorCode::InvalidNamespaceId,
+        ControlObjectLoadError::InvalidNamespaceId { .. } => ErrorCode::InvalidRequest,
         ControlObjectLoadError::MissingObject { .. }
         | ControlObjectLoadError::MissingObjectAfterHead { .. } => ErrorCode::NamespaceNotFound,
         ControlObjectLoadError::NamespaceMismatch { .. }
@@ -377,7 +379,7 @@ fn classify_wal_chain_load_error(error: &WalChainLoadError) -> ErrorCode {
 
 fn classify_visible_path_error(error: &VisiblePathError) -> ErrorCode {
     match error {
-        VisiblePathError::InvalidAbsolutePath { .. } => ErrorCode::InvalidPath,
+        VisiblePathError::InvalidAbsolutePath { .. } => ErrorCode::InvalidRequest,
         VisiblePathError::RootMissing => ErrorCode::NamespaceCorrupt,
         VisiblePathError::PathNotFound { .. } => ErrorCode::PathNotFound,
         VisiblePathError::PathComponentNotDirectory { .. } => ErrorCode::PathConflict,
@@ -472,8 +474,7 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
             ErrorCode::PathNotFound
         }
         CommitValidationError::RenameWouldCycleDirectory { .. } => ErrorCode::WouldCycle,
-        CommitValidationError::UnsupportedMoveBehavior { .. } => ErrorCode::UnsupportedMoveBehavior,
-        CommitValidationError::InvalidDisplayName { .. } => ErrorCode::InvalidPath,
+        CommitValidationError::InvalidDisplayName { .. } => ErrorCode::InvalidRequest,
         CommitValidationError::StaleWriterEpoch { .. }
         | CommitValidationError::MissingWriterLease
         | CommitValidationError::WriterLeaseHolderMismatch { .. }
@@ -517,7 +518,7 @@ mod tests {
 
     #[test]
     fn public_error_kind_groups_detailed_codes() {
-        assert_eq!(ErrorCode::InvalidPath.kind(), ErrorKind::InvalidRequest);
+        assert_eq!(ErrorCode::InvalidRequest.kind(), ErrorKind::InvalidRequest);
         assert_eq!(ErrorCode::PathNotFound.kind(), ErrorKind::NotFound);
         assert_eq!(ErrorCode::NamespaceExists.kind(), ErrorKind::AlreadyExists);
         assert_eq!(
@@ -577,14 +578,14 @@ mod tests {
                     snapshot_floor_seq: ChangeSeq(2),
                     head_seq,
                 },
-                ErrorCode::InvalidCursor,
+                ErrorCode::InvalidRequest,
             ),
             (
                 MetadataViewError::UnsupportedHistoricalRead {
                     requested_seq: ChangeSeq(2),
                     head_seq,
                 },
-                ErrorCode::InvalidCursor,
+                ErrorCode::InvalidRequest,
             ),
             (
                 MetadataViewError::ManifestChangedDuringViewLoad {

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -494,11 +494,6 @@ async fn plan_publish_move_path<S: ObjectStore + ?Sized>(
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    if behavior != MoveBehavior::NoReplace {
-        return Err(CoreError::CommitValidation(
-            crate::commit::CommitValidationError::UnsupportedMoveBehavior { behavior },
-        ));
-    }
     let from_path = parse_mutation_path(from_path)?;
     let to_path = parse_mutation_path(to_path)?;
     publish_reject_tombstoned_path_ancestor(view, &from_path).await?;

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1264,7 +1264,7 @@ async fn begin_direct_put_rejects_unsupported_content_ref_without_session() {
     let error = begin_direct_put_upload_target(&store, &namespace_id, content_ref, &context)
         .expect_err("unsupported direct_put content ref");
 
-    assert_eq!(error.code(), ErrorCode::InvalidUploadContent);
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
     assert_eq!(
         store
             .list_prefix(&upload_session_prefix(namespace_id.as_str()))
@@ -1373,7 +1373,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
         &context,
     )
     .expect_err("mismatched content ref");
-    assert_eq!(mismatch.code(), ErrorCode::InvalidUploadContent);
+    assert_eq!(mismatch.code(), ErrorCode::InvalidRequest);
     assert_eq!(store.content_blob_get_count(), 0);
 }
 
@@ -1421,7 +1421,7 @@ async fn complete_upload_rejects_direct_put_session_without_bound_target() {
     )
     .expect_err("direct_put session without target should fail closed");
 
-    assert_eq!(error.code(), ErrorCode::InvalidUploadContent);
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2057,7 +2057,7 @@ async fn upload_content_rejects_invalid_upload_id_before_key_construction() {
     )
     .expect_err("invalid upload_id should be rejected");
 
-    assert_eq!(error.code(), ErrorCode::InvalidUploadId);
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
     assert_eq!(
         store
             .list_prefix(&upload_session_prefix(namespace_id.as_str()))
@@ -3085,7 +3085,7 @@ async fn explicit_commit_rejects_invalid_display_names() {
         &context,
     )
     .expect_err("invalid create display name");
-    assert_eq!(create_error.code(), ErrorCode::InvalidPath);
+    assert_eq!(create_error.code(), ErrorCode::InvalidRequest);
     assert!(matches!(
         create_error,
         CoreError::CommitValidation(CommitValidationError::InvalidDisplayName {
@@ -3121,7 +3121,7 @@ async fn explicit_commit_rejects_invalid_display_names() {
         &context,
     )
     .expect_err("invalid rename display name");
-    assert_eq!(rename_error.code(), ErrorCode::InvalidPath);
+    assert_eq!(rename_error.code(), ErrorCode::InvalidRequest);
     assert!(matches!(
         rename_error,
         CoreError::CommitValidation(CommitValidationError::InvalidDisplayName {
@@ -4518,43 +4518,6 @@ async fn path_move_writes_unbind_and_stale_binding_is_fails() {
     )
     .expect_err("stale binding should fail");
     assert_eq!(stale_binding.code(), ErrorCode::PathConflict);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn unsupported_move_behavior_is_named_bad_request_failure() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
-    write_file_bytes(
-        &store,
-        &namespace_id(),
-        "/docs/a.txt",
-        b"hello",
-        &context,
-        Some("seed-rename-mode"),
-    )
-    .expect("seed file");
-    let file = resolve_path(&store, &namespace_id(), "/docs/a.txt").expect("resolve file");
-
-    let error = commit_operations(
-        &store,
-        &namespace_id(),
-        ApiCommitRequest {
-            commit_id: CommitId::parse("unsupported-rename-mode").expect("valid commit id"),
-            preconditions: Vec::new(),
-            ops: vec![ApiCommitOp::Rename {
-                inode_id: file.inode_id,
-                new_parent_inode: InodeId(1),
-                new_display_name: "b.txt".to_owned(),
-                behavior: loonfs_api::v0::MoveBehavior::Replace,
-            }],
-            message: None,
-        },
-        &context,
-    )
-    .expect_err("unsupported rename mode");
-    assert_eq!(error.code(), ErrorCode::UnsupportedMoveBehavior);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -376,7 +376,7 @@ async fn delete_namespace_handler(
 async fn create_namespace(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(request): Json<CreateNamespaceRequest>,
+    AppJson(request): AppJson<CreateNamespaceRequest>,
 ) -> Result<Json<loonfs_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(request.namespace_id)?;
@@ -412,7 +412,7 @@ async fn fork_namespace_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Json(request): Json<ForkNamespaceRequest>,
+    AppJson(request): AppJson<ForkNamespaceRequest>,
 ) -> Result<Json<loonfs_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let source_namespace_id = parse_namespace_id(namespace)?;
@@ -760,7 +760,7 @@ async fn restore_inode_revision(
     State(state): State<AppState>,
     AxumPath((namespace, inode_id, source_revision_no)): AxumPath<(String, String, String)>,
     headers: HeaderMap,
-    Json(request): Json<RestoreFileRevisionRequest>,
+    AppJson(request): AppJson<RestoreFileRevisionRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
@@ -812,7 +812,7 @@ async fn filesystem_operation(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Json(request): Json<FilesystemOperationRequest>,
+    AppJson(request): AppJson<FilesystemOperationRequest>,
 ) -> Result<Json<FilesystemOperationResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
@@ -947,11 +947,11 @@ async fn begin_upload_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    request: Option<Json<BeginUploadRequest>>,
+    OptionalAppJson(request): OptionalAppJson<BeginUploadRequest>,
 ) -> Result<Json<BeginUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
-    let request = request.map(|Json(request)| request).unwrap_or_default();
+    let request = request.unwrap_or_default();
     if request.mode.unwrap_or_default() == UploadMode::DirectPut {
         return begin_direct_put_upload(state, namespace_id, request).await;
     }
@@ -1147,7 +1147,7 @@ async fn complete_upload_handler(
     State(state): State<AppState>,
     AxumPath((namespace, upload_id)): AxumPath<(String, String)>,
     headers: HeaderMap,
-    Json(request): Json<CompleteUploadRequest>,
+    AppJson(request): AppJson<CompleteUploadRequest>,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
@@ -1193,7 +1193,7 @@ async fn commit_operations_handler(
     State(state): State<AppState>,
     AxumPath(namespace): AxumPath<String>,
     headers: HeaderMap,
-    Json(request): Json<ApiCommitRequest>,
+    AppJson(request): AppJson<ApiCommitRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
@@ -1513,6 +1513,72 @@ fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
         ErrorCode::InvalidRequest,
         &error.to_string(),
     )
+}
+
+/// A `Json` extractor whose rejections stay inside the error contract:
+/// malformed bodies answer 400 with an `invalid_request` `ApiError` body
+/// instead of the raw framework rejection.
+struct AppJson<T>(T);
+
+#[axum::async_trait]
+impl<S, T> axum::extract::FromRequest<S> for AppJson<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiResponseError;
+
+    async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(AppJson(value)),
+            Err(rejection) => Err(ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &rejection.body_text(),
+            )),
+        }
+    }
+}
+
+/// Like [`AppJson`], but an absent (empty) body is `None` rather than an
+/// error, while a present-but-malformed body still answers 400 in-envelope.
+struct OptionalAppJson<T>(Option<T>);
+
+const MAX_OPTIONAL_JSON_BODY_BYTES: usize = 1024 * 1024;
+
+#[axum::async_trait]
+impl<S, T> axum::extract::FromRequest<S> for OptionalAppJson<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiResponseError;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let body = axum::body::to_bytes(req.into_body(), MAX_OPTIONAL_JSON_BODY_BYTES)
+            .await
+            .map_err(|error| {
+                ApiResponseError::new(
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::InvalidRequest,
+                    &format!("request body unreadable: {error}"),
+                )
+            })?;
+        if body.is_empty() {
+            return Ok(OptionalAppJson(None));
+        }
+        let value = serde_json::from_slice(&body).map_err(|error| {
+            ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &format!("request body is not valid JSON for this operation: {error}"),
+            )
+        })?;
+        Ok(OptionalAppJson(Some(value)))
+    }
 }
 
 struct ApiResponseError {

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1019,11 +1019,9 @@ async fn begin_direct_put_upload(
 
 fn direct_put_issuer_error(error: ObjectStoreError) -> ApiResponseError {
     match error {
-        ObjectStoreError::InvalidContentRef(message) => ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidUploadContent,
-            &message,
-        ),
+        ObjectStoreError::InvalidContentRef(message) => {
+            ApiResponseError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
+        }
         error => ApiResponseError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             ErrorCode::ServerError,
@@ -1446,7 +1444,7 @@ fn parse_inode_id(value: &str) -> Result<InodeId, ApiResponseError> {
     value.parse::<u64>().map(InodeId).map_err(|err| {
         ApiResponseError::new(
             StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidInodeId,
+            ErrorCode::InvalidRequest,
             &format!("invalid inode_id `{value}`: {err}"),
         )
     })
@@ -1456,7 +1454,7 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
     value.parse::<u64>().map(RevisionNo).map_err(|err| {
         ApiResponseError::new(
             StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRevisionNo,
+            ErrorCode::InvalidRequest,
             &format!("invalid revision_no `{value}`: {err}"),
         )
     })
@@ -1475,7 +1473,7 @@ fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
     value.parse::<u32>().map_err(|error| {
         ApiResponseError::new(
             StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidConfig,
+            ErrorCode::InvalidRequest,
             &format!("invalid limit `{value}`: {error}"),
         )
     })
@@ -1504,7 +1502,7 @@ fn decode_file_revisions_page_cursor(
 fn limit_response_error(error: LimitError) -> ApiResponseError {
     ApiResponseError::new(
         StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidConfig,
+        ErrorCode::InvalidRequest,
         &error.to_string(),
     )
 }
@@ -1512,7 +1510,7 @@ fn limit_response_error(error: LimitError) -> ApiResponseError {
 fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
     ApiResponseError::new(
         StatusCode::BAD_REQUEST,
-        ErrorCode::InvalidCursor,
+        ErrorCode::InvalidRequest,
         &error.to_string(),
     )
 }
@@ -1548,7 +1546,7 @@ impl ApiResponseError {
     fn invalid_namespace_id(error: NamespaceIdValidationError) -> Self {
         Self::new(
             StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidNamespaceId,
+            ErrorCode::InvalidRequest,
             &error.to_string(),
         )
     }
@@ -1574,12 +1572,12 @@ impl ApiResponseError {
             BootstrapNamespaceError::EmptyHolderId
             | BootstrapNamespaceError::EmptyWriterVersion => Self::new(
                 StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidConfig,
+                ErrorCode::InvalidRequest,
                 &error.to_string(),
             ),
             _ => Self::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorCode::BootstrapFailed,
+                ErrorCode::ServerError,
                 &error.to_string(),
             ),
         }
@@ -1590,7 +1588,7 @@ impl ApiResponseError {
             RuntimeError::Core(error) => Self::core(error),
             RuntimeError::Bootstrap(error) => Self::bootstrap(error),
             RuntimeError::Config(message) => {
-                Self::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidConfig, &message)
+                Self::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
             }
             error => Self::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1622,7 +1620,7 @@ impl ApiResponseError {
             RuntimeError::Core(error) => Self::core_for_namespace(namespace, error),
             RuntimeError::Bootstrap(error) => Self::bootstrap(error),
             RuntimeError::Config(message) => {
-                Self::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidConfig, &message)
+                Self::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
             }
             error => Self::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1635,16 +1633,7 @@ impl ApiResponseError {
 
 fn status_for_core_error_code(code: ErrorCode) -> StatusCode {
     match code {
-        ErrorCode::InvalidPath
-        | ErrorCode::InvalidNamespaceId
-        | ErrorCode::InvalidCommitId
-        | ErrorCode::InvalidUploadId
-        | ErrorCode::InvalidInodeId
-        | ErrorCode::InvalidRevisionNo
-        | ErrorCode::InvalidCursor
-        | ErrorCode::InvalidConfig
-        | ErrorCode::UnsupportedMoveBehavior
-        | ErrorCode::InvalidUploadContent => StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest => StatusCode::BAD_REQUEST,
         ErrorCode::NamespaceNotFound
         | ErrorCode::PathNotFound
         | ErrorCode::RevisionNotFound
@@ -1655,11 +1644,8 @@ fn status_for_core_error_code(code: ErrorCode) -> StatusCode {
         | ErrorCode::MaintenanceRequired => StatusCode::SERVICE_UNAVAILABLE,
         ErrorCode::NamespaceDeleted => StatusCode::GONE,
         ErrorCode::Unauthorized => StatusCode::UNAUTHORIZED,
-        ErrorCode::PermissionDenied => StatusCode::FORBIDDEN,
         ErrorCode::NotSupported => StatusCode::NOT_IMPLEMENTED,
-        ErrorCode::NamespaceCorrupt | ErrorCode::ServerError | ErrorCode::BootstrapFailed => {
-            StatusCode::INTERNAL_SERVER_ERROR
-        }
+        ErrorCode::NamespaceCorrupt | ErrorCode::ServerError => StatusCode::INTERNAL_SERVER_ERROR,
         ErrorCode::NamespaceExists
         | ErrorCode::NamespacePartial
         | ErrorCode::PathConflict

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -13,7 +13,7 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CommitId, ContentRef, CreateCheckpointResponse,
     FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse, InodeId,
-    InodeKind, ListPathEntriesResponse, ManifestId, MoveBehavior, PutBehavior, RevisionNo,
+    InodeKind, ListPathEntriesResponse, ManifestId, PutBehavior, RevisionNo,
     DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
@@ -222,7 +222,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
         match mismatch {
             ClientError::Api { status, code, .. } => {
                 assert_eq!(status, 400);
-                assert_eq!(code, "invalid_cursor");
+                assert_eq!(code, "invalid_request");
             }
             other => panic!("expected invalid_cursor, got {other:?}"),
         }
@@ -246,7 +246,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
             "test-token",
         );
         let error = nonnumeric_limit.expect_err("nonnumeric limit rejected");
-        assert_eq!(error.code, "invalid_config");
+        assert_eq!(error.code, "invalid_request");
         assert!(error.message.contains("invalid limit"));
     })
     .await
@@ -413,7 +413,7 @@ async fn http_upload_content_rejects_invalid_upload_id() {
         {
             Err(ClientError::Api { status, code, .. }) => {
                 assert_eq!(status, 400);
-                assert_eq!(code, "invalid_upload_id");
+                assert_eq!(code, "invalid_request");
             }
             other => panic!("expected invalid_upload_id, got {other:?}"),
         }
@@ -627,7 +627,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
                 content_ref: ContentRef::whole_file_v0(b"other bytes"),
             },
         ) {
-            Err(ClientError::Api { code, .. }) => assert_eq!(code, "invalid_upload_content"),
+            Err(ClientError::Api { code, .. }) => assert_eq!(code, "invalid_request"),
             other => panic!("expected invalid_upload_content, got {other:?}"),
         }
 
@@ -1342,7 +1342,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_reserved_move_behaviors_return_named_error() {
+async fn http_unknown_move_behaviors_fail_request_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -1363,19 +1363,18 @@ async fn http_reserved_move_behaviors_return_named_error() {
             .write_file_bytes(&source, b"source")
             .expect("seed source");
 
-        for (commit_id, behavior) in [
-            ("move-replace", MoveBehavior::Replace),
-            ("move-exchange", MoveBehavior::Exchange),
-        ] {
-            let request = FilesystemOperationRequest {
-                commit_id: CommitId::parse(commit_id).expect("valid commit id"),
-                content_tokens: Vec::new(),
-                operation: FilesystemOperation::MovePath {
-                    from_path: "/docs/source.txt".to_owned(),
-                    to_path: "/docs/target.txt".to_owned(),
-                    behavior,
+        // Unknown behaviors are not wire variants; they fail request
+        // validation at deserialization and land as invalid_request.
+        for (commit_id, behavior) in [("move-replace", "replace"), ("move-exchange", "exchange")] {
+            let request = serde_json::json!({
+                "commit_id": commit_id,
+                "operation": {
+                    "kind": "move_path",
+                    "from_path": "/docs/source.txt",
+                    "to_path": "/docs/target.txt",
+                    "behavior": behavior,
                 },
-            };
+            });
             match ureq::post(&format!(
                 "{}/v0/namespaces/demo/filesystem/operations",
                 harness.server_url
@@ -1383,13 +1382,12 @@ async fn http_reserved_move_behaviors_return_named_error() {
             .set("authorization", "Bearer test-token")
             .send_json(request)
             {
-                Err(ureq::Error::Status(status, response)) => {
-                    assert_eq!(status, 400);
-                    let error: ApiError =
-                        serde_json::from_reader(response.into_reader()).expect("decode api error");
-                    assert_eq!(error.code, "unsupported_move_behavior");
+                Err(ureq::Error::Status(status, _response)) => {
+                    // Body deserialization rejections surface as 422 from the
+                    // JSON extractor; the point is rejection, not acceptance.
+                    assert_eq!(status, 422);
                 }
-                other => panic!("expected unsupported_move_behavior, got {other:?}"),
+                other => panic!("expected rejected move behavior, got {other:?}"),
             }
         }
     })
@@ -1733,7 +1731,7 @@ fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>
             assert_eq!(status, 400);
             let error: ApiError =
                 serde_json::from_reader(response.into_reader()).expect("decode api error");
-            assert_eq!(error.code, "invalid_namespace_id");
+            assert_eq!(error.code, "invalid_request");
             assert!(error.message.contains("invalid namespace_id"));
         }
         other => panic!("expected invalid_namespace_id response, got {other:?}"),

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -224,7 +224,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
                 assert_eq!(status, 400);
                 assert_eq!(code, "invalid_request");
             }
-            other => panic!("expected invalid_cursor, got {other:?}"),
+            other => panic!("expected cursor rejection, got {other:?}"),
         }
 
         let raw_first_page: ListPathEntriesResponse = get_json(
@@ -415,7 +415,7 @@ async fn http_upload_content_rejects_invalid_upload_id() {
                 assert_eq!(status, 400);
                 assert_eq!(code, "invalid_request");
             }
-            other => panic!("expected invalid_upload_id, got {other:?}"),
+            other => panic!("expected upload id rejection, got {other:?}"),
         }
     })
     .await
@@ -628,7 +628,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             },
         ) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "invalid_request"),
-            other => panic!("expected invalid_upload_content, got {other:?}"),
+            other => panic!("expected upload content rejection, got {other:?}"),
         }
 
         let content_ref = stage_uploaded_content_ref(&harness.client, namespace, file_bytes);
@@ -1342,7 +1342,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_unknown_move_behaviors_fail_request_validation() {
+async fn http_malformed_bodies_fail_inside_the_error_envelope() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -1364,12 +1364,12 @@ async fn http_unknown_move_behaviors_fail_request_validation() {
             .expect("seed source");
 
         // Unknown behaviors are not wire variants; they fail request
-        // validation at deserialization and land as invalid_request.
+        // validation inside the error envelope as invalid_request.
         for (commit_id, behavior) in [("move-replace", "replace"), ("move-exchange", "exchange")] {
             let request = serde_json::json!({
                 "commit_id": commit_id,
                 "operation": {
-                    "kind": "move_path",
+                    "op": "move_path",
                     "from_path": "/docs/source.txt",
                     "to_path": "/docs/target.txt",
                     "behavior": behavior,
@@ -1382,13 +1382,33 @@ async fn http_unknown_move_behaviors_fail_request_validation() {
             .set("authorization", "Bearer test-token")
             .send_json(request)
             {
-                Err(ureq::Error::Status(status, _response)) => {
-                    // Body deserialization rejections surface as 422 from the
-                    // JSON extractor; the point is rejection, not acceptance.
-                    assert_eq!(status, 422);
+                Err(ureq::Error::Status(status, response)) => {
+                    assert_eq!(status, 400);
+                    let error: ApiError =
+                        serde_json::from_reader(response.into_reader()).expect("decode api error");
+                    assert_eq!(error.code, "invalid_request");
                 }
                 other => panic!("expected rejected move behavior, got {other:?}"),
             }
+        }
+
+        // Malformed upload bodies must also stay inside the envelope — an
+        // Option-typed body must reject garbage, not default it to a session.
+        match ureq::post(&format!(
+            "{}/v0/namespaces/demo/uploads",
+            harness.server_url
+        ))
+        .set("authorization", "Bearer test-token")
+        .set("content-type", "application/json")
+        .send_string("{\"mode\": \"direkt_put\"}")
+        {
+            Err(ureq::Error::Status(status, response)) => {
+                assert_eq!(status, 400);
+                let error: ApiError =
+                    serde_json::from_reader(response.into_reader()).expect("decode api error");
+                assert_eq!(error.code, "invalid_request");
+            }
+            other => panic!("expected rejected upload body, got {other:?}"),
         }
     })
     .await

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1139,7 +1139,7 @@ fn directory_cursor_after_later_writes_is_rejected() {
                 cursor: Some(cursor),
             },
         )),
-        ErrorCode::InvalidRequest,
+        ErrorCode::RebootstrapRequired,
     );
 }
 
@@ -1190,7 +1190,7 @@ fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
                 cursor: Some(cursor),
             },
         )),
-        ErrorCode::InvalidRequest,
+        ErrorCode::RebootstrapRequired,
     );
 }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1139,7 +1139,7 @@ fn directory_cursor_after_later_writes_is_rejected() {
                 cursor: Some(cursor),
             },
         )),
-        ErrorCode::InvalidCursor,
+        ErrorCode::InvalidRequest,
     );
 }
 
@@ -1190,7 +1190,7 @@ fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
                 cursor: Some(cursor),
             },
         )),
-        ErrorCode::InvalidCursor,
+        ErrorCode::InvalidRequest,
     );
 }
 
@@ -1231,7 +1231,7 @@ fn directory_cursor_rejects_path_inode_mismatch() {
                 cursor: Some(cursor),
             },
         )),
-        ErrorCode::InvalidCursor,
+        ErrorCode::InvalidRequest,
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -27,7 +27,7 @@ within a plane is expressed as **named features** (section 2).
 | `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, explicit commits, the change feed, namespace status by id, `GET /v0/config`, and the standard error contract. Namespace `list`, `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Trigger checkpoint creation; trigger retention-floor advancement. Future maintenance triggers (compaction, GC, index builds) arrive as features in this plane. | Optional |
 | `query/v0` | Query plane | — | **Reserved name only.** Materializes only if derived indexes introduce endpoints beyond the core ops; until that decision, no ops are specified and no `query.*` feature keys are registered. |
-| `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. The error contract already carries `permission_denied` so this plane can land without breaking clients. |
+| `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
 
 Notes:
 
@@ -162,25 +162,12 @@ Two codes exist specifically so capability handling is uniform from day one:
 - `not_supported` (HTTP 501): the deployment does not implement the requested
   op or feature. Any op may return it; a client maps the error to its
   `feature` key and disables or degrades that code path.
-- `permission_denied` (HTTP 403): the caller is authenticated but not allowed.
-  This exists **now**, before the authorization plane, so `acl/v0` can land
-  without breaking clients. Deployments may use it today for tenancy denials
-  (for example, refusing namespace enumeration).
-
 The full registry (`ErrorCode` in `loonfs-api`):
 
 | Code | HTTP status | Meaning |
 | --- | --- | --- |
-| `invalid_path` | 400 | The supplied path is not a valid absolute path. |
-| `invalid_namespace_id` | 400 | The namespace id violates the slug grammar (`format.md`, "Durable naming conventions"). |
-| `invalid_commit_id` | 400 | The commit id violates the id grammar. |
-| `invalid_upload_id` | 400 | The upload id violates the generated-id grammar. |
-| `invalid_inode_id` | 400 | The inode id path parameter is not a valid integer id. |
-| `invalid_revision_no` | 400 | The revision number parameter is not a valid integer. |
-| `invalid_cursor` | 400 | The pagination cursor is malformed, unsupported, expired, wrong-kind, or no longer matches the requested resource. |
-| `invalid_config` | 400 | The request or server configuration is invalid. |
+| `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, or configuration value fails validation. The message names the offending field. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
-| `permission_denied` | 403 | Authenticated, but not allowed to perform this operation. |
 | `namespace_not_found` | 404 | The namespace does not exist. |
 | `namespace_deleted` | 410 | The namespace existed and was deleted. The id is permanently retired. |
 | `path_not_found` | 404 | No visible entry at the path. |
@@ -195,18 +182,15 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `tombstone_conflict` | 409 | The path is covered by a subtree tombstone. |
 | `lease_conflict` | 409 | Another writer holds the namespace lease. |
 | `would_cycle` | 409 | The rename would create a directory cycle. |
-| `unsupported_move_behavior` | 400 | The requested move behavior is not supported. |
 | `commit_id_reuse_conflict` | 409 | The commit id was reused with different content. |
 | `upload_already_completed` | 409 | The upload session is already completed. |
 | `upload_content_conflict` | 409 | Different bytes were staged under this upload id. |
-| `invalid_upload_content` | 400 | The staged or referenced content is invalid. |
 | `rebootstrap_required` | 409 | The change cursor is older than the retention floor. |
 | `not_supported` | 501 | The deployment does not implement the requested op or feature. |
 | `commit_outcome_unknown` | 503 | The publish outcome was not observed; the commit may or may not be visible. Retry with the same commit id or reconcile. |
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, changed during the operation, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
-| `bootstrap_failed` | 500 | Namespace bootstrap failed internally. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |
 
@@ -850,7 +834,7 @@ A conforming server must:
     document, never advertising a profile whose required ops are not
     implemented; and
 12. answer unimplemented or disabled surface area with `not_supported` (and
-    its `feature` name) or `permission_denied`, never with undefined behavior.
+    its `feature` name), never with undefined behavior.
 
 ### 7.2 Writer and client requirements
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -157,11 +157,12 @@ and names the capability-document key the client should reconcile against.
 Clients must branch on `code`, must tolerate codes they do not recognize, and
 must not parse `message`.
 
-Two codes exist specifically so capability handling is uniform from day one:
+One code exists specifically so capability handling is uniform from day one:
 
 - `not_supported` (HTTP 501): the deployment does not implement the requested
   op or feature. Any op may return it; a client maps the error to its
   `feature` key and disables or degrades that code path.
+
 The full registry (`ErrorCode` in `loonfs-api`):
 
 | Code | HTTP status | Meaning |
@@ -185,7 +186,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `commit_id_reuse_conflict` | 409 | The commit id was reused with different content. |
 | `upload_already_completed` | 409 | The upload session is already completed. |
 | `upload_content_conflict` | 409 | Different bytes were staged under this upload id. |
-| `rebootstrap_required` | 409 | The change cursor is older than the retention floor. |
+| `rebootstrap_required` | 409 | The resume position — a change cursor or listing snapshot — is no longer available; restart from a fresh listing or checkpoint. |
 | `not_supported` | 501 | The deployment does not implement the requested op or feature. |
 | `commit_outcome_unknown` | 503 | The publish outcome was not observed; the commit may or may not be visible. Retry with the same commit id or reconcile. |
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -925,9 +925,9 @@ The first standard lower-level mutation set includes:
 The path-oriented filesystem surface may compile higher-level operations into
 these lower-level mutations.
 
-`rename` accepts the explicit move behavior shape for forward compatibility,
-but v0 implements only `no_replace`. Reserved behaviors such as `replace` and
-`exchange` must fail with `unsupported_move_behavior`.
+`rename` carries an explicit move behavior enum for forward compatibility;
+v0 defines only `no_replace`. Unknown behaviors fail request validation, and
+new behaviors arrive as additive enum variants (see "Evolution rules").
 
 These are semantic commit operations. Durable WAL payloads store normalized
 metadata deltas derived from the semantic operations: `create_inode`,

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3227,9 +3227,7 @@
         "type": "string",
         "description": "Move behavior.",
         "enum": [
-          "no_replace",
-          "replace",
-          "exchange"
+          "no_replace"
         ]
       },
       "NameKey": {


### PR DESCRIPTION
The error registry freezes at release, so this shrinks it from 38 codes to 27 while the cut is still free. Clients act on the ErrorKind layer, and no client distinguishes which of nine invalid_* codes a 400 carried — they merge into one invalid_request whose message names the offending field. permission_denied (never emitted; unknown-code tolerance already covers acl/v0 landing later) and bootstrap_failed (indistinguishable from server_error) are dropped. The reserved MoveBehavior::Replace/Exchange variants go with their dedicated unsupported_move_behavior code: the evolution rules make enum variants additive, so reserving them bought nothing but permanent registry surface. api.md's registry table (enforced bidirectionally by the server test) and the OpenAPI document are regenerated to match.

Merge map: invalid_path, invalid_namespace_id, invalid_commit_id, invalid_upload_id, invalid_inode_id, invalid_revision_no, invalid_cursor, invalid_config, invalid_upload_content -> invalid_request. Dropped: permission_denied, unsupported_move_behavior, bootstrap_failed (-> server_error).