### PR TITLE
feat(cli): admin plane parity across surfaces

### DIFF
--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -36,6 +36,11 @@ pub(crate) enum Command {
     Rm(FilesystemPathArgs),
     Mv(FilesystemMoveArgs),
     Cp(FilesystemMoveArgs),
+    Changes(ChangesArgs),
+    Admin {
+        #[command(subcommand)]
+        command: AdminCommand,
+    },
     Config {
         #[command(subcommand)]
         command: ConfigCommand,
@@ -303,6 +308,31 @@ pub(crate) struct FilesystemRestoreArgs {
     pub revision: u64,
 }
 
+#[derive(Debug, Args)]
+pub(crate) struct ChangesArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Return committed changes after this sequence (defaults to 0, the
+    /// start of retained history).
+    #[arg(long)]
+    pub after: Option<u64>,
+    /// Maximum number of changes to return.
+    #[arg(long)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum AdminCommand {
+    Checkpoint(AdminNamespaceArgs),
+    RetentionAdvance(AdminNamespaceArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminNamespaceArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum ConfigCommand {
     Path,
@@ -355,6 +385,9 @@ pub(crate) enum CommandKind {
     FilesystemRm,
     FilesystemMv,
     FilesystemCp,
+    Changes,
+    AdminCheckpoint,
+    AdminRetentionAdvance,
     ConfigPath,
     ConfigShow,
     Version,
@@ -386,6 +419,9 @@ impl CommandKind {
             CommandKind::FilesystemRm => "filesystem_rm",
             CommandKind::FilesystemMv => "filesystem_mv",
             CommandKind::FilesystemCp => "filesystem_cp",
+            CommandKind::Changes => "changes",
+            CommandKind::AdminCheckpoint => "admin_checkpoint",
+            CommandKind::AdminRetentionAdvance => "admin_retention_advance",
             CommandKind::ConfigPath => "config_path",
             CommandKind::ConfigShow => "config_show",
             CommandKind::Version => "version",
@@ -427,6 +463,11 @@ impl Cli {
             Command::Rm(_) => CommandKind::FilesystemRm,
             Command::Mv(_) => CommandKind::FilesystemMv,
             Command::Cp(_) => CommandKind::FilesystemCp,
+            Command::Changes(_) => CommandKind::Changes,
+            Command::Admin { command } => match command {
+                AdminCommand::Checkpoint(_) => CommandKind::AdminCheckpoint,
+                AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
+            },
             Command::Config { command } => match command {
                 ConfigCommand::Path => CommandKind::ConfigPath,
                 ConfigCommand::Show => CommandKind::ConfigShow,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -1,217 +1,30 @@
+//! Profile-mode wiring for the [`Backend`] seam.
+//!
+//! The trait and its HTTP implementation live in `loonfs_client::backend`;
+//! this module keeps the embedded implementation (the CLI is the only host
+//! that embeds the `loonfs` runtime today, and `loonfs-client` must stay
+//! wire-only) plus the profile-to-backend resolution.
+
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use loonfs::{
-    BootstrapNamespaceError, CopyOptions, CoreError, CreateDirOptions, CreateNamespaceOptions,
-    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, Fs, FsConfig,
-    MoveOptions, PutFileOptions, RestoreRevisionOptions, RuntimeCacheConfig, RuntimeError,
-    SharedObjectStore, TraceMode, TraceStoreKind,
+    BootstrapNamespaceError, ChangesResponse, CopyOptions, CoreError, CreateDirOptions,
+    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
+    ErrorCode, Fs, FsConfig, ListChangesOptions, MoveOptions, PutFileOptions,
+    RestoreRevisionOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
+    TraceStoreKind,
 };
 use loonfs_api::{
-    AuthoritativePathEntry, ChangeSeq, CommitId, DeleteDirectoryBehavior, EffectiveLimit,
-    ListFileRevisionsResponse, MoveBehavior, MutationResult, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, PaginationPolicy, PutBehavior, RevisionNo,
+    AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CommitId,
+    CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit, ListFileRevisionsResponse,
+    MoveBehavior, MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    PaginationPolicy, PutBehavior, RevisionNo,
 };
-use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
+use loonfs_client::{Client, ClientConfig, NamespacePath};
 use std::future::Future;
 use std::sync::Arc;
 
-pub(crate) trait Backend {
-    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError>;
-    fn delete_namespace(
-        &self,
-        namespace_id: &str,
-        expected_head_seq: Option<u64>,
-    ) -> Result<DeleteNamespaceResponse, CliError>;
-    fn fork_namespace(
-        &self,
-        source: &str,
-        new_namespace_id: &str,
-    ) -> Result<NamespaceSummary, CliError>;
-    fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError>;
-    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError>;
-    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError>;
-    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError>;
-    fn read_file_revision_bytes(
-        &self,
-        spec: &NamespacePath,
-        revision_no: RevisionNo,
-    ) -> Result<Vec<u8>, CliError>;
-    fn list_file_revisions(
-        &self,
-        spec: &NamespacePath,
-        limit: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<ListFileRevisionsResponse, CliError>;
-    fn put_file_bytes(
-        &self,
-        spec: &NamespacePath,
-        bytes: &[u8],
-        force: bool,
-    ) -> Result<MutationResult, CliError>;
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, CliError>;
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError>;
-    fn move_path(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-    ) -> Result<MutationResult, CliError>;
-    fn copy_path(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-    ) -> Result<MutationResult, CliError>;
-    fn restore_file_revision(
-        &self,
-        spec: &NamespacePath,
-        source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, CliError>;
-}
-
-// --- Remote backend (HTTP via loonfs-client) ---
-
-pub(crate) struct RemoteBackend {
-    client: Client,
-}
-
-impl Backend for RemoteBackend {
-    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
-        self.client
-            .create_namespace(namespace_id)
-            .map_err(map_client_error)
-    }
-
-    fn delete_namespace(
-        &self,
-        namespace_id: &str,
-        expected_head_seq: Option<u64>,
-    ) -> Result<DeleteNamespaceResponse, CliError> {
-        self.client
-            .delete_namespace(namespace_id, expected_head_seq.map(ChangeSeq))
-            .map_err(map_client_error)
-    }
-
-    fn fork_namespace(
-        &self,
-        source: &str,
-        new_namespace_id: &str,
-    ) -> Result<NamespaceSummary, CliError> {
-        self.client
-            .fork_namespace(source, new_namespace_id)
-            .map_err(map_client_error)
-    }
-
-    fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError> {
-        self.client
-            .namespace_status(namespace_id)
-            .map_err(map_client_error)
-    }
-
-    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
-        Ok(self
-            .client
-            .list_path(spec)
-            .map_err(map_client_error)?
-            .entries)
-    }
-
-    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
-        self.client.stat_path(spec).map_err(map_client_error)
-    }
-
-    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
-        self.client.read_file_bytes(spec).map_err(map_client_error)
-    }
-
-    fn read_file_revision_bytes(
-        &self,
-        spec: &NamespacePath,
-        revision_no: RevisionNo,
-    ) -> Result<Vec<u8>, CliError> {
-        self.client
-            .read_file_revision_bytes(spec, revision_no)
-            .map_err(map_client_error)
-    }
-
-    fn list_file_revisions(
-        &self,
-        spec: &NamespacePath,
-        limit: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<ListFileRevisionsResponse, CliError> {
-        self.client
-            .list_file_revisions_page(spec, limit, cursor)
-            .map_err(map_client_error)
-    }
-
-    fn put_file_bytes(
-        &self,
-        spec: &NamespacePath,
-        bytes: &[u8],
-        force: bool,
-    ) -> Result<MutationResult, CliError> {
-        self.client
-            .put_file_bytes(spec, bytes, force)
-            .map_err(map_client_error)
-    }
-
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
-        self.client.delete_path(spec).map_err(map_client_error)
-    }
-
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
-        self.client.create_dir(spec).map_err(map_client_error)
-    }
-
-    fn move_path(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-    ) -> Result<MutationResult, CliError> {
-        self.client.move_path(from, to).map_err(map_client_error)
-    }
-
-    fn copy_path(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-    ) -> Result<MutationResult, CliError> {
-        self.client.copy_path(from, to).map_err(map_client_error)
-    }
-
-    fn restore_file_revision(
-        &self,
-        spec: &NamespacePath,
-        source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, CliError> {
-        self.client
-            .restore_file_revision(spec, source_revision_no)
-            .map_err(map_client_error)
-    }
-}
-
-fn map_client_error(error: ClientError) -> CliError {
-    match error {
-        ClientError::ConfigIo(message) | ClientError::ConfigDecode(message) => {
-            CliError::invalid_config(message)
-        }
-        ClientError::MissingConfigField { field } => {
-            CliError::invalid_config(format!("missing `{field}`"))
-        }
-        ClientError::ConfigValidation { field, reason } => {
-            CliError::invalid_config(format!("invalid `{field}`: {reason}"))
-        }
-        ClientError::InvalidNamespacePath(message) => CliError::invalid_input(message),
-        ClientError::InvalidCommitId(message) => {
-            // The registry code core and server report for a malformed commit
-            // id, so pre-flight client validation matches backend behavior.
-            CliError::new(ErrorCode::InvalidRequest.as_str(), message)
-        }
-        ClientError::Http(message) | ClientError::Json(message) => CliError::client_error(message),
-        ClientError::Api { code, message, .. } => CliError::new(code, message),
-        ClientError::Io(message) => CliError::io(std::io::Error::other(message)),
-        other => CliError::client_error(other.to_string()),
-    }
-}
+pub(crate) use loonfs_client::backend::{Backend, BackendError, RemoteBackend};
 
 // --- Embedded backend (embedded/direct mode uses the shared loonfs runtime) ---
 
@@ -221,14 +34,14 @@ pub(crate) struct EmbeddedBackend {
 }
 
 impl EmbeddedBackend {
-    fn block_on<T, F>(&self, future: F) -> Result<T, CliError>
+    fn block_on<T, F>(&self, future: F) -> Result<T, BackendError>
     where
         F: Future<Output = loonfs::Result<T>>,
     {
         self.runtime.block_on(future).map_err(map_runtime_error)
     }
 
-    fn block_on_scoped<T, F>(&self, namespace: &str, future: F) -> Result<T, CliError>
+    fn block_on_scoped<T, F>(&self, namespace: &str, future: F) -> Result<T, BackendError>
     where
         F: Future<Output = loonfs::Result<T>>,
     {
@@ -239,7 +52,7 @@ impl EmbeddedBackend {
 }
 
 impl Backend for EmbeddedBackend {
-    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, CliError> {
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError> {
         let namespace_id = parse_namespace_id(namespace_id)?;
         self.block_on(
             self.fs
@@ -251,7 +64,7 @@ impl Backend for EmbeddedBackend {
         &self,
         namespace_id: &str,
         expected_head_seq: Option<u64>,
-    ) -> Result<DeleteNamespaceResponse, CliError> {
+    ) -> Result<DeleteNamespaceResponse, BackendError> {
         let namespace_id = parse_namespace_id(namespace_id)?;
         let options = DeleteNamespaceOptions {
             expected_head_seq: expected_head_seq.map(ChangeSeq),
@@ -263,7 +76,7 @@ impl Backend for EmbeddedBackend {
         &self,
         source: &str,
         new_namespace_id: &str,
-    ) -> Result<NamespaceSummary, CliError> {
+    ) -> Result<NamespaceSummary, BackendError> {
         let source_namespace_id = parse_namespace_id(source)?;
         let new_namespace_id = parse_namespace_id(new_namespace_id)?;
         self.block_on(
@@ -272,12 +85,15 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn namespace_status(&self, namespace_id: &str) -> Result<NamespaceStatusResponse, CliError> {
+    fn namespace_status(
+        &self,
+        namespace_id: &str,
+    ) -> Result<NamespaceStatusResponse, BackendError> {
         let parsed = parse_namespace_id(namespace_id)?;
         self.block_on_scoped(namespace_id, self.fs.namespace_status(&parsed))
     }
 
-    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, CliError> {
+    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
@@ -285,7 +101,7 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, CliError> {
+    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
@@ -293,7 +109,7 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, CliError> {
+    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let result = self.block_on_scoped(
             &spec.namespace,
@@ -306,7 +122,7 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         revision_no: RevisionNo,
-    ) -> Result<Vec<u8>, CliError> {
+    ) -> Result<Vec<u8>, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let result = self.block_on_scoped(
             &spec.namespace,
@@ -321,7 +137,7 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         limit: Option<u32>,
         cursor: Option<&str>,
-    ) -> Result<ListFileRevisionsResponse, CliError> {
+    ) -> Result<ListFileRevisionsResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         self.block_on_scoped(
             &spec.namespace,
@@ -334,7 +150,7 @@ impl Backend for EmbeddedBackend {
                         .map(loonfs_api::decode_file_revisions_cursor)
                         .transpose()
                         .map_err(|error| {
-                            CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                            BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
                         })?,
                 },
             ),
@@ -346,7 +162,7 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, CliError> {
+    ) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let behavior = if force {
             PutBehavior::Replace
@@ -368,7 +184,7 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
+    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
@@ -384,7 +200,7 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, CliError> {
+    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
@@ -403,7 +219,7 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, CliError> {
+    ) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
@@ -424,7 +240,7 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, CliError> {
+    ) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
@@ -444,7 +260,7 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, CliError> {
+    ) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
@@ -459,40 +275,78 @@ impl Backend for EmbeddedBackend {
             ),
         )
     }
+
+    // The admin methods mirror the server handlers' error scoping exactly:
+    // checkpoint/retention map runtime errors unscoped, the change feed is
+    // namespace-scoped. Parity keeps embedded and remote outputs identical.
+
+    fn create_checkpoint(
+        &self,
+        namespace_id: &str,
+    ) -> Result<CreateCheckpointResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        self.block_on(self.fs.create_checkpoint(&parsed))
+    }
+
+    fn advance_retention(
+        &self,
+        namespace_id: &str,
+    ) -> Result<AdvanceRetentionResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        self.block_on(self.fs.advance_retention_floor(&parsed))
+    }
+
+    fn list_changes(
+        &self,
+        namespace_id: &str,
+        after_seq: ChangeSeq,
+        limit: Option<u32>,
+    ) -> Result<ChangesResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        let limit = resolve_cli_page_limit(limit)?;
+        self.block_on_scoped(
+            namespace_id,
+            self.fs.list_changes_after(
+                &parsed,
+                after_seq,
+                ListChangesOptions { limit: Some(limit) },
+            ),
+        )
+    }
 }
 
-fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
+fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, BackendError> {
     NamespaceId::parse(namespace)
-        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
+        .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
 }
 
-fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, CliError> {
+fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendError> {
     PaginationPolicy::default()
         .resolve_limit(limit)
-        .map_err(|error| CliError::invalid_input(error.to_string()))
+        .map_err(|error| BackendError::invalid_input(error.to_string()))
 }
 
 fn generated_commit_id() -> CommitId {
     CommitId::generate()
 }
 
-fn map_runtime_error(error: RuntimeError) -> CliError {
+fn map_runtime_error(error: RuntimeError) -> BackendError {
     match error {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
-        RuntimeError::Config(message) => CliError::invalid_config(message),
-        RuntimeError::RuntimeTask(message) => CliError::runtime_error(message),
-        other => CliError::runtime_error(other.to_string()),
+        RuntimeError::Config(message) => BackendError::invalid_config(message),
+        RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
+        other => BackendError::runtime_error(other.to_string()),
     }
 }
 
-fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> CliError {
+fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> BackendError {
     match error {
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
-        RuntimeError::Config(message) => CliError::invalid_config(message),
-        RuntimeError::RuntimeTask(message) => CliError::runtime_error(message),
-        other => CliError::runtime_error(other.to_string()),
+        RuntimeError::Config(message) => BackendError::invalid_config(message),
+        RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
+        other => BackendError::runtime_error(other.to_string()),
     }
 }
 
@@ -500,13 +354,13 @@ fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> C
 // serve for the identical failure, so `loon --json` consumers see one code
 // per mistake regardless of profile mode.
 
-fn map_core_error(error: CoreError) -> CliError {
-    CliError::new(error.code().as_str(), error.to_string())
+fn map_core_error(error: CoreError) -> BackendError {
+    BackendError::new(error.code().as_str(), error.to_string())
 }
 
-fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliError {
+fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> BackendError {
     if matches!(error.code(), ErrorCode::NamespaceNotFound) {
-        return CliError::new(
+        return BackendError::new(
             ErrorCode::NamespaceNotFound.as_str(),
             format!("namespace `{namespace}` does not exist"),
         );
@@ -515,8 +369,8 @@ fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> CliErro
     map_core_error(error)
 }
 
-fn map_bootstrap_error(error: BootstrapNamespaceError) -> CliError {
-    CliError::new(error.code().as_str(), error.to_string())
+fn map_bootstrap_error(error: BootstrapNamespaceError) -> BackendError {
+    BackendError::new(error.code().as_str(), error.to_string())
 }
 
 fn default_writer_id() -> String {
@@ -626,7 +480,7 @@ impl RemoteTarget {
             auth_token: auth_token.map(ToOwned::to_owned),
         });
         Ok(Self {
-            backend: RemoteBackend { client },
+            backend: RemoteBackend::new(client),
         })
     }
 }
@@ -706,5 +560,28 @@ mod tests {
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
         assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());
+    }
+
+    #[test]
+    fn embedded_admin_methods_surface_registry_codes_for_missing_namespaces() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let store = StoreConfig::LocalFs {
+            root: temp_dir.path().display().to_string(),
+            key_prefix: None,
+        };
+        let target = EmbeddedTarget::new(&store, None, None).expect("build embedded target");
+
+        let checkpoint = target
+            .backend
+            .create_checkpoint("missing")
+            .expect_err("checkpoint on missing namespace");
+        assert_eq!(checkpoint.code, ErrorCode::NamespaceNotFound.as_str());
+
+        let changes = target
+            .backend
+            .list_changes("missing", ChangeSeq(0), None)
+            .expect_err("changes on missing namespace");
+        assert_eq!(changes.code, ErrorCode::NamespaceNotFound.as_str());
+        assert_eq!(changes.message, "namespace `missing` does not exist");
     }
 }

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,0 +1,95 @@
+use super::context::{fail, resolve_command_context};
+use super::output::{CommandData, CommandFailure, CommandOutput};
+use crate::args::{AdminCommand, AdminNamespaceArgs, ChangesArgs, CommandKind};
+use loonfs_api::ChangeSeq;
+
+// --- maintenance/admin plane ---
+
+pub(crate) fn run_admin_command(
+    kind: CommandKind,
+    command: AdminCommand,
+) -> Result<CommandOutput, CommandFailure> {
+    match command {
+        AdminCommand::Checkpoint(args) => run_admin_checkpoint(kind, args),
+        AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args),
+    }
+}
+
+fn run_admin_checkpoint(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let response = context
+        .target
+        .backend()
+        .create_checkpoint(&context.namespace)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::CheckpointCreated(response),
+    })
+}
+
+fn run_admin_retention_advance(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let response = context
+        .target
+        .backend()
+        .advance_retention(&context.namespace)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::RetentionAdvanced(response),
+    })
+}
+
+pub(crate) fn run_changes(
+    kind: CommandKind,
+    args: ChangesArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target)?;
+    let after_seq = ChangeSeq(args.after.unwrap_or(0));
+    let response = context
+        .target
+        .backend()
+        .list_changes(&context.namespace, after_seq, args.limit)
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::Changes(response),
+    })
+}

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -133,12 +133,12 @@ pub(crate) fn fail(
     kind: CommandKind,
     profile: Option<String>,
     mode: Option<String>,
-    error: CliError,
+    error: impl Into<CliError>,
 ) -> CommandFailure {
     CommandFailure {
         kind,
         profile,
         mode,
-        error,
+        error: error.into(),
     }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -448,7 +448,10 @@ fn run_filesystem_path_lookup<F>(
     op: F,
 ) -> Result<CommandOutput, CommandFailure>
 where
-    F: FnOnce(&dyn crate::backend::Backend, &NamespacePath) -> Result<CommandData, CliError>,
+    F: FnOnce(
+        &dyn crate::backend::Backend,
+        &NamespacePath,
+    ) -> Result<CommandData, crate::backend::BackendError>,
 {
     let context = resolve_command_context(kind, &args.target)?;
     let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod config;
 mod context;
 mod fs;
@@ -47,5 +48,7 @@ pub(crate) fn run(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, C
         Command::Rm(args) => fs::run_filesystem_rm(kind, args),
         Command::Mv(args) => fs::run_filesystem_mv(kind, args),
         Command::Cp(args) => fs::run_filesystem_cp(kind, args),
+        Command::Changes(args) => admin::run_changes(kind, args),
+        Command::Admin { command } => admin::run_admin_command(kind, command),
     }
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -2,7 +2,11 @@ use crate::args::CommandKind;
 use crate::config::{CliConfig, ProfileConfig};
 use crate::error::CliError;
 use crate::profiles::ProfileSummary;
-use loonfs_api::{AuthoritativePathEntry, DeleteNamespaceResponse, FileRevision, NamespaceSummary};
+use loonfs_api::v0::ChangesResponse;
+use loonfs_api::{
+    AdvanceRetentionResponse, AuthoritativePathEntry, CreateCheckpointResponse,
+    DeleteNamespaceResponse, FileRevision, NamespaceSummary,
+};
 use serde::Serialize;
 
 pub(crate) struct CommandOutput {
@@ -41,6 +45,9 @@ pub(crate) enum CommandData {
     },
     NamespaceSummary(NamespaceSummary),
     NamespaceDeleted(DeleteNamespaceResponse),
+    CheckpointCreated(CreateCheckpointResponse),
+    RetentionAdvanced(AdvanceRetentionResponse),
+    Changes(ChangesResponse),
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,
     },

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -3,24 +3,40 @@ use serde::{Deserialize, Serialize};
 
 /// Structured failure surfaced by every CLI command (`--json` renders it verbatim).
 ///
-/// `code` draws from exactly two namespaces:
+/// `code` draws from exactly three namespaces:
 ///
 /// - **Registry codes** ([`loonfs_api::ErrorCode`]) pass through verbatim from
 ///   whichever backend produced them, so embedded and remote profiles surface
 ///   the same code for the same failure. Never restate a registry code as a
 ///   string literal; use `ErrorCode::X.as_str()` or an error's `code()`.
-///   (`invalid_config` deliberately reports the registry `invalid_request`
-///   code: it is the code the server serves for configuration mistakes.)
+/// - **Backend-local codes** ([`loonfs_client::backend::BackendError`]) pass
+///   through verbatim from the backend seam: `invalid_config`,
+///   `invalid_input`, `client_error`, `io_error`, and `runtime_error`.
 /// - **CLI-local codes** cover failures that never reach a backend. The
 ///   complete list, each owned by a constructor below, is: `invalid_input`,
 ///   `profile_not_found`, `no_default_profile`, `no_default_namespace`,
 ///   `profile_already_exists`, `config_already_exists`,
 ///   `non_interactive_input_required`, `json_not_supported_for_streaming`,
-///   `client_error`, `io_error`, `runtime_error`, and `cancelled`.
+///   `io_error`, and `cancelled`. Overlaps with backend-local codes are
+///   deliberate: the same string means the same thing on both sides of the
+///   seam. (The CLI's own `invalid_config` constructor is the one exception:
+///   it deliberately reports the registry `invalid_request` code, the code the
+///   server serves for configuration mistakes.)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CliError {
     pub code: String,
     pub message: String,
+}
+
+impl From<loonfs_client::backend::BackendError> for CliError {
+    /// Backend failures pass through verbatim: the seam already carries the
+    /// registry or backend-local code and message this CLI reports.
+    fn from(error: loonfs_client::backend::BackendError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message,
+        }
+    }
 }
 
 impl CliError {
@@ -89,16 +105,8 @@ impl CliError {
         )
     }
 
-    pub(crate) fn client_error(message: impl Into<String>) -> Self {
-        Self::new("client_error", message)
-    }
-
     pub(crate) fn io(error: std::io::Error) -> Self {
         Self::new("io_error", format!("i/o error: {error}"))
-    }
-
-    pub(crate) fn runtime_error(message: impl Into<String>) -> Self {
-        Self::new("runtime_error", message)
     }
 
     pub(crate) fn cancelled() -> Self {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -145,6 +145,39 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             "deleted {} (head_seq {})",
             response.namespace_id, response.head_seq.0
         ),
+        CommandData::CheckpointCreated(response) => format!(
+            "checkpointed {} @ seq {} (checkpoint {}, manifest {})",
+            response.namespace_id,
+            response.checkpoint_seq.0,
+            response.checkpoint_id,
+            response.manifest_id
+        ),
+        CommandData::RetentionAdvanced(response) => format!(
+            "advanced retention floor for {} to seq {}; changes before this floor are no longer replayable",
+            response.namespace_id, response.retention_floor_seq.0
+        ),
+        CommandData::Changes(response) => {
+            let mut lines = vec![
+                format!(
+                    "changes for {} after seq {} (through seq {})",
+                    response.namespace_id, response.after_seq.0, response.through_seq.0
+                ),
+                "SEQ\tCOMMIT_ID\tDELTAS\tMESSAGE".to_owned(),
+            ];
+            for change in &response.changes {
+                lines.push(format!(
+                    "{}\t{}\t{}\t{}",
+                    change.seq.0,
+                    change.commit_id,
+                    change.deltas.len(),
+                    change.message.as_deref().unwrap_or("-")
+                ));
+            }
+            if let Some(next_after_seq) = response.next_after_seq {
+                lines.push(format!("next_after_seq: {}", next_after_seq.0));
+            }
+            lines.join("\n")
+        }
         CommandData::PathEntries { entries } => entries
             .iter()
             .map(|entry| {
@@ -288,7 +321,9 @@ mod tests {
             kind: CommandKind::ConfigShow,
             profile: Some("default".to_owned()),
             mode: Some("remote".to_owned()),
-            error: CliError::client_error("connection refused"),
+            error: CliError::from(crate::backend::BackendError::client_error(
+                "connection refused",
+            )),
         };
         assert_json_snapshot!(serde_json::from_str::<serde_json::Value>(
             &json_error(&failure).expect("json error renders")

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -926,6 +926,209 @@ fn help_omits_legacy_commands_and_config_flag() {
     assert!(stdout.contains("use"));
 }
 
+/// Pins the capability registry to the CLI surface: every profile and every
+/// feature key advertised by the embedded runtime must map to a CLI command
+/// path that exercises it, so no advertised capability is unreachable from
+/// this surface.
+///
+/// When `Fs::capabilities()` (crates/loonfs/src/fs.rs) grows a profile or a
+/// feature key, this test fails until the tables below either name the CLI
+/// command path that covers the new capability, or record a deliberately
+/// deferred CLI gap with a comment (none today).
+#[test]
+fn every_advertised_capability_maps_to_a_cli_command_path() {
+    // Advertised profile -> the CLI command paths exercising that plane.
+    const PROFILE_COMMAND_PATHS: &[(&str, &[&[&str]])] = &[
+        (
+            "core/v0",
+            &[
+                &["namespace", "create"],
+                &["namespace", "delete"],
+                &["namespace", "fork"],
+                &["use"],
+                &["ls"],
+                &["stat"],
+                &["cat"],
+                &["get"],
+                &["put"],
+                &["mkdir"],
+                &["rm"],
+                &["mv"],
+                &["cp"],
+                &["revisions"],
+                &["restore"],
+                &["changes"],
+            ],
+        ),
+        (
+            "admin/v0",
+            &[&["admin", "checkpoint"], &["admin", "retention-advance"]],
+        ),
+    ];
+    // Advertised feature key -> the CLI command path exercising it. Keys are
+    // listed whether the embedded build advertises them `true` or `false`;
+    // gating is the backend's job, reachability is this surface's job.
+    const FEATURE_COMMAND_PATHS: &[(&str, &[&str])] = &[
+        ("core.namespaces.create", &["namespace", "create"]),
+        ("core.namespaces.delete", &["namespace", "delete"]),
+        ("core.namespaces.fork", &["namespace", "fork"]),
+        // Direct-put is a transfer mode negotiated inside the same upload
+        // staging flow `put` drives; it needs no separate verb.
+        ("core.uploads.direct_put", &["put"]),
+    ];
+
+    let harness = Harness::new();
+    let document = embedded_capability_document();
+
+    for profile in &document.profiles {
+        let (_, command_paths) = PROFILE_COMMAND_PATHS
+            .iter()
+            .find(|(advertised, _)| *advertised == profile.as_str())
+            .unwrap_or_else(|| {
+                panic!(
+                    "capability profile `{profile}` has no CLI command mapping; \
+                     add its command paths to PROFILE_COMMAND_PATHS"
+                )
+            });
+        for command_path in *command_paths {
+            assert_cli_command_path_exists(&harness, command_path);
+        }
+    }
+
+    for feature in document.features.keys() {
+        let (_, command_path) = FEATURE_COMMAND_PATHS
+            .iter()
+            .find(|(advertised, _)| *advertised == feature.as_str())
+            .unwrap_or_else(|| {
+                panic!(
+                    "capability feature `{feature}` has no CLI command mapping; \
+                     add its command path to FEATURE_COMMAND_PATHS"
+                )
+            });
+        assert_cli_command_path_exists(&harness, command_path);
+    }
+}
+
+/// The admin plane and the change feed work end to end, and both profile
+/// modes emit the same `--json` shapes and error codes for them.
+#[test]
+fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "admin-parity"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    let first_payload = harness.temp_dir.path().join("first.txt");
+    let second_payload = harness.temp_dir.path().join("second.txt");
+    fs::write(&first_payload, b"first change\n").expect("first payload");
+    fs::write(&second_payload, b"second change\n").expect("second payload");
+
+    let mut shapes_by_mode = Vec::new();
+    for profile in ["embedded", "remote"] {
+        assert_success(&harness.run(&["namespace", "create", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&["use", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&[
+            "put",
+            "--profile",
+            profile,
+            first_payload.to_str().unwrap(),
+            "/first.txt",
+        ]));
+        assert_success(&harness.run(&[
+            "put",
+            "--profile",
+            profile,
+            second_payload.to_str().unwrap(),
+            "/second.txt",
+        ]));
+
+        let changes = harness.run(&["--json", "changes", "--profile", profile]);
+        assert_success(&changes);
+        let changes_data = json_data(&changes);
+        assert_eq!(changes_data["kind"], "changes");
+        assert_eq!(changes_data["namespace_id"], "demo");
+        assert_eq!(changes_data["after_seq"], 0);
+        assert_eq!(changes_data["through_seq"], 2);
+        assert!(changes_data["next_after_seq"].is_null());
+        let listed = changes_data["changes"].as_array().unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0]["seq"], 1);
+        assert_eq!(listed[1]["seq"], 2);
+        assert!(listed[0]["commit_id"].as_str().unwrap().starts_with("c_"));
+        assert!(!listed[1]["deltas"].as_array().unwrap().is_empty());
+
+        let paged = harness.run(&["--json", "changes", "--profile", profile, "--limit", "1"]);
+        assert_success(&paged);
+        let paged_data = json_data(&paged);
+        assert_eq!(paged_data["changes"].as_array().unwrap().len(), 1);
+        assert_eq!(paged_data["changes"][0]["seq"], 1);
+        assert_eq!(paged_data["next_after_seq"], 1);
+
+        let resumed = harness.run(&["--json", "changes", "--profile", profile, "--after", "1"]);
+        assert_success(&resumed);
+        let resumed_data = json_data(&resumed);
+        assert_eq!(resumed_data["after_seq"], 1);
+        assert_eq!(resumed_data["changes"].as_array().unwrap().len(), 1);
+        assert_eq!(resumed_data["changes"][0]["seq"], 2);
+
+        let checkpoint = harness.run(&["--json", "admin", "checkpoint", "--profile", profile]);
+        assert_success(&checkpoint);
+        let checkpoint_data = json_data(&checkpoint);
+        assert_eq!(checkpoint_data["kind"], "checkpoint_created");
+        assert_eq!(checkpoint_data["namespace_id"], "demo");
+        assert_eq!(checkpoint_data["checkpoint_seq"], 2);
+        assert!(checkpoint_data["checkpoint_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("chk_"));
+
+        let retention =
+            harness.run(&["--json", "admin", "retention-advance", "--profile", profile]);
+        assert_success(&retention);
+        let retention_data = json_data(&retention);
+        assert_eq!(retention_data["kind"], "retention_advanced");
+        assert_eq!(retention_data["namespace_id"], "demo");
+        assert_eq!(retention_data["retention_floor_seq"], 2);
+
+        // Admin failures surface the registry code in both modes.
+        let missing = harness.run(&[
+            "--json",
+            "admin",
+            "checkpoint",
+            "--profile",
+            profile,
+            "--namespace",
+            "missing",
+        ]);
+        assert_failure(&missing);
+        assert_eq!(json_error(&missing)["code"], "namespace_not_found");
+
+        shapes_by_mode.push((
+            sorted_object_keys(&changes_data),
+            sorted_object_keys(&checkpoint_data),
+            sorted_object_keys(&retention_data),
+        ));
+    }
+
+    assert_eq!(
+        shapes_by_mode[0], shapes_by_mode[1],
+        "embedded and remote --json payloads diverged in shape"
+    );
+}
+
 struct Harness {
     temp_dir: TempDir,
     home_dir: PathBuf,
@@ -1167,4 +1370,49 @@ fn json_data(output: &Output) -> Value {
 
 fn json_error(output: &Output) -> Value {
     parse_json(&output.stderr)["error"].clone()
+}
+
+fn sorted_object_keys(value: &Value) -> Vec<String> {
+    let mut keys: Vec<String> = value
+        .as_object()
+        .expect("json object")
+        .keys()
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// The embedded capability document: the registry of advertised profiles and
+/// feature keys (`crates/loonfs/tests/capability_conformance.rs` pins it to
+/// the spec text).
+fn embedded_capability_document() -> loonfs::CapabilityDocument {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let store = std::sync::Arc::new(
+        loonfs_objectstore::fs::LocalFsStore::new(temp_dir.path()).expect("store"),
+    ) as loonfs::SharedObjectStore;
+    let fs = loonfs::Fs::open(
+        store,
+        loonfs::FsConfig {
+            writer_id: "cli-capability-conformance".to_owned(),
+            writer_version: "test".to_owned(),
+            runtime_cache: loonfs::RuntimeCacheConfig::default(),
+            trace_mode: loonfs::TraceMode::Embedded,
+            trace_store_kind: loonfs::TraceStoreKind::LocalFs,
+        },
+    )
+    .expect("open runtime");
+    fs.capabilities()
+}
+
+fn assert_cli_command_path_exists(harness: &Harness, command_path: &[&str]) {
+    let mut args = command_path.to_vec();
+    args.push("--help");
+    let output = harness.run(&args);
+    assert!(
+        output.status.success(),
+        "no CLI command path `loon {}`:\n{}",
+        command_path.join(" "),
+        stderr_string(&output)
+    );
 }

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -1,0 +1,397 @@
+//! The backend seam: one logical LoonFS API over interchangeable transports.
+//!
+//! [`Backend`] is the host-facing abstraction every LoonFS surface programs
+//! against: the `loon` CLI today, and future hosts (SDKs, FUSE adapters,
+//! agents) tomorrow. A host writes its features once against this trait and
+//! lets the selected profile decide whether calls travel over HTTP or run
+//! against an embedded runtime.
+//!
+//! This crate ships the trait and its HTTP implementation, [`RemoteBackend`].
+//! The embedded implementation lives with the host that embeds the `loonfs`
+//! runtime (currently `loonfs-cli`), which keeps this crate's dependency
+//! surface wire-only (`loonfs-api`).
+
+use crate::{Client, ClientError, NamespacePath};
+use loonfs_api::{
+    v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
+    CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode, ListFileRevisionsResponse,
+    MutationResult, NamespaceStatusResponse, NamespaceSummary, RevisionNo,
+};
+use thiserror::Error;
+
+/// Failure surfaced by a [`Backend`], as a `(code, message)` pair.
+///
+/// `code` draws from exactly two namespaces:
+///
+/// - **Registry codes** ([`loonfs_api::ErrorCode`]) pass through verbatim
+///   from whichever transport produced them, so embedded and remote backends
+///   surface the same code for the same failure. Never restate a registry
+///   code as a string literal; use `ErrorCode::X.as_str()` or an error's
+///   `code()`.
+/// - **Backend-local codes** cover failures that never produce a registry
+///   code. The complete list, each owned by a constructor below, is:
+///   `invalid_config` (deliberately the same string as the registry code of
+///   the same meaning), `invalid_input`, `client_error`, `io_error`, and
+///   `runtime_error`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{code}: {message}")]
+pub struct BackendError {
+    /// Registry or backend-local error code.
+    pub code: String,
+    /// Human-readable description of the failure.
+    pub message: String,
+}
+
+impl BackendError {
+    /// Builds an error carrying a registry code verbatim.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    /// A backend configuration that could not be loaded or used.
+    pub fn invalid_config(message: impl Into<String>) -> Self {
+        Self::new("invalid_config", message)
+    }
+
+    /// Caller input rejected before it reached a backend.
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::new("invalid_input", message)
+    }
+
+    /// Transport failure between a client and a remote server.
+    pub fn client_error(message: impl Into<String>) -> Self {
+        Self::new("client_error", message)
+    }
+
+    /// Local i/o failure while moving bytes for a backend call.
+    pub fn io_error(message: impl Into<String>) -> Self {
+        Self::new("io_error", message)
+    }
+
+    /// Embedded-runtime failure without a registry code.
+    pub fn runtime_error(message: impl Into<String>) -> Self {
+        Self::new("runtime_error", message)
+    }
+}
+
+impl From<ClientError> for BackendError {
+    fn from(error: ClientError) -> Self {
+        match error {
+            ClientError::ConfigIo(message) | ClientError::ConfigDecode(message) => {
+                Self::invalid_config(message)
+            }
+            ClientError::MissingConfigField { field } => {
+                Self::invalid_config(format!("missing `{field}`"))
+            }
+            ClientError::ConfigValidation { field, reason } => {
+                Self::invalid_config(format!("invalid `{field}`: {reason}"))
+            }
+            ClientError::InvalidNamespacePath(message) => Self::invalid_input(message),
+            ClientError::InvalidCommitId(message) => {
+                // The registry code core and server report for a malformed
+                // commit id, so pre-flight client validation matches backend
+                // behavior.
+                Self::new(ErrorCode::InvalidRequest.as_str(), message)
+            }
+            ClientError::Http(message) | ClientError::Json(message) => Self::client_error(message),
+            ClientError::Api { code, message, .. } => Self::new(code, message),
+            ClientError::Io(message) => Self::io_error(format!("i/o error: {message}")),
+        }
+    }
+}
+
+/// One logical LoonFS API over two transports.
+///
+/// Implementations must report the same registry error code for the same
+/// failure, so a host renders identical outcomes regardless of which
+/// transport a profile selects (`loonfs-cli`'s two-mode parity tests hold
+/// this line).
+pub trait Backend {
+    /// Creates a new empty namespace.
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError>;
+    /// Marks a namespace deleted; `expected_head_seq` guards against deleting
+    /// a namespace that moved since the caller last observed it.
+    fn delete_namespace(
+        &self,
+        namespace_id: &str,
+        expected_head_seq: Option<u64>,
+    ) -> Result<DeleteNamespaceResponse, BackendError>;
+    /// Creates a new namespace as a fork of the source's durable view.
+    fn fork_namespace(
+        &self,
+        source: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, BackendError>;
+    /// Summarizes a namespace's current head state.
+    fn namespace_status(&self, namespace_id: &str)
+        -> Result<NamespaceStatusResponse, BackendError>;
+    /// Lists the entries of a directory.
+    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, BackendError>;
+    /// Describes a single path entry.
+    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, BackendError>;
+    /// Reads a file's current content.
+    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, BackendError>;
+    /// Reads a retained file revision's content.
+    fn read_file_revision_bytes(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, BackendError>;
+    /// Lists one page of a file's retained revisions.
+    fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListFileRevisionsResponse, BackendError>;
+    /// Writes a file; `force` replaces existing content.
+    fn put_file_bytes(
+        &self,
+        spec: &NamespacePath,
+        bytes: &[u8],
+        force: bool,
+    ) -> Result<MutationResult, BackendError>;
+    /// Creates a directory.
+    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    /// Deletes a file or empty directory.
+    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    /// Moves a path within a namespace.
+    fn move_path(
+        &self,
+        from: &NamespacePath,
+        to: &NamespacePath,
+    ) -> Result<MutationResult, BackendError>;
+    /// Copies a file within a namespace.
+    fn copy_path(
+        &self,
+        from: &NamespacePath,
+        to: &NamespacePath,
+    ) -> Result<MutationResult, BackendError>;
+    /// Restores a file to one of its retained revisions.
+    fn restore_file_revision(
+        &self,
+        spec: &NamespacePath,
+        source_revision_no: RevisionNo,
+    ) -> Result<MutationResult, BackendError>;
+
+    // --- maintenance/admin plane (`admin/v0`) ---
+
+    /// Creates or reuses a checkpoint pinning the namespace's current view.
+    fn create_checkpoint(
+        &self,
+        namespace_id: &str,
+    ) -> Result<CreateCheckpointResponse, BackendError>;
+    /// Advances the namespace retention floor. Irreversible: WAL history
+    /// before the floor stops being replayable.
+    fn advance_retention(
+        &self,
+        namespace_id: &str,
+    ) -> Result<AdvanceRetentionResponse, BackendError>;
+    /// Reads the ordered change feed after the `after_seq` cursor.
+    fn list_changes(
+        &self,
+        namespace_id: &str,
+        after_seq: ChangeSeq,
+        limit: Option<u32>,
+    ) -> Result<ChangesResponse, BackendError>;
+}
+
+/// [`Backend`] over HTTP: wraps a [`Client`] pointed at a LoonFS server.
+#[derive(Debug)]
+pub struct RemoteBackend {
+    client: Client,
+}
+
+impl RemoteBackend {
+    /// Wraps a configured HTTP client.
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Backend for RemoteBackend {
+    fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError> {
+        self.client
+            .create_namespace(namespace_id)
+            .map_err(BackendError::from)
+    }
+
+    fn delete_namespace(
+        &self,
+        namespace_id: &str,
+        expected_head_seq: Option<u64>,
+    ) -> Result<DeleteNamespaceResponse, BackendError> {
+        self.client
+            .delete_namespace(namespace_id, expected_head_seq.map(ChangeSeq))
+            .map_err(BackendError::from)
+    }
+
+    fn fork_namespace(
+        &self,
+        source: &str,
+        new_namespace_id: &str,
+    ) -> Result<NamespaceSummary, BackendError> {
+        self.client
+            .fork_namespace(source, new_namespace_id)
+            .map_err(BackendError::from)
+    }
+
+    fn namespace_status(
+        &self,
+        namespace_id: &str,
+    ) -> Result<NamespaceStatusResponse, BackendError> {
+        self.client
+            .namespace_status(namespace_id)
+            .map_err(BackendError::from)
+    }
+
+    fn list_path(&self, spec: &NamespacePath) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
+        Ok(self
+            .client
+            .list_path(spec)
+            .map_err(BackendError::from)?
+            .entries)
+    }
+
+    fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, BackendError> {
+        self.client.stat_path(spec).map_err(BackendError::from)
+    }
+
+    fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, BackendError> {
+        self.client
+            .read_file_bytes(spec)
+            .map_err(BackendError::from)
+    }
+
+    fn read_file_revision_bytes(
+        &self,
+        spec: &NamespacePath,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>, BackendError> {
+        self.client
+            .read_file_revision_bytes(spec, revision_no)
+            .map_err(BackendError::from)
+    }
+
+    fn list_file_revisions(
+        &self,
+        spec: &NamespacePath,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListFileRevisionsResponse, BackendError> {
+        self.client
+            .list_file_revisions_page(spec, limit, cursor)
+            .map_err(BackendError::from)
+    }
+
+    fn put_file_bytes(
+        &self,
+        spec: &NamespacePath,
+        bytes: &[u8],
+        force: bool,
+    ) -> Result<MutationResult, BackendError> {
+        self.client
+            .put_file_bytes(spec, bytes, force)
+            .map_err(BackendError::from)
+    }
+
+    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+        self.client.create_dir(spec).map_err(BackendError::from)
+    }
+
+    fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+        self.client.delete_path(spec).map_err(BackendError::from)
+    }
+
+    fn move_path(
+        &self,
+        from: &NamespacePath,
+        to: &NamespacePath,
+    ) -> Result<MutationResult, BackendError> {
+        self.client.move_path(from, to).map_err(BackendError::from)
+    }
+
+    fn copy_path(
+        &self,
+        from: &NamespacePath,
+        to: &NamespacePath,
+    ) -> Result<MutationResult, BackendError> {
+        self.client.copy_path(from, to).map_err(BackendError::from)
+    }
+
+    fn restore_file_revision(
+        &self,
+        spec: &NamespacePath,
+        source_revision_no: RevisionNo,
+    ) -> Result<MutationResult, BackendError> {
+        self.client
+            .restore_file_revision(spec, source_revision_no)
+            .map_err(BackendError::from)
+    }
+
+    fn create_checkpoint(
+        &self,
+        namespace_id: &str,
+    ) -> Result<CreateCheckpointResponse, BackendError> {
+        self.client
+            .create_checkpoint(namespace_id)
+            .map_err(BackendError::from)
+    }
+
+    fn advance_retention(
+        &self,
+        namespace_id: &str,
+    ) -> Result<AdvanceRetentionResponse, BackendError> {
+        self.client
+            .advance_retention(namespace_id)
+            .map_err(BackendError::from)
+    }
+
+    fn list_changes(
+        &self,
+        namespace_id: &str,
+        after_seq: ChangeSeq,
+        limit: Option<u32>,
+    ) -> Result<ChangesResponse, BackendError> {
+        self.client
+            .list_changes_page(namespace_id, after_seq, limit)
+            .map_err(BackendError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendError, ClientError};
+
+    #[test]
+    fn api_errors_pass_their_code_and_message_through_verbatim() {
+        let error = BackendError::from(ClientError::Api {
+            status: 404,
+            code: "namespace_not_found".to_owned(),
+            feature: None,
+            message: "namespace `demo` does not exist".to_owned(),
+        });
+
+        assert_eq!(error.code, "namespace_not_found");
+        assert_eq!(error.message, "namespace `demo` does not exist");
+    }
+
+    #[test]
+    fn config_and_transport_errors_map_to_backend_local_codes() {
+        let error = BackendError::from(ClientError::MissingConfigField {
+            field: "server_url",
+        });
+        assert_eq!(error.code, "invalid_config");
+        assert_eq!(error.message, "missing `server_url`");
+
+        let error = BackendError::from(ClientError::Http("connection refused".to_owned()));
+        assert_eq!(error.code, "client_error");
+
+        let error = BackendError::from(ClientError::Io("read failed".to_owned()));
+        assert_eq!(error.code, "io_error");
+        assert_eq!(error.message, "i/o error: read failed");
+    }
+}

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -4,6 +4,11 @@
 //! instead of embedding the runtime directly. The client keeps paths simple:
 //! pass a [`NamespacePath`] for filesystem operations and use explicit commit
 //! helpers when you need retry control.
+//!
+//! Hosts that want to stay transport-agnostic should program against the
+//! [`backend::Backend`] trait instead of [`Client`] directly.
+
+pub mod backend;
 
 use http::Uri;
 use loonfs_api::{
@@ -13,12 +18,12 @@ use loonfs_api::{
         CompleteUploadRequest, CompleteUploadResponse, MoveBehavior, ObjectTransferAccess,
         UploadContentResponse, UploadMode, ValidatedContentToken,
     },
-    ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CommitId, ContentRef,
-    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind,
-    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse,
-    ForkNamespaceRequest, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
-    RestoreFileRevisionRequest, RevisionNo,
+    AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
+    CommitId, ContentRef, CreateCheckpointResponse, CreateNamespaceRequest,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind, FilesystemOperation,
+    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, InodeId,
+    ListFileRevisionsResponse, ListPathEntriesResponse, MutationResult, NamespaceId,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -521,6 +526,36 @@ impl Client {
             url.push_str(&format!("&limit={limit}"));
         }
         self.request_json::<(), ChangesResponse>(self.agent.get(&url), None)
+    }
+
+    /// Creates or reuses a checkpoint pinning the namespace's current view
+    /// (admin plane). This is a maintenance operation, not a file mutation;
+    /// the request carries no body.
+    pub fn create_checkpoint(
+        &self,
+        namespace: &str,
+    ) -> Result<CreateCheckpointResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/checkpoint",
+            self.base_url
+        );
+        self.request_json::<(), CreateCheckpointResponse>(self.agent.post(&url), None)
+    }
+
+    /// Advances the namespace retention floor to what checkpoint state allows
+    /// (admin plane). Irreversible: WAL history before the floor stops being
+    /// replayable. The request carries no body.
+    pub fn advance_retention(
+        &self,
+        namespace: &str,
+    ) -> Result<AdvanceRetentionResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/retention/advance",
+            self.base_url
+        );
+        self.request_json::<(), AdvanceRetentionResponse>(self.agent.post(&url), None)
     }
 
     fn apply_filesystem_operation(
@@ -1108,6 +1143,8 @@ auth_token = "   "
             client
                 .begin_upload("bad/name", &BeginUploadRequest::default())
                 .map(|_| ()),
+            client.create_checkpoint("bad/name").map(|_| ()),
+            client.advance_retention("bad/name").map(|_| ()),
         ] {
             assert!(matches!(result, Err(ClientError::InvalidNamespacePath(_))));
         }


### PR DESCRIPTION
The server exposes and advertises an admin plane (checkpoint, retention advance, change feed) that neither the client nor the CLI could reach — two of three surfaces couldn't exercise an advertised profile. The client gains create_checkpoint/advance_retention (list_changes already existed), and the embedded-vs-remote Backend trait — the product's real one-logical-API-two-transports seam — is promoted out of the CLI into loonfs-client with a concrete BackendError carrying registry codes verbatim (EmbeddedBackend stays in the CLI so the client crate remains wire-only). New commands: loon admin checkpoint, loon admin retention-advance, and loon changes, all following the existing render/exit-code/json conventions and the loon-use namespace context. A capability-conformance test maps every advertised profile and feature key to a live CLI command path so the registry can't grow silently unreachable again, and an end-to-end test pins identical shapes and codes across both modes. Namespace listing remains deliberately out of scope.