### PR TITLE
refactor(cli): map errors through the shared error-code registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,6 @@ dependencies = [
  "loonfs",
  "loonfs-api",
  "loonfs-client",
- "loonfs-core",
  "loonfs-objectstore",
  "serde",
  "serde_json",

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -28,7 +28,6 @@ toml.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.39", features = ["json"] }
-loonfs-core = { path = "../loonfs-core" }
 tempfile.workspace = true
 ureq.workspace = true
 

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -200,12 +200,15 @@ fn map_client_error(error: ClientError) -> CliError {
         ClientError::ConfigValidation { field, reason } => {
             CliError::invalid_config(format!("invalid `{field}`: {reason}"))
         }
-        ClientError::InvalidNamespacePath(message) | ClientError::InvalidCommitId(message) => {
-            CliError::invalid_input(message)
+        ClientError::InvalidNamespacePath(message) => CliError::invalid_input(message),
+        ClientError::InvalidCommitId(message) => {
+            // The registry code core and server report for a malformed commit
+            // id, so pre-flight client validation matches backend behavior.
+            CliError::new(ErrorCode::InvalidRequest.as_str(), message)
         }
         ClientError::Http(message) | ClientError::Json(message) => CliError::client_error(message),
         ClientError::Api { code, message, .. } => CliError::new(code, message),
-        ClientError::Io(message) => CliError::new("io_error", format!("i/o error: {message}")),
+        ClientError::Io(message) => CliError::io(std::io::Error::other(message)),
         other => CliError::client_error(other.to_string()),
     }
 }
@@ -337,7 +340,9 @@ impl Backend for EmbeddedBackend {
                     cursor: cursor
                         .map(loonfs_api::decode_file_revisions_cursor)
                         .transpose()
-                        .map_err(|error| CliError::new("invalid_request", error.to_string()))?,
+                        .map_err(|error| {
+                            CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                        })?,
                 },
             ),
         )
@@ -464,7 +469,8 @@ impl Backend for EmbeddedBackend {
 }
 
 fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
-    NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))
+    NamespaceId::parse(namespace)
+        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
 }
 
 fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, CliError> {
@@ -482,8 +488,8 @@ fn map_runtime_error(error: RuntimeError) -> CliError {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
-        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
-        other => CliError::new("runtime_error", other.to_string()),
+        RuntimeError::RuntimeTask(message) => CliError::runtime_error(message),
+        other => CliError::runtime_error(other.to_string()),
     }
 }
 
@@ -492,23 +498,23 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => CliError::invalid_config(message),
-        RuntimeError::RuntimeTask(message) => CliError::new("runtime_error", message),
-        other => CliError::new("runtime_error", other.to_string()),
+        RuntimeError::RuntimeTask(message) => CliError::runtime_error(message),
+        other => CliError::runtime_error(other.to_string()),
     }
 }
 
-fn map_core_error(error: CoreError) -> CliError {
-    if matches!(error.code(), ErrorCode::InvalidRequest) {
-        return CliError::invalid_input(error.to_string());
-    }
+// Embedded-mode failures surface the same registry code the server would
+// serve for the identical failure, so `loon --json` consumers see one code
+// per mistake regardless of profile mode.
 
+fn map_core_error(error: CoreError) -> CliError {
     CliError::new(error.code().as_str(), error.to_string())
 }
 
 fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliError {
     if matches!(error.code(), ErrorCode::NamespaceNotFound) {
         return CliError::new(
-            "namespace_not_found",
+            ErrorCode::NamespaceNotFound.as_str(),
             format!("namespace `{namespace}` does not exist"),
         );
     }
@@ -517,24 +523,7 @@ fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliErro
 }
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {
-    match &error {
-        BootstrapNamespaceError::InvalidNamespaceId(_) => {
-            CliError::invalid_input(error.to_string())
-        }
-        BootstrapNamespaceError::NamespaceAlreadyExists { .. } => {
-            CliError::new("namespace_exists", error.to_string())
-        }
-        BootstrapNamespaceError::NamespacePartiallyInitialized { .. } => {
-            CliError::new("namespace_partial", error.to_string())
-        }
-        BootstrapNamespaceError::NamespaceDeleted { .. } => {
-            CliError::new("namespace_deleted", error.to_string())
-        }
-        BootstrapNamespaceError::EmptyHolderId | BootstrapNamespaceError::EmptyWriterVersion => {
-            CliError::invalid_config(error.to_string())
-        }
-        _ => CliError::new("server_error", error.to_string()),
-    }
+    CliError::new(error.code().as_str(), error.to_string())
 }
 
 fn default_writer_id() -> String {
@@ -659,24 +648,41 @@ impl RemoteTarget {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_core_error, Backend, EmbeddedTarget};
+    use super::{map_bootstrap_error, map_core_error, Backend, EmbeddedTarget};
     use crate::config::StoreConfig;
-    use loonfs::CoreError;
+    use loonfs::{BootstrapNamespaceError, CoreError, ErrorCode};
     use loonfs_api::{ChangeSeq, InodeId, NamespaceId, RevisionNo};
     use loonfs_client::NamespacePath;
-    use loonfs_core::commit::CommitValidationError;
     use tempfile::tempdir;
 
     #[test]
-    fn map_core_error_uses_revision_not_found_code() {
-        let error = map_core_error(CoreError::CommitValidation(
-            CommitValidationError::RestoreRevisionSourceRevisionMissing {
-                inode_id: InodeId(42),
-                source_revision_no: RevisionNo(7),
-            },
-        ));
+    fn map_core_error_surfaces_registry_codes_verbatim() {
+        let error = map_core_error(CoreError::MissingRevision {
+            inode_id: InodeId(42),
+            revision_no: RevisionNo(7),
+        });
 
-        assert_eq!(error.code, "revision_not_found");
+        assert_eq!(error.code, ErrorCode::RevisionNotFound.as_str());
+    }
+
+    #[test]
+    fn map_core_error_does_not_rewrite_invalid_id_codes() {
+        // Embedded mode must report the same code the server serves for the
+        // identical failure, not a CLI-local `invalid_input` rewrite.
+        let invalid_id = NamespaceId::parse("bad/name").expect_err("invalid namespace id");
+        let error = map_core_error(CoreError::InvalidNamespaceId(invalid_id));
+
+        assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+    }
+
+    #[test]
+    fn map_bootstrap_error_surfaces_registry_codes_verbatim() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let error =
+            map_bootstrap_error(BootstrapNamespaceError::NamespaceAlreadyExists { namespace_id });
+
+        assert_eq!(error.code, ErrorCode::NamespaceExists.as_str());
+        assert!(error.message.contains("already exists"));
     }
 
     #[test]

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -2,7 +2,7 @@ use super::output::CommandFailure;
 use crate::args::{CommandKind, TargetSelectorArgs};
 use crate::error::CliError;
 use crate::resolve::{load_cli_config, resolve_namespace, resolve_target_profile_from_config};
-use loonfs_api::NamespaceId;
+use loonfs_api::{ErrorCode, NamespaceId};
 use loonfs_client::NamespacePath;
 use std::path::{Path, PathBuf};
 
@@ -50,9 +50,11 @@ pub(crate) fn resolve_command_context(
 // --- general helpers ---
 
 pub(crate) fn validate_namespace_id(namespace: &str) -> Result<(), CliError> {
+    // A malformed namespace id surfaces its registry code so both profile
+    // modes report the same code the server would serve for it.
     NamespaceId::parse(namespace)
         .map(|_| ())
-        .map_err(|error| CliError::invalid_input(error.to_string()))
+        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
 }
 
 pub(crate) fn namespace_path(

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -148,7 +148,7 @@ fn run_profile_remove(
                 kind,
                 Some(name.to_owned()),
                 None,
-                CliError::new("cancelled", "operation cancelled"),
+                CliError::cancelled(),
             ));
         }
     }

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -1,5 +1,22 @@
+use loonfs_api::ErrorCode;
 use serde::{Deserialize, Serialize};
 
+/// Structured failure surfaced by every CLI command (`--json` renders it verbatim).
+///
+/// `code` draws from exactly two namespaces:
+///
+/// - **Registry codes** ([`loonfs_api::ErrorCode`]) pass through verbatim from
+///   whichever backend produced them, so embedded and remote profiles surface
+///   the same code for the same failure. Never restate a registry code as a
+///   string literal; use `ErrorCode::X.as_str()` or an error's `code()`.
+///   (`invalid_config` deliberately reports the registry `invalid_request`
+///   code: it is the code the server serves for configuration mistakes.)
+/// - **CLI-local codes** cover failures that never reach a backend. The
+///   complete list, each owned by a constructor below, is: `invalid_input`,
+///   `profile_not_found`, `no_default_profile`, `no_default_namespace`,
+///   `profile_already_exists`, `config_already_exists`,
+///   `non_interactive_input_required`, `json_not_supported_for_streaming`,
+///   `client_error`, `io_error`, `runtime_error`, and `cancelled`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CliError {
     pub code: String,
@@ -15,7 +32,7 @@ impl CliError {
     }
 
     pub(crate) fn invalid_config(message: impl Into<String>) -> Self {
-        Self::new("invalid_request", message)
+        Self::new(ErrorCode::InvalidRequest.as_str(), message)
     }
 
     pub(crate) fn invalid_input(message: impl Into<String>) -> Self {
@@ -78,5 +95,13 @@ impl CliError {
 
     pub(crate) fn io(error: std::io::Error) -> Self {
         Self::new("io_error", format!("i/o error: {error}"))
+    }
+
+    pub(crate) fn runtime_error(message: impl Into<String>) -> Self {
+        Self::new("runtime_error", message)
+    }
+
+    pub(crate) fn cancelled() -> Self {
+        Self::new("cancelled", "operation cancelled")
     }
 }

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -29,7 +29,7 @@ pub fn main() -> ExitCode {
                     kind: output.kind,
                     profile: output.profile.clone(),
                     mode: output.mode,
-                    error: error::CliError::new("io_error", format!("i/o error: {err}")),
+                    error: error::CliError::io(err),
                 };
                 let _ = render::render_error(&failure, runtime.json);
                 ExitCode::FAILURE

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -288,7 +288,7 @@ mod tests {
             kind: CommandKind::ConfigShow,
             profile: Some("default".to_owned()),
             mode: Some("remote".to_owned()),
-            error: CliError::new("client_error", "connection refused"),
+            error: CliError::client_error("connection refused"),
         };
         assert_json_snapshot!(serde_json::from_str::<serde_json::Value>(
             &json_error(&failure).expect("json error renders")

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -2,7 +2,7 @@ use crate::backend::ResolvedTarget;
 use crate::config::{default_config_path, load_config, CliConfig};
 use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
-use loonfs_api::NamespaceId;
+use loonfs_api::{ErrorCode, NamespaceId};
 
 pub(crate) struct LoadedConfig {
     pub path: std::path::PathBuf,
@@ -58,7 +58,8 @@ pub(crate) fn resolve_namespace(
 }
 
 fn validate_namespace(namespace: &str) -> Result<ResolvedNamespace, CliError> {
-    NamespaceId::parse(namespace).map_err(|error| CliError::invalid_input(error.to_string()))?;
+    NamespaceId::parse(namespace)
+        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))?;
     Ok(ResolvedNamespace {
         namespace: namespace.to_owned(),
     })

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -616,7 +616,7 @@ fn embedded_namespace_commands_reject_invalid_namespace_ids() {
 
     let create = harness.run(&["--json", "namespace", "create", "bad/name"]);
     assert_failure(&create);
-    assert_eq!(json_error(&create)["code"], "invalid_input");
+    assert_eq!(json_error(&create)["code"], "invalid_request");
     assert!(json_error(&create)["message"]
         .as_str()
         .unwrap()
@@ -625,11 +625,11 @@ fn embedded_namespace_commands_reject_invalid_namespace_ids() {
     assert_success(&harness.run(&["namespace", "create", "demo"]));
     let fork = harness.run(&["--json", "namespace", "fork", "demo", "bad/name"]);
     assert_failure(&fork);
-    assert_eq!(json_error(&fork)["code"], "invalid_input");
+    assert_eq!(json_error(&fork)["code"], "invalid_request");
 
     let use_namespace = harness.run(&["--json", "use", "bad/name"]);
     assert_failure(&use_namespace);
-    assert_eq!(json_error(&use_namespace)["code"], "invalid_input");
+    assert_eq!(json_error(&use_namespace)["code"], "invalid_request");
 }
 
 #[test]
@@ -649,15 +649,15 @@ fn remote_namespace_commands_reject_invalid_namespace_ids_before_http() {
 
     let create = harness.run(&["--json", "namespace", "create", "bad/name"]);
     assert_failure(&create);
-    assert_eq!(json_error(&create)["code"], "invalid_input");
+    assert_eq!(json_error(&create)["code"], "invalid_request");
 
     let fork = harness.run(&["--json", "namespace", "fork", "demo", "bad/name"]);
     assert_failure(&fork);
-    assert_eq!(json_error(&fork)["code"], "invalid_input");
+    assert_eq!(json_error(&fork)["code"], "invalid_request");
 
     let use_namespace = harness.run(&["--json", "use", "bad/name"]);
     assert_failure(&use_namespace);
-    assert_eq!(json_error(&use_namespace)["code"], "invalid_input");
+    assert_eq!(json_error(&use_namespace)["code"], "invalid_request");
 }
 
 #[test]
@@ -726,6 +726,78 @@ fn external_remote_profile_executes_through_http() {
     let use_clone = harness.run(&["--json", "use", "clone"]);
     assert_success(&use_clone);
     assert_eq!(json_data(&use_clone)["namespace"], "clone");
+}
+
+/// Embedded and remote profiles must report the same `code` for the same
+/// failure: registry codes pass through verbatim in both modes instead of
+/// being rewritten to CLI-local codes on one side.
+#[test]
+fn embedded_and_remote_profiles_emit_the_same_error_codes() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "error-parity"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    for profile in ["embedded", "remote"] {
+        assert_success(&harness.run(&["namespace", "create", "--profile", profile, "demo"]));
+    }
+
+    // Creating a namespace that already exists.
+    let embedded = harness.run(&[
+        "--json",
+        "namespace",
+        "create",
+        "--profile",
+        "embedded",
+        "demo",
+    ]);
+    let remote = harness.run(&[
+        "--json",
+        "namespace",
+        "create",
+        "--profile",
+        "remote",
+        "demo",
+    ]);
+    assert_failure(&embedded);
+    assert_failure(&remote);
+    assert_eq!(json_error(&embedded)["code"], "namespace_exists");
+    assert_eq!(json_error(&embedded)["code"], json_error(&remote)["code"]);
+
+    // A malformed namespace id.
+    let embedded = harness.run(&[
+        "--json",
+        "namespace",
+        "create",
+        "--profile",
+        "embedded",
+        "bad/name",
+    ]);
+    let remote = harness.run(&[
+        "--json",
+        "namespace",
+        "create",
+        "--profile",
+        "remote",
+        "bad/name",
+    ]);
+    assert_failure(&embedded);
+    assert_failure(&remote);
+    assert_eq!(json_error(&embedded)["code"], "invalid_request");
+    assert_eq!(json_error(&embedded)["code"], json_error(&remote)["code"]);
 }
 
 #[test]

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -15,7 +15,7 @@ use loonfs_api::wire::control::{
     WriterBlock,
 };
 use loonfs_api::{
-    ChangeSeq, ContentStoreId, InodeId, InodeKind, NamePolicy, NamespaceId,
+    ChangeSeq, ContentStoreId, ErrorCode, InodeId, InodeKind, NamePolicy, NamespaceId,
     NamespaceIdValidationError, NamespaceSummary,
 };
 use loonfs_objectstore::keys::{
@@ -50,6 +50,32 @@ pub enum BootstrapNamespaceError {
     HeadWrite(String),
     #[error("failed to write initial namespace manifest: {0}")]
     ManifestWrite(String),
+}
+
+impl BootstrapNamespaceError {
+    /// Returns the stable machine-readable reason for this error.
+    ///
+    /// This is the single source of truth for the wire code every surface
+    /// (HTTP server, CLI) reports for a bootstrap failure, mirroring
+    /// [`CoreError::code`](crate::Error::code).
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            BootstrapNamespaceError::InvalidNamespaceId(_)
+            | BootstrapNamespaceError::EmptyHolderId
+            | BootstrapNamespaceError::EmptyWriterVersion => ErrorCode::InvalidRequest,
+            BootstrapNamespaceError::NamespaceAlreadyExists { .. } => ErrorCode::NamespaceExists,
+            BootstrapNamespaceError::NamespacePartiallyInitialized { .. } => {
+                ErrorCode::NamespacePartial
+            }
+            BootstrapNamespaceError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
+            BootstrapNamespaceError::Descriptor(_)
+            | BootstrapNamespaceError::DescriptorWrite(_)
+            | BootstrapNamespaceError::ContentStoreWrite(_)
+            | BootstrapNamespaceError::Head(_)
+            | BootstrapNamespaceError::HeadWrite(_)
+            | BootstrapNamespaceError::ManifestWrite(_) => ErrorCode::ServerError,
+        }
+    }
 }
 
 impl From<NamespaceInitializationError> for BootstrapNamespaceError {

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1685,35 +1685,8 @@ impl ApiResponseError {
     }
 
     fn bootstrap(error: BootstrapNamespaceError) -> Self {
-        match error {
-            BootstrapNamespaceError::InvalidNamespaceId(error) => Self::invalid_namespace_id(error),
-            BootstrapNamespaceError::NamespaceAlreadyExists { .. } => Self::new(
-                StatusCode::CONFLICT,
-                ErrorCode::NamespaceExists,
-                &error.to_string(),
-            ),
-            BootstrapNamespaceError::NamespacePartiallyInitialized { .. } => Self::new(
-                StatusCode::CONFLICT,
-                ErrorCode::NamespacePartial,
-                &error.to_string(),
-            ),
-            BootstrapNamespaceError::NamespaceDeleted { .. } => Self::new(
-                StatusCode::GONE,
-                ErrorCode::NamespaceDeleted,
-                &error.to_string(),
-            ),
-            BootstrapNamespaceError::EmptyHolderId
-            | BootstrapNamespaceError::EmptyWriterVersion => Self::new(
-                StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidRequest,
-                &error.to_string(),
-            ),
-            _ => Self::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                ErrorCode::ServerError,
-                &error.to_string(),
-            ),
-        }
+        let code = error.code();
+        Self::new(status_for_core_error_code(code), code, &error.to_string())
     }
 
     fn runtime(error: RuntimeError) -> Self {


### PR DESCRIPTION
The CLI re-implemented the server's error mapping with raw string literals (duplicating the bootstrap match down to identical message text), and embedded vs remote modes emitted different codes for the same mistake — `loon --json` reported `invalid_input` embedded but `invalid_commit_id` remote. BootstrapNamespaceError now classifies itself via code(), both the server and CLI mapping sites collapse to one generic status/code/message expression, the embedded-mode code rewrite is deleted so registry codes pass through identically in both modes (pinned by a new two-mode parity test against real binaries), and CliError documents its own CLI-local code namespace with constructor-owned literals only. The CLI's loonfs-core dev-dependency is gone.