### PR TITLE
refactor(objectstore): shared provider config with redacted secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "bytes",
  "fs4",
  "futures",
+ "http",
  "loonfs-api",
  "object_store",
  "serde",
@@ -1179,6 +1180,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/configs/loonfs-server.aws-s3.example.toml
+++ b/configs/loonfs-server.aws-s3.example.toml
@@ -3,7 +3,6 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-aws"
 writer_version = "loonfs-server/0.1.0"
-lease_duration_ms = 60000
 
 [store]
 kind = "aws-s3"

--- a/configs/loonfs-server.azure-abs.example.toml
+++ b/configs/loonfs-server.azure-abs.example.toml
@@ -3,7 +3,6 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-azure"
 writer_version = "loonfs-server/0.1.0"
-lease_duration_ms = 60000
 
 [store]
 kind = "azure-abs"

--- a/configs/loonfs-server.cloudflare-r2.example.toml
+++ b/configs/loonfs-server.cloudflare-r2.example.toml
@@ -3,7 +3,6 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-r2"
 writer_version = "loonfs-server/0.1.0"
-lease_duration_ms = 60000
 
 [store]
 kind = "cloudflare-r2"

--- a/configs/loonfs-server.gcp-gcs.example.toml
+++ b/configs/loonfs-server.gcp-gcs.example.toml
@@ -3,7 +3,6 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-gcp"
 writer_version = "loonfs-server/0.1.0"
-lease_duration_ms = 60000
 
 [store]
 kind = "gcp-gcs"

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -1,9 +1,23 @@
 bind = "127.0.0.1:9400"
+# auth_token and content_token_secret may instead come from the
+# LOONFS_AUTH_TOKEN and LOONFS_CONTENT_TOKEN_SECRET environment variables;
+# a non-blank value in this file takes precedence over the environment.
 auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-local"
 writer_version = "loonfs-server/0.1.0"
-lease_duration_ms = 60000
+
+# Optional runtime cache overrides; omitted fields keep the runtime defaults.
+#[runtime_cache]
+#wal_tail_projection_cache_enabled = true
+#control_cache_enabled = true
+#max_cached_namespaces = 64
+#max_cached_wal_tail_projection_rows = 1000000
+#max_cached_wal_tail_projection_decoded_bytes = 268435456
+#metadata_table_cache_enabled = true
+#metadata_table_cache_max_blocks = 256
+# Decoded-byte budget for the metadata table cache; unlimited by default.
+#metadata_table_cache_max_decoded_bytes = 268435456
 
 [store]
 kind = "local-fs"

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -568,7 +568,7 @@ impl ResolvedTarget {
             } => Ok(Self::Remote(RemoteTarget::new(
                 profile_name,
                 server_url,
-                auth_token.as_deref(),
+                auth_token.as_ref().map(|token| token.expose()),
             )?)),
         }
     }
@@ -594,7 +594,9 @@ impl EmbeddedTarget {
         writer_id: Option<&str>,
         writer_version: Option<&str>,
     ) -> Result<Self, CliError> {
-        let store = store_config.object_store()?;
+        let store = store_config
+            .configured_object_store()
+            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))?;
         let store: SharedObjectStore = Arc::new(store);
         let fs = Fs::open(
             store,
@@ -607,7 +609,7 @@ impl EmbeddedTarget {
                     .unwrap_or_else(|| format!("loon/{}", env!("CARGO_PKG_VERSION"))),
                 runtime_cache: RuntimeCacheConfig::default(),
                 trace_mode: TraceMode::Embedded,
-                trace_store_kind: trace_store_kind(store_config),
+                trace_store_kind: TraceStoreKind::from(store_config.kind()),
             },
         )
         .map_err(map_runtime_error)?;
@@ -617,16 +619,6 @@ impl EmbeddedTarget {
             .map_err(|error| CliError::invalid_config(error.to_string()))?;
         let backend = EmbeddedBackend { fs, runtime };
         Ok(Self { backend })
-    }
-}
-
-fn trace_store_kind(store: &StoreConfig) -> TraceStoreKind {
-    match store {
-        StoreConfig::LocalFs { .. } => TraceStoreKind::LocalFs,
-        StoreConfig::AwsS3 { .. } => TraceStoreKind::S3,
-        StoreConfig::CloudflareR2 { .. } => TraceStoreKind::R2,
-        StoreConfig::GcpGcs { .. } => TraceStoreKind::Gcs,
-        StoreConfig::AzureAbs { .. } => TraceStoreKind::Abs,
     }
 }
 

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -2,6 +2,7 @@ use crate::args::{InitArgs, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavio
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use crate::prompt;
+use loonfs_objectstore::{ConfiguredObjectStoreKind, SecretString};
 
 const AWS_REGIONS: &[&str] = &[
     "us-east-1",
@@ -33,6 +34,205 @@ const AWS_REGIONS: &[&str] = &[
     "af-south-1",
     "il-central-1",
 ];
+
+// --- provider flag matrix ---
+
+/// A target a provider flag can apply to: one of the embedded store kinds or
+/// a remote profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlagTarget {
+    LocalFs,
+    AwsS3,
+    CloudflareR2,
+    GcpGcs,
+    AzureAbs,
+    Remote,
+}
+
+impl From<ConfiguredObjectStoreKind> for FlagTarget {
+    fn from(kind: ConfiguredObjectStoreKind) -> Self {
+        match kind {
+            ConfiguredObjectStoreKind::LocalFs => Self::LocalFs,
+            ConfiguredObjectStoreKind::AwsS3 => Self::AwsS3,
+            ConfiguredObjectStoreKind::CloudflareR2 => Self::CloudflareR2,
+            ConfiguredObjectStoreKind::GcpGcs => Self::GcpGcs,
+            ConfiguredObjectStoreKind::AzureAbs => Self::AzureAbs,
+        }
+    }
+}
+
+/// Every embedded store kind; used to reject remote-only flags before the
+/// store kind is known.
+const EMBEDDED_TARGETS: &[FlagTarget] = &[
+    FlagTarget::LocalFs,
+    FlagTarget::AwsS3,
+    FlagTarget::CloudflareR2,
+    FlagTarget::GcpGcs,
+    FlagTarget::AzureAbs,
+];
+
+/// One provider flag and the targets it applies to.
+///
+/// Adding a provider flag means adding one row here (plus its arg field and
+/// the point where the value is consumed); both the create and update paths
+/// walk this table to reject flags that do not apply.
+struct ProviderFlag {
+    /// The user-facing `--flag` name.
+    flag: &'static str,
+    /// Targets where the flag is accepted.
+    allowed: &'static [FlagTarget],
+    /// Whether the flag is set on the create/init spec.
+    create_set: fn(&CreateProfileSpec) -> bool,
+    /// Whether the flag is set on the update args; `None` when `profile
+    /// update` has no such flag.
+    update_set: Option<fn(&ProfileUpdateArgs) -> bool>,
+}
+
+use FlagTarget::{AwsS3, AzureAbs, CloudflareR2, GcpGcs, LocalFs, Remote};
+
+const PROVIDER_FLAGS: &[ProviderFlag] = &[
+    ProviderFlag {
+        flag: "server-url",
+        allowed: &[Remote],
+        create_set: |spec| spec.server_url.is_some(),
+        update_set: Some(|args| args.server_url.is_some()),
+    },
+    ProviderFlag {
+        flag: "auth-token",
+        allowed: &[Remote],
+        create_set: |spec| spec.auth_token.is_some(),
+        update_set: Some(|args| args.auth_token.is_some()),
+    },
+    ProviderFlag {
+        flag: "store-kind",
+        allowed: EMBEDDED_TARGETS,
+        create_set: |spec| spec.store_kind.is_some(),
+        update_set: None,
+    },
+    ProviderFlag {
+        flag: "root",
+        allowed: &[LocalFs],
+        create_set: |spec| spec.root.is_some(),
+        update_set: Some(|args| args.root.is_some()),
+    },
+    ProviderFlag {
+        flag: "key-prefix",
+        allowed: EMBEDDED_TARGETS,
+        create_set: |spec| spec.key_prefix.is_some(),
+        update_set: Some(|args| args.key_prefix.is_some()),
+    },
+    ProviderFlag {
+        flag: "bucket",
+        allowed: &[AwsS3, CloudflareR2, GcpGcs],
+        create_set: |spec| spec.bucket.is_some(),
+        update_set: Some(|args| args.bucket.is_some()),
+    },
+    ProviderFlag {
+        flag: "region",
+        allowed: &[AwsS3],
+        create_set: |spec| spec.region.is_some(),
+        update_set: Some(|args| args.region.is_some()),
+    },
+    ProviderFlag {
+        flag: "access-key-id",
+        allowed: &[AwsS3, CloudflareR2],
+        create_set: |spec| spec.access_key_id.is_some(),
+        update_set: Some(|args| args.access_key_id.is_some()),
+    },
+    ProviderFlag {
+        flag: "secret-access-key",
+        allowed: &[AwsS3, CloudflareR2],
+        create_set: |spec| spec.secret_access_key.is_some(),
+        update_set: Some(|args| args.secret_access_key.is_some()),
+    },
+    ProviderFlag {
+        flag: "endpoint-url",
+        allowed: &[AwsS3, CloudflareR2, AzureAbs],
+        create_set: |spec| spec.endpoint_url.is_some(),
+        update_set: Some(|args| args.endpoint_url.is_some()),
+    },
+    ProviderFlag {
+        flag: "session-token",
+        allowed: &[AwsS3],
+        create_set: |spec| spec.session_token.is_some(),
+        update_set: Some(|args| args.session_token.is_some()),
+    },
+    ProviderFlag {
+        flag: "force-path-style",
+        allowed: &[AwsS3],
+        create_set: |spec| spec.force_path_style,
+        update_set: None,
+    },
+    ProviderFlag {
+        flag: "account-id",
+        allowed: &[CloudflareR2],
+        create_set: |spec| spec.account_id.is_some(),
+        update_set: Some(|args| args.account_id.is_some()),
+    },
+    ProviderFlag {
+        flag: "account-name",
+        allowed: &[AzureAbs],
+        create_set: |spec| spec.account_name.is_some(),
+        update_set: Some(|args| args.account_name.is_some()),
+    },
+    ProviderFlag {
+        flag: "container-name",
+        allowed: &[AzureAbs],
+        create_set: |spec| spec.container_name.is_some(),
+        update_set: Some(|args| args.container_name.is_some()),
+    },
+    ProviderFlag {
+        flag: "access-key",
+        allowed: &[AzureAbs],
+        create_set: |spec| spec.access_key.is_some(),
+        update_set: Some(|args| args.access_key.is_some()),
+    },
+    ProviderFlag {
+        flag: "service-account-key-path",
+        allowed: &[GcpGcs],
+        create_set: |spec| spec.service_account_key_path.is_some(),
+        update_set: Some(|args| args.service_account_key_path.is_some()),
+    },
+];
+
+/// Rejects every set create flag whose allowed targets do not intersect
+/// `targets`, reporting `profile_label` in the error.
+fn reject_inapplicable_create_flags(
+    spec: &CreateProfileSpec,
+    targets: &[FlagTarget],
+    profile_label: &str,
+) -> Result<(), CliError> {
+    for row in PROVIDER_FLAGS {
+        if (row.create_set)(spec) && !row.allowed.iter().any(|target| targets.contains(target)) {
+            return Err(inapplicable_flag(row.flag, profile_label));
+        }
+    }
+    Ok(())
+}
+
+/// Rejects every set update flag whose allowed targets do not intersect
+/// `targets`, reporting `profile_label` in the error.
+fn reject_inapplicable_update_flags(
+    args: &ProfileUpdateArgs,
+    targets: &[FlagTarget],
+    profile_label: &str,
+) -> Result<(), CliError> {
+    for row in PROVIDER_FLAGS {
+        let Some(update_set) = row.update_set else {
+            continue;
+        };
+        if update_set(args) && !row.allowed.iter().any(|target| targets.contains(target)) {
+            return Err(inapplicable_flag(row.flag, profile_label));
+        }
+    }
+    Ok(())
+}
+
+fn inapplicable_flag(flag: &str, profile_label: &str) -> CliError {
+    CliError::invalid_input(format!(
+        "`--{flag}` does not apply to {profile_label} profiles"
+    ))
+}
 
 // --- create/update helpers ---
 
@@ -133,15 +333,14 @@ fn build_embedded_profile(
     spec: CreateProfileSpec,
     runtime: RuntimeBehavior,
 ) -> Result<ProfileConfig, CliError> {
-    reject_create_flag("server-url", spec.server_url.is_some(), "embedded")?;
-    reject_create_flag("auth-token", spec.auth_token.is_some(), "embedded")?;
+    reject_inapplicable_create_flags(&spec, EMBEDDED_TARGETS, "embedded")?;
 
     let store_kind = match spec.store_kind.as_deref() {
-        Some("local-fs") => "local-fs",
-        Some("aws-s3") => "aws-s3",
-        Some("cloudflare-r2") => "cloudflare-r2",
-        Some("gcp-gcs") => "gcp-gcs",
-        Some("azure-abs") => "azure-abs",
+        Some("local-fs") => ConfiguredObjectStoreKind::LocalFs,
+        Some("aws-s3") => ConfiguredObjectStoreKind::AwsS3,
+        Some("cloudflare-r2") => ConfiguredObjectStoreKind::CloudflareR2,
+        Some("gcp-gcs") => ConfiguredObjectStoreKind::GcpGcs,
+        Some("azure-abs") => ConfiguredObjectStoreKind::AzureAbs,
         Some(other) => {
             return Err(CliError::invalid_input(format!(
             "unknown store kind: `{other}` (expected local-fs, aws-s3, cloudflare-r2, gcp-gcs, or azure-abs)"
@@ -165,174 +364,71 @@ fn build_embedded_profile(
         None => return Err(CliError::non_interactive_input_required("store-kind")),
     };
 
+    reject_inapplicable_create_flags(&spec, &[store_kind.into()], store_kind.as_str())?;
+
     let store = match store_kind {
-        "local-fs" => {
-            reject_create_flag("bucket", spec.bucket.is_some(), "local-fs")?;
-            reject_create_flag("region", spec.region.is_some(), "local-fs")?;
-            reject_create_flag("access-key-id", spec.access_key_id.is_some(), "local-fs")?;
-            reject_create_flag(
+        ConfiguredObjectStoreKind::LocalFs => StoreConfig::LocalFs {
+            root: require_or_prompt(spec.root.as_ref(), "root", runtime)?,
+            key_prefix: spec.key_prefix,
+        },
+        ConfiguredObjectStoreKind::AwsS3 => StoreConfig::AwsS3 {
+            bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+            region: require_or_prompt_region(spec.region.as_ref(), runtime)?,
+            endpoint_url: spec.endpoint_url,
+            access_key_id: require_or_prompt_secret(
+                spec.access_key_id.as_ref(),
+                "access-key-id",
+                runtime,
+            )?,
+            secret_access_key: require_or_prompt_secret(
+                spec.secret_access_key.as_ref(),
                 "secret-access-key",
-                spec.secret_access_key.is_some(),
-                "local-fs",
-            )?;
-            reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "local-fs")?;
-            reject_create_flag("session-token", spec.session_token.is_some(), "local-fs")?;
-            reject_create_flag("account-id", spec.account_id.is_some(), "local-fs")?;
-            reject_create_flag("account-name", spec.account_name.is_some(), "local-fs")?;
-            reject_create_flag("container-name", spec.container_name.is_some(), "local-fs")?;
-            reject_create_flag("access-key", spec.access_key.is_some(), "local-fs")?;
-            reject_create_flag(
-                "service-account-key-path",
-                spec.service_account_key_path.is_some(),
-                "local-fs",
-            )?;
-            reject_create_flag("force-path-style", spec.force_path_style, "local-fs")?;
-            StoreConfig::LocalFs {
-                root: require_or_prompt(spec.root.as_ref(), "root", runtime)?,
-                key_prefix: spec.key_prefix,
-            }
-        }
-        "aws-s3" => {
-            reject_create_flag("root", spec.root.is_some(), "aws-s3")?;
-            reject_create_flag("account-id", spec.account_id.is_some(), "aws-s3")?;
-            reject_create_flag("account-name", spec.account_name.is_some(), "aws-s3")?;
-            reject_create_flag("container-name", spec.container_name.is_some(), "aws-s3")?;
-            reject_create_flag("access-key", spec.access_key.is_some(), "aws-s3")?;
-            reject_create_flag(
-                "service-account-key-path",
-                spec.service_account_key_path.is_some(),
-                "aws-s3",
-            )?;
-            StoreConfig::AwsS3 {
-                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
-                region: require_or_prompt_region(spec.region.as_ref(), runtime)?,
-                endpoint_url: spec.endpoint_url,
-                access_key_id: require_or_prompt(
-                    spec.access_key_id.as_ref(),
-                    "access-key-id",
-                    runtime,
-                )?,
-                secret_access_key: require_or_prompt(
-                    spec.secret_access_key.as_ref(),
-                    "secret-access-key",
-                    runtime,
-                )?,
-                session_token: spec.session_token,
-                key_prefix: spec.key_prefix,
-                force_path_style: if spec.force_path_style {
-                    Some(true)
-                } else {
-                    None
-                },
-            }
-        }
-        "cloudflare-r2" => {
-            reject_create_flag("root", spec.root.is_some(), "cloudflare-r2")?;
-            reject_create_flag("region", spec.region.is_some(), "cloudflare-r2")?;
-            reject_create_flag(
-                "session-token",
-                spec.session_token.is_some(),
-                "cloudflare-r2",
-            )?;
-            reject_create_flag("force-path-style", spec.force_path_style, "cloudflare-r2")?;
-            reject_create_flag(
-                "service-account-key-path",
-                spec.service_account_key_path.is_some(),
-                "cloudflare-r2",
-            )?;
-            reject_create_flag("account-name", spec.account_name.is_some(), "cloudflare-r2")?;
-            reject_create_flag(
-                "container-name",
-                spec.container_name.is_some(),
-                "cloudflare-r2",
-            )?;
-            reject_create_flag("access-key", spec.access_key.is_some(), "cloudflare-r2")?;
-            StoreConfig::CloudflareR2 {
-                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
-                account_id: require_or_prompt(spec.account_id.as_ref(), "account-id", runtime)?,
-                endpoint_url: require_or_prompt(
-                    spec.endpoint_url.as_ref(),
-                    "endpoint-url",
-                    runtime,
-                )?,
-                access_key_id: require_or_prompt(
-                    spec.access_key_id.as_ref(),
-                    "access-key-id",
-                    runtime,
-                )?,
-                secret_access_key: require_or_prompt(
-                    spec.secret_access_key.as_ref(),
-                    "secret-access-key",
-                    runtime,
-                )?,
-                key_prefix: spec.key_prefix,
-            }
-        }
-        "gcp-gcs" => {
-            reject_create_flag("root", spec.root.is_some(), "gcp-gcs")?;
-            reject_create_flag("region", spec.region.is_some(), "gcp-gcs")?;
-            reject_create_flag("access-key-id", spec.access_key_id.is_some(), "gcp-gcs")?;
-            reject_create_flag(
+                runtime,
+            )?,
+            session_token: spec.session_token.map(SecretString::from),
+            key_prefix: spec.key_prefix,
+            force_path_style: if spec.force_path_style {
+                Some(true)
+            } else {
+                None
+            },
+        },
+        ConfiguredObjectStoreKind::CloudflareR2 => StoreConfig::CloudflareR2 {
+            bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+            account_id: require_or_prompt(spec.account_id.as_ref(), "account-id", runtime)?,
+            endpoint_url: require_or_prompt(spec.endpoint_url.as_ref(), "endpoint-url", runtime)?,
+            access_key_id: require_or_prompt_secret(
+                spec.access_key_id.as_ref(),
+                "access-key-id",
+                runtime,
+            )?,
+            secret_access_key: require_or_prompt_secret(
+                spec.secret_access_key.as_ref(),
                 "secret-access-key",
-                spec.secret_access_key.is_some(),
-                "gcp-gcs",
-            )?;
-            reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "gcp-gcs")?;
-            reject_create_flag("session-token", spec.session_token.is_some(), "gcp-gcs")?;
-            reject_create_flag("account-id", spec.account_id.is_some(), "gcp-gcs")?;
-            reject_create_flag("account-name", spec.account_name.is_some(), "gcp-gcs")?;
-            reject_create_flag("container-name", spec.container_name.is_some(), "gcp-gcs")?;
-            reject_create_flag("access-key", spec.access_key.is_some(), "gcp-gcs")?;
-            reject_create_flag("force-path-style", spec.force_path_style, "gcp-gcs")?;
-            StoreConfig::GcpGcs {
-                bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
-                service_account_key_path: require_or_prompt(
-                    spec.service_account_key_path.as_ref(),
-                    "service-account-key-path",
-                    runtime,
-                )?,
-                key_prefix: spec.key_prefix,
-            }
-        }
-        "azure-abs" => {
-            reject_create_flag("root", spec.root.is_some(), "azure-abs")?;
-            reject_create_flag("bucket", spec.bucket.is_some(), "azure-abs")?;
-            reject_create_flag("region", spec.region.is_some(), "azure-abs")?;
-            reject_create_flag("access-key-id", spec.access_key_id.is_some(), "azure-abs")?;
-            reject_create_flag(
-                "secret-access-key",
-                spec.secret_access_key.is_some(),
-                "azure-abs",
-            )?;
-            reject_create_flag("session-token", spec.session_token.is_some(), "azure-abs")?;
-            reject_create_flag("account-id", spec.account_id.is_some(), "azure-abs")?;
-            reject_create_flag(
+                runtime,
+            )?,
+            key_prefix: spec.key_prefix,
+        },
+        ConfiguredObjectStoreKind::GcpGcs => StoreConfig::GcpGcs {
+            bucket: require_or_prompt(spec.bucket.as_ref(), "bucket name", runtime)?,
+            service_account_key_path: require_or_prompt(
+                spec.service_account_key_path.as_ref(),
                 "service-account-key-path",
-                spec.service_account_key_path.is_some(),
-                "azure-abs",
-            )?;
-            reject_create_flag("force-path-style", spec.force_path_style, "azure-abs")?;
-            StoreConfig::AzureAbs {
-                account_name: require_or_prompt(
-                    spec.account_name.as_ref(),
-                    "account name",
-                    runtime,
-                )?,
-                container_name: require_or_prompt(
-                    spec.container_name.as_ref(),
-                    "container name",
-                    runtime,
-                )?,
-                access_key: require_or_prompt(spec.access_key.as_ref(), "access key", runtime)?,
-                endpoint_url: spec.endpoint_url,
-                key_prefix: spec.key_prefix,
-            }
-        }
-        other => {
-            return Err(CliError::invalid_config(format!(
-                "store kind `{other}` has no embedded profile builder"
-            )))
-        }
+                runtime,
+            )?,
+            key_prefix: spec.key_prefix,
+        },
+        ConfiguredObjectStoreKind::AzureAbs => StoreConfig::AzureAbs {
+            account_name: require_or_prompt(spec.account_name.as_ref(), "account name", runtime)?,
+            container_name: require_or_prompt(
+                spec.container_name.as_ref(),
+                "container name",
+                runtime,
+            )?,
+            access_key: require_or_prompt_secret(spec.access_key.as_ref(), "access key", runtime)?,
+            endpoint_url: spec.endpoint_url,
+            key_prefix: spec.key_prefix,
+        },
     };
 
     Ok(ProfileConfig::Embedded {
@@ -347,36 +443,14 @@ fn build_remote_profile(
     spec: CreateProfileSpec,
     runtime: RuntimeBehavior,
 ) -> Result<ProfileConfig, CliError> {
-    reject_create_flag("store-kind", spec.store_kind.is_some(), "remote")?;
-    reject_create_flag("root", spec.root.is_some(), "remote")?;
-    reject_create_flag("key-prefix", spec.key_prefix.is_some(), "remote")?;
-    reject_create_flag("bucket", spec.bucket.is_some(), "remote")?;
-    reject_create_flag("region", spec.region.is_some(), "remote")?;
-    reject_create_flag("access-key-id", spec.access_key_id.is_some(), "remote")?;
-    reject_create_flag(
-        "secret-access-key",
-        spec.secret_access_key.is_some(),
-        "remote",
-    )?;
-    reject_create_flag("endpoint-url", spec.endpoint_url.is_some(), "remote")?;
-    reject_create_flag("session-token", spec.session_token.is_some(), "remote")?;
-    reject_create_flag("force-path-style", spec.force_path_style, "remote")?;
-    reject_create_flag("account-id", spec.account_id.is_some(), "remote")?;
-    reject_create_flag("account-name", spec.account_name.is_some(), "remote")?;
-    reject_create_flag("container-name", spec.container_name.is_some(), "remote")?;
-    reject_create_flag("access-key", spec.access_key.is_some(), "remote")?;
-    reject_create_flag(
-        "service-account-key-path",
-        spec.service_account_key_path.is_some(),
-        "remote",
-    )?;
+    reject_inapplicable_create_flags(&spec, &[FlagTarget::Remote], "remote")?;
 
     Ok(ProfileConfig::Remote {
         server_url: require_or_prompt(spec.server_url.as_ref(), "server url", runtime)?,
         default_namespace: None,
         auth_token: match spec.auth_token {
             Some(token) if token.trim().is_empty() => None,
-            other => other,
+            other => other.map(SecretString::from),
         },
     })
 }
@@ -393,6 +467,20 @@ fn require_or_prompt(
     }
 }
 
+/// Like [`require_or_prompt`] but prompts with hidden input and returns the
+/// value wrapped as a secret.
+fn require_or_prompt_secret(
+    value: Option<&String>,
+    field: &str,
+    runtime: RuntimeBehavior,
+) -> Result<SecretString, CliError> {
+    match value {
+        Some(v) if !v.trim().is_empty() => Ok(SecretString::from(v.clone())),
+        _ if runtime.interactive => prompt::prompt_secret(field).map(SecretString::from),
+        _ => Err(CliError::non_interactive_input_required(field)),
+    }
+}
+
 fn require_or_prompt_region(
     value: Option<&String>,
     runtime: RuntimeBehavior,
@@ -404,112 +492,18 @@ fn require_or_prompt_region(
     }
 }
 
-fn reject_create_flag(flag: &str, present: bool, profile_kind: &str) -> Result<(), CliError> {
-    if present {
-        return Err(CliError::invalid_input(format!(
-            "`--{flag}` does not apply to {profile_kind} profiles"
-        )));
-    }
-    Ok(())
-}
-
 pub(super) fn apply_update_flags(
     existing: ProfileConfig,
     args: &ProfileUpdateArgs,
 ) -> Result<ProfileConfig, CliError> {
     match &existing {
         ProfileConfig::Embedded { store, .. } => {
-            reject_flag("server-url", &args.server_url, "embedded")?;
-            reject_flag("auth-token", &args.auth_token, "embedded")?;
-            match store {
-                StoreConfig::LocalFs { .. } => {
-                    reject_flag("bucket", &args.bucket, "local-fs")?;
-                    reject_flag("region", &args.region, "local-fs")?;
-                    reject_flag("access-key-id", &args.access_key_id, "local-fs")?;
-                    reject_flag("secret-access-key", &args.secret_access_key, "local-fs")?;
-                    reject_flag("endpoint-url", &args.endpoint_url, "local-fs")?;
-                    reject_flag("session-token", &args.session_token, "local-fs")?;
-                    reject_flag("account-id", &args.account_id, "local-fs")?;
-                    reject_flag("account-name", &args.account_name, "local-fs")?;
-                    reject_flag("container-name", &args.container_name, "local-fs")?;
-                    reject_flag("access-key", &args.access_key, "local-fs")?;
-                    reject_flag(
-                        "service-account-key-path",
-                        &args.service_account_key_path,
-                        "local-fs",
-                    )?;
-                }
-                StoreConfig::AwsS3 { .. } => {
-                    reject_flag("root", &args.root, "aws-s3")?;
-                    reject_flag("account-id", &args.account_id, "aws-s3")?;
-                    reject_flag("account-name", &args.account_name, "aws-s3")?;
-                    reject_flag("container-name", &args.container_name, "aws-s3")?;
-                    reject_flag("access-key", &args.access_key, "aws-s3")?;
-                    reject_flag(
-                        "service-account-key-path",
-                        &args.service_account_key_path,
-                        "aws-s3",
-                    )?;
-                }
-                StoreConfig::CloudflareR2 { .. } => {
-                    reject_flag("root", &args.root, "cloudflare-r2")?;
-                    reject_flag("region", &args.region, "cloudflare-r2")?;
-                    reject_flag("session-token", &args.session_token, "cloudflare-r2")?;
-                    reject_flag("account-name", &args.account_name, "cloudflare-r2")?;
-                    reject_flag("container-name", &args.container_name, "cloudflare-r2")?;
-                    reject_flag("access-key", &args.access_key, "cloudflare-r2")?;
-                    reject_flag(
-                        "service-account-key-path",
-                        &args.service_account_key_path,
-                        "cloudflare-r2",
-                    )?;
-                }
-                StoreConfig::GcpGcs { .. } => {
-                    reject_flag("root", &args.root, "gcp-gcs")?;
-                    reject_flag("region", &args.region, "gcp-gcs")?;
-                    reject_flag("access-key-id", &args.access_key_id, "gcp-gcs")?;
-                    reject_flag("secret-access-key", &args.secret_access_key, "gcp-gcs")?;
-                    reject_flag("endpoint-url", &args.endpoint_url, "gcp-gcs")?;
-                    reject_flag("session-token", &args.session_token, "gcp-gcs")?;
-                    reject_flag("account-id", &args.account_id, "gcp-gcs")?;
-                    reject_flag("account-name", &args.account_name, "gcp-gcs")?;
-                    reject_flag("container-name", &args.container_name, "gcp-gcs")?;
-                    reject_flag("access-key", &args.access_key, "gcp-gcs")?;
-                }
-                StoreConfig::AzureAbs { .. } => {
-                    reject_flag("root", &args.root, "azure-abs")?;
-                    reject_flag("bucket", &args.bucket, "azure-abs")?;
-                    reject_flag("region", &args.region, "azure-abs")?;
-                    reject_flag("access-key-id", &args.access_key_id, "azure-abs")?;
-                    reject_flag("secret-access-key", &args.secret_access_key, "azure-abs")?;
-                    reject_flag("session-token", &args.session_token, "azure-abs")?;
-                    reject_flag("account-id", &args.account_id, "azure-abs")?;
-                    reject_flag(
-                        "service-account-key-path",
-                        &args.service_account_key_path,
-                        "azure-abs",
-                    )?;
-                }
-            }
+            reject_inapplicable_update_flags(args, EMBEDDED_TARGETS, "embedded")?;
+            let store_kind = store.kind();
+            reject_inapplicable_update_flags(args, &[store_kind.into()], store_kind.as_str())?;
         }
         ProfileConfig::Remote { .. } => {
-            reject_flag("root", &args.root, "remote")?;
-            reject_flag("bucket", &args.bucket, "remote")?;
-            reject_flag("region", &args.region, "remote")?;
-            reject_flag("access-key-id", &args.access_key_id, "remote")?;
-            reject_flag("secret-access-key", &args.secret_access_key, "remote")?;
-            reject_flag("endpoint-url", &args.endpoint_url, "remote")?;
-            reject_flag("session-token", &args.session_token, "remote")?;
-            reject_flag("account-id", &args.account_id, "remote")?;
-            reject_flag("account-name", &args.account_name, "remote")?;
-            reject_flag("container-name", &args.container_name, "remote")?;
-            reject_flag("access-key", &args.access_key, "remote")?;
-            reject_flag("key-prefix", &args.key_prefix, "remote")?;
-            reject_flag(
-                "service-account-key-path",
-                &args.service_account_key_path,
-                "remote",
-            )?;
+            reject_inapplicable_update_flags(args, &[FlagTarget::Remote], "remote")?;
         }
     }
 
@@ -538,9 +532,21 @@ pub(super) fn apply_update_flags(
                     bucket: args.bucket.clone().unwrap_or(bucket),
                     region: args.region.clone().unwrap_or(region),
                     endpoint_url: args.endpoint_url.clone().or(endpoint_url),
-                    access_key_id: args.access_key_id.clone().unwrap_or(access_key_id),
-                    secret_access_key: args.secret_access_key.clone().unwrap_or(secret_access_key),
-                    session_token: args.session_token.clone().or(session_token),
+                    access_key_id: args
+                        .access_key_id
+                        .clone()
+                        .map(SecretString::from)
+                        .unwrap_or(access_key_id),
+                    secret_access_key: args
+                        .secret_access_key
+                        .clone()
+                        .map(SecretString::from)
+                        .unwrap_or(secret_access_key),
+                    session_token: args
+                        .session_token
+                        .clone()
+                        .map(SecretString::from)
+                        .or(session_token),
                     key_prefix: args.key_prefix.clone().or(key_prefix),
                     force_path_style,
                 },
@@ -555,8 +561,16 @@ pub(super) fn apply_update_flags(
                     bucket: args.bucket.clone().unwrap_or(bucket),
                     account_id: args.account_id.clone().unwrap_or(account_id),
                     endpoint_url: args.endpoint_url.clone().unwrap_or(endpoint_url),
-                    access_key_id: args.access_key_id.clone().unwrap_or(access_key_id),
-                    secret_access_key: args.secret_access_key.clone().unwrap_or(secret_access_key),
+                    access_key_id: args
+                        .access_key_id
+                        .clone()
+                        .map(SecretString::from)
+                        .unwrap_or(access_key_id),
+                    secret_access_key: args
+                        .secret_access_key
+                        .clone()
+                        .map(SecretString::from)
+                        .unwrap_or(secret_access_key),
                     key_prefix: args.key_prefix.clone().or(key_prefix),
                 },
                 StoreConfig::GcpGcs {
@@ -580,7 +594,11 @@ pub(super) fn apply_update_flags(
                 } => StoreConfig::AzureAbs {
                     account_name: args.account_name.clone().unwrap_or(account_name),
                     container_name: args.container_name.clone().unwrap_or(container_name),
-                    access_key: args.access_key.clone().unwrap_or(access_key),
+                    access_key: args
+                        .access_key
+                        .clone()
+                        .map(SecretString::from)
+                        .unwrap_or(access_key),
                     endpoint_url: args.endpoint_url.clone().or(endpoint_url),
                     key_prefix: args.key_prefix.clone().or(key_prefix),
                 },
@@ -599,18 +617,13 @@ pub(super) fn apply_update_flags(
         } => Ok(ProfileConfig::Remote {
             server_url: args.server_url.clone().unwrap_or(server_url),
             default_namespace,
-            auth_token: args.auth_token.clone().or(auth_token),
+            auth_token: args
+                .auth_token
+                .clone()
+                .map(SecretString::from)
+                .or(auth_token),
         }),
     }
-}
-
-fn reject_flag(flag: &str, value: &Option<String>, profile_kind: &str) -> Result<(), CliError> {
-    if value.is_some() {
-        return Err(CliError::invalid_input(format!(
-            "`--{flag}` does not apply to {profile_kind} profiles"
-        )));
-    }
-    Ok(())
 }
 
 pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<ProfileConfig, CliError> {
@@ -642,16 +655,22 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                             AWS_REGIONS.iter().position(|r| *r == region).unwrap_or(0);
                         prompt::prompt_fuzzy_choice("region", AWS_REGIONS, default_idx)?
                     },
-                    access_key_id: prompt::prompt_line_default("access key id", &access_key_id)?,
-                    secret_access_key: prompt::prompt_line_default(
+                    access_key_id: prompt::prompt_secret_keep_current(
+                        "access key id",
+                        access_key_id.expose(),
+                    )?
+                    .into(),
+                    secret_access_key: prompt::prompt_secret_keep_current(
                         "secret access key",
-                        &secret_access_key,
-                    )?,
+                        secret_access_key.expose(),
+                    )?
+                    .into(),
                     endpoint_url: prompt::prompt_optional("endpoint url", endpoint_url.as_deref())?,
-                    session_token: prompt::prompt_optional(
+                    session_token: prompt::prompt_secret_optional(
                         "session token",
-                        session_token.as_deref(),
-                    )?,
+                        session_token.as_ref().map(SecretString::expose),
+                    )?
+                    .map(SecretString::from),
                     key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
                     force_path_style,
                 },
@@ -666,11 +685,16 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                     bucket: prompt::prompt_line_default("bucket name", &bucket)?,
                     account_id: prompt::prompt_line_default("account id", &account_id)?,
                     endpoint_url: prompt::prompt_line_default("endpoint url", &endpoint_url)?,
-                    access_key_id: prompt::prompt_line_default("access key id", &access_key_id)?,
-                    secret_access_key: prompt::prompt_line_default(
+                    access_key_id: prompt::prompt_secret_keep_current(
+                        "access key id",
+                        access_key_id.expose(),
+                    )?
+                    .into(),
+                    secret_access_key: prompt::prompt_secret_keep_current(
                         "secret access key",
-                        &secret_access_key,
-                    )?,
+                        secret_access_key.expose(),
+                    )?
+                    .into(),
                     key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
                 },
                 StoreConfig::GcpGcs {
@@ -694,7 +718,11 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                 } => StoreConfig::AzureAbs {
                     account_name: prompt::prompt_line_default("account name", &account_name)?,
                     container_name: prompt::prompt_line_default("container name", &container_name)?,
-                    access_key: prompt::prompt_secret_keep_current("access key", &access_key)?,
+                    access_key: prompt::prompt_secret_keep_current(
+                        "access key",
+                        access_key.expose(),
+                    )?
+                    .into(),
                     endpoint_url: prompt::prompt_optional("endpoint url", endpoint_url.as_deref())?,
                     key_prefix: prompt::prompt_optional("key prefix", key_prefix.as_deref())?,
                 },
@@ -713,15 +741,22 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
         } => Ok(ProfileConfig::Remote {
             server_url: prompt::prompt_line_default("server url", &server_url)?,
             default_namespace,
-            auth_token: prompt::prompt_optional("auth token", auth_token.as_deref())?,
+            auth_token: prompt::prompt_secret_optional(
+                "auth token",
+                auth_token.as_ref().map(SecretString::expose),
+            )?
+            .map(SecretString::from),
         }),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_profile_from_create_spec, CreateProfileSpec};
-    use crate::args::RuntimeBehavior;
+    #![allow(clippy::panic)]
+    // Profile tests use panic in unexpected match arms for precise diagnostics.
+
+    use super::{apply_update_flags, build_profile_from_create_spec, CreateProfileSpec};
+    use crate::args::{ProfileUpdateArgs, RuntimeBehavior};
     use crate::config::{ProfileConfig, StoreConfig};
 
     #[test]
@@ -762,12 +797,129 @@ mod tests {
         {
             assert_eq!(account_name, "devstoreaccount1");
             assert_eq!(container_name, "container");
-            assert_eq!(access_key, "account-key");
+            assert_eq!(access_key.expose(), "account-key");
             assert_eq!(
                 endpoint_url.as_deref(),
                 Some("https://devstoreaccount1.blob.core.windows.net")
             );
             assert_eq!(key_prefix.as_deref(), Some("tenant-a"));
+        }
+    }
+
+    #[test]
+    fn create_rejects_flags_outside_their_provider() {
+        let remote_with_bucket = build_profile_from_create_spec(
+            CreateProfileSpec {
+                mode: Some("remote".to_owned()),
+                server_url: Some("http://127.0.0.1:9400".to_owned()),
+                bucket: Some("bucket".to_owned()),
+                ..empty_spec()
+            },
+            non_interactive_runtime(),
+        )
+        .expect_err("bucket must not apply to remote");
+        assert_eq!(
+            remote_with_bucket.message,
+            "`--bucket` does not apply to remote profiles"
+        );
+
+        let embedded_with_server_url = build_profile_from_create_spec(
+            CreateProfileSpec {
+                mode: Some("embedded".to_owned()),
+                store_kind: Some("local-fs".to_owned()),
+                root: Some("/tmp/store".to_owned()),
+                server_url: Some("http://127.0.0.1:9400".to_owned()),
+                ..empty_spec()
+            },
+            non_interactive_runtime(),
+        )
+        .expect_err("server-url must not apply to embedded");
+        assert_eq!(
+            embedded_with_server_url.message,
+            "`--server-url` does not apply to embedded profiles"
+        );
+
+        let local_fs_with_bucket = build_profile_from_create_spec(
+            CreateProfileSpec {
+                mode: Some("embedded".to_owned()),
+                store_kind: Some("local-fs".to_owned()),
+                root: Some("/tmp/store".to_owned()),
+                bucket: Some("bucket".to_owned()),
+                ..empty_spec()
+            },
+            non_interactive_runtime(),
+        )
+        .expect_err("bucket must not apply to local-fs");
+        assert_eq!(
+            local_fs_with_bucket.message,
+            "`--bucket` does not apply to local-fs profiles"
+        );
+    }
+
+    #[test]
+    fn update_rejects_flags_outside_their_provider() {
+        let local_fs = ProfileConfig::Embedded {
+            store: StoreConfig::LocalFs {
+                root: "/tmp/store".to_owned(),
+                key_prefix: None,
+            },
+            default_namespace: None,
+            writer_id: None,
+            writer_version: None,
+        };
+
+        let error = apply_update_flags(
+            local_fs.clone(),
+            &ProfileUpdateArgs {
+                bucket: Some("bucket".to_owned()),
+                ..empty_update_args()
+            },
+        )
+        .expect_err("bucket must not apply to local-fs");
+        assert_eq!(
+            error.message,
+            "`--bucket` does not apply to local-fs profiles"
+        );
+
+        let error = apply_update_flags(
+            local_fs,
+            &ProfileUpdateArgs {
+                auth_token: Some("token".to_owned()),
+                ..empty_update_args()
+            },
+        )
+        .expect_err("auth-token must not apply to embedded");
+        assert_eq!(
+            error.message,
+            "`--auth-token` does not apply to embedded profiles"
+        );
+    }
+
+    #[test]
+    fn update_applies_flags_to_matching_provider() {
+        let remote = ProfileConfig::Remote {
+            server_url: "http://127.0.0.1:9400".to_owned(),
+            default_namespace: None,
+            auth_token: None,
+        };
+
+        let updated = apply_update_flags(
+            remote,
+            &ProfileUpdateArgs {
+                auth_token: Some("new-token".to_owned()),
+                ..empty_update_args()
+            },
+        )
+        .expect("update remote auth token");
+
+        match updated {
+            ProfileConfig::Remote { auth_token, .. } => {
+                assert_eq!(
+                    auth_token.as_ref().map(|token| token.expose()),
+                    Some("new-token")
+                );
+            }
+            other => panic!("expected remote profile, got {other:?}"),
         }
     }
 
@@ -784,6 +936,27 @@ mod tests {
             endpoint_url: None,
             session_token: None,
             force_path_style: false,
+            account_id: None,
+            account_name: None,
+            container_name: None,
+            access_key: None,
+            service_account_key_path: None,
+            server_url: None,
+            auth_token: None,
+        }
+    }
+
+    fn empty_update_args() -> ProfileUpdateArgs {
+        ProfileUpdateArgs {
+            name: "profile".to_owned(),
+            root: None,
+            key_prefix: None,
+            bucket: None,
+            region: None,
+            access_key_id: None,
+            secret_access_key: None,
+            endpoint_url: None,
+            session_token: None,
             account_id: None,
             account_name: None,
             container_name: None,

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -1,20 +1,19 @@
 use crate::error::CliError;
 use http::Uri;
 use loonfs_api::NamespaceId;
-use loonfs_objectstore::abs::AzureAbsStoreConfig;
-use loonfs_objectstore::gcs::GcpGcsStoreConfig;
-use loonfs_objectstore::r2::CloudflareR2StoreConfig;
-use loonfs_objectstore::s3::AwsS3StoreConfig;
-use loonfs_objectstore::ConfiguredObjectStore;
+use loonfs_objectstore::{SecretString, StoreConfigError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+pub(crate) use loonfs_objectstore::StoreConfig;
+
 pub(crate) const CONFIG_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct CliConfig {
     pub config_version: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -26,7 +25,7 @@ pub(crate) struct CliConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "kebab-case")]
+#[serde(tag = "mode", rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) enum ProfileConfig {
     Embedded {
         store: StoreConfig,
@@ -42,55 +41,7 @@ pub(crate) enum ProfileConfig {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         default_namespace: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        auth_token: Option<String>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
-pub(crate) enum StoreConfig {
-    LocalFs {
-        root: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key_prefix: Option<String>,
-    },
-    AwsS3 {
-        bucket: String,
-        region: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        endpoint_url: Option<String>,
-        access_key_id: String,
-        secret_access_key: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        session_token: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key_prefix: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        force_path_style: Option<bool>,
-    },
-    CloudflareR2 {
-        bucket: String,
-        account_id: String,
-        endpoint_url: String,
-        access_key_id: String,
-        secret_access_key: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key_prefix: Option<String>,
-    },
-    GcpGcs {
-        bucket: String,
-        service_account_key_path: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key_prefix: Option<String>,
-    },
-    AzureAbs {
-        account_name: String,
-        container_name: String,
-        access_key: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        endpoint_url: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key_prefix: Option<String>,
+        auth_token: Option<SecretString>,
     },
 }
 
@@ -154,7 +105,7 @@ impl ProfileConfig {
 
     pub(crate) fn store_kind_str(&self) -> Option<&'static str> {
         match self {
-            ProfileConfig::Embedded { store, .. } => Some(store.kind_str()),
+            ProfileConfig::Embedded { store, .. } => Some(store.kind().as_str()),
             ProfileConfig::Remote { .. } => None,
         }
     }
@@ -172,7 +123,9 @@ impl ProfileConfig {
                         namespace,
                     )?;
                 }
-                store.validate(name)
+                store
+                    .validate()
+                    .map_err(|error| profile_store_error(name, &error))
             }
             ProfileConfig::Remote {
                 server_url,
@@ -188,7 +141,7 @@ impl ProfileConfig {
                 }
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
-                    require_non_empty(&profile_field(name, "auth_token"), token)?;
+                    require_non_empty(&profile_field(name, "auth_token"), token.expose())?;
                 }
                 Ok(())
             }
@@ -215,201 +168,22 @@ impl ProfileConfig {
             } => ProfileConfig::Remote {
                 server_url: server_url.clone(),
                 default_namespace: default_namespace.clone(),
-                auth_token: auth_token.as_ref().map(|_| "REDACTED".to_owned()),
+                auth_token: auth_token.as_ref().map(SecretString::masked),
             },
         }
     }
 }
 
-impl StoreConfig {
-    pub(crate) fn kind_str(&self) -> &'static str {
-        match self {
-            StoreConfig::LocalFs { .. } => "local-fs",
-            StoreConfig::AwsS3 { .. } => "aws-s3",
-            StoreConfig::CloudflareR2 { .. } => "cloudflare-r2",
-            StoreConfig::GcpGcs { .. } => "gcp-gcs",
-            StoreConfig::AzureAbs { .. } => "azure-abs",
+/// Prefixes a shared store-validation error (`store.<field>`-rooted) with the
+/// profile name, preserving the CLI's `missing `<profile>.store.<field>``
+/// message shape.
+fn profile_store_error(profile_name: &str, error: &StoreConfigError) -> CliError {
+    match error {
+        StoreConfigError::MissingField { field } => {
+            CliError::invalid_config(format!("missing `{profile_name}.{field}`"))
         }
-    }
-
-    pub(crate) fn object_store(&self) -> Result<ConfiguredObjectStore, CliError> {
-        match self {
-            StoreConfig::LocalFs { root, key_prefix } => {
-                ConfiguredObjectStore::local_fs(root, key_prefix.as_deref())
-                    .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))
-            }
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                session_token,
-                key_prefix,
-                force_path_style,
-            } => ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
-                bucket: bucket.clone(),
-                region: region.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: access_key_id.clone(),
-                secret_access_key: secret_access_key.clone(),
-                session_token: session_token.clone(),
-                key_prefix: key_prefix.clone(),
-                force_path_style: force_path_style.unwrap_or(false),
-            })
-            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                key_prefix,
-            } => ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
-                bucket: bucket.clone(),
-                account_id: account_id.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: access_key_id.clone(),
-                secret_access_key: secret_access_key.clone(),
-                key_prefix: key_prefix.clone(),
-            })
-            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
-            StoreConfig::GcpGcs {
-                bucket,
-                service_account_key_path,
-                key_prefix,
-            } => ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
-                bucket: bucket.clone(),
-                service_account_key_path: service_account_key_path.clone(),
-                key_prefix: key_prefix.clone(),
-            })
-            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                access_key,
-                endpoint_url,
-                key_prefix,
-            } => ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
-                account_name: account_name.clone(),
-                container_name: container_name.clone(),
-                access_key: access_key.clone(),
-                endpoint_url: endpoint_url.clone(),
-                key_prefix: key_prefix.clone(),
-            })
-            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}"))),
-        }
-    }
-
-    fn validate(&self, profile_name: &str) -> Result<(), CliError> {
-        match self {
-            StoreConfig::LocalFs { root, .. } => {
-                require_non_empty(&store_field(profile_name, "root"), root)
-            }
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                access_key_id,
-                secret_access_key,
-                ..
-            } => {
-                require_non_empty(&store_field(profile_name, "bucket"), bucket)?;
-                require_non_empty(&store_field(profile_name, "region"), region)?;
-                require_non_empty(&store_field(profile_name, "access_key_id"), access_key_id)?;
-                require_non_empty(
-                    &store_field(profile_name, "secret_access_key"),
-                    secret_access_key,
-                )
-            }
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                ..
-            } => {
-                require_non_empty(&store_field(profile_name, "bucket"), bucket)?;
-                require_non_empty(&store_field(profile_name, "account_id"), account_id)?;
-                require_non_empty(&store_field(profile_name, "endpoint_url"), endpoint_url)?;
-                require_non_empty(&store_field(profile_name, "access_key_id"), access_key_id)?;
-                require_non_empty(
-                    &store_field(profile_name, "secret_access_key"),
-                    secret_access_key,
-                )
-            }
-            StoreConfig::GcpGcs {
-                bucket,
-                service_account_key_path,
-                ..
-            } => {
-                require_non_empty(&store_field(profile_name, "bucket"), bucket)?;
-                require_non_empty(
-                    &store_field(profile_name, "service_account_key_path"),
-                    service_account_key_path,
-                )
-            }
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                access_key,
-                ..
-            } => {
-                require_non_empty(&store_field(profile_name, "account_name"), account_name)?;
-                require_non_empty(&store_field(profile_name, "container_name"), container_name)?;
-                require_non_empty(&store_field(profile_name, "access_key"), access_key)
-            }
-        }
-    }
-
-    fn redacted(&self) -> Self {
-        match self {
-            StoreConfig::LocalFs { .. } => self.clone(),
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url,
-                key_prefix,
-                force_path_style,
-                ..
-            } => StoreConfig::AwsS3 {
-                bucket: bucket.clone(),
-                region: region.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: "REDACTED".to_owned(),
-                secret_access_key: "REDACTED".to_owned(),
-                session_token: None,
-                key_prefix: key_prefix.clone(),
-                force_path_style: *force_path_style,
-            },
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                key_prefix,
-                ..
-            } => StoreConfig::CloudflareR2 {
-                bucket: bucket.clone(),
-                account_id: account_id.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: "REDACTED".to_owned(),
-                secret_access_key: "REDACTED".to_owned(),
-                key_prefix: key_prefix.clone(),
-            },
-            StoreConfig::GcpGcs { .. } => self.clone(),
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                endpoint_url,
-                key_prefix,
-                ..
-            } => StoreConfig::AzureAbs {
-                account_name: account_name.clone(),
-                container_name: container_name.clone(),
-                access_key: "REDACTED".to_owned(),
-                endpoint_url: endpoint_url.clone(),
-                key_prefix: key_prefix.clone(),
-            },
+        StoreConfigError::InvalidField { field, reason } => {
+            CliError::invalid_config(format!("invalid `{profile_name}.{field}`: {reason}"))
         }
     }
 }
@@ -427,10 +201,6 @@ pub(crate) fn validate_profile_name(name: &str) -> Result<(), CliError> {
 
 fn profile_field(name: &str, field: &str) -> String {
     format!("{name}.{field}")
-}
-
-fn store_field(profile_name: &str, field: &str) -> String {
-    format!("{profile_name}.store.{field}")
 }
 
 pub(crate) fn load_config(path: &Path) -> Result<CliConfig, CliError> {
@@ -554,4 +324,195 @@ fn validate_http_url(field: &str, value: &str) -> Result<(), CliError> {
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic)]
+    // Config tests use panic in unexpected match arms for precise diagnostics.
+
+    use super::{CliConfig, ProfileConfig, StoreConfig};
+
+    fn parse(contents: &str) -> Result<CliConfig, toml::de::Error> {
+        toml::from_str(contents)
+    }
+
+    #[test]
+    fn cli_config_debug_redacts_secrets() {
+        let config = parse(
+            r#"
+config_version = 1
+default_profile = "cloud"
+
+[profiles.cloud]
+mode = "embedded"
+
+[profiles.cloud.store]
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+access_key_id = "debug-access-key-id"
+secret_access_key = "debug-secret-access-key"
+session_token = "debug-session-token"
+
+[profiles.prod]
+mode = "remote"
+server_url = "https://loonfs.example.com"
+auth_token = "debug-auth-token"
+"#,
+        )
+        .expect("parse config");
+        config.validate().expect("valid config");
+
+        let rendered = format!("{config:?}");
+
+        assert!(!rendered.contains("debug-access-key-id"));
+        assert!(!rendered.contains("debug-secret-access-key"));
+        assert!(!rendered.contains("debug-session-token"));
+        assert!(!rendered.contains("debug-auth-token"));
+        assert!(rendered.contains("bucket"));
+    }
+
+    #[test]
+    fn redacted_config_serializes_without_secrets() {
+        let config = parse(
+            r#"
+config_version = 1
+
+[profiles.cloud]
+mode = "embedded"
+
+[profiles.cloud.store]
+kind = "cloudflare-r2"
+bucket = "bucket"
+account_id = "account"
+endpoint_url = "https://account.r2.cloudflarestorage.com"
+access_key_id = "plain-access-key-id"
+secret_access_key = "plain-secret-access-key"
+
+[profiles.prod]
+mode = "remote"
+server_url = "https://loonfs.example.com"
+auth_token = "plain-auth-token"
+"#,
+        )
+        .expect("parse config");
+
+        let rendered =
+            toml::to_string_pretty(&config.redacted()).expect("serialize redacted config");
+
+        assert!(!rendered.contains("plain-access-key-id"));
+        assert!(!rendered.contains("plain-secret-access-key"));
+        assert!(!rendered.contains("plain-auth-token"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected_at_every_level() {
+        let top_level = parse(
+            r#"
+config_version = 1
+default_profil = "typo"
+"#,
+        )
+        .expect_err("typo'd top-level key");
+        assert!(top_level.to_string().contains("default_profil"));
+
+        let profile_level = parse(
+            r#"
+config_version = 1
+
+[profiles.local]
+mode = "embedded"
+default_namespac = "typo"
+
+[profiles.local.store]
+kind = "local-fs"
+root = "/tmp/store"
+"#,
+        )
+        .expect_err("typo'd profile key");
+        assert!(profile_level.to_string().contains("default_namespac"));
+
+        let store_level = parse(
+            r#"
+config_version = 1
+
+[profiles.local]
+mode = "embedded"
+
+[profiles.local.store]
+kind = "local-fs"
+root = "/tmp/store"
+key_prefiks = "typo"
+"#,
+        )
+        .expect_err("typo'd store key");
+        assert!(store_level.to_string().contains("key_prefiks"));
+    }
+
+    #[test]
+    fn validation_reports_profile_prefixed_store_fields() {
+        let config = parse(
+            r#"
+config_version = 1
+
+[profiles.cloud]
+mode = "embedded"
+
+[profiles.cloud.store]
+kind = "aws-s3"
+bucket = " "
+region = "us-east-1"
+access_key_id = "access"
+secret_access_key = "secret"
+"#,
+        )
+        .expect("parse config");
+
+        let error = config.validate().expect_err("blank bucket");
+        assert_eq!(error.message, "missing `cloud.store.bucket`");
+    }
+
+    /// Every CLI example config must keep parsing into [`CliConfig`]
+    /// (including under `deny_unknown_fields`) and passing validation.
+    #[test]
+    fn cli_example_configs_parse_and_validate() {
+        let configs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../configs");
+        let mut examples = 0usize;
+        for entry in std::fs::read_dir(configs_dir).expect("read configs directory") {
+            let path = entry.expect("read configs entry").path();
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !name.starts_with("loon.") || !name.ends_with(".example.toml") {
+                continue;
+            }
+            let contents = std::fs::read_to_string(&path).expect("read example config");
+            let config: CliConfig =
+                toml::from_str(&contents).unwrap_or_else(|err| panic!("{name} must parse: {err}"));
+            config
+                .validate()
+                .unwrap_or_else(|err| panic!("{name} must validate: {}", err.message));
+            examples += 1;
+        }
+        assert!(
+            examples >= 2,
+            "expected at least 2 CLI example configs, found {examples}"
+        );
+    }
+
+    #[test]
+    fn store_kind_str_matches_config_tags() {
+        let profile = ProfileConfig::Embedded {
+            store: StoreConfig::LocalFs {
+                root: "/tmp/store".to_owned(),
+                key_prefix: None,
+            },
+            default_namespace: None,
+            writer_id: None,
+            writer_version: None,
+        };
+        assert_eq!(profile.store_kind_str(), Some("local-fs"));
+    }
 }

--- a/crates/loonfs-cli/src/prompt.rs
+++ b/crates/loonfs-cli/src/prompt.rs
@@ -16,6 +16,14 @@ pub(crate) fn prompt_line_default(label: &str, default: &str) -> Result<String, 
         .map_err(|err| CliError::io(std::io::Error::other(err)))
 }
 
+/// Prompts for a new secret with hidden input; empty input re-prompts.
+pub(crate) fn prompt_secret(label: &str) -> Result<String, CliError> {
+    Password::new()
+        .with_prompt(format!("{label} (hidden)"))
+        .interact()
+        .map_err(|err| CliError::io(std::io::Error::other(err)))
+}
+
 pub(crate) fn prompt_secret_keep_current(label: &str, current: &str) -> Result<String, CliError> {
     let value = Password::new()
         .with_prompt(format!("{label} (hidden, enter to keep current)"))
@@ -26,6 +34,28 @@ pub(crate) fn prompt_secret_keep_current(label: &str, current: &str) -> Result<S
         Ok(current.to_owned())
     } else {
         Ok(value)
+    }
+}
+
+/// Prompts for an optional secret with hidden input. Empty input keeps the
+/// current value (or stays unset); the current value is never displayed.
+pub(crate) fn prompt_secret_optional(
+    label: &str,
+    current: Option<&str>,
+) -> Result<Option<String>, CliError> {
+    let prompt = match current {
+        Some(_) => format!("{label} (hidden, enter to keep current)"),
+        None => format!("{label} (optional, hidden, enter to skip)"),
+    };
+    let value = Password::new()
+        .with_prompt(prompt)
+        .allow_empty_password(true)
+        .interact()
+        .map_err(|err| CliError::io(std::io::Error::other(err)))?;
+    if value.is_empty() {
+        Ok(current.map(ToOwned::to_owned))
+    } else {
+        Ok(Some(value))
     }
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -59,7 +59,7 @@ fn profile_create_list_show_remove_work() {
     assert_success(&show);
     let stdout = stdout_string(&show);
     assert!(stdout.contains("mode = \"remote\""));
-    assert!(stdout.contains("REDACTED"));
+    assert!(stdout.contains("<redacted>"));
     assert!(!stdout.contains("test-token"));
 
     let show_default = harness.run(&["--json", "profile", "show"]);
@@ -992,7 +992,6 @@ auth_token = "test-token"
 content_token_secret = "test-content-token-secret"
 writer_id = "{name}"
 writer_version = "{name}/0.1.0"
-lease_duration_ms = 200
 
 [store]
 kind = "local-fs"

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -13,6 +13,7 @@ base64.workspace = true
 bytes.workspace = true
 fs4.workspace = true
 futures.workspace = true
+http.workspace = true
 loonfs-api = { path = "../loonfs-api" }
 object_store.workspace = true
 serde.workspace = true
@@ -23,6 +24,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+toml.workspace = true
 
 [lints]
 workspace = true

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,4 +1,5 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::secret::SecretString;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -10,7 +11,7 @@ use std::sync::Arc;
 pub struct AzureAbsStoreConfig {
     pub account_name: String,
     pub container_name: String,
-    pub access_key: String,
+    pub access_key: SecretString,
     pub endpoint_url: Option<String>,
     pub key_prefix: Option<String>,
 }
@@ -38,7 +39,7 @@ impl AzureAbsStore {
                 "container name must not be empty".to_owned(),
             ));
         }
-        if config.access_key.trim().is_empty() {
+        if config.access_key.expose().trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "access key must not be empty".to_owned(),
             ));
@@ -47,7 +48,7 @@ impl AzureAbsStore {
         let mut builder = MicrosoftAzureBuilder::new()
             .with_account(config.account_name)
             .with_container_name(config.container_name)
-            .with_access_key(config.access_key);
+            .with_access_key(config.access_key.expose());
         if let Some(endpoint_url) = config.endpoint_url {
             let endpoint_url = endpoint_url.trim();
             if endpoint_url.is_empty() {
@@ -144,7 +145,7 @@ mod tests {
         let error = AzureAbsStore::new(AzureAbsStoreConfig {
             account_name: "account".to_owned(),
             container_name: "container".to_owned(),
-            access_key: " ".to_owned(),
+            access_key: " ".into(),
             endpoint_url: None,
             key_prefix: None,
         })
@@ -160,7 +161,7 @@ mod tests {
         AzureAbsStore::new(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
             container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.to_owned(),
+            access_key: AZURITE_ACCOUNT_KEY.into(),
             endpoint_url: Some("http://127.0.0.1:10000/devstoreaccount1".to_owned()),
             key_prefix: None,
         })
@@ -172,7 +173,7 @@ mod tests {
         AzureAbsStore::new(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
             container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.to_owned(),
+            access_key: AZURITE_ACCOUNT_KEY.into(),
             endpoint_url: Some("HTTP://127.0.0.1:10000/devstoreaccount1".to_owned()),
             key_prefix: None,
         })
@@ -184,7 +185,7 @@ mod tests {
         let store = AzureAbsStore::new(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
             container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.to_owned(),
+            access_key: AZURITE_ACCOUNT_KEY.into(),
             endpoint_url: None,
             key_prefix: Some("tenant-a".to_owned()),
         })

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -24,6 +24,20 @@ pub enum ConfiguredObjectStoreKind {
     AzureAbs,
 }
 
+impl ConfiguredObjectStoreKind {
+    /// Returns the stable kebab-case label, matching the `kind` tag used in
+    /// config files.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalFs => "local-fs",
+            Self::AwsS3 => "aws-s3",
+            Self::CloudflareR2 => "cloudflare-r2",
+            Self::GcpGcs => "gcp-gcs",
+            Self::AzureAbs => "azure-abs",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ConfiguredObjectStore {
     kind: ConfiguredObjectStoreKind,
@@ -316,8 +330,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "secret".into(),
             session_token: None,
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
@@ -330,8 +344,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),
             endpoint_url: "https://example.r2.cloudflarestorage.com".to_owned(),
-            access_key_id: "debug-access-key".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "debug-access-key".into(),
+            secret_access_key: "secret".into(),
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct r2 store");
@@ -352,7 +366,7 @@ mod tests {
         let azure = ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
             container_name: "container".to_owned(),
-            access_key: AZURITE_ACCOUNT_KEY.to_owned(),
+            access_key: AZURITE_ACCOUNT_KEY.into(),
             endpoint_url: None,
             key_prefix: Some("tenant-a".to_owned()),
         })
@@ -367,8 +381,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),
             endpoint_url: "https://account.r2.cloudflarestorage.com".to_owned(),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "secret".into(),
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct r2 store");
@@ -397,8 +411,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             account_id: "account".to_owned(),
             endpoint_url: "https://account.r2.cloudflarestorage.com".to_owned(),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "debug-secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "debug-secret".into(),
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct r2 store");

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -23,6 +23,8 @@ mod provider_object_store;
 pub mod r2;
 pub mod s3;
 mod s3_compatible;
+mod secret;
+mod store_config;
 
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 pub use object_store::{
@@ -30,5 +32,7 @@ pub use object_store::{
     SharedObjectStore,
 };
 pub use provider_object_store::{ProviderObjectStore, ProviderObjectStoreConfig};
+pub use secret::SecretString;
+pub use store_config::{StoreConfig, StoreConfigError};
 
 pub mod object_store;

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -3,45 +3,28 @@ use crate::presign::aws_sigv4::{
     aws_dates, canonical_query_string, hex_lower, hmac_sha256, normalize_header_value,
     percent_encode_path, percent_encode_segment,
 };
+use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use base64::Engine as _;
 use loonfs_api::{ContentRef, ContentRefKind};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::fmt::{self, Write as _};
+use std::fmt::Write as _;
 use std::time::SystemTime;
 
 const S3_CREATE_ONLY_HEADER: &str = "if-none-match";
 const S3_SHA256_CHECKSUM_HEADER: &str = "x-amz-checksum-sha256";
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S3PresignerConfig {
     pub bucket: String,
     pub region: String,
     pub endpoint_url: Option<String>,
-    pub access_key_id: String,
-    pub secret_access_key: String,
-    pub session_token: Option<String>,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
+    pub session_token: Option<SecretString>,
     pub key_prefix: Option<String>,
     pub force_path_style: bool,
-}
-
-impl fmt::Debug for S3PresignerConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("S3PresignerConfig")
-            .field("bucket", &self.bucket)
-            .field("region", &self.region)
-            .field("endpoint_url", &self.endpoint_url)
-            .field("access_key_id", &"<redacted>")
-            .field("secret_access_key", &"<redacted>")
-            .field(
-                "session_token",
-                &self.session_token.as_ref().map(|_| "<redacted>"),
-            )
-            .field("key_prefix", &self.key_prefix)
-            .field("force_path_style", &self.force_path_style)
-            .finish()
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -61,12 +44,12 @@ impl S3CompatiblePresigner {
                 "region must not be empty".to_owned(),
             ));
         }
-        if config.access_key_id.trim().is_empty() {
+        if config.access_key_id.expose().trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "access key id must not be empty".to_owned(),
             ));
         }
-        if config.secret_access_key.trim().is_empty() {
+        if config.secret_access_key.expose().trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "secret access key must not be empty".to_owned(),
             ));
@@ -159,7 +142,11 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
             "{}/{}/s3/aws4_request",
             dates.short_date, self.config.region
         );
-        let credential = format!("{}/{}", self.config.access_key_id, credential_scope);
+        let credential = format!(
+            "{}/{}",
+            self.config.access_key_id.expose(),
+            credential_scope
+        );
 
         let mut headers_to_sign = BTreeMap::from([("host".to_owned(), endpoint.host.clone())]);
         for (name, value) in &required_headers {
@@ -187,7 +174,7 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
             ("X-Amz-SignedHeaders".to_owned(), signed_headers.clone()),
         ]);
         if let Some(token) = &self.config.session_token {
-            query.insert("X-Amz-Security-Token".to_owned(), token.clone());
+            query.insert("X-Amz-Security-Token".to_owned(), token.expose().to_owned());
         }
         let canonical_query = canonical_query_string(&query);
         let canonical_request = format!(
@@ -200,7 +187,7 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
             dates.amz_date, credential_scope, hashed_request
         );
         let signing_key = signing_key(
-            &self.config.secret_access_key,
+            self.config.secret_access_key.expose(),
             &dates.short_date,
             &self.config.region,
         );
@@ -361,8 +348,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: None,
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "secret".into(),
             session_token: None,
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: false,
@@ -407,8 +394,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: None,
-            access_key_id: "debug-access-key".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "debug-access-key".into(),
+            secret_access_key: "secret".into(),
             session_token: None,
             key_prefix: None,
             force_path_style: false,
@@ -441,8 +428,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-2".to_owned(),
             endpoint_url: Some("https://bucket.s3.us-east-2.amazonaws.com".to_owned()),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "secret".into(),
             session_token: None,
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: false,
@@ -472,9 +459,9 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: None,
-            access_key_id: "access".to_owned(),
-            secret_access_key: "debug-secret".to_owned(),
-            session_token: Some("debug-session-token".to_owned()),
+            access_key_id: "access".into(),
+            secret_access_key: "debug-secret".into(),
+            session_token: Some("debug-session-token".into()),
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: false,
         };

--- a/crates/loonfs-objectstore/src/r2.rs
+++ b/crates/loonfs-objectstore/src/r2.rs
@@ -1,5 +1,6 @@
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -10,8 +11,8 @@ pub struct CloudflareR2StoreConfig {
     pub bucket: String,
     pub account_id: String,
     pub endpoint_url: String,
-    pub access_key_id: String,
-    pub secret_access_key: String,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
     pub key_prefix: Option<String>,
 }
 

--- a/crates/loonfs-objectstore/src/s3.rs
+++ b/crates/loonfs-objectstore/src/s3.rs
@@ -1,5 +1,6 @@
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -10,9 +11,9 @@ pub struct AwsS3StoreConfig {
     pub bucket: String,
     pub region: String,
     pub endpoint_url: Option<String>,
-    pub access_key_id: String,
-    pub secret_access_key: String,
-    pub session_token: Option<String>,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
+    pub session_token: Option<SecretString>,
     pub key_prefix: Option<String>,
     pub force_path_style: bool,
 }

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,3 +1,4 @@
+use crate::secret::SecretString;
 use crate::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, ProviderObjectStore,
     ProviderObjectStoreConfig, PutMode,
@@ -15,9 +16,9 @@ pub(crate) struct S3CompatibleConfig {
     pub bucket: String,
     pub region: String,
     pub endpoint_url: Option<String>,
-    pub access_key_id: String,
-    pub secret_access_key: String,
-    pub session_token: Option<String>,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
+    pub session_token: Option<SecretString>,
     pub key_prefix: Option<String>,
     pub force_path_style: bool,
     pub sha256_checksum_metadata: bool,
@@ -51,8 +52,8 @@ impl S3CompatibleStore {
         let mut builder = AmazonS3Builder::new()
             .with_bucket_name(config.bucket)
             .with_region(config.region)
-            .with_access_key_id(config.access_key_id)
-            .with_secret_access_key(config.secret_access_key)
+            .with_access_key_id(config.access_key_id.expose())
+            .with_secret_access_key(config.secret_access_key.expose())
             .with_virtual_hosted_style_request(!config.force_path_style);
 
         if let Some(endpoint_url) = endpoint_url {
@@ -61,8 +62,8 @@ impl S3CompatibleStore {
                 .with_endpoint(endpoint_url)
                 .with_allow_http(allow_http);
         }
-        if let Some(session_token) = config.session_token {
-            builder = builder.with_token(session_token);
+        if let Some(session_token) = &config.session_token {
+            builder = builder.with_token(session_token.expose());
         }
         if config.sha256_checksum_metadata {
             builder = builder.with_checksum_algorithm(Checksum::SHA256);
@@ -143,12 +144,12 @@ fn validate_config(config: &S3CompatibleConfig) -> Result<(), ObjectStoreError> 
             "region must not be empty".to_owned(),
         ));
     }
-    if config.access_key_id.trim().is_empty() {
+    if config.access_key_id.expose().trim().is_empty() {
         return Err(ObjectStoreError::Configuration(
             "access key id must not be empty".to_owned(),
         ));
     }
-    if config.secret_access_key.trim().is_empty() {
+    if config.secret_access_key.expose().trim().is_empty() {
         return Err(ObjectStoreError::Configuration(
             "secret access key must not be empty".to_owned(),
         ));
@@ -219,8 +220,8 @@ mod tests {
             bucket: "bucket".to_owned(),
             region: "us-east-1".to_owned(),
             endpoint_url: Some("http://127.0.0.1:9000".to_owned()),
-            access_key_id: "access".to_owned(),
-            secret_access_key: "secret".to_owned(),
+            access_key_id: "access".into(),
+            secret_access_key: "secret".into(),
             session_token: None,
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
@@ -238,7 +239,7 @@ mod tests {
     #[test]
     fn s3_compatible_store_rejects_blank_credentials() {
         let mut config = test_config();
-        config.access_key_id.clear();
+        config.access_key_id = "".into();
         assert!(S3CompatibleStore::new(config).is_err());
     }
 

--- a/crates/loonfs-objectstore/src/secret.rs
+++ b/crates/loonfs-objectstore/src/secret.rs
@@ -1,0 +1,102 @@
+//! A string wrapper that keeps credential material out of logs and debug
+//! output.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// The placeholder printed in place of secret material.
+const REDACTED: &str = "<redacted>";
+
+/// A secret string such as an access key, token, or signing secret.
+///
+/// `Debug` and `Display` both print `<redacted>` so secrets never leak
+/// through logging, tracing, or error formatting. Call [`SecretString::expose`]
+/// at the sites that genuinely need the raw value (request signing, provider
+/// builders, config persistence).
+///
+/// Serde serialization is transparent and **writes the actual secret** —
+/// config files need the real value round-tripped — so never serialize a
+/// secret-bearing struct into logs or display output; use a redacted copy
+/// (see [`SecretString::masked`]) instead.
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Wraps a secret value.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the raw secret. Keep the exposure site as small as possible.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns a copy whose *stored value* is the redaction placeholder.
+    ///
+    /// Use this to build display-safe copies of config structs that are
+    /// subsequently serialized (serde serialization is transparent and would
+    /// otherwise write the real secret).
+    pub fn masked(&self) -> Self {
+        Self(REDACTED.to_owned())
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl fmt::Display for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl From<String> for SecretString {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SecretString {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SecretString;
+
+    #[test]
+    fn debug_and_display_redact_the_value() {
+        let secret = SecretString::new("super-secret-value");
+
+        assert_eq!(format!("{secret:?}"), "<redacted>");
+        assert_eq!(format!("{secret}"), "<redacted>");
+        assert_eq!(secret.expose(), "super-secret-value");
+    }
+
+    #[test]
+    fn masked_replaces_the_stored_value() {
+        let secret = SecretString::new("super-secret-value");
+
+        let masked = secret.masked();
+
+        assert_eq!(masked.expose(), "<redacted>");
+    }
+
+    #[test]
+    fn serde_round_trips_the_raw_value() {
+        let secret = SecretString::new("super-secret-value");
+
+        let encoded = serde_json::to_string(&secret).expect("serialize secret");
+        assert_eq!(encoded, "\"super-secret-value\"");
+
+        let decoded: SecretString = serde_json::from_str(&encoded).expect("deserialize secret");
+        assert_eq!(decoded, secret);
+    }
+}

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -1,0 +1,585 @@
+//! The shared serde-facing object-store provider configuration.
+//!
+//! Both the server config file (`[store]`) and the CLI profile config
+//! (`[profiles.<name>.store]`) deserialize into [`StoreConfig`], validate it
+//! with [`StoreConfig::validate`], and construct the runtime store with
+//! [`StoreConfig::configured_object_store`]. The TOML shape is kind-tagged
+//! and kebab-case, documented by the examples in `configs/`.
+
+use crate::abs::AzureAbsStoreConfig;
+use crate::gcs::GcpGcsStoreConfig;
+use crate::r2::CloudflareR2StoreConfig;
+use crate::s3::AwsS3StoreConfig;
+use crate::secret::SecretString;
+use crate::{ConfiguredObjectStore, ConfiguredObjectStoreKind, ObjectStoreError};
+use http::Uri;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Provider selection plus credentials, as written in config files.
+///
+/// Serialization is transparent for secret fields and therefore writes the
+/// real credentials; only serialize a [`StoreConfig::redacted`] copy into
+/// display output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum StoreConfig {
+    LocalFs {
+        root: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+    },
+    AwsS3 {
+        bucket: String,
+        region: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        endpoint_url: Option<String>,
+        access_key_id: SecretString,
+        secret_access_key: SecretString,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_token: Option<SecretString>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        force_path_style: Option<bool>,
+    },
+    CloudflareR2 {
+        bucket: String,
+        account_id: String,
+        endpoint_url: String,
+        access_key_id: SecretString,
+        secret_access_key: SecretString,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+    },
+    GcpGcs {
+        bucket: String,
+        service_account_key_path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+    },
+    AzureAbs {
+        account_name: String,
+        container_name: String,
+        access_key: SecretString,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        endpoint_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_prefix: Option<String>,
+    },
+}
+
+/// Validation failure for a [`StoreConfig`].
+///
+/// Field paths are rooted at the store table (`store.bucket`, ...) so callers
+/// can report them directly or prefix them with their own config path.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum StoreConfigError {
+    #[error("missing `{field}`")]
+    MissingField { field: &'static str },
+    #[error("invalid `{field}`: {reason}")]
+    InvalidField { field: &'static str, reason: String },
+}
+
+impl StoreConfigError {
+    /// The `store.`-rooted path of the offending field.
+    pub fn field(&self) -> &'static str {
+        match self {
+            StoreConfigError::MissingField { field }
+            | StoreConfigError::InvalidField { field, .. } => field,
+        }
+    }
+}
+
+impl StoreConfig {
+    /// The provider kind this configuration selects.
+    pub fn kind(&self) -> ConfiguredObjectStoreKind {
+        match self {
+            StoreConfig::LocalFs { .. } => ConfiguredObjectStoreKind::LocalFs,
+            StoreConfig::AwsS3 { .. } => ConfiguredObjectStoreKind::AwsS3,
+            StoreConfig::CloudflareR2 { .. } => ConfiguredObjectStoreKind::CloudflareR2,
+            StoreConfig::GcpGcs { .. } => ConfiguredObjectStoreKind::GcpGcs,
+            StoreConfig::AzureAbs { .. } => ConfiguredObjectStoreKind::AzureAbs,
+        }
+    }
+
+    /// Builds the configured runtime object store for this provider.
+    pub fn configured_object_store(&self) -> Result<ConfiguredObjectStore, ObjectStoreError> {
+        match self {
+            StoreConfig::LocalFs { root, key_prefix } => {
+                ConfiguredObjectStore::local_fs(root, key_prefix.as_deref())
+            }
+            StoreConfig::AwsS3 {
+                bucket,
+                region,
+                endpoint_url,
+                access_key_id,
+                secret_access_key,
+                session_token,
+                key_prefix,
+                force_path_style,
+            } => ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
+                bucket: bucket.clone(),
+                region: region.clone(),
+                endpoint_url: endpoint_url.clone(),
+                access_key_id: access_key_id.clone(),
+                secret_access_key: secret_access_key.clone(),
+                session_token: session_token.clone(),
+                key_prefix: key_prefix.clone(),
+                force_path_style: force_path_style.unwrap_or(false),
+            }),
+            StoreConfig::CloudflareR2 {
+                bucket,
+                account_id,
+                endpoint_url,
+                access_key_id,
+                secret_access_key,
+                key_prefix,
+            } => ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
+                bucket: bucket.clone(),
+                account_id: account_id.clone(),
+                endpoint_url: endpoint_url.clone(),
+                access_key_id: access_key_id.clone(),
+                secret_access_key: secret_access_key.clone(),
+                key_prefix: key_prefix.clone(),
+            }),
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                key_prefix,
+            } => ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
+                bucket: bucket.clone(),
+                service_account_key_path: service_account_key_path.clone(),
+                key_prefix: key_prefix.clone(),
+            }),
+            StoreConfig::AzureAbs {
+                account_name,
+                container_name,
+                access_key,
+                endpoint_url,
+                key_prefix,
+            } => ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
+                account_name: account_name.clone(),
+                container_name: container_name.clone(),
+                access_key: access_key.clone(),
+                endpoint_url: endpoint_url.clone(),
+                key_prefix: key_prefix.clone(),
+            }),
+        }
+    }
+
+    /// Checks required fields and URL shapes, reporting `store.`-rooted field
+    /// paths.
+    pub fn validate(&self) -> Result<(), StoreConfigError> {
+        match self {
+            StoreConfig::LocalFs { root, .. } => {
+                require_non_empty("store.root", root)?;
+            }
+            StoreConfig::AwsS3 {
+                bucket,
+                region,
+                endpoint_url,
+                access_key_id,
+                secret_access_key,
+                ..
+            } => {
+                require_non_empty("store.bucket", bucket)?;
+                require_non_empty("store.region", region)?;
+                require_non_empty("store.access_key_id", access_key_id.expose())?;
+                require_non_empty("store.secret_access_key", secret_access_key.expose())?;
+                if let Some(url) = endpoint_url {
+                    validate_absolute_http_url("store.endpoint_url", url)?;
+                }
+            }
+            StoreConfig::CloudflareR2 {
+                bucket,
+                account_id,
+                endpoint_url,
+                access_key_id,
+                secret_access_key,
+                ..
+            } => {
+                require_non_empty("store.bucket", bucket)?;
+                require_non_empty("store.account_id", account_id)?;
+                require_non_empty("store.access_key_id", access_key_id.expose())?;
+                require_non_empty("store.secret_access_key", secret_access_key.expose())?;
+                validate_absolute_http_url("store.endpoint_url", endpoint_url)?;
+            }
+            StoreConfig::GcpGcs {
+                bucket,
+                service_account_key_path,
+                ..
+            } => {
+                require_non_empty("store.bucket", bucket)?;
+                require_non_empty("store.service_account_key_path", service_account_key_path)?;
+            }
+            StoreConfig::AzureAbs {
+                account_name,
+                container_name,
+                access_key,
+                endpoint_url,
+                ..
+            } => {
+                require_non_empty("store.account_name", account_name)?;
+                require_non_empty("store.container_name", container_name)?;
+                require_non_empty("store.access_key", access_key.expose())?;
+                if let Some(url) = endpoint_url {
+                    validate_absolute_http_url("store.endpoint_url", url)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns a copy whose secret fields hold the redaction placeholder, for
+    /// serialization into `show`-style display output.
+    pub fn redacted(&self) -> Self {
+        let mut redacted = self.clone();
+        match &mut redacted {
+            StoreConfig::LocalFs { .. } | StoreConfig::GcpGcs { .. } => {}
+            StoreConfig::AwsS3 {
+                access_key_id,
+                secret_access_key,
+                session_token,
+                ..
+            } => {
+                *access_key_id = access_key_id.masked();
+                *secret_access_key = secret_access_key.masked();
+                *session_token = session_token.as_ref().map(SecretString::masked);
+            }
+            StoreConfig::CloudflareR2 {
+                access_key_id,
+                secret_access_key,
+                ..
+            } => {
+                *access_key_id = access_key_id.masked();
+                *secret_access_key = secret_access_key.masked();
+            }
+            StoreConfig::AzureAbs { access_key, .. } => {
+                *access_key = access_key.masked();
+            }
+        }
+        redacted
+    }
+}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), StoreConfigError> {
+    if value.trim().is_empty() {
+        Err(StoreConfigError::MissingField { field })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), StoreConfigError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(StoreConfigError::MissingField { field });
+    }
+
+    let uri: Uri =
+        trimmed.parse().map_err(
+            |err: http::uri::InvalidUri| StoreConfigError::InvalidField {
+                field,
+                reason: err.to_string(),
+            },
+        )?;
+
+    match uri.scheme_str() {
+        Some("http" | "https") => {}
+        Some(other) => {
+            return Err(StoreConfigError::InvalidField {
+                field,
+                reason: format!("scheme must be http or https, got `{other}`"),
+            });
+        }
+        None => {
+            return Err(StoreConfigError::InvalidField {
+                field,
+                reason: "must be an absolute http or https URL".to_owned(),
+            });
+        }
+    }
+
+    if uri.authority().is_none() {
+        return Err(StoreConfigError::InvalidField {
+            field,
+            reason: "must be an absolute http or https URL".to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic)]
+    // Config tests use panic in unexpected match arms for precise diagnostics.
+
+    use super::{StoreConfig, StoreConfigError};
+    use crate::ConfiguredObjectStoreKind;
+    use std::path::{Path, PathBuf};
+
+    fn parse(contents: &str) -> StoreConfig {
+        toml::from_str(contents).expect("parse store config")
+    }
+
+    #[test]
+    fn parses_all_provider_kinds_and_reports_their_kind() {
+        let cases: [(&str, ConfiguredObjectStoreKind); 5] = [
+            (
+                "kind = \"local-fs\"\nroot = \"/tmp/store\"",
+                ConfiguredObjectStoreKind::LocalFs,
+            ),
+            (
+                r#"
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+access_key_id = "access"
+secret_access_key = "secret"
+"#,
+                ConfiguredObjectStoreKind::AwsS3,
+            ),
+            (
+                r#"
+kind = "cloudflare-r2"
+bucket = "bucket"
+account_id = "account"
+endpoint_url = "https://account.r2.cloudflarestorage.com"
+access_key_id = "access"
+secret_access_key = "secret"
+"#,
+                ConfiguredObjectStoreKind::CloudflareR2,
+            ),
+            (
+                r#"
+kind = "gcp-gcs"
+bucket = "bucket"
+service_account_key_path = "/tmp/service-account.json"
+"#,
+                ConfiguredObjectStoreKind::GcpGcs,
+            ),
+            (
+                r#"
+kind = "azure-abs"
+account_name = "account"
+container_name = "container"
+access_key = "key"
+"#,
+                ConfiguredObjectStoreKind::AzureAbs,
+            ),
+        ];
+
+        for (contents, kind) in cases {
+            let config = parse(contents);
+            assert_eq!(config.kind(), kind);
+            config.validate().expect("valid config");
+        }
+    }
+
+    #[test]
+    fn validate_reports_store_rooted_field_paths() {
+        let blank_bucket = parse(
+            r#"
+kind = "cloudflare-r2"
+bucket = " "
+account_id = "account"
+endpoint_url = "https://example.com"
+access_key_id = "access"
+secret_access_key = "secret"
+"#,
+        );
+        assert_eq!(
+            blank_bucket.validate(),
+            Err(StoreConfigError::MissingField {
+                field: "store.bucket"
+            })
+        );
+
+        let bad_scheme = parse(
+            r#"
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+endpoint_url = "ftp://example.com"
+access_key_id = "access"
+secret_access_key = "secret"
+"#,
+        );
+        match bad_scheme.validate() {
+            Err(StoreConfigError::InvalidField { field, reason }) => {
+                assert_eq!(field, "store.endpoint_url");
+                assert!(reason.contains("ftp"));
+            }
+            other => panic!("expected invalid endpoint_url, got {other:?}"),
+        }
+
+        let blank_azure_account = parse(
+            r#"
+kind = "azure-abs"
+account_name = " "
+container_name = "container"
+access_key = "key"
+"#,
+        );
+        assert_eq!(
+            blank_azure_account.validate(),
+            Err(StoreConfigError::MissingField {
+                field: "store.account_name"
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected_and_named() {
+        // `deny_unknown_fields` must keep working through the internally
+        // tagged (`kind = ...`) enum representation: a typo'd key in the
+        // store table has to fail the parse and name the offending key.
+        let error = toml::from_str::<StoreConfig>(
+            r#"
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+access_key_id = "access"
+secret_access_key = "secret"
+buckt = "typo"
+"#,
+        )
+        .expect_err("typo'd key must be rejected");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("buckt"),
+            "error must name the unknown key, got: {message}"
+        );
+    }
+
+    #[test]
+    fn debug_output_redacts_credentials() {
+        let config = parse(
+            r#"
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+access_key_id = "debug-access-key-id"
+secret_access_key = "debug-secret-access-key"
+session_token = "debug-session-token"
+"#,
+        );
+
+        let rendered = format!("{config:?}");
+
+        assert!(!rendered.contains("debug-access-key-id"));
+        assert!(!rendered.contains("debug-secret-access-key"));
+        assert!(!rendered.contains("debug-session-token"));
+        assert!(rendered.contains("bucket"));
+    }
+
+    #[test]
+    fn redacted_copy_serializes_without_credentials() {
+        let config = parse(
+            r#"
+kind = "cloudflare-r2"
+bucket = "bucket"
+account_id = "account"
+endpoint_url = "https://account.r2.cloudflarestorage.com"
+access_key_id = "plain-access-key-id"
+secret_access_key = "plain-secret-access-key"
+"#,
+        );
+
+        let rendered = toml::to_string_pretty(&config.redacted()).expect("serialize redacted");
+
+        assert!(!rendered.contains("plain-access-key-id"));
+        assert!(!rendered.contains("plain-secret-access-key"));
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("account"));
+    }
+
+    #[test]
+    fn serialization_round_trips_the_store_table() {
+        let config = parse(
+            r#"
+kind = "aws-s3"
+bucket = "bucket"
+region = "us-east-1"
+access_key_id = "access"
+secret_access_key = "secret"
+key_prefix = "demo"
+"#,
+        );
+
+        let rendered = toml::to_string_pretty(&config).expect("serialize store config");
+        assert!(rendered.contains("kind = \"aws-s3\""));
+        assert!(!rendered.contains("session_token"));
+        assert!(!rendered.contains("endpoint_url"));
+
+        let reparsed: StoreConfig = toml::from_str(&rendered).expect("reparse store config");
+        assert_eq!(reparsed, config);
+    }
+
+    /// Every example config in `configs/*.example.toml` must keep parsing
+    /// into the shared [`StoreConfig`]: the examples document the frozen TOML
+    /// shape.
+    #[test]
+    fn example_configs_store_sections_parse() {
+        let configs_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../configs");
+        let mut store_sections = 0usize;
+
+        for path in example_config_paths(&configs_dir) {
+            let contents = std::fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+            let value: toml::Value = toml::from_str(&contents)
+                .unwrap_or_else(|err| panic!("parse {}: {err}", path.display()));
+
+            for store in store_tables(&value) {
+                let config: StoreConfig = store.clone().try_into().unwrap_or_else(|err| {
+                    panic!("store section in {} must parse: {err}", path.display())
+                });
+                config.validate().unwrap_or_else(|err| {
+                    panic!("store section in {} must validate: {err}", path.display())
+                });
+                store_sections += 1;
+            }
+        }
+
+        // Five server examples plus the embedded CLI example.
+        assert!(
+            store_sections >= 6,
+            "expected at least 6 store sections across configs/*.example.toml, found {store_sections}"
+        );
+    }
+
+    fn example_config_paths(configs_dir: &Path) -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(configs_dir)
+            .expect("read configs directory")
+            .map(|entry| entry.expect("read configs entry").path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(".example.toml"))
+            })
+            .collect();
+        paths.sort();
+        assert!(!paths.is_empty(), "no example configs found");
+        paths
+    }
+
+    /// Collects `[store]` tables from server configs and
+    /// `[profiles.<name>.store]` tables from CLI configs.
+    fn store_tables(value: &toml::Value) -> Vec<&toml::Value> {
+        let mut sections = Vec::new();
+        if let Some(store) = value.get("store") {
+            sections.push(store);
+        }
+        if let Some(profiles) = value.get("profiles").and_then(toml::Value::as_table) {
+            for profile in profiles.values() {
+                if let Some(store) = profile.get("store") {
+                    sections.push(store);
+                }
+            }
+        }
+        sections
+    }
+}

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -336,9 +336,9 @@ async fn aws_s3_real_provider_conformance() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
-        session_token: config.session_token,
+        access_key_id: config.access_key_id.into(),
+        secret_access_key: config.secret_access_key.into(),
+        session_token: config.session_token.map(Into::into),
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -355,8 +355,8 @@ async fn cloudflare_r2_real_provider_conformance() {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id,
-        secret_access_key: config.secret_access_key,
+        access_key_id: config.access_key_id.into(),
+        secret_access_key: config.secret_access_key.into(),
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
@@ -385,7 +385,7 @@ async fn azure_abs_real_provider_conformance() {
     let store = AzureAbsStore::new(AzureAbsStoreConfig {
         account_name: config.account_name,
         container_name: config.container_name,
-        access_key: config.access_key,
+        access_key: config.access_key.into(),
         endpoint_url: config.endpoint,
         key_prefix: Some(config.prefix),
     })

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1,22 +1,37 @@
-use http::Uri;
 use loonfs::RuntimeCacheConfig;
-use loonfs_objectstore::abs::AzureAbsStoreConfig;
-use loonfs_objectstore::gcs::GcpGcsStoreConfig;
-use loonfs_objectstore::r2::CloudflareR2StoreConfig;
-use loonfs_objectstore::s3::AwsS3StoreConfig;
-use loonfs_objectstore::ConfiguredObjectStore;
+use loonfs_objectstore::{ConfiguredObjectStore, SecretString, StoreConfigError};
 use serde::Deserialize;
-use std::fmt;
+use std::env;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
 use thiserror::Error;
 
-#[derive(Clone, Deserialize)]
+pub use loonfs_objectstore::StoreConfig;
+
+/// Environment fallback for [`ServerConfig::auth_token`].
+const AUTH_TOKEN_ENV: &str = "LOONFS_AUTH_TOKEN";
+/// Environment fallback for [`ServerConfig::content_token_secret`].
+const CONTENT_TOKEN_SECRET_ENV: &str = "LOONFS_CONTENT_TOKEN_SECRET";
+
+/// The server config file.
+///
+/// # Secret precedence
+///
+/// `auth_token` and `content_token_secret` may be supplied through the
+/// `LOONFS_AUTH_TOKEN` and `LOONFS_CONTENT_TOKEN_SECRET` environment
+/// variables instead of the file. A non-blank value in the file always takes
+/// precedence; the environment variable fills the field only when the file
+/// leaves it unset (blank environment values are ignored).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     pub bind: String,
-    pub auth_token: Option<String>,
-    pub content_token_secret: String,
+    pub auth_token: Option<SecretString>,
+    /// Signs content tokens; unset or empty here falls back to
+    /// `LOONFS_CONTENT_TOKEN_SECRET`.
+    #[serde(default)]
+    pub content_token_secret: SecretString,
     pub writer_id: String,
     pub writer_version: String,
     #[serde(default)]
@@ -25,6 +40,7 @@ pub struct ServerConfig {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RuntimeCacheConfigOverrides {
     pub wal_tail_projection_cache_enabled: Option<bool>,
     pub control_cache_enabled: Option<bool>,
@@ -34,137 +50,6 @@ pub struct RuntimeCacheConfigOverrides {
     pub metadata_table_cache_enabled: Option<bool>,
     pub metadata_table_cache_max_blocks: Option<usize>,
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
-}
-
-#[derive(Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
-pub enum StoreConfig {
-    LocalFs {
-        root: String,
-        key_prefix: Option<String>,
-    },
-    AwsS3 {
-        bucket: String,
-        region: String,
-        endpoint_url: Option<String>,
-        access_key_id: String,
-        secret_access_key: String,
-        session_token: Option<String>,
-        key_prefix: Option<String>,
-        force_path_style: Option<bool>,
-    },
-    CloudflareR2 {
-        bucket: String,
-        account_id: String,
-        endpoint_url: String,
-        access_key_id: String,
-        secret_access_key: String,
-        key_prefix: Option<String>,
-    },
-    GcpGcs {
-        bucket: String,
-        service_account_key_path: String,
-        key_prefix: Option<String>,
-    },
-    AzureAbs {
-        account_name: String,
-        container_name: String,
-        access_key: String,
-        endpoint_url: Option<String>,
-        key_prefix: Option<String>,
-    },
-}
-
-impl fmt::Debug for ServerConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ServerConfig")
-            .field("bind", &self.bind)
-            .field(
-                "auth_token",
-                &self.auth_token.as_ref().map(|_| "<redacted>"),
-            )
-            .field("content_token_secret", &"<redacted>")
-            .field("writer_id", &self.writer_id)
-            .field("writer_version", &self.writer_version)
-            .field("runtime_cache", &self.runtime_cache)
-            .field("store", &self.store)
-            .finish()
-    }
-}
-
-impl fmt::Debug for StoreConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            StoreConfig::LocalFs { root, key_prefix } => f
-                .debug_struct("LocalFs")
-                .field("root", root)
-                .field("key_prefix", key_prefix)
-                .finish(),
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url,
-                access_key_id: _,
-                secret_access_key: _,
-                session_token,
-                key_prefix,
-                force_path_style,
-            } => f
-                .debug_struct("AwsS3")
-                .field("bucket", bucket)
-                .field("region", region)
-                .field("endpoint_url", endpoint_url)
-                .field("access_key_id", &"<redacted>")
-                .field("secret_access_key", &"<redacted>")
-                .field(
-                    "session_token",
-                    &session_token.as_ref().map(|_| "<redacted>"),
-                )
-                .field("key_prefix", key_prefix)
-                .field("force_path_style", force_path_style)
-                .finish(),
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id: _,
-                secret_access_key: _,
-                key_prefix,
-            } => f
-                .debug_struct("CloudflareR2")
-                .field("bucket", bucket)
-                .field("account_id", account_id)
-                .field("endpoint_url", endpoint_url)
-                .field("access_key_id", &"<redacted>")
-                .field("secret_access_key", &"<redacted>")
-                .field("key_prefix", key_prefix)
-                .finish(),
-            StoreConfig::GcpGcs {
-                bucket,
-                service_account_key_path,
-                key_prefix,
-            } => f
-                .debug_struct("GcpGcs")
-                .field("bucket", bucket)
-                .field("service_account_key_path", service_account_key_path)
-                .field("key_prefix", key_prefix)
-                .finish(),
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                access_key: _,
-                endpoint_url,
-                key_prefix,
-            } => f
-                .debug_struct("AzureAbs")
-                .field("account_name", account_name)
-                .field("container_name", container_name)
-                .field("access_key", &"<redacted>")
-                .field("endpoint_url", endpoint_url)
-                .field("key_prefix", key_prefix)
-                .finish(),
-        }
-    }
 }
 
 #[derive(Debug, Error)]
@@ -181,7 +66,27 @@ pub enum ServerConfigError {
 
 impl ServerConfig {
     pub(crate) fn content_token_secret(&self) -> &str {
-        &self.content_token_secret
+        self.content_token_secret.expose()
+    }
+
+    /// Fills `auth_token` and `content_token_secret` from the environment
+    /// when the file left them unset. Non-blank file values win; blank
+    /// environment values are ignored.
+    fn apply_env_fallbacks(
+        &mut self,
+        auth_token_env: Option<String>,
+        content_token_secret_env: Option<String>,
+    ) {
+        if self.auth_token.is_none() {
+            if let Some(token) = non_blank(auth_token_env) {
+                self.auth_token = Some(SecretString::new(token));
+            }
+        }
+        if self.content_token_secret.expose().trim().is_empty() {
+            if let Some(secret) = non_blank(content_token_secret_env) {
+                self.content_token_secret = SecretString::new(secret);
+            }
+        }
     }
 
     pub fn runtime_cache_config(&self) -> RuntimeCacheConfig {
@@ -217,88 +122,12 @@ impl ServerConfig {
     }
 
     pub fn object_store(&self) -> Result<ConfiguredObjectStore, ServerConfigError> {
-        match &self.store {
-            StoreConfig::LocalFs { root, key_prefix } => {
-                ConfiguredObjectStore::local_fs(root, key_prefix.as_deref()).map_err(|err| {
-                    ServerConfigError::InvalidField {
-                        field: "store.key_prefix",
-                        reason: err.to_string(),
-                    }
-                })
-            }
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                session_token,
-                key_prefix,
-                force_path_style,
-            } => ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
-                bucket: bucket.clone(),
-                region: region.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: access_key_id.clone(),
-                secret_access_key: secret_access_key.clone(),
-                session_token: session_token.clone(),
-                key_prefix: key_prefix.clone(),
-                force_path_style: force_path_style.unwrap_or(false),
-            })
+        self.store
+            .configured_object_store()
             .map_err(|err| ServerConfigError::InvalidField {
                 field: "store.key_prefix",
                 reason: err.to_string(),
-            }),
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                key_prefix,
-            } => ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
-                bucket: bucket.clone(),
-                account_id: account_id.clone(),
-                endpoint_url: endpoint_url.clone(),
-                access_key_id: access_key_id.clone(),
-                secret_access_key: secret_access_key.clone(),
-                key_prefix: key_prefix.clone(),
             })
-            .map_err(|err| ServerConfigError::InvalidField {
-                field: "store.key_prefix",
-                reason: err.to_string(),
-            }),
-            StoreConfig::GcpGcs {
-                bucket,
-                service_account_key_path,
-                key_prefix,
-            } => ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
-                bucket: bucket.clone(),
-                service_account_key_path: service_account_key_path.clone(),
-                key_prefix: key_prefix.clone(),
-            })
-            .map_err(|err| ServerConfigError::InvalidField {
-                field: "store.key_prefix",
-                reason: err.to_string(),
-            }),
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                access_key,
-                endpoint_url,
-                key_prefix,
-            } => ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
-                account_name: account_name.clone(),
-                container_name: container_name.clone(),
-                access_key: access_key.clone(),
-                endpoint_url: endpoint_url.clone(),
-                key_prefix: key_prefix.clone(),
-            })
-            .map_err(|err| ServerConfigError::InvalidField {
-                field: "store.key_prefix",
-                reason: err.to_string(),
-            }),
-        }
     }
 
     fn validate(&self) -> Result<(), ServerConfigError> {
@@ -307,85 +136,48 @@ impl ServerConfig {
         require_non_empty("writer_version", &self.writer_version)?;
 
         if let Some(token) = &self.auth_token {
-            if token.trim().is_empty() {
+            if token.expose().trim().is_empty() {
                 return Err(ServerConfigError::InvalidField {
                     field: "auth_token",
                     reason: "must not be empty".to_owned(),
                 });
             }
         }
-        require_non_empty("content_token_secret", &self.content_token_secret)?;
-        match &self.store {
-            StoreConfig::LocalFs { root, .. } => {
-                require_non_empty("store.root", root)?;
-            }
-            StoreConfig::AwsS3 {
-                bucket,
-                region,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                ..
-            } => {
-                require_non_empty("store.bucket", bucket)?;
-                require_non_empty("store.region", region)?;
-                require_non_empty("store.access_key_id", access_key_id)?;
-                require_non_empty("store.secret_access_key", secret_access_key)?;
-                if let Some(url) = endpoint_url {
-                    validate_optional_absolute_http_url("store.endpoint_url", url)?;
-                }
-            }
-            StoreConfig::CloudflareR2 {
-                bucket,
-                account_id,
-                endpoint_url,
-                access_key_id,
-                secret_access_key,
-                ..
-            } => {
-                require_non_empty("store.bucket", bucket)?;
-                require_non_empty("store.account_id", account_id)?;
-                require_non_empty("store.access_key_id", access_key_id)?;
-                require_non_empty("store.secret_access_key", secret_access_key)?;
-                validate_absolute_http_url("store.endpoint_url", endpoint_url)?;
-            }
-            StoreConfig::GcpGcs {
-                bucket,
-                service_account_key_path,
-                ..
-            } => {
-                require_non_empty("store.bucket", bucket)?;
-                require_non_empty("store.service_account_key_path", service_account_key_path)?;
-            }
-            StoreConfig::AzureAbs {
-                account_name,
-                container_name,
-                access_key,
-                endpoint_url,
-                ..
-            } => {
-                require_non_empty("store.account_name", account_name)?;
-                require_non_empty("store.container_name", container_name)?;
-                require_non_empty("store.access_key", access_key)?;
-                if let Some(url) = endpoint_url {
-                    validate_optional_absolute_http_url("store.endpoint_url", url)?;
-                }
-            }
-        }
+        require_non_empty("content_token_secret", self.content_token_secret.expose())?;
+        self.store.validate().map_err(ServerConfigError::from)?;
 
         Ok(())
     }
 }
 
+impl From<StoreConfigError> for ServerConfigError {
+    fn from(error: StoreConfigError) -> Self {
+        match error {
+            StoreConfigError::MissingField { field } => ServerConfigError::MissingField { field },
+            StoreConfigError::InvalidField { field, reason } => {
+                ServerConfigError::InvalidField { field, reason }
+            }
+        }
+    }
+}
+
 pub fn load_server_config(path: impl AsRef<Path>) -> Result<ServerConfig, ServerConfigError> {
     let bytes = fs::read(path.as_ref()).map_err(|err| ServerConfigError::Io(err.to_string()))?;
-    let config: ServerConfig = toml::from_str(
+    let mut config: ServerConfig = toml::from_str(
         std::str::from_utf8(&bytes).map_err(|err| ServerConfigError::Decode(err.to_string()))?,
     )
     .map_err(|err| ServerConfigError::Decode(err.to_string()))?;
+    config.apply_env_fallbacks(
+        env::var(AUTH_TOKEN_ENV).ok(),
+        env::var(CONTENT_TOKEN_SECRET_ENV).ok(),
+    );
     config.validate()?;
     config.object_store()?;
     Ok(config)
+}
+
+fn non_blank(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.trim().is_empty())
 }
 
 fn require_non_empty(field: &'static str, value: &str) -> Result<(), ServerConfigError> {
@@ -408,56 +200,6 @@ fn validate_socket_addr(field: &'static str, value: &str) -> Result<(), ServerCo
             field,
             reason: err.to_string(),
         })
-}
-
-fn validate_optional_absolute_http_url(
-    field: &'static str,
-    value: &str,
-) -> Result<(), ServerConfigError> {
-    if value.trim().is_empty() {
-        return Err(ServerConfigError::MissingField { field });
-    }
-    validate_absolute_http_url(field, value)
-}
-
-fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), ServerConfigError> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(ServerConfigError::MissingField { field });
-    }
-
-    let uri: Uri =
-        trimmed.parse().map_err(
-            |err: http::uri::InvalidUri| ServerConfigError::InvalidField {
-                field,
-                reason: err.to_string(),
-            },
-        )?;
-
-    match uri.scheme_str() {
-        Some("http" | "https") => {}
-        Some(other) => {
-            return Err(ServerConfigError::InvalidField {
-                field,
-                reason: format!("scheme must be http or https, got `{other}`"),
-            });
-        }
-        None => {
-            return Err(ServerConfigError::InvalidField {
-                field,
-                reason: "must be an absolute http or https URL".to_owned(),
-            });
-        }
-    }
-
-    if uri.authority().is_none() {
-        return Err(ServerConfigError::InvalidField {
-            field,
-            reason: "must be an absolute http or https URL".to_owned(),
-        });
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -738,6 +480,148 @@ force_path_style = false
     }
 
     #[test]
+    fn env_fallbacks_fill_only_unset_secrets() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "file-auth-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let mut config = load_server_config(&path).expect("load config");
+
+        // File values win over the environment.
+        config.apply_env_fallbacks(
+            Some("env-auth-token".to_owned()),
+            Some("env-content-token-secret".to_owned()),
+        );
+        assert_eq!(
+            config.auth_token.as_ref().map(|token| token.expose()),
+            Some("file-auth-token")
+        );
+        assert_eq!(config.content_token_secret(), "dev-content-token-secret");
+
+        // The environment fills fields the file left unset.
+        config.auth_token = None;
+        config.content_token_secret = loonfs_objectstore::SecretString::default();
+        config.apply_env_fallbacks(
+            Some("env-auth-token".to_owned()),
+            Some("env-content-token-secret".to_owned()),
+        );
+        assert_eq!(
+            config.auth_token.as_ref().map(|token| token.expose()),
+            Some("env-auth-token")
+        );
+        assert_eq!(config.content_token_secret(), "env-content-token-secret");
+
+        // Blank environment values are ignored.
+        config.auth_token = None;
+        config.content_token_secret = loonfs_objectstore::SecretString::default();
+        config.apply_env_fallbacks(Some("   ".to_owned()), Some(String::new()));
+        assert!(config.auth_token.is_none());
+        assert!(config.content_token_secret().is_empty());
+    }
+
+    #[test]
+    fn load_rejects_unknown_keys_at_every_level() {
+        let top_level = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+lease_duration = 60000
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let store_level = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+key_prefiks = "typo"
+"#,
+        );
+        let runtime_cache_level = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[runtime_cache]
+control_cache_enable = true
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        for (path, typo) in [
+            (top_level, "lease_duration"),
+            (store_level, "key_prefiks"),
+            (runtime_cache_level, "control_cache_enable"),
+        ] {
+            let error = load_server_config(&path).expect_err("typo'd key must be rejected");
+            match error {
+                ServerConfigError::Decode(message) => {
+                    assert!(
+                        message.contains(typo),
+                        "decode error must name `{typo}`, got: {message}"
+                    );
+                }
+                other => panic!("expected decode error naming {typo}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn load_accepts_config_without_content_token_secret_field() {
+        // `content_token_secret` may come from LOONFS_CONTENT_TOKEN_SECRET
+        // instead of the file; omitting both must still fail validation.
+        let path = write_config_verbatim(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let mut config: super::ServerConfig =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("config without content_token_secret parses");
+        assert!(config.content_token_secret().is_empty());
+
+        config.apply_env_fallbacks(None, Some("env-content-token-secret".to_owned()));
+        assert_eq!(config.content_token_secret(), "env-content-token-secret");
+
+        // Without the env fallback the load path reports the missing field.
+        if std::env::var("LOONFS_CONTENT_TOKEN_SECRET").is_err() {
+            let error = load_server_config(&path).expect_err("missing content token secret");
+            assert_missing_field(error, "content_token_secret");
+        }
+    }
+
+    #[test]
     fn load_uses_default_runtime_cache_when_omitted() {
         let path = write_config(
             r#"
@@ -850,9 +734,35 @@ root = "/tmp/loonfs-server"
         }
     }
 
+    /// Every server example config must keep parsing into [`ServerConfig`]
+    /// (including under `deny_unknown_fields`) and passing field validation.
+    #[test]
+    fn server_example_configs_parse_and_validate() {
+        let configs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../configs");
+        let mut examples = 0usize;
+        for entry in fs::read_dir(configs_dir).expect("read configs directory") {
+            let path = entry.expect("read configs entry").path();
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !name.starts_with("loonfs-server.") || !name.ends_with(".example.toml") {
+                continue;
+            }
+            let contents = fs::read_to_string(&path).expect("read example config");
+            let config: super::ServerConfig =
+                toml::from_str(&contents).unwrap_or_else(|err| panic!("{name} must parse: {err}"));
+            config
+                .validate()
+                .unwrap_or_else(|err| panic!("{name} must validate: {err}"));
+            examples += 1;
+        }
+        assert!(
+            examples >= 5,
+            "expected at least 5 server example configs, found {examples}"
+        );
+    }
+
     fn write_config(contents: &str) -> std::path::PathBuf {
-        let temp_dir = tempdir().expect("tempdir");
-        let path = temp_dir.path().join("server.toml");
         let contents = if contents.contains("content_token_secret") {
             contents.to_owned()
         } else {
@@ -862,6 +772,12 @@ root = "/tmp/loonfs-server"
                 1,
             )
         };
+        write_config_verbatim(&contents)
+    }
+
+    fn write_config_verbatim(contents: &str) -> std::path::PathBuf {
+        let temp_dir = tempdir().expect("tempdir");
+        let path = temp_dir.path().join("server.toml");
         fs::write(&path, contents).expect("write config");
         let _ = temp_dir.keep();
         path

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -1,4 +1,4 @@
-use crate::config::{ServerConfig, ServerConfigError, StoreConfig};
+use crate::config::{ServerConfig, ServerConfigError};
 use crate::publisher::PublisherRegistry;
 use axum::body::Bytes;
 use axum::extract::{Path as AxumPath, Query, State};
@@ -214,7 +214,7 @@ fn build_fs_with_metrics_jsonl_path(
     store: SharedStore,
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<Fs, ServerConfigError> {
-    let trace_store_kind = trace_store_kind(&config.store);
+    let trace_store_kind = TraceStoreKind::from(config.store.kind());
     let mut builder = Fs::builder(store)
         .writer_id(config.writer_id.clone())
         .writer_version(config.writer_version.clone())
@@ -250,16 +250,6 @@ fn object_store_metrics_recorder(
             field: OBJECT_STORE_METRICS_JSONL_ENV,
             reason: error.to_string(),
         })
-}
-
-fn trace_store_kind(store: &StoreConfig) -> TraceStoreKind {
-    match store {
-        StoreConfig::LocalFs { .. } => TraceStoreKind::LocalFs,
-        StoreConfig::AwsS3 { .. } => TraceStoreKind::S3,
-        StoreConfig::CloudflareR2 { .. } => TraceStoreKind::R2,
-        StoreConfig::GcpGcs { .. } => TraceStoreKind::Gcs,
-        StoreConfig::AzureAbs { .. } => TraceStoreKind::Abs,
-    }
 }
 
 /// Failure starting or running the HTTP server.
@@ -909,7 +899,7 @@ async fn filesystem_operation(
             "loon.put",
             operation = "put",
             mode = "remote",
-            store_kind = trace_store_kind(&state.config.store).as_str(),
+            store_kind = TraceStoreKind::from(state.config.store.kind()).as_str(),
             payload_class,
         );
         async {
@@ -1506,7 +1496,7 @@ fn authorize(config: &ServerConfig, headers: &HeaderMap) -> Result<(), ApiRespon
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .unwrap_or_default();
-    if actual == format!("Bearer {expected}") {
+    if actual == format!("Bearer {}", expected.expose()) {
         Ok(())
     } else {
         Err(ApiResponseError::new(
@@ -2386,8 +2376,8 @@ mod tests {
     fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         ServerConfig {
             bind: "127.0.0.1:0".to_owned(),
-            auth_token: Some("test-token".to_owned()),
-            content_token_secret: "test-content-token-secret".to_owned(),
+            auth_token: Some("test-token".into()),
+            content_token_secret: "test-content-token-secret".into(),
             writer_id: writer_id.to_owned(),
             writer_version: format!("{writer_id}/0.1.0"),
             runtime_cache: RuntimeCacheConfigOverrides::default(),

--- a/crates/loonfs-server/src/publisher.rs
+++ b/crates/loonfs-server/src/publisher.rs
@@ -1176,7 +1176,7 @@ mod tests {
         Arc::new(ServerConfig {
             bind: "127.0.0.1:0".to_owned(),
             auth_token: None,
-            content_token_secret: "test-content-token-secret".to_owned(),
+            content_token_secret: "test-content-token-secret".into(),
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             runtime_cache: RuntimeCacheConfigOverrides::default(),
@@ -1658,7 +1658,7 @@ mod tests {
         let config = Arc::new(ServerConfig {
             bind: "127.0.0.1:0".to_owned(),
             auth_token: None,
-            content_token_secret: "test-content-token-secret".to_owned(),
+            content_token_secret: "test-content-token-secret".into(),
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             runtime_cache: RuntimeCacheConfigOverrides::default(),
@@ -1712,7 +1712,7 @@ mod tests {
         let config = Arc::new(ServerConfig {
             bind: "127.0.0.1:0".to_owned(),
             auth_token: None,
-            content_token_secret: "test-content-token-secret".to_owned(),
+            content_token_secret: "test-content-token-secret".into(),
             writer_id: "writer-a".to_owned(),
             writer_version: "test".to_owned(),
             runtime_cache: RuntimeCacheConfigOverrides::default(),

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -21,8 +21,8 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
     let config = AwsS3DirectPutConfig::from_env().expect("load AWS S3 direct-put environment");
     direct_put_round_trip(ServerConfig {
         bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some(AUTH_TOKEN.to_owned()),
-        content_token_secret: CONTENT_TOKEN_SECRET.to_owned(),
+        auth_token: Some(AUTH_TOKEN.into()),
+        content_token_secret: CONTENT_TOKEN_SECRET.into(),
         writer_id: "direct-put-aws-s3".to_owned(),
         writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
@@ -30,9 +30,9 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
             bucket: config.bucket,
             region: config.region,
             endpoint_url: config.endpoint,
-            access_key_id: config.access_key_id,
-            secret_access_key: config.secret_access_key,
-            session_token: config.session_token,
+            access_key_id: config.access_key_id.into(),
+            secret_access_key: config.secret_access_key.into(),
+            session_token: config.session_token.map(Into::into),
             key_prefix: Some(config.prefix),
             force_path_style: Some(false),
         },
@@ -47,8 +47,8 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
         CloudflareR2DirectPutConfig::from_env().expect("load Cloudflare R2 direct-put environment");
     direct_put_round_trip(ServerConfig {
         bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some(AUTH_TOKEN.to_owned()),
-        content_token_secret: CONTENT_TOKEN_SECRET.to_owned(),
+        auth_token: Some(AUTH_TOKEN.into()),
+        content_token_secret: CONTENT_TOKEN_SECRET.into(),
         writer_id: "direct-put-r2".to_owned(),
         writer_version: "direct-put-r2/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
@@ -56,8 +56,8 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
             bucket: config.bucket,
             account_id: config.account_id,
             endpoint_url: config.endpoint,
-            access_key_id: config.access_key_id,
-            secret_access_key: config.secret_access_key,
+            access_key_id: config.access_key_id.into(),
+            secret_access_key: config.secret_access_key.into(),
             key_prefix: Some(config.prefix),
         },
     })

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1779,8 +1779,8 @@ async fn start_server(config: ServerConfig) -> TestServer {
 fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str) -> ServerConfig {
     ServerConfig {
         bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some("test-token".to_owned()),
-        content_token_secret: "test-content-token-secret".to_owned(),
+        auth_token: Some("test-token".into()),
+        content_token_secret: "test-content-token-secret".into(),
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),

--- a/crates/loonfs/src/trace.rs
+++ b/crates/loonfs/src/trace.rs
@@ -1,5 +1,7 @@
 //! Low-cardinality labels attached to runtime trace spans and metrics.
 
+use loonfs_objectstore::ConfiguredObjectStoreKind;
+
 /// Runtime deployment mode label used in trace spans.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraceMode {
@@ -50,6 +52,21 @@ impl TraceStoreKind {
     }
 }
 
+impl From<ConfiguredObjectStoreKind> for TraceStoreKind {
+    /// Derives the trace label from a configured object-store kind, so
+    /// callers wiring a [`ConfiguredObjectStoreKind`]-reporting store into the
+    /// runtime never hand-maintain the mapping.
+    fn from(kind: ConfiguredObjectStoreKind) -> Self {
+        match kind {
+            ConfiguredObjectStoreKind::LocalFs => Self::LocalFs,
+            ConfiguredObjectStoreKind::AwsS3 => Self::S3,
+            ConfiguredObjectStoreKind::CloudflareR2 => Self::R2,
+            ConfiguredObjectStoreKind::GcpGcs => Self::Gcs,
+            ConfiguredObjectStoreKind::AzureAbs => Self::Abs,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CachePath {
     MaterializedTables,
@@ -76,6 +93,21 @@ pub fn payload_class(size_bytes: usize) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{payload_class, CachePath, TraceMode, TraceStoreKind};
+    use loonfs_objectstore::ConfiguredObjectStoreKind;
+
+    #[test]
+    fn trace_store_kind_derives_from_configured_kind() {
+        let cases = [
+            (ConfiguredObjectStoreKind::LocalFs, TraceStoreKind::LocalFs),
+            (ConfiguredObjectStoreKind::AwsS3, TraceStoreKind::S3),
+            (ConfiguredObjectStoreKind::CloudflareR2, TraceStoreKind::R2),
+            (ConfiguredObjectStoreKind::GcpGcs, TraceStoreKind::Gcs),
+            (ConfiguredObjectStoreKind::AzureAbs, TraceStoreKind::Abs),
+        ];
+        for (kind, expected) in cases {
+            assert_eq!(TraceStoreKind::from(kind), expected);
+        }
+    }
 
     #[test]
     fn trace_labels_are_low_cardinality() {


### PR DESCRIPTION
The five-variant provider StoreConfig enum, its ~70-line object-store constructor, its validation walk, and the trace-kind label mapping were each maintained twice — once in the server, once in the CLI — and had already drifted on redaction. One serde-compatible StoreConfig now lives in loonfs-objectstore next to ConfiguredObjectStore (a new test parses every example config in configs/ to pin compatibility), and adding a provider is one enum variant plus one CLI flag-table row instead of ~10 scattered edits (the 120-call reject matrix became a 17-row table with byte-identical error messages).

Secrets get one rule: a SecretString newtype whose Debug and Display print <redacted>, applied across provider configs, ServerConfig, and CLI profiles — which let the hand-written redacting Debug impls become derives while keeping their tests, and which surfaced two silent traps at exposure sites (the presigner would have signed with the redaction marker). All secret prompts are hidden input now; AWS/R2 update flows no longer display the current secret as the visible default. Config files reject typo'd keys with the key named (deny_unknown_fields proven through the tagged-enum/toml path), and LOONFS_AUTH_TOKEN / LOONFS_CONTENT_TOKEN_SECRET can supply the server secrets when the file leaves them unset.