### PR TITLE
refactor(runtime): complete the facade seam

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -274,14 +274,7 @@ impl Backend for EmbeddedBackend {
 
     fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError> {
         let parsed = parse_namespace_id(namespace_id)?;
-        let status = self.block_on_scoped(namespace_id, self.fs.namespace_status(&parsed))?;
-        Ok(NamespaceStatusResponse {
-            namespace_id: status.namespace_id,
-            head_seq: status.head_seq,
-            current_manifest_id: status.current_manifest_id,
-            wal_tail_segments: status.wal_tail_segments,
-            retention_floor_seq: status.retention_floor_seq,
-        })
+        self.block_on_scoped(namespace_id, self.fs.namespace_status(&parsed))
     }
 
     fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -22,7 +22,6 @@ bytes.workspace = true
 clap.workspace = true
 http.workspace = true
 loonfs-api = { path = "../loonfs-api" }
-loonfs-core = { path = "../loonfs-core" }
 loonfs = { path = "../loonfs" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
 serde.workspace = true
@@ -38,6 +37,9 @@ utoipa = { workspace = true, optional = true }
 async-trait.workspace = true
 futures.workspace = true
 loonfs-client = { path = "../loonfs-client" }
+# Test-only white-box access to the durable head-control plane
+# (`load_namespace_head_control`); production code depends on `loonfs` alone.
+loonfs-core = { path = "../loonfs-core" }
 tempfile.workspace = true
 ureq.workspace = true
 

--- a/crates/loonfs-server/src/http.rs
+++ b/crates/loonfs-server/src/http.rs
@@ -6,6 +6,9 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
+use loonfs::content_tokens::{
+    mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
+};
 use loonfs::publish::PathMutationIntent;
 use loonfs::{
     payload_class, BootstrapNamespaceError, ChangeSeq, CoreError, CreateNamespaceOptions,
@@ -27,9 +30,6 @@ use loonfs_api::{
     GcResponse, InodeId, LimitError, ListFileRevisionsResponse, NamespaceId,
     NamespaceIdValidationError, PageCursorError, PageRequest, PaginationPolicy,
     RestoreFileRevisionRequest, RevisionNo, UploadId, FEATURE_UPLOADS_DIRECT_PUT,
-};
-use loonfs_core::content::{
-    mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
 };
 use loonfs_objectstore::{
     presign::{ObjectTransferIssuer, PresignedPutRequest},
@@ -516,13 +516,7 @@ async fn namespace_status_handler(
         .namespace_status(&namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    Ok(Json(loonfs_api::NamespaceStatusResponse {
-        namespace_id: status.namespace_id,
-        head_seq: status.head_seq,
-        current_manifest_id: status.current_manifest_id,
-        wal_tail_segments: status.wal_tail_segments,
-        retention_floor_seq: status.retention_floor_seq,
-    }))
+    Ok(Json(status))
 }
 
 #[cfg_attr(
@@ -1357,8 +1351,8 @@ async fn gc_namespace_handler(
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(namespace)?;
     let request = request.unwrap_or_default();
-    let defaults = loonfs_core::GcConfig::default();
-    let config = loonfs_core::GcConfig {
+    let defaults = loonfs::GcConfig::default();
+    let config = loonfs::GcConfig {
         grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),
         reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
     };
@@ -1786,8 +1780,8 @@ impl IntoResponse for ApiResponseError {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::panic, clippy::disallowed_methods)]
-    // HTTP smoke helpers use wall-clock lease timestamps and panic in unexpected match arms.
+    #![allow(clippy::panic)]
+    // HTTP smoke helpers panic in unexpected match arms for precise diagnostics.
 
     /// The compile-time forcing function for new error codes moved here when
     /// `ErrorCode` became `#[non_exhaustive]`: every registered code must
@@ -1856,12 +1850,11 @@ mod tests {
     use axum::body::Bytes;
     use futures::stream::BoxStream;
     use loonfs::{
-        CreateNamespaceOptions, Fs, FsConfig, PutFileOptions, RuntimeCacheConfig, TraceMode,
-        TraceStoreKind,
+        CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, PutFileOptions, RuntimeCacheConfig,
+        TraceMode, TraceStoreKind,
     };
     use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
     use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-    use loonfs_core::{BootstrapOptions, MutationContext, NamespaceEngine, WriteOptions};
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::{
@@ -1870,7 +1863,6 @@ mod tests {
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
     use tempfile::tempdir;
 
     #[derive(Debug)]
@@ -2101,15 +2093,7 @@ mod tests {
     async fn http_delete_missing_path_returns_path_not_found() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-        let now_ms = now_ms();
-        bootstrap_namespace(
-            store.as_ref(),
-            &namespace_id("demo"),
-            &context("server-writer", now_ms),
-            false,
-        )
-        .await
-        .expect("bootstrap namespace");
+        bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
@@ -2131,41 +2115,31 @@ mod tests {
     async fn http_put_over_directory_and_move_into_existing_target_return_path_conflict() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-        let now_ms = now_ms();
-        let context = context("server-writer", now_ms);
-        bootstrap_namespace(store.as_ref(), &namespace_id("demo"), &context, false)
-            .await
-            .expect("bootstrap namespace");
+        let seeder = bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
         write_file_bytes(
-            store.as_ref(),
+            &seeder,
             &namespace_id("demo"),
             "/docs/readme.txt",
             b"readme",
-            &context,
-            Some("seed-docs"),
+            "seed-docs",
         )
-        .await
-        .expect("seed docs");
+        .await;
         write_file_bytes(
-            store.as_ref(),
+            &seeder,
             &namespace_id("demo"),
             "/tmp/a.txt",
             b"from tmp",
-            &context,
-            Some("seed-tmp"),
+            "seed-tmp",
         )
-        .await
-        .expect("seed tmp");
+        .await;
         write_file_bytes(
-            store.as_ref(),
+            &seeder,
             &namespace_id("demo"),
             "/docs/a.txt",
             b"in docs",
-            &context,
-            Some("seed-target"),
+            "seed-target",
         )
-        .await
-        .expect("seed target");
+        .await;
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
@@ -2196,40 +2170,24 @@ mod tests {
     async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-        let now_ms = now_ms();
-        let context = context("server-writer", now_ms);
-        bootstrap_namespace(store.as_ref(), &namespace_id("demo"), &context, false)
-            .await
-            .expect("bootstrap namespace");
+        let seeder = bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
         write_file_bytes(
-            store.as_ref(),
+            &seeder,
             &namespace_id("demo"),
             "/docs/old.txt",
             b"old",
-            &context,
-            Some("seed-docs"),
+            "seed-docs",
         )
-        .await
-        .expect("seed docs");
+        .await;
         write_file_bytes(
-            store.as_ref(),
+            &seeder,
             &namespace_id("demo"),
             "/tmp/source.txt",
             b"source",
-            &context,
-            Some("seed-source"),
+            "seed-source",
         )
-        .await
-        .expect("seed source");
-        delete_path(
-            store.as_ref(),
-            &namespace_id("demo"),
-            "/docs",
-            &context,
-            Some("delete-docs"),
-        )
-        .await
-        .expect("delete docs");
+        .await;
+        delete_path_recursive(&seeder, &namespace_id("demo"), "/docs", "delete-docs").await;
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
@@ -2265,15 +2223,7 @@ mod tests {
     async fn http_path_mutation_retries_transient_stale_head_cas() {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(StaleHeadOnceStore::new(temp_dir.path(), "demo")) as SharedStore;
-        let now_ms = now_ms();
-        bootstrap_namespace(
-            store.as_ref(),
-            &namespace_id("demo"),
-            &context("server-writer", now_ms),
-            false,
-        )
-        .await
-        .expect("bootstrap namespace");
+        bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
         tokio::task::spawn_blocking(move || {
@@ -2296,15 +2246,7 @@ mod tests {
         // epoch immediately and fences the previous session.
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-        let now_ms = now_ms();
-        bootstrap_namespace(
-            store.as_ref(),
-            &namespace_id("demo"),
-            &context("other-writer", now_ms),
-            false,
-        )
-        .await
-        .expect("bootstrap namespace");
+        bootstrap_namespace(&store, "other-writer", &namespace_id("demo")).await;
         let store_for_check = store.clone();
 
         let harness = start_server(store, temp_dir.path(), "server-writer").await;
@@ -2388,91 +2330,61 @@ mod tests {
         }
     }
 
-    fn context(writer_id: &str, now_ms: u64) -> MutationContext {
-        MutationContext {
-            writer_id: writer_id.to_owned(),
-            writer_session_id: format!("wrs_{writer_id}"),
-            writer_version: format!("{writer_id}/0.1.0"),
-            now_ms,
-        }
-    }
-
-    fn namespace_engine<'a, S: ObjectStore + ?Sized>(
-        store: &'a S,
+    /// Bootstraps a namespace through a second embedded runtime — seeding
+    /// durable state as `writer_id` would from another process — and returns
+    /// that runtime for follow-up seed writes.
+    async fn bootstrap_namespace(
+        store: &SharedStore,
+        writer_id: &str,
         namespace_id: &NamespaceId,
-        context: &MutationContext,
-    ) -> NamespaceEngine<&'a S> {
-        NamespaceEngine::builder(store)
-            .namespace(namespace_id.clone())
-            .writer(context.writer_id.clone())
-            .writer_session_id(context.writer_session_id.clone())
-            .writer_version(context.writer_version.clone())
-            .build()
-            .expect("test context should build namespace engine")
-    }
-
-    async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
-        store: &S,
-        namespace_id: &NamespaceId,
-        context: &MutationContext,
-        allow_existing: bool,
-    ) -> Result<loonfs_api::NamespaceSummary, loonfs_core::BootstrapNamespaceError> {
-        namespace_engine(store, namespace_id, context)
-            .bootstrap_namespace(BootstrapOptions { allow_existing })
+    ) -> Fs {
+        let fs = test_runtime(store.clone(), writer_id);
+        fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
+            .expect("bootstrap namespace");
+        fs
     }
 
-    async fn write_file_bytes<S: ObjectStore + ?Sized>(
-        store: &S,
+    async fn write_file_bytes(
+        fs: &Fs,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         bytes: &[u8],
-        context: &MutationContext,
-        commit_id: Option<&str>,
-    ) -> Result<loonfs_api::MutationResult, loonfs_core::Error> {
-        namespace_engine(store, namespace_id, context)
-            .put_file(
-                absolute_path,
-                bytes,
-                WriteOptions {
-                    commit_id: commit_id
-                        .map(|value| CommitId::parse(value).expect("valid test commit id")),
-                    put_behavior: PutBehavior::Replace,
-                    ..WriteOptions::default()
-                },
-            )
-            .await
+        commit_id: &str,
+    ) {
+        fs.put_file_bytes(
+            namespace_id,
+            absolute_path,
+            bytes,
+            PutFileOptions {
+                behavior: PutBehavior::Replace,
+                commit_id: Some(CommitId::parse(commit_id).expect("valid test commit id")),
+            },
+        )
+        .await
+        .unwrap_or_else(|error| panic!("seed `{absolute_path}`: {error}"));
     }
 
-    async fn delete_path<S: ObjectStore + ?Sized>(
-        store: &S,
+    async fn delete_path_recursive(
+        fs: &Fs,
         namespace_id: &NamespaceId,
         absolute_path: &str,
-        context: &MutationContext,
-        commit_id: Option<&str>,
-    ) -> Result<loonfs_api::MutationResult, loonfs_core::Error> {
-        namespace_engine(store, namespace_id, context)
-            .delete_path(
-                absolute_path,
-                WriteOptions {
-                    commit_id: commit_id
-                        .map(|value| CommitId::parse(value).expect("valid test commit id")),
-                    delete_behavior: DeleteDirectoryBehavior::Recursive,
-                    ..WriteOptions::default()
-                },
-            )
-            .await
+        commit_id: &str,
+    ) {
+        fs.delete_path(
+            namespace_id,
+            absolute_path,
+            DeleteOptions {
+                behavior: DeleteDirectoryBehavior::Recursive,
+                commit_id: Some(CommitId::parse(commit_id).expect("valid test commit id")),
+            },
+        )
+        .await
+        .unwrap_or_else(|error| panic!("delete `{absolute_path}`: {error}"));
     }
 
     fn namespace_id(value: &str) -> NamespaceId {
         NamespaceId::parse(value).expect("valid namespace id")
-    }
-
-    fn now_ms() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_millis() as u64
     }
 
     fn assert_api_error<T: std::fmt::Debug>(

--- a/crates/loonfs-server/src/publisher.rs
+++ b/crates/loonfs-server/src/publisher.rs
@@ -1,9 +1,11 @@
-use loonfs::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use loonfs::content_tokens::ContentAdmission;
+use loonfs::publish::{
+    CommitHeadPublishError, NamespaceMutationCandidate, PathMutationIntent,
+    SemanticMutationIdentity,
+};
 use loonfs::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, Fs, RuntimeError};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, NamespaceId};
-use loonfs_core::commit::{CommitHeadPublishError, SemanticMutationIdentity};
-use loonfs_core::content::ContentAdmission;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{oneshot, Notify};
@@ -823,14 +825,12 @@ mod tests {
     use bytes::Bytes;
     use futures::stream::BoxStream;
     use loonfs::{
-        CreateNamespaceOptions, ErrorCode, Fs, FsConfig, RuntimeCacheConfig,
+        BeginUploadRequest, CreateNamespaceOptions, ErrorCode, Fs, FsConfig, RuntimeCacheConfig,
         SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
     };
     use loonfs_api::v0::{CommitOp, CommitRequest};
     use loonfs_api::wire::wal::decode_wal_segment_envelope_zstd;
     use loonfs_api::{ChangeSeq, InodeId, PutBehavior};
-    use loonfs_core::content::store_bytes_as_content;
-    use loonfs_core::publish::PathMutationIntent;
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::{
@@ -1724,7 +1724,18 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let fs = test_fs(store.clone(), &config);
         create_namespace(&fs, &namespace_id).await;
-        let content = store_bytes_as_content(store.as_ref(), &namespace_id, b"hello")
+        let upload = fs
+            .begin_upload(
+                &namespace_id,
+                BeginUploadRequest {
+                    mode: None,
+                    content_ref: None,
+                },
+            )
+            .await
+            .expect("begin upload");
+        let staged = fs
+            .upload_content(&namespace_id, &upload.upload_id, b"hello")
             .await
             .expect("stage content");
         let registry = PublisherRegistry::new(fs);
@@ -1741,7 +1752,7 @@ mod tests {
         let path_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("path-put").expect("valid commit id"),
             absolute_path: "/file.txt".to_owned(),
-            content_ref: content.content_ref,
+            content_ref: staged.content_ref,
             behavior: PutBehavior::NoReplace,
         };
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -16,8 +16,8 @@ use crate::{
     DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId, ListChangesOptions,
     ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
     MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
-    NamespaceStatus, NamespaceSummary, ObjectStore, ObjectStoreMetricsRecorder, PutFileOptions,
-    RestoreRevisionOptions, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats,
+    NamespaceStatusResponse, NamespaceSummary, ObjectStore, ObjectStoreMetricsRecorder,
+    PutFileOptions, RestoreRevisionOptions, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats,
     UploadContentResponse,
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
@@ -305,9 +305,12 @@ impl Fs {
 
     /// Summarizes a namespace's current head: manifest, latest checkpoint,
     /// WAL tail, and retention floor.
-    pub async fn namespace_status(&self, namespace_id: &NamespaceId) -> Result<NamespaceStatus> {
+    pub async fn namespace_status(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceStatusResponse> {
         let summary = load_namespace_head_summary(self.store(), namespace_id).await?;
-        Ok(NamespaceStatus {
+        Ok(NamespaceStatusResponse {
             namespace_id: summary.namespace_id,
             head_seq: summary.head_seq,
             current_manifest_id: summary.current_manifest_id,
@@ -402,8 +405,8 @@ impl Fs {
     async fn run_tick_gc(
         &self,
         namespace_id: &NamespaceId,
-        config: Option<&loonfs_core::GcConfig>,
-    ) -> Result<Option<loonfs_core::GcReport>> {
+        config: Option<&crate::GcConfig>,
+    ) -> Result<Option<crate::GcReport>> {
         let Some(config) = config else {
             return Ok(None);
         };
@@ -417,8 +420,8 @@ impl Fs {
     pub async fn gc_namespace(
         &self,
         namespace_id: &NamespaceId,
-        config: &loonfs_core::GcConfig,
-    ) -> Result<loonfs_core::GcReport> {
+        config: &crate::GcConfig,
+    ) -> Result<crate::GcReport> {
         let report =
             loonfs_core::gc_namespace(self.store(), namespace_id, config, &self.mutation_context())
                 .await
@@ -1288,7 +1291,7 @@ impl Fs {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    pub(crate) fn store(&self) -> &(dyn ObjectStore + Send + Sync) {
+    pub(crate) fn store(&self) -> &dyn ObjectStore {
         self.inner.store.as_ref()
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -12,8 +12,6 @@ mod options;
 mod time;
 mod trace;
 
-use std::sync::Arc;
-
 use thiserror::Error;
 
 pub use loonfs_api::v0::{
@@ -28,27 +26,37 @@ pub use loonfs_api::{
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DirectoryPageCursor, DisplayName,
     EffectiveLimit, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse, InodeId,
     InodeKind, ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult,
-    NameKey, NamePolicy, NamespaceId, NamespaceSummary, Page, PageRequest, PaginationPolicy,
-    PutBehavior, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
-    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROTOCOL_VERSION,
+    NameKey, NamePolicy, NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest,
+    PaginationPolicy, PutBehavior, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT,
+    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapNamespaceError, DeleteNamespaceOptions,
-    DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind,
+    DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind, GcConfig, GcReport,
 };
 
 /// Server-integration seam: the vocabulary a batching publisher uses to
 /// submit work to the runtime. Most embedded users never need this module.
 pub mod publish {
+    pub use loonfs_core::commit::{CommitHeadPublishError, SemanticMutationIdentity};
     pub use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+}
+
+/// Server-integration seam: mint/verify surface for the short-lived content
+/// tokens a serving session uses to admit already-validated direct-put
+/// content. Most embedded users never need this module.
+pub mod content_tokens {
+    pub use loonfs_core::content::{
+        mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
+    };
 }
 pub use loonfs_objectstore::metrics::{
     JsonlObjectStoreMetricsRecorder, KeyClass, ObjectStoreMetricSample, ObjectStoreMetricsRecorder,
     ObjectStoreOperation, ObjectStoreResultClass, PutModeClass, RangeClass,
 };
-pub use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+pub use loonfs_objectstore::{ObjectStore, ObjectStoreError, SharedObjectStore};
 
 pub use cache::RuntimeCacheStats;
 pub use config::{
@@ -60,12 +68,10 @@ pub use fs::{Fs, FsBuilder};
 pub use options::{
     CopyOptions, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions,
-    NamespaceStatus, PutFileOptions, RestoreRevisionOptions,
+    PutFileOptions, RestoreRevisionOptions,
 };
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 
-/// Shared object-store handle used by the runtime.
-pub type SharedObjectStore = Arc<dyn ObjectStore + Send + Sync>;
 /// Result type used by the embedded runtime.
 pub type Result<T> = std::result::Result<T, RuntimeError>;
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -3,23 +3,8 @@
 use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, EffectiveLimit, ManifestId, MoveBehavior,
-    NamespaceId, PutBehavior,
+    NamespaceId, NamespaceStatusResponse, PutBehavior,
 };
-
-/// Current maintenance-related namespace status.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NamespaceStatus {
-    /// Namespace being inspected.
-    pub namespace_id: NamespaceId,
-    /// Current visible namespace sequence.
-    pub head_seq: ChangeSeq,
-    /// Current manifest pointer recorded by the head.
-    pub current_manifest_id: Option<ManifestId>,
-    /// Number of visible WAL segments after the manifest materialization.
-    pub wal_tail_segments: u64,
-    /// Oldest sequence still promised for incremental replay.
-    pub retention_floor_seq: ChangeSeq,
-}
 
 /// Options for one maintenance tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,7 +13,7 @@ pub struct MaintenanceTickOptions {
     pub max_wal_tail_segments: u64,
     /// Run the mark-and-sweep garbage collector after the tick's checkpoint
     /// and retention work. Nothing sweeps unless this is set.
-    pub gc: Option<loonfs_core::GcConfig>,
+    pub gc: Option<crate::GcConfig>,
 }
 
 impl Default for MaintenanceTickOptions {
@@ -70,11 +55,11 @@ pub struct MaintenanceTickResult {
     /// Namespace the tick ran against.
     pub namespace_id: NamespaceId,
     /// Namespace status observed before the tick acted.
-    pub status_before: NamespaceStatus,
+    pub status_before: NamespaceStatusResponse,
     /// What the tick did.
     pub outcome: MaintenanceTickOutcome,
     /// Garbage-collection report when the tick opted into sweeping.
-    pub gc: Option<loonfs_core::GcReport>,
+    pub gc: Option<crate::GcReport>,
 }
 
 /// Options for creating a namespace.

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -11,9 +11,9 @@ use loonfs::{
     CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteOptions,
     DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
-    MutationResult, NamespaceId, NamespaceStatus, PageRequest, PaginationPolicy, PutBehavior,
-    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode, TraceStoreKind,
-    UploadContentResponse, UploadId,
+    MutationResult, NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy,
+    PutBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
+    TraceStoreKind, UploadContentResponse, UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::fs::LocalFsStore;
@@ -87,7 +87,7 @@ trait FsTestExt {
     fn namespace_status_blocking(
         &self,
         namespace_id: &NamespaceId,
-    ) -> loonfs::Result<NamespaceStatus>;
+    ) -> loonfs::Result<NamespaceStatusResponse>;
     fn maintenance_tick_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
@@ -202,7 +202,7 @@ impl FsTestExt for Fs {
     fn namespace_status_blocking(
         &self,
         namespace_id: &NamespaceId,
-    ) -> loonfs::Result<NamespaceStatus> {
+    ) -> loonfs::Result<NamespaceStatusResponse> {
         block_on(self.namespace_status(namespace_id))
     }
 


### PR DESCRIPTION
The loonfs facade bills itself as the layer the reference server builds on and exposes a deliberate publish seam, but the seam was incomplete, so loonfs-server also depended on loonfs-core directly for commit identity and content-token types — core-internal renames could break the server even with a stable facade. The seam now carries the missing vocabulary (publish gains the commit-identity types; a curated content_tokens module carries mint/verify), the server's engine-based test seeding was rewritten through Fs so loonfs-core leaves the server's dependencies entirely (cargo tree shows the single transitive path via loonfs), Fs::namespace_status returns the wire NamespaceStatusResponse directly — deleting the identical six-field copies in the server and CLI and the redundant runtime struct — and the two differently-spelled SharedObjectStore aliases collapse into one re-export. Net −95 lines.