### PR TITLE
refactor(core): standardize error sources, context, and naming

### DIFF
--- a/AUDIT_PR_PLANS.md
+++ b/AUDIT_PR_PLANS.md
@@ -1,0 +1,453 @@
+# LoonFS pre-release cleanup — PR execution plans
+
+Derived from the July 2026 consistency/structure audit of this branch (pre-`main`). Each section below is a self-contained plan for one PR, sized for a single implementing agent session, ordered so that earlier PRs never rebase onto later ones.
+
+> **Round 1 scope:** waves 1, 2, 4, 5, and 6, executed as a stacked branch series based on the current branch. Waves 3 (observability), 7 (tests), and 8 (CI/docs) are deferred to a later round — skip them entirely for now.
+>
+> **Progress ledger** (stack base: `conor/pr155-conflict-resolution`):
+> - PR-01 `conor/wire-field-names-and-tags` → [#179](https://github.com/loonfs/loonfs/pull/179) ✅ (scope grew per decision 2: also `child_inode`→`child_inode_id`, `new_parent_inode`→`new_parent_inode_id`, 3 straggler error fields; fingerprint pins re-pinned under v0)
+> - PR-02 `conor/format-key-table-sync` → [#180](https://github.com/loonfs/loonfs/pull/180) ✅ (7 drifted rows fixed, not 2; sync test covers all 18 families)
+> - PR-03 `conor/error-display-messages` → [#181](https://github.com/loonfs/loonfs/pull/181) ✅ (79 variants; `WriterEpoch` doesn't exist — audit ref was stale; FenceToken + InodeKind got Display too)
+> - PR-04 `conor/id-newtype-macro` → [#182](https://github.com/loonfs/loonfs/pull/182) ✅ (fixture sample id `up_`→`upl_` fixed rather than worked around)
+> - PR-05 `conor/client-listing-order` → [#183](https://github.com/loonfs/loonfs/pull/183) ✅
+> - PR-06 `conor/single-op-effect-encoding` → [#184](https://github.com/loonfs/loonfs/pull/184) ✅ (no pre-existing divergence; shared delta-applier, −180 prod lines)
+> - PR-07 `conor/one-error-taxonomy` → [#185](https://github.com/loonfs/loonfs/pull/185) ✅ (PreconditionFailed kind removed, Gone added; statuses bit-identical)
+> - PR-08 `conor/cli-error-registry` → [#186](https://github.com/loonfs/loonfs/pull/186) ✅ (embedded/remote code parity, pinned by two-binary test)
+> - PR-09 `conor/error-style-sweep` → [#187](https://github.com/loonfs/loonfs/pull/187) ✅ (note: ObjectStoreError reshape forced mechanical construction-site fixes in loonfs-sim/fault_store.rs — no sim public API change; flagged in PR body)
+> - PR-14 `conor/split-protocol-module` → [#188](https://github.com/loonfs/loonfs/pull/188) ✅ (5 submodules incl. candidates.rs; enter-across-await fixed; `acquired_writer` expects were already gone — stale audit ref)
+> - PR-15 `conor/unify-commit-validators` → [#189](https://github.com/loonfs/loonfs/pull/189) ✅ (CommitValidationView trait; 40→19 helpers; −551 prod lines; mutation_guards untouched; includes lockfile catch-up commit from PR-08's dep drop)
+> - PR-16 `conor/split-metadata-state` → [#190](https://github.com/loonfs/loonfs/pull/190) ✅ (rows/apply/queries/tests; 2 walk pairs collapsed, 9 left with reasons; wal tests → sibling file)
+> - PR-17 `conor/single-visibility-implementation` → [#191](https://github.com/loonfs/loonfs/pull/191) ✅ (**real drift found**: current_view's two visible_child copies lacked the bound-child-visible check — unified on the stricter rule; BindingIdentity + MetadataVisibilityReads trait; 859 duplicated lines deleted)
+> - PR-18 `conor/read-context-parameter` → [#192](https://github.com/loonfs/loonfs/pull/192) ✅ (A7 shadow methods were already gone — done by 92e715c0; shipped as the _with_X folding: single begin_upload/list_changes_after per layer + ListChangesOptions)
+> - PR-19 `conor/shared-provider-config` → [#193](https://github.com/loonfs/loonfs/pull/193) ✅ (StoreConfig + SecretString in objectstore; caught two live traps — presigner would have signed with `<redacted>`; 17-row flag table replaces 120 reject calls)
+> - PR-21 `conor/complete-facade-seam` → [#194](https://github.com/loonfs/loonfs/pull/194) ✅ (loonfs-core fully out of server deps — no dev-dep even needed; Fs::namespace_status returns wire type; one SharedObjectStore)
+> - PR-22 `conor/client-dead-code` → [#195](https://github.com/loonfs/loonfs/pull/195) ✅ (−180 lines + walkdir; param-typing note moved into PR-23's Backend remodel)
+> - PR-20 `conor/split-http-module` → [#196](https://github.com/loonfs/loonfs/pull/196) ✅ (7-file split; NamespaceIdPath extractor preserves 401-before-400; operationId `_handler` suffixes REMOVED from openapi — overrode the agent's byte-identical pinning since ids are pre-release-free and become SDK names)
+> - PR-23 `conor/admin-plane-parity` → [#197](https://github.com/loonfs/loonfs/pull/197) ✅ (Backend trait promoted to loonfs-client w/ BackendError; EmbeddedBackend stays CLI-side; `loon admin checkpoint|retention-advance` + `loon changes`; capability→command conformance table; round-2 note: advance_retention on missing namespace classifies `namespace_corrupt` in both modes — core LoadHead quirk)
+> - PR-24 `conor/publisher-into-runtime` → [#198](https://github.com/loonfs/loonfs/pull/198) ✅ (opt-in per amended decision 6; server −1789 lines; core publisher.rs→commit_engine.rs collision fix rode along)
+> - PR-25 `conor/naming-canon` → [#199](https://github.com/loonfs/loonfs/pull/199) ✅ (InodeKind::Directory w/ wire pin held; v0/ module consolidation; ls prints "dir"/"file" now — the one human-output change)
+>
+> **ROUND 1 COMPLETE** — 21 stacked PRs, [#179](https://github.com/loonfs/loonfs/pull/179) → [#199](https://github.com/loonfs/loonfs/pull/199), each green on fmt + clippy `-D warnings` + full `cargo test --all` (560 tests at stack tip). Merge order = PR number order (each PR's base is the previous branch). Round-2 queue: waves 3 (observability), 7 (tests), 8 (CI/docs/CONTRIBUTING+STYLE codification), plus noted quirks (advance_retention→namespace_corrupt classification; namespace-list design).
+> - Wave 0 cleanup ✅ (stale local configs deleted; gcs local kept chmod 600; key rotation with Conor)
+>
+> Stale-audit notes discovered during execution (for future reference): `WriterEpochAcquireError`/`writer_epoch.rs` no longer exist; `metadata/view.rs` became `path/read/{current_view,materialized_view}.rs`; `_base_seq` dead params already removed; `commit_validation_from_core` replaced by `#[from]`.
+
+## Context for the implementing agent
+
+- **There are no users and no deployments. Backwards compatibility is a non-goal.** Break wire formats, rename public APIs, delete dead code without deprecation cycles. Do it the clean way, not the compatible way.
+- **North star: the codebase should read as if one very thoughtful engineer wrote it.** When a plan says "canonicalize", pick the stated pattern and eliminate the others everywhere — half-migrations are worse than no migration.
+- **Prefer deletion over abstraction.** If a plan can be satisfied by removing code, that beats adding a layer.
+- Workspace lints (`Cargo.toml`) and `clippy.toml` disallowed methods (no ambient `SystemTime::now`/`Instant::now`/`sleep`/`rand`) apply to all new code. In tests, use function-scoped `#[allow(clippy::disallowed_methods)]` with a reason — never file-scoped.
+- CLI output goes through `crates/loonfs-cli/src/render.rs` (that's how the `print_stdout` lint is satisfied). Don't add bare `println!`.
+
+### Git conventions (mandatory)
+
+- Branch names: `conor/<kebab-description>` (project convention — every PR branch starts with `conor/`). Never include "claude", "ai", or any agent identifier in branch names, commits, or PRs.
+- Commit messages: single line, matching the repo convention `type(scope): lowercase summary` (verify with `git log --oneline -15`). No bodies, no bullet changelogs.
+- **Never add `Co-Authored-By: Claude`, "Generated with Claude Code", or any AI attribution anywhere.** Check `git log -1` before pushing; amend if tooling injected anything.
+- PR descriptions: 1–4 sentences of rationale-first prose (why the change exists). No section templates, no diff restatement.
+- Base every PR on `main` (after the current branch merges). If stacking is unavoidable, note the base in the PR description.
+
+### Definition of done (every PR)
+
+1. `cargo fmt --all --check`
+2. `cargo clippy --all-targets --all-features -- -D warnings`
+3. `cargo test --all` (build `loonfs-server` first; the CLI suite probes its binary)
+4. Spec-locked artifacts updated deliberately, never hand-edited to silence tests:
+   - OpenAPI: the failing `openapi_static_file_is_current` test prints the regen command — run it.
+   - Golden wire fixtures: `crates/loonfs-api/tests/golden/` — updating them **is expected** for wire-format PRs; say so in the PR description.
+   - `docs/specs/api.md` / `format.md` tables are test-enforced; change doc and code together.
+   - CLI snapshots: `cargo insta review`.
+5. If the PR changes a convention, sweep it to 100% — grep for stragglers before finishing.
+
+### Decisions baked into this plan (veto before executing)
+
+1. **All internally-tagged serde enums in wire/durable formats use `tag = "kind"`** — including today's `op`, `delta`, `type`, `row_kind`. Scope: wire + durable + CLI JSON output shapes. NOT in scope: human-authored config TOML (`mode = "embedded"` in CLI profiles stays — semantic keys are right for config), and `loonfs-sim` (frozen, decision 5).
+2. **Id-typed fields are suffixed `_id`** in every serialized format (`parent_inode_id`, not `parent_inode`).
+3. **HTTP statuses do not change.** `ErrorKind` is reconciled *to* the currently-served statuses, then becomes the single source statuses derive from.
+4. **`parse()` is the canonical fallible constructor** for validating string types; `try_new` is deleted.
+5. **`loonfs-sim` is frozen — do not modify, adopt, or delete it.** The simulator lives in another repo and consumes these hooks; treat the crate (including its `inspection` feature and its dependency list) as an external contract.
+6. **The batching publisher moves from `loonfs-server` into the `loonfs` runtime crate** (PR-24). The one big architectural move; skipping it does not block anything else. **Execution amendment:** it lands as an *opt-in* concurrent-write front-end, NOT wired into embedded `Fs` default paths — the measured pacing constants (100ms coalescing delay, 1s per-namespace CAS interval) would regress every solo embedded/CLI write if always-on. Server behavior unchanged; embedded many-writer hosts construct the registry explicitly.
+7. **`loon namespace list` is deferred — do not implement it.** It needs design thought (it rides on list calls). Leave the doc/spec references alone for now; they get reconciled in the docs wave of a later round.
+8. Wire types keep **tolerant decoding** (no `deny_unknown_fields`); config-file structs get `deny_unknown_fields`.
+9. Rust-side names spell out `Directory`; frozen wire values (e.g. `"dir"`) are untouched.
+
+---
+
+## Wave 0 — operator action (not a PR)
+
+Key rotation for the Cloudflare R2 credential in `configs/loond.cloudflare-r2.host-a.local.toml` is handled by the lead directly. Workspace cleanup (delete the stale untracked local configs — `loond.*`, `loon.host-a/host-c.*` old-schema files, the `loonfs-server.azure-abs.local.toml` example twin — and `chmod 600` remaining `*.local.toml`) is done. Git history was already clean.
+
+---
+
+## Wave 1 — wire-format freeze and verified bugs
+
+These change durable/wire shapes or observable behavior. Land before everything else; every later PR rebases cleanly on top.
+
+### PR-01 · `conor/wire-field-names-and-tags`
+**Title:** `refactor(api): unify wire field names and enum tag discriminators`
+**Effort:** M · **Depends on:** —
+**Why:** The same concept serializes as `parent_inode` in the WAL format but `parent_inode_id` in the manifest format, and internally-tagged enums use five different discriminators (`kind`, `op`, `type`, `delta`, `row_kind`). These freeze at first release.
+**Do:**
+- Rename `parent_inode` → `parent_inode_id`, `root_inode` → `root_inode_id`, `child_inode` → `child_inode_id`, `new_parent_inode` → `new_parent_inode_id` (decision 2 covers all id-typed fields) in `crates/loonfs-api/src/wal.rs` and `crates/loonfs-api/src/v0.rs`, rippled through core/model/tests.
+- Change every wire-format `#[serde(tag = ...)]` to `tag = "kind"`: loonfs-api `wal.rs`/`v0.rs`/`http.rs`/`manifest.rs`, plus core `commit/{operation,materialize,precondition}.rs`, `path/write/planner.rs`, and cli `commands/output.rs`. (loonfs-sim and CLI config-TOML tags stay per decision 1 scope.)
+- Update golden fixtures, regen OpenAPI, update `docs/specs/format.md`/`api.md` examples.
+- Add one line to `format.md` stating the policy: snake_case values, `kind` discriminator, tolerant decoding (unknown fields ignored).
+**Done when:** grep for `tag = "` in loonfs-api shows only `"kind"`; grep for `parent_inode:` / `root_inode:` (without `_id`) is empty workspace-wide; golden + openapi tests green.
+
+### PR-02 · `conor/format-key-table-sync`
+**Title:** `docs(specs): fix format.md key table and pin it with a sync test`
+**Effort:** S · **Depends on:** —
+**Why:** The normative key table says `{manifest_id}.manifest` and `{table_id}.sst`; the code writes `.manifest.json` (zero-padded id) and `.sst.zst` (`crates/loonfs-objectstore/src/layout.rs:183,190`). The test named `key_builders_match_spec_examples` (`keys.rs:108`) asserts the code's values, not the spec's.
+**Do:**
+- Correct the `format.md` table rows (manifest, metadata SST; note `{manifest_id:020}` padding).
+- Add a sync test that parses the `format.md` key-pattern table and asserts each pattern against `ObjectLayout` builders — same mechanism as `error_status_mapping_matches_the_api_spec_table` (`crates/loonfs-server/src/http.rs:~1700`).
+- Fix the stale `seg_…` WAL-id example in `keys.rs:119` to match the real `{start_seq:020}-{suffix}` grammar.
+**Done when:** the new test fails if either the doc table or the layout code changes unilaterally.
+
+### PR-03 · `conor/error-display-messages`
+**Title:** `refactor(core): give commit pipeline errors real display messages`
+**Effort:** S–M · **Depends on:** —
+**Why:** Five core error enums have no `Display`, so `CoreError` Debug-formats them (`{0:?}`, `crates/loonfs-core/src/error.rs:44-51`) and clients receive raw Rust syntax like `CreateChildNameCollision { parent_inode: InodeId(2), ... }` in HTTP bodies.
+**Do:**
+- Derive `thiserror::Error` with `#[error(...)]` messages on `CommitValidationError` (`commit/validate_error.rs`), `CommitHeadPublishError` (`commit/publish_error.rs`), `WalBuildError` + `WalReplayError` (`wal/frame.rs:19,192`), `MetadataApplyError` (`metadata/mod.rs:174`). serde derives coexist fine (`ManifestLoadError` is the in-repo precedent).
+- Switch the `CoreError` wrappers from `{0:?}` to prefixed `{0}`; same for `WalChainLoadError::Replay` (`frame.rs:175`).
+- Add `Display` to numeric newtypes `RevisionNo`, `ChangeSeq`, `WriterEpoch` (`crates/loonfs-api/src/ids.rs:682,690`) and convert message interpolations from `{field:?}` to `{field}` (e.g. `error.rs:64,139`, `frame.rs:148,173`, `checkpoint/error.rs:31`).
+- Message style: lowercase, backticked identifiers, no trailing period — match the existing majority.
+**Done when:** no `{0:?}`/`{field:?}` remains in any `#[error(...)]` string for types that now have Display; an http_smoke assertion shows a human-readable name-collision message.
+
+### PR-04 · `conor/id-newtype-macro`
+**Title:** `refactor(api): macro-generate id newtypes and retire raw string ids`
+**Effort:** M–L · **Depends on:** PR-01 (rebase order only)
+**Why:** `ids.rs` hand-rolls ~750 lines of near-identical impls with real drift (`NameKey` missing `TryFrom`/`Ord`; only `ManifestId` has `From<u64>`), while upload/WAL-segment/table/pin ids are bare `String`s with free `generate_*`/`validate_*` functions — a second, weaker id system.
+**Do:**
+- Write `string_id!` / `numeric_id!` macros (precedent: `typed_key!` in `crates/loonfs-objectstore/src/layout.rs:30-51`) generating the full uniform suite: `parse`, `as_str`, `TryFrom<&str>`, `TryFrom<String>`, `AsRef`, `Borrow<str>`, `Display`, `FromStr`, serde, `Ord`, `Hash`.
+- Regenerate `NamespaceId`, `ContentStoreId`, `CommitId`, `CheckpointId`, `NameKey` through it; fix the drift (NameKey gets the missing impls and derives; `InodeKind` gains `Copy` + `Hash`).
+- Newtype the stragglers: `UploadId`, `WalSegmentId`, `MetadataTableId`, `GcPinId`. Delete the free `generate_upload_id`/`validate_upload_id`/`generate_wal_segment_id`/`generate_checkpoint_id` functions (`ids.rs:165-194`) — generation becomes inherent `::generate()`. Wire representation stays a plain string; this is API-only.
+- Canonicalize constructors: keep `parse()`, **delete `try_new()`** everywhere (`ids.rs:112/119` pattern ×5).
+- Use `NameKey` (not `String`) in manifest rows (`manifest.rs:132`) and the model.
+- Give `AbsolutePath`/`DisplayName`/`PathComponent` (`crates/loonfs-api/src/path.rs`) the same trait suite.
+- Ripple signatures through core/server/cli (e.g. `CoreError::UploadNotFound { upload_id: UploadId }`).
+**Done when:** `ids.rs` has zero hand-written per-type serde/Borrow/TryFrom impls; grep for `try_new` is empty; golden fixtures byte-identical (string representations unchanged) — if fixtures change, something is wrong.
+
+### PR-05 · `conor/client-listing-order`
+**Title:** `fix(client): preserve canonical server listing order`
+**Effort:** S · **Depends on:** —
+**Why:** The server pages directory entries in canonical casefolded name-key order; the client re-sorts aggregated pages by raw `display_name` (`crates/loonfs-client/src/lib.rs:244-248`), so `loon ls` can print different orders for embedded vs remote profiles.
+**Do:**
+- Delete the client re-sort; concatenated pages are already canonical.
+- State the canonical presentation order in `docs/specs/api.md` (one sentence next to the list endpoint).
+- Add a test with names that order differently by display-name vs name-key (e.g. `B.txt` vs `a.txt`) asserting client output matches server page order.
+**Done when:** embedded and remote listings agree in the test.
+
+### PR-06 · `conor/single-op-effect-encoding`
+**Title:** `refactor(core): derive commit overlay rows from wal materialization`
+**Effort:** S–M · **Depends on:** —
+**Why:** `ValidatedOp` effects are encoded twice — `apply_validated_op_mut` (`crates/loonfs-core/src/commit/metadata_overlay.rs:27`) maps ops→rows directly while `materialize_validated_op` (`commit/materialize.rs:76`) maps ops→WAL deltas which `apply_committed_wal_delta_mut` (`metadata/mod.rs:350`) maps to rows. Nothing forces the two paths to agree; divergence = validation preview disagreeing with durable replay, a correctness bug.
+**Do:**
+- Reimplement the overlay application as composition: `materialize_validated_op(op)` then delta-application onto the overlay rows. Delete the hand-maintained direct mapping.
+- Keep a regression test asserting overlay rows == materialize-then-apply rows for every `CommitOp` variant (this test is the point of the PR — write it first against the old code).
+**Done when:** exactly one op→rows path exists; the per-variant equivalence test passes.
+
+---
+
+## Wave 2 — error architecture
+
+### PR-07 · `conor/one-error-taxonomy`
+**Title:** `refactor(api): derive http status from a single error taxonomy`
+**Effort:** M · **Depends on:** PR-03
+**Why:** The code→category grouping is maintained three times (`ErrorCode::kind()` at `crates/loonfs-api/src/error.rs:129-169`, the 38-arm status match at `crates/loonfs-server/src/http.rs:1636-1682`, and the api.md table). `ErrorKind` has zero production consumers and has already drifted (`StaleRevision` → `PreconditionFailed` kind, but served 409).
+**Do:**
+- Reconcile kinds to currently-served statuses (statuses are the tested, spec-locked truth): `StaleRevision` joins the Conflict kind; `CommitOutcomeUnknown`'s kind maps to 503; audit all 38.
+- Replace the per-code server match with one small `kind → StatusCode` function; keep the spec-table test — it now transitively pins `kind()`.
+- Give `ClientError` typed access: `error_code() -> Option<ErrorCode>` and `kind()` (unknown codes fall back by HTTP status class), making the client the reference consumer of the registry's retry semantics. `ApiError::error_code()` (`crates/loonfs-api/src/http.rs:28-31`) finally gets a caller.
+- Apply the `#[non_exhaustive]` rule: present on cross-crate public error enums (api, `CoreError`, `RuntimeError`, `ClientError`, `ObjectStoreError`), removed from internal per-op enums.
+- Replace the hand-maintained `ErrorCode::ALL` triple-entry ritual (`error.rs:88-127`) with a macro that emits variant + string + list together.
+**Done when:** one grouping exists; the spec test still passes with zero api.md status changes; `ErrorCode::ALL` cannot drift from the variants.
+
+### PR-08 · `conor/cli-error-registry`
+**Title:** `refactor(cli): map errors through the shared error-code registry`
+**Effort:** S–M · **Depends on:** PR-07
+**Why:** The CLI re-derives the server's error mappings with raw string literals (`crates/loonfs-cli/src/backend.rs:503-544` vs `crates/loonfs-server/src/http.rs:1554-1615`, including a byte-identical 404 message), and embedded vs remote modes emit *different codes for the same error* (`invalid_input` vs `invalid_commit_id`).
+**Do:**
+- Add `code() -> ErrorCode` to `BootstrapNamespaceError` (and any core error the CLI matches on), mirroring `CoreError::code()`.
+- Collapse both mapping sites to generic code+message conversion; CLI uses `ErrorCode::as_str()`, never string literals for registry codes.
+- Remove the embedded-mode rewrite at `backend.rs:503-509` so both modes surface identical codes; add a parity test.
+- Keep CLI-only codes (`profile_not_found`, `invalid_config`, …) as a documented, distinct set in `crates/loonfs-cli/src/error.rs`; use the existing `CliError::io()` helper at `backend.rs:210`.
+- Drop the now-unneeded `loonfs-core` dev-dependency from loonfs-cli (only consumer is one mapping test, `backend.rs:677`).
+**Done when:** `loon --json` emits the same `code` for the same failure in embedded and remote modes (tested); no registry code appears as a string literal in loonfs-cli.
+
+### PR-09 · `conor/error-style-sweep`
+**Title:** `refactor(core): standardize error sources, context, and naming`
+**Effort:** M · **Depends on:** PR-03, PR-07
+**Why:** Remaining error-shape drift: `#[from]` vs manual `From` vs transparent-without-from in three combinations; store/codec wrappers inconsistently carry `object_key`; variant names diverge from the frozen wire codes; two `Result` alias schemes.
+**Do:**
+- `#[from]` wherever an inner type maps to exactly one variant (e.g. `CoreError::InvalidUploadId` at `error.rs:60`, the manual `From`s at `error.rs:217-239` — most fall out of PR-03; `WalChainLoadError` manual From at `frame.rs:179`); one-line comment where transparent-without-from is deliberate (shared inner types, e.g. `bootstrap.rs:39-46`).
+- Every store/codec wrapper variant carries `object_key` (`ControlObjectLoadError::Store` at `control.rs:137`, `ObjectStoreError::NotFound`/`Transport` at `object_store.rs:59-74`, `CoreError::Store`/`WalWrite`). Ban bare `#[error("{0}")]` on String payloads (`error.rs:83`, `content.rs:85`) — always a prefix.
+- Rename variants to mirror wire codes: `MissingPath`→`PathNotFound`, `MissingRevision`→`RevisionNotFound`, etc.
+- Document the rule that core errors are `Clone + Serialize` so foreign causes become prefixed message strings; in unconstrained crates (client, server config) use `#[source]`.
+- Result alias canon: the facade pattern (`pub type Result<T>` + used everywhere) — adopt in core (124 signatures currently spell it out) or delete core's unused alias; pick `pub use X as Error` OR `pub type Error = X`, once.
+- Honest errors in upper layers: replace the fabricated `CoreError::Store("publisher task stopped")` (`crates/loonfs-server/src/publisher.rs:192`) and the handler-minted `CoreError::InvalidUploadContent` (`http.rs:979-984`) with proper publisher/`ApiResponseError` variants.
+- Messages on every `unreachable!` (`profile_config.rs:128,331`); give `serve()` a real `ServeError` instead of `Result<(), String>` (`http.rs:260`).
+- Dedupe near-identical variants where cheap (`MissingEtag`/`MissingHeadEtag` ×3); rename the private `ManifestLoadErrorKind` to avoid colliding with api's `ErrorKind` concept.
+**Done when:** grep finds no `#[error("{0}")]` with String payload, no manual `From` impls thiserror could derive, no `MissingX` variants; clippy green.
+
+---
+
+## Wave 3 — observability (DEFERRED — skip in round 1)
+
+### PR-10 · `conor/telemetry-foundation`
+**Title:** `feat(server): default-on tracing with startup and shutdown logging`
+**Effort:** M · **Depends on:** —
+**Why:** The subscriber is opt-in via undocumented `LOONFS_TRACE=json` (`crates/loonfs-server/src/trace.rs:26-31`), so a default production server emits nothing — no "listening on", no request record, no error on a 500 — and the CLI/client can't emit at all.
+**Do:**
+- Server: compact stderr subscriber at `info` by default; `LOONFS_TRACE=json|pretty|compact` selects format (json currently the only mode, `trace.rs:52`); `RUST_LOG` overrides. Add `loonfs_objectstore` to the default filter (`trace.rs:9`).
+- Startup `info!` (bind addr, store kind, writer id, version — the redacted config Debug exists for this) and shutdown `info!`; add SIGINT/SIGTERM graceful shutdown via `axum::serve(...).with_graceful_shutdown` (tokio `signal` feature already enabled).
+- CLI: `-v/-vv` global flags → stderr subscriber at info/debug (stdout stays machine-stable). `tracing-subscriber` is already a workspace dep.
+- Document `LOONFS_TRACE` and `LOONFS_OBJECT_STORE_METRICS_JSONL` in the server example configs.
+- Write the span/field taxonomy doc (span names, `phase` values, `key_class` values, standard fields: `namespace_id`, `seq`, `operation`, `store_kind`, `object_key`, `elapsed_ms`, `error`) as `docs/observability.md`; dedupe the two reused `phase` labels (`project_metadata_state`, `project_manifest`) and rename core's `publisher.*` spans to `commit.*` (`protocol.rs:857+`) so "publisher" means only the server/runtime component.
+**Done when:** `loonfs-server --config …` with no env vars prints a startup line and per-request output; `loon -v ls /` shows spans; Ctrl-C shuts down cleanly.
+
+### PR-11 · `conor/durability-failure-events`
+**Title:** `feat(core): emit errors and identifiers on durability failure paths`
+**Effort:** M · **Depends on:** PR-10; land after PR-14 if both are pending (same file regions)
+**Why:** The workspace contains zero `error!`/`warn!` macros. WAL-write and head-CAS failures record `result="error"` on a span and discard the error, key, and namespace (`crates/loonfs-core/src/protocol.rs:1011-1021`); a publisher panic fails all in-flight waiters silently (`PublishAbortGuard`, `crates/loonfs-server/src/publisher.rs:700-732`).
+**Do:**
+- `error!(namespace_id, object_key, %error)` at the origin of WAL-write, head-CAS, checkpoint-publish, and lease failures; `warn!` on CAS retries/stale-head races and publisher delete failures (`publisher.rs:540-547`); `error!` in the abort guard (namespace, orphaned-waiter count).
+- Add `namespace_id` (and `seq`/`commit_id` where in scope) as span/event fields on every per-namespace operation — publisher events have it in scope and omit it (`publisher.rs:361-370`); keep ids out of metric label sets (cardinality stance is correct for metrics only).
+- Fix the two `enter()`-held-across-`.await` sites (`protocol.rs:999-1001`, `1058-1061`) → `.instrument()` (correct pattern 20 lines earlier at `:972`).
+- Demote the per-candidate `info!` firehose (`publisher.rs:444-453`, `624-633`) to `debug!`; keep one per-batch `info!` summary.
+**Done when:** killing the store mid-commit in a test produces an `error!` with namespace + key; steady-state writes emit ≤1 info line per batch.
+
+### PR-12 · `conor/request-and-store-visibility`
+**Title:** `feat(server): request middleware, auth layer, and object-store telemetry`
+**Effort:** M · **Depends on:** PR-10
+**Why:** No HTTP request lifecycle exists — the router has no layers (`http.rs:126-196`), `ApiResponseError::into_response` logs nothing (`http.rs:1684-1688`), and only PUT-class ops get a span. Separately, the bearer check is non-constant-time string equality repeated in all 21 handlers (`http.rs:1430`), and the object-store layer is fully dark (providers have zero tracing; the metrics recorder only writes JSONL to an opt-in file and skips `list_prefix_stream`, `metrics.rs:313-318`).
+**Do:**
+- Request-span middleware: method, route template, namespace, status, `elapsed_ms`; `error!` on 5xx / `warn!` on 4xx at `ApiResponseError` construction.
+- Auth middleware on the router with an explicit `/health` allowlist, constant-time comparison (`subtle`), no per-request `format!` allocation; delete the 21 `authorize(...)` call sites.
+- Default tracing-backed `ObjectStoreMetricsRecorder` (debug-level per-op event; `warn!` on transport errors); instrument `list_prefix_stream`; keep the JSONL recorder as an option.
+**Done when:** a forced 500 in a test leaves a server-side error event with route + namespace + status; a route added without auth is caught by a test asserting the middleware covers everything except the allowlist.
+
+### PR-13 · `conor/instrument-recovery-paths`
+**Title:** `feat(core): instrument recovery, retention, and remaining facade operations`
+**Effort:** M · **Depends on:** PR-10
+**Why:** The code that runs when something already went wrong — WAL replay, writer-epoch acquire, bootstrap, fork, delete, retention — has zero instrumentation (`wal/replay.rs`, `namespace/*.rs`, `checkpoint/retention.rs`), and the facade instruments only 5 of ~44 public ops (`loon.stat` exists; `loon.get`/`loon.list`/`loon.delete` do not).
+**Do:**
+- Outcome `info!` events + `loon.phase` spans: replay (segments/records/final seq), writer-epoch acquire (epoch, contended?), namespace create/fork/delete, retention advance (floor before/after, objects deleted — it's irreversible; it must leave a record).
+- Extend the existing `loon.<op>` root-span template (copy `stat_path`/`put_file_bytes`, `crates/loonfs/src/fs.rs:402,675`) to all public facade ops.
+- Delete the orphaned `#[instrument]` on the `#[cfg(test)]`-only loader (`checkpoint/load.rs:217-225`).
+**Done when:** every public `Fs` method carries a `loon.*` span (add the forcing-function test suggested by the existing spec-table pattern); recovery paths emit outcome events in the fault tests.
+
+---
+
+## Wave 4 — core deduplication and structure
+
+Order within this wave matters: 14 → 15 → 16 → 17 (moves before rewrites; validators before visibility).
+
+### PR-14 · `conor/split-protocol-module`
+**Title:** `refactor(core): split protocol.rs into focused modules`
+**Effort:** M · **Depends on:** —
+**Why:** `crates/loonfs-core/src/protocol.rs` (1,572 non-test lines) is five modules in a trenchcoat: upload sessions (:197-488), publish-view loading (:609-822), the 273-line batch publisher (:824-1096), candidate prep/idempotency (:1099-1282), change feed (:1284+), WAL→API delta conversion (:1376+).
+**Do:**
+- Pure moves into `protocol/{uploads,publish_view,batch,changes}.rs`; `protocol/mod.rs` = doc + re-exports (house style: `checkpoint/mod.rs`).
+- Extract `abort_batch(...)` — the identical 3-line failure exit is repeated verbatim at :1026, :1044, :1074.
+- `prepare_candidate_request` returns `Result<Option<CandidateCoreRequest>>` instead of writing through three `&mut` out-params; batch dedup state becomes a small struct.
+- Publish-view carries a non-optional `AcquiredWriter` (kills the ×4 repeated `.expect("publish view should carry acquired writer")`).
+- Delete the pure rename-shim `publish_namespace_mutations_batch` (:555) — one function, one name.
+- Wrap the inline `let _span = ….entered(); match …` phase blocks (:912-960) in `#[instrument]`ed helper fns (sets up PR-11).
+**Done when:** no file in `protocol/` exceeds ~500 lines; no function exceeds ~120; behavior-neutral (existing tests unchanged and green).
+
+### PR-15 · `conor/unify-commit-validators`
+**Title:** `refactor(core): collapse duplicate commit validators`
+**Effort:** M · **Depends on:** PR-14 (rebase only)
+**Why:** `validate_metadata_preconditions` (310 lines, `commit/validate.rs:290`) and `validate_publish_metadata_preconditions` (277 lines, `:601`) are the same function twice — only view construction and error plumbing differ — as are the two `build_commit_plan` variants (`:94`, `:165`). Twelve helpers differ only in which error variant they return; 19 helpers take an ignored `_base_seq`.
+**Do:**
+- Keep only the generic `MetadataView`-based validator; the in-memory path constructs an `InMemoryMetadataView` and converts errors once at the boundary via the existing `commit_validation_from_core`. Same collapse for the plan builders.
+- One parameterized helper per check shape taking an error-constructor closure (tombstone-coverage ×6, inode-kind ×2, name-absent ×2).
+- Delete the 19 `_base_seq` params and their call-site threading.
+- Fold the facade's lone pre-flight duplicate (`validate_runtime_mutation_path`, `crates/loonfs/src/fs.rs:1205`) into a named core helper the facade calls, with a comment explaining it avoids orphaned content writes.
+**Done when:** `validate.rs` is ~700 lines with one validator; a rule change (add a precondition in one place) demonstrably flows to both entry paths via the existing mutation-guard tests.
+
+### PR-16 · `conor/split-metadata-state`
+**Title:** `refactor(core): split metadata state into rows, apply, and queries`
+**Effort:** M · **Depends on:** PR-15 (rebase only)
+**Why:** `metadata/mod.rs` is a 1,951-line implementation file in a codebase whose house style is curated re-export mod.rs (`checkpoint/mod.rs`); its seq-gated query API repeats the `if base_seq >= indexed_seq { at_head } else { scan }` guard ~12 times with two fully-duplicated 20-line ancestor walks.
+**Do:**
+- Move `MetadataState` into `metadata/state.rs` split as `rows.rs` (records + accounting), `apply.rs` (WAL application), `queries.rs` (seq-gated reads); `mod.rs` = doc + re-exports. Move the 706 inline test lines to `metadata/tests.rs`; same for `wal/mod.rs`'s 450-line inline test mod.
+- Collapse each at-seq/at-head duplicated traversal pair by parameterizing on a lookup closure (`covering_subtree_tombstone` at `:670` vs `:699` is the worst).
+**Done when:** `metadata/mod.rs` < 60 lines; no duplicated traversal bodies; pure refactor, tests unchanged.
+
+### PR-17 · `conor/single-visibility-implementation`
+**Title:** `refactor(core): single implementation of visibility semantics`
+**Effort:** L · **Depends on:** PR-15, PR-16
+**Why:** The most safety-critical rule in the system — "is this direntry visible" — exists four times with copies identical down to variable names (`metadata/state` sync version, `view.rs:314`, `view.rs:902` cached session, `path/write/planner.rs:273`), and `resolve_visible_path` three times. A maintainer fixing a visibility bug cannot know they found all copies.
+**Do:**
+- One binding-identity helper on the record type (`DirentryBindRecord::is_same_binding(&other)`) used by every check including the planner.
+- Make `MetadataViewSession` the single composite-visibility implementation; uncached callers construct a session (caching is harmless). The sync `MetadataState` versions may remain for at-head index primitives only — composite rules (visible_child, resolve_visible_path) live once.
+- The model's copy (`loonfs-model/src/metadata.rs:404`) is an *intentional* independent implementation — add a doc comment saying so, so nobody "deduplicates" the oracle.
+**Done when:** grep for the 5-condition binding comparison finds one implementation + the documented model mirror; full mutation-guard + differential suites green.
+
+### PR-18 · `conor/read-context-parameter`
+**Title:** `refactor(core): thread read context as a parameter`
+**Effort:** M · **Depends on:** —
+**Why:** Every one of `NamespaceEngine`'s 10 read ops exists three times (`X`, `#[doc(hidden)] X_with_runtime_context`, private `X_with_context` — `engine.rs:186-517`, ~30 bodies) purely to thread the facade's caches; the "public" API and the API actually used are parallel surfaces. The facade doubles methods the same way (`begin_upload_with_request`, `list_changes_after_with_limit`).
+**Do:**
+- One method set taking `ReadContext` (with `ReadContext::latest()` for the plain case), or engine-owned optional cache handles at construction — pick whichever deletes more code; kill the `#[doc(hidden)]` shadow family and the hidden re-exports (`lib.rs:82-83`).
+- Facade canon is options structs: fold `limit` into `ListChangesOptions`, the request into `begin_upload(options)`.
+**Done when:** `engine.rs` has one public read surface; no `#[doc(hidden)]` items remain in loonfs-core's API.
+
+---
+
+## Wave 5 — cross-crate structure
+
+### PR-19 · `conor/shared-provider-config`
+**Title:** `refactor(objectstore): shared provider config with redacted secrets`
+**Effort:** M–L · **Depends on:** —
+**Why:** Server and CLI each define the same 5-variant `StoreConfig` enum + ~70-line `object_store()` constructor + verbatim `trace_store_kind()` (server `config.rs:42-77,221-303`; cli `config.rs:53-97,239-305`), already drifted on redaction. Adding a provider touches ≥6 sites in 4 crates. Secret handling has three Debug policies and echoing prompts.
+**Do:**
+- One serde-ready `StoreConfig` in `loonfs-objectstore` next to `ConfiguredObjectStore`: kind-tagged, kebab-case, one fallible constructor, one validation walk; both binaries consume it. Derive the trace label from `ConfiguredObjectStoreKind` (delete `TraceStoreKind` duplication).
+- `Secret<String>` newtype (Debug/Display print `<redacted>`; `expose()` for use) for every secret field — provider configs, `content_token_secret`, `auth_token`. Every config type derives Debug (ServerConfig currently can't be logged at all); keep the existing redaction test, now generic.
+- Masked input (`prompt_secret_keep_current`, already exists at `crates/loonfs-cli/src/prompt.rs:19`) for **all** secret prompts — AWS/R2 currently echo and even display the current secret as the default (`profile_config.rs:646-673`); Azure alone is masked.
+- `#[serde(deny_unknown_fields)]` on config-file structs (test the tagged-enum interaction); add a commented `[runtime_cache]` block to one server example (8 override fields are documented nowhere).
+- Env fallbacks for server secrets: `LOONFS_AUTH_TOKEN`, `LOONFS_CONTENT_TOKEN_SECRET`; steer `examples/SKILL.md` away from secrets-as-flags.
+- Data-drive the CLI provider-flag rejection matrix — `build_embedded_profile` (:132) and `apply_update_flags` (:413) hand-write 64 `reject_*` calls; replace with one `[(flag, accessor, allowed_kinds)]` table used by both.
+**Done when:** adding a hypothetical provider touches loonfs-objectstore + one CLI table row + one server match arm; `{:?}` on any config type shows no secret (test); all secret prompts are masked.
+
+### PR-20 · `conor/split-http-module`
+**Title:** `refactor(server): split http.rs by resource and drop handler suffixes`
+**Effort:** M · **Depends on:** — (PR-12 is deferred with wave 3: keep the per-handler `authorize(...)` calls as-is; the namespace-parse extractor still applies)
+**Why:** One 2,390-line file holds the whole HTTP surface (30% inline tests); half the handlers are named `create_namespace`, half `delete_namespace_handler` — same file, same router.
+**Do:**
+- Mechanical split: `http/{handlers_namespace,handlers_filesystem,handlers_uploads,error,openapi}.rs`, tests to `http/tests.rs`; router table stays in one place.
+- Drop the `_handler` suffix everywhere (~10 fns); an axum extractor for `parse_namespace_id` removes the 18 repeated parse+map lines (auth stays as per-handler `authorize(...)` calls until wave 3 lands).
+**Done when:** no `_handler` names; no http file > ~600 lines; route table diff-clean.
+
+### PR-21 · `conor/complete-facade-seam`
+**Title:** `refactor(runtime): complete the facade seam so the server stops importing core`
+**Effort:** S–M · **Depends on:** —
+**Why:** `loonfs::publish` exists as a deliberate server-integration seam (`crates/loonfs/src/lib.rs:43-46`) but is incomplete, so loonfs-server also depends on loonfs-core directly (`publisher.rs:5-6`, `http.rs:30-32` for commit identity + content tokens) — core-internal renames break the server even when the facade is stable. Small response types are also copied field-by-field in two places.
+**Do:**
+- Widen the seam: re-export (or move) `SemanticMutationIdentity`, `CommitHeadPublishError`, and the content-token mint/verify surface through `loonfs`; drop `loonfs-core` from `loonfs-server/Cargo.toml`.
+- `Fs::namespace_status` returns `loonfs_api::NamespaceStatusResponse` directly — delete the six-field copies in `http.rs:505-512` and `backend.rs:277-284` and the redundant intermediate struct; apply the same test to `MaintenanceTickResult`.
+- Unify on one `SharedObjectStore` alias (drop the redundant `+ Send + Sync` spelling in `loonfs/src/lib.rs:68`).
+- CI guard: a check that `loonfs-server` does not depend on `loonfs-core` (cargo-deny bans or a small script).
+**Done when:** `cargo tree -p loonfs-server` shows loonfs-core only via loonfs; the CI guard fails if the dep returns.
+
+### PR-22 · `conor/client-dead-code`
+**Title:** `refactor(client): remove dead transfer helpers and take typed ids`
+**Effort:** S · **Depends on:** —
+**Why:** `Client::get_to_path`/`put_from_path`/`get_directory` (+`GetPathResult`/`PutPathResult`, ~150 lines, `lib.rs:803-908`) have zero callers — the CLI implements those flows itself — and the `walkdir` dependency exists solely for them. Client methods also take raw `&str` where the facade takes typed ids.
+**Do:** Delete the helpers and the walkdir dep; switch client method params to `&NamespaceId`/typed ids to match `Fs`.
+**Done when:** no unused public API in loonfs-client; `cargo udeps`-style check (or manual) shows no orphan deps.
+
+### PR-23 · `conor/surface-parity`
+**Title:** `feat(cli): admin plane parity across surfaces`
+**Effort:** L · **Depends on:** PR-22
+**Why:** The server exposes `/v0/admin/…` and `/changes`, but loonfs-client has zero checkpoint/retention/changes methods and the CLI no admin commands — advertised profiles are unreachable from two of three surfaces. The embedded-vs-remote `Backend` trait that solves this is trapped `pub(crate)` in the CLI (`backend.rs:20-70`).
+**Note:** `loon namespace list` is explicitly OUT of scope (decision 7) — do not add a listing route, command, or capability key.
+**Do:**
+- Promote `Backend` (trimmed) out of the CLI — into loonfs-client as the "one logical API, two transports" seam.
+- Client methods for checkpoint/retention/changes/status; CLI `loon admin checkpoint|retention` and `loon changes` wired through `Backend` so embedded and remote both work.
+- Follow the CLI's existing render/exit-code conventions; `--json` support like every other command.
+**Done when:** every feature key advertised in the capability document except namespace listing is exercisable from CLI in both modes (add a conformance test iterating the registry, with the deferred listing feature explicitly excluded).
+
+### PR-24 · `conor/publisher-into-runtime`
+**Title:** `refactor(runtime): move the batching publisher into the runtime crate`
+**Effort:** L · **Depends on:** PR-21; do last in this wave. **Decision-gated — confirm before starting.**
+**Why:** `NamespacePublisher`/`PublisherRegistry` (coalescing, commit-id idempotency dedup, delete-as-barrier, CAS pacing — `crates/loonfs-server/src/publisher.rs`, 810 code lines) is generic multi-writer machinery with no HTTP dependency, yet embedded hosts (the README's "many writers" pitch) get none of it — embedded submissions serialize on a mutex with no coalescing or dedup.
+**Do:**
+- Move publisher + its 960 test lines into `loonfs` (e.g. `loonfs::publisher`); server keeps construction + config wiring. Embedded `Fs` write paths route through it (this is the point — decide whether `Fs` always owns a registry or exposes it opt-in; prefer always-on for one code path).
+- Re-home the queue telemetry consistently with the PR-10 taxonomy (`publisher.*` spans now genuinely mean the publisher).
+- Revisit the PR-21 seam: re-exports that existed only for the server's publisher can now be deleted.
+**Done when:** embedded and server writes share one concurrency front-end; a two-writer embedded test shows coalescing/dedup behavior that previously only the server had.
+
+---
+
+## Wave 6 — naming canon sweep
+
+### PR-25 · `conor/naming-canon`
+**Title:** `refactor: apply naming canon across the workspace`
+**Effort:** M · **Depends on:** waves 4–5 (renames after moves = clean diffs)
+**Why:** Residual pattern-A/pattern-B drift a style guide must settle once.
+**Do:**
+- Builder setters: bare field names — `NamespaceEngineBuilder::writer` → `writer_id` (`engine.rs:843`); drop the lone `with_metrics_recorder` prefix (`fs.rs:146`).
+- `Dir` → `Directory` in Rust names (`InodeKind::Dir`, `create_dir`, `CreateDirOptions` → align with `CommitOp::CreateDirectory`); serialized values (`"dir"`) untouched — assert via golden fixtures.
+- Parameter naming: `namespace_id: &NamespaceId` everywhere (166/49/17/12 split today).
+- CLI dispatch: one scheme for `run_*` functions (`commands/mod.rs` currently mixes three).
+- File renames for grep-ambiguity: `loonfs-core/src/publisher.rs` → `commit_engine.rs` (matches its type), `loonfs-objectstore/src/fs.rs` → `local_fs_store.rs`, disambiguate the three `trace.rs` (sim's is `sim_trace`).
+- loonfs-api module homes: all v0 HTTP shapes under `v0` (today split across private `http.rs`, `server.rs`, `v0.rs` with flat re-exports — `CreateNamespaceRequest` vs `v0::CommitRequest`); `//!` docs on each file stating what belongs there. Curated re-export style for loonfs-sim's root (currently double-pathed).
+- Boundary types: `lease_duration_ms: u64` → `Duration` at API boundaries; unify `PutFileOptions.behavior` vs core `put_behavior` field naming; rename the reused `FilesystemMoveArgs` for `cp`; fix human render printing Rust Debug of `InodeKind` (`render.rs:155,163`).
+**Done when:** each bullet's grep is clean; golden fixtures byte-identical (proves no wire leakage).
+
+---
+
+## Wave 7 — tests (DEFERRED — skip in round 1; PR-26 must NOT touch loonfs-sim, see decision 5)
+
+### PR-26 · `conor/shared-test-support`
+**Title:** `test: shared test-support crate for fixtures and fault stores`
+**Effort:** L (test-only risk) · **Depends on:** PR-17 (avoid churn)
+**Why:** Five big suites hand-roll 13 fault-injection stores — including two same-named-but-diverged `HeadCasFailureStore`s (`runtime.rs:2245` vs `checkpoint/tests.rs:2665`) — three `block_on` implementations, and two `page_limit` helpers with different semantics.
+**Note:** `loonfs-sim` is an external contract (decision 5) — the support crate must NOT depend on, modify, or duplicate-into it. Consolidate the ad-hoc wrappers into the support crate on their own terms.
+**Do:**
+- New `crates/loonfs-test-support` (`publish = false`): one configurable fault-injecting store covering what the 13 wrappers do (lost puts/acks, stale reads/CAS, get counting, access limits); namespace/engine bootstrap builders; the single `block_on`; `page_limit`; the `FsTestExt` blocking trait.
+- Delete all 13 ad-hoc wrappers, migrating their suites.
+- Async idiom canon: bare `#[tokio::test]` unless multi-thread is semantically required (comment why when it is); fix the mixed idioms inside `http_smoke.rs`.
+- Split `mutation_guards.rs` (5,607 lines, helpers at both ends) into `tests/mutation_guards/{main,harness,commit_validation,uploads,query_reads,batch_publish,forks,restore,path_ops}.rs` — one binary, navigable domains.
+- Scope the three file-wide `#![allow(clippy::disallowed_methods)]` escapes (`http_smoke.rs:1`, `cli.rs:1`, `direct_put_real_provider.rs:1`) down to the individual polling functions (house pattern: `objectstore_conformance.rs:705`).
+- Fix the CLI suite's implicit server-binary dependency (`cli.rs:992` probes `target/debug/loonfs-server`): add loonfs-server as a dev-dependency so `CARGO_BIN_EXE_loonfs-server` works, or document the build prerequisite in CONTRIBUTING.
+- Remove sim's unused `loonfs-core` dependency if still unused after adoption.
+**Done when:** zero `impl ObjectStore` in test files outside the support crate/sim; `cargo test -p loonfs-cli` works from a clean checkout (or the prerequisite is documented); sim has real consumers.
+
+### PR-27 · `conor/seeded-differential`
+**Title:** `test(core): seeded differential exploration against the reference model`
+**Effort:** M · **Depends on:** PR-26 · **Optional — highest-leverage use of the sim crate; cut if schedule demands.**
+**Why:** The differential suite replays 6 hand-written scenarios; the model oracle has one self-test. Sim's `DeterministicRng`/`ReplaySeed` were built for exactly this and are unused.
+**Do:** Seeded generator of random valid op sequences (create/write/move/delete/tombstone/restore mixes) replayed through `loonfs_model::MetadataState` and core after every publish; normalize + compare; print the failing seed; a fixed-seed corpus runs in CI, an env var widens the search locally. Add model self-tests for the semantics the generator exercises.
+**Done when:** a deliberately-introduced visibility bug in core (mutation test) is caught by the differential run within the CI seed corpus.
+
+### PR-28 · `conor/client-integration`
+**Title:** `test(client): direct integration coverage against the in-process server`
+**Effort:** S–M · **Depends on:** PR-23
+**Why:** loonfs-client's only tests are six config-parsing cases; request construction, decoding, pagination, and error mapping are covered only as a side effect of other crates' suites.
+**Do:** `crates/loonfs-client/tests/` suite driving `Client` against `loonfs_server::app` on an ephemeral port: happy paths per method family, error-code decoding (now typed via PR-07), pagination aggregation, auth failure.
+**Done when:** a client-only regression (e.g. wrong path template) fails in the client's own test binary.
+
+---
+
+## Wave 8 — CI, docs, release (DEFERRED — skip in round 1)
+
+### PR-29 · `conor/harden-pipeline`
+**Title:** `ci: pin toolchain, verify msrv and macos, gate releases on all targets`
+**Effort:** M · **Depends on:** —
+**Why:** CI is fmt/clippy/test on floating stable, Linux-only, without `--locked`; new-stable clippy will break unrelated PRs (`-D warnings`); macOS breaks surface at release time; the release workflow publishes even if 3 of 4 target builds fail (`if: always()` + "at least one artifact"); the live-provider conformance suites are never executed anywhere.
+**Do:**
+- Pin the CI toolchain (from `rust-toolchain.toml`, itself pinned to a specific stable); add `--locked` everywhere; MSRV job (`cargo +1.83 check --all`); macOS test job; `concurrency:` group cancelling superseded runs; `cargo doc --no-deps` with warnings denied; cargo-deny (advisories + licenses + the loonfs-server→core ban from PR-21).
+- Release: publish requires `needs.build.result == 'success'` for all four targets; decide and state the `loonfs-server` distribution story (artifact, or an explicit "built from source" README note).
+- Weekly scheduled, secret-gated workflow running `cargo test -p loonfs-objectstore -- --ignored` per configured provider (start with S3 + R2), plus `direct_put_real_provider`.
+**Done when:** a PR with a lockfile drift, an MSRV break, or a macOS-only break fails CI; a single failed target build blocks release publish.
+
+### PR-30 · `conor/contributing-and-cli-polish`
+**Title:** `docs: contributing guide, style guide, and cli reference`
+**Effort:** M · **Depends on:** best last (it codifies the canons the earlier PRs establish)
+**Why:** CONTRIBUTING.md is two lines; the conventions this plan enforces exist nowhere in writing; `--help` has real text on exactly two flags; neither binary supports `--version`; the CLI README and agent docs have drifted.
+**Do:**
+- CONTRIBUTING.md: crate map + which crates are spec-locked; test tiers (inline units / sibling `tests.rs` for private-internals suites / `tests/` integration / golden fixtures / insta / `#[ignore]`d live suites + `provider-conformance.env.example`); determinism rules (the five clippy bans, named escape-hatch pattern, function-scoped allows); spec-locked artifact workflow (never hand-edit `openapi.json` — regen command; api.md/format.md tables are test-enforced; golden changes = format break); naming/test-naming conventions; build prerequisites.
+- STYLE.md (or a CONTRIBUTING section): the canons — constructors (`parse`/`new -> Result`/builders), error shape (thiserror, `#[from]` rule, context fields, non_exhaustive rule), serde policy (tag `kind`, tolerant wire decoding, strict config decoding), observability policy (from `docs/observability.md`), mod.rs = docs + re-exports, options structs over `_with_X`.
+- CLI: `#[command(version, about)]` on both binaries (`args.rs:4`, server main); `///` help on every arg/subcommand; regenerate `crates/loonfs-cli/README.md` from the now-authoritative help (add `namespace delete/fork`, the gcs/azure provider flags) or snapshot-test rendered help.
+- One confirmation policy for destructive commands: `--yes` flag + interactive prompt + clear `non_interactive_input_required` error (namespace delete currently panics under `--no-input`, `commands/namespace.rs:80`; profile remove silently proceeds, `profile.rs:143`).
+- Doc fixes: README quickstart `--release` copy; `examples/SKILL.md` revisions columns (no timestamp exists); one canonical install URL; workspace keywords (`"r2"` leftover); explicit `publish` set + per-crate descriptions in Cargo.tomls; rename root `examples/` (agent skills, not Rust examples) to `skills/`; PR template + CODEOWNERS stubs.
+- `#![warn(missing_docs)]` on `loonfs-api` + `loonfs-objectstore` with backfill (the two vocabulary crates; ~53% and ~11% today — the `ObjectStore` trait itself is undocumented). Core/client backfill can be a follow-up wave; state the policy either way.
+**Done when:** a new maintainer can go from clone to green tests to first PR using only in-repo docs; `loon --version` works; help snapshot test pins the reference.
+
+---
+
+## Round 1 execution order (stacked branch series)
+
+One stack, each branch based on the previous, in this order:
+
+**01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → 09 → 14 → 15 → 16 → 17 → 18 → 19 → 21 → 22 → 20 → 23 → 24 → 25**
+
+(Waves 3, 7, 8 — PRs 10–13 and 26–30 — are deferred to a later round.)
+
+Round 1 total: 21 PRs — 8 S, 10 M, 3 L. The three L items (17 visibility singleton, 23 admin parity, 24 publisher relocation) are the ones to schedule deliberately; everything else is a focused half-day-or-less change for an implementing agent.

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn map_core_error_surfaces_registry_codes_verbatim() {
-        let error = map_core_error(CoreError::MissingRevision {
+        let error = map_core_error(CoreError::RevisionNotFound {
             inode_id: InodeId(42),
             revision_no: RevisionNo(7),
         });

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -125,7 +125,7 @@ pub(super) fn build_profile_from_create_spec(
     match mode.as_str() {
         "embedded" => build_embedded_profile(spec, runtime),
         "remote" => build_remote_profile(spec, runtime),
-        _ => unreachable!(),
+        _ => unreachable!("mode is validated to `embedded` or `remote` above"),
     }
 }
 
@@ -328,7 +328,11 @@ fn build_embedded_profile(
                 key_prefix: spec.key_prefix,
             }
         }
-        _ => unreachable!(),
+        other => {
+            return Err(CliError::invalid_config(format!(
+                "store kind `{other}` has no embedded profile builder"
+            )))
+        }
     };
 
     Ok(ProfileConfig::Embedded {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -76,6 +76,9 @@ pub struct NamespacePath {
 }
 
 /// Error returned by the blocking HTTP client.
+///
+/// Foreign causes (io, json, ureq) are stringified for now; this crate has no
+/// Clone/serde constraint, so switching to `#[source]` chains later is fine.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientError {

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -6,7 +6,7 @@ use super::runs::{
     MetadataTableManifest, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
     MAX_MAINTENANCE_TABLE_IO,
 };
-use crate::error::CoreError;
+use crate::error::{CoreError, Result};
 use crate::metadata::MetadataState;
 use crate::storage::content::write_immutable_object;
 use futures::future::try_join_all;
@@ -26,7 +26,7 @@ pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     metadata_state: &MetadataState,
     writer_version: &str,
     max_rows_per_segment: usize,
-) -> Result<Vec<MetadataTableManifest>, CoreError> {
+) -> Result<Vec<MetadataTableManifest>> {
     build_manifest_tables_from_rows(
         store,
         namespace_id,
@@ -67,7 +67,7 @@ pub(super) async fn build_manifest_l0_run_tables<S: ObjectStore + ?Sized>(
     after_seq: ChangeSeq,
     metadata_state: &MetadataState,
     writer_version: &str,
-) -> Result<Vec<MetadataTableManifest>, CoreError> {
+) -> Result<Vec<MetadataTableManifest>> {
     build_manifest_tables_from_rows(
         store,
         namespace_id,
@@ -106,7 +106,7 @@ pub(super) async fn build_manifest_tables_from_rows<S, RowsForFamily>(
     writer_version: &str,
     mut rows_for_family: RowsForFamily,
     segmentation: MetadataTableSegmentation,
-) -> Result<Vec<MetadataTableManifest>, CoreError>
+) -> Result<Vec<MetadataTableManifest>>
 where
     S: ObjectStore + ?Sized,
     RowsForFamily: FnMut(MetadataTableFamily) -> Vec<MetadataRow>,
@@ -126,7 +126,7 @@ where
         let mut requests = Vec::with_capacity(segments.len());
         for (segment_index, segment_rows) in segments.into_iter().enumerate() {
             let segment_index = u32::try_from(segment_index)
-                .map_err(|_| CoreError::Store("metadata SST index overflow".to_owned()))?;
+                .map_err(|_| CoreError::Internal("metadata SST index overflow".to_owned()))?;
             let table_id = MetadataTableId::generate();
             let object_key = metadata_table(namespace_id.as_str(), table_id.as_str());
             requests.push(MetadataSstWriteRequest {
@@ -186,7 +186,7 @@ pub(super) struct MetadataSstWriteRequest<'a> {
 pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,
     request: MetadataSstWriteRequest<'_>,
-) -> Result<MetadataFileRef, CoreError> {
+) -> Result<MetadataFileRef> {
     let row_keys = request
         .rows
         .iter()
@@ -212,10 +212,19 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
         max_key: page.max_key.clone(),
         pages: vec![page],
     };
-    let envelope = MetadataSstEnvelope::from_payload(request.writer_version, payload)
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-    let encoded = encode_metadata_sst_envelope_zstd(&envelope)
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+    let envelope =
+        MetadataSstEnvelope::from_payload(request.writer_version, payload).map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to build metadata SST envelope `{}`: {err}",
+                request.object_key
+            ))
+        })?;
+    let encoded = encode_metadata_sst_envelope_zstd(&envelope).map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to encode metadata SST `{}`: {err}",
+            request.object_key
+        ))
+    })?;
     write_immutable_object(store, &request.object_key, &encoded).await?;
     Ok(MetadataFileRef {
         owner_namespace_id: request.namespace_id.clone(),

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -26,6 +26,7 @@ use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
+use crate::error::Result;
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_metadata_state;
 use crate::namespace::catalog::load_namespace_catalog_entry;
@@ -63,7 +64,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
-) -> Result<CreateCheckpointResponse, CoreError> {
+) -> Result<CreateCheckpointResponse> {
     create_checkpoint_with_policy(store, namespace_id, context, MetadataLsmPolicy::default()).await
 }
 
@@ -80,7 +81,7 @@ pub(crate) async fn create_checkpoint_with_policy<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: MetadataLsmPolicy,
-) -> Result<CreateCheckpointResponse, CoreError> {
+) -> Result<CreateCheckpointResponse> {
     create_checkpoint_with_policy_and_owner(store, namespace_id, context, policy, None).await
 }
 
@@ -90,7 +91,7 @@ pub(crate) async fn create_checkpoint_with_policy_and_owner<S: ObjectStore + ?Si
     context: &MutationContext,
     policy: MetadataLsmPolicy,
     owner: Option<CheckpointOwner>,
-) -> Result<CreateCheckpointResponse, CoreError> {
+) -> Result<CreateCheckpointResponse> {
     // Checkpoint creation pins a manifest version as a first-class record
     // under `checkpoints/`, write-then-verify (format spec, "Checkpoints"):
     //
@@ -171,7 +172,7 @@ pub(crate) async fn create_checkpoint_with_policy_and_owner<S: ObjectStore + ?Si
                 }
             }
             let Some(manifest) = written_manifest else {
-                return Err(CoreError::Store(
+                return Err(CoreError::Internal(
                     "manifest id allocation retry exhausted".to_owned(),
                 ));
             };
@@ -283,7 +284,7 @@ struct CheckpointProjection<'a, S: ObjectStore + ?Sized> {
 async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
-) -> Result<CheckpointProjection<'a, S>, CoreError> {
+) -> Result<CheckpointProjection<'a, S>> {
     load_namespace_catalog_entry(store, namespace_id)
         .await
         .map_err(|error| CoreError::MetadataProjection(error.into()))?;
@@ -362,7 +363,7 @@ async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
 pub(super) async fn load_checkpoint_projection_metadata_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<(HeadState, MetadataState), CoreError> {
+) -> Result<(HeadState, MetadataState)> {
     let projection = load_checkpoint_projection(store, namespace_id).await?;
     let mut metadata_state = MetadataStateBuilder::default();
     for family in CHECKPOINT_TABLE_FAMILIES {
@@ -386,7 +387,7 @@ pub(super) async fn load_checkpoint_projection_metadata_state<S: ObjectStore + ?
 fn ensure_checkpoint_reconstructed_head_matches(
     current_head: &HeadState,
     reconstructed: &HeadState,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     if current_head.namespace_id != reconstructed.namespace_id
         || current_head.seq != reconstructed.seq
         || current_head.head_commit_id != reconstructed.head_commit_id
@@ -404,12 +405,12 @@ fn ensure_checkpoint_reconstructed_head_matches(
     Ok(())
 }
 
-pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId, CoreError> {
+pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> {
     current
         .0
         .checked_add(1)
         .map(ManifestId)
-        .ok_or_else(|| CoreError::Store("manifest id overflow".to_owned()))
+        .ok_or_else(|| CoreError::Internal("manifest id overflow".to_owned()))
 }
 
 pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
@@ -417,7 +418,7 @@ pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     initial_head: &HeadState,
     writer_version: &str,
-) -> Result<NamespaceManifestEnvelope, CoreError> {
+) -> Result<NamespaceManifestEnvelope> {
     let manifest_id = ManifestId(initial_head.seq.0);
     let metadata_state = bootstrap_metadata_state();
     let run_tables = build_manifest_tables(
@@ -453,7 +454,11 @@ pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
             metadata_files: flatten_manifest_tables(run_tables),
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace manifest envelope: {err}"
+        ))
+    })
 }
 
 #[tracing::instrument(
@@ -470,7 +475,7 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
     writer_version: &str,
     policy: MetadataLsmPolicy,
     manifest_id: ManifestId,
-) -> Result<NamespaceManifestEnvelope, CoreError> {
+) -> Result<NamespaceManifestEnvelope> {
     let head_seq = projection.head.seq;
     let previous_manifest = projection.manifest_tables.manifest();
 
@@ -535,7 +540,11 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
             metadata_files,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace manifest envelope: {err}"
+        ))
+    })
 }
 
 /// Unnamed checkpoint records are maintenance bookkeeping; a manifest keeps
@@ -549,7 +558,7 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
 pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     // The latest revision at or below the floor is what the floor itself
     // observes; every older one is superseded at every retained sequence.
     let mut latest_revision_at_floor = BTreeMap::new();
@@ -731,7 +740,7 @@ async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
     projection: &CheckpointProjection<'_, S>,
     writer_version: &str,
     max_rows_per_segment: usize,
-) -> Result<Vec<super::runs::MetadataTableManifest>, CoreError> {
+) -> Result<Vec<super::runs::MetadataTableManifest>> {
     let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
     for family in CHECKPOINT_TABLE_FAMILIES {
         let mut rows = projection
@@ -832,7 +841,7 @@ pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
     writer_version: &str,
     policy: MetadataLsmPolicy,
     manifest_id: ManifestId,
-) -> Result<NamespaceManifestEnvelope, CoreError> {
+) -> Result<NamespaceManifestEnvelope> {
     let head = source.head;
     let metadata_state = source.metadata_state;
     let head_seq = head.seq;
@@ -927,7 +936,11 @@ pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             metadata_files,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace manifest envelope: {err}"
+        ))
+    })
 }
 
 fn is_bootstrap_seed_manifest(payload: &NamespaceManifestPayload) -> bool {

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -5,8 +5,12 @@ use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Coarse failure class of a manifest load: corruption versus store trouble.
+///
+/// Deliberately not named `*ErrorKind` to avoid colliding with the wire-level
+/// caller-action concept in [`loonfs_api::ErrorKind`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ManifestLoadErrorKind {
+pub enum ManifestLoadFailureClass {
     Corrupt,
     Store,
 }
@@ -150,12 +154,12 @@ pub enum ManifestLoadError {
 }
 
 impl ManifestLoadError {
-    pub fn kind(&self) -> ManifestLoadErrorKind {
+    pub fn failure_class(&self) -> ManifestLoadFailureClass {
         match self {
             Self::ReadManifest { .. }
             | Self::ReadSegment { .. }
-            | Self::ManifestConflict { .. } => ManifestLoadErrorKind::Store,
-            _ => ManifestLoadErrorKind::Corrupt,
+            | Self::ManifestConflict { .. } => ManifestLoadFailureClass::Store,
+            _ => ManifestLoadFailureClass::Corrupt,
         }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -37,7 +37,7 @@ pub use self::cache::{
     MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
     WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
 };
-pub use self::error::{ManifestLoadError, ManifestLoadErrorKind};
+pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::{

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -54,7 +54,7 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
         .await
     {
         Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
             let Some(existing) = load_namespace_manifest_envelope_if_present(
                 store,
                 &manifest.payload.namespace_id,
@@ -140,9 +140,12 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             writer_version,
             next.clone(),
         )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| {
+            CoreError::Internal(format!("failed to build metadata root envelope: {err}"))
+        })?;
+        let encoded = encode_control_object(&envelope).map_err(|err| {
+            CoreError::Internal(format!("failed to encode metadata root object: {err}"))
+        })?;
         let expected_etag = loaded.metadata.etag.as_deref().ok_or_else(|| {
             CoreError::NamespaceCorrupt(format!("missing root etag for `{}`", loaded.object_key))
         })?;
@@ -151,8 +154,10 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             .await
         {
             Ok(_) => return Ok(ManifestPublicationOutcome::Published(next)),
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(error) => return Err(CoreError::Store(error.to_string())),
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
+            ) => continue,
+            Err(error) => return Err(CoreError::store(&loaded.object_key, &error)),
         }
     }
     Ok(ManifestPublicationOutcome::RootCasRaceLost)

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -60,24 +60,27 @@ pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
         writer_version,
         record.clone(),
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
-    let encoded =
-        encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| {
+        CoreError::Internal(format!("failed to build checkpoint record envelope: {err}"))
+    })?;
+    let encoded = encode_control_object(&envelope).map_err(|err| {
+        CoreError::Internal(format!("failed to encode checkpoint record object: {err}"))
+    })?;
     let object_key = checkpoint_record(record.namespace_id.as_str(), record.checkpoint_id.as_str());
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
         Ok(_) => Ok(CheckpointRecordWrite::Created),
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
             let existing =
                 read_checkpoint_record(store, &record.namespace_id, &record.checkpoint_id)
                     .await?
                     .ok_or_else(|| {
-                        CoreError::Store(format!(
+                        CoreError::Internal(format!(
                             "checkpoint record `{object_key}` conflicted but cannot be read back"
                         ))
                     })?;
             Ok(CheckpointRecordWrite::Existing(Box::new(existing.state)))
         }
-        Err(error) => Err(CoreError::Store(error.to_string())),
+        Err(error) => Err(CoreError::store(&object_key, &error)),
     }
 }
 
@@ -95,7 +98,7 @@ pub(crate) async fn read_checkpoint_record<S: ObjectStore + ?Sized>(
     let Some(body) = store
         .get_with_metadata(&object_key)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?
+        .map_err(|error| CoreError::store(&object_key, &error))?
     else {
         return Ok(None);
     };
@@ -127,7 +130,7 @@ pub(crate) async fn set_checkpoint_record_state<S: ObjectStore + ?Sized>(
     let object_key = checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str());
     for _attempt in 0..STATE_CAS_ATTEMPTS {
         let Some(loaded) = read_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
-            return Err(CoreError::Store(format!(
+            return Err(CoreError::Internal(format!(
                 "checkpoint record `{object_key}` disappeared during a state change"
             )));
         };
@@ -141,9 +144,12 @@ pub(crate) async fn set_checkpoint_record_state<S: ObjectStore + ?Sized>(
             writer_version,
             next,
         )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| {
+            CoreError::Internal(format!("failed to build checkpoint record envelope: {err}"))
+        })?;
+        let encoded = encode_control_object(&envelope).map_err(|err| {
+            CoreError::Internal(format!("failed to encode checkpoint record object: {err}"))
+        })?;
         let Some(etag) = loaded.etag.as_deref() else {
             return Err(CoreError::NamespaceCorrupt(format!(
                 "missing etag for checkpoint record `{object_key}`"
@@ -154,11 +160,13 @@ pub(crate) async fn set_checkpoint_record_state<S: ObjectStore + ?Sized>(
             .await
         {
             Ok(_) => return Ok(()),
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(error) => return Err(CoreError::Store(error.to_string())),
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
+            ) => continue,
+            Err(error) => return Err(CoreError::store(&object_key, &error)),
         }
     }
-    Err(CoreError::Store(format!(
+    Err(CoreError::Internal(format!(
         "checkpoint record `{object_key}` state change retries exhausted"
     )))
 }

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -77,7 +77,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             let present = store
                 .head(&metadata_file.object_key)
                 .await
-                .map_err(|error| CoreError::Store(error.to_string()))?
+                .map_err(|error| CoreError::store(&metadata_file.object_key, &error))?
                 .is_some();
             if present {
                 Ok(())
@@ -120,9 +120,10 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             &context.writer_version,
             next,
         )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| CoreError::Internal(format!("failed to build wal floor envelope: {err}")))?;
+        let encoded = encode_control_object(&envelope).map_err(|err| {
+            CoreError::Internal(format!("failed to encode wal floor object: {err}"))
+        })?;
         let expected_etag = loaded.metadata.etag.as_deref().ok_or_else(|| {
             CoreError::NamespaceCorrupt(format!("missing floor etag for `{}`", loaded.object_key))
         })?;
@@ -136,11 +137,13 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
                     retention_floor_seq: target_floor,
                 })
             }
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
-            Err(error) => return Err(CoreError::Store(error.to_string())),
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
+            ) => continue,
+            Err(error) => return Err(CoreError::store(&loaded.object_key, &error)),
         }
     }
-    Err(CoreError::Store(
-        "retention floor cas retry exhausted".to_owned(),
+    Err(CoreError::Internal(
+        "retention floor compare-and-swap retry exhausted".to_owned(),
     ))
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -1432,7 +1432,9 @@ impl ObjectStore for ManifestSwapOnCasConflictStore {
         if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
             self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
             self.install_competing_manifest_id().await;
-            return Err(ObjectStoreError::PreconditionFailed);
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         self.inner.compare_and_swap(key, expected_etag, bytes).await
     }
@@ -3708,7 +3710,9 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
         {
             self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
             self.install_higher_floor().await;
-            return Err(ObjectStoreError::PreconditionFailed);
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         self.inner.compare_and_swap(key, expected_etag, bytes).await
     }
@@ -4030,7 +4034,9 @@ impl ObjectStore for HeadCasFailureStore {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
         {
-            return Err(ObjectStoreError::PreconditionFailed);
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         self.inner.put(key, bytes, mode).await
     }
@@ -4185,7 +4191,9 @@ impl ObjectStore for ConflictOnManifestCreateStore {
                 self.inner
                     .put_overwrite(key, Bytes::copy_from_slice(&self.replacement_bytes))
                     .await?;
-                return Err(ObjectStoreError::Conflict);
+                return Err(ObjectStoreError::Conflict {
+                    object_key: key.to_owned(),
+                });
             }
         }
         self.inner.put(key, bytes, mode).await

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -164,12 +164,14 @@ pub async fn publish_commit_head<S: ObjectStore + ?Sized>(
 
 fn map_object_store_error(err: ObjectStoreError) -> CommitHeadPublishError {
     match err {
-        ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict => {
+        ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. } => {
             CommitHeadPublishError::StaleHead
         }
         // A transport failure after the CAS was sent leaves the outcome
         // unobserved: the head may already reference the new segment.
-        ObjectStoreError::Transport(message) => CommitHeadPublishError::OutcomeUnknown(message),
+        ObjectStoreError::Transport { message, .. } => {
+            CommitHeadPublishError::OutcomeUnknown(message)
+        }
         other => CommitHeadPublishError::Store(other.to_string()),
     }
 }
@@ -182,15 +184,22 @@ mod tests {
     #[test]
     fn head_cas_transport_failure_maps_to_unknown_outcome_not_failure() {
         assert_eq!(
-            map_object_store_error(ObjectStoreError::Transport("timeout".to_owned())),
+            map_object_store_error(ObjectStoreError::transport(
+                "namespaces/demo/control/head.json",
+                "timeout",
+            )),
             CommitHeadPublishError::OutcomeUnknown("timeout".to_owned())
         );
         assert_eq!(
-            map_object_store_error(ObjectStoreError::PreconditionFailed),
+            map_object_store_error(ObjectStoreError::PreconditionFailed {
+                object_key: "namespaces/demo/control/head.json".to_owned(),
+            }),
             CommitHeadPublishError::StaleHead
         );
         assert!(matches!(
-            map_object_store_error(ObjectStoreError::NotFound),
+            map_object_store_error(ObjectStoreError::NotFound {
+                object_key: "namespaces/demo/control/head.json".to_owned(),
+            }),
             CommitHeadPublishError::Store(_)
         ));
     }

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -73,7 +73,10 @@ where
                     .await
                 {
                     Ok(_) => return Ok(outcome),
-                    Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+                    Err(
+                        ObjectStoreError::PreconditionFailed { .. }
+                        | ObjectStoreError::Conflict { .. },
+                    ) => {
                         continue;
                     }
                     Err(error) => {
@@ -114,24 +117,30 @@ where
                     writer_version,
                     *next,
                 )
-                .map_err(|err| CoreError::Store(err.to_string()))?;
-                let encoded = encode_control_object(&envelope)
-                    .map_err(|err| CoreError::Store(err.to_string()))?;
+                .map_err(|err| {
+                    CoreError::Internal(format!("failed to build upload session envelope: {err}"))
+                })?;
+                let encoded = encode_control_object(&envelope).map_err(|err| {
+                    CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
+                })?;
                 match store
                     .compare_and_swap(&loaded.object_key, expected_etag, Bytes::from(encoded))
                     .await
                 {
                     Ok(_) => return Ok(outcome),
-                    Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+                    Err(
+                        ObjectStoreError::PreconditionFailed { .. }
+                        | ObjectStoreError::Conflict { .. },
+                    ) => {
                         continue;
                     }
-                    Err(error) => return Err(CoreError::Store(error.to_string())),
+                    Err(error) => return Err(CoreError::store(&loaded.object_key, &error)),
                 }
             }
         }
     }
 
-    Err(CoreError::Store(
+    Err(CoreError::Internal(
         "upload session compare-and-swap retry exhausted".to_owned(),
     ))
 }
@@ -158,10 +167,10 @@ fn required_etag_core<'a>(
     metadata: &'a ObjectMetadata,
     object_key: &str,
 ) -> Result<&'a str, CoreError> {
-    metadata
-        .etag
-        .as_deref()
-        .ok_or_else(|| CoreError::Store(format!("missing control object etag for `{object_key}`")))
+    metadata.etag.as_deref().ok_or_else(|| CoreError::Store {
+        object_key: object_key.to_owned(),
+        message: "missing control object etag".to_owned(),
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -180,21 +189,21 @@ async fn read_upload_session_object<S: ObjectStore + ?Sized>(
     let body = store
         .get_with_metadata(&object_key)
         .await
-        .map_err(|err| CoreError::Store(err.to_string()))?
+        .map_err(|err| CoreError::store(&object_key, &err))?
         .ok_or_else(|| CoreError::UploadNotFound {
             upload_id: upload_id.clone(),
         })?;
     let envelope: UploadSessionEnvelope =
         decode_control_object(&body.bytes, ControlObjectKind::UploadSession).map_err(|err| {
-            CoreError::Store(format!("invalid upload session `{object_key}`: {err}"))
+            CoreError::Internal(format!("invalid upload session `{object_key}`: {err}"))
         })?;
     if envelope.state.namespace_id != *namespace_id {
-        return Err(CoreError::Store(format!(
+        return Err(CoreError::Internal(format!(
             "upload session namespace mismatch for `{object_key}`"
         )));
     }
     if envelope.state.upload_id != *upload_id {
-        return Err(CoreError::Store(format!(
+        return Err(CoreError::Internal(format!(
             "upload session id mismatch for `{object_key}`"
         )));
     }
@@ -354,7 +363,9 @@ mod tests {
         ) -> Result<ObjectMetadata, ObjectStoreError> {
             if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
                 self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
-                return Err(ObjectStoreError::PreconditionFailed);
+                return Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                });
             }
             self.inner.compare_and_swap(key, expected_etag, bytes).await
         }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -1,3 +1,10 @@
+//! Core error types and their wire-code classification.
+//!
+//! Stringification rule: core errors are `Clone`/serde-constrained, so foreign
+//! causes (object-store, codec, io) are captured as prefixed message strings
+//! next to the object key they are about, not as `#[source]` chains. Crates
+//! without those constraints (server, CLI) prefer `#[source]` chains instead.
+
 use crate::checkpoint::ManifestLoadError;
 use crate::commit::{CommitConversionError, CommitHeadPublishError, CommitValidationError};
 use crate::metadata::{MetadataApplyError, VisiblePathError};
@@ -11,13 +18,14 @@ use loonfs_api::{
     ChangeSeq, CommitIdValidationError, GeneratedIdValidationError, InodeId, InodeKind, ManifestId,
     NamespaceId, NamespaceIdValidationError, UploadId,
 };
+use loonfs_objectstore::ObjectStoreError;
 use thiserror::Error;
 
 /// Public error type returned by `loonfs-core`.
 ///
 /// Use [`Error::kind`] for broad caller action and [`Error::code`] for a stable
 /// machine-readable reason.
-pub type Error = CoreError;
+pub use self::CoreError as Error;
 
 /// Result type used by `loonfs-core` entrypoints.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -49,8 +57,8 @@ pub enum CoreError {
     MetadataApply(#[from] MetadataApplyError),
     #[error("head publish failed: {0}")]
     HeadPublish(#[from] CommitHeadPublishError),
-    #[error("failed to write wal object: {0}")]
-    WalWrite(String),
+    #[error("failed to write wal object `{object_key}`: {message}")]
+    WalWrite { object_key: String, message: String },
     #[error("invalid absolute path `{0}`")]
     InvalidPath(String),
     #[error(transparent)]
@@ -58,11 +66,11 @@ pub enum CoreError {
     #[error(transparent)]
     InvalidCommitId(#[from] CommitIdValidationError),
     #[error(transparent)]
-    InvalidUploadId(GeneratedIdValidationError),
+    InvalidUploadId(#[from] GeneratedIdValidationError),
     #[error("path not found `{0}`")]
-    MissingPath(String),
+    PathNotFound(String),
     #[error("revision `{revision_no}` not found for inode `{inode_id}`")]
-    MissingRevision {
+    RevisionNotFound {
         inode_id: InodeId,
         revision_no: loonfs_api::RevisionNo,
     },
@@ -80,7 +88,7 @@ pub enum CoreError {
     CommitIdReuseConflict(String),
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
-    #[error("{0}")]
+    #[error("checkpoint unavailable: {0}")]
     CheckpointUnavailable(String),
     #[error("upload session `{upload_id}` was not found")]
     UploadNotFound { upload_id: UploadId },
@@ -115,8 +123,12 @@ pub enum CoreError {
     /// callers surface it without reacquiring.
     #[error("writer session fenced: {0}")]
     WriterFenced(String),
-    #[error("object store error: {0}")]
-    Store(String),
+    #[error("object store error for `{object_key}`: {message}")]
+    Store { object_key: String, message: String },
+    /// Non-store internal failure (codec, overflow, invariant breach). Same
+    /// wire code as [`ErrorCode::ServerError`]; the message is the detail.
+    #[error("internal error: {0}")]
+    Internal(String),
     #[error("namespace `{namespace_id}` already exists")]
     NamespaceAlreadyExists { namespace_id: NamespaceId },
     #[error("namespace `{namespace_id}` is deleted")]
@@ -167,6 +179,8 @@ pub enum MetadataViewError {
 ///
 /// These variants name durable/control failure cases without implying that a
 /// full namespace state was reconstructed.
+// Four Load* variants share ControlObjectLoadError; only the head load (the
+// dominant path) gets `#[from]`, the others stay explicit conversions.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum MetadataProjectionLoadError {
     #[error("failed to load namespace descriptor: {0}")]
@@ -233,11 +247,28 @@ impl From<NamespaceCatalogLoadError> for CoreError {
 
 impl From<ImmutableObjectWriteError> for CoreError {
     fn from(value: ImmutableObjectWriteError) -> Self {
-        Self::Store(value.to_string())
+        match value {
+            ImmutableObjectWriteError::Store {
+                object_key,
+                message,
+            } => Self::Store {
+                object_key,
+                message,
+            },
+        }
     }
 }
 
 impl CoreError {
+    /// Builds [`CoreError::Store`] for a failed object-store operation on
+    /// `object_key`.
+    pub(crate) fn store(object_key: impl Into<String>, error: &ObjectStoreError) -> Self {
+        Self::Store {
+            object_key: object_key.into(),
+            message: error.message(),
+        }
+    }
+
     pub fn kind(&self) -> ErrorKind {
         self.code().kind()
     }
@@ -252,8 +283,9 @@ impl CoreError {
             CoreError::CommitValidation(error) => classify_commit_validation_error(error),
             CoreError::WalBuild(_)
             | CoreError::MetadataApply(_)
-            | CoreError::WalWrite(_)
-            | CoreError::Store(_) => ErrorCode::ServerError,
+            | CoreError::WalWrite { .. }
+            | CoreError::Store { .. }
+            | CoreError::Internal(_) => ErrorCode::ServerError,
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
             CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
                 ErrorCode::InvalidRequest
@@ -261,8 +293,8 @@ impl CoreError {
             CoreError::InvalidNamespaceId(_) => ErrorCode::InvalidRequest,
             CoreError::InvalidCommitId(_) => ErrorCode::InvalidRequest,
             CoreError::InvalidUploadId(_) => ErrorCode::InvalidRequest,
-            CoreError::MissingPath(_) => ErrorCode::PathNotFound,
-            CoreError::MissingRevision { .. } => ErrorCode::RevisionNotFound,
+            CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
+            CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,
             CoreError::NamespaceAlreadyExists { .. } => ErrorCode::NamespaceExists,
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
             CoreError::NamespacePartiallyInitialized { .. } => ErrorCode::NamespacePartial,
@@ -313,7 +345,7 @@ fn classify_metadata_projection_load_error(error: &MetadataProjectionLoadError) 
         }
         MetadataProjectionLoadError::LoadContentStoreDescriptor(error) => match error {
             ControlObjectLoadError::InvalidNamespaceId { .. } => ErrorCode::InvalidRequest,
-            ControlObjectLoadError::Store(_) => ErrorCode::ServerError,
+            ControlObjectLoadError::Store { .. } => ErrorCode::ServerError,
             _ => ErrorCode::NamespaceCorrupt,
         },
         MetadataProjectionLoadError::LoadHead(error) => match error {
@@ -324,9 +356,9 @@ fn classify_metadata_projection_load_error(error: &MetadataProjectionLoadError) 
         MetadataProjectionLoadError::WalChainLoad(error) => classify_wal_chain_load_error(error),
         MetadataProjectionLoadError::WalReplay(_)
         | MetadataProjectionLoadError::ReplayedHeadMismatch { .. } => ErrorCode::NamespaceCorrupt,
-        MetadataProjectionLoadError::ManifestLoad(error) => match error.kind() {
-            crate::checkpoint::ManifestLoadErrorKind::Corrupt => ErrorCode::NamespaceCorrupt,
-            crate::checkpoint::ManifestLoadErrorKind::Store => ErrorCode::ServerError,
+        MetadataProjectionLoadError::ManifestLoad(error) => match error.failure_class() {
+            crate::checkpoint::ManifestLoadFailureClass::Corrupt => ErrorCode::NamespaceCorrupt,
+            crate::checkpoint::ManifestLoadFailureClass::Store => ErrorCode::ServerError,
         },
         MetadataProjectionLoadError::MissingHeadEtag { .. } => ErrorCode::ServerError,
         MetadataProjectionLoadError::HeadChangedDuringLoad { .. } => ErrorCode::StaleHead,
@@ -343,7 +375,7 @@ fn classify_control_object_load_error(error: &ControlObjectLoadError) -> ErrorCo
         | ControlObjectLoadError::ContentStoreMismatch { .. }
         | ControlObjectLoadError::ChecksumMismatch { .. }
         | ControlObjectLoadError::Codec { .. } => ErrorCode::NamespaceCorrupt,
-        ControlObjectLoadError::Store(_) => ErrorCode::ServerError,
+        ControlObjectLoadError::Store { .. } => ErrorCode::ServerError,
     }
 }
 
@@ -390,7 +422,12 @@ impl From<crate::control_update::ControlUpdateError> for CoreError {
             ControlUpdateError::LoadHead(error) => {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
             }
-            other => CoreError::Store(other.to_string()),
+            // The remaining variants (missing etag, codec, control store error,
+            // retries exhausted) are control-plane plumbing failures with no
+            // single object key in scope at this blanket conversion. They share
+            // the ServerError wire code with `Store`; keep the detail as a
+            // prefixed message.
+            other => CoreError::Internal(other.to_string()),
         }
     }
 }

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -51,12 +51,12 @@ impl Default for GcConfig {
 impl GcConfig {
     fn validate(&self) -> Result<(), CoreError> {
         if self.grace_window_ms == 0 {
-            return Err(CoreError::Store(
+            return Err(CoreError::Internal(
                 "gc grace_window_ms must be greater than zero".to_owned(),
             ));
         }
         if self.reap_window_ms < self.grace_window_ms {
-            return Err(CoreError::Store(
+            return Err(CoreError::Internal(
                 "gc reap_window_ms must be at least the grace window".to_owned(),
             ));
         }
@@ -105,7 +105,7 @@ pub async fn gc_namespace<S: ObjectStore + ?Sized>(
     let namespace_complete = store
         .head(&config_key)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?
+        .map_err(|error| CoreError::store(&config_key, &error))?
         .is_some();
     if !namespace_complete {
         return reap_abandoned_bootstrap(store, namespace_id, config, context).await;
@@ -246,7 +246,7 @@ async fn collect_live_set<S: ObjectStore + ?Sized>(
         let Some(bytes) = store
             .get(&key, None)
             .await
-            .map_err(|error| CoreError::Store(error.to_string()))?
+            .map_err(|error| CoreError::store(&key, &error))?
         else {
             continue;
         };
@@ -277,7 +277,7 @@ async fn collect_live_set<S: ObjectStore + ?Sized>(
         let Some(bytes) = store
             .get(&key, None)
             .await
-            .map_err(|error| CoreError::Store(error.to_string()))?
+            .map_err(|error| CoreError::store(&key, &error))?
         else {
             continue;
         };
@@ -379,7 +379,7 @@ async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         let Some(metadata) = store
             .head(key)
             .await
-            .map_err(|error| CoreError::Store(error.to_string()))?
+            .map_err(|error| CoreError::store(key, &error))?
         else {
             continue;
         };
@@ -398,7 +398,7 @@ async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
     let complete_now = store
         .head(&namespace_config(namespace_id.as_str()))
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?
+        .map_err(|error| CoreError::store(namespace_config(namespace_id.as_str()), &error))?
         .is_some();
     if complete_now {
         report.retained_candidates = u64::try_from(keys.len()).unwrap_or(u64::MAX);
@@ -408,7 +408,7 @@ async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         store
             .delete(&key)
             .await
-            .map_err(|error| CoreError::Store(error.to_string()))?;
+            .map_err(|error| CoreError::store(&key, &error))?;
         report.reaped_abandoned_objects += 1;
     }
     Ok(report)
@@ -424,7 +424,7 @@ async fn delete_if_aged<S: ObjectStore + ?Sized>(
     let Some(metadata) = store
         .head(key)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?
+        .map_err(|error| CoreError::store(key, &error))?
     else {
         // Already gone; nothing to count.
         return Ok(false);
@@ -441,7 +441,7 @@ async fn delete_if_aged<S: ObjectStore + ?Sized>(
     store
         .delete(key)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?;
+        .map_err(|error| CoreError::store(key, &error))?;
     Ok(true)
 }
 
@@ -465,7 +465,7 @@ async fn list_prefix<S: ObjectStore + ?Sized>(
     store
         .list_prefix(prefix)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))
+        .map_err(|error| CoreError::store(prefix, &error))
 }
 
 fn manifest_id_of(key: &str) -> Option<ManifestId> {

--- a/crates/loonfs-core/src/inspection.rs
+++ b/crates/loonfs-core/src/inspection.rs
@@ -23,7 +23,7 @@ pub async fn visible_tree_hash<S: ObjectStore + ?Sized>(
 ) -> Result<String, CoreError> {
     let entries = list_visible_paths(store, namespace_id).await?;
     let bytes = serde_json::to_vec(&entries).map_err(|error| {
-        CoreError::Store(format!("failed to encode visible tree hash: {error}"))
+        CoreError::Internal(format!("failed to encode visible tree hash: {error}"))
     })?;
     let digest = Sha256::digest(bytes);
     Ok(format!("sha256:{digest:x}"))

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -50,7 +50,7 @@ mod wal;
 
 pub mod cache {
     pub use crate::checkpoint::{
-        ManifestLoadError, ManifestLoadErrorKind, MetadataLsmPolicy, MetadataTableCache,
+        ManifestLoadError, ManifestLoadFailureClass, MetadataLsmPolicy, MetadataTableCache,
         MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
         WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
     };

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -4,8 +4,8 @@ use super::row_decode::{
     tombstone_from_manifest_row, unbind_matches_binding,
 };
 use crate::checkpoint::{string_prefix_upper_bound, ManifestLoadError, VerifiedMetadataTables};
-use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
+use crate::error::{CoreError, Result};
 use crate::metadata::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneRecord,
@@ -21,7 +21,7 @@ pub(super) fn manifest_error_to_core(error: ManifestLoadError) -> CoreError {
 pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
-) -> Result<Option<InodeRecord>, CoreError> {
+) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
         .get(MetadataTableFamily::Inodes, &key)
@@ -33,7 +33,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     parent_inode_id: InodeId,
-) -> Result<Vec<DirentryBindRecord>, CoreError> {
+) -> Result<Vec<DirentryBindRecord>> {
     let prefix = format!("direntry-{:020}-", parent_inode_id.0);
     Ok(tables
         .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
@@ -55,7 +55,7 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
     start_after_name_key: Option<&str>,
     start_after_row_key: Option<&str>,
     limit: usize,
-) -> Result<Vec<ManifestDirentryBindCandidate>, CoreError> {
+) -> Result<Vec<ManifestDirentryBindCandidate>> {
     let parent_prefix = format!("direntry-{:020}-", parent_inode_id.0);
     let lower_bound = if let Some(row_key) = start_after_row_key {
         resume_after_row_key(row_key)
@@ -85,7 +85,7 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     parent_inode_id: InodeId,
     name_key: &str,
-) -> Result<Vec<DirentryBindRecord>, CoreError> {
+) -> Result<Vec<DirentryBindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(name_key);
     let prefix = format!("direntry-{:020}-{encoded_name_key}-", parent_inode_id.0);
     Ok(tables
@@ -100,7 +100,7 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
 pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     child_inode_id: InodeId,
-) -> Result<Vec<DirentryBindRecord>, CoreError> {
+) -> Result<Vec<DirentryBindRecord>> {
     let prefix = format!("direntry-child-{:020}-", child_inode_id.0);
     Ok(tables
         .scan_prefix(MetadataTableFamily::DirentryChildBinds, &prefix)
@@ -114,7 +114,7 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
 pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     direntry: &DirentryBindRecord,
-) -> Result<Vec<DirentryUnbindRecord>, CoreError> {
+) -> Result<Vec<DirentryUnbindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(&direntry.name_key);
     let prefix = format!(
         "direntry-unbind-{:020}-{}-{:020}-{:010}-",
@@ -157,7 +157,7 @@ impl RevisionPagePosition {
 pub(super) async fn latest_revision_for_inode<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
-) -> Result<Option<RevisionRecord>, CoreError> {
+) -> Result<Option<RevisionRecord>> {
     Ok(revisions_for_inode_page_desc(tables, inode_id, None, 1)
         .await?
         .into_iter()
@@ -168,7 +168,7 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
     revision_no: RevisionNo,
-) -> Result<Option<RevisionRecord>, CoreError> {
+) -> Result<Option<RevisionRecord>> {
     let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
     Ok(tables
         .scan_range_page(
@@ -189,7 +189,7 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     start_after: Option<RevisionPagePosition>,
     limit: usize,
-) -> Result<Vec<RevisionRecord>, CoreError> {
+) -> Result<Vec<RevisionRecord>> {
     if limit == 0 {
         return Ok(Vec::new());
     }
@@ -214,7 +214,7 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
 pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     root_inode_id: InodeId,
-) -> Result<Vec<SubtreeTombstoneRecord>, CoreError> {
+) -> Result<Vec<SubtreeTombstoneRecord>> {
     let prefix = format!("tombstone-{:020}-", root_inode_id.0);
     Ok(tables
         .scan_prefix(MetadataTableFamily::Tombstones, &prefix)
@@ -228,7 +228,7 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
 pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     commit_id: &CommitId,
-) -> Result<Option<CommitReceiptRecord>, CoreError> {
+) -> Result<Option<CommitReceiptRecord>> {
     let encoded_commit_id = hex_encode_row_key_component(commit_id.as_str());
     let prefix = format!("commit-receipt-{encoded_commit_id}-");
     Ok(tables

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -410,7 +410,7 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         let inode = self
             .inode_at_seq(inode_id)
             .await?
-            .ok_or_else(|| CoreError::MissingPath(inode_id.to_string()))?;
+            .ok_or_else(|| CoreError::PathNotFound(inode_id.to_string()))?;
         if inode.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
                 path: inode_id.to_string(),
@@ -419,7 +419,7 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         }
         self.revision_at_head(inode_id, revision_no)
             .await?
-            .ok_or(CoreError::MissingRevision {
+            .ok_or(CoreError::RevisionNotFound {
                 inode_id,
                 revision_no,
             })

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -24,6 +24,8 @@ use loonfs_objectstore::keys::{
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
+// Descriptor and Head both wrap ControlObjectLoadError; conversion stays
+// explicit so `?` cannot pick a variant silently.
 #[derive(Debug, Error)]
 pub enum BootstrapNamespaceError {
     #[error(transparent)]
@@ -84,10 +86,14 @@ impl From<NamespaceInitializationError> for BootstrapNamespaceError {
             NamespaceInitializationError::InvalidNamespaceId(error) => {
                 Self::InvalidNamespaceId(error)
             }
-            NamespaceInitializationError::InspectNamespaceDescriptor(message) => {
-                Self::DescriptorWrite(message)
-            }
-            NamespaceInitializationError::InspectNamespaceHead(message) => Self::HeadWrite(message),
+            NamespaceInitializationError::InspectNamespaceDescriptor {
+                object_key,
+                message,
+            } => Self::DescriptorWrite(format!("failed to inspect `{object_key}`: {message}")),
+            NamespaceInitializationError::InspectNamespaceHead {
+                object_key,
+                message,
+            } => Self::HeadWrite(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::LoadNamespaceDescriptor(error)
             | NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
                 Self::Descriptor(error)
@@ -262,7 +268,9 @@ async fn create_new_content_store<S: ObjectStore + ?Sized>(
         let key = content_store_descriptor(content_store_id.as_str());
         match store.put_if_absent(&key, Bytes::from(bytes)).await {
             Ok(_) => return Ok(content_store_id),
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
+            ) => continue,
             Err(err) => return Err(BootstrapNamespaceError::ContentStoreWrite(err.to_string())),
         }
     }

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -7,6 +7,8 @@ use loonfs_objectstore::keys::{namespace_config, wal_head};
 use loonfs_objectstore::ObjectStore;
 use thiserror::Error;
 
+// Both variants share ControlObjectLoadError; conversion stays explicit so
+// `?` cannot pick a variant silently.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum NamespaceCatalogLoadError {
     #[error("failed to load namespace descriptor: {0}")]
@@ -28,14 +30,16 @@ pub(crate) enum NamespaceInitializationState {
     Complete,
 }
 
+// The two Load* variants share ControlObjectLoadError; conversion stays
+// explicit so `?` cannot pick a variant silently.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum NamespaceInitializationError {
     #[error(transparent)]
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
-    #[error("failed to inspect namespace descriptor object: {0}")]
-    InspectNamespaceDescriptor(String),
-    #[error("failed to inspect namespace head object: {0}")]
-    InspectNamespaceHead(String),
+    #[error("failed to inspect namespace descriptor object `{object_key}`: {message}")]
+    InspectNamespaceDescriptor { object_key: String, message: String },
+    #[error("failed to inspect namespace head object `{object_key}`: {message}")]
+    InspectNamespaceHead { object_key: String, message: String },
     #[error("failed to load namespace descriptor: {0}")]
     LoadNamespaceDescriptor(ControlObjectLoadError),
     #[error("failed to load content store descriptor: {0}")]
@@ -89,12 +93,20 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
     let descriptor_exists = store
         .head(&descriptor_key)
         .await
-        .map_err(|err| NamespaceInitializationError::InspectNamespaceDescriptor(err.to_string()))?
+        .map_err(
+            |err| NamespaceInitializationError::InspectNamespaceDescriptor {
+                object_key: descriptor_key.clone(),
+                message: err.message(),
+            },
+        )?
         .is_some();
     let head_exists = store
         .head(&head_key)
         .await
-        .map_err(|err| NamespaceInitializationError::InspectNamespaceHead(err.to_string()))?
+        .map_err(|err| NamespaceInitializationError::InspectNamespaceHead {
+            object_key: head_key.clone(),
+            message: err.message(),
+        })?
         .is_some();
 
     match (descriptor_exists, head_exists) {

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -131,8 +131,8 @@ pub enum ControlObjectLoadError {
     },
     #[error("control object codec error for `{object_key}`: {message}")]
     Codec { object_key: String, message: String },
-    #[error("control object store error: {0}")]
-    Store(String),
+    #[error("control object store error for `{object_key}`: {message}")]
+    Store { object_key: String, message: String },
 }
 
 pub(crate) async fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
@@ -398,9 +398,13 @@ fn control_identity(
     object_key: &str,
     metadata: &ObjectMetadata,
 ) -> Result<ControlObjectIdentity, ControlObjectLoadError> {
-    let etag = metadata.etag.clone().ok_or_else(|| {
-        ControlObjectLoadError::Store(format!("missing control object etag for `{object_key}`"))
-    })?;
+    let etag = metadata
+        .etag
+        .clone()
+        .ok_or_else(|| ControlObjectLoadError::Store {
+            object_key: object_key.to_owned(),
+            message: "missing control object etag".to_owned(),
+        })?;
     Ok(ControlObjectIdentity { etag })
 }
 
@@ -411,7 +415,7 @@ async fn read_control_object_bytes<S: ObjectStore + ?Sized>(
     let body = store
         .get_with_metadata(object_key)
         .await
-        .map_err(map_store_load_error)?
+        .map_err(|err| map_store_load_error(object_key, err))?
         .ok_or_else(|| ControlObjectLoadError::MissingObject {
             object_key: object_key.to_owned(),
         })?;
@@ -463,6 +467,9 @@ pub(crate) fn map_control_codec_error(
     }
 }
 
-fn map_store_load_error(err: ObjectStoreError) -> ControlObjectLoadError {
-    ControlObjectLoadError::Store(err.to_string())
+fn map_store_load_error(object_key: &str, err: ObjectStoreError) -> ControlObjectLoadError {
+    ControlObjectLoadError::Store {
+        object_key: object_key.to_owned(),
+        message: err.message(),
+    }
 }

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -94,9 +94,9 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             &context.writer_version,
             deleted_head,
         )
-        .map_err(|err| CoreError::Store(err.to_string()))?;
-        let encoded =
-            encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
+        let encoded = encode_control_object(&envelope)
+            .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?;
 
         let swap = store
             .put(
@@ -116,14 +116,16 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             }
             // The head moved (a commit, fence takeover, or another deleter
             // landed first). Reload and re-evaluate.
-            Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => continue,
+            Err(
+                ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
+            ) => continue,
             // Outcome unobserved; the reload at the top of the loop resolves
             // it, because the target state is terminal.
-            Err(ObjectStoreError::Transport(_)) => {
+            Err(ObjectStoreError::Transport { .. }) => {
                 attempted_swap = true;
                 continue;
             }
-            Err(other) => return Err(CoreError::Store(other.to_string())),
+            Err(other) => return Err(CoreError::store(&loaded.object_key, &other)),
         }
     }
 

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -4,8 +4,8 @@ use crate::checkpoint::{
     write_namespace_manifest,
 };
 use crate::context::MutationContext;
-use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
+use crate::error::{CoreError, Result};
 use crate::namespace::catalog::{
     load_namespace_descriptor, namespace_initialization_state, NamespaceInitializationError,
     NamespaceInitializationState,
@@ -33,7 +33,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     source_namespace_id: &NamespaceId,
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
-) -> Result<NamespaceSummary, CoreError> {
+) -> Result<NamespaceSummary> {
     match namespace_initialization_state(store, new_namespace_id)
         .await
         .map_err(map_namespace_initialization_error_to_core)?
@@ -122,13 +122,13 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             name_policy: source_config.name_policy,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build fork control envelope: {err}")))?;
     let head = HeadStateEnvelope::from_state(
         ControlObjectKind::WalHead,
         &context.writer_version,
         initial_head,
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build fork control envelope: {err}")))?;
     let head_key = wal_head(new_namespace_id.as_str());
     let descriptor_key = namespace_config(new_namespace_id.as_str());
     let target_manifest = NamespaceManifestEnvelope::from_payload(
@@ -141,7 +141,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             &source_record,
         ),
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build fork control envelope: {err}")))?;
     let gc_pin_envelope = NamespaceGcPinStateEnvelope::from_state(
         ControlObjectKind::NamespaceGcPinState,
         &context.writer_version,
@@ -157,7 +157,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             created_at_ms: context.now_ms,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build fork control envelope: {err}")))?;
     let gc_pin_key = pin(
         source_namespace_id.as_str(),
         gc_pin_envelope.state.pin_id.as_str(),
@@ -184,12 +184,14 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             updated_at_ms: context.now_ms,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build metadata root envelope: {err}")))?;
     put_target_namespace_control_object(
         store,
         new_namespace_id,
         &metadata_root(new_namespace_id.as_str()),
-        &encode_control_object(&target_root).map_err(|err| CoreError::Store(err.to_string()))?,
+        &encode_control_object(&target_root).map_err(|err| {
+            CoreError::Internal(format!("failed to encode metadata root object: {err}"))
+        })?,
     )
     .await?;
     let target_floor = WalFloorEnvelope::from_state(
@@ -207,27 +209,33 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             updated_at_ms: context.now_ms,
         },
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build wal floor envelope: {err}")))?;
     put_target_namespace_control_object(
         store,
         new_namespace_id,
         &loonfs_objectstore::keys::wal_floor(new_namespace_id.as_str()),
-        &encode_control_object(&target_floor).map_err(|err| CoreError::Store(err.to_string()))?,
+        &encode_control_object(&target_floor).map_err(|err| {
+            CoreError::Internal(format!("failed to encode wal floor object: {err}"))
+        })?,
     )
     .await?;
     put_target_namespace_control_object(
         store,
         new_namespace_id,
         &head_key,
-        &encode_control_object(&head).map_err(|err| CoreError::Store(err.to_string()))?,
+        &encode_control_object(&head)
+            .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?,
     )
     .await?;
     put_target_namespace_control_object(
         store,
         new_namespace_id,
         &descriptor_key,
-        &encode_control_object(&namespace_descriptor_envelope)
-            .map_err(|err| CoreError::Store(err.to_string()))?,
+        &encode_control_object(&namespace_descriptor_envelope).map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to encode namespace descriptor object: {err}"
+            ))
+        })?,
     )
     .await?;
 
@@ -276,14 +284,15 @@ async fn write_source_gc_pin<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     expected: &NamespaceGcPinStateEnvelope,
-) -> Result<(), CoreError> {
-    let bytes = encode_control_object(expected).map_err(|err| CoreError::Store(err.to_string()))?;
+) -> Result<()> {
+    let bytes = encode_control_object(expected)
+        .map_err(|err| CoreError::Internal(format!("failed to encode GC pin object: {err}")))?;
     match store.put_if_absent(object_key, Bytes::from(bytes)).await {
         Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
             verify_existing_gc_pin(store, object_key, expected).await
         }
-        Err(err) => Err(CoreError::Store(err.to_string())),
+        Err(err) => Err(CoreError::store(object_key, &err)),
     }
 }
 
@@ -315,7 +324,7 @@ async fn verify_written_gc_pin<S: ObjectStore + ?Sized>(
     source_namespace_id: &NamespaceId,
     pin_key: &str,
     pin: &NamespaceGcPinState,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     let verified = match crate::checkpoint::read_checkpoint_record(
         store,
         source_namespace_id,
@@ -334,7 +343,7 @@ async fn verify_written_gc_pin<S: ObjectStore + ?Sized>(
     store
         .delete(pin_key)
         .await
-        .map_err(|error| CoreError::Store(error.to_string()))?;
+        .map_err(|error| CoreError::store(pin_key, &error))?;
     Err(CoreError::CheckpointUnavailable(format!(
         "fork pin `{}` failed verification against source checkpoint `{}`",
         pin.pin_id, pin.source_checkpoint_id
@@ -345,15 +354,16 @@ async fn verify_existing_gc_pin<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     expected: &NamespaceGcPinStateEnvelope,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     let Some(bytes) = store
         .get(object_key, None)
         .await
-        .map_err(|err| CoreError::Store(err.to_string()))?
+        .map_err(|err| CoreError::store(object_key, &err))?
     else {
-        return Err(CoreError::Store(format!(
-            "GC pin `{object_key}` write conflicted, but the existing object is missing"
-        )));
+        return Err(CoreError::Store {
+            object_key: object_key.to_owned(),
+            message: "GC pin write conflicted, but the existing object is missing".to_owned(),
+        });
     };
     let existing: NamespaceGcPinStateEnvelope =
         decode_control_object(&bytes, ControlObjectKind::NamespaceGcPinState).map_err(|err| {
@@ -384,13 +394,13 @@ async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     object_key: &str,
     bytes: &[u8],
-) -> Result<(), CoreError> {
+) -> Result<()> {
     match store
         .put_if_absent(object_key, Bytes::copy_from_slice(bytes))
         .await
     {
         Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed | ObjectStoreError::Conflict) => {
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
             match namespace_initialization_state(store, namespace_id)
                 .await
                 .map_err(map_namespace_initialization_error_to_core)?
@@ -403,12 +413,13 @@ async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
                         namespace_id: namespace_id.clone(),
                     })
                 }
-                NamespaceInitializationState::Absent => Err(CoreError::Store(format!(
-                    "target namespace control object `{object_key}` write failed, but namespace remains absent"
-                ))),
+                NamespaceInitializationState::Absent => Err(CoreError::Store {
+                    object_key: object_key.to_owned(),
+                    message: "control object write failed, but namespace remains absent".to_owned(),
+                }),
             }
         }
-        Err(err) => Err(CoreError::Store(err.to_string())),
+        Err(err) => Err(CoreError::store(object_key, &err)),
     }
 }
 
@@ -417,7 +428,7 @@ fn map_namespace_initialization_error_to_core(error: NamespaceInitializationErro
         NamespaceInitializationError::InvalidNamespaceId(error) => {
             CoreError::InvalidNamespaceId(error)
         }
-        other => CoreError::Store(BootstrapNamespaceError::from(other).to_string()),
+        other => CoreError::Internal(BootstrapNamespaceError::from(other).to_string()),
     }
 }
 

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -1,6 +1,6 @@
 use crate::checkpoint::load_namespace_manifest_envelope;
-use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
+use crate::error::{CoreError, Result};
 use crate::namespace::catalog::{
     namespace_initialization_state, NamespaceInitializationError, NamespaceInitializationState,
 };
@@ -42,7 +42,7 @@ pub struct NamespaceHeadEtagProbe {
 pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
-) -> Result<NamespaceHeadSummary, CoreError> {
+) -> Result<NamespaceHeadSummary> {
     match namespace_initialization_state(store, expected_namespace).await {
         Ok(NamespaceInitializationState::Complete) => {}
         Ok(NamespaceInitializationState::Absent) => {
@@ -111,11 +111,12 @@ async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     manifest_head_seq: ChangeSeq,
-) -> Result<u64, CoreError> {
+) -> Result<u64> {
+    let wal_prefix = wal_segment_prefix(namespace_id.as_str());
     let keys = store
-        .list_prefix(&wal_segment_prefix(namespace_id.as_str()))
+        .list_prefix(&wal_prefix)
         .await
-        .map_err(|error| CoreError::Store(format!("list WAL tail segments: {error}")))?;
+        .map_err(|error| CoreError::store(&wal_prefix, &error))?;
     let tail_segments = keys
         .iter()
         .filter_map(|key| wal_segment_id_from_key(key))
@@ -123,7 +124,7 @@ async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
         .filter(|start_seq| *start_seq > manifest_head_seq)
         .count();
     u64::try_from(tail_segments)
-        .map_err(|_| CoreError::Store("WAL tail segment count overflow".to_owned()))
+        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))
 }
 
 #[tracing::instrument(
@@ -136,7 +137,7 @@ async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
 pub async fn probe_namespace_head_etag<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace: &NamespaceId,
-) -> Result<NamespaceHeadEtagProbe, CoreError> {
+) -> Result<NamespaceHeadEtagProbe> {
     NamespaceId::parse(expected_namespace.as_str())?;
     let object_key = wal_head(expected_namespace.as_str());
     let metadata = store
@@ -144,7 +145,10 @@ pub async fn probe_namespace_head_etag<S: ObjectStore + ?Sized>(
         .await
         .map_err(|err| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
-                ControlObjectLoadError::Store(err.to_string()),
+                ControlObjectLoadError::Store {
+                    object_key: object_key.clone(),
+                    message: err.message(),
+                },
             ))
         })?
         .ok_or_else(|| {
@@ -175,9 +179,16 @@ fn map_namespace_initialization_error_to_core(error: NamespaceInitializationErro
                 error,
             ))
         }
-        NamespaceInitializationError::InspectNamespaceDescriptor(_)
-        | NamespaceInitializationError::InspectNamespaceHead(_) => {
-            CoreError::Store(error.to_string())
+        NamespaceInitializationError::InspectNamespaceDescriptor {
+            object_key,
+            message,
         }
+        | NamespaceInitializationError::InspectNamespaceHead {
+            object_key,
+            message,
+        } => CoreError::Store {
+            object_key,
+            message,
+        },
     }
 }

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -590,7 +590,9 @@ mod tests {
             if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
                 self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
                 self.inject_winner().await;
-                return Err(ObjectStoreError::PreconditionFailed);
+                return Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                });
             }
             self.inner.compare_and_swap(key, expected_etag, bytes).await
         }

--- a/crates/loonfs-core/src/path/helpers.rs
+++ b/crates/loonfs-core/src/path/helpers.rs
@@ -1,15 +1,15 @@
-use crate::error::CoreError;
+use crate::error::{CoreError, Result};
 use loonfs_api::{AbsolutePath, PathError};
 
-pub(crate) fn validate_path_for_mutation(absolute_path: &str) -> Result<(), CoreError> {
+pub(crate) fn validate_path_for_mutation(absolute_path: &str) -> Result<()> {
     parse_mutation_path(absolute_path).map(|_| ())
 }
 
-pub(crate) fn parse_absolute_path_for_core(absolute_path: &str) -> Result<AbsolutePath, CoreError> {
+pub(crate) fn parse_absolute_path_for_core(absolute_path: &str) -> Result<AbsolutePath> {
     AbsolutePath::parse(absolute_path).map_err(map_path_error_to_core)
 }
 
-pub(crate) fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath, CoreError> {
+pub(crate) fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
     let path = parse_absolute_path_for_core(absolute_path)?;
     if path.is_root() {
         return Err(CoreError::RootMutationForbidden);
@@ -21,7 +21,7 @@ pub(crate) fn map_path_error_to_core(error: PathError) -> CoreError {
     CoreError::InvalidPath(error.invalid_path_input().to_owned())
 }
 
-pub(crate) fn final_component(absolute_path: &AbsolutePath) -> Result<String, CoreError> {
+pub(crate) fn final_component(absolute_path: &AbsolutePath) -> Result<String> {
     absolute_path
         .final_component()
         .map(|component| component.as_str().to_owned())

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -1,11 +1,11 @@
-use crate::error::{CoreError, MetadataViewError};
+use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::ResolvedVisiblePath;
 use loonfs_api::{ChangeSeq, DirectoryPageCursor, InodeKind};
 
 pub(super) fn page_head_seq(
     current_head_seq: ChangeSeq,
     cursor: Option<&DirectoryPageCursor>,
-) -> Result<ChangeSeq, CoreError> {
+) -> Result<ChangeSeq> {
     let Some(cursor) = cursor else {
         return Ok(current_head_seq);
     };
@@ -22,7 +22,7 @@ pub(super) fn page_head_seq(
 pub(super) fn validate_directory_cursor(
     cursor: &DirectoryPageCursor,
     resolved: &ResolvedVisiblePath,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     if resolved.inode_kind != InodeKind::Dir {
         return Err(invalid_cursor(
             "directory cursor resolved to a non-directory path",

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -293,7 +293,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let content_ref = entry
             .content_ref
             .clone()
-            .ok_or_else(|| CoreError::MissingPath(absolute_path.to_owned()))?;
+            .ok_or_else(|| CoreError::PathNotFound(absolute_path.to_owned()))?;
         let read = read_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
         Ok(AuthoritativeFileBytes {
             entry,
@@ -373,7 +373,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .metadata_view()
             .inode_at_seq(inode_id)
             .await?
-            .ok_or_else(|| CoreError::MissingPath(inode_id.to_string()))?;
+            .ok_or_else(|| CoreError::PathNotFound(inode_id.to_string()))?;
         if inode.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
                 path: inode_id.to_string(),

--- a/crates/loonfs-core/src/path/write/content_write.rs
+++ b/crates/loonfs-core/src/path/write/content_write.rs
@@ -1,4 +1,4 @@
-use crate::error::CoreError;
+use crate::error::Result;
 use crate::path::helpers::validate_path_for_mutation;
 use crate::storage::content::store_bytes_as_content;
 use loonfs_api::{ContentRef, NamespaceId};
@@ -9,7 +9,7 @@ pub(super) async fn store_file_bytes_before_metadata_publish<S: ObjectStore + ?S
     namespace_id: &NamespaceId,
     absolute_path: &str,
     bytes: &[u8],
-) -> Result<ContentRef, CoreError> {
+) -> Result<ContentRef> {
     validate_path_for_mutation(absolute_path)?;
     let stored = store_bytes_as_content(store, namespace_id, bytes).await?;
     Ok(stored.content_ref)

--- a/crates/loonfs-core/src/path/write/executor.rs
+++ b/crates/loonfs-core/src/path/write/executor.rs
@@ -1,6 +1,6 @@
 use super::intent::PathMutationIntent;
 use crate::context::MutationContext;
-use crate::error::CoreError;
+use crate::error::Result;
 use crate::publisher::{DirectObjectStorePublisher, PublishOptions};
 use loonfs_api::{CommitId, MutationResult, NamespaceId};
 use loonfs_objectstore::ObjectStore;
@@ -14,7 +14,7 @@ pub(super) async fn submit_path_intent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<MutationResult, CoreError> {
+) -> Result<MutationResult> {
     DirectObjectStorePublisher::new(store)
         .submit_path_intent(namespace_id, intent, context, PublishOptions::default())
         .await

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -82,7 +82,7 @@ fn path_intent_fingerprint(
         intent: identity,
     })
     .map(PathIntentFingerprint::new_unchecked)
-    .map_err(|err| CoreError::Store(err.to_string()))
+    .map_err(|err| CoreError::Internal(format!("failed to fingerprint path intent: {err}")))
 }
 
 pub(crate) fn path_intent_fingerprint_for_path_intent(
@@ -154,7 +154,7 @@ fn normalized_path_for_fingerprint(absolute_path: &str) -> Result<String, CoreEr
 fn is_missing_visible_path(error: &CoreError) -> bool {
     matches!(
         error,
-        CoreError::MissingPath(_) | CoreError::VisiblePath(VisiblePathError::PathNotFound { .. })
+        CoreError::PathNotFound(_) | CoreError::VisiblePath(VisiblePathError::PathNotFound { .. })
     )
 }
 
@@ -241,9 +241,9 @@ async fn publish_binding_is_precondition<S: ObjectStore + ?Sized>(
         .metadata_state
         .current_parent_binding_for_child(resolved.inode_id)
         .await?
-        .ok_or_else(|| CoreError::MissingPath(resolved.absolute_path.clone()))?;
+        .ok_or_else(|| CoreError::PathNotFound(resolved.absolute_path.clone()))?;
     if binding.parent_inode_id != parent_inode_id {
-        return Err(CoreError::MissingPath(resolved.absolute_path.clone()));
+        return Err(CoreError::PathNotFound(resolved.absolute_path.clone()));
     }
     Ok(ApiCommitPrecondition::BindingIs {
         parent_inode_id,
@@ -391,7 +391,7 @@ async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
                 .metadata_state
                 .latest_revision_head(existing.inode_id)
                 .await?
-                .ok_or_else(|| CoreError::MissingPath(absolute_path.as_str().to_owned()))?;
+                .ok_or_else(|| CoreError::PathNotFound(absolute_path.as_str().to_owned()))?;
             preconditions.push(publish_binding_is_precondition(view, &existing).await?);
             ops.push(ApiCommitOp::ReplaceFile {
                 inode_id: existing.inode_id,
@@ -557,7 +557,7 @@ async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
         .metadata_state
         .latest_revision_head(source.inode_id)
         .await?
-        .ok_or_else(|| CoreError::MissingPath(from_path.as_str().to_owned()))?;
+        .ok_or_else(|| CoreError::PathNotFound(from_path.as_str().to_owned()))?;
 
     let target_parent = publish_resolve_parent_directory(view, &to_path).await?;
     let target_name = final_component(&to_path)?;
@@ -608,7 +608,7 @@ async fn plan_publish_restore_revision<S: ObjectStore + ?Sized>(
         .metadata_state
         .latest_revision_head(target.inode_id)
         .await?
-        .ok_or_else(|| CoreError::MissingPath(absolute_path.as_str().to_owned()))?;
+        .ok_or_else(|| CoreError::PathNotFound(absolute_path.as_str().to_owned()))?;
 
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
@@ -657,7 +657,7 @@ async fn publish_ensure_parent_directories<S: ObjectStore + ?Sized>(
                     .metadata_state
                     .visible_inode(child.child_inode_id)
                     .await?
-                    .ok_or_else(|| CoreError::MissingPath(component.as_str().to_owned()))?;
+                    .ok_or_else(|| CoreError::PathNotFound(component.as_str().to_owned()))?;
                 if inode.inode_kind != InodeKind::Dir {
                     return Err(CoreError::NonDirectoryPathComponent(
                         component.as_str().to_owned(),
@@ -714,9 +714,9 @@ fn binding_is_precondition(
     let binding = view
         .metadata_state
         .current_parent_binding_for_child(resolved.inode_id, view.head.seq)
-        .ok_or_else(|| CoreError::MissingPath(resolved.absolute_path.clone()))?;
+        .ok_or_else(|| CoreError::PathNotFound(resolved.absolute_path.clone()))?;
     if binding.parent_inode_id != parent_inode_id {
-        return Err(CoreError::MissingPath(resolved.absolute_path.clone()));
+        return Err(CoreError::PathNotFound(resolved.absolute_path.clone()));
     }
     Ok(ApiCommitPrecondition::BindingIs {
         parent_inode_id,

--- a/crates/loonfs-core/src/protocol.rs
+++ b/crates/loonfs-core/src/protocol.rs
@@ -14,7 +14,7 @@ use crate::context::MutationContext;
 use crate::control_update::{update_upload_session, UploadSessionUpdate};
 use crate::engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, MetadataViewError};
+use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::catalog::{
     load_namespace_catalog_entry, load_namespace_content_store_id, namespace_initialization_state,
@@ -59,7 +59,7 @@ const UPLOAD_SESSION_RETRY_LIMIT: usize = 8;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PublishBatchAgainstViewResult {
-    pub(crate) results: Vec<Result<ApiCommitResponse, CoreError>>,
+    pub(crate) results: Vec<Result<ApiCommitResponse>>,
     pub(crate) published_records: Vec<WalCommitPayload>,
     pub(crate) resulting_head: Option<HeadState>,
     pub(crate) resulting_head_etag: Option<String>,
@@ -67,7 +67,7 @@ pub(crate) struct PublishBatchAgainstViewResult {
 }
 
 impl PublishBatchAgainstViewResult {
-    fn new(results: Vec<Result<ApiCommitResponse, CoreError>>) -> Self {
+    fn new(results: Vec<Result<ApiCommitResponse>>) -> Self {
         Self {
             results,
             published_records: Vec::new(),
@@ -77,7 +77,7 @@ impl PublishBatchAgainstViewResult {
         }
     }
 
-    fn invalidate_projection(results: Vec<Result<ApiCommitResponse, CoreError>>) -> Self {
+    fn invalidate_projection(results: Vec<Result<ApiCommitResponse>>) -> Self {
         Self {
             results,
             published_records: Vec::new(),
@@ -88,7 +88,7 @@ impl PublishBatchAgainstViewResult {
     }
 
     fn published(
-        results: Vec<Result<ApiCommitResponse, CoreError>>,
+        results: Vec<Result<ApiCommitResponse>>,
         published_records: Vec<WalCommitPayload>,
         resulting_head: HeadState,
         resulting_head_etag: Option<String>,
@@ -130,7 +130,7 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
     async fn find_commit_receipt(
         &self,
         commit_id: &CommitId,
-    ) -> Result<Option<CommitReceiptRecord>, CoreError> {
+    ) -> Result<Option<CommitReceiptRecord>> {
         self.metadata_view().find_commit_receipt(commit_id).await
     }
 }
@@ -205,7 +205,7 @@ pub(crate) async fn begin_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     request: BeginUploadRequest,
     context: &MutationContext,
-) -> Result<BeginUploadResponse, CoreError> {
+) -> Result<BeginUploadResponse> {
     ensure_upload_namespace_available(store, namespace_id).await?;
     let mode = request.mode.unwrap_or_default();
     if mode == UploadMode::DirectPut {
@@ -234,7 +234,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     content_ref: ContentRef,
     context: &MutationContext,
-) -> Result<BeginDirectPutUploadTargetResponse, CoreError> {
+) -> Result<BeginDirectPutUploadTargetResponse> {
     ensure_upload_namespace_available(store, namespace_id).await?;
     ensure_direct_put_content_ref_supported(&content_ref)?;
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
@@ -258,7 +258,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     })
 }
 
-fn ensure_direct_put_content_ref_supported(content_ref: &ContentRef) -> Result<(), CoreError> {
+fn ensure_direct_put_content_ref_supported(content_ref: &ContentRef) -> Result<()> {
     if content_ref.kind != ContentRefKind::WholeFileV0 {
         return Err(CoreError::InvalidUploadContent(
             "direct_put only supports whole_file_v0 content refs".to_owned(),
@@ -273,7 +273,7 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
     mode: UploadMode,
     direct_put_content_ref: Option<ContentRef>,
     context: &MutationContext,
-) -> Result<UploadId, CoreError> {
+) -> Result<UploadId> {
     let upload_id = UploadId::generate();
     let state = UploadSessionState {
         namespace_id: namespace_id.clone(),
@@ -289,21 +289,24 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
         &context.writer_version,
         state,
     )
-    .map_err(|err| CoreError::Store(err.to_string()))?;
-    let encoded =
-        encode_control_object(&envelope).map_err(|err| CoreError::Store(err.to_string()))?;
+    .map_err(|err| {
+        CoreError::Internal(format!("failed to build upload session envelope: {err}"))
+    })?;
+    let encoded = encode_control_object(&envelope).map_err(|err| {
+        CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
+    })?;
     let object_key = upload_session(namespace_id.as_str(), upload_id.as_str());
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
         .await
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| CoreError::store(&object_key, &err))?;
     Ok(upload_id)
 }
 
 async fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     match namespace_initialization_state(store, namespace_id).await {
         Ok(NamespaceInitializationState::Complete) => {
             let descriptor = load_namespace_descriptor_control(store, namespace_id)
@@ -358,10 +361,17 @@ fn map_upload_namespace_initialization_error(error: NamespaceInitializationError
                 error,
             ))
         }
-        NamespaceInitializationError::InspectNamespaceDescriptor(_)
-        | NamespaceInitializationError::InspectNamespaceHead(_) => {
-            CoreError::Store(error.to_string())
+        NamespaceInitializationError::InspectNamespaceDescriptor {
+            object_key,
+            message,
         }
+        | NamespaceInitializationError::InspectNamespaceHead {
+            object_key,
+            message,
+        } => CoreError::Store {
+            object_key,
+            message,
+        },
     }
 }
 
@@ -371,11 +381,11 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     bytes: &[u8],
     context: &MutationContext,
-) -> Result<UploadContentResponse, CoreError> {
+) -> Result<UploadContentResponse> {
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_ref = ContentRef::whole_file_v0(bytes);
     let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| CoreError::Internal(format!("failed to derive content blob key: {err}")))?;
 
     update_upload_session(
         store,
@@ -433,7 +443,7 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     request: &CompleteUploadRequest,
     context: &MutationContext,
-) -> Result<CompleteUploadResponse, CoreError> {
+) -> Result<CompleteUploadResponse> {
     update_upload_session(
         store,
         namespace_id,
@@ -496,7 +506,7 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     state: &UploadSessionState,
     request: &CompleteUploadRequest,
-) -> Result<ContentRef, CoreError> {
+) -> Result<ContentRef> {
     if state.mode != UploadMode::DirectPut {
         return Err(CoreError::InvalidUploadContent(
             "upload content has not been staged".to_owned(),
@@ -528,7 +538,7 @@ pub(crate) async fn commit_operations<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     request: ApiCommitRequest,
     context: &MutationContext,
-) -> Result<ApiCommitResponse, CoreError> {
+) -> Result<ApiCommitResponse> {
     publish_namespace_mutations_batch(
         store,
         namespace_id,
@@ -537,7 +547,7 @@ pub(crate) async fn commit_operations<S: ObjectStore + ?Sized>(
     )
     .await
     .pop()
-    .unwrap_or_else(|| Err(CoreError::Store("empty commit batch".to_owned())))
+    .unwrap_or_else(|| Err(CoreError::Internal("empty commit batch".to_owned())))
 }
 
 pub(crate) async fn commit_operations_batch<S: ObjectStore + ?Sized>(
@@ -545,7 +555,7 @@ pub(crate) async fn commit_operations_batch<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     requests: Vec<ApiCommitRequest>,
     context: &MutationContext,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse>> {
     publish_namespace_mutations_batch(
         store,
         namespace_id,
@@ -563,7 +573,7 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse>> {
     commit_namespace_mutations_batch(store, namespace_id, candidates, context).await
 }
 
@@ -572,7 +582,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse>> {
     if candidates.is_empty() {
         return Vec::new();
     }
@@ -638,7 +648,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     acquired_writer: Option<AcquiredWriter>,
     cached_projection: Option<&PublishTailProjection>,
     options: &PublishTailOptions,
-) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection), CoreError> {
+) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection)> {
     let catalog_entry = load_namespace_catalog_entry(store, namespace_id)
         .await
         .map_err(|error| CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)))?;
@@ -726,7 +736,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
 fn ensure_publish_head_matches_acquired_writer(
     head: &HeadState,
     acquired_writer: &AcquiredWriter,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     if head.writer_epoch != acquired_writer.writer_epoch {
         let winner = head
             .writer
@@ -750,7 +760,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     manifest_id: ManifestId,
     manifest_head: &HeadState,
     manifest_payload_checksum: String,
-) -> Result<PublishTailProjection, CoreError> {
+) -> Result<PublishTailProjection> {
     let wal_chain = load_validated_wal_chain(
         store,
         WalChainLoadRequest {
@@ -793,7 +803,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
 fn ensure_publish_reconstructed_head_matches(
     current_head: &HeadState,
     reconstructed: &HeadState,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     if current_head.namespace_id != reconstructed.namespace_id
         || current_head.seq != reconstructed.seq
         || current_head.head_commit_id != reconstructed.head_commit_id
@@ -815,14 +825,17 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     loaded_head_etag: &str,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     let object_key = wal_head(namespace_id.as_str());
     let metadata = store
         .head(&object_key)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
-                ControlObjectLoadError::Store(error.to_string()),
+                ControlObjectLoadError::Store {
+                    object_key: object_key.clone(),
+                    message: error.message(),
+                },
             ))
         })?
         .ok_or_else(|| {
@@ -874,14 +887,14 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
         return PublishBatchAgainstViewResult::new(
             (0..candidates.len())
                 .map(|_| {
-                    Err(CoreError::Store(
+                    Err(CoreError::Internal(
                         "publish view namespace mismatch".to_owned(),
                     ))
                 })
                 .collect(),
         );
     }
-    let mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>> =
+    let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> =
         (0..candidates.len()).map(|_| None).collect();
     let mut session = PublishPlanningSession::new(&view.head);
     let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
@@ -967,7 +980,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 ) {
                     Ok(value) => value,
                     Err(error) => {
-                        outcomes[index] = Some(Err(CoreError::Store(format!(
+                        outcomes[index] = Some(Err(CoreError::Internal(format!(
                             "commit preparation failed: {error}"
                         ))));
                         continue;
@@ -1032,7 +1045,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
         result = tracing::field::Empty
     );
     let put_started_ms = timer.monotonic_now_ms();
-    let wal_result: Result<_, CoreError> = {
+    let wal_result: Result<_> = {
         let _span = wal_span.enter();
         match prepare_wal_segment(
             namespace_id.clone(),
@@ -1049,9 +1062,12 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 .await
             {
                 Ok(_) => Ok(wal),
-                Err(error) => Err(CoreError::WalWrite(error.to_string())),
+                Err(error) => Err(CoreError::WalWrite {
+                    object_key: wal.object_key.clone(),
+                    message: error.message(),
+                }),
             },
-            Err(error) => Err(CoreError::Store(format!("wal build failed: {error}"))),
+            Err(error) => Err(CoreError::Internal(format!("wal build failed: {error}"))),
         }
     };
     wal_span.record("result", if wal_result.is_ok() { "ok" } else { "error" });
@@ -1076,7 +1092,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     let head_publish = match head_publish {
         Ok(value) => value,
         Err(error) => {
-            let error = CoreError::Store(format!("head publish preparation failed: {error}"));
+            let error = CoreError::Internal(format!("head publish preparation failed: {error}"));
             fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, &accepted, &error);
             return PublishBatchAgainstViewResult::invalidate_projection(
                 finish_batch_outcomes_with_aliases(outcomes, &aliases),
@@ -1149,7 +1165,7 @@ async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     session: &PublishPlanningSession,
     candidate: &NamespaceMutationCandidate,
     index: usize,
-    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    outcomes: &mut [Option<Result<ApiCommitResponse>>],
     in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
 ) -> Option<CandidateCoreRequest> {
@@ -1189,7 +1205,9 @@ async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             let semantic_identity = match core_commit_fingerprint(&request) {
                 Ok(value) => value,
                 Err(error) => {
-                    outcomes[index] = Some(Err(CoreError::Store(error.to_string())));
+                    outcomes[index] = Some(Err(CoreError::Internal(format!(
+                        "failed to fingerprint commit request: {error}"
+                    ))));
                     return None;
                 }
             };
@@ -1283,7 +1301,7 @@ async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     }
 }
 
-fn validate_commit_id(commit_id: &CommitId) -> Result<(), CoreError> {
+fn validate_commit_id(commit_id: &CommitId) -> Result<()> {
     CommitId::parse(commit_id.as_str())
         .map(|_| ())
         .map_err(CoreError::InvalidCommitId)
@@ -1293,13 +1311,13 @@ fn validate_commit_id(commit_id: &CommitId) -> Result<(), CoreError> {
 async fn record_primary_request_or_complete_idempotent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     view: &PublishMetadataView<'_, S>,
-    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    outcomes: &mut [Option<Result<ApiCommitResponse>>],
     in_batch_requests: &mut HashMap<CommitId, InBatchRequest>,
     aliases: &mut Vec<(usize, usize)>,
     index: usize,
     commit_id: &CommitId,
     semantic_identity: &SemanticMutationIdentity,
-) -> Result<bool, CoreError> {
+) -> Result<bool> {
     if let Some(existing) = view.find_commit_receipt(commit_id).await? {
         outcomes[index] = Some(
             if existing.semantic_commit_fingerprint != semantic_identity.as_str() {
@@ -1333,7 +1351,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     after_seq: ChangeSeq,
     limit: EffectiveLimit,
-) -> Result<ChangesResponse, CoreError> {
+) -> Result<ChangesResponse> {
     load_namespace_catalog_entry(store, namespace_id).await?;
     let head = load_namespace_head_control(store, namespace_id)
         .await
@@ -1398,7 +1416,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
                         .deltas
                         .iter()
                         .map(commit_delta_from_wal)
-                        .collect::<Result<Vec<_>, _>>()?,
+                        .collect::<std::result::Result<Vec<_>, _>>()?,
                 });
                 if changes.len() == limit.as_usize() {
                     through_seq = seq;
@@ -1420,7 +1438,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     })
 }
 
-fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta, CoreError> {
+fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta> {
     let semantic_op_index = delta.semantic_op_index;
     Ok(match &delta.delta {
         WalDelta::CreateInode {
@@ -1511,7 +1529,7 @@ async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     resolved_restore_content_refs: &[Option<ContentRef>],
     admissions: CommitContentAdmissions<'_>,
     content_validation: &mut ContentValidationTracker,
-) -> Result<(), CoreError> {
+) -> Result<()> {
     let mut content_refs = Vec::new();
     for (index, op) in request.ops.iter().enumerate() {
         match op {
@@ -1580,7 +1598,7 @@ fn commit_response_from_commit_receipt(
 /// commit receipts and stand. Alias slots stay unfilled here and inherit
 /// their primary's final outcome.
 fn fail_outcomes_contingent_on_unpublished_batch(
-    outcomes: &mut [Option<Result<ApiCommitResponse, CoreError>>],
+    outcomes: &mut [Option<Result<ApiCommitResponse>>],
     accepted: &[(usize, MaterializedCommit)],
     error: &CoreError,
 ) {
@@ -1598,20 +1616,24 @@ fn fail_outcomes_contingent_on_unpublished_batch(
 }
 
 fn finish_batch_outcomes_with_aliases(
-    mut outcomes: Vec<Option<Result<ApiCommitResponse, CoreError>>>,
+    mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
     aliases: &[(usize, usize)],
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse>> {
     for (alias_index, primary_index) in aliases {
         let primary_outcome = outcomes
             .get(*primary_index)
             .and_then(Clone::clone)
-            .unwrap_or_else(|| Err(CoreError::Store("missing primary batch outcome".to_owned())));
+            .unwrap_or_else(|| {
+                Err(CoreError::Internal(
+                    "missing primary batch outcome".to_owned(),
+                ))
+            });
         outcomes[*alias_index] = Some(primary_outcome);
     }
     outcomes
         .into_iter()
         .map(|outcome| {
-            outcome.unwrap_or_else(|| Err(CoreError::Store("missing batch outcome".to_owned())))
+            outcome.unwrap_or_else(|| Err(CoreError::Internal("missing batch outcome".to_owned())))
         })
         .collect()
 }

--- a/crates/loonfs-core/src/publisher.rs
+++ b/crates/loonfs-core/src/publisher.rs
@@ -1,7 +1,7 @@
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
-use crate::error::{CoreError, ErrorCode, MetadataViewError};
+use crate::error::{CoreError, ErrorCode, MetadataViewError, Result};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::planner::plan_path_mutation_against_publish_view;
 use crate::path::write::{
@@ -41,11 +41,13 @@ impl NamespaceMutationCandidate {
     pub fn semantic_identity(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<SemanticMutationIdentity, CoreError> {
+    ) -> Result<SemanticMutationIdentity> {
         match self {
             Self::Commit(request) => core_commit_fingerprint_for_v0_request(namespace_id, request)
                 .map(SemanticMutationIdentity::CoreCommit)
-                .map_err(|err| CoreError::Store(err.to_string())),
+                .map_err(|err| {
+                    CoreError::Internal(format!("failed to fingerprint commit request: {err}"))
+                }),
             Self::Path(intent) | Self::PathWithContentAdmission { intent, .. } => {
                 path_intent_fingerprint_for_path_intent(namespace_id, intent)
                     .map(SemanticMutationIdentity::PathIntent)
@@ -83,7 +85,7 @@ pub(crate) const WAL_TAIL_BACKPRESSURE_SEGMENTS: u64 = 128;
 
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
-    pub results: Vec<Result<ApiCommitResponse, CoreError>>,
+    pub results: Vec<Result<ApiCommitResponse>>,
     /// WAL tail length observed by this publish, for opportunistic
     /// maintenance scheduling. Zero when no projection was loaded.
     pub wal_tail_segments: u64,
@@ -294,7 +296,7 @@ impl NamespaceCommitEngine {
     }
 }
 
-fn repeated_error(count: usize, error: CoreError) -> Vec<Result<ApiCommitResponse, CoreError>> {
+fn repeated_error(count: usize, error: CoreError) -> Vec<Result<ApiCommitResponse>> {
     (0..count).map(|_| Err(error.clone())).collect()
 }
 
@@ -311,7 +313,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         &self,
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
-    ) -> Result<PlannedPathMutation, CoreError> {
+    ) -> Result<PlannedPathMutation> {
         let (view, _projection) = load_publish_metadata_view(
             self.store,
             namespace_id,
@@ -338,7 +340,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         intent: PathMutationIntent,
         context: &MutationContext,
         options: PublishOptions,
-    ) -> Result<MutationResult, CoreError> {
+    ) -> Result<MutationResult> {
         let attempts = options.stale_head_retry_limit.max(1);
         let mut last_error = None;
 
@@ -350,9 +352,9 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
                 context,
             )
             .await;
-            let result = results
-                .pop()
-                .unwrap_or_else(|| Err(CoreError::Store("empty path mutation batch".to_owned())));
+            let result = results.pop().unwrap_or_else(|| {
+                Err(CoreError::Internal("empty path mutation batch".to_owned()))
+            });
             match result {
                 Ok(response) => {
                     return Ok(MutationResult {
@@ -368,7 +370,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         }
 
         Err(last_error.unwrap_or_else(|| {
-            CoreError::Store("path mutation stale-head retry exhausted".to_owned())
+            CoreError::Internal("path mutation stale-head retry exhausted".to_owned())
         }))
     }
 
@@ -377,7 +379,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         namespace_id: &NamespaceId,
         request: ApiCommitRequest,
         context: &MutationContext,
-    ) -> Result<ApiCommitResponse, CoreError> {
+    ) -> Result<ApiCommitResponse> {
         crate::protocol::commit_operations(self.store, namespace_id, request, context).await
     }
 
@@ -386,7 +388,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
         namespace_id: &NamespaceId,
         requests: Vec<ApiCommitRequest>,
         context: &MutationContext,
-    ) -> Vec<Result<ApiCommitResponse, CoreError>> {
+    ) -> Vec<Result<ApiCommitResponse>> {
         crate::protocol::commit_operations_batch(self.store, namespace_id, requests, context).await
     }
 }
@@ -396,7 +398,7 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-) -> Vec<Result<ApiCommitResponse, CoreError>> {
+) -> Vec<Result<ApiCommitResponse>> {
     let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
     engine
         .publish_batch(store, candidates, context)

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -83,8 +83,8 @@ pub enum DurableContentValidationError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub(crate) enum ImmutableObjectWriteError {
-    #[error("{0}")]
-    Store(String),
+    #[error("failed to write immutable object `{object_key}`: {message}")]
+    Store { object_key: String, message: String },
 }
 
 pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
@@ -183,7 +183,7 @@ async fn validate_content_metadata<S: ObjectStore + ?Sized>(
         Err(err) => {
             return Err(DurableContentValidationError::Store {
                 object_key: object_key.to_owned(),
-                message: err.to_string(),
+                message: err.message(),
             })
         }
     };
@@ -237,7 +237,7 @@ pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_ref = ContentRef::whole_file_v0(bytes);
     let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
-        .map_err(|err| CoreError::Store(err.to_string()))?;
+        .map_err(|err| CoreError::Internal(format!("failed to derive content blob key: {err}")))?;
     write_immutable_object(store, &object_key, bytes).await?;
 
     Ok(StoredContent {
@@ -259,15 +259,19 @@ pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
         .await
     {
         Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed) => {
+        Err(ObjectStoreError::PreconditionFailed { .. }) => {
             if existing_object_matches_expected_bytes(store, object_key, expected_bytes).await? {
                 return Ok(());
             }
-            Err(ImmutableObjectWriteError::Store(format!(
-                "immutable object `{object_key}` already exists with different bytes"
-            )))
+            Err(ImmutableObjectWriteError::Store {
+                object_key: object_key.to_owned(),
+                message: "object already exists with different bytes".to_owned(),
+            })
         }
-        Err(err) => Err(ImmutableObjectWriteError::Store(err.to_string())),
+        Err(err) => Err(ImmutableObjectWriteError::Store {
+            object_key: object_key.to_owned(),
+            message: err.message(),
+        }),
     }
 }
 
@@ -278,11 +282,12 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
 ) -> Result<bool, ImmutableObjectWriteError> {
     let expected_size = expected_bytes.len() as u64;
     let expected_digest = sha256_digest(expected_bytes);
-    if let Some(metadata) = store
-        .head_with_checksum(object_key)
-        .await
-        .map_err(|err| ImmutableObjectWriteError::Store(err.to_string()))?
-    {
+    if let Some(metadata) = store.head_with_checksum(object_key).await.map_err(|err| {
+        ImmutableObjectWriteError::Store {
+            object_key: object_key.to_owned(),
+            message: err.message(),
+        }
+    })? {
         if metadata.size_bytes != expected_size {
             return Ok(false);
         }
@@ -294,11 +299,13 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
     let existing = store
         .get(object_key, None)
         .await
-        .map_err(|err| ImmutableObjectWriteError::Store(err.to_string()))?
-        .ok_or_else(|| {
-            ImmutableObjectWriteError::Store(format!(
-                "missing immutable object `{object_key}` after precondition failure"
-            ))
+        .map_err(|err| ImmutableObjectWriteError::Store {
+            object_key: object_key.to_owned(),
+            message: err.message(),
+        })?
+        .ok_or_else(|| ImmutableObjectWriteError::Store {
+            object_key: object_key.to_owned(),
+            message: "object is missing after precondition failure".to_owned(),
         })?;
     Ok(existing == expected_bytes)
 }
@@ -314,7 +321,7 @@ async fn load_required_object<S: ObjectStore + ?Sized>(
         }),
         Err(err) => Err(DurableContentValidationError::Store {
             object_key: object_key.to_owned(),
-            message: err.to_string(),
+            message: err.message(),
         }),
     }
 }

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -2718,10 +2718,10 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
         .expect_err("materialization-decided rejection");
     assert_eq!(materialization_rejection.code(), ErrorCode::PathNotFound);
     let accepted = failed[1].as_ref().expect_err("accepted candidate fails");
-    assert!(matches!(accepted, CoreError::WalWrite(_)));
+    assert!(matches!(accepted, CoreError::WalWrite { .. }));
     let speculative = failed[2].as_ref().expect_err("speculative rejection");
     assert!(
-        matches!(speculative, CoreError::WalWrite(_)),
+        matches!(speculative, CoreError::WalWrite { .. }),
         "rejection decided against unpublished in-batch state must take the \
          batch error, got {speculative:?}"
     );
@@ -4774,11 +4774,17 @@ impl InjectedCreateFailure {
         }
     }
 
-    fn error(&self) -> ObjectStoreError {
+    fn error(&self, attempted_key: &str) -> ObjectStoreError {
         match self {
-            Self::Transport { message } => ObjectStoreError::Transport((*message).to_owned()),
-            Self::Conflict { .. } => ObjectStoreError::Conflict,
-            Self::PreconditionFailed { .. } => ObjectStoreError::PreconditionFailed,
+            Self::Transport { message } => {
+                ObjectStoreError::transport(attempted_key, (*message).to_owned())
+            }
+            Self::Conflict { .. } => ObjectStoreError::Conflict {
+                object_key: attempted_key.to_owned(),
+            },
+            Self::PreconditionFailed { .. } => ObjectStoreError::PreconditionFailed {
+                object_key: attempted_key.to_owned(),
+            },
         }
     }
 }
@@ -4824,7 +4830,7 @@ impl ObjectStore for InjectCreateFailureStore {
                 self.failure
                     .apply_before_error(&self.inner, key, bytes.clone())
                     .await?;
-                return Err(self.failure.error());
+                return Err(self.failure.error(key));
             }
         }
 
@@ -4945,9 +4951,10 @@ impl ReplayReadGuardStore {
             .any(|prefix| key.starts_with(prefix))
         {
             self.guarded_gets.fetch_add(1, Ordering::SeqCst);
-            return Err(ObjectStoreError::Transport(format!(
-                "begin_upload unexpectedly read replay object `{key}`"
-            )));
+            return Err(ObjectStoreError::transport(
+                key,
+                "begin_upload unexpectedly read replay object",
+            ));
         }
         Ok(())
     }
@@ -5190,9 +5197,10 @@ impl ContentStoreAccessLimitStore {
 
         let previous = self.content_store_accesses.fetch_add(1, Ordering::SeqCst);
         if previous >= self.max_content_store_accesses {
-            return Err(ObjectStoreError::Transport(format!(
-                "unexpected content-store descriptor access: {key}",
-            )));
+            return Err(ObjectStoreError::transport(
+                key,
+                "unexpected content-store descriptor access",
+            ));
         }
         Ok(())
     }
@@ -5443,8 +5451,9 @@ impl ObjectStore for AckLostHeadCasStore {
             if should_inject {
                 // Apply the CAS, then lose the acknowledgment.
                 self.inner.put(key, bytes, mode).await?;
-                return Err(ObjectStoreError::Transport(
-                    "response lost after head compare-and-swap".to_owned(),
+                return Err(ObjectStoreError::transport(
+                    key,
+                    "response lost after head compare-and-swap",
                 ));
             }
         }
@@ -5531,7 +5540,9 @@ impl ObjectStore for StaleHeadAfterWalWriteStore {
                 if let Some(existing) = self.inner.get(key, None).await? {
                     self.inner.put_overwrite(key, existing).await?;
                 }
-                return Err(ObjectStoreError::PreconditionFailed);
+                return Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                });
             }
         }
         self.inner.put(key, bytes, mode).await
@@ -5555,13 +5566,15 @@ async fn head_cas_advances_seq(
     candidate_bytes: &[u8],
 ) -> Result<bool, ObjectStoreError> {
     let candidate: HeadStateEnvelope =
-        decode_control_object(candidate_bytes, ControlObjectKind::WalHead)
-            .map_err(|err| ObjectStoreError::Transport(format!("decode candidate head: {err}")))?;
+        decode_control_object(candidate_bytes, ControlObjectKind::WalHead).map_err(|err| {
+            ObjectStoreError::transport(key, format!("decode candidate head: {err}"))
+        })?;
     let Some(existing_bytes) = store.get(key, None).await? else {
         return Ok(true);
     };
     let existing: HeadStateEnvelope =
-        decode_control_object(&existing_bytes, ControlObjectKind::WalHead)
-            .map_err(|err| ObjectStoreError::Transport(format!("decode existing head: {err}")))?;
+        decode_control_object(&existing_bytes, ControlObjectKind::WalHead).map_err(|err| {
+            ObjectStoreError::transport(key, format!("decode existing head: {err}"))
+        })?;
     Ok(candidate.state.seq > existing.state.seq)
 }

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -29,17 +29,17 @@ pub struct AzureAbsStore {
 impl AzureAbsStore {
     pub fn new(config: AzureAbsStoreConfig) -> Result<Self, ObjectStoreError> {
         if config.account_name.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "account name must not be empty".to_owned(),
             ));
         }
         if config.container_name.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "container name must not be empty".to_owned(),
             ));
         }
         if config.access_key.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "access key must not be empty".to_owned(),
             ));
         }
@@ -51,7 +51,7 @@ impl AzureAbsStore {
         if let Some(endpoint_url) = config.endpoint_url {
             let endpoint_url = endpoint_url.trim();
             if endpoint_url.is_empty() {
-                return Err(ObjectStoreError::Transport(
+                return Err(ObjectStoreError::Configuration(
                     "endpoint url must not be empty".to_owned(),
                 ));
             }
@@ -64,7 +64,7 @@ impl AzureAbsStore {
 
         let provider = builder
             .build()
-            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
         let inner = ProviderObjectStore::new(
             Arc::new(provider),
             ProviderObjectStoreConfig {
@@ -151,7 +151,7 @@ mod tests {
         .expect_err("blank access key should be rejected");
 
         assert!(
-            matches!(error, ObjectStoreError::Transport(message) if message.contains("access key"))
+            matches!(error, ObjectStoreError::Configuration(message) if message.contains("access key"))
         );
     }
 
@@ -199,6 +199,9 @@ mod tests {
             .await
             .expect_err("invalid key should be rejected before provider request");
 
-        assert!(matches!(error, ObjectStoreError::InvalidKey(_)));
+        assert!(matches!(
+            error,
+            ObjectStoreError::InvalidKey { object_key, .. } if object_key == "../escape"
+        ));
     }
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -419,7 +419,10 @@ mod tests {
             .put_overwrite("../head.json", Bytes::from_static(br#"{"ok":true}"#))
             .await
             .expect_err("traversal key should be rejected");
-        assert!(matches!(error, ObjectStoreError::InvalidKey(_)));
+        assert!(matches!(
+            error,
+            ObjectStoreError::InvalidKey { object_key, .. } if object_key == "../head.json"
+        ));
     }
 
     #[allow(clippy::disallowed_methods)]

--- a/crates/loonfs-objectstore/src/fs.rs
+++ b/crates/loonfs-objectstore/src/fs.rs
@@ -24,7 +24,12 @@ pub struct LocalFsStore {
 impl LocalFsStore {
     pub fn new(root: impl Into<PathBuf>) -> Result<Self, ObjectStoreError> {
         let root = root.into();
-        std::fs::create_dir_all(&root).map_err(io_error)?;
+        std::fs::create_dir_all(&root).map_err(|err| {
+            ObjectStoreError::Configuration(format!(
+                "failed to create store root `{}`: {err}",
+                root.display()
+            ))
+        })?;
         Ok(Self {
             root,
             write_lock: Mutex::new(()),
@@ -34,8 +39,12 @@ impl LocalFsStore {
     /// Extends the in-process write mutex across processes with an advisory
     /// file lock on the store root. Check-then-act writes (compare-and-swap,
     /// delete-then-prune) are only safe while both are held.
-    async fn acquire_cross_process_write_lock(&self) -> Result<std::fs::File, ObjectStoreError> {
+    async fn acquire_cross_process_write_lock(
+        &self,
+        key: &str,
+    ) -> Result<std::fs::File, ObjectStoreError> {
         let lock_path = self.root.join(STORE_LOCK_FILE_NAME);
+        let lock_key = key.to_owned();
         tokio::task::spawn_blocking(move || {
             let file = std::fs::OpenOptions::new()
                 .read(true)
@@ -43,12 +52,12 @@ impl LocalFsStore {
                 .create(true)
                 .truncate(false)
                 .open(&lock_path)
-                .map_err(io_error)?;
-            fs4::fs_std::FileExt::lock_exclusive(&file).map_err(io_error)?;
+                .map_err(|err| io_error(&lock_key, err))?;
+            fs4::fs_std::FileExt::lock_exclusive(&file).map_err(|err| io_error(&lock_key, err))?;
             Ok(file)
         })
         .await
-        .map_err(|err| ObjectStoreError::Transport(format!("store lock task failed: {err}")))?
+        .map_err(|err| ObjectStoreError::transport(key, format!("store lock task failed: {err}")))?
     }
 
     pub fn root(&self) -> &Path {
@@ -61,7 +70,10 @@ impl LocalFsStore {
         // from listings, so accepting them as keys would create objects a
         // listing can never report.
         if segments.iter().any(|segment| is_scratch_name(segment)) {
-            return Err(ObjectStoreError::InvalidKey(key.to_owned()));
+            return Err(ObjectStoreError::InvalidKey {
+                object_key: key.to_owned(),
+                message: "key uses a segment name reserved for store scratch files".to_owned(),
+            });
         }
         let mut path = self.root.clone();
         for segment in segments {
@@ -71,30 +83,34 @@ impl LocalFsStore {
     }
 
     async fn metadata_for_path(
+        key: &str,
         path: &Path,
         include_checksum: bool,
     ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         let metadata = match fs::metadata(path).await {
             Ok(metadata) => metadata,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(io_error(err)),
+            Err(err) => return Err(io_error(key, err)),
         };
-        let content_digest = sha256_digest(&fs::read(path).await.map_err(io_error)?);
+        let content_digest =
+            sha256_digest(&fs::read(path).await.map_err(|err| io_error(key, err))?);
         let checksum_sha256 = include_checksum.then_some(content_digest.clone());
-        Self::metadata_from_fs_metadata(&metadata, &content_digest, checksum_sha256, path).map(Some)
+        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, checksum_sha256, path)
+            .map(Some)
     }
 
     fn metadata_from_fs_metadata(
+        key: &str,
         metadata: &std::fs::Metadata,
         content_digest: &str,
         checksum_sha256: Option<String>,
         path: &Path,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         if !metadata.is_file() {
-            return Err(ObjectStoreError::Transport(format!(
-                "object path is not a file: {}",
-                path.display()
-            )));
+            return Err(ObjectStoreError::transport(
+                key,
+                format!("object path is not a file: {}", path.display()),
+            ));
         }
 
         let last_modified_ms = metadata
@@ -112,11 +128,12 @@ impl LocalFsStore {
     }
 
     async fn create_new_object(
+        key: &str,
         root: &Path,
         path: &Path,
         bytes: &[u8],
     ) -> Result<(), ObjectStoreError> {
-        let created_dirs = ensure_parent_dir(path).await?;
+        let created_dirs = ensure_parent_dir(key, path).await?;
         let mut file = match OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -124,12 +141,14 @@ impl LocalFsStore {
             .await
         {
             Ok(file) => file,
-            Err(err) => return Err(map_create_error(err)),
+            Err(err) => return Err(map_create_error(key, err)),
         };
 
         let result: Result<(), ObjectStoreError> = async {
-            file.write_all(bytes).await.map_err(io_error)?;
-            file.sync_all().await.map_err(io_error)
+            file.write_all(bytes)
+                .await
+                .map_err(|err| io_error(key, err))?;
+            file.sync_all().await.map_err(|err| io_error(key, err))
         }
         .await;
 
@@ -139,17 +158,18 @@ impl LocalFsStore {
         }
 
         if created_dirs {
-            sync_dir_chain(path, root).await?;
+            sync_dir_chain(key, path, root).await?;
         }
-        sync_parent_dir(path).await
+        sync_parent_dir(key, path).await
     }
 
     async fn replace_object(
+        key: &str,
         root: &Path,
         path: &Path,
         bytes: &[u8],
     ) -> Result<(), ObjectStoreError> {
-        let created_dirs = ensure_parent_dir(path).await?;
+        let created_dirs = ensure_parent_dir(key, path).await?;
         let temp_path = temp_path(path);
 
         let result: Result<(), ObjectStoreError> = async {
@@ -158,9 +178,11 @@ impl LocalFsStore {
                 .create_new(true)
                 .open(&temp_path)
                 .await
-                .map_err(io_error)?;
-            file.write_all(bytes).await.map_err(io_error)?;
-            file.sync_all().await.map_err(io_error)?;
+                .map_err(|err| io_error(key, err))?;
+            file.write_all(bytes)
+                .await
+                .map_err(|err| io_error(key, err))?;
+            file.sync_all().await.map_err(|err| io_error(key, err))?;
 
             match fs::rename(&temp_path, path).await {
                 Ok(()) => Ok(()),
@@ -172,10 +194,14 @@ impl LocalFsStore {
                                 | std::io::ErrorKind::PermissionDenied
                         ) =>
                 {
-                    fs::remove_file(path).await.map_err(io_error)?;
-                    fs::rename(&temp_path, path).await.map_err(io_error)
+                    fs::remove_file(path)
+                        .await
+                        .map_err(|err| io_error(key, err))?;
+                    fs::rename(&temp_path, path)
+                        .await
+                        .map_err(|err| io_error(key, err))
                 }
-                Err(rename_error) => Err(io_error(rename_error)),
+                Err(rename_error) => Err(io_error(key, rename_error)),
             }
         }
         .await;
@@ -186,9 +212,9 @@ impl LocalFsStore {
         }
 
         if created_dirs {
-            sync_dir_chain(path, root).await?;
+            sync_dir_chain(key, path, root).await?;
         }
-        sync_parent_dir(path).await
+        sync_parent_dir(key, path).await
     }
 }
 
@@ -199,7 +225,7 @@ impl LocalFsStore {
         include_checksum: bool,
     ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         let path = self.resolve_key(key)?;
-        Self::metadata_for_path(&path, include_checksum).await
+        Self::metadata_for_path(key, &path, include_checksum).await
     }
 
     async fn get_with_metadata_object(
@@ -210,15 +236,18 @@ impl LocalFsStore {
         let mut file = match File::open(&path).await {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(io_error(err)),
+            Err(err) => return Err(io_error(key, err)),
         };
-        let fs_metadata = file.metadata().await.map_err(io_error)?;
+        let fs_metadata = file.metadata().await.map_err(|err| io_error(key, err))?;
 
         let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes).await.map_err(io_error)?;
+        file.read_to_end(&mut bytes)
+            .await
+            .map_err(|err| io_error(key, err))?;
 
         let content_digest = sha256_digest(&bytes);
         let metadata = Self::metadata_from_fs_metadata(
+            key,
             &fs_metadata,
             &content_digest,
             Some(content_digest.clone()),
@@ -236,22 +265,25 @@ impl LocalFsStore {
         let mut file = match File::open(&path).await {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(io_error(err)),
+            Err(err) => return Err(io_error(key, err)),
         };
 
         let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes).await.map_err(io_error)?;
+        file.read_to_end(&mut bytes)
+            .await
+            .map_err(|err| io_error(key, err))?;
 
         match range {
             None => Ok(Some(bytes)),
             Some(range) => {
-                let start = usize::try_from(range.start_inclusive)
-                    .map_err(|_| ObjectStoreError::InvalidRange)?;
-                let mut end = usize::try_from(range.end_exclusive)
-                    .map_err(|_| ObjectStoreError::InvalidRange)?;
+                let invalid_range = || ObjectStoreError::InvalidRange {
+                    object_key: key.to_owned(),
+                };
+                let start = usize::try_from(range.start_inclusive).map_err(|_| invalid_range())?;
+                let mut end = usize::try_from(range.end_exclusive).map_err(|_| invalid_range())?;
 
                 if end < start || start > bytes.len() {
-                    return Err(ObjectStoreError::InvalidRange);
+                    return Err(invalid_range());
                 }
 
                 end = end.min(bytes.len());
@@ -268,45 +300,51 @@ impl LocalFsStore {
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         let path = self.resolve_key(key)?;
         let _guard = self.write_lock.lock().await;
-        let _cross_process_guard = self.acquire_cross_process_write_lock().await?;
+        let _cross_process_guard = self.acquire_cross_process_write_lock(key).await?;
+        let precondition_failed = || ObjectStoreError::PreconditionFailed {
+            object_key: key.to_owned(),
+        };
 
         match mode {
-            PutMode::Overwrite => Self::replace_object(&self.root, &path, bytes).await?,
+            PutMode::Overwrite => Self::replace_object(key, &self.root, &path, bytes).await?,
             PutMode::CreateIfAbsent => {
-                if fs::try_exists(&path).await.map_err(io_error)? {
-                    return Err(ObjectStoreError::PreconditionFailed);
+                if fs::try_exists(&path)
+                    .await
+                    .map_err(|err| io_error(key, err))?
+                {
+                    return Err(precondition_failed());
                 }
-                Self::create_new_object(&self.root, &path, bytes).await?;
+                Self::create_new_object(key, &self.root, &path, bytes).await?;
             }
             PutMode::CompareAndSwap { expected_etag } => {
-                let current = Self::metadata_for_path(&path, false)
+                let current = Self::metadata_for_path(key, &path, false)
                     .await?
-                    .ok_or(ObjectStoreError::PreconditionFailed)?;
+                    .ok_or_else(precondition_failed)?;
                 if current.etag.as_deref() != Some(expected_etag.as_str()) {
-                    return Err(ObjectStoreError::PreconditionFailed);
+                    return Err(precondition_failed());
                 }
-                Self::replace_object(&self.root, &path, bytes).await?;
+                Self::replace_object(key, &self.root, &path, bytes).await?;
             }
         }
 
-        Self::metadata_for_path(&path, true)
+        Self::metadata_for_path(key, &path, true)
             .await?
-            .ok_or_else(|| ObjectStoreError::Transport(format!("object disappeared: {key}")))
+            .ok_or_else(|| ObjectStoreError::transport(key, "object disappeared after write"))
     }
 
     async fn delete_object(&self, key: &str) -> Result<(), ObjectStoreError> {
         let path = self.resolve_key(key)?;
         let _guard = self.write_lock.lock().await;
-        let _cross_process_guard = self.acquire_cross_process_write_lock().await?;
+        let _cross_process_guard = self.acquire_cross_process_write_lock(key).await?;
 
         match fs::remove_file(&path).await {
             Ok(()) => {
-                sync_parent_dir(&path).await?;
-                prune_empty_parent_dirs(path.parent(), &self.root).await?;
+                sync_parent_dir(key, &path).await?;
+                prune_empty_parent_dirs(key, path.parent(), &self.root).await?;
                 Ok(())
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(io_error(err)),
+            Err(err) => Err(io_error(key, err)),
         }
     }
 }
@@ -374,11 +412,14 @@ async fn list_prefix_for_root(
 ) -> Result<Vec<String>, ObjectStoreError> {
     validate_segments(&prefix, true)?;
 
-    if !fs::try_exists(&root).await.map_err(io_error)? {
+    if !fs::try_exists(&root)
+        .await
+        .map_err(|err| io_error(&prefix, err))?
+    {
         return Ok(Vec::new());
     }
 
-    let mut keys = collect_keys(root).await?;
+    let mut keys = collect_keys(&prefix, root).await?;
     keys.retain(|key| key.starts_with(&prefix));
     keys.sort();
     Ok(keys)
@@ -386,33 +427,41 @@ async fn list_prefix_for_root(
 
 /// Creates the parent directory chain. Returns whether anything was created,
 /// so callers know the new directory entries also need to be made durable.
-async fn ensure_parent_dir(path: &Path) -> Result<bool, ObjectStoreError> {
+async fn ensure_parent_dir(key: &str, path: &Path) -> Result<bool, ObjectStoreError> {
     match path.parent() {
         Some(parent) => {
-            if fs::try_exists(parent).await.map_err(io_error)? {
+            if fs::try_exists(parent)
+                .await
+                .map_err(|err| io_error(key, err))?
+            {
                 return Ok(false);
             }
-            fs::create_dir_all(parent).await.map_err(io_error)?;
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|err| io_error(key, err))?;
             Ok(true)
         }
-        None => Err(ObjectStoreError::InvalidKey(path.display().to_string())),
+        None => Err(ObjectStoreError::InvalidKey {
+            object_key: key.to_owned(),
+            message: format!("object path `{}` has no parent directory", path.display()),
+        }),
     }
 }
 
 /// Fsyncs the directory holding `path`, making a rename, create, or unlink
 /// of that entry durable. Without this, the file data can survive a crash
 /// while the directory entry pointing at it does not.
-async fn sync_parent_dir(path: &Path) -> Result<(), ObjectStoreError> {
+async fn sync_parent_dir(key: &str, path: &Path) -> Result<(), ObjectStoreError> {
     #[cfg(unix)]
     {
         if let Some(parent) = path.parent() {
-            let dir = File::open(parent).await.map_err(io_error)?;
-            dir.sync_all().await.map_err(io_error)?;
+            let dir = File::open(parent).await.map_err(|err| io_error(key, err))?;
+            dir.sync_all().await.map_err(|err| io_error(key, err))?;
         }
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
+        let _ = (key, path);
     }
     Ok(())
 }
@@ -420,13 +469,13 @@ async fn sync_parent_dir(path: &Path) -> Result<(), ObjectStoreError> {
 /// Fsyncs every directory from `path`'s parent up to and including the
 /// store root, so a freshly created directory chain survives a crash. The
 /// root itself pre-exists, so the chain never needs to go past it.
-async fn sync_dir_chain(path: &Path, root: &Path) -> Result<(), ObjectStoreError> {
+async fn sync_dir_chain(key: &str, path: &Path, root: &Path) -> Result<(), ObjectStoreError> {
     #[cfg(unix)]
     {
         let mut current = path.parent();
         while let Some(dir) = current {
-            let handle = File::open(dir).await.map_err(io_error)?;
-            handle.sync_all().await.map_err(io_error)?;
+            let handle = File::open(dir).await.map_err(|err| io_error(key, err))?;
+            handle.sync_all().await.map_err(|err| io_error(key, err))?;
             if dir == root {
                 break;
             }
@@ -435,25 +484,33 @@ async fn sync_dir_chain(path: &Path, root: &Path) -> Result<(), ObjectStoreError
     }
     #[cfg(not(unix))]
     {
-        let _ = (path, root);
+        let _ = (key, path, root);
     }
     Ok(())
 }
 
-async fn collect_keys(root: PathBuf) -> Result<Vec<String>, ObjectStoreError> {
+async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>, ObjectStoreError> {
     let mut keys = Vec::new();
     let mut dirs = vec![root.clone()];
 
     while let Some(current) = dirs.pop() {
         let mut entries = Vec::new();
-        let mut reader = fs::read_dir(&current).await.map_err(io_error)?;
-        while let Some(entry) = reader.next_entry().await.map_err(io_error)? {
+        let mut reader = fs::read_dir(&current)
+            .await
+            .map_err(|err| io_error(prefix, err))?;
+        while let Some(entry) = reader
+            .next_entry()
+            .await
+            .map_err(|err| io_error(prefix, err))?
+        {
             entries.push(entry.path());
         }
         entries.sort();
 
         for path in entries.into_iter().rev() {
-            let metadata = fs::metadata(&path).await.map_err(io_error)?;
+            let metadata = fs::metadata(&path)
+                .await
+                .map_err(|err| io_error(prefix, err))?;
             if metadata.is_dir() {
                 dirs.push(path);
                 continue;
@@ -467,7 +524,7 @@ async fn collect_keys(root: PathBuf) -> Result<Vec<String>, ObjectStoreError> {
                 {
                     continue;
                 }
-                keys.push(relative_key(&root, &path)?);
+                keys.push(relative_key(prefix, &root, &path)?);
             }
         }
     }
@@ -476,12 +533,15 @@ async fn collect_keys(root: PathBuf) -> Result<Vec<String>, ObjectStoreError> {
     Ok(keys)
 }
 
-fn relative_key(root: &Path, path: &Path) -> Result<String, ObjectStoreError> {
+fn relative_key(prefix: &str, root: &Path, path: &Path) -> Result<String, ObjectStoreError> {
     let relative = path.strip_prefix(root).map_err(|err| {
-        ObjectStoreError::Transport(format!(
-            "failed to strip object-store root from path {}: {err}",
-            path.display()
-        ))
+        ObjectStoreError::transport(
+            prefix,
+            format!(
+                "failed to strip object-store root from path {}: {err}",
+                path.display()
+            ),
+        )
     })?;
 
     let mut parts = Vec::new();
@@ -489,9 +549,12 @@ fn relative_key(root: &Path, path: &Path) -> Result<String, ObjectStoreError> {
         match component {
             Component::Normal(part) => parts.push(part.to_string_lossy().into_owned()),
             other => {
-                return Err(ObjectStoreError::Transport(format!(
-                    "unsupported relative path component {other:?} under local object store"
-                )))
+                return Err(ObjectStoreError::transport(
+                    prefix,
+                    format!(
+                        "unsupported relative path component {other:?} under local object store"
+                    ),
+                ))
             }
         }
     }
@@ -500,6 +563,7 @@ fn relative_key(root: &Path, path: &Path) -> Result<String, ObjectStoreError> {
 }
 
 async fn prune_empty_parent_dirs(
+    key: &str,
     mut current: Option<&Path>,
     root: &Path,
 ) -> Result<(), ObjectStoreError> {
@@ -512,7 +576,7 @@ async fn prune_empty_parent_dirs(
             Ok(()) => current = dir.parent(),
             Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => break,
-            Err(err) => return Err(io_error(err)),
+            Err(err) => return Err(io_error(key, err)),
         }
     }
 
@@ -543,16 +607,18 @@ fn temp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(".{file_name}.tmp-{}-{stamp}", std::process::id()))
 }
 
-fn map_create_error(err: std::io::Error) -> ObjectStoreError {
+fn map_create_error(key: &str, err: std::io::Error) -> ObjectStoreError {
     if err.kind() == std::io::ErrorKind::AlreadyExists {
-        ObjectStoreError::PreconditionFailed
+        ObjectStoreError::PreconditionFailed {
+            object_key: key.to_owned(),
+        }
     } else {
-        io_error(err)
+        io_error(key, err)
     }
 }
 
-fn io_error(err: std::io::Error) -> ObjectStoreError {
-    ObjectStoreError::Transport(err.to_string())
+fn io_error(key: &str, err: std::io::Error) -> ObjectStoreError {
+    ObjectStoreError::transport(key, err.to_string())
 }
 
 #[cfg(test)]
@@ -663,7 +729,7 @@ mod tests {
                             .await;
                         match put {
                             Ok(_) => break,
-                            Err(ObjectStoreError::PreconditionFailed) => continue,
+                            Err(ObjectStoreError::PreconditionFailed { .. }) => continue,
                             Err(err) => panic!("unexpected CAS error: {err}"),
                         }
                     }
@@ -703,7 +769,11 @@ mod tests {
         assert_eq!(keys, vec![key]);
 
         let reserved = store.get(super::STORE_LOCK_FILE_NAME, None).await;
-        assert!(matches!(reserved, Err(ObjectStoreError::InvalidKey(_))));
+        assert!(matches!(
+            reserved,
+            Err(ObjectStoreError::InvalidKey { object_key, .. })
+                if object_key == super::STORE_LOCK_FILE_NAME
+        ));
         let temp_shaped = store
             .put(
                 "namespaces/ns-scratch/control/.head.json.tmp-9-9",
@@ -711,7 +781,10 @@ mod tests {
                 PutMode::Overwrite,
             )
             .await;
-        assert!(matches!(temp_shaped, Err(ObjectStoreError::InvalidKey(_))));
+        assert!(matches!(
+            temp_shaped,
+            Err(ObjectStoreError::InvalidKey { .. })
+        ));
     }
 
     struct TestDir {

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -28,12 +28,12 @@ pub struct GcpGcsStore {
 impl GcpGcsStore {
     pub fn new(config: GcpGcsStoreConfig) -> Result<Self, ObjectStoreError> {
         if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
             ));
         }
         if config.service_account_key_path.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "service account key path must not be empty".to_owned(),
             ));
         }
@@ -44,7 +44,7 @@ impl GcpGcsStore {
 
         let provider = builder
             .build()
-            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
         let inner = ProviderObjectStore::new(
             Arc::new(provider),
             ProviderObjectStoreConfig {
@@ -63,11 +63,16 @@ impl GcpGcsStore {
         }
     }
 
-    fn require_generation_compare_token(expected_etag: &str) -> Result<(), ObjectStoreError> {
+    fn require_generation_compare_token(
+        key: &str,
+        expected_etag: &str,
+    ) -> Result<(), ObjectStoreError> {
         expected_etag
             .parse::<u64>()
             .map(|_| ())
-            .map_err(|_| ObjectStoreError::PreconditionFailed)
+            .map_err(|_| ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            })
     }
 }
 
@@ -115,7 +120,7 @@ impl ObjectStore for GcpGcsStore {
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         self.inner.validate_key(key)?;
         if let PutMode::CompareAndSwap { expected_etag } = &mode {
-            Self::require_generation_compare_token(expected_etag)?;
+            Self::require_generation_compare_token(key, expected_etag)?;
         }
         Ok(Self::generation_as_compare_token(
             self.inner.put(key, bytes, mode).await?,
@@ -159,7 +164,7 @@ mod tests {
             store
                 .compare_and_swap("../escape", "not-a-generation", Bytes::from_static(b"oops"))
                 .await,
-            Err(ObjectStoreError::InvalidKey(_))
+            Err(ObjectStoreError::InvalidKey { .. })
         ));
     }
 
@@ -171,7 +176,7 @@ mod tests {
                 service_account_key_path: " ".to_owned(),
                 key_prefix: None,
             }),
-            Err(ObjectStoreError::Transport(_))
+            Err(ObjectStoreError::Configuration(_))
         ));
     }
 

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -18,11 +18,17 @@ pub(crate) fn validate_segments(
                 continue;
             }
 
-            return Err(ObjectStoreError::InvalidKey(key.to_owned()));
+            return Err(ObjectStoreError::InvalidKey {
+                object_key: key.to_owned(),
+                message: "key must not contain empty segments".to_owned(),
+            });
         }
 
         if *segment == "." || *segment == ".." {
-            return Err(ObjectStoreError::InvalidKey(key.to_owned()));
+            return Err(ObjectStoreError::InvalidKey {
+                object_key: key.to_owned(),
+                message: "key must not contain `.` or `..` segments".to_owned(),
+            });
         }
 
         segments.push(*segment);
@@ -96,11 +102,11 @@ mod tests {
     fn normalize_key_prefix_rejects_traversal_and_empty_segments() {
         assert!(matches!(
             normalize_key_prefix(Some("tenant-a//bad")),
-            Err(ObjectStoreError::InvalidKey(key)) if key == "tenant-a//bad"
+            Err(ObjectStoreError::InvalidKey { object_key, .. }) if object_key == "tenant-a//bad"
         ));
         assert!(matches!(
             normalize_key_prefix(Some("../escape")),
-            Err(ObjectStoreError::InvalidKey(key)) if key == "../escape"
+            Err(ObjectStoreError::InvalidKey { object_key, .. }) if object_key == "../escape"
         ));
     }
 
@@ -142,7 +148,7 @@ mod tests {
         assert!(validate_segments("namespaces/ns-1/", true).is_ok());
         assert!(matches!(
             validate_segments("namespaces/ns-1/", false),
-            Err(ObjectStoreError::InvalidKey(_))
+            Err(ObjectStoreError::InvalidKey { .. })
         ));
     }
 }

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -325,16 +325,25 @@ fn parsed(
 
 pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
     let Some(hex) = digest.strip_prefix("sha256:") else {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+        return Err(ObjectStoreError::InvalidKey {
+            object_key: digest.to_owned(),
+            message: "digest must start with `sha256:`".to_owned(),
+        });
     };
     if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+        return Err(ObjectStoreError::InvalidKey {
+            object_key: digest.to_owned(),
+            message: "digest must be 64 hex characters".to_owned(),
+        });
     }
     if !hex
         .bytes()
         .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
     {
-        return Err(ObjectStoreError::InvalidKey(digest.to_owned()));
+        return Err(ObjectStoreError::InvalidKey {
+            object_key: digest.to_owned(),
+            message: "digest hex must be lowercase".to_owned(),
+        });
     }
     Ok(hex)
 }

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -512,14 +512,17 @@ fn classify_result<T>(result: &Result<T, ObjectStoreError>) -> ObjectStoreResult
 
 fn classify_error(error: &ObjectStoreError) -> ObjectStoreResultClass {
     match error {
-        ObjectStoreError::NotFound => ObjectStoreResultClass::NotFound,
-        ObjectStoreError::InvalidKey(_) => ObjectStoreResultClass::InvalidKey,
+        ObjectStoreError::NotFound { .. } => ObjectStoreResultClass::NotFound,
+        ObjectStoreError::InvalidKey { .. } => ObjectStoreResultClass::InvalidKey,
         ObjectStoreError::InvalidContentRef(_) => ObjectStoreResultClass::InvalidContentRef,
-        ObjectStoreError::InvalidRange => ObjectStoreResultClass::InvalidRange,
-        ObjectStoreError::PreconditionFailed => ObjectStoreResultClass::PreconditionFailed,
-        ObjectStoreError::Conflict => ObjectStoreResultClass::Conflict,
+        ObjectStoreError::InvalidRange { .. } => ObjectStoreResultClass::InvalidRange,
+        ObjectStoreError::PreconditionFailed { .. } => ObjectStoreResultClass::PreconditionFailed,
+        ObjectStoreError::Conflict { .. } => ObjectStoreResultClass::Conflict,
         ObjectStoreError::Unsupported(_) => ObjectStoreResultClass::Unsupported,
-        ObjectStoreError::Transport(_) => ObjectStoreResultClass::Transport,
+        // Configuration failures happen at store construction, before any
+        // metered operation; classify defensively as transport.
+        ObjectStoreError::Configuration(_) => ObjectStoreResultClass::Transport,
+        ObjectStoreError::Transport { .. } => ObjectStoreResultClass::Transport,
     }
 }
 

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -59,25 +59,79 @@ pub struct ByteRange {
     pub end_exclusive: u64,
 }
 
+/// Failure of one object-store operation.
+///
+/// Every object-scoped variant names the object it is about via `object_key`
+/// (for list operations, the listed prefix). The exceptions are deliberate:
+/// `InvalidContentRef` fails before a key exists, `Unsupported` is about a
+/// store capability, and `Configuration` is about store construction.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ObjectStoreError {
-    #[error("object not found")]
-    NotFound,
-    #[error("invalid object key: {0}")]
-    InvalidKey(String),
+    #[error("object not found `{object_key}`")]
+    NotFound { object_key: String },
+    #[error("invalid object key `{object_key}`: {message}")]
+    InvalidKey { object_key: String, message: String },
+    /// Not object-scoped: the content ref never resolved to an object key.
     #[error("invalid content ref: {0}")]
     InvalidContentRef(String),
-    #[error("invalid byte range")]
-    InvalidRange,
-    #[error("precondition failed")]
-    PreconditionFailed,
-    #[error("conflict")]
-    Conflict,
+    #[error("invalid byte range for `{object_key}`")]
+    InvalidRange { object_key: String },
+    #[error("precondition failed for `{object_key}`")]
+    PreconditionFailed { object_key: String },
+    #[error("conflict for `{object_key}`")]
+    Conflict { object_key: String },
+    /// Not object-scoped: the store lacks a required capability.
     #[error("unsupported capability: {0}")]
     Unsupported(&'static str),
-    #[error("transport error: {0}")]
-    Transport(String),
+    /// Not object-scoped: store construction or configuration failed before
+    /// any object was addressed.
+    #[error("invalid object store configuration: {0}")]
+    Configuration(String),
+    #[error("transport error for `{object_key}`: {message}")]
+    Transport { object_key: String, message: String },
+}
+
+impl ObjectStoreError {
+    /// Builds a [`ObjectStoreError::Transport`] for an operation on `object_key`.
+    pub fn transport(object_key: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Transport {
+            object_key: object_key.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Key of the object (or listed prefix) the failing operation targeted,
+    /// when the failure is object-scoped.
+    pub fn object_key(&self) -> Option<&str> {
+        match self {
+            Self::NotFound { object_key }
+            | Self::InvalidKey { object_key, .. }
+            | Self::InvalidRange { object_key }
+            | Self::PreconditionFailed { object_key }
+            | Self::Conflict { object_key }
+            | Self::Transport { object_key, .. } => Some(object_key),
+            Self::InvalidContentRef(_) | Self::Unsupported(_) | Self::Configuration(_) => None,
+        }
+    }
+
+    /// Failure text without the object key, for wrappers that record the key
+    /// as their own structured field.
+    pub fn message(&self) -> String {
+        match self {
+            Self::NotFound { .. } => "object not found".to_owned(),
+            Self::InvalidKey { message, .. } => format!("invalid object key: {message}"),
+            Self::InvalidContentRef(message) => format!("invalid content ref: {message}"),
+            Self::InvalidRange { .. } => "invalid byte range".to_owned(),
+            Self::PreconditionFailed { .. } => "precondition failed".to_owned(),
+            Self::Conflict { .. } => "conflict".to_owned(),
+            Self::Unsupported(capability) => format!("unsupported capability: {capability}"),
+            Self::Configuration(message) => {
+                format!("invalid object store configuration: {message}")
+            }
+            Self::Transport { message, .. } => message.clone(),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
+++ b/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
@@ -12,11 +12,17 @@ pub(crate) struct AwsSigV4Dates {
     pub(crate) amz_date: String,
 }
 
-pub(crate) fn aws_dates(time: SystemTime) -> Result<AwsSigV4Dates, ObjectStoreError> {
+pub(crate) fn aws_dates(
+    object_key: &str,
+    time: SystemTime,
+) -> Result<AwsSigV4Dates, ObjectStoreError> {
     let seconds = time
         .duration_since(UNIX_EPOCH)
         .map_err(|err| {
-            ObjectStoreError::Transport(format!("system time is before unix epoch: {err}"))
+            ObjectStoreError::transport(
+                object_key,
+                format!("system time is before unix epoch: {err}"),
+            )
         })?
         .as_secs() as i64;
     let days = seconds.div_euclid(86_400);

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -52,22 +52,22 @@ pub struct S3CompatiblePresigner {
 impl S3CompatiblePresigner {
     pub fn new(config: S3PresignerConfig) -> Result<Self, ObjectStoreError> {
         if config.bucket.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
             ));
         }
         if config.region.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "region must not be empty".to_owned(),
             ));
         }
         if config.access_key_id.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "access key id must not be empty".to_owned(),
             ));
         }
         if config.secret_access_key.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "secret access key must not be empty".to_owned(),
             ));
         }
@@ -140,19 +140,21 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
         now: SystemTime,
     ) -> Result<PresignedUrl, ObjectStoreError> {
         if request.expires_in.is_zero() {
-            return Err(ObjectStoreError::Transport(
-                "presigned URL expiry must be greater than zero".to_owned(),
+            return Err(ObjectStoreError::transport(
+                request.object_key,
+                "presigned URL expiry must be greater than zero",
             ));
         }
         if request.expires_in.as_secs() > 604_800 {
-            return Err(ObjectStoreError::Transport(
-                "presigned URL expiry must not exceed seven days".to_owned(),
+            return Err(ObjectStoreError::transport(
+                request.object_key,
+                "presigned URL expiry must not exceed seven days",
             ));
         }
 
         let endpoint = self.endpoint(request.object_key)?;
         let required_headers = s3_direct_put_required_headers(request.content_ref)?;
-        let dates = aws_dates(now)?;
+        let dates = aws_dates(request.object_key, now)?;
         let credential_scope = format!(
             "{}/{}/s3/aws4_request",
             dates.short_date, self.config.region
@@ -207,7 +209,8 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
             "{}://{}{}?{}&X-Amz-Signature={}",
             endpoint.scheme, endpoint.host, endpoint.canonical_uri, canonical_query, signature
         );
-        let expires_at_ms = unix_ms(now)? + request.expires_in.as_millis() as u64;
+        let expires_at_ms =
+            unix_ms(request.object_key, now)? + request.expires_in.as_millis() as u64;
 
         Ok(PresignedUrl {
             method: "PUT".to_owned(),
@@ -289,13 +292,13 @@ fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint, ObjectStoreError> {
         .map(|rest| ("https", rest))
         .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
         .ok_or_else(|| {
-            ObjectStoreError::Transport(
+            ObjectStoreError::Configuration(
                 "endpoint url must start with http:// or https://".to_owned(),
             )
         })?;
     let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
     if authority.is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "endpoint url must include authority".to_owned(),
         ));
     }
@@ -314,9 +317,10 @@ fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint, ObjectStoreError> {
 fn scope_object_key(prefix: Option<&str>, key: &str) -> Result<String, ObjectStoreError> {
     let key = key.trim_start_matches('/');
     if key.is_empty() {
-        return Err(ObjectStoreError::InvalidKey(
-            "object key must not be empty".to_owned(),
-        ));
+        return Err(ObjectStoreError::InvalidKey {
+            object_key: key.to_owned(),
+            message: "object key must not be empty".to_owned(),
+        });
     }
     Ok(match prefix {
         Some(prefix) if !prefix.trim_matches('/').is_empty() => {
@@ -326,9 +330,12 @@ fn scope_object_key(prefix: Option<&str>, key: &str) -> Result<String, ObjectSto
     })
 }
 
-fn unix_ms(time: SystemTime) -> Result<u64, ObjectStoreError> {
+fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64, ObjectStoreError> {
     let duration = time.duration_since(std::time::UNIX_EPOCH).map_err(|err| {
-        ObjectStoreError::Transport(format!("system time is before unix epoch: {err}"))
+        ObjectStoreError::transport(
+            object_key,
+            format!("system time is before unix epoch: {err}"),
+        )
     })?;
     Ok(duration.as_millis() as u64)
 }

--- a/crates/loonfs-objectstore/src/probes.rs
+++ b/crates/loonfs-objectstore/src/probes.rs
@@ -353,7 +353,7 @@ fn assert_precondition_failed<T>(
     result: Result<T, ObjectStoreError>,
 ) -> Result<(), ContractProbeError> {
     match result {
-        Err(ObjectStoreError::PreconditionFailed) => Ok(()),
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(()),
         Err(err) => Err(probe_error(probe, err)),
         Ok(_) => Err(ContractProbeError::Probe {
             probe,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -51,7 +51,10 @@ impl ProviderObjectStore {
 
     fn to_path(&self, key: &str) -> Result<Path, ObjectStoreError> {
         let scoped = scope_object_key(self.key_prefix.as_deref(), key)?;
-        Path::parse(scoped).map_err(|err| ObjectStoreError::InvalidKey(err.to_string()))
+        Path::parse(scoped).map_err(|err| ObjectStoreError::InvalidKey {
+            object_key: key.to_owned(),
+            message: err.to_string(),
+        })
     }
 
     pub(crate) fn validate_key(&self, key: &str) -> Result<(), ObjectStoreError> {
@@ -65,7 +68,10 @@ impl ProviderObjectStore {
         }
         Path::parse(scoped)
             .map(Some)
-            .map_err(|err| ObjectStoreError::InvalidKey(err.to_string()))
+            .map_err(|err| ObjectStoreError::InvalidKey {
+                object_key: prefix.to_owned(),
+                message: err.to_string(),
+            })
     }
 
     fn from_meta(meta: ObjectMeta, checksum_sha256: Option<String>) -> ObjectMetadata {
@@ -102,12 +108,18 @@ impl ProviderObjectStore {
         };
         let metadata = match self.head(key).await? {
             Some(metadata) => metadata,
-            None => return Err(ObjectStoreError::NotFound),
+            None => {
+                return Err(ObjectStoreError::NotFound {
+                    object_key: key.to_owned(),
+                })
+            }
         };
         if range.end_exclusive < range.start_inclusive
             || range.start_inclusive > metadata.size_bytes
         {
-            return Err(ObjectStoreError::InvalidRange);
+            return Err(ObjectStoreError::InvalidRange {
+                object_key: key.to_owned(),
+            });
         }
 
         let bounded_end = range.end_exclusive.min(metadata.size_bytes);
@@ -128,7 +140,7 @@ impl ObjectStore for ProviderObjectStore {
         match self.inner.head(&path).await {
             Ok(meta) => Ok(Some(Self::from_meta(meta, None))),
             Err(err) if provider_not_found(&err) => Ok(None),
-            Err(err) => Err(map_provider_error(err)),
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -144,14 +156,17 @@ impl ObjectStore for ProviderObjectStore {
         match self.inner.get(&path).await {
             Ok(result) => {
                 let metadata = Self::from_meta(result.meta.clone(), None);
-                let bytes = result.bytes().await.map_err(map_provider_error)?;
+                let bytes = result
+                    .bytes()
+                    .await
+                    .map_err(|err| map_provider_error(key, err))?;
                 Ok(Some(ObjectBody {
                     metadata,
                     bytes: bytes.to_vec(),
                 }))
             }
             Err(err) if provider_not_found(&err) => Ok(None),
-            Err(err) => Err(map_provider_error(err)),
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -163,9 +178,13 @@ impl ObjectStore for ProviderObjectStore {
         let path = self.to_path(key)?;
         let Some(provider_range) = self.provider_range(key, range).await? else {
             return match self.inner.get(&path).await {
-                Ok(result) => result.bytes().await.map(Some).map_err(map_provider_error),
+                Ok(result) => result
+                    .bytes()
+                    .await
+                    .map(Some)
+                    .map_err(|err| map_provider_error(key, err)),
                 Err(err) if provider_not_found(&err) => Ok(None),
-                Err(err) => Err(map_provider_error(err)),
+                Err(err) => Err(map_provider_error(key, err)),
             };
         };
 
@@ -178,9 +197,13 @@ impl ObjectStore for ProviderObjectStore {
             ..Default::default()
         };
         match self.inner.get_opts(&path, options).await {
-            Ok(result) => result.bytes().await.map(Some).map_err(map_provider_error),
+            Ok(result) => result
+                .bytes()
+                .await
+                .map(Some)
+                .map_err(|err| map_provider_error(key, err)),
             Err(err) if provider_not_found(&err) => Ok(None),
-            Err(err) => Err(map_provider_error(err)),
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -206,9 +229,11 @@ impl ObjectStore for ProviderObjectStore {
         {
             Ok(result) => Ok(Self::from_put_result(result, size_bytes, checksum_sha256)),
             Err(err) if compare_and_swap && provider_not_found(&err) => {
-                Err(ObjectStoreError::PreconditionFailed)
+                Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                })
             }
-            Err(err) => Err(map_provider_error(err)),
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -217,7 +242,7 @@ impl ObjectStore for ProviderObjectStore {
         match self.inner.delete(&path).await {
             Ok(()) => Ok(()),
             Err(err) if provider_not_found(&err) => Ok(()),
-            Err(err) => Err(map_provider_error(err)),
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -230,10 +255,12 @@ impl ObjectStore for ProviderObjectStore {
             Err(err) => return stream::once(async { Err(err) }).boxed(),
         };
         let key_prefix = self.key_prefix.clone();
+        let listed_prefix = prefix.to_owned();
         self.inner
             .list(prefix_path.as_ref())
             .filter_map(move |result| {
                 let key_prefix = key_prefix.clone();
+                let listed_prefix = listed_prefix.clone();
                 async move {
                     match result {
                         Ok(meta) => {
@@ -243,7 +270,7 @@ impl ObjectStore for ProviderObjectStore {
                                 None => Some(Ok(key.to_owned())),
                             }
                         }
-                        Err(err) => Some(Err(map_provider_error(err))),
+                        Err(err) => Some(Err(map_provider_error(&listed_prefix, err))),
                     }
                 }
             })
@@ -277,32 +304,40 @@ fn provider_not_found(err: &provider_store::Error) -> bool {
     matches!(err, provider_store::Error::NotFound { .. })
 }
 
-fn map_provider_error(err: provider_store::Error) -> ObjectStoreError {
+fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectStoreError {
     match err {
-        provider_store::Error::NotFound { .. } => ObjectStoreError::NotFound,
+        provider_store::Error::NotFound { .. } => ObjectStoreError::NotFound {
+            object_key: object_key.to_owned(),
+        },
         provider_store::Error::AlreadyExists { .. }
         | provider_store::Error::Precondition { .. }
-        | provider_store::Error::NotModified { .. } => ObjectStoreError::PreconditionFailed,
-        provider_store::Error::InvalidPath { source } => {
-            ObjectStoreError::InvalidKey(source.to_string())
-        }
+        | provider_store::Error::NotModified { .. } => ObjectStoreError::PreconditionFailed {
+            object_key: object_key.to_owned(),
+        },
+        provider_store::Error::InvalidPath { source } => ObjectStoreError::InvalidKey {
+            object_key: object_key.to_owned(),
+            message: source.to_string(),
+        },
         provider_store::Error::NotSupported { .. } | provider_store::Error::NotImplemented => {
             ObjectStoreError::Unsupported("provider object store operation")
         }
+        provider_store::Error::UnknownConfigurationKey { key, store } => {
+            ObjectStoreError::transport(
+                object_key,
+                format!("unknown {store} configuration key `{key}`"),
+            )
+        }
         provider_store::Error::Generic { source, .. } => {
-            ObjectStoreError::Transport(source.to_string())
+            ObjectStoreError::transport(object_key, source.to_string())
         }
         provider_store::Error::JoinError { source } => {
-            ObjectStoreError::Transport(source.to_string())
+            ObjectStoreError::transport(object_key, source.to_string())
         }
         provider_store::Error::PermissionDenied { source, .. }
         | provider_store::Error::Unauthenticated { source, .. } => {
-            ObjectStoreError::Transport(source.to_string())
+            ObjectStoreError::transport(object_key, source.to_string())
         }
-        provider_store::Error::UnknownConfigurationKey { key, store } => {
-            ObjectStoreError::Transport(format!("unknown {store} configuration key `{key}`"))
-        }
-        other => ObjectStoreError::Transport(other.to_string()),
+        other => ObjectStoreError::transport(object_key, other.to_string()),
     }
 }
 
@@ -359,13 +394,13 @@ mod tests {
 
         assert!(matches!(
             store.put_if_absent(key, Bytes::from_static(b"two")).await,
-            Err(ObjectStoreError::PreconditionFailed)
+            Err(ObjectStoreError::PreconditionFailed { .. })
         ));
         assert!(matches!(
             store
                 .compare_and_swap(key, "stale", Bytes::from_static(b"two"))
                 .await,
-            Err(ObjectStoreError::PreconditionFailed)
+            Err(ObjectStoreError::PreconditionFailed { .. })
         ));
         assert!(matches!(
             store
@@ -375,7 +410,7 @@ mod tests {
                     Bytes::from_static(b"two")
                 )
                 .await,
-            Err(ObjectStoreError::PreconditionFailed)
+            Err(ObjectStoreError::PreconditionFailed { .. })
         ));
         let etag = first.etag.expect("etag");
         store
@@ -433,7 +468,7 @@ mod tests {
                     }),
                 )
                 .await,
-            Err(ObjectStoreError::InvalidRange)
+            Err(ObjectStoreError::InvalidRange { .. })
         ));
     }
 
@@ -443,7 +478,7 @@ mod tests {
         let mut stream = store.list_prefix_stream("../");
         assert!(matches!(
             stream.next().await,
-            Some(Err(ObjectStoreError::InvalidKey(_)))
+            Some(Err(ObjectStoreError::InvalidKey { .. }))
         ));
     }
 }

--- a/crates/loonfs-objectstore/src/r2.rs
+++ b/crates/loonfs-objectstore/src/r2.rs
@@ -23,7 +23,7 @@ pub struct CloudflareR2Store {
 impl CloudflareR2Store {
     pub fn new(config: CloudflareR2StoreConfig) -> Result<Self, ObjectStoreError> {
         if config.account_id.trim().is_empty() {
-            return Err(ObjectStoreError::Transport(
+            return Err(ObjectStoreError::Configuration(
                 "account id must not be empty".to_owned(),
             ));
         }

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -70,7 +70,7 @@ impl S3CompatibleStore {
 
         let provider = builder
             .build()
-            .map_err(|err| ObjectStoreError::Transport(err.to_string()))?;
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
         let inner = ProviderObjectStore::new(
             Arc::new(provider),
             ProviderObjectStoreConfig {
@@ -134,22 +134,22 @@ impl ObjectStore for S3CompatibleStore {
 
 fn validate_config(config: &S3CompatibleConfig) -> Result<(), ObjectStoreError> {
     if config.bucket.trim().is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "bucket must not be empty".to_owned(),
         ));
     }
     if config.region.trim().is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "region must not be empty".to_owned(),
         ));
     }
     if config.access_key_id.trim().is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "access key id must not be empty".to_owned(),
         ));
     }
     if config.secret_access_key.trim().is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "secret access key must not be empty".to_owned(),
         ));
     }
@@ -192,13 +192,13 @@ fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>, ObjectStoreErro
         .map(|rest| ("https", rest))
         .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
         .ok_or_else(|| {
-            ObjectStoreError::Transport(
+            ObjectStoreError::Configuration(
                 "endpoint url must start with http:// or https://".to_owned(),
             )
         })?;
     let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
     if authority.is_empty() {
-        return Err(ObjectStoreError::Transport(
+        return Err(ObjectStoreError::Configuration(
             "endpoint url must include authority".to_owned(),
         ));
     }

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -655,42 +655,44 @@ async fn assert_supports_range_reads<S: ObjectStore>(store: &S) {
 }
 
 async fn assert_rejects_invalid_keys_consistently<S: ObjectStore>(store: &S) {
+    fn assert_invalid_key<T: std::fmt::Debug>(key: &str, result: Result<T, ObjectStoreError>) {
+        let carries_rejected_key = matches!(
+            &result,
+            Err(ObjectStoreError::InvalidKey { object_key, .. }) if object_key == key
+        );
+        assert!(
+            carries_rejected_key,
+            "expected invalid key error for `{key}`, got {result:?}"
+        );
+    }
+
     for key in ["../escape", "namespaces//bad", "./escape"] {
-        assert!(matches!(
-            store.head(key).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
-            store.get(key, None).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
+        assert_invalid_key(key, store.head(key).await);
+        assert_invalid_key(key, store.get(key, None).await);
+        assert_invalid_key(
+            key,
             store.put_if_absent(key, Bytes::from_static(b"oops")).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
+        );
+        assert_invalid_key(
+            key,
             store.put_overwrite(key, Bytes::from_static(b"oops")).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
+        );
+        assert_invalid_key(
+            key,
             store
                 .compare_and_swap(key, "etag", Bytes::from_static(b"oops"))
                 .await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
-            store.delete(key).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
-        assert!(matches!(
-            store.list_prefix(key).await,
-            Err(ObjectStoreError::InvalidKey(_))
-        ));
+        );
+        assert_invalid_key(key, store.delete(key).await);
+        assert_invalid_key(key, store.list_prefix(key).await);
     }
 }
 
 fn assert_precondition_failed<T>(result: Result<T, ObjectStoreError>) {
-    assert!(matches!(result, Err(ObjectStoreError::PreconditionFailed)));
+    assert!(matches!(
+        result,
+        Err(ObjectStoreError::PreconditionFailed { .. })
+    ));
 }
 
 #[derive(Debug)]

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -38,6 +38,7 @@ use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
 use tracing::Instrument;
 
 type SharedStore = SharedObjectStore;
@@ -260,18 +261,37 @@ fn trace_store_kind(store: &StoreConfig) -> TraceStoreKind {
     }
 }
 
-pub async fn serve(config: ServerConfig) -> Result<(), String> {
-    let bind: SocketAddr = config
-        .bind
-        .parse()
-        .map_err(|err: std::net::AddrParseError| err.to_string())?;
-    let app = app(config).map_err(|err| err.to_string())?;
+/// Failure starting or running the HTTP server.
+#[derive(Debug, Error)]
+pub enum ServeError {
+    #[error("invalid bind address `{addr}`: {source}")]
+    BindAddr {
+        addr: String,
+        #[source]
+        source: std::net::AddrParseError,
+    },
+    #[error("invalid server config: {0}")]
+    Config(#[from] ServerConfigError),
+    #[error("failed to bind `{addr}`: {source}")]
+    Bind {
+        addr: SocketAddr,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("server failed while serving requests: {0}")]
+    Serve(#[source] std::io::Error),
+}
+
+pub async fn serve(config: ServerConfig) -> Result<(), ServeError> {
+    let bind: SocketAddr = config.bind.parse().map_err(|source| ServeError::BindAddr {
+        addr: config.bind.clone(),
+        source,
+    })?;
+    let app = app(config)?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
-        .map_err(|err| err.to_string())?;
-    axum::serve(listener, app)
-        .await
-        .map_err(|err| err.to_string())
+        .map_err(|source| ServeError::Bind { addr: bind, source })?;
+    axum::serve(listener, app).await.map_err(ServeError::Serve)
 }
 
 #[cfg_attr(
@@ -978,11 +998,10 @@ async fn begin_direct_put_upload(
         ));
     };
     let Some(content_ref) = request.content_ref else {
-        return Err(ApiResponseError::runtime_for_namespace(
-            &namespace_id,
-            RuntimeError::Core(CoreError::InvalidUploadContent(
-                "direct_put requires content_ref at begin_upload".to_owned(),
-            )),
+        return Err(ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidRequest,
+            "invalid upload content: direct_put requires content_ref at begin_upload",
         ));
     };
 

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -13,7 +13,7 @@ mod trace;
 pub use config::{
     load_server_config, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
 };
-pub use http::{app, serve};
+pub use http::{app, serve, ServeError};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
 pub use trace::{init_tracing_from_env, TraceInitError};

--- a/crates/loonfs-server/src/publisher.rs
+++ b/crates/loonfs-server/src/publisher.rs
@@ -187,9 +187,13 @@ impl NamespacePublisher {
             operation_class,
             enqueued_at,
         )?;
-        receiver
-            .await
-            .unwrap_or_else(|_| Err(CoreError::Store("publisher task stopped".to_owned())))
+        receiver.await.unwrap_or_else(|_| {
+            Err(CoreError::HeadPublish(
+                CommitHeadPublishError::OutcomeUnknown(
+                    "publisher task stopped before reporting an outcome".to_owned(),
+                ),
+            ))
+        })
     }
 
     fn admit(
@@ -604,7 +608,7 @@ impl NamespacePublisher {
             let mut results = results.into_iter();
             for candidate in candidates {
                 let result = results.next().unwrap_or_else(|| {
-                    Err(CoreError::Store(
+                    Err(CoreError::Internal(
                         "publisher returned too few batch results".to_owned(),
                     ))
                 });
@@ -754,10 +758,10 @@ fn is_retryable_head_publish(result: &CommitResult) -> bool {
 fn runtime_error_to_core(error: RuntimeError) -> CoreError {
     match error {
         RuntimeError::Core(error) => error,
-        RuntimeError::Bootstrap(error) => CoreError::Store(error.to_string()),
-        RuntimeError::Config(message) => CoreError::Store(message),
-        RuntimeError::RuntimeTask(message) => CoreError::Store(message),
-        other => CoreError::Store(other.to_string()),
+        RuntimeError::Bootstrap(error) => CoreError::Internal(error.to_string()),
+        RuntimeError::Config(message) => CoreError::Internal(message),
+        RuntimeError::RuntimeTask(message) => CoreError::Internal(message),
+        other => CoreError::Internal(other.to_string()),
     }
 }
 
@@ -1148,8 +1152,9 @@ mod tests {
                 && self.lose_next_head_cas_ack.swap(false, Ordering::SeqCst);
             let metadata = self.inner.put(key, bytes, mode).await?;
             if lose_ack {
-                return Err(ObjectStoreError::Transport(
-                    "injected lost head CAS acknowledgement".to_owned(),
+                return Err(ObjectStoreError::transport(
+                    key,
+                    "injected lost head CAS acknowledgement",
                 ));
             }
             Ok(metadata)
@@ -1271,7 +1276,9 @@ mod tests {
         assert_eq!(operation_class(&path), "path_mutation");
         assert_eq!(result_label(&Ok::<_, CoreError>(())), "ok");
         assert_eq!(
-            result_label(&Err::<(), _>(CoreError::Store("private error".to_owned()))),
+            result_label(&Err::<(), _>(CoreError::Internal(
+                "private error".to_owned()
+            ))),
             "error"
         );
         assert_eq!(usize_to_u64(7), 7);

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -135,8 +135,9 @@ impl<S> FaultInjectingObjectStore<S> {
                         class: "transport".to_owned(),
                     },
                 );
-                Err(ObjectStoreError::Transport(
-                    "simulated transient put failure".to_owned(),
+                Err(ObjectStoreError::transport(
+                    key,
+                    "simulated transient put failure",
                 ))
             }
             Some(ObjectStoreFault::PutSucceedsButResponseLost) => {
@@ -152,8 +153,9 @@ impl<S> FaultInjectingObjectStore<S> {
                             class: "transport".to_owned(),
                         },
                     );
-                    Err(ObjectStoreError::Transport(
-                        "simulated lost put response".to_owned(),
+                    Err(ObjectStoreError::transport(
+                        key,
+                        "simulated lost put response",
                     ))
                 } else {
                     self.push_trace(
@@ -174,7 +176,9 @@ impl<S> FaultInjectingObjectStore<S> {
                         class: "precondition_failed".to_owned(),
                     },
                 );
-                Err(ObjectStoreError::PreconditionFailed)
+                Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                })
             }
             Some(incompatible) => {
                 let fault = incompatible.clone();
@@ -244,7 +248,7 @@ where
                         Some(ObjectStoreFault::GetReturnsStaleValue),
                         SimEventResult::Ok,
                     );
-                    return Ok(Some(apply_range(body.bytes, range)?));
+                    return Ok(Some(apply_range(key, body.bytes, range)?));
                 }
                 let result = self.inner.get(key, range).await;
                 self.push_trace(
@@ -377,8 +381,9 @@ where
                         class: "transport".to_owned(),
                     },
                 );
-                Err(ObjectStoreError::Transport(
-                    "simulated transient delete failure".to_owned(),
+                Err(ObjectStoreError::transport(
+                    key,
+                    "simulated transient delete failure",
                 ))
             }
             Some(incompatible) => {
@@ -504,15 +509,21 @@ fn put_mode_kind(mode: &PutMode) -> ObjectOpKind {
     }
 }
 
-fn apply_range(bytes: Vec<u8>, range: Option<ByteRange>) -> Result<Bytes, ObjectStoreError> {
+fn apply_range(
+    key: &str,
+    bytes: Vec<u8>,
+    range: Option<ByteRange>,
+) -> Result<Bytes, ObjectStoreError> {
     let Some(range) = range else {
         return Ok(Bytes::from(bytes));
     };
-    let start =
-        usize::try_from(range.start_inclusive).map_err(|_| ObjectStoreError::InvalidRange)?;
-    let end = usize::try_from(range.end_exclusive).map_err(|_| ObjectStoreError::InvalidRange)?;
+    let invalid_range = || ObjectStoreError::InvalidRange {
+        object_key: key.to_owned(),
+    };
+    let start = usize::try_from(range.start_inclusive).map_err(|_| invalid_range())?;
+    let end = usize::try_from(range.end_exclusive).map_err(|_| invalid_range())?;
     if start > end || end > bytes.len() {
-        return Err(ObjectStoreError::InvalidRange);
+        return Err(invalid_range());
     }
     Ok(Bytes::copy_from_slice(&bytes[start..end]))
 }
@@ -528,25 +539,25 @@ fn recent_key_to_omit(keys: &[String], prefix: &str, recent_writes: &[String]) -
 fn result_class<T>(result: &Result<T, ObjectStoreError>) -> SimEventResult {
     match result {
         Ok(_) => SimEventResult::Ok,
-        Err(ObjectStoreError::NotFound) => SimEventResult::Error {
+        Err(ObjectStoreError::NotFound { .. }) => SimEventResult::Error {
             class: "not_found".to_owned(),
         },
-        Err(ObjectStoreError::InvalidKey(_)) => SimEventResult::Error {
+        Err(ObjectStoreError::InvalidKey { .. }) => SimEventResult::Error {
             class: "invalid_key".to_owned(),
         },
-        Err(ObjectStoreError::InvalidRange) => SimEventResult::Error {
+        Err(ObjectStoreError::InvalidRange { .. }) => SimEventResult::Error {
             class: "invalid_range".to_owned(),
         },
-        Err(ObjectStoreError::PreconditionFailed) => SimEventResult::Error {
+        Err(ObjectStoreError::PreconditionFailed { .. }) => SimEventResult::Error {
             class: "precondition_failed".to_owned(),
         },
-        Err(ObjectStoreError::Conflict) => SimEventResult::Error {
+        Err(ObjectStoreError::Conflict { .. }) => SimEventResult::Error {
             class: "conflict".to_owned(),
         },
         Err(ObjectStoreError::Unsupported(_)) => SimEventResult::Error {
             class: "unsupported".to_owned(),
         },
-        Err(ObjectStoreError::Transport(_)) => SimEventResult::Error {
+        Err(ObjectStoreError::Transport { .. }) => SimEventResult::Error {
             class: "transport".to_owned(),
         },
         // Keep the label set low-cardinality for error kinds this build
@@ -610,7 +621,7 @@ mod tests {
 
         assert!(matches!(
             store.put_overwrite("a", Bytes::from_static(b"abc")).await,
-            Err(ObjectStoreError::Transport(_))
+            Err(ObjectStoreError::Transport { .. })
         ));
         assert_eq!(
             store.inner().get("a", None).await.expect("inner get"),
@@ -634,7 +645,7 @@ mod tests {
 
         assert!(matches!(
             store.put_overwrite("a", Bytes::from_static(b"abc")).await,
-            Err(ObjectStoreError::Transport(_))
+            Err(ObjectStoreError::Transport { .. })
         ));
         assert_eq!(store.inner().get("a", None).await.expect("inner get"), None);
     }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -314,7 +314,12 @@ impl Fs {
         let descriptor_key = namespace_config(namespace_id.as_str());
         let descriptor_exists = match self.store().head(&descriptor_key).await {
             Ok(value) => value.is_some(),
-            Err(error) => return RuntimeError::Core(CoreError::Store(error.to_string())),
+            Err(error) => {
+                return RuntimeError::Core(CoreError::Store {
+                    object_key: descriptor_key,
+                    message: error.message(),
+                })
+            }
         };
         if descriptor_exists {
             RuntimeError::Core(CoreError::MetadataProjection(
@@ -342,14 +347,18 @@ impl Fs {
             .store()
             .head(object_key)
             .await
-            .map_err(|error| ControlObjectLoadError::Store(error.to_string()))?
+            .map_err(|error| ControlObjectLoadError::Store {
+                object_key: object_key.to_owned(),
+                message: error.message(),
+            })?
             .ok_or_else(|| ControlObjectLoadError::MissingObject {
                 object_key: object_key.to_owned(),
             })?;
         let Some(etag) = metadata.etag else {
-            return Err(ControlObjectLoadError::Store(format!(
-                "missing control object etag for `{object_key}`"
-            )));
+            return Err(ControlObjectLoadError::Store {
+                object_key: object_key.to_owned(),
+                message: "missing control object etag".to_owned(),
+            });
         };
         Ok(etag == identity.etag)
     }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -380,7 +380,7 @@ impl Fs {
             }
         } else {
             let Some(current_manifest_id) = checkpoint.current_manifest_id else {
-                return Err(RuntimeError::Core(CoreError::Store(
+                return Err(RuntimeError::Core(CoreError::Internal(
                     "checkpoint publication returned no current manifest id".to_owned(),
                 )));
             };
@@ -989,7 +989,7 @@ impl Fs {
         .into_iter()
         .next()
         .unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Store(
+            Err(RuntimeError::Core(CoreError::Internal(
                 "empty commit batch".to_owned(),
             )))
         })
@@ -1024,7 +1024,7 @@ impl Fs {
             )
             .await;
         let response = results.pop().unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Store(
+            Err(RuntimeError::Core(CoreError::Internal(
                 "empty path mutation batch".to_owned(),
             )))
         })?;

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2377,13 +2377,17 @@ impl ObjectStore for HeadCasFailureStore {
             && matches!(&mode, PutMode::CompareAndSwap { .. })
             && self.fail_head_cas.load(Ordering::SeqCst)
         {
-            return Err(ObjectStoreError::PreconditionFailed);
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         if key == self.root_key
             && matches!(&mode, PutMode::CompareAndSwap { .. })
             && self.fail_root_cas.load(Ordering::SeqCst)
         {
-            return Err(ObjectStoreError::PreconditionFailed);
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
         }
         self.inner.put(key, bytes, mode).await
     }


### PR DESCRIPTION
Final consistency sweep over error handling. Every store/codec wrapper now carries the object key it failed on (ObjectStoreError restructured through all five providers; CoreError::Store became { object_key, message } — of its 63 former constructions, 21 were real store failures and now carry real keys, while the other ~40 were disguised codec/invariant/plumbing failures and moved to a new honest CoreError::Internal on the same server_error code). A new ObjectStoreError::Configuration variant stops store-construction failures from masquerading as transport errors. #[from] applies wherever an inner type maps to one variant, with a stated comment where explicit conversion is deliberate; variant names mirror wire codes (PathNotFound, RevisionNotFound); core adopts the facade's Result alias (~230 signatures) and re-export Error naming; the publisher's dropped-channel case now honestly serves commit_outcome_unknown/503 instead of a fake store error/500; serve() gets a real ServeError; and the conformance suite is strengthened to assert carried keys.

Note for review: the ObjectStoreError shape change forced 32/21 strictly mechanical construction-site adaptations inside crates/loonfs-sim/src/fault_store.rs (it is a workspace member consuming that enum). No loonfs-sim public API, config, or trace behavior changed — but flagging it since that crate is otherwise hands-off as the external simulator's contract.