### PR TITLE
refactor(core): give commit pipeline errors real display messages

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -762,6 +762,33 @@ impl fmt::Display for InodeId {
     }
 }
 
+impl fmt::Display for RevisionNo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for ChangeSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for WriterEpoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for InodeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File => f.write_str("file"),
+            Self::Dir => f.write_str("dir"),
+        }
+    }
+}
+
 impl From<u64> for ManifestId {
     fn from(value: u64) -> Self {
         Self(value)

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -314,7 +314,7 @@ async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
             })?;
     if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
         return Err(CoreError::NamespaceCorrupt(format!(
-            "metadata root for `{}` references manifest {:?} with checksum {} but the manifest carries {}",
+            "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",
             namespace_id.as_str(),
             root.manifest_id,
             root.manifest_payload_checksum,
@@ -681,7 +681,7 @@ pub(super) fn drop_rows_below_retention_floor(
                 ))
             {
                 return Err(CoreError::NamespaceCorrupt(format!(
-                    "bind at seq {bind_seq:?} delta {bind_delta_index} for parent {parent_inode_id:?} is superseded at or below the retention floor without an unbind; refusing to drop rows"
+                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
                 )));
             }
         }

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -28,7 +28,7 @@ pub enum ManifestLoadError {
         actual: NamespaceId,
     },
     #[error(
-        "namespace manifest id mismatch for `{object_key}`: expected `{expected:?}`, actual `{actual:?}`"
+        "namespace manifest id mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     ManifestIdMismatch {
         object_key: String,
@@ -36,7 +36,7 @@ pub enum ManifestLoadError {
         actual: ManifestId,
     },
     #[error(
-        "namespace manifest conflict for `{object_key}` manifest `{manifest_id:?}`: expected payload checksum `{expected_payload_checksum}`, actual `{actual_payload_checksum}`"
+        "namespace manifest conflict for `{object_key}` manifest `{manifest_id}`: expected payload checksum `{expected_payload_checksum}`, actual `{actual_payload_checksum}`"
     )]
     ManifestConflict {
         object_key: String,
@@ -73,7 +73,7 @@ pub enum ManifestLoadError {
         actual: NamespaceId,
     },
     #[error(
-        "metadata SST seq mismatch for `{object_key}`: expected `{expected:?}`, actual `{actual:?}`"
+        "metadata SST seq mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
     )]
     SegmentSeqMismatch {
         object_key: String,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -299,7 +299,7 @@ fn validate_manifest_table_descriptors(
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: manifest_object_key.to_owned(),
                 message: format!(
-                    "metadata run {:?} has {direntry_bind_rows} direntry bind rows but {direntry_child_bind_rows} child-bind index rows",
+                    "metadata run `{}` has {direntry_bind_rows} direntry bind rows but {direntry_child_bind_rows} child-bind index rows",
                     run.run_seq
                 ),
             });
@@ -308,7 +308,7 @@ fn validate_manifest_table_descriptors(
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: manifest_object_key.to_owned(),
                 message: format!(
-                    "metadata run {:?} has {revision_rows} revision rows but {revision_by_inode_desc_rows} revision index rows",
+                    "metadata run `{}` has {revision_rows} revision rows but {revision_by_inode_desc_rows} revision index rows",
                     run.run_seq
                 ),
             });

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -38,7 +38,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         })?;
     if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
         return Err(CoreError::NamespaceCorrupt(format!(
-            "metadata root for `{}` references manifest {:?} with checksum {} but the manifest carries {}",
+            "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",
             namespace_id.as_str(),
             root.manifest_id,
             root.manifest_payload_checksum,

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -51,7 +51,7 @@ pub(super) fn validate_manifest_materialization_ranges(
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: object_key.to_owned(),
             message: format!(
-                "base_seq {:?} is after manifest head_seq {:?}",
+                "base_seq `{}` is after manifest head_seq `{}`",
                 payload.base_seq, payload.head_seq
             ),
         });
@@ -85,7 +85,7 @@ pub(super) fn validate_manifest_materialization_ranges(
             return Err(ManifestLoadError::RunManifestMismatch {
                 object_key: object_key.to_owned(),
                 message: format!(
-                    "metadata file `{}` run seq {:?} is outside [{:?}, {:?}]",
+                    "metadata file `{}` run seq `{}` is outside [`{}`, `{}`]",
                     metadata_file.table_id,
                     metadata_file.run_seq,
                     payload.base_seq,
@@ -101,7 +101,7 @@ pub(super) fn validate_manifest_materialization_ranges(
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: object_key.to_owned(),
             message: format!(
-                "namespace manifest has no metadata file at base_seq {:?}",
+                "namespace manifest has no metadata file at base_seq `{}`",
                 payload.base_seq
             ),
         });
@@ -110,7 +110,7 @@ pub(super) fn validate_manifest_materialization_ranges(
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: object_key.to_owned(),
             message: format!(
-                "namespace manifest has no metadata file at head_seq {:?}",
+                "namespace manifest has no metadata file at head_seq `{}`",
                 payload.head_seq
             ),
         });
@@ -303,7 +303,7 @@ pub(super) fn validate_manifest_row_seq_range(
                 return Err(ManifestLoadError::SegmentDescriptorMismatch {
                     object_key: object_key.to_owned(),
                     message: format!(
-                        "row {row_index} seq `{row_seq:?}` is before expected min `{min_seq:?}`"
+                        "row {row_index} seq `{row_seq}` is before expected min `{min_seq}`"
                     ),
                 });
             }
@@ -312,7 +312,7 @@ pub(super) fn validate_manifest_row_seq_range(
             return Err(ManifestLoadError::SegmentDescriptorMismatch {
                 object_key: object_key.to_owned(),
                 message: format!(
-                    "row {row_index} seq `{row_seq:?}` is after expected max `{max_seq:?}`"
+                    "row {row_index} seq `{row_seq}` is after expected max `{max_seq}`"
                 ),
             });
         }

--- a/crates/loonfs-core/src/commit/prepared.rs
+++ b/crates/loonfs-core/src/commit/prepared.rs
@@ -29,7 +29,7 @@ pub struct PreparedCommit {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommitPrepareError {
-    #[error("prepared commit namespace mismatch: request={request:?}, plan={plan:?}")]
+    #[error("prepared commit namespace mismatch: request `{request}`, plan `{plan}`")]
     NamespaceMismatch {
         request: NamespaceId,
         plan: NamespaceId,

--- a/crates/loonfs-core/src/commit/publish_error.rs
+++ b/crates/loonfs-core/src/commit/publish_error.rs
@@ -1,50 +1,60 @@
 use loonfs_api::{ChangeSeq, NamespaceId, WriterEpoch};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 #[non_exhaustive]
 pub enum CommitHeadPublishError {
+    #[error("writer version must not be empty")]
     EmptyWriterVersion,
+    #[error("expected head etag must not be empty")]
     EmptyExpectedHeadEtag,
+    #[error("publish namespace mismatch: head `{head}`, plan `{plan}`")]
     NamespaceMismatch {
         head: NamespaceId,
         plan: NamespaceId,
     },
-    WalSegmentNamespaceMismatch {
-        head: NamespaceId,
-        wal: NamespaceId,
-    },
+    #[error("WAL segment namespace mismatch: head `{head}`, wal `{wal}`")]
+    WalSegmentNamespaceMismatch { head: NamespaceId, wal: NamespaceId },
+    #[error("WAL segment writer epoch mismatch: expected `{expected}`, actual `{actual}`")]
     WalSegmentWriterEpochMismatch {
         expected: WriterEpoch,
         actual: WriterEpoch,
     },
+    #[error("WAL segment base head seq mismatch: expected `{expected}`, actual `{actual}`")]
     WalSegmentBaseHeadSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("WAL segment start seq mismatch: expected `{expected}`, actual `{actual}`")]
     WalSegmentStartSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("WAL segment end seq mismatch: expected `{expected}`, actual `{actual}`")]
     WalSegmentEndSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("WAL segment contains no records")]
     EmptyWalSegment,
+    #[error("sequence counter overflow")]
     SeqOverflow,
+    #[error("namespace head changed since the publish view was loaded")]
     StaleHead,
     /// The self-enforced publish budget elapsed between starting the WAL
     /// segment PUT and reaching the head CAS. The segment is abandoned as an
     /// orphan for GC and the commit must be rebuilt as a fresh segment, so
     /// callers retry exactly as they do for `StaleHead`.
-    PublishBudgetExceeded {
-        elapsed_ms: u64,
-        budget_ms: u64,
-    },
+    #[error("publish budget exceeded: elapsed `{elapsed_ms}` ms over budget `{budget_ms}` ms")]
+    PublishBudgetExceeded { elapsed_ms: u64, budget_ms: u64 },
     /// The head compare-and-swap was sent but its outcome was never
     /// observed (for example, a transport failure waiting for the
     /// response). The commit may or may not be visible.
+    #[error("head compare-and-swap outcome unknown: {0}")]
     OutcomeUnknown(String),
+    #[error("head codec error: {0}")]
     Codec(String),
+    #[error("head object store error: {0}")]
     Store(String),
 }

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -1,169 +1,230 @@
 use loonfs_api::{ChangeSeq, InodeId, InodeKind, RevisionNo, WriterEpoch};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum CommitValidationError {
+    #[error("commit contains no operations")]
     EmptyCommit,
+    #[error("commit namespace does not match the namespace head")]
     NamespaceMismatch,
-    NamePreconditionParentMissing {
-        parent_inode_id: InodeId,
-    },
+    #[error("name precondition parent inode `{parent_inode_id}` is missing")]
+    NamePreconditionParentMissing { parent_inode_id: InodeId },
+    #[error(
+        "name precondition parent inode `{parent_inode_id}` is not a directory (found `{actual_kind}`)"
+    )]
     NamePreconditionParentNotDirectory {
         parent_inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "binding precondition failed: name `{name_key}` is not bound under parent inode `{parent_inode_id}`"
+    )]
     BindingPreconditionMissing {
         parent_inode_id: InodeId,
         name_key: String,
     },
+    #[error(
+        "binding precondition failed: name `{name_key}` under parent inode `{parent_inode_id}` expected child inode `{expected_child_inode_id}` but found `{actual_child_inode_id:?}`"
+    )]
     BindingPreconditionMismatch {
         parent_inode_id: InodeId,
         name_key: String,
         expected_child_inode_id: InodeId,
         actual_child_inode_id: Option<InodeId>,
     },
-    DirectoryEmptyPreconditionInodeMissing {
-        inode_id: InodeId,
-    },
+    #[error("directory-empty precondition inode `{inode_id}` is missing")]
+    DirectoryEmptyPreconditionInodeMissing { inode_id: InodeId },
+    #[error(
+        "directory-empty precondition inode `{inode_id}` is not a directory (found `{actual_kind}`)"
+    )]
     DirectoryEmptyPreconditionInodeNotDirectory {
         inode_id: InodeId,
         actual_kind: InodeKind,
     },
-    DirectoryEmptyPreconditionNotEmpty {
-        inode_id: InodeId,
-    },
-    CreateParentMissing {
-        parent_inode_id: InodeId,
-    },
+    #[error("directory-empty precondition failed: directory inode `{inode_id}` is not empty")]
+    DirectoryEmptyPreconditionNotEmpty { inode_id: InodeId },
+    #[error("create parent inode `{parent_inode_id}` is missing")]
+    CreateParentMissing { parent_inode_id: InodeId },
+    #[error("create parent inode `{parent_inode_id}` is not a directory (found `{actual_kind}`)")]
     CreateParentNotDirectory {
         parent_inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "create collides with existing name `{name_key}` under parent inode `{parent_inode_id}` (bound to inode `{child_inode_id}`)"
+    )]
     CreateChildNameCollision {
         parent_inode_id: InodeId,
         name_key: String,
         child_inode_id: InodeId,
     },
-    InvalidDisplayName {
-        display_name: String,
-    },
+    #[error("invalid display name `{display_name}`")]
+    InvalidDisplayName { display_name: String },
+    #[error(
+        "create under parent inode `{parent_inode_id}` conflicts with subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     CreateUnderSubtreeTombstone {
         parent_inode_id: InodeId,
         root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
-    ReplaceFileInodeMissing {
-        inode_id: InodeId,
-    },
+    #[error("replace target file inode `{inode_id}` is missing")]
+    ReplaceFileInodeMissing { inode_id: InodeId },
+    #[error("replace target inode `{inode_id}` is not a file (found `{actual_kind}`)")]
     ReplaceFileInodeNotFile {
         inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "replace base revision mismatch for inode `{inode_id}`: expected `{expected}`, actual `{actual:?}`"
+    )]
     ReplaceFileBaseRevisionMismatch {
         inode_id: InodeId,
         expected: RevisionNo,
         actual: Option<RevisionNo>,
     },
-    RestoreRevisionInodeMissing {
-        inode_id: InodeId,
-    },
+    #[error("restore target file inode `{inode_id}` is missing")]
+    RestoreRevisionInodeMissing { inode_id: InodeId },
+    #[error("restore target inode `{inode_id}` is not a file (found `{actual_kind}`)")]
     RestoreRevisionInodeNotFile {
         inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "restore base revision mismatch for inode `{inode_id}`: expected `{expected}`, actual `{actual:?}`"
+    )]
     RestoreRevisionBaseRevisionMismatch {
         inode_id: InodeId,
         expected: RevisionNo,
         actual: Option<RevisionNo>,
     },
+    #[error("restore source revision `{source_revision_no}` not found for inode `{inode_id}`")]
     RestoreRevisionSourceRevisionMissing {
         inode_id: InodeId,
         source_revision_no: RevisionNo,
     },
+    #[error(
+        "restore of inode `{inode_id}` conflicts with subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     RestoreRevisionUnderSubtreeTombstone {
         inode_id: InodeId,
         root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
+    #[error(
+        "replace of inode `{inode_id}` conflicts with subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     ReplaceFileUnderSubtreeTombstone {
         inode_id: InodeId,
         root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
-    DeleteFileInodeMissing {
-        inode_id: InodeId,
-    },
+    #[error("delete target file inode `{inode_id}` is missing")]
+    DeleteFileInodeMissing { inode_id: InodeId },
+    #[error("delete target inode `{inode_id}` is not a file (found `{actual_kind}`)")]
     DeleteFileInodeNotFile {
         inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "delete of file inode `{inode_id}` is already covered by subtree tombstone rooted at inode `{covering_root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     DeleteFileCoveredByTombstone {
         inode_id: InodeId,
         covering_root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
-    RenameInodeMissing {
-        inode_id: InodeId,
-    },
-    RenameSourceBindingMissing {
-        inode_id: InodeId,
-    },
-    SourceBindingMissing {
-        inode_id: InodeId,
-    },
-    RenameTargetParentMissing {
-        parent_inode_id: InodeId,
-    },
+    #[error("rename source inode `{inode_id}` is missing")]
+    RenameInodeMissing { inode_id: InodeId },
+    #[error("rename source inode `{inode_id}` has no current binding")]
+    RenameSourceBindingMissing { inode_id: InodeId },
+    #[error("source inode `{inode_id}` has no current binding")]
+    SourceBindingMissing { inode_id: InodeId },
+    #[error("rename target parent inode `{parent_inode_id}` is missing")]
+    RenameTargetParentMissing { parent_inode_id: InodeId },
+    #[error(
+        "rename target parent inode `{parent_inode_id}` is not a directory (found `{actual_kind}`)"
+    )]
     RenameTargetParentNotDirectory {
         parent_inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "rename collides with existing name `{name_key}` under parent inode `{parent_inode_id}` (bound to inode `{child_inode_id}`)"
+    )]
     RenameTargetNameCollision {
         parent_inode_id: InodeId,
         name_key: String,
         child_inode_id: InodeId,
     },
+    #[error(
+        "rename of directory inode `{inode_id}` into inode `{new_parent_inode_id}` would create a cycle"
+    )]
     RenameWouldCycleDirectory {
         inode_id: InodeId,
         new_parent_inode_id: InodeId,
     },
+    #[error(
+        "rename of inode `{inode_id}` conflicts with subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     RenameInodeUnderSubtreeTombstone {
         inode_id: InodeId,
         root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
+    #[error(
+        "rename target parent inode `{parent_inode_id}` conflicts with subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     RenameTargetParentUnderSubtreeTombstone {
         parent_inode_id: InodeId,
         root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
-    DeleteSubtreeRootMissing {
-        root_inode_id: InodeId,
-    },
+    #[error("delete subtree root inode `{root_inode_id}` is missing")]
+    DeleteSubtreeRootMissing { root_inode_id: InodeId },
+    #[error(
+        "delete subtree root inode `{root_inode_id}` is not a directory (found `{actual_kind}`)"
+    )]
     DeleteSubtreeRootNotDirectory {
         root_inode_id: InodeId,
         actual_kind: InodeKind,
     },
+    #[error(
+        "delete subtree root inode `{root_inode_id}` is already covered by subtree tombstone rooted at inode `{covering_root_inode_id}` from seq `{tombstone_seq}`"
+    )]
     DeleteSubtreeRootCoveredByTombstone {
         root_inode_id: InodeId,
         covering_root_inode_id: InodeId,
         tombstone_seq: ChangeSeq,
     },
+    #[error(
+        "revision counter overflow restoring inode `{inode_id}` at base revision `{base_revision_no}`"
+    )]
     RestoreRevisionOverflow {
         inode_id: InodeId,
         base_revision_no: RevisionNo,
     },
+    #[error(
+        "revision counter overflow replacing inode `{inode_id}` at base revision `{base_revision_no}`"
+    )]
     ReplaceFileRevisionOverflow {
         inode_id: InodeId,
         base_revision_no: RevisionNo,
     },
+    #[error("stale writer epoch: requested `{requested}` but active is `{active}`")]
     StaleWriterEpoch {
         active: WriterEpoch,
         requested: WriterEpoch,
     },
+    #[error("validated preview apply failed: {0}")]
     ValidatedPreviewApplyFailed(String),
+    #[error("sequence counter overflow")]
     SeqOverflow,
+    #[error("next inode id counter overflow")]
     NextInodeOverflow,
+    #[error("op index overflow")]
     OpIndexOverflow,
+    #[error("delta index overflow")]
     DeltaIndexOverflow,
 }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -41,14 +41,14 @@ pub enum CoreError {
     DurableContent(#[from] DurableContentValidationError),
     #[error(transparent)]
     WriterEpoch(#[from] WriterEpochAcquireError),
-    #[error("commit validation failed: {0:?}")]
-    CommitValidation(CommitValidationError),
-    #[error("wal build failed: {0:?}")]
-    WalBuild(WalBuildError),
-    #[error("metadata apply failed: {0:?}")]
-    MetadataApply(MetadataApplyError),
-    #[error("head publish failed: {0:?}")]
-    HeadPublish(CommitHeadPublishError),
+    #[error("commit validation failed: {0}")]
+    CommitValidation(#[from] CommitValidationError),
+    #[error("wal build failed: {0}")]
+    WalBuild(#[from] WalBuildError),
+    #[error("metadata apply failed: {0}")]
+    MetadataApply(#[from] MetadataApplyError),
+    #[error("head publish failed: {0}")]
+    HeadPublish(#[from] CommitHeadPublishError),
     #[error("failed to write wal object: {0}")]
     WalWrite(String),
     #[error("invalid absolute path `{0}`")]
@@ -61,14 +61,14 @@ pub enum CoreError {
     InvalidUploadId(GeneratedIdValidationError),
     #[error("path not found `{0}`")]
     MissingPath(String),
-    #[error("revision `{revision_no:?}` not found for inode `{inode_id}`")]
+    #[error("revision `{revision_no}` not found for inode `{inode_id}`")]
     MissingRevision {
         inode_id: InodeId,
         revision_no: loonfs_api::RevisionNo,
     },
-    #[error("expected file at `{path}` but found `{kind:?}`")]
+    #[error("expected file at `{path}` but found `{kind}`")]
     ExpectedFile { path: String, kind: InodeKind },
-    #[error("expected directory at `{path}` but found `{kind:?}`")]
+    #[error("expected directory at `{path}` but found `{kind}`")]
     ExpectedDirectory { path: String, kind: InodeKind },
     #[error("directory not empty `{0}`")]
     DirectoryNotEmpty(String),
@@ -93,14 +93,14 @@ pub enum CoreError {
     #[error("invalid cursor: {0}")]
     InvalidCursor(String),
     #[error(
-        "change feed cursor `{after_seq:?}` is older than retention floor `{retention_floor_seq:?}`"
+        "change feed cursor `{after_seq}` is older than retention floor `{retention_floor_seq}`"
     )]
     RebootstrapRequired {
         after_seq: ChangeSeq,
         retention_floor_seq: ChangeSeq,
     },
     #[error(
-        "path `{path}` is covered by subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq:?}`"
+        "path `{path}` is covered by subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
     )]
     TombstoneConflict {
         path: String,
@@ -140,21 +140,21 @@ pub enum MetadataViewError {
         reason: String,
     },
     #[error(
-        "the cursor's snapshot (seq {requested_seq:?}) is no longer available (current head {head_seq:?}); restart the listing"
+        "the cursor's snapshot (seq `{requested_seq}`) is no longer available (current head `{head_seq}`); restart the listing"
     )]
     SnapshotUnavailable {
         requested_seq: ChangeSeq,
         head_seq: ChangeSeq,
     },
     #[error(
-        "metadata view only supports the loaded head `{head_seq:?}`, not historical snapshot `{requested_seq:?}`"
+        "metadata view only supports the loaded head `{head_seq}`, not historical snapshot `{requested_seq}`"
     )]
     UnsupportedHistoricalRead {
         requested_seq: ChangeSeq,
         head_seq: ChangeSeq,
     },
     #[error(
-        "namespace `{namespace_id}` current manifest changed during metadata view load: expected `{expected_manifest_id:?}`, found `{actual_manifest_id:?}`"
+        "namespace `{namespace_id}` current manifest changed during metadata view load: expected `{expected_manifest_id}`, found `{actual_manifest_id:?}`"
     )]
     ManifestChangedDuringViewLoad {
         namespace_id: NamespaceId,
@@ -193,8 +193,8 @@ pub enum MetadataProjectionLoadError {
     WalChainLoad(#[from] WalChainLoadError),
     #[error(transparent)]
     ManifestLoad(#[from] ManifestLoadError),
-    #[error("wal replay failed: {0:?}")]
-    WalReplay(WalReplayError),
+    #[error("wal replay failed: {0}")]
+    WalReplay(#[from] WalReplayError),
     #[error(
         "metadata projection head mismatch: expected current head `{expected:?}`, replayed `{actual:?}`"
     )]
@@ -214,30 +214,6 @@ impl From<NamespaceCatalogLoadError> for MetadataProjectionLoadError {
                 Self::LoadContentStoreDescriptor(error)
             }
         }
-    }
-}
-
-impl From<CommitValidationError> for CoreError {
-    fn from(value: CommitValidationError) -> Self {
-        Self::CommitValidation(value)
-    }
-}
-
-impl From<WalBuildError> for CoreError {
-    fn from(value: WalBuildError) -> Self {
-        Self::WalBuild(value)
-    }
-}
-
-impl From<MetadataApplyError> for CoreError {
-    fn from(value: MetadataApplyError) -> Self {
-        Self::MetadataApply(value)
-    }
-}
-
-impl From<CommitHeadPublishError> for CoreError {
-    fn from(value: CommitHeadPublishError) -> Self {
-        Self::HeadPublish(value)
     }
 }
 

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -162,7 +162,7 @@ pub enum VisiblePathError {
     #[error("visible path not found: `{absolute_path}`")]
     PathNotFound { absolute_path: String },
     #[error(
-        "path component traversal expected directory at `{absolute_path}` but found inode `{inode_id:?}` kind `{inode_kind:?}`"
+        "path component traversal expected directory at `{absolute_path}` but found inode `{inode_id}` kind `{inode_kind}`"
     )]
     PathComponentNotDirectory {
         absolute_path: String,
@@ -171,8 +171,11 @@ pub enum VisiblePathError {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum MetadataApplyError {
+    #[error(
+        "revision counter overflow for inode `{inode_id}` at base revision `{base_revision_no}`"
+    )]
     RevisionOverflow {
         inode_id: InodeId,
         base_revision_no: RevisionNo,

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -1051,7 +1051,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 Ok(_) => Ok(wal),
                 Err(error) => Err(CoreError::WalWrite(error.to_string())),
             },
-            Err(error) => Err(CoreError::Store(format!("wal build failed: {error:?}"))),
+            Err(error) => Err(CoreError::Store(format!("wal build failed: {error}"))),
         }
     };
     wal_span.record("result", if wal_result.is_ok() { "ok" } else { "error" });
@@ -1076,7 +1076,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {
-            let error = CoreError::Store(format!("head publish preparation failed: {error:?}"));
+            let error = CoreError::Store(format!("head publish preparation failed: {error}"));
             fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstViewResult::invalidate_projection(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -16,22 +16,25 @@ pub struct PreparedWalSegment {
     pub checked_invariants: Vec<InvariantId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WalBuildError {
+    #[error("writer version must not be empty")]
     EmptyWriterVersion,
+    #[error("WAL segment contains no records")]
     EmptySegment,
+    #[error("WAL build namespace mismatch: request `{request}`, plan `{plan}`")]
     NamespaceMismatch {
         request: NamespaceId,
         plan: NamespaceId,
     },
-    BaseHeadSeqMismatch {
-        request: ChangeSeq,
-        plan: ChangeSeq,
-    },
+    #[error("WAL build base head seq mismatch: request `{request}`, plan `{plan}`")]
+    BaseHeadSeqMismatch { request: ChangeSeq, plan: ChangeSeq },
+    #[error("non-contiguous WAL seq: expected `{expected}`, actual `{actual}`")]
     NonContiguousSeq {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("WAL codec error: {0}")]
     Codec(String),
 }
 
@@ -150,14 +153,14 @@ impl ValidatedWalChain {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WalChainLoadError {
-    #[error("invalid WAL chain seq range: base `{chain_base_seq:?}` is after head `{head_seq:?}`")]
+    #[error("invalid WAL chain seq range: base `{chain_base_seq}` is after head `{head_seq}`")]
     InvalidSeqRange {
         chain_base_seq: ChangeSeq,
         head_seq: ChangeSeq,
     },
-    #[error("missing visible WAL tip for seq `{seq:?}` under `{prefix}`")]
+    #[error("missing visible WAL tip for seq `{seq}` under `{prefix}`")]
     MissingVisibleTip { prefix: String, seq: ChangeSeq },
-    #[error("visible WAL tip ends at `{actual:?}`, expected head seq `{expected:?}`")]
+    #[error("visible WAL tip ends at `{actual}`, expected head seq `{expected}`")]
     TipEndSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
@@ -169,22 +172,16 @@ pub enum WalChainLoadError {
     #[error("WAL pointer does not match segment payload for `{object_key}`")]
     PointerMismatch { object_key: String },
     #[error(
-        "WAL chain does not reach expected head seq: expected `{expected:?}`, actual `{actual:?}`"
+        "WAL chain does not reach expected head seq: expected `{expected}`, actual `{actual}`"
     )]
     HeadSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
-    #[error("WAL chain suffix does not cover requested cursor `{after_seq:?}`")]
+    #[error("WAL chain suffix does not cover requested cursor `{after_seq}`")]
     CursorNotCovered { after_seq: ChangeSeq },
-    #[error("wal replay validation failed: {0:?}")]
-    Replay(WalReplayError),
-}
-
-impl From<WalReplayError> for WalChainLoadError {
-    fn from(value: WalReplayError) -> Self {
-        Self::Replay(value)
-    }
+    #[error("wal replay validation failed: {0}")]
+    Replay(#[from] WalReplayError),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -194,31 +191,40 @@ pub(crate) struct ReplayedWalTail {
     pub checked_invariants: Vec<InvariantId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WalReplayError {
+    #[error("WAL codec error: {0}")]
     Codec(String),
-    ObjectKeyMismatch {
-        expected: String,
-        actual: String,
-    },
+    #[error("WAL object key mismatch: expected `{expected}`, actual `{actual}`")]
+    ObjectKeyMismatch { expected: String, actual: String },
+    #[error("WAL segment namespace mismatch: expected `{expected}`, actual `{actual}`")]
     NamespaceMismatch {
         expected: NamespaceId,
         actual: NamespaceId,
     },
+    #[error("WAL segment base head seq mismatch: expected `{expected}`, actual `{actual}`")]
     BaseHeadSeqMismatch {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error("non-contiguous WAL seq: expected `{expected}`, actual `{actual}`")]
     NonContiguousSeq {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
+    #[error(
+        "WAL segment writer epoch mismatch: expected at most `{expected_max}`, actual `{actual}`"
+    )]
     WriterEpochMismatch {
         expected_max: WriterEpoch,
         actual: WriterEpoch,
     },
+    #[error("WAL segment contains no records")]
     EmptySegment,
+    #[error("WAL segment summary does not match its records")]
     SegmentSummaryMismatch,
-    MetadataApply(MetadataApplyError),
+    #[error(transparent)]
+    MetadataApply(#[from] MetadataApplyError),
+    #[error("sequence counter overflow")]
     SeqOverflow,
 }

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1144,6 +1144,82 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_commit_name_collision_reports_readable_error_message() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-collision-message",
+        "http-collision-message",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = "demo";
+        harness
+            .client
+            .create_namespace(namespace)
+            .expect("create namespace");
+
+        let content_ref = stage_uploaded_content_ref(&harness.client, namespace, b"taken bytes\n");
+        harness
+            .client
+            .commit_operations(
+                namespace,
+                &ApiCommitRequest {
+                    commit_id: CommitId::parse("req-collision-create").expect("valid commit id"),
+                    preconditions: Vec::new(),
+                    ops: vec![CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "taken.txt".to_owned(),
+                        content_ref: content_ref.clone(),
+                    }],
+                    message: None,
+                },
+            )
+            .expect("create file");
+
+        match harness.client.commit_operations(
+            namespace,
+            &ApiCommitRequest {
+                commit_id: CommitId::parse("req-collision-repeat").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "taken.txt".to_owned(),
+                    content_ref,
+                }],
+                message: None,
+            },
+        ) {
+            Err(ClientError::Api {
+                status,
+                code,
+                message,
+                ..
+            }) => {
+                assert_eq!(status, 409);
+                assert_eq!(code, "path_conflict");
+                // The error body carries the human-readable Display message,
+                // not Rust Debug syntax.
+                assert!(
+                    message.contains("collides with existing name `taken.txt`"),
+                    "expected readable collision message, got {message:?}"
+                );
+                assert!(
+                    !message.contains("InodeId(") && !message.contains('{'),
+                    "expected no Debug formatting in message, got {message:?}"
+                );
+            }
+            other => panic!("expected path_conflict, got {other:?}"),
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(


### PR DESCRIPTION
Five core error enums (commit validation, head publish, WAL build/replay, metadata apply) were serde-only data enums with no Display, so CoreError wrapped them with `{0:?}` and API clients received raw Rust Debug syntax like `CreateChildNameCollision { parent_inode_id: InodeId(2), ... }` in HTTP error bodies. Every variant now carries a thiserror message in the house style, the numeric id newtypes gained the missing Display impls, and error messages across core no longer Debug-format Display-able values. The redundant hand-written From impls collapsed into `#[from]`, and a new http_smoke test pins the readable message shape (and the absence of Debug syntax) at the HTTP boundary.