### PR TITLE
refactor: apply naming canon across the workspace

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -573,14 +573,18 @@ pub enum InodeKind {
     /// File with revision history.
     File,
     /// Directory with child bindings.
-    Dir,
+    ///
+    /// The wire value is pinned to `"dir"`; only the Rust name spells the
+    /// word out.
+    #[serde(rename = "dir")]
+    Directory,
 }
 
 impl fmt::Display for InodeKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::File => f.write_str("file"),
-            Self::Dir => f.write_str("dir"),
+            Self::Directory => f.write_str("dir"),
         }
     }
 }

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -6,6 +6,10 @@
 //! (WAL segments, metadata SSTs, namespace manifests, and control objects).
 //! Other LoonFS crates depend on this one for vocabulary; it depends on none
 //! of them.
+//!
+//! Module rule: v0 HTTP shapes live in [`v0`]; the crate root keeps the
+//! ids/paths/errors/wire-format modules and re-exports the common v0
+//! surface as a curated explicit list below.
 
 mod capability;
 mod content;
@@ -13,13 +17,11 @@ mod control;
 mod digest;
 mod envelope;
 mod error;
-mod http;
 mod ids;
 mod manifest;
 mod name_policy;
 mod pagination;
 mod path;
-mod server;
 pub mod v0;
 mod wal;
 
@@ -45,13 +47,6 @@ pub use capability::{
 pub use content::{ContentRef, ContentRefKind};
 pub use digest::sha256_digest;
 pub use error::{ErrorCode, ErrorKind};
-pub use http::{
-    AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
-    GcResponse, ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
-};
 pub use ids::{
     generated_id, wal_segment_id_start_seq, ChangeSeq, CheckpointId, CommitId,
     CommitIdValidationError, ContentStoreId, GcPinId, GeneratedIdValidationError, InodeId,
@@ -67,8 +62,17 @@ pub use pagination::{
     PAGE_CURSOR_VERSION,
 };
 pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
-pub use server::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
-pub use v0::MoveBehavior;
+
+// Curated root re-exports of the common v0 HTTP surface. v0 HTTP shapes live
+// in `v0`; add here only what most consumers touch.
+pub use v0::{
+    AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
+    CreateCheckpointResponse, CreateNamespaceRequest, DeleteDirectoryBehavior,
+    DeleteNamespaceResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
+    FilesystemOperationResponse, ForkNamespaceRequest, GcRequest, GcResponse,
+    ListFileRevisionsResponse, ListPathEntriesResponse, MoveBehavior, MutationResult,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -1,9 +1,13 @@
+//! Explicit-commit and change-feed shapes for the v0 HTTP API: commit
+//! requests with preconditions and semantic operations, the materialized
+//! deltas those commits produce, and the ordered change feed that exposes
+//! them. Path-oriented convenience operations live in [`super::operations`].
+
 use crate::{
     ChangeSeq, CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamePolicy,
-    NamespaceId, RevisionNo, UploadId,
+    NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 /// Move behavior.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -13,114 +17,6 @@ pub enum MoveBehavior {
     /// Move only if the destination name is absent.
     #[default]
     NoReplace,
-}
-
-/// Upload transport mode.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum UploadMode {
-    /// The service receives bytes and writes content to object storage.
-    #[default]
-    ServiceProxied,
-    /// The service mints a short-lived presigned PUT URL for the content object.
-    DirectPut,
-}
-
-impl UploadMode {
-    pub fn is_service_proxied(&self) -> bool {
-        matches!(self, Self::ServiceProxied)
-    }
-}
-
-/// Request for starting an upload session.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct BeginUploadRequest {
-    /// Requested upload transport. Absent keeps the existing service-proxied path.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode: Option<UploadMode>,
-    /// Required for `direct_put`; the server signs exactly this content object.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub content_ref: Option<ContentRef>,
-}
-
-/// Client-facing direct transfer capability.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum ObjectTransferAccess {
-    /// Short-lived URL plus required headers for one object-store write.
-    #[cfg_attr(
-        feature = "openapi",
-        schema(title = "ObjectTransferAccessPresignedUrl")
-    )]
-    PresignedUrl {
-        /// HTTP method the client must use.
-        method: String,
-        /// Full presigned URL.
-        url: String,
-        /// Headers that are covered by the signature and must be sent.
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        headers: BTreeMap<String, String>,
-        /// Expiration timestamp in Unix milliseconds.
-        expires_at_ms: u64,
-    },
-}
-
-/// Presigned direct_put upload details. The raw object key is intentionally not public.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct DirectPutUpload {
-    pub content_ref: ContentRef,
-    pub access: ObjectTransferAccess,
-}
-
-/// Stateless proof that a LoonFS server already validated a content ref.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct ValidatedContentToken {
-    pub content_ref: ContentRef,
-    /// Opaque, server-signed token. Clients must not parse it.
-    pub token: String,
-}
-
-/// Response for starting an upload session.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct BeginUploadResponse {
-    pub namespace_id: NamespaceId,
-    pub upload_id: UploadId,
-    pub mode: UploadMode,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub direct_put: Option<DirectPutUpload>,
-}
-
-/// Response after uploading bytes into a session.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct UploadContentResponse {
-    pub namespace_id: NamespaceId,
-    pub upload_id: UploadId,
-    pub content_ref: ContentRef,
-}
-
-/// Request to complete an upload with the expected content ref.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct CompleteUploadRequest {
-    pub content_ref: ContentRef,
-}
-
-/// Response after an upload session is completed.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct CompleteUploadResponse {
-    pub namespace_id: NamespaceId,
-    pub upload_id: UploadId,
-    pub content_ref: ContentRef,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub validated_content_token: Option<String>,
 }
 
 /// Explicit semantic commit request.
@@ -376,55 +272,8 @@ impl CommitPrecondition {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        BeginUploadRequest, BeginUploadResponse, CommitDelta, CommitOp, CommitPrecondition,
-        DirectPutUpload, MoveBehavior, ObjectTransferAccess, UploadMode,
-    };
-    use crate::{ChangeSeq, ContentRef, InodeId, InodeKind, NameKey, NamespaceId, UploadId};
-    use std::collections::BTreeMap;
-
-    #[test]
-    fn direct_put_upload_mode_serializes_as_expected() {
-        assert_eq!(
-            serde_json::to_string(&UploadMode::DirectPut).expect("serialize mode"),
-            r#""direct_put""#
-        );
-    }
-
-    #[test]
-    fn begin_upload_request_keeps_service_proxied_as_default() {
-        let request: BeginUploadRequest = serde_json::from_str("{}").expect("decode request");
-        assert_eq!(request.mode.unwrap_or_default(), UploadMode::ServiceProxied);
-    }
-
-    #[test]
-    fn direct_put_response_exposes_only_presigned_access() {
-        let response = BeginUploadResponse {
-            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            upload_id: UploadId::parse("upl_00000000000000000000000000000001")
-                .expect("valid upload id"),
-            mode: UploadMode::DirectPut,
-            direct_put: Some(DirectPutUpload {
-                content_ref: ContentRef::whole_file_v0(b"hello"),
-                access: ObjectTransferAccess::PresignedUrl {
-                    method: "PUT".to_owned(),
-                    url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
-                    headers: BTreeMap::from([
-                        ("if-none-match".to_owned(), "*".to_owned()),
-                        (
-                            "x-provider-checksum".to_owned(),
-                            "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=".to_owned(),
-                        ),
-                    ]),
-                    expires_at_ms: 1,
-                },
-            }),
-        };
-
-        let json = serde_json::to_string(&response).expect("serialize response");
-        assert!(json.contains(r#""kind":"presigned_url""#));
-        assert!(!json.contains("object_key"));
-    }
+    use super::{CommitDelta, CommitOp, CommitPrecondition, MoveBehavior};
+    use crate::{ChangeSeq, InodeId, InodeKind, NameKey};
 
     #[test]
     fn commit_precondition_name_key_serializes_as_plain_string() {

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -1,0 +1,37 @@
+//! The v0 HTTP protocol shapes.
+//!
+//! Every request/response body served by the v0 HTTP API lives under this
+//! module, re-exported flat so `loonfs_api::v0::X` is the canonical path for
+//! any v0 shape. The submodules group the surface by plane:
+//!
+//! - [`operations`] — namespace lifecycle, path-oriented filesystem
+//!   operations, file revisions, maintenance, and the `ApiError` body.
+//! - [`reads`] — authoritative read results (stat/list entries, file bytes).
+//! - [`commits`] — explicit semantic commits and the change feed.
+//! - [`uploads`] — upload sessions and direct-put access.
+//!
+//! The crate root re-exports the common surface for convenience; see the
+//! crate docs for the rule.
+
+mod commits;
+mod operations;
+mod reads;
+mod uploads;
+
+pub use commits::{
+    ChangesResponse, CommitDelta, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
+    CommittedChange, MoveBehavior,
+};
+pub use operations::{
+    AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
+    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse,
+    NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
+};
+pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
+pub use uploads::{
+    BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
+    DirectPutUpload, ObjectTransferAccess, UploadContentResponse, UploadMode,
+    ValidatedContentToken,
+};

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -1,5 +1,11 @@
+//! Request/response shapes for the v0 HTTP API's operation endpoints:
+//! namespace lifecycle (create/fork/status/delete), path-oriented filesystem
+//! operations, file revisions, maintenance (checkpoint/retention), and the
+//! shared [`ApiError`] body. Explicit commits and the change feed live in
+//! [`super::commits`]; read-result shapes live in [`super::reads`].
+
+use super::{MoveBehavior, ValidatedContentToken};
 use crate::{
-    v0::{MoveBehavior, ValidatedContentToken},
     ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -1,3 +1,7 @@
+//! Authoritative read-result shapes for the v0 HTTP API: the stat/list
+//! entry, the directory-listing envelope, and the file-bytes read result.
+//! The mutating operation shapes live in [`super::operations`].
+
 use crate::{ChangeSeq, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -1,0 +1,168 @@
+//! Upload-session shapes for the v0 HTTP API: transport modes, session
+//! begin/append/complete requests and responses, and the direct-put
+//! presigned-access envelope. Content moves through these shapes; the
+//! metadata that later references it commits through [`super::commits`].
+
+use crate::{ContentRef, NamespaceId, UploadId};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Upload transport mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum UploadMode {
+    /// The service receives bytes and writes content to object storage.
+    #[default]
+    ServiceProxied,
+    /// The service mints a short-lived presigned PUT URL for the content object.
+    DirectPut,
+}
+
+impl UploadMode {
+    pub fn is_service_proxied(&self) -> bool {
+        matches!(self, Self::ServiceProxied)
+    }
+}
+
+/// Request for starting an upload session.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BeginUploadRequest {
+    /// Requested upload transport. Absent keeps the existing service-proxied path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<UploadMode>,
+    /// Required for `direct_put`; the server signs exactly this content object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_ref: Option<ContentRef>,
+}
+
+/// Client-facing direct transfer capability.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ObjectTransferAccess {
+    /// Short-lived URL plus required headers for one object-store write.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "ObjectTransferAccessPresignedUrl")
+    )]
+    PresignedUrl {
+        /// HTTP method the client must use.
+        method: String,
+        /// Full presigned URL.
+        url: String,
+        /// Headers that are covered by the signature and must be sent.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: BTreeMap<String, String>,
+        /// Expiration timestamp in Unix milliseconds.
+        expires_at_ms: u64,
+    },
+}
+
+/// Presigned direct_put upload details. The raw object key is intentionally not public.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DirectPutUpload {
+    pub content_ref: ContentRef,
+    pub access: ObjectTransferAccess,
+}
+
+/// Stateless proof that a LoonFS server already validated a content ref.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ValidatedContentToken {
+    pub content_ref: ContentRef,
+    /// Opaque, server-signed token. Clients must not parse it.
+    pub token: String,
+}
+
+/// Response for starting an upload session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BeginUploadResponse {
+    pub namespace_id: NamespaceId,
+    pub upload_id: UploadId,
+    pub mode: UploadMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direct_put: Option<DirectPutUpload>,
+}
+
+/// Response after uploading bytes into a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct UploadContentResponse {
+    pub namespace_id: NamespaceId,
+    pub upload_id: UploadId,
+    pub content_ref: ContentRef,
+}
+
+/// Request to complete an upload with the expected content ref.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CompleteUploadRequest {
+    pub content_ref: ContentRef,
+}
+
+/// Response after an upload session is completed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CompleteUploadResponse {
+    pub namespace_id: NamespaceId,
+    pub upload_id: UploadId,
+    pub content_ref: ContentRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validated_content_token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BeginUploadRequest, BeginUploadResponse, DirectPutUpload, ObjectTransferAccess, UploadMode,
+    };
+    use crate::{ContentRef, NamespaceId, UploadId};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn direct_put_upload_mode_serializes_as_expected() {
+        assert_eq!(
+            serde_json::to_string(&UploadMode::DirectPut).expect("serialize mode"),
+            r#""direct_put""#
+        );
+    }
+
+    #[test]
+    fn begin_upload_request_keeps_service_proxied_as_default() {
+        let request: BeginUploadRequest = serde_json::from_str("{}").expect("decode request");
+        assert_eq!(request.mode.unwrap_or_default(), UploadMode::ServiceProxied);
+    }
+
+    #[test]
+    fn direct_put_response_exposes_only_presigned_access() {
+        let response = BeginUploadResponse {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            upload_id: UploadId::parse("upl_00000000000000000000000000000001")
+                .expect("valid upload id"),
+            mode: UploadMode::DirectPut,
+            direct_put: Some(DirectPutUpload {
+                content_ref: ContentRef::whole_file_v0(b"hello"),
+                access: ObjectTransferAccess::PresignedUrl {
+                    method: "PUT".to_owned(),
+                    url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
+                    headers: BTreeMap::from([
+                        ("if-none-match".to_owned(), "*".to_owned()),
+                        (
+                            "x-provider-checksum".to_owned(),
+                            "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=".to_owned(),
+                        ),
+                    ]),
+                    expires_at_ms: 1,
+                },
+            }),
+        };
+
+        let json = serde_json::to_string(&response).expect("serialize response");
+        assert!(json.contains(r#""kind":"presigned_url""#));
+        assert!(!json.contains("object_key"));
+    }
+}

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -145,7 +145,7 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             delta: WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(7),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             },
         },
         WalCommitDelta {
@@ -215,7 +215,7 @@ fn sample_sst_envelope() -> MetadataSstEnvelope {
     let rows = vec![
         MetadataRow::Inode {
             inode_id: InodeId(7),
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(2),
         },
         MetadataRow::DirentryBind {
@@ -805,7 +805,7 @@ fn wal_delta_wire_tags_match_spec_names() {
             serde_json::to_value(WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             }),
             "create_inode",
         ),

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -34,8 +34,8 @@ pub(crate) enum Command {
     Restore(FilesystemRestoreArgs),
     Mkdir(FilesystemPathArgs),
     Rm(FilesystemPathArgs),
-    Mv(FilesystemMoveArgs),
-    Cp(FilesystemMoveArgs),
+    Mv(FilesystemTransferArgs),
+    Cp(FilesystemTransferArgs),
     Changes(ChangesArgs),
     Admin {
         #[command(subcommand)]
@@ -292,7 +292,7 @@ pub(crate) struct FilesystemPutArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct FilesystemMoveArgs {
+pub(crate) struct FilesystemTransferArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     pub source_path: String,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -8,7 +8,7 @@
 use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use loonfs::{
-    BootstrapNamespaceError, ChangesResponse, CopyOptions, CoreError, CreateDirOptions,
+    BootstrapNamespaceError, ChangesResponse, CopyOptions, CoreError, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
     ErrorCode, Fs, FsConfig, ListChangesOptions, MoveOptions, PutFileOptions,
     RestoreRevisionOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
@@ -200,15 +200,15 @@ impl Backend for EmbeddedBackend {
         )
     }
 
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let commit_id = generated_commit_id();
         self.block_on_scoped(
             &spec.namespace,
-            self.fs.create_dir(
+            self.fs.create_directory(
                 &namespace_id,
                 &spec.absolute_path,
-                CreateDirOptions {
+                CreateDirectoryOptions {
                     commit_id: Some(commit_id),
                 },
             ),

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -67,7 +67,7 @@ fn run_admin_retention_advance(
     })
 }
 
-pub(crate) fn run_changes(
+pub(crate) fn run_admin_changes(
     kind: CommandKind,
     args: ChangesArgs,
 ) -> Result<CommandOutput, CommandFailure> {

--- a/crates/loonfs-cli/src/commands/config.rs
+++ b/crates/loonfs-cli/src/commands/config.rs
@@ -11,7 +11,7 @@ use crate::prompt;
 
 // --- init ---
 
-pub(crate) fn run_init(
+pub(crate) fn run_config_init(
     kind: CommandKind,
     args: InitArgs,
     runtime: RuntimeBehavior,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -4,8 +4,8 @@ use super::context::{
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
-    CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemLsArgs, FilesystemMoveArgs,
-    FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs, FilesystemRevisionsArgs,
+    CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemLsArgs, FilesystemPathArgs,
+    FilesystemPutArgs, FilesystemRestoreArgs, FilesystemRevisionsArgs, FilesystemTransferArgs,
     RuntimeBehavior,
 };
 use crate::error::CliError;
@@ -128,7 +128,7 @@ pub(crate) fn run_filesystem_get(
             error,
         )
     })?;
-    if entry.inode_kind == InodeKind::Dir {
+    if entry.inode_kind == InodeKind::Directory {
         return Err(fail(
             kind,
             Some(context.profile_name.clone()),
@@ -407,7 +407,7 @@ pub(crate) fn run_filesystem_mkdir(
     let result = context
         .target
         .backend()
-        .create_dir(&spec)
+        .create_directory(&spec)
         .map_err(|error| {
             fail(
                 kind,
@@ -430,16 +430,16 @@ pub(crate) fn run_filesystem_mkdir(
 
 pub(crate) fn run_filesystem_mv(
     kind: CommandKind,
-    args: FilesystemMoveArgs,
+    args: FilesystemTransferArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_move(kind, args, false)
+    run_filesystem_transfer(kind, args, false)
 }
 
 pub(crate) fn run_filesystem_cp(
     kind: CommandKind,
-    args: FilesystemMoveArgs,
+    args: FilesystemTransferArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_move(kind, args, true)
+    run_filesystem_transfer(kind, args, true)
 }
 
 fn run_filesystem_path_lookup<F>(
@@ -479,9 +479,9 @@ where
     })
 }
 
-fn run_filesystem_move(
+fn run_filesystem_transfer(
     kind: CommandKind,
-    args: FilesystemMoveArgs,
+    args: FilesystemTransferArgs,
     copy: bool,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target)?;
@@ -511,7 +511,7 @@ fn run_filesystem_move(
                 error,
             )
         })?;
-        if entry.inode_kind == InodeKind::Dir {
+        if entry.inode_kind == InodeKind::Directory {
             return Err(fail(
                 kind,
                 Some(context.profile_name.clone()),

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -31,12 +31,12 @@ pub(crate) fn run(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, C
                 version: env!("CARGO_PKG_VERSION").to_owned(),
             },
         }),
-        Command::Init(args) => config::run_init(kind, args, runtime),
+        Command::Init(args) => config::run_config_init(kind, args, runtime),
         Command::Config { command } => config::run_config_command(kind, command),
         Command::Profile { command } => profile::run_profile_command(kind, command, runtime),
         Command::Namespace { command } => namespace::run_namespace_command(kind, command),
         Command::Use(args) => namespace::run_namespace_use(kind, args),
-        Command::Current(args) => namespace::run_current(kind, args),
+        Command::Current(args) => namespace::run_namespace_current(kind, args),
         Command::Ls(args) => fs::run_filesystem_ls(kind, args),
         Command::Stat(args) => fs::run_filesystem_stat(kind, args),
         Command::Cat(args) => fs::run_filesystem_cat(kind, args),
@@ -48,7 +48,7 @@ pub(crate) fn run(cli: Cli, runtime: RuntimeBehavior) -> Result<CommandOutput, C
         Command::Rm(args) => fs::run_filesystem_rm(kind, args),
         Command::Mv(args) => fs::run_filesystem_mv(kind, args),
         Command::Cp(args) => fs::run_filesystem_cp(kind, args),
-        Command::Changes(args) => admin::run_changes(kind, args),
+        Command::Changes(args) => admin::run_admin_changes(kind, args),
         Command::Admin { command } => admin::run_admin_command(kind, command),
     }
 }

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -233,7 +233,7 @@ pub(crate) fn run_namespace_use(
     })
 }
 
-pub(crate) fn run_current(
+pub(crate) fn run_namespace_current(
     kind: CommandKind,
     args: CurrentArgs,
 ) -> Result<CommandOutput, CommandFailure> {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -185,7 +185,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     .size_bytes
                     .map(|value: u64| value.to_string())
                     .unwrap_or_else(|| "-".to_owned());
-                format!("{:?}\t{}\t{}", entry.inode_kind, size, entry.absolute_path)
+                format!("{}\t{}\t{}", entry.inode_kind, size, entry.absolute_path)
             })
             .collect::<Vec<_>>()
             .join("\n"),
@@ -193,7 +193,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             let mut lines = vec![
                 format!("path: {}", entry.absolute_path),
                 format!("inode: {}", entry.inode_id),
-                format!("kind: {:?}", entry.inode_kind),
+                format!("kind: {}", entry.inode_kind),
                 format!("seq: {}", entry.head_seq.0),
             ];
             if let Some(size) = entry.size_bytes {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1389,7 +1389,7 @@ fn sorted_object_keys(value: &Value) -> Vec<String> {
 fn embedded_capability_document() -> loonfs::CapabilityDocument {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     let store = std::sync::Arc::new(
-        loonfs_objectstore::fs::LocalFsStore::new(temp_dir.path()).expect("store"),
+        loonfs_objectstore::local_fs_store::LocalFsStore::new(temp_dir.path()).expect("store"),
     ) as loonfs::SharedObjectStore;
     let fs = loonfs::Fs::open(
         store,

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -155,7 +155,7 @@ pub trait Backend {
         force: bool,
     ) -> Result<MutationResult, BackendError>;
     /// Creates a directory.
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
     /// Deletes a file or empty directory.
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
     /// Moves a path within a namespace.
@@ -298,8 +298,10 @@ impl Backend for RemoteBackend {
             .map_err(BackendError::from)
     }
 
-    fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
-        self.client.create_dir(spec).map_err(BackendError::from)
+    fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+        self.client
+            .create_directory(spec)
+            .map_err(BackendError::from)
     }
 
     fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -652,11 +652,11 @@ impl Client {
         self.put_file_bytes_with_commit_id(spec, bytes, true, commit_id)
     }
 
-    pub fn create_dir(&self, spec: &NamespacePath) -> Result<MutationResult, ClientError> {
-        self.create_dir_with_commit_id(spec, &generated_commit_id())
+    pub fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, ClientError> {
+        self.create_directory_with_commit_id(spec, &generated_commit_id())
     }
 
-    pub fn create_dir_with_commit_id(
+    pub fn create_directory_with_commit_id(
         &self,
         spec: &NamespacePath,
         commit_id: &str,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -53,8 +53,8 @@ use loonfs_api::{
     ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId, NameKey, NamespaceId,
     PutBehavior, RevisionNo,
 };
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{metadata_manifest, metadata_table, wal_head, wal_segment};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };

--- a/crates/loonfs-core/src/commit/materialize.rs
+++ b/crates/loonfs-core/src/commit/materialize.rs
@@ -93,7 +93,7 @@ pub(super) fn materialize_validated_op(
                 WalDelta::CreateInode {
                     delta_index: *create_inode_delta_index,
                     inode_id: *child_inode_id,
-                    inode_kind: InodeKind::Dir,
+                    inode_kind: InodeKind::Directory,
                 },
             );
             push_delta(

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -243,7 +243,7 @@ pub(super) async fn validate_metadata_preconditions<V: CommitValidationView>(
                 validate_inode_kind(
                     &metadata_state,
                     *root_inode_id,
-                    InodeKind::Dir,
+                    InodeKind::Directory,
                     || CommitValidationError::DeleteSubtreeRootMissing {
                         root_inode_id: *root_inode_id,
                     },
@@ -456,7 +456,7 @@ async fn validate_name_absent<V: CommitValidationView>(
     validate_inode_kind(
         metadata_state,
         parent_inode_id,
-        InodeKind::Dir,
+        InodeKind::Directory,
         parent_missing,
         parent_not_directory,
     )
@@ -596,7 +596,7 @@ async fn validate_name_precondition_parent<V: CommitValidationView>(
     validate_inode_kind(
         metadata_state,
         parent_inode_id,
-        InodeKind::Dir,
+        InodeKind::Directory,
         || CommitValidationError::NamePreconditionParentMissing { parent_inode_id },
         |actual_kind| CommitValidationError::NamePreconditionParentNotDirectory {
             parent_inode_id,
@@ -615,7 +615,7 @@ async fn validate_directory_empty_precondition<V: CommitValidationView>(
         .visible_inode(inode_id)
         .await?
         .ok_or(CommitValidationError::DirectoryEmptyPreconditionInodeMissing { inode_id })?;
-    if inode.inode_kind != InodeKind::Dir {
+    if inode.inode_kind != InodeKind::Directory {
         return Err(
             CommitValidationError::DirectoryEmptyPreconditionInodeNotDirectory {
                 inode_id,
@@ -765,7 +765,7 @@ async fn validate_rename_does_not_cycle<V: CommitValidationView>(
         .inode_at_seq(inode_id)
         .await?
         .ok_or(CommitValidationError::RenameInodeMissing { inode_id })?;
-    if inode.inode_kind != InodeKind::Dir {
+    if inode.inode_kind != InodeKind::Directory {
         return Ok(());
     }
     if metadata_state

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -552,12 +552,12 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     }
 
     /// Creates a directory at an absolute path.
-    pub async fn create_dir(
+    pub async fn create_directory(
         &self,
         path: impl AsRef<str>,
         options: WriteOptions,
     ) -> CoreResult<MutationResult> {
-        crate::path::write::ops::create_dir_path(
+        crate::path::write::ops::create_directory_path(
             &self.store,
             &self.namespace_id,
             path.as_ref(),
@@ -812,13 +812,13 @@ pub struct NamespaceEngineBuilder<S> {
 
 impl<S: ObjectStore> NamespaceEngineBuilder<S> {
     /// Sets the namespace this engine will operate on.
-    pub fn namespace(mut self, namespace_id: NamespaceId) -> Self {
+    pub fn namespace_id(mut self, namespace_id: NamespaceId) -> Self {
         self.namespace_id = Some(namespace_id);
         self
     }
 
     /// Sets the writer identity used for epoch acquisition and commits.
-    pub fn writer(mut self, writer_id: impl Into<String>) -> Self {
+    pub fn writer_id(mut self, writer_id: impl Into<String>) -> Self {
         self.writer_id = Some(writer_id.into());
         self
     }
@@ -895,7 +895,7 @@ fn current_time_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
     #[test]
@@ -905,8 +905,8 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
 
         let engine = NamespaceEngine::builder(store)
-            .namespace(namespace_id.clone())
-            .writer("writer-a")
+            .namespace_id(namespace_id.clone())
+            .writer_id("writer-a")
             .build()
             .expect("engine builds");
 
@@ -927,7 +927,7 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let err = NamespaceEngine::builder(store)
-            .namespace(NamespaceId::parse("demo").expect("valid namespace id"))
+            .namespace_id(NamespaceId::parse("demo").expect("valid namespace id"))
             .build()
             .expect_err("missing writer");
         assert_eq!(err, NamespaceEngineBuildError::MissingWriter);

--- a/crates/loonfs-core/src/inspection.rs
+++ b/crates/loonfs-core/src/inspection.rs
@@ -37,7 +37,7 @@ async fn visit_visible_tree<S: ObjectStore + ?Sized>(
     let mut pending = vec![absolute_path.to_owned()];
     while let Some(path) = pending.pop() {
         for entry in view.list_path(&path).await? {
-            let is_dir = entry.inode_kind == InodeKind::Dir;
+            let is_dir = entry.inode_kind == InodeKind::Directory;
             let child_path = entry.absolute_path.clone();
             entries.push(entry);
             if is_dir {
@@ -52,7 +52,7 @@ async fn visit_visible_tree<S: ObjectStore + ?Sized>(
 mod tests {
     use super::*;
     use crate::{BootstrapOptions, NamespaceEngine, WriteOptions};
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -86,8 +86,8 @@ mod tests {
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
         let namespace = NamespaceId::parse("inspection").expect("valid namespace id");
         let engine = NamespaceEngine::builder(store.clone())
-            .namespace(namespace.clone())
-            .writer("inspection-test")
+            .namespace_id(namespace.clone())
+            .writer_id("inspection-test")
             .build()
             .expect("engine");
 
@@ -96,11 +96,11 @@ mod tests {
             .await
             .expect("bootstrap");
         engine
-            .create_dir("/z", WriteOptions::default())
+            .create_directory("/z", WriteOptions::default())
             .await
             .expect("create z");
         engine
-            .create_dir("/a", WriteOptions::default())
+            .create_directory("/a", WriteOptions::default())
             .await
             .expect("create a");
         engine

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -13,14 +13,14 @@
 //! ```no_run
 //! use loonfs_api::NamespaceId;
 //! use loonfs_core::{BootstrapOptions, NamespaceEngine, WriteOptions};
-//! use loonfs_objectstore::fs::LocalFsStore;
+//! use loonfs_objectstore::local_fs_store::LocalFsStore;
 //!
 //! let store = LocalFsStore::new(std::env::temp_dir()).expect("store");
 //! let namespace = NamespaceId::parse("docs").expect("valid namespace id");
 //!
 //! let engine = NamespaceEngine::builder(store)
-//!     .namespace(namespace)
-//!     .writer("example-writer")
+//!     .namespace_id(namespace)
+//!     .writer_id("example-writer")
 //!     .build()
 //!     .expect("engine");
 //!

--- a/crates/loonfs-core/src/metadata/queries.rs
+++ b/crates/loonfs-core/src/metadata/queries.rs
@@ -306,7 +306,7 @@ impl MetadataState {
         let Some(parent) = self.visible_inode(parent_inode_id, base_seq) else {
             return Vec::new();
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Vec::new();
         }
 
@@ -373,7 +373,7 @@ impl MetadataState {
         let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
             return Vec::new();
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Vec::new();
         }
 
@@ -400,7 +400,7 @@ impl MetadataState {
         let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
             return Vec::new();
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Vec::new();
         }
 

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -35,7 +35,7 @@ fn child_lookup_uses_persisted_name_key_without_recanonicalizing() {
         vec![
             InodeRecord {
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(1),
             },
             InodeRecord {
@@ -72,12 +72,12 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         vec![
             InodeRecord {
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(0),
             },
             InodeRecord {
                 inode_id: InodeId(2),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(1),
             },
             InodeRecord {
@@ -200,7 +200,7 @@ fn rebuilt_indexes_answer_current_head_queries_after_deserialize() {
         vec![
             InodeRecord {
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(0),
             },
             InodeRecord {
@@ -247,7 +247,7 @@ fn stale_binding_is_not_active_after_newer_bind_claims_same_name() {
         vec![
             InodeRecord {
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(0),
             },
             InodeRecord {
@@ -303,7 +303,7 @@ fn resolve_visible_path_uses_explicit_name_policy_and_stored_display_name() {
         vec![
             InodeRecord {
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
                 created_seq: ChangeSeq(1),
             },
             InodeRecord {
@@ -344,7 +344,7 @@ fn metadata_state_serialized_shape_preserves_row_field_names() {
     let metadata_state = MetadataState::from_rows(
         vec![InodeRecord {
             inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(0),
         }],
         Vec::new(),
@@ -377,7 +377,7 @@ fn metadata_state_accessors_expose_rows_read_only() {
     let metadata_state = MetadataState::from_rows(
         vec![InodeRecord {
             inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(0),
         }],
         Vec::new(),
@@ -535,7 +535,7 @@ fn churned_binding_state() -> MetadataState {
             &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             }],
         )
         .expect("seed root");
@@ -546,7 +546,7 @@ fn churned_binding_state() -> MetadataState {
                 WalDelta::CreateInode {
                     delta_index: 0,
                     inode_id: InodeId(2),
-                    inode_kind: InodeKind::Dir,
+                    inode_kind: InodeKind::Directory,
                 },
                 WalDelta::BindDirentry {
                     delta_index: 1,
@@ -558,7 +558,7 @@ fn churned_binding_state() -> MetadataState {
                 WalDelta::CreateInode {
                     delta_index: 2,
                     inode_id: InodeId(4),
-                    inode_kind: InodeKind::Dir,
+                    inode_kind: InodeKind::Directory,
                 },
                 WalDelta::BindDirentry {
                     delta_index: 3,
@@ -607,7 +607,7 @@ fn churned_binding_state() -> MetadataState {
                 WalDelta::CreateInode {
                     delta_index: 0,
                     inode_id: InodeId(3),
-                    inode_kind: InodeKind::Dir,
+                    inode_kind: InodeKind::Directory,
                 },
                 WalDelta::BindDirentry {
                     delta_index: 1,

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -212,7 +212,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         let Some(parent) = self.visible_inode(parent_inode_id).await? else {
             return Ok(Vec::new());
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Ok(Vec::new());
         }
 
@@ -740,7 +740,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         let Some(parent) = self.visible_inode(parent_inode_id).await? else {
             return Ok(Vec::new());
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Ok(Vec::new());
         }
 

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -330,7 +330,7 @@ pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
     let Some(parent) = reads.visible_inode(parent_inode_id).await? else {
         return Ok(None);
     };
-    if parent.inode_kind != InodeKind::Dir {
+    if parent.inode_kind != InodeKind::Directory {
         return Ok(None);
     }
 
@@ -413,7 +413,7 @@ where
             .ok_or_else(|| VisiblePathError::PathNotFound {
                 absolute_path: current_absolute_path.clone(),
             })?;
-        if current_inode.inode_kind != InodeKind::Dir {
+        if current_inode.inode_kind != InodeKind::Directory {
             return Err(VisiblePathError::PathComponentNotDirectory {
                 absolute_path: current_absolute_path,
                 inode_id: current_inode_id,

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -284,7 +284,7 @@ pub(crate) fn bootstrap_metadata_state() -> MetadataState {
     MetadataState::from_rows(
         vec![InodeRecord {
             inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(0),
         }],
         Vec::new(),

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -48,9 +48,9 @@ pub(crate) enum NamespaceInitializationError {
 
 pub(crate) async fn load_namespace_descriptor<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<NamespaceConfigState, NamespaceCatalogLoadError> {
-    let loaded_descriptor = read_namespace_descriptor_object(store, expected_namespace)
+    let loaded_descriptor = read_namespace_descriptor_object(store, expected_namespace_id)
         .await
         .map_err(NamespaceCatalogLoadError::LoadNamespaceDescriptor)?;
     Ok(loaded_descriptor.envelope.state)
@@ -58,9 +58,9 @@ pub(crate) async fn load_namespace_descriptor<S: ObjectStore + ?Sized>(
 
 pub(crate) async fn load_namespace_catalog_entry<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<VerifiedNamespaceCatalogEntry, NamespaceCatalogLoadError> {
-    let namespace_config = load_namespace_descriptor(store, expected_namespace).await?;
+    let namespace_config = load_namespace_descriptor(store, expected_namespace_id).await?;
     let content_store_id = namespace_config.content_store_id.clone();
     read_content_store_descriptor_object(store, &content_store_id)
         .await
@@ -74,9 +74,9 @@ pub(crate) async fn load_namespace_catalog_entry<S: ObjectStore + ?Sized>(
 
 pub(crate) async fn load_namespace_content_store_id<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<ContentStoreId, NamespaceCatalogLoadError> {
-    Ok(load_namespace_catalog_entry(store, expected_namespace)
+    Ok(load_namespace_catalog_entry(store, expected_namespace_id)
         .await?
         .content_store_id)
 }

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -137,17 +137,17 @@ pub enum ControlObjectLoadError {
 
 pub(crate) async fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedNamespaceDescriptorObject, ControlObjectLoadError> {
-    validate_namespace_id_for_control_key(expected_namespace)?;
-    let object_key = namespace_config(expected_namespace.as_str());
+    validate_namespace_id_for_control_key(expected_namespace_id)?;
+    let object_key = namespace_config(expected_namespace_id.as_str());
     let (metadata, encoded_bytes) = read_control_object_bytes(store, &object_key).await?;
     let envelope: NamespaceConfigEnvelope =
         decode_control_object(&encoded_bytes, ControlObjectKind::NamespaceConfig)
             .map_err(|err| map_control_codec_error(&object_key, err))?;
     validate_expected_namespace(
         &object_key,
-        expected_namespace,
+        expected_namespace_id,
         &envelope.state.namespace_id,
     )?;
 
@@ -184,17 +184,17 @@ pub(crate) async fn read_content_store_descriptor_object<S: ObjectStore + ?Sized
 
 pub(crate) async fn read_wal_floor_object<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedWalFloorObject, ControlObjectLoadError> {
-    validate_namespace_id_for_control_key(expected_namespace)?;
-    let object_key = wal_floor(expected_namespace.as_str());
+    validate_namespace_id_for_control_key(expected_namespace_id)?;
+    let object_key = wal_floor(expected_namespace_id.as_str());
     let (metadata, encoded_bytes) = read_control_object_bytes(store, &object_key).await?;
     let envelope: WalFloorEnvelope =
         decode_control_object(&encoded_bytes, ControlObjectKind::WalFloor)
             .map_err(|err| map_control_codec_error(&object_key, err))?;
     validate_expected_namespace(
         &object_key,
-        expected_namespace,
+        expected_namespace_id,
         &envelope.state.namespace_id,
     )?;
 
@@ -209,9 +209,9 @@ pub(crate) async fn read_wal_floor_object<S: ObjectStore + ?Sized>(
 /// "retain more history", never less.
 pub(crate) async fn read_wal_floor_seq_or_zero<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<loonfs_api::ChangeSeq, ControlObjectLoadError> {
-    match read_wal_floor_object(store, expected_namespace).await {
+    match read_wal_floor_object(store, expected_namespace_id).await {
         Ok(loaded) => Ok(loaded.envelope.state.floor_seq),
         Err(ControlObjectLoadError::MissingObject { .. }) => Ok(loonfs_api::ChangeSeq(0)),
         Err(error) => Err(error),
@@ -220,17 +220,17 @@ pub(crate) async fn read_wal_floor_seq_or_zero<S: ObjectStore + ?Sized>(
 
 pub(crate) async fn read_metadata_root_object<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedMetadataRootObject, ControlObjectLoadError> {
-    validate_namespace_id_for_control_key(expected_namespace)?;
-    let object_key = metadata_root(expected_namespace.as_str());
+    validate_namespace_id_for_control_key(expected_namespace_id)?;
+    let object_key = metadata_root(expected_namespace_id.as_str());
     let (metadata, encoded_bytes) = read_control_object_bytes(store, &object_key).await?;
     let envelope: MetadataRootEnvelope =
         decode_control_object(&encoded_bytes, ControlObjectKind::MetadataRoot)
             .map_err(|err| map_control_codec_error(&object_key, err))?;
     validate_expected_namespace(
         &object_key,
-        expected_namespace,
+        expected_namespace_id,
         &envelope.state.namespace_id,
     )?;
 
@@ -250,12 +250,12 @@ pub(crate) async fn read_metadata_root_object<S: ObjectStore + ?Sized>(
 /// (format spec, "metadata/root.json").
 pub(crate) async fn read_head_and_metadata_root<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadObject, LoadedMetadataRootObject), ControlObjectLoadError> {
     const ROOT_AHEAD_HEAD_RELOADS: usize = 3;
     let (head, root) = futures::join!(
-        read_head_object(store, expected_namespace),
-        read_metadata_root_object(store, expected_namespace)
+        read_head_object(store, expected_namespace_id),
+        read_metadata_root_object(store, expected_namespace_id)
     );
     let mut head = head?;
     let root = root?;
@@ -263,7 +263,7 @@ pub(crate) async fn read_head_and_metadata_root<S: ObjectStore + ?Sized>(
         if root.envelope.state.manifest_head_seq <= head.envelope.state.seq {
             return Ok((head, root));
         }
-        head = read_head_object(store, expected_namespace).await?;
+        head = read_head_object(store, expected_namespace_id).await?;
     }
     Err(ControlObjectLoadError::RootAheadOfHead {
         root_manifest_head_seq: root.envelope.state.manifest_head_seq,
@@ -273,17 +273,17 @@ pub(crate) async fn read_head_and_metadata_root<S: ObjectStore + ?Sized>(
 
 pub(crate) async fn read_head_object<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadObject, ControlObjectLoadError> {
-    validate_namespace_id_for_control_key(expected_namespace)?;
-    let object_key = wal_head(expected_namespace.as_str());
+    validate_namespace_id_for_control_key(expected_namespace_id)?;
+    let object_key = wal_head(expected_namespace_id.as_str());
     let (metadata, encoded_bytes) = read_control_object_bytes(store, &object_key).await?;
     let envelope: HeadStateEnvelope =
         decode_control_object(&encoded_bytes, ControlObjectKind::WalHead)
             .map_err(|err| map_control_codec_error(&object_key, err))?;
     validate_expected_namespace(
         &object_key,
-        expected_namespace,
+        expected_namespace_id,
         &envelope.state.namespace_id,
     )?;
 
@@ -296,9 +296,9 @@ pub(crate) async fn read_head_object<S: ObjectStore + ?Sized>(
 
 pub async fn load_namespace_descriptor_control<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedNamespaceDescriptorControl, ControlObjectLoadError> {
-    let loaded = read_namespace_descriptor_object(store, expected_namespace).await?;
+    let loaded = read_namespace_descriptor_object(store, expected_namespace_id).await?;
     let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
     Ok(LoadedNamespaceDescriptorControl {
         object_key: loaded.object_key,
@@ -322,9 +322,9 @@ pub async fn load_content_store_descriptor_control<S: ObjectStore + ?Sized>(
 
 pub async fn load_namespace_wal_floor_control<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedWalFloorControl, ControlObjectLoadError> {
-    let loaded = read_wal_floor_object(store, expected_namespace).await?;
+    let loaded = read_wal_floor_object(store, expected_namespace_id).await?;
     let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
     Ok(LoadedWalFloorControl {
         object_key: loaded.object_key,
@@ -335,11 +335,11 @@ pub async fn load_namespace_wal_floor_control<S: ObjectStore + ?Sized>(
 
 pub async fn load_namespace_checkpoint_record_control<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
     checkpoint_id: &loonfs_api::CheckpointId,
 ) -> Result<Option<loonfs_api::wire::control::CheckpointRecordState>, crate::error::CoreError> {
     Ok(
-        crate::checkpoint::read_checkpoint_record(store, expected_namespace, checkpoint_id)
+        crate::checkpoint::read_checkpoint_record(store, expected_namespace_id, checkpoint_id)
             .await?
             .map(|loaded| loaded.state),
     )
@@ -347,9 +347,9 @@ pub async fn load_namespace_checkpoint_record_control<S: ObjectStore + ?Sized>(
 
 pub async fn load_namespace_metadata_root_control<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedMetadataRootControl, ControlObjectLoadError> {
-    let loaded = read_metadata_root_object(store, expected_namespace).await?;
+    let loaded = read_metadata_root_object(store, expected_namespace_id).await?;
     let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
     Ok(LoadedMetadataRootControl {
         object_key: loaded.object_key,
@@ -362,9 +362,9 @@ pub async fn load_namespace_metadata_root_control<S: ObjectStore + ?Sized>(
 /// (see [`read_head_and_metadata_root`] for the race rule).
 pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<(LoadedHeadControl, LoadedMetadataRootControl), ControlObjectLoadError> {
-    let (head, root) = read_head_and_metadata_root(store, expected_namespace).await?;
+    let (head, root) = read_head_and_metadata_root(store, expected_namespace_id).await?;
     let head_identity = control_identity(&head.object_key, &head.metadata)?;
     let root_identity = control_identity(&root.object_key, &root.metadata)?;
     Ok((
@@ -383,9 +383,9 @@ pub async fn load_namespace_read_anchor<S: ObjectStore + ?Sized>(
 
 pub async fn load_namespace_head_control<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadControl, ControlObjectLoadError> {
-    let loaded = read_head_object(store, expected_namespace).await?;
+    let loaded = read_head_object(store, expected_namespace_id).await?;
     let identity = control_identity(&loaded.object_key, &loaded.metadata)?;
     Ok(LoadedHeadControl {
         object_key: loaded.object_key,

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -445,8 +445,8 @@ mod tests {
     use loonfs_api::{
         ChangeSeq, CheckpointId, CommitId, GcPinId, InodeId, ManifestId, NamespaceId, WriterEpoch,
     };
-    use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::pin;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
     use std::collections::BTreeMap;
     use tempfile::tempdir;

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -41,51 +41,51 @@ pub struct NamespaceHeadEtagProbe {
 
 pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<NamespaceHeadSummary> {
-    match namespace_initialization_state(store, expected_namespace).await {
+    match namespace_initialization_state(store, expected_namespace_id).await {
         Ok(NamespaceInitializationState::Complete) => {}
         Ok(NamespaceInitializationState::Absent) => {
             return Err(CoreError::MetadataProjection(
                 MetadataProjectionLoadError::LoadNamespaceDescriptor(
                     ControlObjectLoadError::MissingObject {
-                        object_key: namespace_config(expected_namespace.as_str()),
+                        object_key: namespace_config(expected_namespace_id.as_str()),
                     },
                 ),
             ));
         }
         Ok(NamespaceInitializationState::Partial) => {
             return Err(CoreError::NamespacePartiallyInitialized {
-                namespace_id: expected_namespace.clone(),
+                namespace_id: expected_namespace_id.clone(),
             });
         }
         Err(error) => return Err(map_namespace_initialization_error_to_core(error)),
     }
 
-    let (loaded_head, loaded_root) = read_head_and_metadata_root(store, expected_namespace)
+    let (loaded_head, loaded_root) = read_head_and_metadata_root(store, expected_namespace_id)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
         })?;
     if loaded_head.envelope.state.state == NamespaceState::Deleted {
         return Err(CoreError::NamespaceDeleted {
-            namespace_id: expected_namespace.clone(),
+            namespace_id: expected_namespace_id.clone(),
         });
     }
     let head = loaded_head.envelope.state;
     let root = loaded_root.envelope.state;
-    let manifest = load_namespace_manifest_envelope(store, expected_namespace, root.manifest_id)
+    let manifest = load_namespace_manifest_envelope(store, expected_namespace_id, root.manifest_id)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
     let manifest_head_seq = manifest.payload.head_seq;
     let wal_tail_segments = if head.visible_wal_tip.is_some() {
-        count_wal_tail_segments_by_position(store, expected_namespace, manifest_head_seq).await?
+        count_wal_tail_segments_by_position(store, expected_namespace_id, manifest_head_seq).await?
     } else {
         0
     };
-    let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace)
+    let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace_id)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
@@ -136,10 +136,10 @@ async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
 )]
 pub async fn probe_namespace_head_etag<S: ObjectStore + ?Sized>(
     store: &S,
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
 ) -> Result<NamespaceHeadEtagProbe> {
-    NamespaceId::parse(expected_namespace.as_str())?;
-    let object_key = wal_head(expected_namespace.as_str());
+    NamespaceId::parse(expected_namespace_id.as_str())?;
+    let object_key = wal_head(expected_namespace_id.as_str());
     let metadata = store
         .head(&object_key)
         .await

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -23,7 +23,7 @@ pub(super) fn validate_directory_cursor(
     cursor: &DirectoryPageCursor,
     resolved: &ResolvedVisiblePath,
 ) -> Result<()> {
-    if resolved.inode_kind != InodeKind::Dir {
+    if resolved.inode_kind != InodeKind::Directory {
         return Err(invalid_cursor(
             "directory cursor resolved to a non-directory path",
         ));

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -248,7 +248,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         if resolved.inode_kind == InodeKind::File {
             return Ok(vec![self.build_authoritative_path_entry(&resolved).await?]);
         }
-        if resolved.inode_kind != InodeKind::Dir {
+        if resolved.inode_kind != InodeKind::Directory {
             return Err(CoreError::ExpectedDirectory {
                 path: resolved.absolute_path,
                 kind: resolved.inode_kind,
@@ -509,7 +509,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 next_cursor: None,
             });
         }
-        if resolved.inode_kind != InodeKind::Dir {
+        if resolved.inode_kind != InodeKind::Directory {
             return Err(CoreError::ExpectedDirectory {
                 path: resolved.absolute_path,
                 kind: resolved.inode_kind,

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -53,7 +53,7 @@ pub(crate) async fn write_file_bytes<S: ObjectStore + ?Sized>(
     .await
 }
 
-pub(crate) async fn create_dir_path<S: ObjectStore + ?Sized>(
+pub(crate) async fn create_directory_path<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     absolute_path: &str,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -172,7 +172,7 @@ pub(crate) async fn plan_path_mutation_against_publish_view<S: ObjectStore + ?Si
     };
     let commit_request = match intent {
         PathMutationIntent::CreateDir { absolute_path, .. } => {
-            plan_publish_create_dir(absolute_path, &commit_id, &view).await?
+            plan_publish_create_directory(absolute_path, &commit_id, &view).await?
         }
         PathMutationIntent::PutFile {
             absolute_path,
@@ -314,7 +314,7 @@ async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
     Ok(())
 }
 
-async fn plan_publish_create_dir<S: ObjectStore + ?Sized>(
+async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
@@ -455,10 +455,10 @@ async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
         InodeKind::File => ApiCommitOp::DeleteFile {
             inode_id: resolved.inode_id,
         },
-        InodeKind::Dir if recursive => ApiCommitOp::DeleteSubtree {
+        InodeKind::Directory if recursive => ApiCommitOp::DeleteSubtree {
             root_inode_id: resolved.inode_id,
         },
-        InodeKind::Dir => {
+        InodeKind::Directory => {
             let children = view
                 .metadata_state
                 .visible_children(resolved.inode_id)
@@ -474,7 +474,7 @@ async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
         }
     };
     let mut preconditions = vec![publish_binding_is_precondition(view, &resolved).await?];
-    if !recursive && resolved.inode_kind == InodeKind::Dir {
+    if !recursive && resolved.inode_kind == InodeKind::Directory {
         preconditions.push(ApiCommitPrecondition::DirectoryEmpty {
             inode_id: resolved.inode_id,
         });
@@ -658,7 +658,7 @@ async fn publish_ensure_parent_directories<S: ObjectStore + ?Sized>(
                     .visible_inode(child.child_inode_id)
                     .await?
                     .ok_or_else(|| CoreError::PathNotFound(component.as_str().to_owned()))?;
-                if inode.inode_kind != InodeKind::Dir {
+                if inode.inode_kind != InodeKind::Directory {
                     return Err(CoreError::NonDirectoryPathComponent(
                         component.as_str().to_owned(),
                     ));
@@ -694,7 +694,7 @@ async fn publish_resolve_parent_directory<S: ObjectStore + ?Sized>(
         .metadata_state
         .resolve_visible_path(&parent_path)
         .await?;
-    if resolved.inode_kind != InodeKind::Dir {
+    if resolved.inode_kind != InodeKind::Directory {
         return Err(CoreError::ExpectedDirectory {
             path: parent_path.as_str().to_owned(),
             kind: resolved.inode_kind,
@@ -742,7 +742,7 @@ mod tests {
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::v0::{CommitOp, CommitPrecondition, CommitRequest as ApiCommitRequest};
     use loonfs_api::RevisionNo;
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
     fn test_context() -> MutationContext {
@@ -900,7 +900,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_dir_plan_contains_semantic_op_and_target_absence_precondition() {
+    async fn create_directory_plan_contains_semantic_op_and_target_absence_precondition() {
         let (_temp_dir, store, namespace_id, _context) = setup_namespace().await;
         let planned = plan_against_current_state(
             &store,
@@ -1032,7 +1032,7 @@ mod tests {
             vec![
                 InodeRecord {
                     inode_id: InodeId(1),
-                    inode_kind: InodeKind::Dir,
+                    inode_kind: InodeKind::Directory,
                     created_seq: ChangeSeq(0),
                 },
                 InodeRecord {

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, PutBehavior};
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
     fn test_context() -> MutationContext {
@@ -117,8 +117,8 @@ mod tests {
         context: &MutationContext,
     ) -> NamespaceEngine<&'a LocalFsStore> {
         NamespaceEngine::builder(store)
-            .namespace(namespace_id.clone())
-            .writer(context.writer_id.clone())
+            .namespace_id(namespace_id.clone())
+            .writer_id(context.writer_id.clone())
             .writer_version(context.writer_version.clone())
             .build()
             .expect("test engine")

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -336,8 +336,8 @@ mod tests {
     use bytes::Bytes;
     use futures::stream::BoxStream;
     use loonfs_api::{ContentRef, ContentRefKind, ContentStoreId};
-    use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::content_blob;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::{
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -108,7 +108,7 @@ fn validate_replay_record(
 }
 
 pub(super) fn validate_wal_segment_for_replay(
-    expected_namespace: &NamespaceId,
+    expected_namespace_id: &NamespaceId,
     expected_base_head_seq: ChangeSeq,
     object_key: &str,
     envelope: &WalSegmentEnvelope,
@@ -127,9 +127,9 @@ pub(super) fn validate_wal_segment_for_replay(
         });
     }
 
-    if &envelope.payload.namespace_id != expected_namespace {
+    if &envelope.payload.namespace_id != expected_namespace_id {
         return Err(WalReplayError::NamespaceMismatch {
-            expected: expected_namespace.clone(),
+            expected: expected_namespace_id.clone(),
             actual: envelope.payload.namespace_id.clone(),
         });
     }

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -9,8 +9,8 @@ use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentEnvelope};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch};
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::wal_segment;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use std::borrow::Cow;
 use tempfile::tempdir;
@@ -67,7 +67,7 @@ async fn build_wal_record_payload_matches_segment_record_payload() {
 #[tokio::test]
 async fn prepared_wal_segments_use_unique_segment_ids_and_object_keys() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let record = materialized_create_dir(
+    let record = materialized_create_directory(
         &namespace_id,
         "c_wal_unique",
         "docs",
@@ -103,7 +103,7 @@ async fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let segment = write_create_dir_segment(
+    let segment = write_create_directory_segment(
         &store,
         &namespace_id,
         None,
@@ -135,7 +135,7 @@ async fn validated_wal_chain_loads_visible_segments_in_ascending_order() {
 #[test]
 fn canonical_replay_advances_head_and_applies_metadata_rows() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let commit = materialized_create_dir(
+    let commit = materialized_create_directory(
         &namespace_id,
         "c_wal_replay",
         "docs",
@@ -191,7 +191,7 @@ fn canonical_replay_advances_head_and_applies_metadata_rows() {
 #[test]
 fn canonical_replay_rejects_writer_epoch_above_expected_bound() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let commit = materialized_create_dir(
+    let commit = materialized_create_directory(
         &namespace_id,
         "c_wal_replay_epoch",
         "docs",
@@ -245,7 +245,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let first = write_create_dir_segment(
+    let first = write_create_directory_segment(
         &store,
         &namespace_id,
         None,
@@ -255,7 +255,7 @@ async fn validated_wal_chain_can_load_cursor_suffix_without_full_base() {
         ChangeSeq(1),
     )
     .await;
-    let second = write_create_dir_segment(
+    let second = write_create_directory_segment(
         &store,
         &namespace_id,
         Some(first.envelope.pointer(first.object_key.clone())),
@@ -355,7 +355,7 @@ async fn validated_wal_chain_rejects_corrupt_visible_segments() {
     .await;
 }
 
-fn materialized_create_dir(
+fn materialized_create_directory(
     namespace_id: &NamespaceId,
     commit_id: &str,
     display_name: &str,
@@ -409,7 +409,7 @@ async fn assert_wal_chain_corruption_rejected(
         namespace_id.clone(),
         WriterEpoch(1),
         None,
-        &[materialized_create_dir(
+        &[materialized_create_directory(
             &namespace_id,
             "c_wal_corrupt",
             "docs",
@@ -451,7 +451,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let first = write_create_dir_segment(
+    let first = write_create_directory_segment(
         &store,
         &namespace_id,
         None,
@@ -461,7 +461,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
         ChangeSeq(1),
     )
     .await;
-    let second = write_create_dir_segment(
+    let second = write_create_directory_segment(
         &store,
         &namespace_id,
         Some(first.envelope.pointer(first.object_key.clone())),
@@ -537,7 +537,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     assert_eq!(survived.segments(), unhinted.segments());
 }
 
-async fn write_create_dir_segment(
+async fn write_create_directory_segment(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
     prev_visible_segment: Option<WalSegmentPointer>,
@@ -550,7 +550,7 @@ async fn write_create_dir_segment(
         namespace_id.clone(),
         WriterEpoch(1),
         prev_visible_segment,
-        &[materialized_create_dir(
+        &[materialized_create_directory(
             namespace_id,
             commit_id,
             display_name,

--- a/crates/loonfs-core/tests/differential.rs
+++ b/crates/loonfs-core/tests/differential.rs
@@ -24,7 +24,7 @@ fn content_ref(seed: &str) -> ContentRef {
     }
 }
 
-fn create_dir(
+fn create_directory(
     delta_index: u32,
     inode_id: InodeId,
     parent_inode_id: InodeId,
@@ -34,7 +34,7 @@ fn create_dir(
         WalDelta::CreateInode {
             delta_index,
             inode_id,
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
         },
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
@@ -125,7 +125,7 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
     let core_state = core_bootstrap_state();
     let model_state = model_bootstrap_state();
 
-    let create_dir = create_dir(0, InodeId(2), InodeId(1), "docs");
+    let create_directory = create_directory(0, InodeId(2), InodeId(1), "docs");
     let create_file = create_file(
         0,
         InodeId(3),
@@ -136,7 +136,7 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
     let replace_file = append_revision(0, InodeId(3), RevisionNo(2), content_ref("content-2"));
 
     let core_state = core_state
-        .apply_committed_wal_deltas(ChangeSeq(1), &create_dir)
+        .apply_committed_wal_deltas(ChangeSeq(1), &create_directory)
         .expect("core applies create-dir delta")
         .metadata_state
         .apply_committed_wal_deltas(ChangeSeq(2), &create_file)
@@ -147,7 +147,7 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
         .metadata_state;
 
     let model_state = model_state
-        .apply_committed_wal_deltas(ChangeSeq(1), &create_dir)
+        .apply_committed_wal_deltas(ChangeSeq(1), &create_directory)
         .expect("model applies create-dir delta")
         .metadata_state
         .apply_committed_wal_deltas(ChangeSeq(2), &create_file)
@@ -163,7 +163,7 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
 #[test]
 fn metadata_apply_matches_model_for_rename() {
     assert_states_match(&[
-        create_dir(0, InodeId(2), InodeId(1), "docs"),
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
         create_file(
             0,
             InodeId(3),
@@ -178,7 +178,7 @@ fn metadata_apply_matches_model_for_rename() {
 #[test]
 fn metadata_apply_matches_model_for_restore_revision() {
     assert_states_match(&[
-        create_dir(0, InodeId(2), InodeId(1), "docs"),
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
         create_file(
             0,
             InodeId(3),
@@ -194,7 +194,7 @@ fn metadata_apply_matches_model_for_restore_revision() {
 #[test]
 fn metadata_apply_matches_model_for_restore_revision_of_current_head() {
     assert_states_match(&[
-        create_dir(0, InodeId(2), InodeId(1), "docs"),
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
         create_file(
             0,
             InodeId(3),
@@ -209,7 +209,7 @@ fn metadata_apply_matches_model_for_restore_revision_of_current_head() {
 #[test]
 fn metadata_apply_matches_model_for_delete_file() {
     assert_states_match(&[
-        create_dir(0, InodeId(2), InodeId(1), "docs"),
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
         create_file(
             0,
             InodeId(3),
@@ -224,8 +224,8 @@ fn metadata_apply_matches_model_for_delete_file() {
 #[test]
 fn metadata_apply_matches_model_for_delete_subtree() {
     assert_states_match(&[
-        create_dir(0, InodeId(2), InodeId(1), "docs"),
-        create_dir(0, InodeId(3), InodeId(2), "nested"),
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
+        create_directory(0, InodeId(3), InodeId(2), "nested"),
         tombstone(0, InodeId(2)),
     ]);
 }
@@ -237,7 +237,7 @@ fn core_bootstrap_state() -> CoreMetadataState {
             &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             }],
         )
         .expect("bootstrap core root")
@@ -372,7 +372,7 @@ fn normalize_inode(
     (
         inode_id,
         match inode_kind {
-            InodeKind::Dir => "dir",
+            InodeKind::Directory => "dir",
             InodeKind::File => "file",
         },
         created_seq,

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -37,8 +37,8 @@ fn engine<'a, S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> NamespaceEngine<&'a S> {
     NamespaceEngine::builder(store)
-        .namespace(namespace_id.clone())
-        .writer(context.writer_id.clone())
+        .namespace_id(namespace_id.clone())
+        .writer_id(context.writer_id.clone())
         .writer_session_id(context.writer_session_id.clone())
         .writer_version(context.writer_version.clone())
         .build()

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -41,11 +41,11 @@ use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapOptions, Error as CoreError, ErrorCode,
     MutationContext, NamespaceEngine, WriteOptions,
 };
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{
     content_blob, content_store_descriptor, metadata_manifest, namespace_config, pin as pin_key,
     upload_session, upload_session_prefix, wal_head,
 };
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
@@ -75,8 +75,8 @@ fn namespace_engine<'a, S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> NamespaceEngine<&'a S> {
     NamespaceEngine::builder(store)
-        .namespace(namespace_id.clone())
-        .writer(context.writer_id.clone())
+        .namespace_id(namespace_id.clone())
+        .writer_id(context.writer_id.clone())
         .writer_session_id(context.writer_session_id.clone())
         .writer_version(context.writer_version.clone())
         .build()
@@ -265,20 +265,23 @@ fn write_file_bytes<S: ObjectStore + ?Sized>(
     )
 }
 
-fn create_dir_path<S: ObjectStore + ?Sized>(
+fn create_directory_path<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
 ) -> Result<loonfs_api::MutationResult, CoreError> {
-    block_on(namespace_engine(store, namespace_id, context).create_dir(
-        absolute_path,
-        WriteOptions {
-            commit_id: commit_id.map(|value| CommitId::parse(value).expect("valid test commit id")),
-            ..WriteOptions::default()
-        },
-    ))
+    block_on(
+        namespace_engine(store, namespace_id, context).create_directory(
+            absolute_path,
+            WriteOptions {
+                commit_id: commit_id
+                    .map(|value| CommitId::parse(value).expect("valid test commit id")),
+                ..WriteOptions::default()
+            },
+        ),
+    )
 }
 
 fn delete_path<S: ObjectStore + ?Sized>(
@@ -516,7 +519,7 @@ fn list_path_latest<S: ObjectStore + ?Sized>(
     block_on(engine.list_path(absolute_path))
 }
 
-fn wal_create_dir(
+fn wal_create_directory(
     delta_index: u32,
     inode_id: InodeId,
     parent_inode_id: InodeId,
@@ -526,7 +529,7 @@ fn wal_create_dir(
         WalDelta::CreateInode {
             delta_index,
             inode_id,
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
         },
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
@@ -597,7 +600,7 @@ fn wal_tombstone(delta_index: u32, root_inode_id: InodeId) -> Vec<WalDelta> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stale_revision_precondition_is_rejected() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -683,7 +686,7 @@ async fn failed_multi_op_plan_uses_preview_without_mutating_base_metadata() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -752,8 +755,12 @@ async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_validation_rejects_missing_inode() {
-    let metadata_state =
-        metadata_state_after(&[wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned())]);
+    let metadata_state = metadata_state_after(&[wal_create_directory(
+        0,
+        InodeId(2),
+        InodeId(1),
+        "docs".to_owned(),
+    )]);
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
@@ -783,8 +790,12 @@ async fn restore_revision_validation_rejects_missing_inode() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_validation_rejects_non_file_target() {
-    let metadata_state =
-        metadata_state_after(&[wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned())]);
+    let metadata_state = metadata_state_after(&[wal_create_directory(
+        0,
+        InodeId(2),
+        InodeId(1),
+        "docs".to_owned(),
+    )]);
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
         namespace_id: namespace_id(),
@@ -808,7 +819,7 @@ async fn restore_revision_validation_rejects_non_file_target() {
         error,
         CommitValidationError::RestoreRevisionInodeNotFile {
             inode_id: InodeId(2),
-            actual_kind: InodeKind::Dir,
+            actual_kind: InodeKind::Directory,
         }
     ));
 }
@@ -816,7 +827,7 @@ async fn restore_revision_validation_rejects_non_file_target() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_validation_rejects_stale_or_missing_source_revision() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -887,7 +898,7 @@ async fn restore_revision_validation_rejects_stale_or_missing_source_revision() 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_can_reference_revision_created_earlier_in_same_request() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -937,7 +948,7 @@ async fn restore_revision_can_reference_revision_created_earlier_in_same_request
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_can_reference_restore_created_earlier_in_same_request() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -995,7 +1006,7 @@ async fn restore_revision_can_reference_restore_created_earlier_in_same_request(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restore_revision_under_tombstoned_ancestor_is_rejected() {
     let metadata_state = metadata_state_after(&[
-        wal_create_dir(0, InodeId(2), InodeId(1), "docs".to_owned()),
+        wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
             0,
             InodeId(3),
@@ -1056,7 +1067,7 @@ async fn restore_revision_overflow_is_rejected() {
             &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             }],
         )
         .expect("bootstrap root")
@@ -1635,7 +1646,7 @@ async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
     let namespace_id = namespace_id();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
-    create_dir_path(&store, &namespace_id, "/docs", &context, Some("mkdir-docs"))
+    create_directory_path(&store, &namespace_id, "/docs", &context, Some("mkdir-docs"))
         .expect("create docs");
 
     for index in 0..3 {
@@ -1855,9 +1866,9 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
     let namespace_id = namespace_id();
 
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
-    create_dir_path(&store, &namespace_id, "/docs", &context, Some("mkdir-docs"))
+    create_directory_path(&store, &namespace_id, "/docs", &context, Some("mkdir-docs"))
         .expect("create docs");
-    create_dir_path(
+    create_directory_path(
         &store,
         &namespace_id,
         "/docs/a-dir",
@@ -1924,7 +1935,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
         Some("put-d-tail"),
     )
     .expect("put d-tail");
-    create_dir_path(
+    create_directory_path(
         &store,
         &namespace_id,
         "/docs/e-tail-dir",
@@ -2017,7 +2028,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
             .iter()
             .find(|entry| entry.display_name == directory_name)
             .expect("directory entry");
-        assert_eq!(entry.inode_kind, InodeKind::Dir);
+        assert_eq!(entry.inode_kind, InodeKind::Directory);
         assert_eq!(entry.revision_no, None);
         assert_eq!(entry.size_bytes, None);
         assert!(entry.content_ref.is_none());
@@ -2247,7 +2258,7 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
         CommitDelta::CreateInode {
             semantic_op_index: 0,
             delta_index: 0,
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             ..
         }
     ));
@@ -2270,7 +2281,7 @@ async fn change_feed_validates_wal_chain_before_current_manifest() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
-    create_dir_path(&store, &namespace_id, "/docs", &context, None).expect("create docs");
+    create_directory_path(&store, &namespace_id, "/docs", &context, None).expect("create docs");
     create_checkpoint(&store, &namespace_id, &context).expect("checkpoint");
 
     let wal_keys = store
@@ -2848,7 +2859,7 @@ async fn direct_publisher_retries_after_stale_head_get_during_publish_view_load(
     let store = StaleHeadGetStore::new(temp_dir.path(), &namespace_id);
     bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
 
-    create_dir_path(
+    create_directory_path(
         &store,
         &namespace_id,
         "/parent",
@@ -2884,7 +2895,7 @@ async fn direct_publisher_retries_after_stale_head_get_during_publish_view_load(
     );
 
     store.inject_stale_head_get_after(1);
-    let result = create_dir_path(
+    let result = create_directory_path(
         &store,
         &namespace_id,
         "/parent/child",
@@ -4432,13 +4443,13 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn create_dir_path_creates_directory_without_auto_parents() {
+async fn create_directory_path_creates_directory_without_auto_parents() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
 
-    let created = create_dir_path(
+    let created = create_directory_path(
         &store,
         &namespace_id(),
         "/docs",
@@ -4448,9 +4459,9 @@ async fn create_dir_path_creates_directory_without_auto_parents() {
     .expect("create dir");
     assert_eq!(created.committed_seq, ChangeSeq(1));
     let docs = resolve_path(&store, &namespace_id(), "/docs").expect("resolve docs");
-    assert_eq!(docs.inode_kind, InodeKind::Dir);
+    assert_eq!(docs.inode_kind, InodeKind::Directory);
 
-    let missing_parent = create_dir_path(
+    let missing_parent = create_directory_path(
         &store,
         &namespace_id(),
         "/missing/nested",
@@ -4860,7 +4871,7 @@ fn metadata_state_after(sequences: &[Vec<WalDelta>]) -> MetadataState {
             &[WalDelta::CreateInode {
                 delta_index: 0,
                 inode_id: InodeId(1),
-                inode_kind: InodeKind::Dir,
+                inode_kind: InodeKind::Directory,
             }],
         )
         .expect("bootstrap root")

--- a/crates/loonfs-model/src/genesis.rs
+++ b/crates/loonfs-model/src/genesis.rs
@@ -5,7 +5,7 @@ pub fn bootstrap_metadata_state() -> MetadataState {
     MetadataState {
         inodes: vec![InodeRecord {
             inode_id: InodeId(1),
-            inode_kind: InodeKind::Dir,
+            inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(0),
         }],
         direntry_binds: Vec::new(),

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -362,7 +362,7 @@ impl MetadataState {
         base_seq: ChangeSeq,
     ) -> Option<DirentryBindRecord> {
         let parent = self.visible_inode(parent_inode_id, base_seq)?;
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return None;
         }
 
@@ -379,7 +379,7 @@ impl MetadataState {
         let Some(parent) = self.visible_inode(parent_inode_id, base_seq) else {
             return Vec::new();
         };
-        if parent.inode_kind != InodeKind::Dir {
+        if parent.inode_kind != InodeKind::Directory {
             return Vec::new();
         }
 
@@ -443,7 +443,7 @@ impl MetadataState {
                     absolute_path: current_absolute_path.clone(),
                 },
             )?;
-            if current_inode.inode_kind != InodeKind::Dir {
+            if current_inode.inode_kind != InodeKind::Directory {
                 return Err(VisiblePathError::PathComponentNotDirectory {
                     absolute_path: current_absolute_path,
                     inode_id: current_inode_id,

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -1,10 +1,10 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::abs::{AzureAbsStore, AzureAbsStoreConfig};
-use crate::fs::LocalFsStore;
 use crate::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
+use crate::local_fs_store::LocalFsStore;
 use crate::presign::{ObjectTransferIssuer, S3CompatiblePresigner, S3PresignerConfig};
 use crate::r2::{CloudflareR2Store, CloudflareR2StoreConfig};
 use crate::s3::{AwsS3Store, AwsS3StoreConfig};
@@ -274,9 +274,9 @@ impl ObjectStore for ConfiguredObjectStore {
 mod tests {
     use super::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
     use crate::abs::AzureAbsStoreConfig;
-    use crate::fs::LocalFsStore;
     use crate::gcs::GcpGcsStoreConfig;
     use crate::keys::wal_head;
+    use crate::local_fs_store::LocalFsStore;
     use crate::presign::PresignedPutRequest;
     use crate::r2::CloudflareR2StoreConfig;
     use crate::s3::AwsS3StoreConfig;

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -10,12 +10,13 @@
 
 pub mod abs;
 mod configured;
-pub mod fs;
 pub mod gcs;
 pub mod keys;
 mod keyspace;
 pub mod layout;
+pub mod local_fs_store;
 pub mod metrics;
+pub mod object_store;
 pub mod presign;
 pub mod probes;
 pub mod provider;
@@ -26,6 +27,10 @@ mod s3_compatible;
 mod secret;
 mod store_config;
 
+/// Compatibility alias for [`local_fs_store`], kept so existing imports of
+/// `loonfs_objectstore::fs::LocalFsStore` keep resolving.
+pub use local_fs_store as fs;
+
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 pub use object_store::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -34,5 +39,3 @@ pub use object_store::{
 pub use provider_object_store::{ProviderObjectStore, ProviderObjectStoreConfig};
 pub use secret::SecretString;
 pub use store_config::{StoreConfig, StoreConfigError};
-
-pub mod object_store;

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -1,3 +1,5 @@
+//! [`LocalFsStore`]: the local-filesystem [`ObjectStore`] provider.
+
 use crate::keyspace::validate_segments;
 use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use async_trait::async_trait;

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -182,7 +182,7 @@ impl<S> InstrumentedObjectStore<S> {
         }
     }
 
-    pub fn with_store_kind(mut self, store_kind: impl Into<String>) -> Self {
+    pub fn store_kind(mut self, store_kind: impl Into<String>) -> Self {
         self.store_kind = Some(store_kind.into());
         self
     }

--- a/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use loonfs_api::ManifestId;
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{
     metadata_manifest, metadata_table, namespace_config, wal_head, wal_segment,
 };
 use loonfs_objectstore::layout::ObjectLayout;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::metrics::{
     InstrumentedObjectStore, JsonlObjectStoreMetricsRecorder, KeyClass, ObjectStoreMetricsRecorder,
     ObjectStoreOperation, ObjectStoreResultClass, PutModeClass, RangeClass,
@@ -326,7 +326,7 @@ where
     R: ObjectStoreMetricsRecorder,
 {
     InstrumentedObjectStore::new(LocalFsStore::new(root).expect("local fs store"), recorder)
-        .with_store_kind("local-fs")
+        .store_kind("local-fs")
 }
 
 #[derive(Debug, Default)]

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -3,12 +3,12 @@ mod provider_env;
 use bytes::Bytes;
 use loonfs_api::ManifestId;
 use loonfs_objectstore::abs::{AzureAbsStore, AzureAbsStoreConfig};
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use loonfs_objectstore::keys::{
     content_blob, content_store_descriptor, metadata_manifest, metadata_table, namespace_config,
     upload_session, wal_head, wal_segment,
 };
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::probes::run_contract_probes;
 use loonfs_objectstore::provider::{
     Expectation, AWS_S3, AZURE_ABS, CLOUDFLARE_R2, GCP_GCS, LOCAL_FS,

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -68,21 +68,21 @@ impl ApiResponseError {
         Self::new(status, error.code(), &error.to_string())
     }
 
-    pub(super) fn core_for_namespace(namespace: &NamespaceId, error: CoreError) -> Self {
+    pub(super) fn core_for_namespace(namespace_id: &NamespaceId, error: CoreError) -> Self {
         if matches!(error.code(), ErrorCode::NamespaceNotFound) {
             return Self::new(
                 StatusCode::NOT_FOUND,
                 ErrorCode::NamespaceNotFound,
-                &format!("namespace `{}` does not exist", namespace.as_str()),
+                &format!("namespace `{}` does not exist", namespace_id.as_str()),
             );
         }
 
         Self::core(error)
     }
 
-    pub(super) fn runtime_for_namespace(namespace: &NamespaceId, error: RuntimeError) -> Self {
+    pub(super) fn runtime_for_namespace(namespace_id: &NamespaceId, error: RuntimeError) -> Self {
         match error {
-            RuntimeError::Core(error) => Self::core_for_namespace(namespace, error),
+            RuntimeError::Core(error) => Self::core_for_namespace(namespace_id, error),
             RuntimeError::Bootstrap(error) => Self::bootstrap(error),
             RuntimeError::Config(message) => {
                 Self::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -187,7 +187,7 @@ fn build_fs_with_metrics_jsonl_path(
         .trace_store_kind(trace_store_kind);
 
     if let Some(recorder) = object_store_metrics_recorder(metrics_jsonl_path)? {
-        builder = builder.with_metrics_recorder(recorder);
+        builder = builder.metrics_recorder(recorder);
     }
 
     builder

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -74,8 +74,8 @@ use loonfs::{
 };
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::wal_head;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -176,8 +176,14 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
             .expect("create namespace");
         let docs = NamespacePath::parse("demo:/docs").expect("docs path");
         let other = NamespacePath::parse("demo:/other").expect("other path");
-        harness.client.create_dir(&docs).expect("create docs dir");
-        harness.client.create_dir(&other).expect("create other dir");
+        harness
+            .client
+            .create_directory(&docs)
+            .expect("create docs dir");
+        harness
+            .client
+            .create_directory(&other)
+            .expect("create other dir");
         for name in ["a.txt", "b.txt", "c.txt"] {
             let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
             harness
@@ -266,7 +272,10 @@ async fn http_client_listing_preserves_canonical_name_key_order() {
             .create_namespace("demo")
             .expect("create namespace");
         let docs = NamespacePath::parse("demo:/docs").expect("docs path");
-        harness.client.create_dir(&docs).expect("create docs dir");
+        harness
+            .client
+            .create_directory(&docs)
+            .expect("create docs dir");
         for name in ["B.txt", "a.txt", "c.txt"] {
             let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
             harness
@@ -302,13 +311,13 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         let directory = NamespacePath::parse("demo:/notes").expect("parse directory path");
         harness
             .client
-            .create_dir(&directory)
+            .create_directory(&directory)
             .expect("create directory");
         let directory_entry = harness
             .client
             .stat_path(&directory)
             .expect("stat directory");
-        assert_eq!(directory_entry.inode_kind, InodeKind::Dir);
+        assert_eq!(directory_entry.inode_kind, InodeKind::Directory);
 
         let target = NamespacePath::parse("demo:/notes/hello.txt").expect("parse namespace path");
         harness

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -1,7 +1,7 @@
 use loonfs::{
     CreateNamespaceOptions, Fs, NamespaceId, PutBehavior, PutFileOptions, SharedObjectStore,
 };
-use loonfs_objectstore::fs::LocalFsStore;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use std::sync::Arc;
 
 #[allow(clippy::print_stdout)]

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -12,9 +12,9 @@ use crate::{
     BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse, ChangeSeq,
     ChangesResponse, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions, CoreError,
-    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
-    DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId, ListChangesOptions,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
+    CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions,
+    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId,
+    ListChangesOptions, ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
     MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, ObjectStore, ObjectStoreMetricsRecorder,
     PutFileOptions, RestoreRevisionOptions, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats,
@@ -134,11 +134,11 @@ impl FsBuilder {
         self
     }
 
-    /// Install object-store metrics collection for this runtime.
+    /// Installs object-store metrics collection for this runtime.
     ///
     /// The runtime wraps the provided object store before opening `Fs`; callers do not need to
     /// manually construct an instrumented store.
-    pub fn with_metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
+    pub fn metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
         self.metrics_recorder = Some(recorder);
         self
     }
@@ -152,7 +152,7 @@ impl FsBuilder {
         let store = match self.metrics_recorder {
             Some(recorder) => Arc::new(
                 InstrumentedObjectStore::new(self.store, recorder)
-                    .with_store_kind(trace_store_kind.as_str()),
+                    .store_kind(trace_store_kind.as_str()),
             ) as SharedObjectStore,
             None => self.store,
         };
@@ -795,11 +795,11 @@ impl Fs {
     }
 
     /// Creates a directory at an absolute path.
-    pub async fn create_dir(
+    pub async fn create_directory(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
-        options: CreateDirOptions,
+        options: CreateDirectoryOptions,
     ) -> Result<MutationResult> {
         self.publish_path_intent(
             namespace_id,
@@ -1308,8 +1308,8 @@ impl Fs {
         store: S,
     ) -> NamespaceEngine<S> {
         NamespaceEngine::builder(store)
-            .namespace(namespace_id.clone())
-            .writer(self.inner.config.writer_id.clone())
+            .namespace_id(namespace_id.clone())
+            .writer_id(self.inner.config.writer_id.clone())
             .writer_session_id(self.inner.writer_session_id.clone())
             .writer_version(self.inner.config.writer_version.clone())
             .build()

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -70,7 +70,7 @@ pub use config::{
 };
 pub use fs::{Fs, FsBuilder};
 pub use options::{
-    CopyOptions, CreateDirOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
+    CopyOptions, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions,
     PutFileOptions, RestoreRevisionOptions,
 };

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -62,10 +62,11 @@ pub struct MaintenanceTickResult {
     pub gc: Option<crate::GcReport>,
 }
 
-/// Options for creating a namespace.
+/// Options for creating a namespace; feeds core's
+/// [`loonfs_core::BootstrapOptions`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateNamespaceOptions {
-    /// Treat an existing namespace as success.
+    /// If true, creating an already-existing namespace is treated as success.
     pub allow_existing: bool,
 }
 
@@ -89,7 +90,7 @@ impl Default for PutFileOptions {
 
 /// Options for creating a directory.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CreateDirOptions {
+pub struct CreateDirectoryOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -869,8 +869,8 @@ mod tests {
     use loonfs_api::v0::{CommitOp, CommitRequest};
     use loonfs_api::wire::wal::decode_wal_segment_envelope_zstd;
     use loonfs_api::{ChangeSeq, InodeId, PutBehavior};
-    use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::{
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };
@@ -1232,7 +1232,7 @@ mod tests {
             .expect("bootstrap");
     }
 
-    fn create_dir_request(
+    fn create_directory_request(
         commit_id: impl Into<String>,
         display_name: impl Into<String>,
     ) -> CommitRequest {
@@ -1288,8 +1288,10 @@ mod tests {
 
     #[test]
     fn publisher_trace_labels_are_low_cardinality() {
-        let commit =
-            NamespaceMutationCandidate::Commit(create_dir_request("commit-trace", "private-name"));
+        let commit = NamespaceMutationCandidate::Commit(create_directory_request(
+            "commit-trace",
+            "private-name",
+        ));
         let path = NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("path-trace").expect("valid commit id"),
             absolute_path: "/private/path".to_owned(),
@@ -1321,14 +1323,14 @@ mod tests {
         let active = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("active", "active"),
+            create_directory_request("active", "active"),
         );
         store.wait_for_blocked_head_cas().await;
 
         let pending = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending", "pending"),
+            create_directory_request("pending", "pending"),
         );
         {
             let state = publisher
@@ -1374,19 +1376,19 @@ mod tests {
         let active = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("active", "active"),
+            create_directory_request("active", "active"),
         );
         store.wait_for_blocked_head_cas().await;
 
         let duplicate = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("active", "active"),
+            create_directory_request("active", "active"),
         );
         let conflict = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("active", "different-active"),
+            create_directory_request("active", "different-active"),
         );
         assert!(matches!(
             conflict,
@@ -1414,7 +1416,7 @@ mod tests {
         let active = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("active", "active"),
+            create_directory_request("active", "active"),
         );
         store.wait_for_blocked_head_cas().await;
 
@@ -1423,19 +1425,19 @@ mod tests {
             pending.push(admit_commit(
                 &publisher,
                 &namespace_id,
-                create_dir_request(format!("pending-{index}"), format!("pending-{index}")),
+                create_directory_request(format!("pending-{index}"), format!("pending-{index}")),
             ));
         }
 
         let duplicate = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending-0", "pending-0"),
+            create_directory_request("pending-0", "pending-0"),
         );
         let conflict = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("pending-0", "different-pending"),
+            create_directory_request("pending-0", "different-pending"),
         );
         assert!(matches!(
             conflict,
@@ -1445,7 +1447,7 @@ mod tests {
         let overflow = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("overflow", "overflow"),
+            create_directory_request("overflow", "overflow"),
         );
         assert!(matches!(overflow, Err(CoreError::CommitQueueFull)));
 
@@ -1482,7 +1484,7 @@ mod tests {
             receivers.push(admit_commit(
                 &publisher,
                 &namespace_id,
-                create_dir_request(format!("full-{index}"), format!("full-{index}")),
+                create_directory_request(format!("full-{index}"), format!("full-{index}")),
             ));
         }
 
@@ -1522,7 +1524,7 @@ mod tests {
             admit_commit(
                 &publisher,
                 &namespace_id,
-                create_dir_request("unknown-ack", "unknown-ack"),
+                create_directory_request("unknown-ack", "unknown-ack"),
             ),
             "unknown-ack",
         )
@@ -1544,7 +1546,7 @@ mod tests {
         let doomed = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("doomed", "doomed"),
+            create_directory_request("doomed", "doomed"),
         );
         store.wait_for_blocked_head_cas().await;
 
@@ -1553,7 +1555,7 @@ mod tests {
         let queued = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("queued", "queued"),
+            create_directory_request("queued", "queued"),
         );
 
         store.release_into_panic();
@@ -1573,7 +1575,7 @@ mod tests {
         let after = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("after", "after"),
+            create_directory_request("after", "after"),
         );
         assert_eq!(
             recv_commit(after, "after").await.committed_seq,
@@ -1596,13 +1598,13 @@ mod tests {
         let before_a = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("before-a", "before-a"),
+            create_directory_request("before-a", "before-a"),
         );
         store.wait_for_blocked_head_cas().await;
         let before_b = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("before-b", "before-b"),
+            create_directory_request("before-b", "before-b"),
         );
 
         // The delete arrives: everything above was admitted before it,
@@ -1632,7 +1634,7 @@ mod tests {
         let after = admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("after", "after"),
+            create_directory_request("after", "after"),
         );
 
         store.release_head_cas();
@@ -1662,7 +1664,7 @@ mod tests {
         let fast_fail = try_admit_commit(
             &publisher,
             &namespace_id,
-            create_dir_request("too-late", "too-late"),
+            create_directory_request("too-late", "too-late"),
         );
         assert!(matches!(fast_fail, Err(CoreError::NamespaceDeleted { .. })));
     }

--- a/crates/loonfs/tests/capability_conformance.rs
+++ b/crates/loonfs/tests/capability_conformance.rs
@@ -8,7 +8,7 @@ use loonfs::{
     CapabilityDocument, Fs, FsConfig, RuntimeCacheConfig, SharedObjectStore, TraceMode,
     TraceStoreKind,
 };
-use loonfs_objectstore::fs::LocalFsStore;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use tempfile::tempdir;

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -8,7 +8,7 @@ use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
     BeginUploadResponse, ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest,
     CommitResponse, CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
-    CreateCheckpointResponse, CreateDirOptions, CreateNamespaceOptions, DeleteOptions,
+    CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
     DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
     MutationResult, NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy,
@@ -16,8 +16,8 @@ use loonfs::{
     TraceStoreKind, UploadContentResponse, UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
-use loonfs_objectstore::fs::LocalFsStore;
 use loonfs_objectstore::keys::{metadata_manifest, namespace_config, wal_head};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::metrics::{ObjectStoreOperation, VecObjectStoreMetricsRecorder};
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -39,7 +39,7 @@ fn runtime(root: &Path, writer_id: &str) -> Fs {
         .expect("build runtime")
 }
 
-fn namespace() -> NamespaceId {
+fn namespace_id() -> NamespaceId {
     NamespaceId::parse("demo").expect("valid namespace id")
 }
 
@@ -115,11 +115,11 @@ trait FsTestExt {
         bytes: &[u8],
         options: PutFileOptions,
     ) -> loonfs::Result<MutationResult>;
-    fn create_dir_blocking(
+    fn create_directory_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
-        options: CreateDirOptions,
+        options: CreateDirectoryOptions,
     ) -> loonfs::Result<MutationResult>;
     fn delete_path_blocking(
         &self,
@@ -248,13 +248,13 @@ impl FsTestExt for Fs {
         block_on(self.put_file_bytes(namespace_id, absolute_path, bytes, options))
     }
 
-    fn create_dir_blocking(
+    fn create_directory_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
-        options: CreateDirOptions,
+        options: CreateDirectoryOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.create_dir(namespace_id, absolute_path, options))
+        block_on(self.create_directory(namespace_id, absolute_path, options))
     }
 
     fn delete_path_blocking(
@@ -410,11 +410,11 @@ fn builder_metrics_recorder_instruments_object_store() {
     let fs = Fs::builder(store(temp_dir.path()))
         .writer_id("metrics-test")
         .trace_store_kind(TraceStoreKind::LocalFs)
-        .with_metrics_recorder(recorder.clone())
+        .metrics_recorder(recorder.clone())
         .build()
         .expect("build runtime");
 
-    fs.create_namespace_blocking(&namespace(), CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id(), CreateNamespaceOptions::default())
         .expect("create namespace");
 
     let samples = recorder.samples();
@@ -431,7 +431,7 @@ fn builder_metrics_recorder_instruments_object_store() {
 fn filesystem_operations_match_core_semantics() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "filesystem-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -501,7 +501,7 @@ fn filesystem_operations_match_core_semantics() {
 async fn async_runtime_methods_are_the_engine_boundary() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "async-runtime-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     Fs::create_namespace(&fs, &namespace_id, CreateNamespaceOptions::default())
         .await
@@ -527,7 +527,7 @@ async fn async_runtime_methods_are_the_engine_boundary() {
 #[test]
 fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -585,7 +585,7 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
 #[test]
 fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -604,15 +604,19 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     setup
-        .create_dir_blocking(&namespace_id, "/seed-a", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/seed-a", CreateDirectoryOptions::default())
         .expect("seed first WAL segment");
     setup
-        .create_dir_blocking(&namespace_id, "/seed-b", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/seed-b", CreateDirectoryOptions::default())
         .expect("seed second WAL segment");
 
     raw_store.reset_wal_get_count();
     measured
-        .create_dir_blocking(&namespace_id, "/measured-a", CreateDirOptions::default())
+        .create_directory_blocking(
+            &namespace_id,
+            "/measured-a",
+            CreateDirectoryOptions::default(),
+        )
         .expect("first measured write loads existing tail");
     assert!(
         raw_store.wal_get_count() > 0,
@@ -621,7 +625,11 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 
     raw_store.reset_wal_get_count();
     measured
-        .create_dir_blocking(&namespace_id, "/measured-b", CreateDirOptions::default())
+        .create_directory_blocking(
+            &namespace_id,
+            "/measured-b",
+            CreateDirectoryOptions::default(),
+        )
         .expect("second measured write advances cached publish tail");
     assert_eq!(
         raw_store.wal_get_count(),
@@ -633,7 +641,7 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 #[test]
 fn runtime_publish_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -652,17 +660,17 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     setup
-        .create_dir_blocking(&namespace_id, "/seed-a", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/seed-a", CreateDirectoryOptions::default())
         .expect("seed first WAL segment");
     setup
-        .create_dir_blocking(&namespace_id, "/seed-b", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/seed-b", CreateDirectoryOptions::default())
         .expect("seed second WAL segment");
 
     measured
-        .create_dir_blocking(
+        .create_directory_blocking(
             &namespace_id,
             "/should-succeed",
-            CreateDirOptions::default(),
+            CreateDirectoryOptions::default(),
         )
         .expect("publish projects the visible WAL tail without a segment limit");
 }
@@ -670,7 +678,7 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
 #[test]
 fn runtime_cache_observes_head_advanced_by_another_runtime() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -689,7 +697,7 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
 
     reader
@@ -697,7 +705,11 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
         .expect("prime reader cache");
 
     writer
-        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_directory_blocking(
+            &namespace_id,
+            "/docs/new",
+            CreateDirectoryOptions::default(),
+        )
         .expect("advance head from another runtime");
 
     raw_store.reset_wal_get_count();
@@ -712,7 +724,7 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
 #[test]
 fn runtime_cache_can_be_disabled() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -796,7 +808,7 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
 #[test]
 fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -837,7 +849,7 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
 #[test]
 fn runtime_read_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let fs = Fs::builder(store(temp_dir.path()))
         .writer_id("tail-read-test")
         .build()
@@ -845,9 +857,9 @@ fn runtime_read_allows_multi_segment_wal_tail() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
-    fs.create_dir_blocking(&namespace_id, "/more", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/more", CreateDirectoryOptions::default())
         .expect("create another WAL segment");
 
     fs.stat_path_blocking(&namespace_id, "/docs")
@@ -857,7 +869,7 @@ fn runtime_read_allows_multi_segment_wal_tail() {
 #[test]
 fn stale_head_write_error_invalidates_runtime_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -870,21 +882,25 @@ fn stale_head_write_error_invalidates_runtime_cache() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
     fs.stat_path_blocking(&namespace_id, "/docs")
         .expect("prime read cache");
 
     raw_store.fail_head_cas();
     assert_core_error_kind(
-        fs.create_dir_blocking(&namespace_id, "/stale", CreateDirOptions::default()),
+        fs.create_directory_blocking(&namespace_id, "/stale", CreateDirectoryOptions::default()),
         ErrorCode::StaleHead,
     );
 
     raw_store.allow_head_cas();
     raw_store.reset_wal_get_count();
-    fs.create_dir_blocking(&namespace_id, "/after-stale", CreateDirOptions::default())
-        .expect("write after stale head should reload publish tail");
+    fs.create_directory_blocking(
+        &namespace_id,
+        "/after-stale",
+        CreateDirectoryOptions::default(),
+    )
+    .expect("write after stale head should reload publish tail");
     assert!(
         raw_store.wal_get_count() > 0,
         "failed publish attempt should invalidate cached publish tail"
@@ -900,7 +916,7 @@ fn stale_head_write_error_invalidates_runtime_cache() {
 fn delete_options_select_recursive_behavior() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "delete-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -942,7 +958,7 @@ fn delete_options_select_recursive_behavior() {
 fn directory_pages_use_canonical_name_key_order() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-order-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in [
@@ -998,7 +1014,7 @@ fn directory_pages_use_canonical_name_key_order() {
 fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "file-revision-page-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
@@ -1080,7 +1096,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
 fn directory_cursor_after_later_writes_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-snapshot-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
@@ -1131,7 +1147,7 @@ fn directory_cursor_after_later_writes_is_rejected() {
 fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-floor-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
@@ -1182,7 +1198,7 @@ fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
 fn directory_cursor_rejects_path_inode_mismatch() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-mismatch-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt"] {
@@ -1223,7 +1239,7 @@ fn directory_cursor_rejects_path_inode_mismatch() {
 fn forked_namespace_shares_content_then_diverges() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "fork-test");
-    let source = namespace();
+    let source = namespace_id();
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
 
     fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
@@ -1275,7 +1291,7 @@ fn forked_namespace_shares_content_then_diverges() {
 fn upload_flow_is_available_from_runtime() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "upload-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1306,7 +1322,7 @@ fn upload_flow_is_available_from_runtime() {
 fn direct_put_upload_flow_validates_durable_object_on_complete() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "direct-put-upload-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let bytes = b"direct uploaded";
     let content_ref = ContentRef::whole_file_v0(bytes);
 
@@ -1350,12 +1366,12 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
 #[test]
 fn stat_and_list_use_initial_manifest_without_checkpoint() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let fs = runtime(temp_dir.path(), "read-fallback-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
 
     fs.stat_path_blocking(&namespace_id, "/docs")
@@ -1370,7 +1386,7 @@ fn stat_and_list_use_initial_manifest_without_checkpoint() {
 #[test]
 fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = Fs::builder(object_store)
@@ -1405,7 +1421,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn concurrent_materialized_stat_and_list_share_async_store() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let fs = runtime(temp_dir.path(), "concurrent-materialized-read-test");
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -1442,7 +1458,7 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
 #[test]
 fn repeated_materialized_stat_uses_metadata_table_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let fs = runtime(temp_dir.path(), "metadata-table-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -1472,7 +1488,7 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 #[test]
 fn put_file_bytes_validates_content_ref_before_publish() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = Fs::builder(object_store)
@@ -1499,7 +1515,7 @@ fn put_file_bytes_validates_content_ref_before_publish() {
 #[test]
 fn begin_upload_validates_controls_without_replay_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -1545,7 +1561,7 @@ fn begin_upload_validates_controls_without_replay_reads() {
 #[test]
 fn runtime_control_cache_reuses_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -1558,7 +1574,7 @@ fn runtime_control_cache_reuses_head_for_materialization_validation() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
 
     fs.stat_path_blocking(&namespace_id, "/docs")
@@ -1576,7 +1592,7 @@ fn runtime_control_cache_reuses_head_for_materialization_validation() {
 #[test]
 fn control_cache_eviction_reloads_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
@@ -1594,11 +1610,11 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    fs.create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
     fs.create_namespace_blocking(&other_namespace, CreateNamespaceOptions::default())
         .expect("create other namespace");
-    fs.create_dir_blocking(&other_namespace, "/docs", CreateDirOptions::default())
+    fs.create_directory_blocking(&other_namespace, "/docs", CreateDirectoryOptions::default())
         .expect("create other docs");
 
     fs.stat_path_blocking(&namespace_id, "/docs")
@@ -1618,7 +1634,7 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
 #[test]
 fn runtime_control_cache_reloads_head_after_external_change() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -1637,7 +1653,7 @@ fn runtime_control_cache_reloads_head_after_external_change() {
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     writer
-        .create_dir_blocking(&namespace_id, "/docs", CreateDirOptions::default())
+        .create_directory_blocking(&namespace_id, "/docs", CreateDirectoryOptions::default())
         .expect("create docs");
     reader
         .stat_path_blocking(&namespace_id, "/docs")
@@ -1652,7 +1668,11 @@ fn runtime_control_cache_reloads_head_after_external_change() {
     assert_eq!(raw_store.head_get_count(), 0);
 
     writer
-        .create_dir_blocking(&namespace_id, "/docs/new", CreateDirOptions::default())
+        .create_directory_blocking(
+            &namespace_id,
+            "/docs/new",
+            CreateDirectoryOptions::default(),
+        )
         .expect("advance head");
     raw_store.reset_control_get_counts();
     reader
@@ -1670,7 +1690,7 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
         .writer_id("begin-upload-missing-partial-test")
         .build()
         .expect("build runtime");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     assert_core_error_kind(
         fs.begin_upload_blocking(&namespace_id),
@@ -1697,7 +1717,7 @@ fn begin_upload_rejects_malformed_descriptors() {
         .writer_id("begin-upload-malformed-test")
         .build()
         .expect("build runtime");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1760,7 +1780,7 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
 fn explicit_commit_appears_in_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "commit-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1792,7 +1812,7 @@ fn explicit_commit_appears_in_change_feed() {
 fn publish_auto_ticks_maintenance_once_tail_reaches_threshold() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "auto-tick-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
@@ -1825,7 +1845,7 @@ fn publish_auto_ticks_maintenance_once_tail_reaches_threshold() {
 fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "status-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1859,7 +1879,7 @@ fn namespace_status_reports_wal_tail_segments() {
 fn root_stat_and_list_work_immediately_after_namespace_create() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "initial-manifest-read-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1869,7 +1889,7 @@ fn root_stat_and_list_work_immediately_after_namespace_create() {
         .expect("stat root after create");
     assert_eq!(root.absolute_path, "/");
     assert_eq!(root.inode_id, InodeId(1));
-    assert_eq!(root.inode_kind, InodeKind::Dir);
+    assert_eq!(root.inode_kind, InodeKind::Directory);
     assert_eq!(root.head_seq, ChangeSeq(0));
 
     let entries = fs
@@ -1882,7 +1902,7 @@ fn root_stat_and_list_work_immediately_after_namespace_create() {
 fn namespace_status_and_tick_reject_missing_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "missing-status-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     assert_core_error_kind(
         fs.namespace_status_blocking(&namespace_id),
@@ -1903,7 +1923,7 @@ fn namespace_status_and_tick_reject_partial_namespace() {
         .writer_id("partial-status-test")
         .build()
         .expect("build runtime");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1924,7 +1944,7 @@ fn namespace_status_and_tick_reject_partial_namespace() {
 fn maintenance_tick_below_threshold_is_not_needed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-not-needed-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1954,7 +1974,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
 fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-publish-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1994,7 +2014,7 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
 fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-l0-run-publish-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2066,7 +2086,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
 fn maintenance_tick_counts_segments_not_commits() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-segment-count-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2149,7 +2169,7 @@ fn maintenance_tick_counts_segments_not_commits() {
 fn maintenance_tick_rejects_zero_threshold() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-config-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2171,7 +2191,7 @@ fn maintenance_tick_rejects_zero_threshold() {
 #[test]
 fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
         temp_dir.path(),
         namespace_id.as_str(),
@@ -2220,7 +2240,7 @@ fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
 fn checkpoint_and_retention_hooks_are_available() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "maintenance-test");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2246,7 +2266,7 @@ fn separate_runtime_instances_share_object_store_state() {
     let temp_dir = tempdir().expect("tempdir");
     let writer = runtime(temp_dir.path(), "writer");
     let reader = runtime(temp_dir.path(), "reader");
-    let namespace_id = namespace();
+    let namespace_id = namespace_id();
 
     writer
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())


### PR DESCRIPTION
The residual pattern-A/pattern-B naming drift, settled once: builder setters are bare field names (writer_id, metrics_recorder, store_kind); Rust names spell out Directory (InodeKind::Directory with the wire value pinned to "dir" — openapi.json and golden fixtures verified byte-identical), with create_directory/CreateDirectoryOptions rippled through every surface; namespace parameters are namespace_id when typed; CLI dispatch follows one run_noun_verb scheme; the objectstore's fs.rs becomes local_fs_store.rs (compat alias keeps the frozen sim crate untouched); loonfs-api's v0 HTTP shapes consolidate under v0/ submodules with one canonical path per type and a stated root-re-export rule; FsBuilder takes a Duration for lease duration; cp stops parsing move-named args; and loon ls prints the wire kind strings instead of leaked Rust Debug casing ("dir"/"file", the one human-output change). Deliberate skips, each noted in-code: WAL-adjacent enum variant names stay, and WriteOptions.put_behavior keeps its qualifier because the struct also carries delete_behavior.