### PR TITLE
refactor(server): construct explicit runtime handles

### DIFF
--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -102,7 +102,7 @@ pub(super) async fn list_entries(
     let namespace_id = namespace.into_id()?;
     let path = query.path;
     let listing = state
-        .fs
+        .reader
         .list_path_entries_page(
             &namespace_id,
             &path,
@@ -147,7 +147,7 @@ pub(super) async fn stat_entry(
     let namespace_id = namespace.into_id()?;
     let path = query.path;
     let entry = state
-        .fs
+        .reader
         .stat_path(&namespace_id, &path)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -193,11 +193,11 @@ pub(super) async fn get_content(
     let file = match revision_no {
         Some(revision_no) => {
             state
-                .fs
+                .reader
                 .read_file_revision_bytes(&namespace_id, &path, revision_no)
                 .await
         }
-        None => state.fs.read_file_bytes(&namespace_id, &path).await,
+        None => state.reader.read_file_bytes(&namespace_id, &path).await,
     }
     .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok((StatusCode::OK, file.bytes).into_response())
@@ -236,7 +236,7 @@ pub(super) async fn list_path_revisions(
     let namespace_id = namespace.into_id()?;
     let path = query.path;
     let response = state
-        .fs
+        .reader
         .list_file_revisions_page(
             &namespace_id,
             &path,
@@ -284,7 +284,7 @@ pub(super) async fn list_inode_revisions(
     let namespace_id = namespace.into_id()?;
     let inode_id = parse_inode_id(&inode_id)?;
     let response = state
-        .fs
+        .reader
         .list_file_revisions_for_inode_page(
             &namespace_id,
             inode_id,
@@ -334,7 +334,7 @@ pub(super) async fn get_inode_revision_content(
     let inode_id = parse_inode_id(&inode_id)?;
     let revision_no = parse_revision_no(&revision_no)?;
     let bytes = state
-        .fs
+        .reader
         .read_file_revision_bytes_for_inode(&namespace_id, inode_id, revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -606,7 +606,7 @@ pub(super) async fn list_changes(
     let after_seq = loonfs_api::ChangeSeq(query.after_seq);
     let limit = resolve_page_limit(query.limit)?;
     let response = state
-        .fs
+        .reader
         .list_changes_after(
             &namespace_id,
             after_seq,

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -40,7 +40,7 @@ pub(super) async fn config(
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::CapabilityDocument>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let mut capabilities = state.fs.capabilities();
+    let mut capabilities = state.reader.capabilities();
     capabilities.features.insert(
         FEATURE_UPLOADS_DIRECT_PUT.to_owned(),
         state.transfer_issuer.is_some(),
@@ -74,7 +74,7 @@ pub(super) async fn create_namespace(
     authorize(&state.config, &headers)?;
     let namespace_id = parse_namespace_id(request.namespace_id)?;
     let summary = state
-        .fs
+        .writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .map_err(ApiResponseError::runtime)?;
@@ -107,7 +107,7 @@ pub(super) async fn namespace_status(
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let status = state
-        .fs
+        .admin
         .namespace_status(&namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -185,7 +185,7 @@ pub(super) async fn fork_namespace(
     let source_namespace_id = namespace.into_id()?;
     let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
     let summary = state
-        .fs
+        .writer
         .fork_namespace(&source_namespace_id, &new_namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
@@ -219,7 +219,7 @@ pub(super) async fn create_checkpoint(
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let response = state
-        .fs
+        .admin
         .create_checkpoint(&namespace_id)
         .await
         .map_err(ApiResponseError::runtime)?;
@@ -252,7 +252,7 @@ pub(super) async fn advance_retention(
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let response = state
-        .fs
+        .admin
         .advance_retention_floor(&namespace_id)
         .await
         .map_err(ApiResponseError::runtime)?;
@@ -292,7 +292,7 @@ pub(super) async fn gc_namespace(
         reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
     };
     let report = state
-        .fs
+        .admin
         .gc_namespace(&namespace_id, &config)
         .await
         .map_err(ApiResponseError::runtime)?;

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -66,7 +66,7 @@ pub(super) async fn begin_upload(
     }
 
     let response = state
-        .fs
+        .writer
         .begin_upload(&namespace_id, request)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -93,7 +93,7 @@ async fn begin_direct_put_upload(
     };
 
     let prepared = state
-        .fs
+        .writer
         .begin_direct_put_upload_target(&namespace_id, content_ref)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -223,7 +223,7 @@ pub(super) async fn upload_content(
     let upload_id = parse_upload_id(&upload_id)?;
     let bytes = body.to_vec();
     let response = state
-        .fs
+        .writer
         .upload_content(&namespace_id, &upload_id, &bytes)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
@@ -264,7 +264,7 @@ pub(super) async fn complete_upload(
     let namespace_id = namespace.into_id()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let mut response = state
-        .fs
+        .writer
         .complete_upload(&namespace_id, &upload_id, &request)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -47,8 +47,8 @@ use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use loonfs::publisher::PublisherRegistry;
 use loonfs::{
-    ErrorCode, Fs, JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder, SharedObjectStore,
-    TraceMode, TraceStoreKind,
+    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, JsonlObjectStoreMetricsRecorder,
+    ObjectStoreMetricsRecorder, SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::presign::ObjectTransferIssuer;
@@ -60,52 +60,58 @@ use thiserror::Error;
 type SharedStore = SharedObjectStore;
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
 
+/// Purpose-specific handles over one shared store client: read endpoints go
+/// through `reader`, mutations through `writer` (and its publisher),
+/// maintenance endpoints through `admin`.
 #[derive(Clone)]
 struct AppState {
     config: Arc<ServerConfig>,
-    fs: Arc<Fs>,
+    writer: FsWriter,
+    reader: FsReader,
+    admin: FsAdmin,
     publisher: PublisherRegistry,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 }
 
-pub fn app(config: ServerConfig) -> Result<Router, ServerConfigError> {
+pub async fn app(config: ServerConfig) -> Result<Router, ServerConfigError> {
     let store = config.object_store()?;
     let transfer_issuer = store.transfer_issuer();
     let store = Arc::new(store) as SharedStore;
-    app_with_store_and_transfer_issuer(config, store, transfer_issuer)
+    app_with_store_and_transfer_issuer(config, store, transfer_issuer).await
 }
 
 #[cfg(test)]
-fn app_with_store(config: ServerConfig, store: SharedStore) -> Result<Router, ServerConfigError> {
-    app_with_store_and_transfer_issuer(config, store, None)
+async fn app_with_store(
+    config: ServerConfig,
+    store: SharedStore,
+) -> Result<Router, ServerConfigError> {
+    app_with_store_and_transfer_issuer(config, store, None).await
 }
 
-fn app_with_store_and_transfer_issuer(
+async fn app_with_store_and_transfer_issuer(
     config: ServerConfig,
     store: SharedStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<Router, ServerConfigError> {
-    let fs = Arc::new(build_fs(&config, store)?);
-    Ok(app_with_fs(config, fs, transfer_issuer))
-}
-
-fn app_with_fs(
-    config: ServerConfig,
-    fs: Arc<Fs>,
-    transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
-) -> Router {
+    let (writer, reader, admin) = build_handles(&config, store).await?;
     let config = Arc::new(config);
-    let publisher = PublisherRegistry::new(fs.clone());
+    let publisher = PublisherRegistry::new(writer.clone());
     let state = AppState {
         config,
-        fs,
+        writer,
+        reader,
+        admin,
         publisher,
         transfer_issuer,
     };
+    Ok(router(state))
+}
+
+fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
-        // Module-qualified because `app_with_fs`'s `config` parameter shadows
-        // an imported bare handler name in this scope.
+        // Module-qualified because handler modules also export a bare
+        // `config` name in this scope.
         .route("/v0/config", get(handlers_namespace::config))
         .route("/v0/namespaces", post(create_namespace))
         .route(
@@ -165,37 +171,61 @@ fn app_with_fs(
         .with_state(state)
 }
 
-fn build_fs(config: &ServerConfig, store: SharedStore) -> Result<Fs, ServerConfigError> {
-    build_fs_with_metrics_jsonl_path(
+/// Opens the server's runtime handles inside the serving runtime.
+///
+/// The long-lived server writer opts into background maintenance; the
+/// reader shares its caches so read endpoints observe writes immediately;
+/// the admin handle drives the explicit maintenance endpoints under its own
+/// actor identity. All three deliberately share one provider client inside
+/// this one runtime ownership domain.
+async fn build_handles(
+    config: &ServerConfig,
+    store: SharedStore,
+) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
+    build_handles_with_metrics_jsonl_path(
         config,
         store,
         std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
     )
+    .await
 }
 
-fn build_fs_with_metrics_jsonl_path(
+async fn build_handles_with_metrics_jsonl_path(
     config: &ServerConfig,
     store: SharedStore,
     metrics_jsonl_path: Option<OsString>,
-) -> Result<Fs, ServerConfigError> {
+) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
+    let metrics_recorder = object_store_metrics_recorder(metrics_jsonl_path)?;
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
-    let mut builder = Fs::builder(store)
+    let runtime_error = |error: loonfs::RuntimeError| ServerConfigError::InvalidField {
+        field: "runtime",
+        reason: error.to_string(),
+    };
+
+    let mut writer_builder = FsWriter::builder_with_store(store.clone())
         .writer_id(config.writer_id.clone())
         .writer_version(config.writer_version.clone())
+        .background_work(FsBackgroundWork::Enabled)
         .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
-
-    if let Some(recorder) = object_store_metrics_recorder(metrics_jsonl_path)? {
-        builder = builder.metrics_recorder(recorder);
+    if let Some(recorder) = metrics_recorder.clone() {
+        writer_builder = writer_builder.metrics_recorder(recorder);
     }
+    let writer = writer_builder.build().await.map_err(runtime_error)?;
+    let reader = writer.reader();
 
-    builder
-        .build()
-        .map_err(|error| ServerConfigError::InvalidField {
-            field: "runtime",
-            reason: error.to_string(),
-        })
+    let mut admin_builder = FsAdmin::builder_with_store(store)
+        .actor_id(format!("{}-admin", config.writer_id))
+        .actor_version(config.writer_version.clone())
+        .trace_mode(TraceMode::Remote)
+        .trace_store_kind(trace_store_kind);
+    if let Some(recorder) = metrics_recorder {
+        admin_builder = admin_builder.metrics_recorder(recorder);
+    }
+    let admin = admin_builder.build().await.map_err(runtime_error)?;
+
+    Ok((writer, reader, admin))
 }
 
 fn object_store_metrics_recorder(
@@ -242,7 +272,7 @@ pub async fn serve(config: ServerConfig) -> Result<(), ServeError> {
         addr: config.bind.clone(),
         source,
     })?;
-    let app = app(config)?;
+    let app = app(config).await?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -61,7 +61,7 @@ fn error_status_mapping_matches_the_api_spec_table() {
 }
 
 use super::error::status_for_core_error_code;
-use super::{app_with_store, build_fs_with_metrics_jsonl_path, SharedStore};
+use super::{app_with_store, build_handles_with_metrics_jsonl_path, SharedStore};
 use crate::config::RuntimeCacheConfigOverrides;
 use crate::{ServerConfig, StoreConfig};
 use async_trait::async_trait;
@@ -148,8 +148,8 @@ impl ObjectStore for StaleHeadOnceStore {
     }
 }
 
-#[test]
-fn build_fs_installs_jsonl_object_store_metrics_recorder() {
+#[tokio::test]
+async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
     let store_dir = tempdir().expect("store tempdir");
     let metrics_dir = tempdir().expect("metrics tempdir");
     let store = Arc::new(LocalFsStore::new(store_dir.path()).expect("store")) as SharedStore;
@@ -157,19 +157,16 @@ fn build_fs_installs_jsonl_object_store_metrics_recorder() {
     let metrics_path = metrics_dir.path().join("object-store.ndjson");
 
     {
-        let fs = build_fs_with_metrics_jsonl_path(
+        let (writer, _reader, _admin) = build_handles_with_metrics_jsonl_path(
             &config,
             store,
             Some(metrics_path.clone().into_os_string()),
         )
-        .expect("build fs");
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("runtime")
-            .block_on(
-                fs.create_namespace(&namespace_id("metrics"), CreateNamespaceOptions::default()),
-            )
+        .await
+        .expect("build handles");
+        writer
+            .create_namespace(&namespace_id("metrics"), CreateNamespaceOptions::default())
+            .await
             .expect("create namespace");
     }
 
@@ -500,7 +497,7 @@ async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestH
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app_with_store(config, store).expect("build app");
+    let router = app_with_store(config, store).await.expect("build app");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -267,7 +267,7 @@ async fn start_server(config: ServerConfig) -> TestServer {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app(config).expect("build app");
+    let router = app(config).await.expect("build app");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1774,7 +1774,7 @@ async fn start_server(config: ServerConfig) -> TestServer {
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
-    let router = app(config).expect("build app");
+    let router = app(config).await.expect("build app");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -62,6 +62,12 @@ impl FsWriter {
         FsReader::from_core(self.core.clone())
     }
 
+    /// Shared runtime core, for in-crate front-ends like the batching
+    /// publisher.
+    pub(crate) fn core(&self) -> &Fs {
+        &self.core
+    }
+
     /// Returns the capability document for this embedded build (API spec,
     /// "Capability discovery").
     pub fn capabilities(&self) -> CapabilityDocument {

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -53,7 +53,8 @@ async fn coalescing_delay() {
     tokio::time::sleep(COALESCING_DELAY).await;
 }
 
-/// Shared front door to the per-namespace publishers of one [`Fs`].
+/// Shared front door to the per-namespace publishers of one
+/// [`FsWriter`](crate::FsWriter).
 ///
 /// Cloning is cheap; clones share the same per-namespace publishers, so
 /// every writer in the process should submit through clones of one
@@ -61,15 +62,20 @@ async fn coalescing_delay() {
 #[derive(Clone)]
 pub struct PublisherRegistry {
     inner: Arc<Mutex<HashMap<NamespaceId, NamespacePublisher>>>,
-    fs: Arc<Fs>,
+    fs: Fs,
 }
 
 impl PublisherRegistry {
-    /// Creates a registry whose publishers submit batches through `fs`.
-    pub fn new(fs: Arc<Fs>) -> Self {
+    /// Creates a registry whose publishers submit batches through `writer`.
+    ///
+    /// The registry lives in the writer's runtime ownership domain: batches
+    /// publish through the writer's session, and its
+    /// [`FsBackgroundWork`](crate::FsBackgroundWork) policy governs any
+    /// post-publish maintenance.
+    pub fn new(writer: crate::FsWriter) -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),
-            fs,
+            fs: writer.core().clone(),
         }
     }
 
@@ -153,7 +159,7 @@ impl PublisherRegistry {
 #[derive(Clone)]
 struct NamespacePublisher {
     namespace_id: NamespaceId,
-    fs: Arc<Fs>,
+    fs: Fs,
     state: Arc<Mutex<NamespacePublisherState>>,
 }
 
@@ -202,7 +208,7 @@ struct InFlightRequest {
 }
 
 impl NamespacePublisher {
-    fn new(namespace_id: NamespaceId, fs: Arc<Fs>) -> Self {
+    fn new(namespace_id: NamespaceId, fs: Fs) -> Self {
         Self {
             namespace_id,
             fs,
@@ -1210,20 +1216,29 @@ mod tests {
         }
     }
 
-    fn test_fs(store: SharedStore) -> Arc<Fs> {
-        Arc::new(
-            Fs::open(
-                store,
-                FsConfig {
-                    writer_id: "writer-a".to_owned(),
-                    writer_version: "test".to_owned(),
-                    runtime_cache: RuntimeCacheConfig::default(),
-                    trace_mode: TraceMode::Remote,
-                    trace_store_kind: TraceStoreKind::LocalFs,
-                },
-            )
-            .expect("open runtime"),
+    fn test_fs(store: SharedStore) -> Fs {
+        Fs::open(
+            store,
+            FsConfig {
+                writer_id: "writer-a".to_owned(),
+                writer_version: "test".to_owned(),
+                runtime_cache: RuntimeCacheConfig::default(),
+                trace_mode: TraceMode::Remote,
+                trace_store_kind: TraceStoreKind::LocalFs,
+            },
         )
+        .expect("open runtime")
+    }
+
+    async fn test_writer(store: SharedStore) -> crate::FsWriter {
+        crate::FsWriter::builder_with_store(store)
+            .writer_id("writer-a")
+            .writer_version("test")
+            .trace_mode(TraceMode::Remote)
+            .trace_store_kind(TraceStoreKind::LocalFs)
+            .build()
+            .await
+            .expect("build writer")
     }
 
     async fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
@@ -1674,9 +1689,9 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let fs = test_fs(store.clone());
-        create_namespace(&fs, &namespace_id).await;
-        let registry = PublisherRegistry::new(fs);
+        let writer = test_writer(store.clone()).await;
+        create_namespace(writer.core(), &namespace_id).await;
+        let registry = PublisherRegistry::new(writer);
 
         let request_a = CommitRequest {
             commit_id: CommitId::parse("req-a").expect("valid commit id"),
@@ -1716,9 +1731,9 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let fs = test_fs(store.clone());
-        create_namespace(&fs, &namespace_id).await;
-        let upload = fs
+        let writer = test_writer(store.clone()).await;
+        create_namespace(writer.core(), &namespace_id).await;
+        let upload = writer
             .begin_upload(
                 &namespace_id,
                 BeginUploadRequest {
@@ -1728,11 +1743,11 @@ mod tests {
             )
             .await
             .expect("begin upload");
-        let staged = fs
+        let staged = writer
             .upload_content(&namespace_id, &upload.upload_id, b"hello")
             .await
             .expect("stage content");
-        let registry = PublisherRegistry::new(fs);
+        let registry = PublisherRegistry::new(writer);
 
         let explicit = CommitRequest {
             commit_id: CommitId::parse("explicit-commit").expect("valid commit id"),


### PR DESCRIPTION
Server startup now opens the runtime handles it actually means, inside the serving runtime: an `Enabled` `FsWriter` backing the mutation plane and its `PublisherRegistry` (which now fronts a writer rather than a bare `Fs`), a reader derived from that writer so read endpoints keep observing writes through the shared caches, and an `FsAdmin` under a distinct `{writer_id}-admin` actor identity for the admin endpoints. The three deliberately share one provider client inside this single runtime ownership domain.