### PR TITLE
refactor(storage): the v1 mark-and-sweep garbage collector

### DIFF
--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -243,6 +243,44 @@ pub struct CreateCheckpointResponse {
 }
 
 /// Result of advancing the retention floor.
+/// Optional overrides for one garbage-collection pass. Absent fields use
+/// the server's conservative defaults.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GcRequest {
+    /// Objects younger than this are never deleted, reachable or not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace_window_ms: Option<u64>,
+    /// Abandoned bootstrap trees older than this may be reaped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reap_window_ms: Option<u64>,
+}
+
+/// Result of one mark-and-sweep garbage-collection pass.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GcResponse {
+    /// Namespace the pass ran against.
+    pub namespace_id: NamespaceId,
+    /// Unreferenced WAL segments deleted.
+    pub deleted_wal_segments: u64,
+    /// Unreferenced metadata tables deleted.
+    pub deleted_metadata_tables: u64,
+    /// Unreferenced manifests deleted.
+    pub deleted_manifests: u64,
+    /// Dead or expired checkpoint records deleted.
+    pub deleted_checkpoint_records: u64,
+    /// Pins released because their target namespace is terminally deleted.
+    pub released_pins: u64,
+    /// Objects removed while reaping an abandoned bootstrap tree.
+    pub reaped_abandoned_objects: u64,
+    /// Candidates retained at delete time (grace window, missing
+    /// timestamps, or reachable from the fresh root set).
+    pub retained_candidates: u64,
+    /// True when ambiguous roots suppressed manifest/table deletion.
+    pub degraded_retention: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AdvanceRetentionResponse {

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -48,9 +48,9 @@ pub use error::{ErrorCode, ErrorKind};
 pub use http::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest,
-    ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
-    PutBehavior, RestoreFileRevisionRequest,
+    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse,
+    NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
 };
 pub use ids::{
     generate_checkpoint_id, generate_gc_pin_id, generate_metadata_table_id, generate_upload_id,

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -1,0 +1,852 @@
+//! v1 listing mark-and-sweep garbage collection (format spec, "Garbage
+//! collection").
+//!
+//! GC and floor advancement are the only consumers of listing. Nothing
+//! sweeps by default: callers opt in through the admin endpoint or an
+//! explicit maintenance-tick option. The safety rules close the two races
+//! the un-serialized layout admits — create-vs-collect and
+//! publish-in-flight — via the grace window, delete-time re-verification,
+//! and retention-wins defaults. When in doubt, this module retains.
+
+use crate::checkpoint::{load_namespace_manifest_envelope, read_checkpoint_record};
+use crate::context::MutationContext;
+use crate::error::{CoreError, MetadataProjectionLoadError};
+use crate::namespace::control::{
+    read_head_object, read_metadata_root_object, read_wal_floor_object, ControlObjectLoadError,
+};
+use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use loonfs_api::wire::control::{
+    decode_control_object, CheckpointRecordLifecycle, CheckpointRecordState, ControlObjectKind,
+    NamespaceGcPinState, NamespaceState,
+};
+use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
+use loonfs_objectstore::keys::{
+    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, namespace_config,
+    pin_prefix, wal_segment_prefix,
+};
+use loonfs_objectstore::ObjectStore;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Grace and reap windows for the sweep (format spec, "Garbage collection",
+/// rules 1 and 9). Both are wall-clock cleanup policy, never validity
+/// inputs. The defaults are deliberately conservative: one hour of
+/// unconditional protection for every object, seven days before an
+/// abandoned bootstrap tree may be reaped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcConfig {
+    pub grace_window_ms: u64,
+    pub reap_window_ms: u64,
+}
+
+impl Default for GcConfig {
+    fn default() -> Self {
+        Self {
+            grace_window_ms: 60 * 60 * 1000,
+            reap_window_ms: 7 * 24 * 60 * 60 * 1000,
+        }
+    }
+}
+
+impl GcConfig {
+    fn validate(&self) -> Result<(), CoreError> {
+        if self.grace_window_ms == 0 {
+            return Err(CoreError::Store(
+                "gc grace_window_ms must be greater than zero".to_owned(),
+            ));
+        }
+        if self.reap_window_ms < self.grace_window_ms {
+            return Err(CoreError::Store(
+                "gc reap_window_ms must be at least the grace window".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcReport {
+    pub deleted_wal_segments: u64,
+    pub deleted_metadata_tables: u64,
+    pub deleted_manifests: u64,
+    pub deleted_checkpoint_records: u64,
+    pub released_pins: u64,
+    /// Objects removed while reaping an abandoned bootstrap tree (rule 9).
+    pub reaped_abandoned_objects: u64,
+    /// Candidates dropped at delete time: still inside the grace window,
+    /// missing a provider timestamp, or reachable from the fresh root set.
+    pub retained_candidates: u64,
+    /// True when a pin's checkpoint could not be read or validated, which
+    /// suppresses manifest and table deletion for the whole pass (rule 5:
+    /// ambiguous roots cause retention).
+    pub degraded_retention: bool,
+}
+
+/// Everything reachable from the fresh root set (rule 4).
+struct LiveSet {
+    manifests: BTreeSet<ManifestId>,
+    tables: BTreeSet<String>,
+    wal_segments: BTreeSet<String>,
+    checkpoint_keys: BTreeSet<String>,
+    pin_keys: BTreeSet<String>,
+    /// Pin resolution failed somewhere: manifest/table deletion must not
+    /// proceed on this pass.
+    degraded: bool,
+}
+
+pub async fn gc_namespace<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+) -> Result<GcReport, CoreError> {
+    config.validate()?;
+    let config_key = namespace_config(namespace_id.as_str());
+    let namespace_complete = store
+        .head(&config_key)
+        .await
+        .map_err(|error| CoreError::Store(error.to_string()))?
+        .is_some();
+    if !namespace_complete {
+        return reap_abandoned_bootstrap(store, namespace_id, config, context).await;
+    }
+
+    // Mark: candidate selection may be arbitrarily stale (rule 3), so one
+    // live-set pass selects candidates...
+    let mark = collect_live_set(store, namespace_id, context.now_ms).await?;
+    let mut report = GcReport::default();
+
+    let candidate_segments = list_prefix(store, &wal_segment_prefix(namespace_id.as_str())).await?;
+    let candidate_tables =
+        list_prefix(store, &metadata_table_prefix(namespace_id.as_str())).await?;
+    let candidate_manifests =
+        list_prefix(store, &metadata_manifest_prefix(namespace_id.as_str())).await?;
+    let candidate_checkpoints =
+        list_prefix(store, &checkpoint_prefix(namespace_id.as_str())).await?;
+    let candidate_pins = list_prefix(store, &pin_prefix(namespace_id.as_str())).await?;
+
+    let segment_candidates: Vec<String> = candidate_segments
+        .into_iter()
+        .filter(|key| !mark.wal_segments.contains(key))
+        .collect();
+    let table_candidates: Vec<String> = candidate_tables
+        .into_iter()
+        .filter(|key| !mark.tables.contains(key))
+        .collect();
+    let manifest_candidates: Vec<String> = candidate_manifests
+        .into_iter()
+        .filter(|key| manifest_id_of(key).is_none_or(|id| !mark.manifests.contains(&id)))
+        .collect();
+    let checkpoint_candidates: Vec<String> = candidate_checkpoints
+        .into_iter()
+        .filter(|key| !mark.checkpoint_keys.contains(key))
+        .collect();
+    let pin_candidates: Vec<String> = candidate_pins
+        .into_iter()
+        .filter(|key| !mark.pin_keys.contains(key))
+        .collect();
+
+    // ...and a second, fresh pass immediately before deletion decides
+    // (rule 3: candidate selection may be stale; deletion may not).
+    let sweep = collect_live_set(store, namespace_id, context.now_ms).await?;
+    report.degraded_retention = sweep.degraded;
+
+    // Data first, records last: a crash mid-sweep leaves orphaned data for
+    // the next pass, never a record whose data vanished under it.
+    for key in segment_candidates {
+        if sweep.wal_segments.contains(&key) {
+            report.retained_candidates += 1;
+            continue;
+        }
+        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
+            report.deleted_wal_segments += 1;
+        }
+    }
+    if sweep.degraded {
+        report.retained_candidates +=
+            u64::try_from(table_candidates.len() + manifest_candidates.len()).unwrap_or(u64::MAX);
+    } else {
+        for key in table_candidates {
+            if sweep.tables.contains(&key) {
+                report.retained_candidates += 1;
+                continue;
+            }
+            if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
+                report.deleted_metadata_tables += 1;
+            }
+        }
+        for key in manifest_candidates {
+            if manifest_id_of(&key).is_some_and(|id| sweep.manifests.contains(&id)) {
+                report.retained_candidates += 1;
+                continue;
+            }
+            if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
+                report.deleted_manifests += 1;
+            }
+        }
+    }
+    for key in checkpoint_candidates {
+        if sweep.checkpoint_keys.contains(&key) {
+            report.retained_candidates += 1;
+            continue;
+        }
+        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
+            report.deleted_checkpoint_records += 1;
+        }
+    }
+    for key in pin_candidates {
+        if sweep.pin_keys.contains(&key) {
+            report.retained_candidates += 1;
+            continue;
+        }
+        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
+            report.released_pins += 1;
+        }
+    }
+
+    Ok(report)
+}
+
+async fn collect_live_set<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    now_ms: u64,
+) -> Result<LiveSet, CoreError> {
+    let loaded_head = read_head_object(store, namespace_id)
+        .await
+        .map_err(load_error)?;
+    let head = loaded_head.envelope.state;
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .map_err(load_error)?
+        .envelope
+        .state;
+    let floor_seq = match read_wal_floor_object(store, namespace_id).await {
+        Ok(loaded) => loaded.envelope.state.floor_seq,
+        // A missing floor means retain everything (format spec, "WAL floor").
+        Err(ControlObjectLoadError::MissingObject { .. }) => ChangeSeq(0),
+        Err(error) => return Err(load_error(error)),
+    };
+
+    let mut live = LiveSet {
+        manifests: BTreeSet::new(),
+        tables: BTreeSet::new(),
+        wal_segments: BTreeSet::new(),
+        checkpoint_keys: BTreeSet::new(),
+        pin_keys: BTreeSet::new(),
+        degraded: false,
+    };
+    live.manifests.insert(root.manifest_id);
+
+    // Active, non-expired checkpoints are roots. Records inside the grace
+    // window are roots regardless of state, which the age check at delete
+    // time enforces; here every readable record's basis is retained so a
+    // young dead record can never strand its manifest.
+    for key in list_prefix(store, &checkpoint_prefix(namespace_id.as_str())).await? {
+        let Some(bytes) = store
+            .get(&key, None)
+            .await
+            .map_err(|error| CoreError::Store(error.to_string()))?
+        else {
+            continue;
+        };
+        match decode_control_object::<CheckpointRecordState>(
+            &bytes,
+            ControlObjectKind::CheckpointRecord,
+        ) {
+            Ok(envelope) => {
+                let record = envelope.state;
+                let expired = record
+                    .expires_at_ms
+                    .is_some_and(|expires_at_ms| expires_at_ms <= now_ms);
+                if record.state == CheckpointRecordLifecycle::Active && !expired {
+                    live.manifests.insert(record.manifest_id);
+                    live.checkpoint_keys.insert(key);
+                }
+            }
+            // Unreadable records are ambiguous roots: retain them and keep
+            // sweeping conservative for manifests/tables.
+            Err(_) => {
+                live.checkpoint_keys.insert(key);
+                live.degraded = true;
+            }
+        }
+    }
+
+    for key in list_prefix(store, &pin_prefix(namespace_id.as_str())).await? {
+        let Some(bytes) = store
+            .get(&key, None)
+            .await
+            .map_err(|error| CoreError::Store(error.to_string()))?
+        else {
+            continue;
+        };
+        let Ok(envelope) = decode_control_object::<NamespaceGcPinState>(
+            &bytes,
+            ControlObjectKind::NamespaceGcPinState,
+        ) else {
+            live.pin_keys.insert(key);
+            live.degraded = true;
+            continue;
+        };
+        let pin = envelope.state;
+        // A pin whose target is verifiably terminally deleted is releasable;
+        // everything else keeps protecting through its checkpoint.
+        if pin_target_terminally_deleted(store, &pin.target_namespace_id).await? {
+            continue;
+        }
+        live.pin_keys.insert(key.clone());
+        match read_checkpoint_record(store, namespace_id, &pin.source_checkpoint_id).await {
+            Ok(Some(record)) => {
+                // Pinned checkpoints protect their basis regardless of the
+                // record's lifecycle: the pin is the reachability fact.
+                live.manifests.insert(record.state.manifest_id);
+                live.checkpoint_keys
+                    .insert(loonfs_objectstore::keys::checkpoint_record(
+                        namespace_id.as_str(),
+                        pin.source_checkpoint_id.as_str(),
+                    ));
+            }
+            // "If GC cannot read or validate a pin's checkpoint, it
+            // retains": suppress manifest/table deletion for the pass.
+            Ok(None) | Err(_) => {
+                live.degraded = true;
+            }
+        }
+    }
+
+    // Live manifests protect their tables (rule 6: only validated manifests
+    // are trusted to protect data — the envelope loader checks the payload
+    // checksum).
+    for manifest_id in live.manifests.clone() {
+        match load_namespace_manifest_envelope(store, namespace_id, manifest_id).await {
+            Ok(manifest) => {
+                for file in &manifest.payload.metadata_files {
+                    live.tables.insert(file.object_key.clone());
+                }
+            }
+            Err(_) => {
+                live.degraded = true;
+            }
+        }
+    }
+
+    // WAL needed to replay from the floor through the head stays (rule 7 is
+    // implied: floor <= root basis, so root-to-head replay is covered).
+    if head.seq > floor_seq {
+        let chain = load_validated_wal_chain(
+            store,
+            WalChainLoadRequest {
+                namespace_id,
+                chain_base_seq: floor_seq,
+                head_seq: head.seq,
+                visible_tip: head.visible_wal_tip.clone(),
+                stop_after_seq: None,
+                recent_segments: &head.recent_segments,
+            },
+        )
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+        })?;
+        for segment in chain.segments() {
+            live.wal_segments.insert(segment.object_key().to_owned());
+        }
+    }
+
+    Ok(live)
+}
+
+/// Rule 9: a namespace tree with no `namespace.json` whose newest object is
+/// older than the reap window may be reaped, re-checking the completion
+/// marker's absence immediately before deleting.
+async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+) -> Result<GcReport, CoreError> {
+    let namespace_prefix = format!("namespaces/{}/", namespace_id.as_str());
+    let keys = list_prefix(store, &namespace_prefix).await?;
+    let mut report = GcReport::default();
+    if keys.is_empty() {
+        return Ok(report);
+    }
+
+    // The newest object bounds the tree's age; a missing timestamp reads as
+    // "young" and blocks the reap.
+    for key in &keys {
+        let Some(metadata) = store
+            .head(key)
+            .await
+            .map_err(|error| CoreError::Store(error.to_string()))?
+        else {
+            continue;
+        };
+        let Some(last_modified_ms) = metadata.last_modified_ms else {
+            report.retained_candidates += u64::try_from(keys.len()).unwrap_or(u64::MAX);
+            return Ok(report);
+        };
+        if context.now_ms.saturating_sub(last_modified_ms) < config.reap_window_ms {
+            report.retained_candidates += u64::try_from(keys.len()).unwrap_or(u64::MAX);
+            return Ok(report);
+        }
+    }
+
+    // Re-check the absence of the completion marker immediately before
+    // deleting (rule 9).
+    let complete_now = store
+        .head(&namespace_config(namespace_id.as_str()))
+        .await
+        .map_err(|error| CoreError::Store(error.to_string()))?
+        .is_some();
+    if complete_now {
+        report.retained_candidates = u64::try_from(keys.len()).unwrap_or(u64::MAX);
+        return Ok(report);
+    }
+    for key in keys {
+        store
+            .delete(&key)
+            .await
+            .map_err(|error| CoreError::Store(error.to_string()))?;
+        report.reaped_abandoned_objects += 1;
+    }
+    Ok(report)
+}
+
+async fn delete_if_aged<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    grace_window_ms: u64,
+    context: &MutationContext,
+    report: &mut GcReport,
+) -> Result<bool, CoreError> {
+    let Some(metadata) = store
+        .head(key)
+        .await
+        .map_err(|error| CoreError::Store(error.to_string()))?
+    else {
+        // Already gone; nothing to count.
+        return Ok(false);
+    };
+    let Some(last_modified_ms) = metadata.last_modified_ms else {
+        // No provider timestamp: treat as young, retain (rule 1).
+        report.retained_candidates += 1;
+        return Ok(false);
+    };
+    if context.now_ms.saturating_sub(last_modified_ms) < grace_window_ms {
+        report.retained_candidates += 1;
+        return Ok(false);
+    }
+    store
+        .delete(key)
+        .await
+        .map_err(|error| CoreError::Store(error.to_string()))?;
+    Ok(true)
+}
+
+async fn pin_target_terminally_deleted<S: ObjectStore + ?Sized>(
+    store: &S,
+    target_namespace_id: &NamespaceId,
+) -> Result<bool, CoreError> {
+    match read_head_object(store, target_namespace_id).await {
+        Ok(loaded) => Ok(loaded.envelope.state.state == NamespaceState::Deleted),
+        // A target that never completed bootstrap (or whose head is
+        // unreadable) is NOT verifiably deleted; rule 9 handles abandoned
+        // targets by age, and ambiguity retains.
+        Err(_) => Ok(false),
+    }
+}
+
+async fn list_prefix<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+) -> Result<Vec<String>, CoreError> {
+    store
+        .list_prefix(prefix)
+        .await
+        .map_err(|error| CoreError::Store(error.to_string()))
+}
+
+fn manifest_id_of(key: &str) -> Option<ManifestId> {
+    let name = key.rsplit('/').next()?;
+    let digits = name.strip_suffix(".json")?;
+    digits.parse::<u64>().ok().map(ManifestId)
+}
+
+fn load_error(error: ControlObjectLoadError) -> CoreError {
+    CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::record::set_checkpoint_record_state;
+    use crate::checkpoint::{advance_retention_floor, create_checkpoint};
+    use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::namespace::delete::delete_namespace;
+    use crate::namespace::fork::fork_namespace;
+    use crate::options::DeleteNamespaceOptions;
+    use crate::path::read::{load_metadata_view, ReadLoadContext};
+    use crate::publish::PathMutationIntent;
+    use crate::publisher::DirectObjectStorePublisher;
+    use crate::storage::content::store_bytes_as_content;
+    use loonfs_api::{CommitId, PutBehavior};
+    use loonfs_objectstore::fs::LocalFsStore;
+    use tempfile::tempdir;
+
+    const GRACE_MS: u64 = 60 * 60 * 1000;
+    const REAP_MS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+    fn config() -> GcConfig {
+        GcConfig {
+            grace_window_ms: GRACE_MS,
+            reap_window_ms: REAP_MS,
+        }
+    }
+
+    fn context(now_ms: u64) -> MutationContext {
+        MutationContext {
+            writer_id: "gc-test".to_owned(),
+            writer_session_id: "wrs_gc_test".to_owned(),
+            writer_version: "gc-test/0.1.0".to_owned(),
+            now_ms,
+        }
+    }
+
+    /// Derives "now" from durable object ages so the tests never touch a
+    /// wall clock: `offset_ms` past the newest object under the namespace.
+    async fn now_after_newest_object(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+        offset_ms: u64,
+    ) -> u64 {
+        let prefix = format!("namespaces/{}/", namespace_id.as_str());
+        let mut newest = 0;
+        for key in store.list_prefix(&prefix).await.expect("list namespace") {
+            let modified = store
+                .head(&key)
+                .await
+                .expect("head object")
+                .expect("object exists")
+                .last_modified_ms
+                .expect("local fs provides timestamps");
+            newest = newest.max(modified);
+        }
+        assert!(newest > 0, "namespace tree must not be empty");
+        newest + offset_ms
+    }
+
+    async fn write_file(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+        path: &str,
+        commit_id: &str,
+        context: &MutationContext,
+    ) {
+        let content_ref = store_bytes_as_content(store, namespace_id, b"body\n")
+            .await
+            .expect("store content")
+            .content_ref;
+        DirectObjectStorePublisher::new(store)
+            .submit_path_intent(
+                namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse(commit_id).expect("commit id"),
+                    absolute_path: path.to_owned(),
+                    content_ref,
+                    behavior: PutBehavior::NoReplace,
+                },
+                context,
+                Default::default(),
+            )
+            .await
+            .expect("write file");
+    }
+
+    async fn stat_root(store: &LocalFsStore, namespace_id: &NamespaceId) {
+        load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("load latest view")
+            .resolve_path("/")
+            .await
+            .expect("resolve root");
+    }
+
+    #[tokio::test]
+    async fn gc_reaps_below_floor_segments_after_the_grace_window() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+        create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("checkpoint");
+        advance_retention_floor(&store, &namespace_id, &setup)
+            .await
+            .expect("advance floor");
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass");
+
+        // The only segment sits at the floor with no replay gap above it.
+        assert_eq!(report.deleted_wal_segments, 1);
+        assert!(!report.degraded_retention);
+        stat_root(&store, &namespace_id).await;
+    }
+
+    #[tokio::test]
+    async fn gc_retains_everything_inside_the_grace_window() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+        create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("checkpoint");
+        advance_retention_floor(&store, &namespace_id, &setup)
+            .await
+            .expect("advance floor");
+
+        let young = context(now_after_newest_object(&store, &namespace_id, 0).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &young)
+            .await
+            .expect("gc pass");
+
+        assert_eq!(report.deleted_wal_segments, 0);
+        assert_eq!(report.deleted_metadata_tables, 0);
+        assert_eq!(report.deleted_manifests, 0);
+        assert!(report.retained_candidates > 0);
+        stat_root(&store, &namespace_id).await;
+    }
+
+    #[tokio::test]
+    async fn gc_never_deletes_the_live_replay_chain() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+        create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("checkpoint");
+        advance_retention_floor(&store, &namespace_id, &setup)
+            .await
+            .expect("advance floor");
+        // A commit past the floor: its segment is the live replay gap.
+        write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass");
+
+        assert_eq!(report.deleted_wal_segments, 1);
+        // Latest reads replay the retained tail over the root basis.
+        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("load view");
+        view.resolve_path("/docs/two.txt")
+            .await
+            .expect("tail commit stays readable");
+    }
+
+    #[tokio::test]
+    async fn gc_reaps_dead_checkpoints_and_their_unreferenced_basis() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+        let first = create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("first checkpoint");
+        write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+        create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("second checkpoint");
+        set_checkpoint_record_state(
+            &store,
+            &namespace_id,
+            &first.checkpoint_id,
+            loonfs_api::wire::control::CheckpointRecordLifecycle::Dead,
+            &setup.writer_version,
+        )
+        .await
+        .expect("mark first dead");
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass");
+
+        assert_eq!(report.deleted_checkpoint_records, 1);
+        assert!(report.deleted_manifests >= 1, "dead basis manifest reaped");
+        assert!(!report.degraded_retention);
+        stat_root(&store, &namespace_id).await;
+        assert!(crate::checkpoint::read_checkpoint_record(
+            &store,
+            &namespace_id,
+            &first.checkpoint_id
+        )
+        .await
+        .expect("read record")
+        .is_none());
+    }
+
+    #[tokio::test]
+    async fn gc_retains_active_checkpoint_bases() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+        let first = create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("first checkpoint");
+        write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+        create_checkpoint(&store, &namespace_id, &setup)
+            .await
+            .expect("second checkpoint");
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass");
+
+        // Only the unpinned bootstrap manifest is collectable; both active
+        // checkpoint bases stay.
+        assert!(report.deleted_manifests <= 1);
+        assert_eq!(report.deleted_checkpoint_records, 0);
+        assert!(crate::checkpoint::load_namespace_manifest_envelope(
+            &store,
+            &namespace_id,
+            first.manifest_id
+        )
+        .await
+        .is_ok());
+    }
+
+    #[tokio::test]
+    async fn gc_releases_pins_of_terminally_deleted_targets() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let source = NamespaceId::parse("source").expect("namespace id");
+        let clone = NamespaceId::parse("clone").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &source, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+        fork_namespace(&store, &source, &clone, &setup)
+            .await
+            .expect("fork");
+
+        let before = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &source, &config(), &before)
+            .await
+            .expect("gc with live target");
+        assert_eq!(report.released_pins, 0);
+
+        delete_namespace(&store, &clone, DeleteNamespaceOptions::default(), &setup)
+            .await
+            .expect("terminal delete of the fork target");
+        let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &source, &config(), &aged)
+            .await
+            .expect("gc after target delete");
+        assert_eq!(report.released_pins, 1);
+        stat_root(&store, &source).await;
+    }
+
+    #[tokio::test]
+    async fn gc_reaps_an_abandoned_bootstrap_tree_after_the_reap_window() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("orphan").expect("namespace id");
+        // A partial tree: a head object but no namespace.json completion
+        // marker.
+        store
+            .put_if_absent(
+                &format!("namespaces/{}/wal/head.json", namespace_id.as_str()),
+                bytes::Bytes::from_static(b"{}"),
+            )
+            .await
+            .expect("write partial head");
+
+        let young = context(now_after_newest_object(&store, &namespace_id, GRACE_MS).await);
+        let retained = gc_namespace(&store, &namespace_id, &config(), &young)
+            .await
+            .expect("gc young tree");
+        assert_eq!(retained.reaped_abandoned_objects, 0);
+        assert!(retained.retained_candidates > 0);
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, REAP_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc aged tree");
+        assert_eq!(report.reaped_abandoned_objects, 1);
+        assert!(store
+            .list_prefix(&format!("namespaces/{}/", namespace_id.as_str()))
+            .await
+            .expect("list")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn gc_degrades_to_retention_when_a_pin_checkpoint_is_unreadable() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let source = NamespaceId::parse("source").expect("namespace id");
+        let clone = NamespaceId::parse("clone").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &source, &setup, false)
+            .await
+            .expect("bootstrap");
+        write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+        fork_namespace(&store, &source, &clone, &setup)
+            .await
+            .expect("fork");
+
+        // Corrupt the pinned checkpoint: ambiguous roots must retain.
+        for key in store
+            .list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(
+                source.as_str(),
+            ))
+            .await
+            .expect("list checkpoints")
+        {
+            store
+                .put_overwrite(&key, bytes::Bytes::from_static(b"not json"))
+                .await
+                .expect("corrupt record");
+        }
+
+        let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &source, &config(), &aged)
+            .await
+            .expect("gc pass");
+        assert!(report.degraded_retention);
+        assert_eq!(report.deleted_manifests, 0);
+        assert_eq!(report.deleted_metadata_tables, 0);
+    }
+}

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -36,6 +36,7 @@ mod context;
 mod control_update;
 mod engine;
 mod error;
+pub mod gc;
 mod invariants;
 pub mod metadata;
 pub mod namespace;
@@ -90,6 +91,7 @@ pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuil
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
 };
+pub use gc::{gc_namespace, GcConfig, GcReport};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions, WriteOptions};
 pub use timing::{MonotonicTimer, StdMonotonicTimer};

--- a/crates/loonfs-objectstore/src/fs.rs
+++ b/crates/loonfs-objectstore/src/fs.rs
@@ -97,11 +97,17 @@ impl LocalFsStore {
             )));
         }
 
+        let last_modified_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
         Ok(ObjectMetadata {
             etag: Some(format!("local-fs-v1:{content_digest}")),
             version: None,
             size_bytes: metadata.len(),
             checksum_sha256,
+            last_modified_ms,
         })
     }
 

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -69,6 +69,14 @@ pub fn metadata_root(namespace: &str) -> String {
     ObjectLayout::new().metadata_root(namespace).into_string()
 }
 
+pub fn metadata_manifest_prefix(namespace: &str) -> String {
+    ObjectLayout::new().metadata_manifest_prefix(namespace)
+}
+
+pub fn metadata_table_prefix(namespace: &str) -> String {
+    ObjectLayout::new().metadata_table_prefix(namespace)
+}
+
 pub fn metadata_manifest(namespace: &str, manifest_id: ManifestId) -> String {
     ObjectLayout::new()
         .metadata_manifest(namespace, manifest_id)

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -24,6 +24,12 @@ pub struct ObjectMetadata {
     /// This is part of the object-store contract only when present. Callers must fall back to
     /// reading and hashing object bytes if this field is absent.
     pub checksum_sha256: Option<String>,
+    /// Provider last-modified time in unix milliseconds, when available.
+    ///
+    /// Advisory: garbage collection uses it for grace/reap age checks and
+    /// treats an absent value as "young" (retain). Never a validity input.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified_ms: Option<u64>,
 }
 
 /// Full object bytes returned with metadata from the same read operation.

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -74,6 +74,7 @@ impl ProviderObjectStore {
             version: meta.version,
             size_bytes: meta.size,
             checksum_sha256,
+            last_modified_ms: u64::try_from(meta.last_modified.timestamp_millis()).ok(),
         }
     }
 
@@ -87,6 +88,7 @@ impl ProviderObjectStore {
             version: result.version,
             size_bytes,
             checksum_sha256,
+            last_modified_ms: None,
         }
     }
 

--- a/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
@@ -352,6 +352,7 @@ impl DelegatingWriteStore {
             version: None,
             size_bytes: 0,
             checksum_sha256: None,
+            last_modified_ms: None,
         }
     }
 }

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -22,10 +22,10 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
     CreateNamespaceRequest, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, InodeId,
-    LimitError, ListFileRevisionsResponse, NamespaceId, NamespaceIdValidationError,
-    PageCursorError, PageRequest, PaginationPolicy, RestoreFileRevisionRequest, RevisionNo,
-    FEATURE_UPLOADS_DIRECT_PUT,
+    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, InodeId, LimitError, ListFileRevisionsResponse, NamespaceId,
+    NamespaceIdValidationError, PageCursorError, PageRequest, PaginationPolicy,
+    RestoreFileRevisionRequest, RevisionNo, FEATURE_UPLOADS_DIRECT_PUT,
 };
 use loonfs_core::content::{
     mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
@@ -191,6 +191,10 @@ fn app_with_fs(
         .route(
             "/v0/admin/namespaces/:namespace/retention/advance",
             post(advance_retention_handler),
+        )
+        .route(
+            "/v0/admin/namespaces/:namespace/gc",
+            post(gc_namespace_handler),
         )
         .with_state(state)
 }
@@ -1310,6 +1314,56 @@ async fn advance_retention_handler(
     Ok(Json(response))
 }
 
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/gc",
+        tag = "admin",
+        summary = "Collect garbage",
+        description = "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        request_body(content = GcRequest, description = "Optional window overrides"),
+        responses(
+            (status = 200, description = "Garbage collection pass completed", body = GcResponse),
+            (status = 400, description = "Invalid namespace id or windows", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError)
+        )
+    )
+)]
+async fn gc_namespace_handler(
+    State(state): State<AppState>,
+    AxumPath(namespace): AxumPath<String>,
+    headers: HeaderMap,
+    OptionalAppJson(request): OptionalAppJson<GcRequest>,
+) -> Result<Json<GcResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = parse_namespace_id(namespace)?;
+    let request = request.unwrap_or_default();
+    let defaults = loonfs_core::GcConfig::default();
+    let config = loonfs_core::GcConfig {
+        grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),
+        reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
+    };
+    let report = state
+        .fs
+        .gc_namespace(&namespace_id, &config)
+        .await
+        .map_err(ApiResponseError::runtime)?;
+    Ok(Json(GcResponse {
+        namespace_id,
+        deleted_wal_segments: report.deleted_wal_segments,
+        deleted_metadata_tables: report.deleted_metadata_tables,
+        deleted_manifests: report.deleted_manifests,
+        deleted_checkpoint_records: report.deleted_checkpoint_records,
+        released_pins: report.released_pins,
+        reaped_abandoned_objects: report.reaped_abandoned_objects,
+        retained_candidates: report.retained_candidates,
+        degraded_retention: report.degraded_retention,
+    }))
+}
+
 #[cfg(feature = "openapi")]
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
     <LoonfsOpenApi as utoipa::OpenApi>::openapi()
@@ -1349,7 +1403,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         commit_operations_handler,
         list_changes_handler,
         create_checkpoint_handler,
-        advance_retention_handler
+        advance_retention_handler,
+        gc_namespace_handler
     ),
     components(schemas(
         loonfs_api::CapabilityDocument,
@@ -1370,6 +1425,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         RestoreFileRevisionRequest,
         CreateCheckpointResponse,
         AdvanceRetentionResponse,
+        GcRequest,
+        GcResponse,
         ContentRef,
         loonfs_api::NamespaceId,
         loonfs_api::ContentStoreId,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1451,6 +1451,47 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-gc",
+        "http-admin-gc",
+    ))
+    .await;
+    let client = harness.client.clone();
+    let server_url = harness.server_url.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = "demo";
+        client
+            .create_namespace(namespace)
+            .expect("create namespace");
+        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        client
+            .write_file_bytes(&target, b"hello gc\n")
+            .expect("write file");
+        post_checkpoint(&server_url, namespace).expect("checkpoint");
+
+        // A freshly written namespace sits entirely inside the grace
+        // window: the pass runs, deletes nothing, and reads keep working.
+        let report = post_gc(&server_url, namespace).expect("gc pass");
+        assert_eq!(report.deleted_wal_segments, 0);
+        assert_eq!(report.deleted_metadata_tables, 0);
+        assert_eq!(report.deleted_manifests, 0);
+        assert_eq!(report.deleted_checkpoint_records, 0);
+        assert!(!report.degraded_retention);
+
+        let bytes = client.read_file_bytes(&target).expect("read file");
+        assert_eq!(bytes, b"hello gc\n");
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_admin_retention_advance_uses_initial_manifest_after_create() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
@@ -1675,6 +1716,13 @@ fn post_checkpoint(
 ) -> Result<CreateCheckpointResponse, ApiError> {
     post_admin_json(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/checkpoint"),
+        "test-token",
+    )
+}
+
+fn post_gc(server_url: &str, namespace: &str) -> Result<loonfs_api::GcResponse, ApiError> {
+    post_admin_json(
+        &format!("{server_url}/v0/admin/namespaces/{namespace}/gc"),
         "test-token",
     )
 }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -349,22 +349,26 @@ impl Fs {
         let status_before = self.namespace_status(namespace_id).await?;
         let observed_head_seq = status_before.head_seq;
         if status_before.wal_tail_segments < options.max_wal_tail_segments {
+            let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
             return Ok(MaintenanceTickResult {
                 namespace_id: namespace_id.clone(),
                 status_before,
                 outcome: MaintenanceTickOutcome::NotNeeded,
+                gc,
             });
         }
 
         let checkpoint = match self.create_checkpoint(namespace_id).await {
             Ok(checkpoint) => checkpoint,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
+                let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
                 return Ok(MaintenanceTickResult {
                     namespace_id: namespace_id.clone(),
                     status_before,
                     outcome: MaintenanceTickOutcome::CheckpointPublishRaceLost {
                         observed_head_seq,
                     },
+                    gc,
                 });
             }
             Err(error) => return Err(error),
@@ -386,11 +390,43 @@ impl Fs {
             }
         };
 
+        let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
         Ok(MaintenanceTickResult {
             namespace_id: namespace_id.clone(),
             status_before,
             outcome,
+            gc,
         })
+    }
+
+    async fn run_tick_gc(
+        &self,
+        namespace_id: &NamespaceId,
+        config: Option<&loonfs_core::GcConfig>,
+    ) -> Result<Option<loonfs_core::GcReport>> {
+        let Some(config) = config else {
+            return Ok(None);
+        };
+        Ok(Some(self.gc_namespace(namespace_id, config).await?))
+    }
+
+    /// Runs the v1 mark-and-sweep garbage collector for one namespace.
+    ///
+    /// Never runs implicitly: callers opt in here or through
+    /// [`MaintenanceTickOptions::gc`].
+    pub async fn gc_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        config: &loonfs_core::GcConfig,
+    ) -> Result<loonfs_core::GcReport> {
+        let report =
+            loonfs_core::gc_namespace(self.store(), namespace_id, config, &self.mutation_context())
+                .await
+                .map_err(RuntimeError::Core)?;
+        // Sweeping can remove objects cached views still reference; drop the
+        // namespace caches rather than trusting them across a collection.
+        self.invalidate_namespace_read_cache(namespace_id);
+        Ok(report)
     }
 
     /// Resolves an absolute path to its authoritative entry at the current

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -27,12 +27,16 @@ pub struct NamespaceStatus {
 pub struct MaintenanceTickOptions {
     /// Publish a checkpoint when the visible WAL tail reaches this many segments.
     pub max_wal_tail_segments: u64,
+    /// Run the mark-and-sweep garbage collector after the tick's checkpoint
+    /// and retention work. Nothing sweeps unless this is set.
+    pub gc: Option<loonfs_core::GcConfig>,
 }
 
 impl Default for MaintenanceTickOptions {
     fn default() -> Self {
         Self {
             max_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
+            gc: None,
         }
     }
 }
@@ -70,6 +74,8 @@ pub struct MaintenanceTickResult {
     pub status_before: NamespaceStatus,
     /// What the tick did.
     pub outcome: MaintenanceTickOutcome,
+    /// Garbage-collection report when the tick opted into sweeping.
+    pub gc: Option<loonfs_core::GcReport>,
 }
 
 /// Options for creating a namespace.

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1941,6 +1941,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
+                gc: None,
             },
         )
         .expect("maintenance tick");
@@ -1970,6 +1971,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
+                gc: None,
             },
         )
         .expect("maintenance tick");
@@ -2007,6 +2009,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
         &namespace_id,
         MaintenanceTickOptions {
             max_wal_tail_segments: 1,
+            gc: None,
         },
     )
     .expect("first maintenance tick");
@@ -2023,6 +2026,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
+                gc: None,
             },
         )
         .expect("second maintenance tick");
@@ -2102,6 +2106,7 @@ fn maintenance_tick_counts_segments_not_commits() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
+                gc: None,
             },
         )
         .expect("maintenance tick");
@@ -2126,6 +2131,7 @@ fn maintenance_tick_counts_segments_not_commits() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 2,
+                gc: None,
             },
         )
         .expect("maintenance tick at segment threshold");
@@ -2152,6 +2158,7 @@ fn maintenance_tick_rejects_zero_threshold() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 0,
+                gc: None,
             },
         )
         .expect_err("zero threshold should fail");
@@ -2191,6 +2198,7 @@ fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
             &namespace_id,
             MaintenanceTickOptions {
                 max_wal_tail_segments: 1,
+                gc: None,
             },
         )
         .expect("maintenance tick should not fail on metadata root publish race");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -306,6 +306,7 @@ A representative v0 binding is shown below.
 | Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
 | Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoint` |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
+| Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; nothing sweeps without an explicit call) |
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile; everything else
 shown belongs to `core/v0`.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1266,24 +1266,54 @@ material to support readers from the new floor forward.
 
 Delete is tombstone-first. Garbage collection is the separate process that
 eventually reclaims content or metadata that is no longer reachable and no
-longer protected by retention policy.
+longer protected by retention policy. GC and floor advancement are the only
+consumers of listing, and nothing sweeps by default: a pass runs only through
+the admin endpoint or an explicit maintenance-tick opt-in.
 
-Reclamation follows the tree's grammar (section 1.3). Ordered streams
-(`wal/`, `manifest/`) reclaim by advancing their boundary
-cursor in `gc/`: range-scan below the cursor, verify the bounded window
-against the reference rules below, sweep, advance. Collections reclaim by
-reachability or expiry. Either way:
+v1 GC is listing mark-and-sweep. Its inputs are `wal/head.json`,
+`wal/floor.json`, `metadata/root.json`, and the `metadata/manifests/`,
+`metadata/tables/`, `checkpoints/`, `pins/`, and `wal/segments/` collections.
+Because floor, root, and checkpoint publication no longer serialize through
+one head CAS, two cross-object races must be closed explicitly —
+create-vs-collect (a record written while GC concludes its basis is
+unreferenced) and publish-in-flight (an object written moments before its
+publishing CAS) — under these rules:
 
-Garbage collection must be conservative. It MUST NOT remove an object that is
-reachable from any retained version. Concretely, it may reclaim an object only
-when:
+1. **Grace window.** A configured window `T`, with
+   `T > publish_budget + request_timeout` and
+   `T > verify_budget + request_timeout` by comfortable margin. GC never
+   deletes any object younger than `T`, reachable or not, and treats any
+   checkpoint or pin record younger than `T` as a root regardless of state.
+   An object without a provider timestamp reads as young.
+2. **Floor is necessary, not sufficient.** Being below `wal/floor.json` only
+   nominates an object for deletion.
+3. **Delete-time re-verification.** Immediately before deleting, GC re-lists
+   `checkpoints/` and `pins/`, re-reads the root, head, and floor, and drops
+   from the batch anything reachable from that fresh root set. Candidate
+   selection may be arbitrarily stale; deletion may not.
+4. Roots: `metadata/root.json`; active, non-expired checkpoint records; pins
+   (resolving pin -> checkpoint -> manifest -> tables); and the visible chain
+   from `wal/head.json.visible_wal_tip` down to the floor.
+5. Missing, corrupt, or ambiguous roots cause retention, not deletion — an
+   unreadable pin checkpoint suppresses manifest and table deletion for the
+   whole pass.
+6. Only validated manifests are trusted to protect data.
+7. WAL needed to replay from the chosen metadata root to the head is never
+   deleted.
+8. **Retention wins residual races.** If the floor is ever observed ahead of
+   an active checkpoint's basis, the checkpoint's objects remain protected;
+   reconciling the floor is an explicit recovery action.
+9. **Abandoned bootstraps.** A namespace tree with no `namespace.json` whose
+   newest object is older than the reap window `R` (`R >= T`) may be reaped,
+   re-checking the marker's absence immediately before deleting. Pins whose
+   target namespace never completed bootstrap are reaped under the same rule.
 
-- no visible metadata references it;
-- no retained historical metadata still needs it;
-- no checkpoint record, fork GC pin, or retention promise still protects it;
-  and
-- no active session, upload, or other control-plane object still depends on
-  it.
+Deletion proceeds data first, records last, so a crash mid-sweep leaves
+orphaned data for the next pass rather than a record whose data vanished.
+Pins whose target namespace is verifiably terminally deleted (target head
+`state = deleted`, re-checked at delete time) are releasable. The intended
+end-state remains tracked deletion derived from manifest predecessor diffs,
+with the listing sweep demoted to a low-frequency backstop.
 
 ### 6.5 Control-object cleanup
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -118,6 +118,80 @@
         }
       }
     },
+    "/v0/admin/namespaces/{namespace}/gc": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Collect garbage",
+        "description": "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
+        "operationId": "gc_namespace_handler",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Optional window overrides",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GcRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Garbage collection pass completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GcResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id or windows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/admin/namespaces/{namespace}/retention/advance": {
       "post": {
         "tags": [
@@ -1844,7 +1918,6 @@
     "schemas": {
       "AdvanceRetentionResponse": {
         "type": "object",
-        "description": "Result of advancing the retention floor.",
         "required": [
           "namespace_id",
           "retention_floor_seq"
@@ -3113,6 +3186,97 @@
           "new_namespace_id": {
             "type": "string",
             "description": "Durable namespace id for the fork target."
+          }
+        }
+      },
+      "GcRequest": {
+        "type": "object",
+        "description": "Result of advancing the retention floor.\nOptional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.",
+        "properties": {
+          "grace_window_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Objects younger than this are never deleted, reachable or not.",
+            "minimum": 0
+          },
+          "reap_window_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Abandoned bootstrap trees older than this may be reaped.",
+            "minimum": 0
+          }
+        }
+      },
+      "GcResponse": {
+        "type": "object",
+        "description": "Result of one mark-and-sweep garbage-collection pass.",
+        "required": [
+          "namespace_id",
+          "deleted_wal_segments",
+          "deleted_metadata_tables",
+          "deleted_manifests",
+          "deleted_checkpoint_records",
+          "released_pins",
+          "reaped_abandoned_objects",
+          "retained_candidates",
+          "degraded_retention"
+        ],
+        "properties": {
+          "degraded_retention": {
+            "type": "boolean",
+            "description": "True when ambiguous roots suppressed manifest/table deletion."
+          },
+          "deleted_checkpoint_records": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Dead or expired checkpoint records deleted.",
+            "minimum": 0
+          },
+          "deleted_manifests": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unreferenced manifests deleted.",
+            "minimum": 0
+          },
+          "deleted_metadata_tables": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unreferenced metadata tables deleted.",
+            "minimum": 0
+          },
+          "deleted_wal_segments": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unreferenced WAL segments deleted.",
+            "minimum": 0
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the pass ran against."
+          },
+          "reaped_abandoned_objects": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Objects removed while reaping an abandoned bootstrap tree.",
+            "minimum": 0
+          },
+          "released_pins": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Pins released because their target namespace is terminally deleted.",
+            "minimum": 0
+          },
+          "retained_candidates": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Candidates retained at delete time (grace window, missing\ntimestamps, or reachable from the fresh root set).",
+            "minimum": 0
           }
         }
       },


### PR DESCRIPTION
Sixth phase of the layout redesign, on top of #176. Everything the earlier phases prepared — monotonic root and floor objects, write-then-verify records, publish and verify budgets — exists so that this sweeper can be deterministically safe rather than probabilistically safe.

The engine is the guide's v1 listing mark-and-sweep under the explicit safety rules. Nothing sweeps by default: a pass runs only through the new `POST /v0/admin/namespaces/{ns}/gc` endpoint (with optional window overrides) or a `MaintenanceTickOptions::gc` opt-in. The un-serialized layout admits two cross-object races — create-vs-collect and publish-in-flight — and the pass closes them the way the format now specifies: a one-hour grace window under which nothing is deleted regardless of reachability (objects without provider timestamps read as young, so unknown age retains), and delete-time re-verification that re-lists the records and re-reads root/head/floor immediately before deleting, so candidate selection may be arbitrarily stale but deletion may not. The mark and sweep passes literally share one live-set function called twice.

Liveness follows rule 4: the root's manifest, active non-expired checkpoint bases, pins resolving through their checkpoints, and the validated visible chain from the head's tip down to the floor. Ambiguity retains — an unreadable pin checkpoint degrades the pass to skip manifest and table deletion entirely, and the report says so. Deletion goes data first, records last, so a crash mid-sweep strands orphans for the next pass rather than records whose data vanished. Pins release when their target is verifiably terminally deleted, re-checked at delete time; abandoned bootstrap trees (no `namespace.json`, newest object older than the seven-day reap window) reap under rule 9 with the marker's absence re-checked before deletion.

Supporting changes: `ObjectMetadata` gains an advisory `last_modified_ms` (local-fs mtime, provider Last-Modified), and the runtime invalidates namespace caches after a sweep rather than trusting views across a collection.

Covered by eight acceptance tests driving the rules end to end — below-floor reaping, grace retention, live-chain protection with post-sweep reads, dead-record cleanup with basis reaping, active-basis retention, pin release on target delete, abandoned-bootstrap age gating, and degraded retention on corrupt pin checkpoints — plus an endpoint smoke test. Ages derive from the objects' own stored timestamps, so no test consults a clock.