### PR TITLE
feat(server): settle runtime handles on graceful shutdown

### DIFF
--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -74,6 +74,13 @@ struct AppState {
 }
 
 pub async fn app(config: ServerConfig) -> Result<Router, ServerConfigError> {
+    Ok(app_parts(config).await?.0)
+}
+
+/// Builds the router plus the writer handle `serve` keeps aside, so a
+/// graceful shutdown can settle writer-scheduled background maintenance
+/// after the listener drains.
+async fn app_parts(config: ServerConfig) -> Result<(Router, FsWriter), ServerConfigError> {
     let store = config.object_store()?;
     let transfer_issuer = store.transfer_issuer();
     let store = Arc::new(store) as SharedStore;
@@ -85,26 +92,28 @@ async fn app_with_store(
     config: ServerConfig,
     store: SharedStore,
 ) -> Result<Router, ServerConfigError> {
-    app_with_store_and_transfer_issuer(config, store, None).await
+    Ok(app_with_store_and_transfer_issuer(config, store, None)
+        .await?
+        .0)
 }
 
 async fn app_with_store_and_transfer_issuer(
     config: ServerConfig,
     store: SharedStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
-) -> Result<Router, ServerConfigError> {
+) -> Result<(Router, FsWriter), ServerConfigError> {
     let (writer, reader, admin) = build_handles(&config, store).await?;
     let config = Arc::new(config);
     let publisher = PublisherRegistry::new(writer.clone());
     let state = AppState {
         config,
-        writer,
+        writer: writer.clone(),
         reader,
         admin,
         publisher,
         transfer_issuer,
     };
-    Ok(router(state))
+    Ok((router(state), writer))
 }
 
 fn router(state: AppState) -> Router {
@@ -265,18 +274,70 @@ pub enum ServeError {
     },
     #[error("server failed while serving requests: {0}")]
     Serve(#[source] std::io::Error),
+    #[error("background maintenance did not settle during shutdown: {0}")]
+    Shutdown(#[source] loonfs::RuntimeError),
 }
 
+/// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
+/// stops accepting, in-flight requests drain, and the writer's scheduled
+/// background maintenance settles before this returns.
 pub async fn serve(config: ServerConfig) -> Result<(), ServeError> {
+    serve_with_shutdown(config, shutdown_signal()).await
+}
+
+/// [`serve`] with a caller-supplied shutdown trigger instead of process
+/// signals, for hosts that manage their own lifecycle.
+pub async fn serve_with_shutdown(
+    config: ServerConfig,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), ServeError> {
     let bind: SocketAddr = config.bind.parse().map_err(|source| ServeError::BindAddr {
         addr: config.bind.clone(),
         source,
     })?;
-    let app = app(config).await?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;
-    axum::serve(listener, app).await.map_err(ServeError::Serve)
+    serve_on(listener, config, shutdown).await
+}
+
+async fn serve_on(
+    listener: tokio::net::TcpListener,
+    config: ServerConfig,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), ServeError> {
+    let (app, writer) = app_parts(config).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .map_err(ServeError::Serve)?;
+    // The listener has drained; settle writer-owned maintenance so a
+    // checkpoint tick in flight is not torn down mid-write-set. Panicked
+    // ticks surface here rather than disappearing with the process.
+    writer.close().await.map_err(ServeError::Shutdown)
+}
+
+/// Resolves on ctrl-c or, on unix, SIGTERM — the stop signal container
+/// orchestrators send before a kill.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("install ctrl-c handler");
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        () = ctrl_c => {}
+        _ = terminate => {}
+    }
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -175,6 +175,45 @@ async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
+    let temp_dir = tempdir().expect("tempdir");
+    let config = test_config(temp_dir.path(), "shutdown-writer");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(super::serve_on(listener, config, async move {
+        let _ = shutdown_rx.await;
+    }));
+
+    // The server accepts work while running.
+    let client = Client::new(ClientConfig {
+        server_url: format!("http://{addr}"),
+        auth_token: Some("test-token".to_owned()),
+    });
+    tokio::task::spawn_blocking(move || {
+        client
+            .create_namespace("demo")
+            .expect("create namespace over http");
+    })
+    .await
+    .expect("join blocking task");
+
+    shutdown_tx.send(()).expect("trigger shutdown");
+    server
+        .await
+        .expect("join server task")
+        .expect("graceful shutdown settles background work");
+
+    // The listener is closed once serve returns.
+    assert!(
+        std::net::TcpStream::connect(addr).is_err(),
+        "listener should refuse connections after shutdown"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runtime_created_state_is_readable_through_http() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -12,7 +12,7 @@ mod trace;
 pub use config::{
     load_server_config, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
 };
-pub use http::{app, serve, ServeError};
+pub use http::{app, serve, serve_with_shutdown, ServeError};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
 pub use trace::{init_tracing_from_env, TraceInitError};


### PR DESCRIPTION
The handle migration gave every handle an async `close()`, but nothing called it: a SIGTERM tore the process down with writer-scheduled checkpoint ticks possibly mid-flight. `serve` now installs ctrl-c/SIGTERM handlers, drains in-flight requests through axum's graceful shutdown, and then settles the writer's background work with `close()` — a panicked tick surfaces as a `ServeError::Shutdown` instead of disappearing with the process. `serve_with_shutdown` exposes the same path with a caller-supplied trigger for hosts that manage their own lifecycle, which is also what the new shutdown test drives.