### PR TITLE
refactor(api): derive http status from a single error taxonomy

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -1,6 +1,11 @@
 use std::fmt;
 
 /// Broad error category for caller or operator action.
+///
+/// Each kind implies one served HTTP status (`status_for_error_kind` in
+/// `loonfs-server`); a code's kind and its documented status in the API spec
+/// must agree in spirit, and the server's spec-table sync test enforces the
+/// composition exactly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
@@ -16,12 +21,15 @@ pub enum ErrorKind {
     NotSupported,
     /// The requested object does not exist. Refresh state or choose another target.
     NotFound,
+    /// The target was deleted and its id is permanently retired. Do not
+    /// retry; choose another target.
+    Gone,
     /// The create target already exists. Pick another id or treat this as idempotent.
     AlreadyExists,
-    /// The request raced with current namespace state. Re-read and retry if desired.
+    /// The request raced with current namespace state, or a caller-supplied
+    /// precondition (base revision, expected head) no longer holds. Re-read
+    /// fresh state, re-plan, and retry if desired.
     Conflict,
-    /// A caller-supplied precondition was false. Re-plan against fresh state.
-    PreconditionFailed,
     /// The system is temporarily unavailable. Back off and retry.
     Unavailable,
     /// The operation may have committed: its acknowledgment was lost. Retry
@@ -34,98 +42,132 @@ pub enum ErrorKind {
     Internal,
 }
 
-/// Stable machine-readable error reason.
+/// Declares the complete wire error-code registry in one place.
 ///
-/// This is the complete registry of `code` values carried by
-/// [`ApiError`](crate::ApiError) bodies and embedded errors. Codes are
-/// permanent once released: the API spec documents each code's meaning and HTTP
-/// status, and clients must tolerate codes they do not recognize.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ErrorCode {
-    InvalidRequest,
-    Unauthorized,
-    NotSupported,
-    NamespaceNotFound,
-    NamespaceDeleted,
-    NamespaceExists,
-    NamespacePartial,
-    PathNotFound,
-    RevisionNotFound,
-    PathConflict,
-    DirectoryNotEmpty,
-    StaleHead,
-    StaleRevision,
-    TombstoneConflict,
-    WriterFenced,
-    WouldCycle,
-    CommitIdReuseConflict,
-    CommitOutcomeUnknown,
-    CommitQueueFull,
-    CheckpointUnavailable,
-    MaintenanceRequired,
-    UploadNotFound,
-    UploadAlreadyCompleted,
-    UploadContentConflict,
-    RebootstrapRequired,
-    NamespaceCorrupt,
-    ServerError,
+/// One `Variant => "wire_string"` line emits the enum variant, its
+/// [`ErrorCode::ALL`] entry (in registry order), its `as_str` arm, its
+/// `parse` arm, and the string-backed serde impls — so registering a new
+/// code is one line here plus a [`ErrorCode::kind`] arm and an api.md row.
+macro_rules! error_codes {
+    (@count) => { 0 };
+    (@count $head:ident $($tail:ident)*) => { 1 + error_codes!(@count $($tail)*) };
+    ($($variant:ident => $wire:literal),+ $(,)?) => {
+        /// Stable machine-readable error reason.
+        ///
+        /// This is the complete registry of `code` values carried by
+        /// [`ApiError`](crate::ApiError) bodies and embedded errors. Codes are
+        /// permanent once released: the API spec documents each code's meaning and HTTP
+        /// status, and clients must tolerate codes they do not recognize.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub enum ErrorCode {
+            $($variant,)+
+        }
+
+        impl ErrorCode {
+            /// Every registered code, in registry order.
+            pub const ALL: [ErrorCode; error_codes!(@count $($variant)+)] =
+                [$(ErrorCode::$variant,)+];
+
+            /// Returns the stable wire string for this code.
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(ErrorCode::$variant => $wire,)+
+                }
+            }
+
+            /// Parses a registered code string, returning `None` for codes this
+            /// build does not know (clients must tolerate those).
+            pub fn parse(value: &str) -> Option<ErrorCode> {
+                match value {
+                    $($wire => Some(ErrorCode::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+
+        impl serde::Serialize for ErrorCode {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for ErrorCode {
+            // Strict: unknown codes fail to deserialize. Wire structs carry
+            // codes as plain strings (`ApiError::code`) precisely so unknown
+            // codes stay tolerated; deserialize into `ErrorCode` only where
+            // strictness is intended.
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let value = String::deserialize(deserializer)?;
+                ErrorCode::parse(&value).ok_or_else(|| {
+                    serde::de::Error::custom(format_args!("unknown error code `{value}`"))
+                })
+            }
+        }
+    };
+}
+
+error_codes! {
+    InvalidRequest => "invalid_request",
+    Unauthorized => "unauthorized",
+    NotSupported => "not_supported",
+    NamespaceNotFound => "namespace_not_found",
+    NamespaceDeleted => "namespace_deleted",
+    NamespaceExists => "namespace_exists",
+    NamespacePartial => "namespace_partial",
+    PathNotFound => "path_not_found",
+    RevisionNotFound => "revision_not_found",
+    PathConflict => "path_conflict",
+    DirectoryNotEmpty => "directory_not_empty",
+    StaleHead => "stale_head",
+    StaleRevision => "stale_revision",
+    TombstoneConflict => "tombstone_conflict",
+    WriterFenced => "writer_fenced",
+    WouldCycle => "would_cycle",
+    CommitIdReuseConflict => "commit_id_reuse_conflict",
+    CommitOutcomeUnknown => "commit_outcome_unknown",
+    CommitQueueFull => "commit_queue_full",
+    CheckpointUnavailable => "checkpoint_unavailable",
+    MaintenanceRequired => "maintenance_required",
+    UploadNotFound => "upload_not_found",
+    UploadAlreadyCompleted => "upload_already_completed",
+    UploadContentConflict => "upload_content_conflict",
+    RebootstrapRequired => "rebootstrap_required",
+    NamespaceCorrupt => "namespace_corrupt",
+    ServerError => "server_error",
 }
 
 impl ErrorCode {
-    /// Every registered code, in registry order.
-    pub const ALL: [ErrorCode; 27] = [
-        ErrorCode::InvalidRequest,
-        ErrorCode::Unauthorized,
-        ErrorCode::NotSupported,
-        ErrorCode::NamespaceNotFound,
-        ErrorCode::NamespaceDeleted,
-        ErrorCode::NamespaceExists,
-        ErrorCode::NamespacePartial,
-        ErrorCode::PathNotFound,
-        ErrorCode::RevisionNotFound,
-        ErrorCode::PathConflict,
-        ErrorCode::DirectoryNotEmpty,
-        ErrorCode::StaleHead,
-        ErrorCode::StaleRevision,
-        ErrorCode::TombstoneConflict,
-        ErrorCode::WriterFenced,
-        ErrorCode::WouldCycle,
-        ErrorCode::CommitIdReuseConflict,
-        ErrorCode::CommitOutcomeUnknown,
-        ErrorCode::CommitQueueFull,
-        ErrorCode::CheckpointUnavailable,
-        ErrorCode::MaintenanceRequired,
-        ErrorCode::UploadNotFound,
-        ErrorCode::UploadAlreadyCompleted,
-        ErrorCode::UploadContentConflict,
-        ErrorCode::RebootstrapRequired,
-        ErrorCode::NamespaceCorrupt,
-        ErrorCode::ServerError,
-    ];
-
+    /// Returns the caller-action category for this code.
+    ///
+    /// The kind agrees with the HTTP status the api.md error table documents
+    /// for the code; the server derives the served status from it.
     pub fn kind(self) -> ErrorKind {
         match self {
             ErrorCode::InvalidRequest => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound
-            | ErrorCode::NamespaceDeleted
             | ErrorCode::PathNotFound
             | ErrorCode::RevisionNotFound
             | ErrorCode::UploadNotFound => ErrorKind::NotFound,
+            ErrorCode::NamespaceDeleted => ErrorKind::Gone,
             ErrorCode::NamespaceExists => ErrorKind::AlreadyExists,
-            ErrorCode::StaleRevision => ErrorKind::PreconditionFailed,
             ErrorCode::CommitQueueFull
             | ErrorCode::CheckpointUnavailable
             | ErrorCode::MaintenanceRequired => ErrorKind::Unavailable,
             ErrorCode::CommitOutcomeUnknown => ErrorKind::OutcomeUnknown,
             ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
             ErrorCode::ServerError => ErrorKind::Internal,
+            // The spec deliberately surfaces precondition failures
+            // (`stale_revision`, `stale_head`, `commit_id_reuse_conflict`) as
+            // 409 resource-state conflicts, not 412 (api.md, "Standard error
+            // contract").
             ErrorCode::NamespacePartial
             | ErrorCode::PathConflict
             | ErrorCode::DirectoryNotEmpty
             | ErrorCode::StaleHead
+            | ErrorCode::StaleRevision
             | ErrorCode::TombstoneConflict
             | ErrorCode::WriterFenced
             | ErrorCode::WouldCycle
@@ -134,46 +176,6 @@ impl ErrorCode {
             | ErrorCode::UploadContentConflict
             | ErrorCode::RebootstrapRequired => ErrorKind::Conflict,
         }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ErrorCode::InvalidRequest => "invalid_request",
-            ErrorCode::Unauthorized => "unauthorized",
-            ErrorCode::NotSupported => "not_supported",
-            ErrorCode::NamespaceNotFound => "namespace_not_found",
-            ErrorCode::NamespaceDeleted => "namespace_deleted",
-            ErrorCode::NamespaceExists => "namespace_exists",
-            ErrorCode::NamespacePartial => "namespace_partial",
-            ErrorCode::PathNotFound => "path_not_found",
-            ErrorCode::RevisionNotFound => "revision_not_found",
-            ErrorCode::PathConflict => "path_conflict",
-            ErrorCode::DirectoryNotEmpty => "directory_not_empty",
-            ErrorCode::StaleHead => "stale_head",
-            ErrorCode::StaleRevision => "stale_revision",
-            ErrorCode::TombstoneConflict => "tombstone_conflict",
-            ErrorCode::WriterFenced => "writer_fenced",
-            ErrorCode::WouldCycle => "would_cycle",
-            ErrorCode::CommitIdReuseConflict => "commit_id_reuse_conflict",
-            ErrorCode::CommitOutcomeUnknown => "commit_outcome_unknown",
-            ErrorCode::CommitQueueFull => "commit_queue_full",
-            ErrorCode::CheckpointUnavailable => "checkpoint_unavailable",
-            ErrorCode::MaintenanceRequired => "maintenance_required",
-            ErrorCode::UploadNotFound => "upload_not_found",
-            ErrorCode::UploadAlreadyCompleted => "upload_already_completed",
-            ErrorCode::UploadContentConflict => "upload_content_conflict",
-            ErrorCode::RebootstrapRequired => "rebootstrap_required",
-            ErrorCode::NamespaceCorrupt => "namespace_corrupt",
-            ErrorCode::ServerError => "server_error",
-        }
-    }
-
-    /// Parses a registered code string, returning `None` for codes this
-    /// build does not know (clients must tolerate those).
-    pub fn parse(value: &str) -> Option<ErrorCode> {
-        ErrorCode::ALL
-            .into_iter()
-            .find(|code| code.as_str() == value)
     }
 }
 
@@ -193,5 +195,16 @@ mod tests {
             assert_eq!(ErrorCode::parse(code.as_str()), Some(code));
         }
         assert_eq!(ErrorCode::parse("not_a_code"), None);
+    }
+
+    #[test]
+    fn error_codes_serde_uses_the_wire_strings() {
+        for code in ErrorCode::ALL {
+            let value = serde_json::to_value(code).expect("serialize error code");
+            assert_eq!(value, serde_json::Value::String(code.as_str().to_owned()));
+            let parsed: ErrorCode = serde_json::from_value(value).expect("deserialize error code");
+            assert_eq!(parsed, code);
+        }
+        assert!(serde_json::from_str::<ErrorCode>("\"not_a_code\"").is_err());
     }
 }

--- a/crates/loonfs-api/src/http.rs
+++ b/crates/loonfs-api/src/http.rs
@@ -1,7 +1,6 @@
 use crate::{
     v0::{MoveBehavior, ValidatedContentToken},
-    ChangeSeq, CheckpointId, CommitId, ContentRef, ErrorCode, InodeId, ManifestId, NamespaceId,
-    RevisionNo,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -9,11 +8,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ApiError {
-    /// Stable machine-readable reason from the [`ErrorCode`] registry.
+    /// Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)
+    /// registry.
     ///
     /// Carried as a string so clients keep working when a newer server
-    /// introduces a code they do not know; use [`ApiError::error_code`] for
-    /// typed access.
+    /// introduces a code they do not know; use
+    /// [`ErrorCode::parse`](crate::ErrorCode::parse) for typed access.
     pub code: String,
     /// For `not_supported` errors, the capability-document feature key the
     /// client should reconcile against.
@@ -21,14 +21,6 @@ pub struct ApiError {
     pub feature: Option<String>,
     /// Human-readable error message.
     pub message: String,
-}
-
-impl ApiError {
-    /// Returns the registered code, or `None` for codes this build does not
-    /// know.
-    pub fn error_code(&self) -> Option<ErrorCode> {
-        ErrorCode::parse(&self.code)
-    }
 }
 
 /// Request to create a namespace.

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -14,10 +14,11 @@ use loonfs_api::{
         UploadContentResponse, UploadMode, ValidatedContentToken,
     },
     ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CommitId, ContentRef,
-    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, InodeId,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MutationResult, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest, RevisionNo,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind,
+    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
+    ForkNamespaceRequest, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -104,6 +105,45 @@ pub enum ClientError {
     Io(String),
     #[error("json error: {0}")]
     Json(String),
+}
+
+impl ClientError {
+    /// Returns the typed code for [`ClientError::Api`] errors, or `None` for
+    /// non-API errors and for codes this build does not know (clients must
+    /// tolerate unknown codes).
+    pub fn error_code(&self) -> Option<ErrorCode> {
+        match self {
+            ClientError::Api { code, .. } => ErrorCode::parse(code),
+            _ => None,
+        }
+    }
+
+    /// Returns the caller-action category for [`ClientError::Api`] errors.
+    ///
+    /// Known codes classify through [`ErrorCode::kind`]. Unknown codes (a
+    /// newer server) fall back to the HTTP status class, so retry decisions
+    /// still work: 503 is [`ErrorKind::Unavailable`], other 5xx are
+    /// [`ErrorKind::Internal`], and 4xx are [`ErrorKind::InvalidRequest`].
+    pub fn kind(&self) -> Option<ErrorKind> {
+        match self {
+            ClientError::Api { status, code, .. } => match ErrorCode::parse(code) {
+                Some(code) => Some(code.kind()),
+                None => kind_for_status_class(*status),
+            },
+            _ => None,
+        }
+    }
+}
+
+/// Coarse status-class fallback for error codes this build does not know.
+fn kind_for_status_class(status: u16) -> Option<ErrorKind> {
+    match status {
+        // 503 stays retryable even when the code is unknown.
+        503 => Some(ErrorKind::Unavailable),
+        400..=499 => Some(ErrorKind::InvalidRequest),
+        500..=599 => Some(ErrorKind::Internal),
+        _ => None,
+    }
 }
 
 impl ClientConfig {
@@ -1085,9 +1125,54 @@ fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), Cl
 
 #[cfg(test)]
 mod tests {
-    use super::{Client, ClientConfig, ClientError, NamespacePath};
+    use super::{Client, ClientConfig, ClientError, ErrorCode, ErrorKind, NamespacePath};
     use std::fs;
     use tempfile::tempdir;
+
+    fn api_error(status: u16, code: &str) -> ClientError {
+        ClientError::Api {
+            status,
+            code: code.to_owned(),
+            feature: None,
+            message: "test".to_owned(),
+        }
+    }
+
+    #[test]
+    fn api_errors_with_known_codes_classify_through_the_registry() {
+        let error = api_error(409, "stale_revision");
+        assert_eq!(error.error_code(), Some(ErrorCode::StaleRevision));
+        assert_eq!(error.kind(), Some(ErrorKind::Conflict));
+
+        let error = api_error(410, "namespace_deleted");
+        assert_eq!(error.error_code(), Some(ErrorCode::NamespaceDeleted));
+        assert_eq!(error.kind(), Some(ErrorKind::Gone));
+
+        let error = api_error(503, "commit_outcome_unknown");
+        assert_eq!(error.error_code(), Some(ErrorCode::CommitOutcomeUnknown));
+        assert_eq!(error.kind(), Some(ErrorKind::OutcomeUnknown));
+    }
+
+    #[test]
+    fn api_errors_with_unknown_codes_fall_back_to_the_status_class() {
+        for (status, kind) in [
+            (400, ErrorKind::InvalidRequest),
+            (404, ErrorKind::InvalidRequest),
+            (500, ErrorKind::Internal),
+            (503, ErrorKind::Unavailable),
+        ] {
+            let error = api_error(status, "code_from_a_newer_server");
+            assert_eq!(error.error_code(), None);
+            assert_eq!(error.kind(), Some(kind), "status {status}");
+        }
+    }
+
+    #[test]
+    fn non_api_errors_have_no_code_or_kind() {
+        let error = ClientError::Http("connection refused".to_owned());
+        assert_eq!(error.error_code(), None);
+        assert_eq!(error.kind(), None);
+    }
 
     #[test]
     fn load_rejects_invalid_server_url() {

--- a/crates/loonfs-core/src/commit/publish_error.rs
+++ b/crates/loonfs-core/src/commit/publish_error.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
-#[non_exhaustive]
 pub enum CommitHeadPublishError {
     #[error("writer version must not be empty")]
     EmptyWriterVersion,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -499,11 +499,11 @@ mod tests {
     fn public_error_kind_groups_detailed_codes() {
         assert_eq!(ErrorCode::InvalidRequest.kind(), ErrorKind::InvalidRequest);
         assert_eq!(ErrorCode::PathNotFound.kind(), ErrorKind::NotFound);
+        assert_eq!(ErrorCode::NamespaceDeleted.kind(), ErrorKind::Gone);
         assert_eq!(ErrorCode::NamespaceExists.kind(), ErrorKind::AlreadyExists);
-        assert_eq!(
-            ErrorCode::StaleRevision.kind(),
-            ErrorKind::PreconditionFailed
-        );
+        // Precondition failures are 409 resource-state conflicts in v0
+        // (api.md, "Standard error contract"), so the kind is Conflict.
+        assert_eq!(ErrorCode::StaleRevision.kind(), ErrorKind::Conflict);
         assert_eq!(ErrorCode::CommitQueueFull.kind(), ErrorKind::Unavailable);
         assert_eq!(
             ErrorCode::MaintenanceRequired.kind(),

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -25,7 +25,6 @@ use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[non_exhaustive]
 pub enum BootstrapNamespaceError {
     #[error(transparent)]
     InvalidNamespaceId(#[from] NamespaceIdValidationError),

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -9,7 +9,7 @@ use axum::{Json, Router};
 use loonfs::publish::PathMutationIntent;
 use loonfs::{
     payload_class, BootstrapNamespaceError, ChangeSeq, CoreError, CreateNamespaceOptions,
-    DeleteNamespaceOptions, ErrorCode, Fs, JsonlObjectStoreMetricsRecorder,
+    DeleteNamespaceOptions, ErrorCode, ErrorKind, Fs, JsonlObjectStoreMetricsRecorder,
     ObjectStoreMetricsRecorder, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use loonfs_api::{
@@ -1765,36 +1765,27 @@ impl ApiResponseError {
 }
 
 fn status_for_core_error_code(code: ErrorCode) -> StatusCode {
-    match code {
-        ErrorCode::InvalidRequest => StatusCode::BAD_REQUEST,
-        ErrorCode::NamespaceNotFound
-        | ErrorCode::PathNotFound
-        | ErrorCode::RevisionNotFound
-        | ErrorCode::UploadNotFound => StatusCode::NOT_FOUND,
-        ErrorCode::CommitQueueFull
-        | ErrorCode::CommitOutcomeUnknown
-        | ErrorCode::CheckpointUnavailable
-        | ErrorCode::MaintenanceRequired => StatusCode::SERVICE_UNAVAILABLE,
-        ErrorCode::NamespaceDeleted => StatusCode::GONE,
-        ErrorCode::Unauthorized => StatusCode::UNAUTHORIZED,
-        ErrorCode::NotSupported => StatusCode::NOT_IMPLEMENTED,
-        ErrorCode::NamespaceCorrupt | ErrorCode::ServerError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorCode::NamespaceExists
-        | ErrorCode::NamespacePartial
-        | ErrorCode::PathConflict
-        | ErrorCode::DirectoryNotEmpty
-        | ErrorCode::StaleHead
-        | ErrorCode::StaleRevision
-        | ErrorCode::TombstoneConflict
-        | ErrorCode::WriterFenced
-        | ErrorCode::WouldCycle
-        | ErrorCode::CommitIdReuseConflict
-        | ErrorCode::UploadAlreadyCompleted
-        | ErrorCode::UploadContentConflict
-        | ErrorCode::RebootstrapRequired => StatusCode::CONFLICT,
-        // A code without an explicit arm serves as 500 until someone decides
+    status_for_error_kind(code.kind())
+}
+
+/// Maps a caller-action [`ErrorKind`] to the HTTP status this server serves:
+/// the api.md error table is the source of truth, and the spec-table sync
+/// test below enforces that this mapping composed with [`ErrorCode::kind`]
+/// reproduces it exactly.
+fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
+    match kind {
+        ErrorKind::InvalidRequest => StatusCode::BAD_REQUEST,
+        ErrorKind::Unauthorized => StatusCode::UNAUTHORIZED,
+        ErrorKind::PermissionDenied => StatusCode::FORBIDDEN,
+        ErrorKind::NotFound => StatusCode::NOT_FOUND,
+        ErrorKind::Gone => StatusCode::GONE,
+        ErrorKind::AlreadyExists | ErrorKind::Conflict => StatusCode::CONFLICT,
+        ErrorKind::NotSupported => StatusCode::NOT_IMPLEMENTED,
+        ErrorKind::Unavailable | ErrorKind::OutcomeUnknown => StatusCode::SERVICE_UNAVAILABLE,
+        ErrorKind::DataCorruption | ErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        // A kind without an explicit arm serves as 500 until someone decides
         // its real status. The spec-table test below fails on any code whose
-        // served status disagrees with the api.md registry, so new codes
+        // served status disagrees with the api.md registry, so new kinds
         // cannot ship on this default silently.
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1943,7 +1943,7 @@
         "properties": {
           "code": {
             "type": "string",
-            "description": "Stable machine-readable reason from the [`ErrorCode`] registry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use [`ApiError::error_code`] for\ntyped access."
+            "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
           },
           "feature": {
             "type": [


### PR DESCRIPTION
The code-to-category classification existed three times: ErrorCode::kind() (zero production consumers, already drifted — stale_revision claimed PreconditionFailed while being served 409), the server's hand-maintained 38-arm status match, and the api.md table. Kinds are now reconciled to the served statuses (which stay bit-identical; the api.md sync test passes unchanged), the server derives status through one 9-arm kind-to-status function, and the ErrorCode variant/string/ALL triple-entry ritual collapsed into an error_codes! macro so a new code is one line plus a compiler-forced kind arm plus a test-forced spec row. ClientError gains typed error_code()/kind() accessors with a status-class fallback for unknown codes, making the client the reference consumer of the retry taxonomy; the never-called ApiError::error_code was deleted. #[non_exhaustive] now follows one rule: the six cross-crate root enums keep it, per-op enums lose it.