### PR TITLE
refactor(core): fold method-doubling variants into single entry points

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -713,12 +713,11 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let changes = target
             .backend
-            .block_on(
-                target
-                    .backend
-                    .fs
-                    .list_changes_after(&namespace_id, ChangeSeq(0)),
-            )
+            .block_on(target.backend.fs.list_changes_after(
+                &namespace_id,
+                ChangeSeq(0),
+                loonfs::ListChangesOptions::default(),
+            ))
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
         assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -416,13 +416,7 @@ impl Client {
         Ok(())
     }
 
-    pub fn begin_upload(&self, namespace: &str) -> Result<BeginUploadResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/namespaces/{namespace}/uploads", self.base_url);
-        self.request_json::<(), BeginUploadResponse>(self.agent.post(&url), None)
-    }
-
-    pub fn begin_upload_with_request(
+    pub fn begin_upload(
         &self,
         namespace: &str,
         request: &BeginUploadRequest,
@@ -437,7 +431,7 @@ impl Client {
         namespace: &str,
         content_ref: ContentRef,
     ) -> Result<BeginUploadResponse, ClientError> {
-        self.begin_upload_with_request(
+        self.begin_upload(
             namespace,
             &BeginUploadRequest {
                 mode: Some(UploadMode::DirectPut),
@@ -562,7 +556,7 @@ impl Client {
         namespace: &str,
         bytes: &[u8],
     ) -> Result<StagedContent, ClientError> {
-        let upload = self.begin_upload(namespace)?;
+        let upload = self.begin_upload(namespace, &BeginUploadRequest::default())?;
         let staged = self.upload_content(namespace, upload.upload_id.as_str(), bytes)?;
         let response = self.complete_upload(
             namespace,
@@ -1128,7 +1122,9 @@ fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), Cl
 
 #[cfg(test)]
 mod tests {
-    use super::{Client, ClientConfig, ClientError, ErrorCode, ErrorKind, NamespacePath};
+    use super::{
+        BeginUploadRequest, Client, ClientConfig, ClientError, ErrorCode, ErrorKind, NamespacePath,
+    };
     use std::fs;
     use tempfile::tempdir;
 
@@ -1258,7 +1254,9 @@ auth_token = "   "
         for result in [
             client.create_namespace("bad/name").map(|_| ()),
             client.fork_namespace("demo", "bad/name").map(|_| ()),
-            client.begin_upload("bad/name").map(|_| ()),
+            client
+                .begin_upload("bad/name", &BeginUploadRequest::default())
+                .map(|_| ()),
         ] {
             assert!(matches!(result, Err(ClientError::InvalidNamespacePath(_))));
         }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -17,17 +17,11 @@ use loonfs_api::{
     ContentRef, CreateCheckpointResponse, DeleteDirectoryBehavior, DirectoryPageCursor,
     FileRevision, FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, ManifestId,
     MutationResult, NamespaceId, NamespaceSummary, Page, PageRequest, RevisionNo, UploadId,
-    DEFAULT_PAGE_LIMIT,
 };
 use loonfs_objectstore::ObjectStore;
-use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
-
-fn default_page_limit() -> EffectiveLimit {
-    EffectiveLimit::new(NonZeroU32::new(DEFAULT_PAGE_LIMIT).unwrap_or(NonZeroU32::MIN))
-}
 
 #[doc(hidden)]
 #[derive(Debug, Clone)]
@@ -700,14 +694,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Reads committed changes after `after_seq`.
-    pub async fn list_changes_after(&self, after_seq: ChangeSeq) -> CoreResult<ChangesResponse> {
-        self.list_changes_after_with_limit(after_seq, default_page_limit())
-            .await
-    }
-
     /// Reads up to `limit` committed changes after `after_seq`.
-    pub async fn list_changes_after_with_limit(
+    pub async fn list_changes_after(
         &self,
         after_seq: ChangeSeq,
         limit: EffectiveLimit,
@@ -715,14 +703,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::protocol::list_changes_after(&self.store, &self.namespace_id, after_seq, limit).await
     }
 
-    /// Starts a durable upload session for this namespace.
-    pub async fn begin_upload(&self) -> CoreResult<BeginUploadResponse> {
-        self.begin_upload_with_request(BeginUploadRequest::default())
-            .await
-    }
-
     /// Starts a durable upload session with explicit transport options.
-    pub async fn begin_upload_with_request(
+    pub async fn begin_upload(
         &self,
         request: BeginUploadRequest,
     ) -> CoreResult<BeginUploadResponse> {

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -6,7 +6,8 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_api::v0::BeginUploadRequest;
+use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
 use loonfs_core::gc::{gc_namespace, GcConfig};
 use loonfs_core::{BootstrapOptions, MutationContext, NamespaceEngine};
 use loonfs_objectstore::fs::LocalFsStore;
@@ -16,6 +17,10 @@ use loonfs_objectstore::{
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
+
+fn page_limit() -> EffectiveLimit {
+    EffectiveLimit::new(std::num::NonZeroU32::new(1024).expect("nonzero limit"))
+}
 
 fn context() -> MutationContext {
     MutationContext {
@@ -122,7 +127,10 @@ async fn reads_commits_and_change_feed_never_list() {
         .expect("write junk");
 
     let baseline = store.list_count();
-    let staged = engine.begin_upload().await.expect("begin upload");
+    let staged = engine
+        .begin_upload(BeginUploadRequest::default())
+        .await
+        .expect("begin upload");
     let uploaded = engine
         .upload_content(&staged.upload_id, b"uploaded\n")
         .await
@@ -146,7 +154,7 @@ async fn reads_commits_and_change_feed_never_list() {
     let bytes = engine.read_file("/docs/hello.txt").await.expect("read");
     assert_eq!(bytes.bytes, b"hello\n");
     let changes = engine
-        .list_changes_after(ChangeSeq(0))
+        .list_changes_after(ChangeSeq(0), page_limit())
         .await
         .expect("change feed");
     assert!(!changes.changes.is_empty());
@@ -192,7 +200,10 @@ async fn maintenance_never_touches_the_wal_head() {
     gc_namespace(&store, &namespace_id, &GcConfig::default(), &context)
         .await
         .expect("gc pass");
-    let staged = engine.begin_upload().await.expect("second upload");
+    let staged = engine
+        .begin_upload(BeginUploadRequest::default())
+        .await
+        .expect("second upload");
     let uploaded = engine
         .upload_content(&staged.upload_id, b"more\n")
         .await

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -166,7 +166,10 @@ fn begin_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<loonfs_api::v0::BeginUploadResponse, CoreError> {
-    block_on(namespace_engine(store, namespace_id, context).begin_upload())
+    block_on(
+        namespace_engine(store, namespace_id, context)
+            .begin_upload(loonfs_api::v0::BeginUploadRequest::default()),
+    )
 }
 
 fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
@@ -206,7 +209,8 @@ fn list_changes_after<S: ObjectStore + ?Sized>(
     after_seq: ChangeSeq,
 ) -> Result<loonfs_api::v0::ChangesResponse, CoreError> {
     block_on(
-        namespace_engine(store, namespace_id, &mutation_context()).list_changes_after(after_seq),
+        namespace_engine(store, namespace_id, &mutation_context())
+            .list_changes_after(after_seq, page_limit(loonfs_api::DEFAULT_PAGE_LIMIT)),
     )
 }
 

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -10,7 +10,8 @@ use loonfs::publish::PathMutationIntent;
 use loonfs::{
     payload_class, BootstrapNamespaceError, ChangeSeq, CoreError, CreateNamespaceOptions,
     DeleteNamespaceOptions, ErrorCode, ErrorKind, Fs, JsonlObjectStoreMetricsRecorder,
-    ObjectStoreMetricsRecorder, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    ListChangesOptions, ObjectStoreMetricsRecorder, RuntimeError, SharedObjectStore, TraceMode,
+    TraceStoreKind,
 };
 use loonfs_api::{
     decode_directory_cursor, decode_file_revisions_cursor,
@@ -980,7 +981,7 @@ async fn begin_upload_handler(
 
     let response = state
         .fs
-        .begin_upload_with_request(&namespace_id, request)
+        .begin_upload(&namespace_id, request)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
@@ -1262,7 +1263,11 @@ async fn list_changes_handler(
     let limit = resolve_page_limit(query.limit)?;
     let response = state
         .fs
-        .list_changes_after_with_limit(&namespace_id, after_seq, limit)
+        .list_changes_after(
+            &namespace_id,
+            after_seq,
+            ListChangesOptions { limit: Some(limit) },
+        )
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -4,8 +4,8 @@
 use bytes::Bytes;
 use loonfs_api::{
     v0::{
-        CommitDelta, CommitOp, CommitRequest as ApiCommitRequest, CompleteUploadRequest,
-        ValidatedContentToken,
+        BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
+        CompleteUploadRequest, ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, ContentRef,
     CreateCheckpointResponse, FilesystemOperation, FilesystemOperationRequest,
@@ -611,7 +611,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
         let begin = harness
             .client
-            .begin_upload(namespace)
+            .begin_upload(namespace, &BeginUploadRequest::default())
             .expect("begin upload");
         let first_content = harness
             .client
@@ -632,7 +632,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
         let mismatch_upload = harness
             .client
-            .begin_upload(namespace)
+            .begin_upload(namespace, &BeginUploadRequest::default())
             .expect("begin mismatch upload");
         let staged = harness
             .client
@@ -748,7 +748,7 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
             .expect("create namespace");
         let begin = harness
             .client
-            .begin_upload(namespace)
+            .begin_upload(namespace, &BeginUploadRequest::default())
             .expect("begin upload");
         let staged = harness
             .client
@@ -1891,7 +1891,9 @@ fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>
 }
 
 fn stage_uploaded_content_ref(client: &Client, namespace: &str, file_bytes: &[u8]) -> ContentRef {
-    let begin = client.begin_upload(namespace).expect("begin upload");
+    let begin = client
+        .begin_upload(namespace, &BeginUploadRequest::default())
+        .expect("begin upload");
     let staged = client
         .upload_content(namespace, begin.upload_id.as_str(), file_bytes)
         .expect("upload content");

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -13,7 +13,7 @@ use crate::{
     ChangesResponse, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions, CoreError,
     CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
-    DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId,
+    DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId, ListChangesOptions,
     ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
     MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
     NamespaceStatus, NamespaceSummary, ObjectStore, ObjectStoreMetricsRecorder, PutFileOptions,
@@ -920,20 +920,14 @@ impl Fs {
     }
 
     /// Starts a durable upload session for a namespace.
-    pub async fn begin_upload(&self, namespace_id: &NamespaceId) -> Result<BeginUploadResponse> {
-        self.begin_upload_with_request(namespace_id, BeginUploadRequest::default())
-            .await
-    }
-
-    /// Starts a durable upload session with explicit transport options.
-    pub async fn begin_upload_with_request(
+    pub async fn begin_upload(
         &self,
         namespace_id: &NamespaceId,
         request: BeginUploadRequest,
     ) -> Result<BeginUploadResponse> {
         Ok(self
             .namespace_engine(namespace_id)
-            .begin_upload_with_request(request)
+            .begin_upload(request)
             .await?)
     }
 
@@ -1235,24 +1229,17 @@ impl Fs {
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
+        options: ListChangesOptions,
     ) -> Result<ChangesResponse> {
-        let limit = PaginationPolicy::default()
-            .resolve_limit(None)
-            .map_err(|error| RuntimeError::Config(error.to_string()))?;
-        self.list_changes_after_with_limit(namespace_id, after_seq, limit)
-            .await
-    }
-
-    /// Reads up to `limit` committed changes after the `after_seq` cursor.
-    pub async fn list_changes_after_with_limit(
-        &self,
-        namespace_id: &NamespaceId,
-        after_seq: ChangeSeq,
-        limit: EffectiveLimit,
-    ) -> Result<ChangesResponse> {
+        let limit = match options.limit {
+            Some(limit) => limit,
+            None => PaginationPolicy::default()
+                .resolve_limit(None)
+                .map_err(|error| RuntimeError::Config(error.to_string()))?,
+        };
         Ok(self
             .namespace_engine(namespace_id)
-            .list_changes_after_with_limit(after_seq, limit)
+            .list_changes_after(after_seq, limit)
             .await?)
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -58,9 +58,9 @@ pub use config::{
 };
 pub use fs::{Fs, FsBuilder};
 pub use options::{
-    CopyOptions, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, NamespaceStatus, PutFileOptions,
-    RestoreRevisionOptions,
+    CopyOptions, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions,
+    NamespaceStatus, PutFileOptions, RestoreRevisionOptions,
 };
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -2,8 +2,8 @@
 
 use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
-    ChangeSeq, CommitId, DeleteDirectoryBehavior, ManifestId, MoveBehavior, NamespaceId,
-    PutBehavior,
+    ChangeSeq, CommitId, DeleteDirectoryBehavior, EffectiveLimit, ManifestId, MoveBehavior,
+    NamespaceId, PutBehavior,
 };
 
 /// Current maintenance-related namespace status.
@@ -157,4 +157,11 @@ pub struct CopyOptions {
 pub struct RestoreRevisionOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+}
+
+/// Options for reading the change feed.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ListChangesOptions {
+    /// Page limit; `None` resolves the default pagination policy.
+    pub limit: Option<EffectiveLimit>,
 }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -5,14 +5,14 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs::{
-    AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadResponse,
-    ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest, CommitResponse,
-    CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
+    AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
+    BeginUploadResponse, ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest,
+    CommitResponse, CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
     CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteOptions,
-    DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
-    NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutBehavior, PutFileOptions,
-    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
+    DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, ListChangesOptions,
+    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
+    MutationResult, NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutBehavior,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
     UploadContentResponse, UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
@@ -290,7 +290,7 @@ impl FsTestExt for Fs {
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<BeginUploadResponse> {
-        block_on(self.begin_upload(namespace_id))
+        block_on(self.begin_upload(namespace_id, BeginUploadRequest::default()))
     }
 
     fn upload_content_blocking(
@@ -332,7 +332,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> loonfs::Result<ChangesResponse> {
-        block_on(self.list_changes_after(namespace_id, after_seq))
+        block_on(self.list_changes_after(namespace_id, after_seq, ListChangesOptions::default()))
     }
 
     fn create_checkpoint_blocking(


### PR DESCRIPTION
The planned read-context collapse turned out to be already done — the engine's doc-hidden *_with_runtime_context shadow families were removed by the earlier read-entrypoint simplification, so what remained of this cleanup was the API-doubling canon: begin_upload/begin_upload_with_request and list_changes_after/list_changes_after_with_limit existed as pairs on the engine, the facade, and the client. Each layer now has one method — the engine takes the resolved limit and the request struct directly, the facade takes a house-style ListChangesOptions (limit resolves the default pagination policy when unset), and the client always sends the request body (a default request serializes to the same empty object the server already accepted). Callers pass explicit defaults, which reads better than remembering which variant is the convenient one.