### PR TITLE
refactor(core): single implementation of visibility semantics

### DIFF
--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -10,7 +10,7 @@ use super::super::{
 };
 use super::view::CommitValidationView;
 use crate::invariants::InvariantId;
-use crate::metadata::{InodeRecord, RevisionRecord, SubtreeTombstoneRecord};
+use crate::metadata::{BindingIdentity, InodeRecord, RevisionRecord, SubtreeTombstoneRecord};
 use loonfs_api::{
     name_key_for_display_name, ChangeSeq, DisplayName, InodeId, InodeKind, NamePolicy, RevisionNo,
 };
@@ -566,10 +566,17 @@ async fn validate_binding_is_precondition<V: CommitValidationView>(
         }
         .into());
     };
-    if existing.child_inode_id != child_inode_id
-        || existing.bind_seq != bind_seq
-        || existing.bind_delta_index != bind_delta_index
-    {
+    // Same parent and name by construction: `existing` was looked up under
+    // `(parent_inode_id, name_key)`, so identity equality reduces to the
+    // remaining binding-identity fields.
+    let expected = BindingIdentity {
+        parent_inode_id,
+        name_key,
+        child_inode_id,
+        bind_seq,
+        bind_delta_index,
+    };
+    if BindingIdentity::from(&existing) != expected {
         return Err(CommitValidationError::BindingPreconditionMismatch {
             parent_inode_id,
             name_key: name_key.to_owned(),

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -1,3 +1,4 @@
+use super::visibility::unbind_matches_binding;
 use super::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneRecord,
@@ -78,7 +79,7 @@ impl MetadataIndexes {
             let Some(latest_child_bind) = latest_by_child.get(&bind.child_inode_id) else {
                 continue;
             };
-            if !same_binding(bind, latest_child_bind) {
+            if !bind.same_binding(latest_child_bind) {
                 continue;
             }
             indexes
@@ -237,7 +238,7 @@ impl MetadataIndexes {
         if self
             .active_child_by_parent_name
             .get(&parent_name_key)
-            .map(|active| unbind_matches_bind(record, active))
+            .map(|active| unbind_matches_binding(record, active))
             .unwrap_or(false)
         {
             self.active_child_by_parent_name.remove(&parent_name_key);
@@ -245,7 +246,7 @@ impl MetadataIndexes {
         if self
             .active_parent_by_child
             .get(&record.child_inode_id)
-            .map(|active| unbind_matches_bind(record, active))
+            .map(|active| unbind_matches_binding(record, active))
             .unwrap_or(false)
         {
             self.active_parent_by_child.remove(&record.child_inode_id);
@@ -285,6 +286,10 @@ impl MetadataIndexes {
     }
 }
 
+/// Owned hash-key twin of [`super::visibility::BindingIdentity`]: the same
+/// five identity fields, owned so unbound binding events can live in a
+/// `HashSet`. Not a comparison rule of its own — membership tests through it
+/// are identity comparisons by construction.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BindingKey {
     parent_inode_id: InodeId,
@@ -382,7 +387,7 @@ fn remove_active_parent_if_same(
 ) {
     if active_parent_by_child
         .get(&record.child_inode_id)
-        .map(|active| same_binding(active, record))
+        .map(|active| active.same_binding(record))
         .unwrap_or(false)
     {
         active_parent_by_child.remove(&record.child_inode_id);
@@ -396,27 +401,11 @@ fn remove_active_child_if_same(
     let key = (record.parent_inode_id, record.name_key.clone());
     if active_child_by_parent_name
         .get(&key)
-        .map(|active| same_binding(active, record))
+        .map(|active| active.same_binding(record))
         .unwrap_or(false)
     {
         active_child_by_parent_name.remove(&key);
     }
-}
-
-fn same_binding(left: &DirentryBindRecord, right: &DirentryBindRecord) -> bool {
-    left.parent_inode_id == right.parent_inode_id
-        && left.name_key == right.name_key
-        && left.child_inode_id == right.child_inode_id
-        && left.bind_seq == right.bind_seq
-        && left.bind_delta_index == right.bind_delta_index
-}
-
-fn unbind_matches_bind(unbind: &DirentryUnbindRecord, bind: &DirentryBindRecord) -> bool {
-    unbind.parent_inode_id == bind.parent_inode_id
-        && unbind.name_key == bind.name_key
-        && unbind.child_inode_id == bind.child_inode_id
-        && unbind.bind_seq == bind.bind_seq
-        && unbind.bind_delta_index == bind.bind_delta_index
 }
 
 fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -1,14 +1,14 @@
 use super::row_decode::{
     commit_receipt_from_manifest_row, direntry_bind_from_manifest_row,
     direntry_unbind_from_manifest_row, inode_from_manifest_row, revision_from_manifest_row,
-    tombstone_from_manifest_row, unbind_matches_binding,
+    tombstone_from_manifest_row,
 };
 use crate::checkpoint::{string_prefix_upper_bound, ManifestLoadError, VerifiedMetadataTables};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::metadata::{
-    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
-    SubtreeTombstoneRecord,
+    unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
+    InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::{hex_encode_row_key_component, MetadataRow, MetadataTableFamily};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -16,6 +16,10 @@
 //!   row scans below it.
 //! - `indexes` maintains the at-head lookup structures behind those fast
 //!   paths.
+//! - `visibility` holds the single authoritative statement of the
+//!   direntry-visibility rules (binding identity, active bindings, tombstone
+//!   coverage, path resolution) that every storage shape above decides
+//!   through.
 
 mod apply;
 mod indexes;
@@ -26,6 +30,7 @@ mod rows;
 #[cfg(test)]
 mod tests;
 mod view;
+mod visibility;
 
 pub use self::apply::{AppliedMetadataState, MetadataApplyError};
 pub use self::queries::{ResolvedVisiblePath, VisiblePathError};
@@ -38,6 +43,7 @@ pub(crate) use self::rows::record_name_key;
 pub(crate) use self::view::{
     InMemoryMetadataView, MetadataView, MetadataViewSession, VisibleChildEntry,
 };
+pub(crate) use self::visibility::{unbind_matches_binding, BindingIdentity};
 
 #[cfg(test)]
 pub(crate) use self::rows::MetadataStateBuilder;

--- a/crates/loonfs-core/src/metadata/queries.rs
+++ b/crates/loonfs-core/src/metadata/queries.rs
@@ -3,14 +3,17 @@
 //!
 //! Every seq-parameterized query routes to its `*_at_head` twin once
 //! `base_seq` reaches [`MetadataState::indexed_seq`], and to a historical
-//! row scan below it.
+//! row scan below it. The composite visibility decisions themselves live in
+//! [`super::visibility`]; this module only chooses which storage arm
+//! (historical scan or at-head index) answers the primitive lookups.
 
+use super::visibility::{self, resolve_in_memory_read, unbind_matches_binding};
 use super::{
     DirentryBindRecord, InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo};
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NamePolicy, RevisionNo};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::future::Future;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -168,11 +171,10 @@ impl MetadataState {
         if base_seq >= self.indexed_seq() {
             return self.current_parent_binding_for_child_at_head(child_inode_id);
         }
-        let direntry = self.latest_parent_binding_for_child_at_seq(child_inode_id, base_seq)?;
-        if self.is_direntry_unbound_at_seq(&direntry, base_seq) {
-            return None;
-        }
-        Some(direntry)
+        read_now(visibility::current_parent_binding_for_child(
+            &mut self.reads_at_seq(base_seq),
+            child_inode_id,
+        ))
     }
 
     pub fn current_parent_binding_for_child_at_head(
@@ -222,54 +224,37 @@ impl MetadataState {
         if base_seq >= self.indexed_seq() {
             return self.covering_subtree_tombstone_at_head(inode_id);
         }
-
-        walk_ancestor_chain(
+        read_now(visibility::covering_subtree_tombstone(
+            &mut self.reads_at_seq(base_seq),
             inode_id,
-            |candidate| self.active_subtree_tombstone(candidate, base_seq),
-            |candidate| {
-                self.current_parent_binding_for_child(candidate, base_seq)
-                    .map(|direntry| direntry.parent_inode_id)
-            },
-        )
+        ))
     }
 
     pub fn covering_subtree_tombstone_at_head(
         &self,
         inode_id: InodeId,
     ) -> Option<SubtreeTombstoneRecord> {
-        walk_ancestor_chain(
+        read_now(visibility::covering_subtree_tombstone(
+            &mut self.reads_at_head(),
             inode_id,
-            |candidate| self.active_subtree_tombstone_at_head(candidate),
-            |candidate| {
-                self.current_parent_binding_for_child_at_head(candidate)
-                    .map(|direntry| direntry.parent_inode_id)
-            },
-        )
+        ))
     }
 
     pub fn visible_inode(&self, inode_id: InodeId, base_seq: ChangeSeq) -> Option<InodeRecord> {
         if base_seq >= self.indexed_seq() {
             return self.visible_inode_at_head(inode_id);
         }
-
-        let inode = self.inode_at_seq(inode_id, base_seq)?;
-        if self
-            .covering_subtree_tombstone(inode_id, base_seq)
-            .is_some()
-        {
-            return None;
-        }
-
-        Some(inode)
+        read_now(visibility::visible_inode(
+            &mut self.reads_at_seq(base_seq),
+            inode_id,
+        ))
     }
 
     pub fn visible_inode_at_head(&self, inode_id: InodeId) -> Option<InodeRecord> {
-        let inode = self.inode_at_head(inode_id)?;
-        if self.covering_subtree_tombstone_at_head(inode_id).is_some() {
-            return None;
-        }
-
-        Some(inode)
+        read_now(visibility::visible_inode(
+            &mut self.reads_at_head(),
+            inode_id,
+        ))
     }
 
     pub fn current_revision_head(
@@ -290,15 +275,11 @@ impl MetadataState {
         if base_seq >= self.indexed_seq() {
             return self.visible_child_at_head(parent_inode_id, name_key);
         }
-
-        let parent = self.visible_inode(parent_inode_id, base_seq)?;
-        if parent.inode_kind != InodeKind::Dir {
-            return None;
-        }
-
-        let direntry = self.active_child_binding_at_seq(parent_inode_id, name_key, base_seq)?;
-        self.visible_inode(direntry.child_inode_id, base_seq)?;
-        Some(direntry)
+        read_now(visibility::visible_child(
+            &mut self.reads_at_seq(base_seq),
+            parent_inode_id,
+            name_key,
+        ))
     }
 
     pub fn visible_child_at_head(
@@ -306,14 +287,11 @@ impl MetadataState {
         parent_inode_id: InodeId,
         name_key: &str,
     ) -> Option<DirentryBindRecord> {
-        let parent = self.visible_inode_at_head(parent_inode_id)?;
-        if parent.inode_kind != InodeKind::Dir {
-            return None;
-        }
-
-        let direntry = self.indexes.active_child(parent_inode_id, name_key)?;
-        self.visible_inode_at_head(direntry.child_inode_id)?;
-        Some(direntry)
+        read_now(visibility::visible_child(
+            &mut self.reads_at_head(),
+            parent_inode_id,
+            name_key,
+        ))
     }
 
     pub fn visible_children(
@@ -332,6 +310,7 @@ impl MetadataState {
             return Vec::new();
         }
 
+        let mut reads = self.reads_at_seq(base_seq);
         let mut children = self
             .direntry_binds
             .iter()
@@ -339,17 +318,7 @@ impl MetadataState {
                 direntry.parent_inode_id == parent_inode_id && direntry.bind_seq <= base_seq
             })
             .filter(|direntry| {
-                self.active_child_binding_at_seq(parent_inode_id, &direntry.name_key, base_seq)
-                    .map(|active| {
-                        active.child_inode_id == direntry.child_inode_id
-                            && active.bind_seq == direntry.bind_seq
-                            && active.bind_delta_index == direntry.bind_delta_index
-                    })
-                    .unwrap_or(false)
-            })
-            .filter(|direntry| {
-                self.visible_inode(direntry.child_inode_id, base_seq)
-                    .is_some()
+                read_now(visibility::is_visible_child_direntry(&mut reads, direntry))
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -458,98 +427,14 @@ impl MetadataState {
         name_policy: NamePolicy,
         base_seq: ChangeSeq,
     ) -> Result<ResolvedVisiblePath, VisiblePathError> {
-        let root_inode_id = InodeId(1);
-        let root = self
-            .visible_inode(root_inode_id, base_seq)
-            .ok_or(VisiblePathError::RootMissing)?;
-        if absolute_path.is_root() {
-            return Ok(ResolvedVisiblePath {
-                absolute_path: "/".to_owned(),
-                inode_id: root_inode_id,
-                inode_kind: root.inode_kind,
-                parent_inode_id: None,
-                display_name: String::new(),
-            });
-        }
-
-        let mut current_inode_id = root_inode_id;
-        let mut current_absolute_path = "/".to_owned();
-        let mut current_parent_inode_id = None;
-        let mut current_display_name = String::new();
-
-        for component in absolute_path.components() {
-            let current_inode = self.visible_inode(current_inode_id, base_seq).ok_or(
-                VisiblePathError::PathNotFound {
-                    absolute_path: current_absolute_path.clone(),
-                },
-            )?;
-            if current_inode.inode_kind != InodeKind::Dir {
-                return Err(VisiblePathError::PathComponentNotDirectory {
-                    absolute_path: current_absolute_path,
-                    inode_id: current_inode_id,
-                    inode_kind: current_inode.inode_kind,
-                });
-            }
-
-            let requested_absolute_path =
-                join_display_path(&current_absolute_path, component.as_str());
-            let display_name = component.to_display_name();
-            let name_key = NameKey::for_display_name(name_policy, &display_name);
-            let direntry = self
-                .visible_child(current_inode_id, name_key.as_str(), base_seq)
-                .ok_or(VisiblePathError::PathNotFound {
-                    absolute_path: requested_absolute_path,
-                })?;
-            current_inode_id = direntry.child_inode_id;
-            current_parent_inode_id = Some(direntry.parent_inode_id);
-            current_display_name = direntry.display_name.clone();
-            current_absolute_path =
-                join_display_path(&current_absolute_path, &direntry.display_name);
-        }
-
-        let inode = self
-            .visible_inode(current_inode_id, base_seq)
-            .ok_or_else(|| VisiblePathError::PathNotFound {
-                absolute_path: current_absolute_path.clone(),
-            })?;
-        Ok(ResolvedVisiblePath {
-            absolute_path: current_absolute_path,
-            inode_id: current_inode_id,
-            inode_kind: inode.inode_kind,
-            parent_inode_id: current_parent_inode_id,
-            display_name: current_display_name,
-        })
+        resolve_in_memory_read(visibility::resolve_visible_path(
+            &mut self.reads_at_seq(base_seq),
+            absolute_path,
+            name_policy,
+        ))
     }
 
-    fn active_child_binding_at_seq(
-        &self,
-        parent_inode_id: InodeId,
-        name_key: &str,
-        base_seq: ChangeSeq,
-    ) -> Option<DirentryBindRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.indexes.active_child(parent_inode_id, name_key);
-        }
-
-        let direntry = self.bound_child_at_seq(parent_inode_id, name_key, base_seq)?;
-        if self.is_direntry_unbound_at_seq(&direntry, base_seq) {
-            return None;
-        }
-        let latest_binding =
-            self.latest_parent_binding_for_child_at_seq(direntry.child_inode_id, base_seq)?;
-        if latest_binding.parent_inode_id != direntry.parent_inode_id
-            || latest_binding.name_key != direntry.name_key
-            || latest_binding.bind_seq != direntry.bind_seq
-            || latest_binding.bind_delta_index != direntry.bind_delta_index
-            || self.is_direntry_unbound_at_seq(&latest_binding, base_seq)
-        {
-            return None;
-        }
-
-        Some(direntry)
-    }
-
-    fn latest_parent_binding_for_child_at_seq(
+    pub(super) fn latest_parent_binding_for_child_at_seq(
         &self,
         child_inode_id: InodeId,
         base_seq: ChangeSeq,
@@ -583,14 +468,9 @@ impl MetadataState {
         direntry: &DirentryBindRecord,
         base_seq: ChangeSeq,
     ) -> bool {
-        self.direntry_unbinds.iter().any(|unbind| {
-            unbind.unbind_seq <= base_seq
-                && unbind.parent_inode_id == direntry.parent_inode_id
-                && unbind.name_key == direntry.name_key
-                && unbind.child_inode_id == direntry.child_inode_id
-                && unbind.bind_seq == direntry.bind_seq
-                && unbind.bind_delta_index == direntry.bind_delta_index
-        })
+        self.direntry_unbinds
+            .iter()
+            .any(|unbind| unbind.unbind_seq <= base_seq && unbind_matches_binding(unbind, direntry))
     }
 
     pub fn would_create_directory_cycle(
@@ -602,16 +482,11 @@ impl MetadataState {
         if base_seq >= self.indexed_seq() {
             return self.would_create_directory_cycle_at_head(inode_id, new_parent_inode_id);
         }
-
-        walk_ancestor_chain(
+        read_now(visibility::would_create_directory_cycle(
+            &mut self.reads_at_seq(base_seq),
+            inode_id,
             new_parent_inode_id,
-            |candidate| (candidate == inode_id).then_some(()),
-            |candidate| {
-                self.current_parent_binding_for_child(candidate, base_seq)
-                    .map(|direntry| direntry.parent_inode_id)
-            },
-        )
-        .is_some()
+        ))
     }
 
     pub fn would_create_directory_cycle_at_head(
@@ -619,50 +494,17 @@ impl MetadataState {
         inode_id: InodeId,
         new_parent_inode_id: InodeId,
     ) -> bool {
-        walk_ancestor_chain(
+        read_now(visibility::would_create_directory_cycle(
+            &mut self.reads_at_head(),
+            inode_id,
             new_parent_inode_id,
-            |candidate| (candidate == inode_id).then_some(()),
-            |candidate| {
-                self.current_parent_binding_for_child_at_head(candidate)
-                    .map(|direntry| direntry.parent_inode_id)
-            },
-        )
-        .is_some()
+        ))
     }
 }
 
-fn join_display_path(base: &str, component: &str) -> String {
-    if base == "/" {
-        format!("/{component}")
-    } else {
-        format!("{base}/{component}")
-    }
-}
-
-/// Walks from `start` up the chain of parents produced by `parent_of`,
-/// returning the first `visit` hit.
-///
-/// The visited set guards the walk against parent-binding cycles: revisiting
-/// an inode terminates the walk instead of looping. The covering-tombstone
-/// and directory-cycle checks are both this walk parameterized by their
-/// per-step lookups.
-fn walk_ancestor_chain<T>(
-    start: InodeId,
-    visit: impl Fn(InodeId) -> Option<T>,
-    parent_of: impl Fn(InodeId) -> Option<InodeId>,
-) -> Option<T> {
-    let mut current = Some(start);
-    let mut visited = BTreeSet::new();
-
-    while let Some(candidate_inode_id) = current {
-        if !visited.insert(candidate_inode_id.0) {
-            break;
-        }
-        if let Some(found) = visit(candidate_inode_id) {
-            return Some(found);
-        }
-        current = parent_of(candidate_inode_id);
-    }
-
-    None
+/// Drives an in-memory visibility read and unwraps its uninhabited error
+/// arm: of the [`super::visibility`] rules only `resolve_visible_path`
+/// constructs a [`VisiblePathError`], and it is not routed through here.
+fn read_now<T>(future: impl Future<Output = Result<T, VisiblePathError>>) -> T {
+    resolve_in_memory_read(future).expect("seq-scoped metadata state reads are infallible")
 }

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -113,14 +113,3 @@ pub(super) fn commit_receipt_from_manifest_row(row: MetadataRow) -> Option<Commi
         _ => None,
     }
 }
-
-pub(super) fn unbind_matches_binding(
-    unbind: &DirentryUnbindRecord,
-    direntry: &DirentryBindRecord,
-) -> bool {
-    unbind.parent_inode_id == direntry.parent_inode_id
-        && unbind.name_key == direntry.name_key
-        && unbind.child_inode_id == direntry.child_inode_id
-        && unbind.bind_seq == direntry.bind_seq
-        && unbind.bind_delta_index == direntry.bind_delta_index
-}

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -1,18 +1,17 @@
-use super::{manifest_index, row_decode::unbind_matches_binding};
+use super::manifest_index;
+use super::visibility::{self, MetadataVisibilityReads};
 use crate::checkpoint::VerifiedMetadataTables;
 use crate::error::CoreError;
 use crate::metadata::{
-    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
-    ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord, VisiblePathError,
+    unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
+    InodeRecord, MetadataState, ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
-use loonfs_api::{
-    AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo,
-};
+use loonfs_api::{AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NamePolicy, RevisionNo};
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
@@ -197,7 +196,15 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     }
 }
 
-impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
+impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
+    /// Adapter presenting this view's primitive lookups as the
+    /// [`MetadataVisibilityReads`] contract, so the composite rules are
+    /// decided once in [`super::visibility`]. The view is `Copy`, so the
+    /// adapter owns a copy and needs no borrow of `self`.
+    fn reads(&self) -> MetadataViewReads<'a, 'store, S> {
+        MetadataViewReads { view: *self }
+    }
+
     pub(crate) async fn visible_children(
         &self,
         parent_inode_id: InodeId,
@@ -210,21 +217,10 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         }
 
         let candidates = self.direntry_binds_for_parent(parent_inode_id).await?;
+        let mut reads = self.reads();
         let mut children = Vec::new();
         for direntry in candidates {
-            let active = self
-                .visible_child(parent_inode_id, &direntry.name_key)
-                .await?;
-            if active
-                .as_ref()
-                .map(|active| {
-                    active.child_inode_id == direntry.child_inode_id
-                        && active.bind_seq == direntry.bind_seq
-                        && active.bind_delta_index == direntry.bind_delta_index
-                })
-                .unwrap_or(false)
-                && self.visible_inode(direntry.child_inode_id).await?.is_some()
-            {
+            if visibility::is_visible_child_direntry(&mut reads, &direntry).await? {
                 children.push(direntry);
             }
         }
@@ -240,74 +236,12 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         &self,
         absolute_path: &AbsolutePath,
     ) -> Result<ResolvedVisiblePath, CoreError> {
-        let root_inode_id = InodeId(1);
-        let root = self
-            .visible_inode(root_inode_id)
-            .await?
-            .ok_or(VisiblePathError::RootMissing)?;
-        if absolute_path.is_root() {
-            return Ok(ResolvedVisiblePath {
-                absolute_path: absolute_path.as_str().to_owned(),
-                inode_id: root_inode_id,
-                inode_kind: root.inode_kind,
-                parent_inode_id: None,
-                display_name: String::new(),
-            });
-        }
-
-        let mut current_inode_id = root_inode_id;
-        let mut current_absolute_path = String::from("/");
-        let mut current_parent_inode_id = None;
-        let mut current_display_name = String::new();
-
-        for component in absolute_path.components() {
-            let current_inode = self.visible_inode(current_inode_id).await?.ok_or_else(|| {
-                VisiblePathError::PathNotFound {
-                    absolute_path: current_absolute_path.clone(),
-                }
-            })?;
-            if current_inode.inode_kind != InodeKind::Dir {
-                return Err(VisiblePathError::PathComponentNotDirectory {
-                    absolute_path: current_absolute_path,
-                    inode_id: current_inode_id,
-                    inode_kind: current_inode.inode_kind,
-                }
-                .into());
-            }
-
-            let requested_absolute_path = if current_absolute_path == "/" {
-                format!("/{}", component.as_str())
-            } else {
-                format!("{}/{}", current_absolute_path, component.as_str())
-            };
-            let display_name = component.to_display_name();
-            let name_key = NameKey::for_display_name(self.snapshot.name_policy, &display_name);
-            let direntry = self
-                .visible_child(current_inode_id, name_key.as_str())
-                .await?
-                .ok_or(VisiblePathError::PathNotFound {
-                    absolute_path: requested_absolute_path,
-                })?;
-
-            current_parent_inode_id = Some(current_inode_id);
-            current_inode_id = direntry.child_inode_id;
-            current_absolute_path =
-                absolute_path_prefix(&current_absolute_path, &direntry.display_name);
-            current_display_name = direntry.display_name;
-        }
-
-        let inode = self.visible_inode(current_inode_id).await?.ok_or_else(|| {
-            VisiblePathError::PathNotFound {
-                absolute_path: current_absolute_path.clone(),
-            }
-        })?;
-        Ok(ResolvedVisiblePath {
-            absolute_path: current_absolute_path,
-            inode_id: current_inode_id,
-            inode_kind: inode.inode_kind,
-            parent_inode_id: current_parent_inode_id,
-            display_name: current_display_name,
-        })
+        visibility::resolve_visible_path(
+            &mut self.reads(),
+            absolute_path,
+            self.snapshot.name_policy,
+        )
+        .await
     }
 
     pub(crate) async fn visible_child(
@@ -315,48 +249,14 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         parent_inode_id: InodeId,
         name_key: &str,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
-        let Some(parent) = self.visible_inode(parent_inode_id).await? else {
-            return Ok(None);
-        };
-        if parent.inode_kind != InodeKind::Dir {
-            return Ok(None);
-        }
-
-        let Some(direntry) = self.bound_child(parent_inode_id, name_key).await? else {
-            return Ok(None);
-        };
-        if self.is_direntry_unbound(&direntry).await? {
-            return Ok(None);
-        }
-        let Some(latest_binding) = self
-            .current_parent_binding_for_child(direntry.child_inode_id)
-            .await?
-        else {
-            return Ok(None);
-        };
-        if latest_binding.parent_inode_id != direntry.parent_inode_id
-            || latest_binding.name_key != direntry.name_key
-            || latest_binding.bind_seq != direntry.bind_seq
-            || latest_binding.bind_delta_index != direntry.bind_delta_index
-            || self.is_direntry_unbound(&latest_binding).await?
-        {
-            return Ok(None);
-        }
-
-        Ok(Some(direntry))
+        visibility::visible_child(&mut self.reads(), parent_inode_id, name_key).await
     }
 
     pub(crate) async fn visible_inode(
         &self,
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
-        let Some(inode) = self.inode_at_seq(inode_id).await? else {
-            return Ok(None);
-        };
-        if self.covering_subtree_tombstone(inode_id).await?.is_some() {
-            return Ok(None);
-        }
-        Ok(Some(inode))
+        visibility::visible_inode(&mut self.reads(), inode_id).await
     }
 
     pub(crate) async fn inode_at_seq(
@@ -490,39 +390,29 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         &self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
+        visibility::current_parent_binding_for_child(&mut self.reads(), child_inode_id).await
+    }
+
+    /// Latest binding whose child is `child_inode_id` at the visible seq,
+    /// regardless of whether it has since been unbound. The
+    /// [`MetadataVisibilityReads`] primitive backing
+    /// [`Self::current_parent_binding_for_child`]'s canonical rule.
+    async fn latest_parent_binding_for_child(
+        &self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, CoreError> {
         let bindings = self.direntry_binds_for_child(child_inode_id).await?;
-        let Some(binding) = bindings
+        Ok(bindings
             .into_iter()
             .filter(|direntry| direntry.bind_seq <= self.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-        else {
-            return Ok(None);
-        };
-        if self.is_direntry_unbound(&binding).await? {
-            return Ok(None);
-        }
-        Ok(Some(binding))
+            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index)))
     }
 
     pub(crate) async fn covering_subtree_tombstone(
         &self,
         inode_id: InodeId,
     ) -> Result<Option<SubtreeTombstoneRecord>, CoreError> {
-        let mut current = Some(inode_id);
-        let mut visited = std::collections::BTreeSet::new();
-        while let Some(candidate_inode_id) = current {
-            if !visited.insert(candidate_inode_id.0) {
-                break;
-            }
-            if let Some(tombstone) = self.active_subtree_tombstone(candidate_inode_id).await? {
-                return Ok(Some(tombstone));
-            }
-            current = self
-                .current_parent_binding_for_child(candidate_inode_id)
-                .await?
-                .map(|direntry| direntry.parent_inode_id);
-        }
-        Ok(None)
+        visibility::covering_subtree_tombstone(&mut self.reads(), inode_id).await
     }
 
     pub(crate) async fn would_create_directory_cycle(
@@ -530,23 +420,8 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
         inode_id: InodeId,
         new_parent_inode_id: InodeId,
     ) -> Result<bool, CoreError> {
-        let mut current = Some(new_parent_inode_id);
-        let mut visited = BTreeSet::new();
-
-        while let Some(candidate_inode_id) = current {
-            if !visited.insert(candidate_inode_id.0) {
-                break;
-            }
-            if candidate_inode_id == inode_id {
-                return Ok(true);
-            }
-            current = self
-                .current_parent_binding_for_child(candidate_inode_id)
-                .await?
-                .map(|direntry| direntry.parent_inode_id);
-        }
-
-        Ok(false)
+        visibility::would_create_directory_cycle(&mut self.reads(), inode_id, new_parent_inode_id)
+            .await
     }
 
     pub(crate) async fn bound_child(
@@ -754,6 +629,54 @@ impl<S: ObjectStore + ?Sized> MetadataView<'_, '_, S> {
     }
 }
 
+/// [`MetadataView`] as a [`MetadataVisibilityReads`] source: it answers only
+/// the primitive lookups (over the manifest tables merged with the row-state
+/// tail) and takes every composite rule from the provided trait methods, so
+/// the object-store-backed view decides visibility through the exact same
+/// bodies as the in-memory state.
+struct MetadataViewReads<'a, 'store, S: ObjectStore + ?Sized> {
+    view: MetadataView<'a, 'store, S>,
+}
+
+impl<S: ObjectStore + ?Sized> MetadataVisibilityReads for MetadataViewReads<'_, '_, S> {
+    type Error = CoreError;
+
+    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
+        self.view.inode_at_seq(inode_id).await
+    }
+
+    async fn find_latest_bound_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        self.view.bound_child(parent_inode_id, name_key).await
+    }
+
+    async fn find_latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        self.view
+            .latest_parent_binding_for_child(child_inode_id)
+            .await
+    }
+
+    async fn find_active_subtree_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        self.view.active_subtree_tombstone(root_inode_id).await
+    }
+
+    async fn is_binding_unbound(
+        &mut self,
+        direntry: &DirentryBindRecord,
+    ) -> Result<bool, Self::Error> {
+        self.view.is_direntry_unbound(direntry).await
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct VisibleChildEntry {
     pub(crate) binding: DirentryBindRecord,
@@ -904,36 +827,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         name_key: &str,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
         self.counters.visible_child_calls = self.counters.visible_child_calls.saturating_add(1);
-
-        let Some(parent) = self.visible_inode(parent_inode_id).await? else {
-            return Ok(None);
-        };
-        if parent.inode_kind != InodeKind::Dir {
-            return Ok(None);
-        }
-
-        let Some(direntry) = self.bound_child(parent_inode_id, name_key).await? else {
-            return Ok(None);
-        };
-        if self.is_direntry_unbound(&direntry).await? {
-            return Ok(None);
-        }
-        let Some(latest_binding) = self
-            .current_parent_binding_for_child(direntry.child_inode_id)
-            .await?
-        else {
-            return Ok(None);
-        };
-        if latest_binding.parent_inode_id != direntry.parent_inode_id
-            || latest_binding.name_key != direntry.name_key
-            || latest_binding.bind_seq != direntry.bind_seq
-            || latest_binding.bind_delta_index != direntry.bind_delta_index
-            || self.is_direntry_unbound(&latest_binding).await?
-        {
-            return Ok(None);
-        }
-
-        Ok(Some(direntry))
+        visibility::visible_child(self, parent_inode_id, name_key).await
     }
 
     pub(crate) async fn visible_inode(
@@ -945,15 +839,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             return Ok(cached);
         }
 
-        let visible = if let Some(inode) = self.inode_at_seq(inode_id).await? {
-            if self.covering_subtree_tombstone(inode_id).await?.is_some() {
-                None
-            } else {
-                Some(inode)
-            }
-        } else {
-            None
-        };
+        let visible = visibility::visible_inode(self, inode_id).await?;
         self.visible_inode_cache.insert(inode_id, visible.clone());
         Ok(visible)
     }
@@ -1010,26 +896,28 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             return Ok(cached);
         }
 
+        let binding = visibility::current_parent_binding_for_child(self, child_inode_id).await?;
+        self.current_parent_binding_cache
+            .insert(child_inode_id, binding.clone());
+        Ok(binding)
+    }
+
+    /// Latest binding whose child is `child_inode_id` at the visible seq,
+    /// regardless of whether it has since been unbound. The
+    /// [`MetadataVisibilityReads`] primitive backing the session's cached
+    /// [`Self::current_parent_binding_for_child`].
+    async fn latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, CoreError> {
         self.counters.direntry_child_scan_calls =
             self.counters.direntry_child_scan_calls.saturating_add(1);
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
         let bindings = self.base.direntry_binds_for_child(child_inode_id).await?;
-        let binding = bindings
+        Ok(bindings
             .into_iter()
             .filter(|direntry| direntry.bind_seq <= self.base.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index));
-        let binding = if let Some(binding) = binding {
-            if self.is_direntry_unbound(&binding).await? {
-                None
-            } else {
-                Some(binding)
-            }
-        } else {
-            None
-        };
-        self.current_parent_binding_cache
-            .insert(child_inode_id, binding.clone());
-        Ok(binding)
+            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index)))
     }
 
     pub(crate) async fn covering_subtree_tombstone(
@@ -1042,22 +930,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             return Ok(cached);
         }
 
-        let mut current = Some(inode_id);
-        let mut visited = BTreeSet::new();
-        let mut tombstone = None;
-        while let Some(candidate_inode_id) = current {
-            if !visited.insert(candidate_inode_id.0) {
-                break;
-            }
-            if let Some(active) = self.active_subtree_tombstone(candidate_inode_id).await? {
-                tombstone = Some(active);
-                break;
-            }
-            current = self
-                .current_parent_binding_for_child(candidate_inode_id)
-                .await?
-                .map(|direntry| direntry.parent_inode_id);
-        }
+        let tombstone = visibility::covering_subtree_tombstone(self, inode_id).await?;
         self.covering_tombstone_cache
             .insert(inode_id, tombstone.clone());
         Ok(tombstone)
@@ -1124,6 +997,70 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     }
 }
 
+/// The session as a [`MetadataVisibilityReads`] source. Its primitives route
+/// through the per-session caches, and it overrides exactly the composite
+/// rules it memoizes (`visible_inode`, `current_parent_binding_for_child`,
+/// `covering_subtree_tombstone`) so a cache hit short-circuits the walk;
+/// every override's miss path, and the un-overridden composites, still decide
+/// through the canonical [`super::visibility`] rule bodies.
+impl<S: ObjectStore + ?Sized> MetadataVisibilityReads for MetadataViewSession<'_, '_, S> {
+    type Error = CoreError;
+
+    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
+        self.inode_at_seq(inode_id).await
+    }
+
+    async fn find_latest_bound_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        self.bound_child(parent_inode_id, name_key).await
+    }
+
+    async fn find_latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        self.latest_parent_binding_for_child(child_inode_id).await
+    }
+
+    async fn find_active_subtree_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        self.active_subtree_tombstone(root_inode_id).await
+    }
+
+    async fn is_binding_unbound(
+        &mut self,
+        direntry: &DirentryBindRecord,
+    ) -> Result<bool, Self::Error> {
+        self.is_direntry_unbound(direntry).await
+    }
+
+    async fn current_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        MetadataViewSession::current_parent_binding_for_child(self, child_inode_id).await
+    }
+
+    async fn covering_subtree_tombstone(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        MetadataViewSession::covering_subtree_tombstone(self, inode_id).await
+    }
+
+    async fn visible_inode(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<InodeRecord>, Self::Error> {
+        MetadataViewSession::visible_inode(self, inode_id).await
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ParentNameCacheKey {
     parent_inode_id: InodeId,
@@ -1187,12 +1124,4 @@ fn revision_is_after_position_desc(
             position.committed_seq,
             position.revision_delta_index,
         )
-}
-
-fn absolute_path_prefix(current: &str, component: &str) -> String {
-    if current == "/" {
-        format!("/{component}")
-    } else {
-        format!("{current}/{component}")
-    }
 }

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -1,0 +1,663 @@
+//! The single authoritative implementation of direntry visibility.
+//!
+//! "Which binding is visible/active" is the most safety-critical rule in the
+//! system, and it must be decided identically no matter which storage shape
+//! answers the underlying lookups (in-memory rows, at-head indexes, paged
+//! manifest tables merged with a WAL tail, or commit-preview overlays). This
+//! module expresses each composite rule exactly once:
+//!
+//! - [`BindingIdentity`] is the identity key of a binding event; every
+//!   binding-identity comparison in the crate goes through it (via
+//!   [`DirentryBindRecord::same_binding`] or [`unbind_matches_binding`]).
+//! - [`MetadataVisibilityReads`] is the storage contract: five primitive
+//!   lookups a storage shape must answer, plus provided composite methods
+//!   that implementors may override only to reuse a cache or an index fast
+//!   path — never to re-derive the rules.
+//! - The free functions ([`active_child_binding`],
+//!   [`current_parent_binding_for_child`], [`covering_subtree_tombstone`],
+//!   [`visible_inode`], [`visible_child`], [`is_visible_child_direntry`],
+//!   [`would_create_directory_cycle`], [`resolve_visible_path`]) are the
+//!   canonical rule bodies that both the provided trait methods and every
+//!   caching/gating override delegate to.
+//!
+//! The at-head indexes ([`super::MetadataState`]'s `indexes`) remain a
+//! materialization of these same rules maintained incrementally; their
+//! congruence with the scan implementations is pinned by the metadata unit
+//! tests and the mutation-guard suite.
+
+use super::queries::{ResolvedVisiblePath, VisiblePathError};
+use super::{
+    DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState, SubtreeTombstoneRecord,
+};
+use futures::FutureExt;
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NameKey, NamePolicy};
+use std::collections::BTreeSet;
+use std::future::Future;
+
+/// The identity key of a direntry binding event.
+///
+/// Two records describe the same binding event iff all five fields agree.
+/// Unbind records carry the identity of the bind they revoke, so an unbind
+/// matches a bind through the same comparison. `display_name` is
+/// presentation, not identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BindingIdentity<'a> {
+    pub(crate) parent_inode_id: InodeId,
+    pub(crate) name_key: &'a str,
+    pub(crate) child_inode_id: InodeId,
+    pub(crate) bind_seq: ChangeSeq,
+    pub(crate) bind_delta_index: u32,
+}
+
+impl<'a> From<&'a DirentryBindRecord> for BindingIdentity<'a> {
+    fn from(record: &'a DirentryBindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: &record.name_key,
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+}
+
+impl<'a> From<&'a DirentryUnbindRecord> for BindingIdentity<'a> {
+    fn from(record: &'a DirentryUnbindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: &record.name_key,
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+}
+
+impl DirentryBindRecord {
+    /// True iff `self` and `other` describe the same binding event.
+    pub(crate) fn same_binding(&self, other: &DirentryBindRecord) -> bool {
+        BindingIdentity::from(self) == BindingIdentity::from(other)
+    }
+}
+
+/// True iff `unbind` revokes exactly the binding event `direntry`.
+pub(crate) fn unbind_matches_binding(
+    unbind: &DirentryUnbindRecord,
+    direntry: &DirentryBindRecord,
+) -> bool {
+    BindingIdentity::from(unbind) == BindingIdentity::from(direntry)
+}
+
+/// The storage lookups the visibility rules are decided over, all scoped to
+/// one read sequence chosen by the implementor (a `base_seq`, a head, or a
+/// preview overlay's view of either).
+///
+/// The `find_*` primitives are required and answer raw questions about the
+/// stored rows; they apply no visibility policy beyond "latest at the read
+/// seq". The provided methods are the composite rules; implementors override
+/// them only to route through a cache or an equivalent index fast path, and
+/// every such override must delegate back to the canonical free functions in
+/// this module on the slow path.
+pub(crate) trait MetadataVisibilityReads {
+    type Error;
+
+    /// The inode record created at or before the read seq, if any.
+    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error>;
+
+    /// Latest bind for `(parent, name_key)` at the read seq, regardless of
+    /// whether it has since been unbound.
+    async fn find_latest_bound_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error>;
+
+    /// Latest bind whose child is `child_inode_id` at the read seq,
+    /// regardless of whether it has since been unbound.
+    async fn find_latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error>;
+
+    /// Latest subtree tombstone rooted at `root_inode_id` at the read seq.
+    async fn find_active_subtree_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error>;
+
+    /// Whether an unbind revoking exactly this binding event exists at the
+    /// read seq.
+    async fn is_binding_unbound(
+        &mut self,
+        direntry: &DirentryBindRecord,
+    ) -> Result<bool, Self::Error>;
+
+    /// Composite rule; see [`current_parent_binding_for_child`].
+    async fn current_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error>
+    where
+        Self: Sized,
+    {
+        current_parent_binding_for_child(self, child_inode_id).await
+    }
+
+    /// Composite rule; see [`active_child_binding`].
+    async fn active_child_binding(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error>
+    where
+        Self: Sized,
+    {
+        active_child_binding(self, parent_inode_id, name_key).await
+    }
+
+    /// Composite rule; see [`covering_subtree_tombstone`].
+    async fn covering_subtree_tombstone(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error>
+    where
+        Self: Sized,
+    {
+        covering_subtree_tombstone(self, inode_id).await
+    }
+
+    /// Composite rule; see [`visible_inode`].
+    async fn visible_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error>
+    where
+        Self: Sized,
+    {
+        visible_inode(self, inode_id).await
+    }
+
+    /// Composite rule; see [`visible_child`].
+    async fn visible_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error>
+    where
+        Self: Sized,
+    {
+        visible_child(self, parent_inode_id, name_key).await
+    }
+}
+
+/// The child's current parent binding: the latest binding for the child that
+/// has not been unbound. Returns `None` when the latest binding was revoked,
+/// even if an older un-revoked binding row still exists — bindings are
+/// superseded by later ones, never resurrected.
+pub(crate) async fn current_parent_binding_for_child<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    child_inode_id: InodeId,
+) -> Result<Option<DirentryBindRecord>, R::Error> {
+    let Some(direntry) = reads
+        .find_latest_parent_binding_for_child(child_inode_id)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if reads.is_binding_unbound(&direntry).await? {
+        return Ok(None);
+    }
+    Ok(Some(direntry))
+}
+
+/// The ACTIVE binding for `(parent, name_key)`: the latest bind under that
+/// name that (1) has not been unbound and (2) is also the child inode's
+/// current binding — a child renamed elsewhere leaves its old name bound in
+/// the rows but inactive.
+///
+/// Equivalent formulation note: condition (2) is checked by comparing
+/// identities against [`current_parent_binding_for_child`] (which already
+/// folds the unbound check). Historical copies of this rule instead compared
+/// against the raw latest binding and re-checked `is_binding_unbound` on it;
+/// the two factorings decide identically because unbound-ness is a function
+/// of the binding identity alone — if the latest binding for the child IS
+/// this binding event, its unbound-ness equals the one already checked in
+/// condition (1).
+pub(crate) async fn active_child_binding<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    parent_inode_id: InodeId,
+    name_key: &str,
+) -> Result<Option<DirentryBindRecord>, R::Error> {
+    let Some(direntry) = reads
+        .find_latest_bound_child(parent_inode_id, name_key)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if reads.is_binding_unbound(&direntry).await? {
+        return Ok(None);
+    }
+    let Some(latest_binding) = reads
+        .current_parent_binding_for_child(direntry.child_inode_id)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if !latest_binding.same_binding(&direntry) {
+        return Ok(None);
+    }
+    Ok(Some(direntry))
+}
+
+/// The first active subtree tombstone rooted at `inode_id` or at any of its
+/// current ancestors (following current parent bindings upward). The visited
+/// set terminates the walk instead of looping on parent-binding cycles.
+pub(crate) async fn covering_subtree_tombstone<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    inode_id: InodeId,
+) -> Result<Option<SubtreeTombstoneRecord>, R::Error> {
+    let mut current = Some(inode_id);
+    let mut visited = BTreeSet::new();
+
+    while let Some(candidate_inode_id) = current {
+        if !visited.insert(candidate_inode_id.0) {
+            break;
+        }
+        if let Some(tombstone) = reads
+            .find_active_subtree_tombstone(candidate_inode_id)
+            .await?
+        {
+            return Ok(Some(tombstone));
+        }
+        current = reads
+            .current_parent_binding_for_child(candidate_inode_id)
+            .await?
+            .map(|direntry| direntry.parent_inode_id);
+    }
+
+    Ok(None)
+}
+
+/// Whether binding `inode_id` under `new_parent_inode_id` would make the
+/// directory graph cyclic: true iff `inode_id` is `new_parent_inode_id` or
+/// one of its current ancestors. Same ancestor walk (and cycle guard) as
+/// [`covering_subtree_tombstone`], visiting for identity instead of
+/// tombstones.
+pub(crate) async fn would_create_directory_cycle<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    inode_id: InodeId,
+    new_parent_inode_id: InodeId,
+) -> Result<bool, R::Error> {
+    let mut current = Some(new_parent_inode_id);
+    let mut visited = BTreeSet::new();
+
+    while let Some(candidate_inode_id) = current {
+        if !visited.insert(candidate_inode_id.0) {
+            break;
+        }
+        if candidate_inode_id == inode_id {
+            return Ok(true);
+        }
+        current = reads
+            .current_parent_binding_for_child(candidate_inode_id)
+            .await?
+            .map(|direntry| direntry.parent_inode_id);
+    }
+
+    Ok(false)
+}
+
+/// An inode is visible iff it exists at the read seq and no subtree
+/// tombstone covers it or any of its current ancestors.
+pub(crate) async fn visible_inode<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    inode_id: InodeId,
+) -> Result<Option<InodeRecord>, R::Error> {
+    let Some(inode) = reads.find_inode(inode_id).await? else {
+        return Ok(None);
+    };
+    if reads.covering_subtree_tombstone(inode_id).await?.is_some() {
+        return Ok(None);
+    }
+    Ok(Some(inode))
+}
+
+/// The visible child under `(parent, name_key)`: the parent must be a
+/// visible directory, the name must have an active binding, and the bound
+/// child inode must itself be visible.
+pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    parent_inode_id: InodeId,
+    name_key: &str,
+) -> Result<Option<DirentryBindRecord>, R::Error> {
+    let Some(parent) = reads.visible_inode(parent_inode_id).await? else {
+        return Ok(None);
+    };
+    if parent.inode_kind != InodeKind::Dir {
+        return Ok(None);
+    }
+
+    let Some(direntry) = reads
+        .active_child_binding(parent_inode_id, name_key)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if reads
+        .visible_inode(direntry.child_inode_id)
+        .await?
+        .is_none()
+    {
+        return Ok(None);
+    }
+    Ok(Some(direntry))
+}
+
+/// The visible-children enumeration filter: a candidate bind row is a
+/// visible child iff it IS the active binding for its `(parent, name_key)`
+/// and its child inode is visible. Enumerating candidate rows is storage
+/// specific; deciding them is not. Callers must already have checked that
+/// the parent is a visible directory.
+pub(crate) async fn is_visible_child_direntry<R: MetadataVisibilityReads>(
+    reads: &mut R,
+    direntry: &DirentryBindRecord,
+) -> Result<bool, R::Error> {
+    let Some(active) = reads
+        .active_child_binding(direntry.parent_inode_id, &direntry.name_key)
+        .await?
+    else {
+        return Ok(false);
+    };
+    if !active.same_binding(direntry) {
+        return Ok(false);
+    }
+    Ok(reads
+        .visible_inode(direntry.child_inode_id)
+        .await?
+        .is_some())
+}
+
+/// Resolves `absolute_path` component by component through visible
+/// directories and visible child bindings, starting at the canonical root
+/// inode.
+pub(crate) async fn resolve_visible_path<R>(
+    reads: &mut R,
+    absolute_path: &AbsolutePath,
+    name_policy: NamePolicy,
+) -> Result<ResolvedVisiblePath, R::Error>
+where
+    R: MetadataVisibilityReads,
+    R::Error: From<VisiblePathError>,
+{
+    let root_inode_id = InodeId(1);
+    let root = reads
+        .visible_inode(root_inode_id)
+        .await?
+        .ok_or(VisiblePathError::RootMissing)?;
+    if absolute_path.is_root() {
+        return Ok(ResolvedVisiblePath {
+            absolute_path: "/".to_owned(),
+            inode_id: root_inode_id,
+            inode_kind: root.inode_kind,
+            parent_inode_id: None,
+            display_name: String::new(),
+        });
+    }
+
+    let mut current_inode_id = root_inode_id;
+    let mut current_absolute_path = "/".to_owned();
+    let mut current_parent_inode_id = None;
+    let mut current_display_name = String::new();
+
+    for component in absolute_path.components() {
+        let current_inode = reads
+            .visible_inode(current_inode_id)
+            .await?
+            .ok_or_else(|| VisiblePathError::PathNotFound {
+                absolute_path: current_absolute_path.clone(),
+            })?;
+        if current_inode.inode_kind != InodeKind::Dir {
+            return Err(VisiblePathError::PathComponentNotDirectory {
+                absolute_path: current_absolute_path,
+                inode_id: current_inode_id,
+                inode_kind: current_inode.inode_kind,
+            }
+            .into());
+        }
+
+        let requested_absolute_path = join_display_path(&current_absolute_path, component.as_str());
+        let display_name = component.to_display_name();
+        let name_key = NameKey::for_display_name(name_policy, &display_name);
+        let direntry = reads
+            .visible_child(current_inode_id, name_key.as_str())
+            .await?
+            .ok_or(VisiblePathError::PathNotFound {
+                absolute_path: requested_absolute_path,
+            })?;
+
+        current_inode_id = direntry.child_inode_id;
+        current_parent_inode_id = Some(direntry.parent_inode_id);
+        current_absolute_path = join_display_path(&current_absolute_path, &direntry.display_name);
+        current_display_name = direntry.display_name;
+    }
+
+    let inode = reads
+        .visible_inode(current_inode_id)
+        .await?
+        .ok_or_else(|| VisiblePathError::PathNotFound {
+            absolute_path: current_absolute_path.clone(),
+        })?;
+    Ok(ResolvedVisiblePath {
+        absolute_path: current_absolute_path,
+        inode_id: current_inode_id,
+        inode_kind: inode.inode_kind,
+        parent_inode_id: current_parent_inode_id,
+        display_name: current_display_name,
+    })
+}
+
+fn join_display_path(base: &str, component: &str) -> String {
+    if base == "/" {
+        format!("/{component}")
+    } else {
+        format!("{base}/{component}")
+    }
+}
+
+/// Drives a visibility future built over in-memory reads to completion
+/// without an executor.
+///
+/// Every [`MetadataVisibilityReads`] method on the in-memory implementors
+/// returns without awaiting, so the composed future finishes on its first
+/// poll; `now_or_never` performs exactly that single poll (the same pattern
+/// commit validation uses to stay synchronous over its in-memory preview).
+pub(crate) fn resolve_in_memory_read<T>(future: impl Future<Output = T>) -> T {
+    future
+        .now_or_never()
+        .expect("in-memory metadata visibility reads never await")
+}
+
+/// [`MetadataState`] reads scoped to `base_seq`, mirroring the historical
+/// row-scan arms of the seq-gated queries.
+///
+/// The composite overrides route back through the seq-gated [`MetadataState`]
+/// composites so that reads at or above the indexed seq keep their at-head
+/// index fast paths (this matters for [`resolve_visible_path`], which is not
+/// itself seq-gated and resolves most paths at head).
+pub(super) struct MetadataStateAtSeqReads<'a> {
+    state: &'a MetadataState,
+    base_seq: ChangeSeq,
+}
+
+/// [`MetadataState`] reads answered by the at-head indexes.
+///
+/// The composite overrides reuse the index materializations
+/// (`visible_*_at_head`, `current_parent_binding_for_child_at_head`); the
+/// ancestor-walk composites are NOT overridden, so both walk rules run their
+/// canonical bodies over these index-backed steps.
+pub(super) struct MetadataStateAtHeadReads<'a> {
+    state: &'a MetadataState,
+}
+
+impl MetadataState {
+    pub(super) fn reads_at_seq(&self, base_seq: ChangeSeq) -> MetadataStateAtSeqReads<'_> {
+        MetadataStateAtSeqReads {
+            state: self,
+            base_seq,
+        }
+    }
+
+    pub(super) fn reads_at_head(&self) -> MetadataStateAtHeadReads<'_> {
+        MetadataStateAtHeadReads { state: self }
+    }
+}
+
+impl MetadataVisibilityReads for MetadataStateAtSeqReads<'_> {
+    type Error = VisiblePathError;
+
+    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
+        Ok(self.state.inode_at_seq(inode_id, self.base_seq))
+    }
+
+    async fn find_latest_bound_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self
+            .state
+            .bound_child_at_seq(parent_inode_id, name_key, self.base_seq))
+    }
+
+    async fn find_latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self
+            .state
+            .latest_parent_binding_for_child_at_seq(child_inode_id, self.base_seq))
+    }
+
+    async fn find_active_subtree_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        Ok(self
+            .state
+            .active_subtree_tombstone(root_inode_id, self.base_seq))
+    }
+
+    async fn is_binding_unbound(
+        &mut self,
+        direntry: &DirentryBindRecord,
+    ) -> Result<bool, Self::Error> {
+        Ok(self
+            .state
+            .is_direntry_unbound_at_seq(direntry, self.base_seq))
+    }
+
+    async fn current_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self
+            .state
+            .current_parent_binding_for_child(child_inode_id, self.base_seq))
+    }
+
+    async fn covering_subtree_tombstone(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        Ok(self
+            .state
+            .covering_subtree_tombstone(inode_id, self.base_seq))
+    }
+
+    async fn visible_inode(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<InodeRecord>, Self::Error> {
+        Ok(self.state.visible_inode(inode_id, self.base_seq))
+    }
+
+    async fn visible_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self
+            .state
+            .visible_child(parent_inode_id, name_key, self.base_seq))
+    }
+}
+
+impl MetadataVisibilityReads for MetadataStateAtHeadReads<'_> {
+    type Error = VisiblePathError;
+
+    async fn find_inode(&mut self, inode_id: InodeId) -> Result<Option<InodeRecord>, Self::Error> {
+        Ok(self.state.inode_at_head(inode_id))
+    }
+
+    async fn find_latest_bound_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self.state.indexes.latest_bind(parent_inode_id, name_key))
+    }
+
+    async fn find_latest_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        // At head every row is at or below the indexed seq, so the seq-scan
+        // with `indexed_seq` as the bound is the honest latest-overall scan.
+        Ok(self
+            .state
+            .latest_parent_binding_for_child_at_seq(child_inode_id, self.state.indexed_seq()))
+    }
+
+    async fn find_active_subtree_tombstone(
+        &mut self,
+        root_inode_id: InodeId,
+    ) -> Result<Option<SubtreeTombstoneRecord>, Self::Error> {
+        Ok(self.state.active_subtree_tombstone_at_head(root_inode_id))
+    }
+
+    async fn is_binding_unbound(
+        &mut self,
+        direntry: &DirentryBindRecord,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.state.is_direntry_unbound_at_head(direntry))
+    }
+
+    async fn current_parent_binding_for_child(
+        &mut self,
+        child_inode_id: InodeId,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self
+            .state
+            .current_parent_binding_for_child_at_head(child_inode_id))
+    }
+
+    async fn active_child_binding(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self.state.indexes.active_child(parent_inode_id, name_key))
+    }
+
+    async fn visible_inode(
+        &mut self,
+        inode_id: InodeId,
+    ) -> Result<Option<InodeRecord>, Self::Error> {
+        Ok(self.state.visible_inode_at_head(inode_id))
+    }
+
+    async fn visible_child(
+        &mut self,
+        parent_inode_id: InodeId,
+        name_key: &str,
+    ) -> Result<Option<DirentryBindRecord>, Self::Error> {
+        Ok(self.state.visible_child_at_head(parent_inode_id, name_key))
+    }
+}

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -1,3 +1,14 @@
+//! Independent implementation of the visibility semantics — on purpose.
+//!
+//! This module re-states the metadata visibility rules (binding identity,
+//! active bindings, tombstone coverage, visible-path resolution) from
+//! scratch, deliberately NOT sharing code with `loonfs-core`'s
+//! `metadata::visibility` module. The differential suite replays the same
+//! logical commits through both implementations and requires identical
+//! outcomes; that comparison only catches bugs while the two sides remain
+//! independent. Do not "deduplicate" this into core — collapsing them would
+//! turn the differential tests into a tautology.
+
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     AbsolutePath, ChangeSeq, ContentRef, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo,


### PR DESCRIPTION
The binding-identity comparison and the composite visibility rules (active binding, visible child/inode, tombstone coverage, visible-path resolution) were implemented five times across MetadataState, the current/materialized read views, the commit previews, and the planner — copies identical down to variable names, with nothing keeping them in sync. They had in fact already drifted: the two current_view.rs copies of visible_child lacked the bound-child-visible check the other three (and the reference model) apply — outcome-equivalent on reachable states today only because deletes write unbind and tombstone atomically (the silent-divergence failure mode this consolidation exists to prevent).

Every rule now lives once in metadata/visibility.rs: a BindingIdentity value type whose derived equality is the one identity comparison, canonical rule functions, and a small MetadataVisibilityReads trait implemented by all six storage shapes (index fast paths and caches are documented overrides that route back to the same rules). The historically-carried fifth identity condition is documented as provably redundant rather than silently dropped, the reference model keeps its intentionally independent copy behind a mirror-contract doc, and 859 lines of quintuplicated rule text are gone. All 531 tests pass with zero test edits; grep shows the identity comparison exists exactly once.