### PR TITLE
refactor(runtime): retire the all-purpose Fs handle

### DIFF
--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1391,18 +1391,13 @@ fn embedded_capability_document() -> loonfs::CapabilityDocument {
     let store = std::sync::Arc::new(
         loonfs_objectstore::local_fs_store::LocalFsStore::new(temp_dir.path()).expect("store"),
     ) as loonfs::SharedObjectStore;
-    let fs = loonfs::Fs::open(
-        store,
-        loonfs::FsConfig {
-            writer_id: "cli-capability-conformance".to_owned(),
-            writer_version: "test".to_owned(),
-            runtime_cache: loonfs::RuntimeCacheConfig::default(),
-            trace_mode: loonfs::TraceMode::Embedded,
-            trace_store_kind: loonfs::TraceStoreKind::LocalFs,
-        },
-    )
-    .expect("open runtime");
-    fs.capabilities()
+    let reader = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(loonfs::FsReader::builder_with_store(store).build())
+        .expect("build reader");
+    reader.capabilities()
 }
 
 fn assert_cli_command_path_exists(harness: &Harness, command_path: &[&str]) {

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -69,8 +69,7 @@ use axum::body::Bytes;
 use futures::stream::BoxStream;
 use loonfs::ErrorCode;
 use loonfs::{
-    CreateNamespaceOptions, DeleteOptions, Fs, FsConfig, PutFileOptions, RuntimeCacheConfig,
-    TraceMode, TraceStoreKind,
+    CreateNamespaceOptions, DeleteOptions, FsWriter, PutFileOptions, TraceMode, TraceStoreKind,
 };
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
@@ -179,7 +178,7 @@ async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
 async fn runtime_created_state_is_readable_through_http() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-    let fs = test_runtime(store.clone(), "runtime-writer");
+    let fs = test_runtime(store.clone(), "runtime-writer").await;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -215,7 +214,7 @@ async fn runtime_created_state_is_readable_through_http() {
 async fn http_created_state_is_readable_through_runtime() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
-    let fs = test_runtime(store.clone(), "runtime-reader");
+    let fs = test_runtime(store.clone(), "runtime-reader").await;
     let harness = start_server(store.clone(), temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
@@ -233,6 +232,7 @@ async fn http_created_state_is_readable_through_runtime() {
     .expect("join blocking task");
 
     let file = fs
+        .reader()
         .read_file_bytes(
             &NamespaceId::parse("demo").expect("valid namespace id"),
             "/notes/from-http.txt",
@@ -511,18 +511,15 @@ async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestH
     }
 }
 
-fn test_runtime(store: SharedStore, writer_id: &str) -> Fs {
-    Fs::open(
-        store,
-        FsConfig {
-            writer_id: writer_id.to_owned(),
-            writer_version: format!("{writer_id}/0.1.0"),
-            runtime_cache: RuntimeCacheConfig::default(),
-            trace_mode: TraceMode::Remote,
-            trace_store_kind: TraceStoreKind::LocalFs,
-        },
-    )
-    .expect("open runtime")
+async fn test_runtime(store: SharedStore, writer_id: &str) -> FsWriter {
+    FsWriter::builder_with_store(store)
+        .writer_id(writer_id)
+        .writer_version(format!("{writer_id}/0.1.0"))
+        .trace_mode(TraceMode::Remote)
+        .trace_store_kind(TraceStoreKind::LocalFs)
+        .build()
+        .await
+        .expect("build writer")
 }
 
 fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
@@ -547,16 +544,17 @@ async fn bootstrap_namespace(
     store: &SharedStore,
     writer_id: &str,
     namespace_id: &NamespaceId,
-) -> Fs {
-    let fs = test_runtime(store.clone(), writer_id);
-    fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+) -> FsWriter {
+    let writer = test_runtime(store.clone(), writer_id).await;
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("bootstrap namespace");
-    fs
+    writer
 }
 
 async fn write_file_bytes(
-    fs: &Fs,
+    fs: &FsWriter,
     namespace_id: &NamespaceId,
     absolute_path: &str,
     bytes: &[u8],
@@ -576,7 +574,7 @@ async fn write_file_bytes(
 }
 
 async fn delete_path_recursive(
-    fs: &Fs,
+    fs: &FsWriter,
     namespace_id: &NamespaceId,
     absolute_path: &str,
     commit_id: &str,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -1,10 +1,10 @@
 //! Runtime caching: control-object reads, WAL-tail projections, and
-//! per-namespace commit-engine serialization, plus the cache-management half of [`Fs`].
+//! per-namespace commit-engine serialization, plus the cache-management half of [`FsCore`].
 //!
 //! Every cache revalidates against durable state before its contents are
 //! used; nothing here weakens read-after-write consistency.
 
-use crate::fs::{should_invalidate_after_result, Fs};
+use crate::fs::{should_invalidate_after_result, FsCore};
 use crate::{CommitResponse, CoreError, NamespaceId};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
@@ -239,7 +239,7 @@ impl RuntimeControlCache {
     }
 }
 
-impl Fs {
+impl FsCore {
     pub(crate) async fn load_namespace_head_cached(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -15,9 +15,9 @@ pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize = 1_000_000;
 /// Default decoded-byte budget for cached WAL-tail projections.
 pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize = 256 * 1024 * 1024;
 
-/// Configuration for an embedded runtime instance.
+/// Configuration for one runtime core, assembled by the handle builders.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FsConfig {
+pub(crate) struct FsConfig {
     /// Writer id used for namespace epoch acquisition and commits.
     pub writer_id: String,
     /// Writer version reported in mutation context.
@@ -28,19 +28,6 @@ pub struct FsConfig {
     pub trace_mode: TraceMode,
     /// Object-store kind label used by tracing.
     pub trace_store_kind: TraceStoreKind,
-}
-
-impl FsConfig {
-    /// Builds a config with default runtime settings.
-    pub fn new(writer_id: impl Into<String>) -> Self {
-        Self {
-            writer_id: writer_id.into(),
-            writer_version: default_writer_version(),
-            runtime_cache: RuntimeCacheConfig::default(),
-            trace_mode: TraceMode::Embedded,
-            trace_store_kind: TraceStoreKind::Unknown,
-        }
-    }
 }
 
 /// Cache configuration for the embedded runtime.

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -1,25 +1,23 @@
-//! The embedded runtime handle: [`Fs`], its builder, and the public
-//! operation surface, each method a thin, cache-aware delegation to
-//! `loonfs-core`.
+//! The shared runtime core behind the purpose-specific handles: caches,
+//! writer session identity, and the operation surface, each method a thin,
+//! cache-aware delegation to `loonfs-core`.
 
-use crate::background::{BackgroundWork, FsBackgroundWork};
+use crate::background::BackgroundWork;
 use crate::cache::{CommitEngineCache, RuntimeCacheStatsInner, RuntimeControlCache};
-use crate::config::{default_writer_version, validate_config};
+use crate::config::{validate_config, FsConfig};
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use crate::time::current_time_ms;
-use crate::trace::{TraceMode, TraceStoreKind};
 use crate::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry,
     BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse, ChangeSeq,
     ChangesResponse, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions, CoreError,
     CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions,
-    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsConfig, InodeId,
+    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, InodeId,
     ListChangesOptions, ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
     MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, ObjectStore, ObjectStoreMetricsRecorder,
-    PutFileOptions, RestoreRevisionOptions, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats,
-    UploadContentResponse,
+    NamespaceStatusResponse, NamespaceSummary, ObjectStore, PutFileOptions, RestoreRevisionOptions,
+    RevisionNo, RuntimeCacheStats, UploadContentResponse,
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
@@ -34,19 +32,16 @@ use loonfs_core::cache::{
     WalTailProjectionCacheConfig,
 };
 use loonfs_core::{MutationContext, NamespaceEngine};
-use loonfs_objectstore::metrics::InstrumentedObjectStore;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-/// Embedded filesystem runtime.
+/// Shared runtime core. [`FsWriter`](crate::FsWriter),
+/// [`FsReader`](crate::FsReader), and [`FsAdmin`](crate::FsAdmin) each wrap
+/// one; handles derived from the same core share its caches and store.
 ///
-/// `Fs` is cheap to clone. Clones share caches and the underlying object store.
-///
-/// This all-purpose handle is transitional: new code should open a
-/// purpose-specific [`FsWriter`](crate::FsWriter),
-/// [`FsReader`](crate::FsReader), or [`FsAdmin`](crate::FsAdmin) instead.
+/// `FsCore` is cheap to clone.
 #[derive(Clone)]
-pub struct Fs {
+pub(crate) struct FsCore {
     pub(crate) inner: Arc<FsInner>,
 }
 
@@ -81,109 +76,7 @@ impl FsInner {
     }
 }
 
-/// Builder for [`Fs`].
-pub struct FsBuilder {
-    store: SharedObjectStore,
-    writer_id: Option<String>,
-    writer_version: String,
-    runtime_cache: RuntimeCacheConfig,
-    trace_mode: TraceMode,
-    trace_store_kind: TraceStoreKind,
-    metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
-}
-
-impl FsBuilder {
-    /// Starts an embedded runtime builder.
-    pub fn new(store: SharedObjectStore) -> Self {
-        Self {
-            store,
-            writer_id: None,
-            writer_version: default_writer_version(),
-            runtime_cache: RuntimeCacheConfig::default(),
-            trace_mode: TraceMode::Embedded,
-            trace_store_kind: TraceStoreKind::Unknown,
-            metrics_recorder: None,
-        }
-    }
-
-    /// Sets the writer id used by namespace mutations.
-    pub fn writer_id(mut self, writer_id: impl Into<String>) -> Self {
-        self.writer_id = Some(writer_id.into());
-        self
-    }
-
-    /// Sets the writer version used in mutation context.
-    pub fn writer_version(mut self, writer_version: impl Into<String>) -> Self {
-        self.writer_version = writer_version.into();
-        self
-    }
-
-    /// Sets runtime cache behavior.
-    pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
-        self.runtime_cache = runtime_cache;
-        self
-    }
-
-    /// Sets the tracing mode label.
-    pub fn trace_mode(mut self, trace_mode: TraceMode) -> Self {
-        self.trace_mode = trace_mode;
-        self
-    }
-
-    /// Sets the object-store kind label used by tracing and metrics.
-    pub fn trace_store_kind(mut self, trace_store_kind: TraceStoreKind) -> Self {
-        self.trace_store_kind = trace_store_kind;
-        self
-    }
-
-    /// Installs object-store metrics collection for this runtime.
-    ///
-    /// The runtime wraps the provided object store before opening `Fs`; callers do not need to
-    /// manually construct an instrumented store.
-    pub fn metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
-        self.metrics_recorder = Some(recorder);
-        self
-    }
-
-    /// Opens the runtime.
-    pub fn build(self) -> Result<Fs> {
-        let writer_id = self
-            .writer_id
-            .ok_or_else(|| RuntimeError::Config("writer_id is required".to_owned()))?;
-        let trace_store_kind = self.trace_store_kind;
-        let store = match self.metrics_recorder {
-            Some(recorder) => Arc::new(
-                InstrumentedObjectStore::new(self.store, recorder)
-                    .store_kind(trace_store_kind.as_str()),
-            ) as SharedObjectStore,
-            None => self.store,
-        };
-        Fs::open(
-            store,
-            FsConfig {
-                writer_id,
-                writer_version: self.writer_version,
-                runtime_cache: self.runtime_cache,
-                trace_mode: self.trace_mode,
-                trace_store_kind,
-            },
-        )
-    }
-}
-
-impl Fs {
-    /// Opens an embedded runtime from an object store and config.
-    pub fn open(store: SharedObjectStore, config: FsConfig) -> Result<Self> {
-        // The all-purpose handle keeps post-publish maintenance on, spawned
-        // on whichever runtime drives the triggering write. Purpose-specific
-        // handles pin their owning runtime instead.
-        Self::open_with_background(
-            store,
-            config,
-            BackgroundWork::new(FsBackgroundWork::Enabled, None),
-        )
-    }
-
+impl FsCore {
     pub(crate) fn open_with_background(
         store: SharedObjectStore,
         config: FsConfig,
@@ -217,13 +110,8 @@ impl Fs {
         })
     }
 
-    /// Starts a runtime builder.
-    pub fn builder(store: SharedObjectStore) -> FsBuilder {
-        FsBuilder::new(store)
-    }
-
     /// Returns this runtime's config.
-    pub fn config(&self) -> &FsConfig {
+    pub(crate) fn config(&self) -> &FsConfig {
         &self.inner.config
     }
 
@@ -236,7 +124,7 @@ impl Fs {
     ///
     /// With `options.allow_existing`, an already-existing namespace is
     /// treated as success.
-    pub async fn create_namespace(
+    pub(crate) async fn create_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
@@ -254,7 +142,7 @@ impl Fs {
     /// Forks `source` into `target` at the source's current head.
     ///
     /// The fork shares immutable file bytes but gets its own metadata history.
-    pub async fn fork_namespace(
+    pub(crate) async fn fork_namespace(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
@@ -278,7 +166,7 @@ impl Fs {
     /// swap stay committed; reads, writes, forks, and re-creation of the id
     /// fail with `namespace_deleted` afterward. Deletion does not reclaim
     /// storage; reclamation is future maintenance work.
-    pub async fn delete_namespace(
+    pub(crate) async fn delete_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: DeleteNamespaceOptions,
@@ -304,7 +192,7 @@ impl Fs {
     /// constant. Callers should still gate on the document rather than on
     /// the backend kind, so the same logic works against remote deployments
     /// that implement less.
-    pub fn capabilities(&self) -> CapabilityDocument {
+    pub(crate) fn capabilities(&self) -> CapabilityDocument {
         CapabilityDocument {
             protocol_version: PROTOCOL_VERSION.to_owned(),
             profiles: vec![PROFILE_CORE_V0.to_owned(), PROFILE_ADMIN_V0.to_owned()],
@@ -320,7 +208,7 @@ impl Fs {
 
     /// Summarizes a namespace's current head: manifest, latest checkpoint,
     /// WAL tail, and retention floor.
-    pub async fn namespace_status(
+    pub(crate) async fn namespace_status(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse> {
@@ -351,7 +239,7 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn maintenance_tick_namespace(
+    pub(crate) async fn maintenance_tick_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
@@ -432,7 +320,7 @@ impl Fs {
     ///
     /// Never runs implicitly: callers opt in here or through
     /// [`MaintenanceTickOptions::gc`].
-    pub async fn gc_namespace(
+    pub(crate) async fn gc_namespace(
         &self,
         namespace_id: &NamespaceId,
         config: &crate::GcConfig,
@@ -461,7 +349,7 @@ impl Fs {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub async fn stat_path(
+    pub(crate) async fn stat_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -485,7 +373,7 @@ impl Fs {
     /// Lists the children of a directory path.
     ///
     /// Entries-only convenience over [`Self::list_path_entries`].
-    pub async fn list_path(
+    pub(crate) async fn list_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -501,7 +389,7 @@ impl Fs {
     /// The envelope and every entry come from one consistent head, so an
     /// empty directory still reports which state answered the question. Entries
     /// are returned in canonical name-key order, matching paged listings.
-    pub async fn list_path_entries(
+    pub(crate) async fn list_path_entries(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -535,7 +423,7 @@ impl Fs {
     }
 
     /// Lists one page of a directory together with the head the page was read from.
-    pub async fn list_path_entries_page(
+    pub(crate) async fn list_path_entries_page(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -586,7 +474,7 @@ impl Fs {
     }
 
     /// Reads a file's current content plus the metadata entry it came from.
-    pub async fn read_file_bytes(
+    pub(crate) async fn read_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -602,7 +490,7 @@ impl Fs {
     }
 
     /// Lists the revision history of a file path.
-    pub async fn list_file_revisions(
+    pub(crate) async fn list_file_revisions(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -618,7 +506,7 @@ impl Fs {
     }
 
     /// Lists one page of a file path's revision history.
-    pub async fn list_file_revisions_page(
+    pub(crate) async fn list_file_revisions_page(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -642,7 +530,7 @@ impl Fs {
 
     /// Lists a file's revision history by inode id, independent of its
     /// current path.
-    pub async fn list_file_revisions_for_inode(
+    pub(crate) async fn list_file_revisions_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -658,7 +546,7 @@ impl Fs {
     }
 
     /// Lists one page of a file inode's revision history.
-    pub async fn list_file_revisions_for_inode_page(
+    pub(crate) async fn list_file_revisions_for_inode_page(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -684,7 +572,7 @@ impl Fs {
     }
 
     /// Reads the content of one historical file revision by path.
-    pub async fn read_file_revision_bytes(
+    pub(crate) async fn read_file_revision_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -701,7 +589,7 @@ impl Fs {
     }
 
     /// Reads the content of one historical file revision by inode id.
-    pub async fn read_file_revision_bytes_for_inode(
+    pub(crate) async fn read_file_revision_bytes_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -734,7 +622,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub async fn put_file_bytes(
+    pub(crate) async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -782,7 +670,7 @@ impl Fs {
             payload_class = tracing::field::Empty,
         )
     )]
-    pub async fn put_file_content_ref(
+    pub(crate) async fn put_file_content_ref(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -810,7 +698,7 @@ impl Fs {
     }
 
     /// Creates a directory at an absolute path.
-    pub async fn create_directory(
+    pub(crate) async fn create_directory(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -830,7 +718,7 @@ impl Fs {
     ///
     /// Deletion is tombstone-first: the commit hides the path without erasing
     /// history. Physical reclamation is background garbage collection.
-    pub async fn delete_path(
+    pub(crate) async fn delete_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -848,7 +736,7 @@ impl Fs {
     }
 
     /// Moves a path within the same namespace.
-    pub async fn move_path(
+    pub(crate) async fn move_path(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -869,7 +757,7 @@ impl Fs {
 
     /// Copies a file to a new path in the same namespace. The new file
     /// reuses the source revision's content reference: no bytes are copied.
-    pub async fn copy_path(
+    pub(crate) async fn copy_path(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
@@ -888,7 +776,7 @@ impl Fs {
     }
 
     /// Restores a prior file revision by appending a new current revision.
-    pub async fn restore_file_revision(
+    pub(crate) async fn restore_file_revision(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -912,7 +800,7 @@ impl Fs {
     /// The commit appends a new current revision from `source_revision_no`
     /// and fails if the inode's current revision is no longer
     /// `base_revision_no`.
-    pub async fn restore_file_revision_for_inode(
+    pub(crate) async fn restore_file_revision_for_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
@@ -938,7 +826,7 @@ impl Fs {
     }
 
     /// Starts a durable upload session for a namespace.
-    pub async fn begin_upload(
+    pub(crate) async fn begin_upload(
         &self,
         namespace_id: &NamespaceId,
         request: BeginUploadRequest,
@@ -950,7 +838,7 @@ impl Fs {
     }
 
     /// Starts a direct_put upload session and returns the internal target for server-side signing.
-    pub async fn begin_direct_put_upload_target(
+    pub(crate) async fn begin_direct_put_upload_target(
         &self,
         namespace_id: &NamespaceId,
         content_ref: ContentRef,
@@ -962,7 +850,7 @@ impl Fs {
     }
 
     /// Uploads whole-file content into an upload session.
-    pub async fn upload_content(
+    pub(crate) async fn upload_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -975,7 +863,7 @@ impl Fs {
     }
 
     /// Completes an upload session when the expected content ref matches.
-    pub async fn complete_upload(
+    pub(crate) async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
@@ -991,7 +879,7 @@ impl Fs {
     ///
     /// This is the lower-level surface for clients that need their own commit
     /// ids, preconditions, and operation lists.
-    pub async fn commit_operations(
+    pub(crate) async fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
@@ -1012,7 +900,7 @@ impl Fs {
 
     /// Submits explicit semantic commit requests as one publication attempt,
     /// returning one result per request in order.
-    pub async fn commit_operations_batch(
+    pub(crate) async fn commit_operations_batch(
         &self,
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
@@ -1054,7 +942,7 @@ impl Fs {
     ///
     /// Server code uses this to push path intents and explicit commits
     /// through one namespace publisher; results match candidates in order.
-    pub async fn publish_namespace_mutations_batch(
+    pub(crate) async fn publish_namespace_mutations_batch(
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
@@ -1165,7 +1053,7 @@ impl Fs {
     /// Call this to quiesce before shutdown, or in tests that assert on
     /// post-maintenance state. Panicked ticks surface as a runtime-task
     /// error.
-    pub async fn wait_for_background_maintenance(&self) -> Result<()> {
+    pub(crate) async fn wait_for_background_maintenance(&self) -> Result<()> {
         self.inner.background.drain().await
     }
 
@@ -1175,7 +1063,7 @@ impl Fs {
     }
 
     /// Snapshots the runtime cache counters.
-    pub fn runtime_cache_stats(&self) -> RuntimeCacheStats {
+    pub(crate) fn runtime_cache_stats(&self) -> RuntimeCacheStats {
         self.inner.cache_stats.snapshot(
             self.inner.metadata_table_cache.stats(),
             self.inner.wal_tail_projection_cache.stats(),
@@ -1183,7 +1071,7 @@ impl Fs {
     }
 
     /// Reads the ordered change feed after the `after_seq` cursor.
-    pub async fn list_changes_after(
+    pub(crate) async fn list_changes_after(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
@@ -1218,7 +1106,7 @@ impl Fs {
             store_kind = tracing::field::Empty,
         )
     )]
-    pub async fn create_checkpoint(
+    pub(crate) async fn create_checkpoint(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
@@ -1234,7 +1122,7 @@ impl Fs {
 
     /// Advances the namespace retention floor when a verified checkpoint
     /// makes it safe.
-    pub async fn advance_retention_floor(
+    pub(crate) async fn advance_retention_floor(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
@@ -1285,7 +1173,7 @@ impl Fs {
 /// on completion, panic, or a task discarded with its runtime — releases the
 /// namespace for the next scheduling decision.
 struct BackgroundTickClaim {
-    fs: Fs,
+    fs: FsCore,
     namespace_id: NamespaceId,
 }
 

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -3,7 +3,7 @@
 use super::HandleBuilderCore;
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
-use crate::fs::Fs;
+use crate::fs::FsCore;
 use crate::{
     AdvanceRetentionResponse, CreateCheckpointResponse, GcConfig, GcReport, MaintenanceTickOptions,
     MaintenanceTickResult, NamespaceId, NamespaceStatusResponse, ObjectStoreMetricsRecorder,
@@ -23,7 +23,7 @@ use std::sync::Arc;
 /// `actor_id` for tracing, reports, and auditability.
 #[derive(Clone)]
 pub struct FsAdmin {
-    core: Fs,
+    core: FsCore,
 }
 
 impl FsAdmin {

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -27,10 +27,11 @@ pub use reader::{FsReader, FsReaderBuilder};
 pub use writer::{FsWriter, FsWriterBuilder};
 
 use crate::background::BackgroundWork;
-use crate::fs::Fs;
+use crate::config::FsConfig;
+use crate::fs::FsCore;
 use crate::{
-    FsConfig, ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError,
-    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
+    StoreConfig, TraceMode, TraceStoreKind,
 };
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
 use std::sync::Arc;
@@ -77,7 +78,7 @@ impl HandleBuilderCore {
         writer_id: String,
         writer_version: String,
         background: BackgroundWork,
-    ) -> Result<Fs> {
+    ) -> Result<FsCore> {
         let (store, derived_kind) = match self.source {
             StoreSource::Config(config) => {
                 let kind = TraceStoreKind::from(config.kind());
@@ -95,7 +96,7 @@ impl HandleBuilderCore {
             ) as SharedObjectStore,
             None => store,
         };
-        Fs::open_with_background(
+        FsCore::open_with_background(
             store,
             FsConfig {
                 writer_id,

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -3,7 +3,7 @@
 use super::HandleBuilderCore;
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
-use crate::fs::Fs;
+use crate::fs::FsCore;
 use crate::{
     AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, ChangesResponse,
     DirectoryPageCursor, FileRevisionsPageCursor, InodeId, ListChangesOptions,
@@ -26,7 +26,7 @@ use std::sync::Arc;
 /// Tokio runtime that will drive its reads. `FsReader` is cheap to clone.
 #[derive(Clone)]
 pub struct FsReader {
-    core: Fs,
+    core: FsCore,
 }
 
 impl FsReader {
@@ -46,7 +46,7 @@ impl FsReader {
     }
 
     /// Wraps a shared runtime core; used by [`FsWriter::reader`](crate::FsWriter::reader).
-    pub(super) fn from_core(core: Fs) -> Self {
+    pub(super) fn from_core(core: FsCore) -> Self {
         Self { core }
     }
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -3,7 +3,7 @@
 use super::{owning_runtime, FsReader, HandleBuilderCore};
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
-use crate::fs::Fs;
+use crate::fs::FsCore;
 use crate::publish::NamespaceMutationCandidate;
 use crate::{
     BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse,
@@ -33,7 +33,7 @@ use std::sync::Arc;
 /// background-work state.
 #[derive(Clone)]
 pub struct FsWriter {
-    core: Fs,
+    core: FsCore,
 }
 
 impl FsWriter {
@@ -64,7 +64,7 @@ impl FsWriter {
 
     /// Shared runtime core, for in-crate front-ends like the batching
     /// publisher.
-    pub(crate) fn core(&self) -> &Fs {
+    pub(crate) fn core(&self) -> &FsCore {
         &self.core
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -25,8 +25,7 @@
 //!
 //! LoonFS never creates a hidden maintenance runtime: any background work a
 //! handle starts is spawned on that handle's owning runtime, and each handle
-//! has an async `close()` that settles what it owns. The all-purpose [`Fs`]
-//! handle remains as a transitional facade; new code should pick a handle.
+//! has an async `close()` that settles what it owns.
 #![warn(missing_docs)]
 
 mod background;
@@ -67,7 +66,7 @@ pub use loonfs_core::{
 /// Integration seam: the vocabulary for handing classified mutation work to
 /// the runtime's batch publication surface. The server's filesystem
 /// handlers build [`publish::PathMutationIntent`]s for the [`publisher`]
-/// front-end, and [`Fs::publish_namespace_mutations_batch`] accepts
+/// front-end, and [`FsWriter::publish_namespace_mutations_batch`] accepts
 /// [`publish::NamespaceMutationCandidate`]s directly. Most embedded users
 /// never need this module.
 pub mod publish {
@@ -91,11 +90,10 @@ pub use loonfs_objectstore::{ObjectStore, ObjectStoreError, SharedObjectStore, S
 pub use background::FsBackgroundWork;
 pub use cache::RuntimeCacheStats;
 pub use config::{
-    FsConfig, RuntimeCacheConfig, DEFAULT_MAX_CACHED_NAMESPACES,
+    RuntimeCacheConfig, DEFAULT_MAX_CACHED_NAMESPACES,
     DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES,
     DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS, DEFAULT_MAX_WAL_TAIL_SEGMENTS,
 };
-pub use fs::{Fs, FsBuilder};
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use options::{
     CopyOptions, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -1,4 +1,4 @@
-//! Per-operation option and result types for the [`Fs`] surface.
+//! Per-operation option and result types for the runtime handle surface.
 
 use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -17,10 +17,11 @@
 //! - paces successive head compare-and-swap attempts per namespace.
 //!
 //! Use it when one process hosts many concurrent writers to the same
-//! namespaces: the reference server constructs a registry over its shared
-//! [`Fs`], and an embedded host with many in-process writer agents can do
-//! exactly the same. A solo writer does not need it — the direct [`Fs`]
-//! mutation methods publish immediately, while this front-end deliberately
+//! namespaces: the reference server constructs a registry over its
+//! [`FsWriter`](crate::FsWriter), and an embedded host with many in-process
+//! writer agents can do exactly the same. A solo writer does not need it —
+//! the direct [`FsWriter`](crate::FsWriter) mutation methods publish
+//! immediately, while this front-end deliberately
 //! trades latency for batching: every submission waits out a 100ms
 //! coalescing window (`COALESCING_DELAY`) so concurrent requests share one
 //! publication, and publications for one namespace are paced at least 1s
@@ -28,8 +29,9 @@
 //! into larger batches instead of thrashing head compare-and-swaps.
 
 use crate::content_tokens::ContentAdmission;
+use crate::fs::FsCore;
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
-use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, Fs, RuntimeError};
+use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeError};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, NamespaceId};
 use loonfs_core::commit::{CommitHeadPublishError, SemanticMutationIdentity};
@@ -62,7 +64,7 @@ async fn coalescing_delay() {
 #[derive(Clone)]
 pub struct PublisherRegistry {
     inner: Arc<Mutex<HashMap<NamespaceId, NamespacePublisher>>>,
-    fs: Fs,
+    fs: FsCore,
 }
 
 impl PublisherRegistry {
@@ -159,7 +161,7 @@ impl PublisherRegistry {
 #[derive(Clone)]
 struct NamespacePublisher {
     namespace_id: NamespaceId,
-    fs: Fs,
+    fs: FsCore,
     state: Arc<Mutex<NamespacePublisherState>>,
 }
 
@@ -208,7 +210,7 @@ struct InFlightRequest {
 }
 
 impl NamespacePublisher {
-    fn new(namespace_id: NamespaceId, fs: Fs) -> Self {
+    fn new(namespace_id: NamespaceId, fs: FsCore) -> Self {
         Self {
             namespace_id,
             fs,
@@ -865,8 +867,10 @@ mod tests {
     // Publisher tests use panic in async result helpers for precise diagnostics.
 
     use super::*;
+    use crate::background::{BackgroundWork, FsBackgroundWork};
+    use crate::config::FsConfig;
     use crate::{
-        BeginUploadRequest, CreateNamespaceOptions, ErrorCode, FsConfig, RuntimeCacheConfig,
+        BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
         SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
     };
     use async_trait::async_trait;
@@ -1216,8 +1220,8 @@ mod tests {
         }
     }
 
-    fn test_fs(store: SharedStore) -> Fs {
-        Fs::open(
+    fn test_fs(store: SharedStore) -> FsCore {
+        FsCore::open_with_background(
             store,
             FsConfig {
                 writer_id: "writer-a".to_owned(),
@@ -1226,6 +1230,7 @@ mod tests {
                 trace_mode: TraceMode::Remote,
                 trace_store_kind: TraceStoreKind::LocalFs,
             },
+            BackgroundWork::new(FsBackgroundWork::ManualOnly, None),
         )
         .expect("open runtime")
     }
@@ -1241,7 +1246,7 @@ mod tests {
             .expect("build writer")
     }
 
-    async fn create_namespace(fs: &Fs, namespace_id: &NamespaceId) {
+    async fn create_namespace(fs: &FsCore, namespace_id: &NamespaceId) {
         fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("bootstrap");

--- a/crates/loonfs/tests/capability_conformance.rs
+++ b/crates/loonfs/tests/capability_conformance.rs
@@ -1,13 +1,10 @@
 //! Pins the capability registry's three copies to each other: the constants
-//! in `loonfs-api`, the document built by [`Fs::capabilities`], and the
+//! in `loonfs-api`, the document the runtime handles advertise, and the
 //! normative text in `docs/specs/api.md`. If any copy drifts, this fails.
 #![allow(clippy::panic)]
 // Spec parsing panics with precise messages when a section is missing.
 
-use loonfs::{
-    CapabilityDocument, Fs, FsConfig, RuntimeCacheConfig, SharedObjectStore, TraceMode,
-    TraceStoreKind,
-};
+use loonfs::{CapabilityDocument, FsReader, SharedObjectStore};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -18,18 +15,13 @@ const API_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/spe
 fn embedded_capabilities() -> CapabilityDocument {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
-    let fs = Fs::open(
-        store,
-        FsConfig {
-            writer_id: "capability-conformance".to_owned(),
-            writer_version: "test".to_owned(),
-            runtime_cache: RuntimeCacheConfig::default(),
-            trace_mode: TraceMode::Embedded,
-            trace_store_kind: TraceStoreKind::LocalFs,
-        },
-    )
-    .expect("open runtime");
-    fs.capabilities()
+    let reader = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(FsReader::builder_with_store(store).build())
+        .expect("build reader");
+    reader.capabilities()
 }
 
 fn spec_section<'a>(spec: &'a str, start: &str, end: &str) -> &'a str {
@@ -58,7 +50,7 @@ fn embedded_capability_document_matches_the_spec_example() {
     document.validate().expect("document is well-formed");
     assert_eq!(
         document, expected,
-        "Fs::capabilities() drifted from the api.md section 2.1 example"
+        "the advertised capability document drifted from the api.md section 2.1 example"
     );
 }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -9,11 +9,12 @@ use loonfs::{
     BeginUploadResponse, ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest,
     CommitResponse, CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
     CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
-    DirectoryPageCursor, ErrorCode, Fs, FsConfig, InodeId, InodeKind, ListChangesOptions,
-    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
-    MutationResult, NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy,
-    PutBehavior, PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceMode,
-    TraceStoreKind, UploadContentResponse, UploadId,
+    DirectoryPageCursor, ErrorCode, FsAdmin, FsReader, FsWriter, FsWriterBuilder, InodeId,
+    InodeKind, ListChangesOptions, MaintenanceTickOptions, MaintenanceTickOutcome,
+    MaintenanceTickResult, ManifestId, MoveOptions, MutationResult, NamespaceId,
+    NamespaceStatusResponse, PageRequest, PaginationPolicy, PutBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind, UploadContentResponse,
+    UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_head};
@@ -32,11 +33,172 @@ fn store(root: &Path) -> SharedObjectStore {
     Arc::new(LocalFsStore::new(root).expect("create local-fs store"))
 }
 
-fn runtime(root: &Path, writer_id: &str) -> Fs {
-    Fs::builder(store(root))
-        .writer_id(writer_id)
+/// One handle set per test fixture: a writer, its derived reader, and an
+/// admin handle sharing the same store, exercised through the blocking
+/// helpers below.
+struct TestRuntime {
+    writer: FsWriter,
+    reader: FsReader,
+    admin: FsAdmin,
+}
+
+fn runtime(root: &Path, writer_id: &str) -> TestRuntime {
+    open_runtime(store(root), writer_id)
+}
+
+fn open_runtime(store: SharedObjectStore, writer_id: &str) -> TestRuntime {
+    open_runtime_with(store, writer_id, |builder| builder)
+}
+
+fn open_runtime_with(
+    store: SharedObjectStore,
+    writer_id: &str,
+    configure: impl FnOnce(FsWriterBuilder) -> FsWriterBuilder,
+) -> TestRuntime {
+    block_on(open_runtime_with_async(store, writer_id, configure))
+}
+
+/// Async-test variant: opens the fixture inside the test's own runtime.
+async fn open_runtime_async(store: SharedObjectStore, writer_id: &str) -> TestRuntime {
+    open_runtime_with_async(store, writer_id, |builder| builder).await
+}
+
+async fn open_runtime_with_async(
+    store: SharedObjectStore,
+    writer_id: &str,
+    configure: impl FnOnce(FsWriterBuilder) -> FsWriterBuilder,
+) -> TestRuntime {
+    let writer = configure(FsWriter::builder_with_store(store.clone()).writer_id(writer_id))
         .build()
-        .expect("build runtime")
+        .await
+        .expect("build writer");
+    let reader = writer.reader();
+    let admin = FsAdmin::builder_with_store(store)
+        .actor_id(writer_id)
+        .build()
+        .await
+        .expect("build admin");
+    TestRuntime {
+        writer,
+        reader,
+        admin,
+    }
+}
+
+/// Direct async access for tests that drive several operations inside one
+/// runtime; everything else goes through the blocking trait below.
+impl TestRuntime {
+    async fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+        options: CreateNamespaceOptions,
+    ) -> loonfs::Result<loonfs::NamespaceSummary> {
+        self.writer.create_namespace(namespace_id, options).await
+    }
+
+    async fn put_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        bytes: &[u8],
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult> {
+        self.writer
+            .put_file_bytes(namespace_id, absolute_path, bytes, options)
+            .await
+    }
+
+    async fn put_file_content_ref(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        content_ref: ContentRef,
+        options: PutFileOptions,
+    ) -> loonfs::Result<MutationResult> {
+        self.writer
+            .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
+            .await
+    }
+
+    async fn stat_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<AuthoritativePathEntry> {
+        self.reader.stat_path(namespace_id, absolute_path).await
+    }
+
+    async fn list_path(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
+        self.reader.list_path(namespace_id, absolute_path).await
+    }
+
+    async fn list_path_entries(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
+        self.reader
+            .list_path_entries(namespace_id, absolute_path)
+            .await
+    }
+
+    async fn list_path_entries_page(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<DirectoryPageCursor>,
+    ) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
+        self.reader
+            .list_path_entries_page(namespace_id, absolute_path, request)
+            .await
+    }
+
+    async fn list_file_revisions_page(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<loonfs::FileRevisionsPageCursor>,
+    ) -> loonfs::Result<loonfs::ListFileRevisionsResponse> {
+        self.reader
+            .list_file_revisions_page(namespace_id, absolute_path, request)
+            .await
+    }
+
+    async fn list_file_revisions_for_inode_page(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        request: PageRequest<loonfs::FileRevisionsPageCursor>,
+    ) -> loonfs::Result<loonfs::ListFileRevisionsResponse> {
+        self.reader
+            .list_file_revisions_for_inode_page(namespace_id, inode_id, request)
+            .await
+    }
+
+    async fn create_checkpoint(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs::Result<CreateCheckpointResponse> {
+        self.admin.create_checkpoint(namespace_id).await
+    }
+
+    async fn begin_direct_put_upload_target(
+        &self,
+        namespace_id: &NamespaceId,
+        content_ref: ContentRef,
+    ) -> loonfs::Result<loonfs::BeginDirectPutUploadTargetResponse> {
+        self.writer
+            .begin_direct_put_upload_target(namespace_id, content_ref)
+            .await
+    }
+
+    fn runtime_cache_stats(&self) -> loonfs::RuntimeCacheStats {
+        self.writer.runtime_cache_stats()
+    }
 }
 
 fn namespace_id() -> NamespaceId {
@@ -182,13 +344,13 @@ trait FsTestExt {
     ) -> loonfs::Result<AdvanceRetentionResponse>;
 }
 
-impl FsTestExt for Fs {
+impl FsTestExt for TestRuntime {
     fn create_namespace_blocking(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> loonfs::Result<loonfs::NamespaceSummary> {
-        block_on(self.create_namespace(namespace_id, options))
+        block_on(self.writer.create_namespace(namespace_id, options))
     }
 
     fn fork_namespace_blocking(
@@ -196,14 +358,14 @@ impl FsTestExt for Fs {
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> loonfs::Result<loonfs::NamespaceSummary> {
-        block_on(self.fork_namespace(source, target))
+        block_on(self.writer.fork_namespace(source, target))
     }
 
     fn namespace_status_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<NamespaceStatusResponse> {
-        block_on(self.namespace_status(namespace_id))
+        block_on(self.admin.namespace_status(namespace_id))
     }
 
     fn maintenance_tick_namespace_blocking(
@@ -211,7 +373,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         options: MaintenanceTickOptions,
     ) -> loonfs::Result<MaintenanceTickResult> {
-        block_on(self.maintenance_tick_namespace(namespace_id, options))
+        block_on(self.admin.maintenance_tick_namespace(namespace_id, options))
     }
 
     fn stat_path_blocking(
@@ -219,7 +381,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativePathEntry> {
-        block_on(self.stat_path(namespace_id, absolute_path))
+        block_on(self.reader.stat_path(namespace_id, absolute_path))
     }
 
     fn list_path_blocking(
@@ -227,7 +389,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
-        block_on(self.list_path(namespace_id, absolute_path))
+        block_on(self.reader.list_path(namespace_id, absolute_path))
     }
 
     fn read_file_bytes_blocking(
@@ -235,7 +397,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativeFileBytes> {
-        block_on(self.read_file_bytes(namespace_id, absolute_path))
+        block_on(self.reader.read_file_bytes(namespace_id, absolute_path))
     }
 
     fn put_file_bytes_blocking(
@@ -245,7 +407,10 @@ impl FsTestExt for Fs {
         bytes: &[u8],
         options: PutFileOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.put_file_bytes(namespace_id, absolute_path, bytes, options))
+        block_on(
+            self.writer
+                .put_file_bytes(namespace_id, absolute_path, bytes, options),
+        )
     }
 
     fn create_directory_blocking(
@@ -254,7 +419,10 @@ impl FsTestExt for Fs {
         absolute_path: &str,
         options: CreateDirectoryOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.create_directory(namespace_id, absolute_path, options))
+        block_on(
+            self.writer
+                .create_directory(namespace_id, absolute_path, options),
+        )
     }
 
     fn delete_path_blocking(
@@ -263,7 +431,10 @@ impl FsTestExt for Fs {
         absolute_path: &str,
         options: DeleteOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.delete_path(namespace_id, absolute_path, options))
+        block_on(
+            self.writer
+                .delete_path(namespace_id, absolute_path, options),
+        )
     }
 
     fn move_path_blocking(
@@ -273,7 +444,10 @@ impl FsTestExt for Fs {
         to_path: &str,
         options: MoveOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.move_path(namespace_id, from_path, to_path, options))
+        block_on(
+            self.writer
+                .move_path(namespace_id, from_path, to_path, options),
+        )
     }
 
     fn copy_path_blocking(
@@ -283,14 +457,20 @@ impl FsTestExt for Fs {
         to_path: &str,
         options: CopyOptions,
     ) -> loonfs::Result<MutationResult> {
-        block_on(self.copy_path(namespace_id, from_path, to_path, options))
+        block_on(
+            self.writer
+                .copy_path(namespace_id, from_path, to_path, options),
+        )
     }
 
     fn begin_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<BeginUploadResponse> {
-        block_on(self.begin_upload(namespace_id, BeginUploadRequest::default()))
+        block_on(
+            self.writer
+                .begin_upload(namespace_id, BeginUploadRequest::default()),
+        )
     }
 
     fn upload_content_blocking(
@@ -299,7 +479,7 @@ impl FsTestExt for Fs {
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> loonfs::Result<UploadContentResponse> {
-        block_on(self.upload_content(namespace_id, upload_id, bytes))
+        block_on(self.writer.upload_content(namespace_id, upload_id, bytes))
     }
 
     fn complete_upload_blocking(
@@ -308,7 +488,10 @@ impl FsTestExt for Fs {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> loonfs::Result<CompleteUploadResponse> {
-        block_on(self.complete_upload(namespace_id, upload_id, request))
+        block_on(
+            self.writer
+                .complete_upload(namespace_id, upload_id, request),
+        )
     }
 
     fn commit_operations_blocking(
@@ -316,7 +499,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> loonfs::Result<CommitResponse> {
-        block_on(self.commit_operations(namespace_id, request))
+        block_on(self.writer.commit_operations(namespace_id, request))
     }
 
     fn commit_operations_batch_blocking(
@@ -324,7 +507,7 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<loonfs::Result<CommitResponse>> {
-        block_on(self.commit_operations_batch(namespace_id, requests))
+        block_on(self.writer.commit_operations_batch(namespace_id, requests))
     }
 
     fn list_changes_after_blocking(
@@ -332,25 +515,29 @@ impl FsTestExt for Fs {
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
     ) -> loonfs::Result<ChangesResponse> {
-        block_on(self.list_changes_after(namespace_id, after_seq, ListChangesOptions::default()))
+        block_on(self.reader.list_changes_after(
+            namespace_id,
+            after_seq,
+            ListChangesOptions::default(),
+        ))
     }
 
     fn create_checkpoint_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<CreateCheckpointResponse> {
-        block_on(self.create_checkpoint(namespace_id))
+        block_on(self.admin.create_checkpoint(namespace_id))
     }
 
     fn advance_retention_floor_blocking(
         &self,
         namespace_id: &NamespaceId,
     ) -> loonfs::Result<AdvanceRetentionResponse> {
-        block_on(self.advance_retention_floor(namespace_id))
+        block_on(self.admin.advance_retention_floor(namespace_id))
     }
 }
 
-fn assert_config_error(result: loonfs::Result<Fs>, expected: &str) {
+fn assert_config_error<T>(result: loonfs::Result<T>, expected: &str) {
     match result {
         Err(RuntimeError::Config(message)) => assert!(
             message.contains(expected),
@@ -374,30 +561,24 @@ fn open_validates_runtime_config() {
     let temp_dir = tempdir().expect("tempdir");
     let object_store = store(temp_dir.path());
 
-    assert_config_error(Fs::builder(object_store.clone()).build(), "writer_id");
     assert_config_error(
-        Fs::open(
-            object_store.clone(),
-            FsConfig {
-                writer_id: "   ".to_owned(),
-                writer_version: "runtime-test/0.1.0".to_owned(),
-                runtime_cache: RuntimeCacheConfig::default(),
-                trace_mode: TraceMode::Embedded,
-                trace_store_kind: TraceStoreKind::LocalFs,
-            },
+        block_on(FsWriter::builder_with_store(object_store.clone()).build()),
+        "writer_id",
+    );
+    assert_config_error(
+        block_on(
+            FsWriter::builder_with_store(object_store.clone())
+                .writer_id("   ")
+                .build(),
         ),
         "writer_id",
     );
     assert_config_error(
-        Fs::open(
-            object_store,
-            FsConfig {
-                writer_id: "runtime-test".to_owned(),
-                writer_version: "   ".to_owned(),
-                runtime_cache: RuntimeCacheConfig::default(),
-                trace_mode: TraceMode::Embedded,
-                trace_store_kind: TraceStoreKind::LocalFs,
-            },
+        block_on(
+            FsWriter::builder_with_store(object_store)
+                .writer_id("runtime-test")
+                .writer_version("   ")
+                .build(),
         ),
         "writer_version",
     );
@@ -407,12 +588,11 @@ fn open_validates_runtime_config() {
 fn builder_metrics_recorder_instruments_object_store() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
-    let fs = Fs::builder(store(temp_dir.path()))
-        .writer_id("metrics-test")
-        .trace_store_kind(TraceStoreKind::LocalFs)
-        .metrics_recorder(recorder.clone())
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime_with(store(temp_dir.path()), "metrics-test", |builder| {
+        builder
+            .trace_store_kind(TraceStoreKind::LocalFs)
+            .metrics_recorder(recorder.clone())
+    });
 
     fs.create_namespace_blocking(&namespace_id(), CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -500,14 +680,14 @@ fn filesystem_operations_match_core_semantics() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn async_runtime_methods_are_the_engine_boundary() {
     let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "async-runtime-test");
+    let fs = open_runtime_async(store(temp_dir.path()), "async-runtime-test").await;
     let namespace_id = namespace_id();
 
-    Fs::create_namespace(&fs, &namespace_id, CreateNamespaceOptions::default())
+    FsWriter::create_namespace(&fs.writer, &namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    Fs::put_file_bytes(
-        &fs,
+    FsWriter::put_file_bytes(
+        &fs.writer,
         &namespace_id,
         "/docs/hello.txt",
         b"hello",
@@ -516,7 +696,7 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     .await
     .expect("put file");
 
-    let async_stat = Fs::stat_path(&fs, &namespace_id, "/docs/hello.txt")
+    let async_stat = FsReader::stat_path(&fs.reader, &namespace_id, "/docs/hello.txt")
         .await
         .expect("async stat");
 
@@ -533,10 +713,7 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("tail-projection-cache-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "tail-projection-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -591,14 +768,8 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let setup = Fs::builder(object_store.clone())
-        .writer_id("publish-tail")
-        .build()
-        .expect("build setup runtime");
-    let measured = Fs::builder(object_store)
-        .writer_id("publish-tail")
-        .build()
-        .expect("build measured runtime");
+    let setup = open_runtime(object_store.clone(), "publish-tail");
+    let measured = open_runtime(object_store, "publish-tail");
 
     setup
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -647,14 +818,8 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let setup = Fs::builder(object_store.clone())
-        .writer_id("publish-tail")
-        .build()
-        .expect("build setup runtime");
-    let measured = Fs::builder(object_store)
-        .writer_id("publish-tail")
-        .build()
-        .expect("build measured runtime");
+    let setup = open_runtime(object_store.clone(), "publish-tail");
+    let measured = open_runtime(object_store, "publish-tail");
 
     setup
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -684,14 +849,8 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let reader = Fs::builder(object_store.clone())
-        .writer_id("tail-cache-reader")
-        .build()
-        .expect("build reader runtime");
-    let writer = Fs::builder(object_store)
-        .writer_id("tail-cache-writer")
-        .build()
-        .expect("build writer runtime");
+    let reader = open_runtime(object_store.clone(), "tail-cache-reader");
+    let writer = open_runtime(object_store, "tail-cache-writer");
 
     writer
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -730,11 +889,9 @@ fn runtime_cache_can_be_disabled() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("tail-cache-disabled-test")
-        .runtime_cache(RuntimeCacheConfig::disabled())
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime_with(object_store, "tail-cache-disabled-test", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig::disabled())
+    });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -761,10 +918,7 @@ fn runtime_cache_can_be_disabled() {
 fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
     let temp_dir = tempdir().expect("tempdir");
     let shared_store = store(temp_dir.path());
-    let setup = Fs::builder(shared_store.clone())
-        .writer_id("tail-count-setup")
-        .build()
-        .expect("build setup runtime");
+    let setup = open_runtime(shared_store.clone(), "tail-count-setup");
     let first = NamespaceId::parse("first").expect("valid namespace id");
     let second = NamespaceId::parse("second").expect("valid namespace id");
 
@@ -781,14 +935,12 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
         .put_file_bytes_blocking(&second, "/file.txt", b"second", PutFileOptions::default())
         .expect("put second file");
 
-    let fs = Fs::builder(shared_store)
-        .writer_id("tail-count-budget")
-        .runtime_cache(RuntimeCacheConfig {
+    let fs = open_runtime_with(shared_store, "tail-count-budget", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
             max_cached_namespaces: 1,
             ..RuntimeCacheConfig::default()
         })
-        .build()
-        .expect("build runtime");
+    });
 
     fs.read_file_bytes_blocking(&first, "/file.txt")
         .expect("cache first tail projection");
@@ -814,14 +966,12 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("tail-oversized-test")
-        .runtime_cache(RuntimeCacheConfig {
+    let fs = open_runtime_with(object_store, "tail-oversized-test", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
             max_cached_wal_tail_projection_rows: 0,
             ..RuntimeCacheConfig::default()
         })
-        .build()
-        .expect("build runtime");
+    });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -850,10 +1000,7 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
 fn runtime_read_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
-    let fs = Fs::builder(store(temp_dir.path()))
-        .writer_id("tail-read-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(store(temp_dir.path()), "tail-read-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -875,10 +1022,7 @@ fn stale_head_write_error_invalidates_runtime_cache() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("tail-cache-stale-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "tail-cache-stale-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1389,10 +1533,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
     let namespace_id = namespace_id();
     let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("read-materialized-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "read-materialized-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1422,7 +1563,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
 async fn concurrent_materialized_stat_and_list_share_async_store() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
-    let fs = runtime(temp_dir.path(), "concurrent-materialized-read-test");
+    let fs = open_runtime_async(store(temp_dir.path()), "concurrent-materialized-read-test").await;
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -1491,10 +1632,7 @@ fn put_file_bytes_validates_content_ref_before_publish() {
     let namespace_id = namespace_id();
     let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("put-file-content-validation-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "put-file-content-validation-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1521,10 +1659,7 @@ fn begin_upload_validates_controls_without_replay_reads() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("begin-upload-cache-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "begin-upload-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1567,10 +1702,7 @@ fn runtime_control_cache_reuses_head_for_materialization_validation() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("control-cache-head-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "control-cache-head-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1599,14 +1731,12 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("control-cache-eviction-test")
-        .runtime_cache(RuntimeCacheConfig {
+    let fs = open_runtime_with(object_store, "control-cache-eviction-test", |builder| {
+        builder.runtime_cache(RuntimeCacheConfig {
             max_cached_namespaces: 1,
             ..RuntimeCacheConfig::default()
         })
-        .build()
-        .expect("build runtime");
+    });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1640,14 +1770,8 @@ fn runtime_control_cache_reloads_head_after_external_change() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let reader = Fs::builder(object_store.clone())
-        .writer_id("control-cache-reader")
-        .build()
-        .expect("build reader runtime");
-    let writer = Fs::builder(object_store)
-        .writer_id("control-cache-writer")
-        .build()
-        .expect("build writer runtime");
+    let reader = open_runtime(object_store.clone(), "control-cache-reader");
+    let writer = open_runtime(object_store, "control-cache-writer");
 
     writer
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -1686,10 +1810,7 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("begin-upload-missing-partial-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "begin-upload-missing-partial-test");
     let namespace_id = namespace_id();
 
     assert_core_error_kind(
@@ -1713,10 +1834,7 @@ fn begin_upload_rejects_malformed_descriptors() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("begin-upload-malformed-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "begin-upload-malformed-test");
     let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -1756,11 +1874,11 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("begin-upload-malformed-control-test")
-        .runtime_cache(RuntimeCacheConfig::disabled())
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime_with(
+        object_store,
+        "begin-upload-malformed-control-test",
+        |builder| builder.runtime_cache(RuntimeCacheConfig::disabled()),
+    );
 
     let head_bad = NamespaceId::parse("head-bad").expect("valid namespace id");
     fs.create_namespace_blocking(&head_bad, CreateNamespaceOptions::default())
@@ -1806,48 +1924,6 @@ fn explicit_commit_appears_in_change_feed() {
     assert_eq!(changes.through_seq, response.committed_seq);
     assert_eq!(changes.changes.len(), 1);
     assert_eq!(changes.changes[0].commit_id, commit_id);
-}
-
-#[test]
-fn publish_auto_ticks_maintenance_once_tail_reaches_threshold() {
-    let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "auto-tick-test");
-    let namespace_id = namespace_id();
-
-    // Auto ticks spawn on the runtime driving the writes, so the writes,
-    // the quiesce, and the assertions share one runtime.
-    block_on(async {
-        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-
-        for round in 0..33u32 {
-            fs.put_file_bytes(
-                &namespace_id,
-                &format!("/docs/file-{round}.txt"),
-                b"body",
-                PutFileOptions::default(),
-            )
-            .await
-            .expect("put file");
-        }
-
-        fs.wait_for_background_maintenance()
-            .await
-            .expect("background maintenance quiesces");
-        let status = fs
-            .namespace_status(&namespace_id)
-            .await
-            .expect("status after auto tick");
-        assert!(
-            status.current_manifest_id > Some(ManifestId(0)),
-            "auto tick should have published a manifest: {status:?}"
-        );
-        assert!(
-            status.wal_tail_segments < 32,
-            "auto tick should have bounded the tail: {status:?}"
-        );
-    });
 }
 
 #[test]
@@ -1928,10 +2004,7 @@ fn namespace_status_and_tick_reject_partial_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("partial-status-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "partial-status-test");
     let namespace_id = namespace_id();
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -2212,10 +2285,7 @@ fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
         namespace_id.as_str(),
     ));
     let object_store: SharedObjectStore = raw_store.clone();
-    let fs = Fs::builder(object_store)
-        .writer_id("tick-race-test")
-        .build()
-        .expect("build runtime");
+    let fs = open_runtime(object_store, "tick-race-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -205,11 +205,11 @@ conditional-request failures.
 One SDK serves both backends; deployment mode never forks the client
 codebase.
 
-- The embedded engine (`loonfs::Fs`) and the remote client
-  (`loonfs_client::Client`) expose the same operations and the same
-  `capabilities()` accessor returning the capability document of section 2.1.
-  For the remote client the document is fetched from `GET /v0/config` and
-  cached; for the embedded engine it is a constant.
+- The embedded handles (`loonfs::FsWriter`, `loonfs::FsReader`) and the
+  remote client (`loonfs_client::Client`) expose the same operations and the
+  same `capabilities()` accessor returning the capability document of
+  section 2.1. For the remote client the document is fetched from
+  `GET /v0/config` and cached; for the embedded handles it is a constant.
 - Unsupported surface area is typed: individual ops return the
   `not_supported` error with its `feature` name, so gating logic — check the
   capability document, fall back on `not_supported` — is identical against


### PR DESCRIPTION
With every host on purpose-specific handles, the all-purpose `Fs` (and `FsBuilder`/`FsConfig`) leaves the public API. The shared internals stay as a crate-private `FsCore` that the three handles wrap — shared lower-level module, no shared public semantics. Tests now exercise the public handle surface: the runtime suite drives a writer/reader/admin fixture from one runtime per test, and the redundant auto-tick test is dropped in favor of the equivalent coverage in `tests/handles.rs`.