### PR TITLE
fix(client): preserve canonical server listing order

### DIFF
--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -241,11 +241,8 @@ impl Client {
             entries.extend(page.entries);
             cursor = page.next_cursor;
             if cursor.is_none() {
-                entries.sort_by(|left, right| {
-                    left.display_name
-                        .cmp(&right.display_name)
-                        .then(left.inode_id.0.cmp(&right.inode_id.0))
-                });
+                // Pages arrive in canonical name-key order; concatenation
+                // preserves it, so aggregation must not re-sort.
                 envelope_ref.entries = entries;
                 return Ok(envelope.expect("first page initializes response envelope"));
             }

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -247,6 +247,43 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
     harness.server.abort();
 }
 
+/// The client aggregates pages without re-ordering: mixed-case names must come
+/// back in the server's canonical casefolded name-key order, not in raw
+/// display-name byte order (`B.txt` sorts after `a.txt`, not before).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_client_listing_preserves_canonical_name_key_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-listing-order",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace("demo")
+            .expect("create namespace");
+        let docs = NamespacePath::parse("demo:/docs").expect("docs path");
+        harness.client.create_dir(&docs).expect("create docs dir");
+        for name in ["B.txt", "a.txt", "c.txt"] {
+            let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
+            harness
+                .client
+                .write_file_bytes(&path, name.as_bytes())
+                .expect("write file");
+        }
+
+        let listing = harness.client.list_path(&docs).expect("directory list");
+        assert_eq!(entry_names(&listing), vec!["a.txt", "B.txt", "c.txt"]);
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_round_trip_supports_namespace_create_and_file_read_write() {
     let temp_dir = tempdir().expect("tempdir");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -491,7 +491,9 @@ an empty directory still reports which state it observed and the response can
 grow without reshaping `entries`. Entries are full path entries with the same
 shape as `stat` (directory entries leave the file-only fields out).
 
-Directory listing advances in canonical `name_key` order. The `path` query parameter is
+Directory listing advances in canonical `name_key` order. Concatenating pages
+in cursor order yields the complete listing in that same order; clients must
+not re-sort aggregated pages. The `path` query parameter is
 required on every page; the cursor pins the snapshot and resume position, but
 the request path remains the authority for what is being listed. Responses
 include `next_cursor` only when another page is available.


### PR DESCRIPTION
The server pages directory listings in canonical casefolded name-key order (api.md pins this), but the client re-sorted aggregated pages by raw display-name bytes, so `loon ls` could print the same directory in different orders depending on whether a profile was embedded or remote (`B.txt` before `a.txt` remotely, after it embedded). The re-sort is deleted — concatenated pages are already canonical — the spec now says aggregation must preserve page order, and a smoke test pins the mixed-case ordering through the client.