### PR TITLE
feat(admin): explicit maintenance tick and gc across surfaces

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -71,7 +71,8 @@ pub use v0::{
     CreateCheckpointResponse, CreateNamespaceRequest, DeleteDirectoryBehavior,
     DeleteNamespaceResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
     FilesystemOperationResponse, ForkNamespaceRequest, GcRequest, GcResponse,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MoveBehavior, MutationResult,
+    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult,
     NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
 };
 

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -26,8 +26,9 @@ pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
     FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
-    GcResponse, ListFileRevisionsResponse, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
+    GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
+    PutBehavior, RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use uploads::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -240,7 +240,6 @@ pub struct CreateCheckpointResponse {
     pub current_manifest_id: Option<ManifestId>,
 }
 
-/// Result of advancing the retention floor.
 /// Optional overrides for one garbage-collection pass. Absent fields use
 /// the server's conservative defaults.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -279,6 +278,7 @@ pub struct GcResponse {
     pub degraded_retention: bool,
 }
 
+/// Result of advancing the retention floor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AdvanceRetentionResponse {
@@ -286,6 +286,62 @@ pub struct AdvanceRetentionResponse {
     pub namespace_id: NamespaceId,
     /// New minimum sequence for incremental replay.
     pub retention_floor_seq: ChangeSeq,
+}
+
+/// Options for one explicit maintenance tick. Absent fields use the
+/// server's defaults; garbage collection runs only when `gc` is present.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct MaintenanceTickRequest {
+    /// Publish a checkpoint when the visible WAL tail reaches this many
+    /// segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_wal_tail_segments: Option<u64>,
+    /// Run the mark-and-sweep garbage collector after the tick's checkpoint
+    /// work. Nothing sweeps unless this is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gc: Option<GcRequest>,
+}
+
+/// What one maintenance tick did.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MaintenanceTickOutcome {
+    /// No checkpoint was needed.
+    NotNeeded,
+    /// A checkpoint was published.
+    CheckpointPublished {
+        /// Sequence covered by the published checkpoint.
+        checkpoint_seq: ChangeSeq,
+    },
+    /// Another checkpoint already covered the attempted sequence.
+    CheckpointSuperseded {
+        /// Sequence this tick attempted to checkpoint.
+        attempted_seq: ChangeSeq,
+        /// Manifest pointer the head currently records.
+        current_manifest_id: ManifestId,
+    },
+    /// A concurrent head update won the race.
+    CheckpointPublishRaceLost {
+        /// Head sequence observed before the checkpoint attempt.
+        observed_head_seq: ChangeSeq,
+    },
+}
+
+/// Result of one explicit maintenance tick.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct MaintenanceTickResponse {
+    /// Namespace the tick ran against.
+    pub namespace_id: NamespaceId,
+    /// Namespace status observed before the tick acted.
+    pub status_before: NamespaceStatusResponse,
+    /// What the tick did.
+    pub outcome: MaintenanceTickOutcome,
+    /// Garbage-collection report when the tick opted into sweeping.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gc: Option<GcResponse>,
 }
 
 impl From<MutationResult> for FilesystemOperationResponse {

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -325,12 +325,41 @@ pub(crate) struct ChangesArgs {
 pub(crate) enum AdminCommand {
     Checkpoint(AdminNamespaceArgs),
     RetentionAdvance(AdminNamespaceArgs),
+    Tick(AdminTickArgs),
+    Gc(AdminGcArgs),
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct AdminNamespaceArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminTickArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Publish a checkpoint when the visible WAL tail reaches this many
+    /// segments (server default when omitted).
+    #[arg(long)]
+    pub max_wal_tail_segments: Option<u64>,
+    /// Run a garbage-collection pass after the tick's checkpoint work.
+    #[arg(long)]
+    pub gc: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminGcArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Objects younger than this are never deleted (server default when
+    /// omitted).
+    #[arg(long)]
+    pub grace_window_ms: Option<u64>,
+    /// Abandoned bootstrap trees older than this may be reaped (server
+    /// default when omitted).
+    #[arg(long)]
+    pub reap_window_ms: Option<u64>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -388,6 +417,8 @@ pub(crate) enum CommandKind {
     Changes,
     AdminCheckpoint,
     AdminRetentionAdvance,
+    AdminTick,
+    AdminGc,
     ConfigPath,
     ConfigShow,
     Version,
@@ -422,6 +453,8 @@ impl CommandKind {
             CommandKind::Changes => "changes",
             CommandKind::AdminCheckpoint => "admin_checkpoint",
             CommandKind::AdminRetentionAdvance => "admin_retention_advance",
+            CommandKind::AdminTick => "admin_tick",
+            CommandKind::AdminGc => "admin_gc",
             CommandKind::ConfigPath => "config_path",
             CommandKind::ConfigShow => "config_show",
             CommandKind::Version => "version",
@@ -467,6 +500,8 @@ impl Cli {
             Command::Admin { command } => match command {
                 AdminCommand::Checkpoint(_) => CommandKind::AdminCheckpoint,
                 AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
+                AdminCommand::Tick(_) => CommandKind::AdminTick,
+                AdminCommand::Gc(_) => CommandKind::AdminGc,
             },
             Command::Config { command } => match command {
                 ConfigCommand::Path => CommandKind::ConfigPath,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -9,16 +9,18 @@ use crate::config::{ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use async_trait::async_trait;
 use loonfs::{
-    BootstrapNamespaceError, ChangesResponse, CopyOptions, CoreError, CreateDirectoryOptions,
-    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, ListChangesOptions, MoveOptions,
+    gc_config_from_request, gc_response_from_report, BootstrapNamespaceError, ChangesResponse,
+    CopyOptions, CoreError, CreateDirectoryOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
+    DeleteNamespaceResponse, DeleteOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader,
+    FsWriter, ListChangesOptions, MaintenanceTickOptions, MaintenanceTickResult, MoveOptions,
     PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, TraceStoreKind,
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CommitId,
-    CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit, ListFileRevisionsResponse,
-    MoveBehavior, MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
-    PaginationPolicy, PutBehavior, RevisionNo,
+    CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit, GcRequest, GcResponse,
+    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
+    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary, PaginationPolicy,
+    PutBehavior, RevisionNo,
 };
 use loonfs_client::{Client, ClientConfig, NamespacePath};
 use std::sync::Arc;
@@ -297,6 +299,34 @@ impl Backend for EmbeddedBackend {
         self.admin
             .advance_retention_floor(&parsed)
             .await
+            .map_err(map_runtime_error)
+    }
+
+    async fn maintenance_tick(
+        &self,
+        namespace_id: &str,
+        request: MaintenanceTickRequest,
+    ) -> Result<MaintenanceTickResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        let options = MaintenanceTickOptions::from_request(request);
+        self.admin
+            .maintenance_tick_namespace(&parsed, options)
+            .await
+            .map(MaintenanceTickResult::into_response)
+            .map_err(map_runtime_error)
+    }
+
+    async fn gc_namespace(
+        &self,
+        namespace_id: &str,
+        request: GcRequest,
+    ) -> Result<GcResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        let config = gc_config_from_request(request);
+        self.admin
+            .gc_namespace(&parsed, &config)
+            .await
+            .map(|report| gc_response_from_report(parsed, report))
             .map_err(map_runtime_error)
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,7 +1,9 @@
 use super::context::{fail, resolve_command_context};
 use super::output::{CommandData, CommandFailure, CommandOutput};
-use crate::args::{AdminCommand, AdminNamespaceArgs, ChangesArgs, CommandKind};
-use loonfs_api::ChangeSeq;
+use crate::args::{
+    AdminCommand, AdminGcArgs, AdminNamespaceArgs, AdminTickArgs, ChangesArgs, CommandKind,
+};
+use loonfs_api::{ChangeSeq, GcRequest, MaintenanceTickRequest};
 
 // --- maintenance/admin plane ---
 
@@ -12,7 +14,71 @@ pub(crate) async fn run_admin_command(
     match command {
         AdminCommand::Checkpoint(args) => run_admin_checkpoint(kind, args).await,
         AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
+        AdminCommand::Tick(args) => run_admin_tick(kind, args).await,
+        AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
     }
+}
+
+async fn run_admin_tick(
+    kind: CommandKind,
+    args: AdminTickArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let request = MaintenanceTickRequest {
+        max_wal_tail_segments: args.max_wal_tail_segments,
+        gc: args.gc.then(GcRequest::default),
+    };
+    let response = context
+        .target
+        .backend()
+        .maintenance_tick(&context.namespace, request)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::MaintenanceTicked(response),
+    })
+}
+
+async fn run_admin_gc(
+    kind: CommandKind,
+    args: AdminGcArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let request = GcRequest {
+        grace_window_ms: args.grace_window_ms,
+        reap_window_ms: args.reap_window_ms,
+    };
+    let response = context
+        .target
+        .backend()
+        .gc_namespace(&context.namespace, request)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::GarbageCollected(response),
+    })
 }
 
 async fn run_admin_checkpoint(

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -5,7 +5,7 @@ use crate::profiles::ProfileSummary;
 use loonfs_api::v0::ChangesResponse;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, CreateCheckpointResponse,
-    DeleteNamespaceResponse, FileRevision, NamespaceSummary,
+    DeleteNamespaceResponse, FileRevision, GcResponse, MaintenanceTickResponse, NamespaceSummary,
 };
 use serde::Serialize;
 
@@ -47,6 +47,8 @@ pub(crate) enum CommandData {
     NamespaceDeleted(DeleteNamespaceResponse),
     CheckpointCreated(CreateCheckpointResponse),
     RetentionAdvanced(AdvanceRetentionResponse),
+    MaintenanceTicked(MaintenanceTickResponse),
+    GarbageCollected(GcResponse),
     Changes(ChangesResponse),
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -1,8 +1,24 @@
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput};
 use crate::error::CliError;
+use loonfs_api::{GcResponse, MaintenanceTickOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
+
+fn gc_summary(report: &GcResponse) -> String {
+    let mut summary = format!(
+        "gc deleted {} wal segments, {} tables, {} manifests, {} checkpoint records ({} retained)",
+        report.deleted_wal_segments,
+        report.deleted_metadata_tables,
+        report.deleted_manifests,
+        report.deleted_checkpoint_records,
+        report.retained_candidates
+    );
+    if report.degraded_retention {
+        summary.push_str("; retention degraded: ambiguous roots suppressed deletion");
+    }
+    summary
+}
 
 const FORMAT_VERSION: u32 = 1;
 
@@ -156,6 +172,38 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             "advanced retention floor for {} to seq {}; changes before this floor are no longer replayable",
             response.namespace_id, response.retention_floor_seq.0
         ),
+        CommandData::MaintenanceTicked(response) => {
+            let outcome = match &response.outcome {
+                MaintenanceTickOutcome::NotNeeded => format!(
+                    "not needed (wal tail {} segments)",
+                    response.status_before.wal_tail_segments
+                ),
+                MaintenanceTickOutcome::CheckpointPublished { checkpoint_seq } => {
+                    format!("checkpoint published @ seq {}", checkpoint_seq.0)
+                }
+                MaintenanceTickOutcome::CheckpointSuperseded {
+                    attempted_seq,
+                    current_manifest_id,
+                } => format!(
+                    "checkpoint @ seq {} superseded (current manifest {})",
+                    attempted_seq.0, current_manifest_id
+                ),
+                MaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq } => {
+                    format!(
+                        "checkpoint race lost (head moved past seq {})",
+                        observed_head_seq.0
+                    )
+                }
+            };
+            let mut line = format!("maintenance tick for {}: {outcome}", response.namespace_id);
+            if let Some(gc) = &response.gc {
+                line.push_str(&format!("; {}", gc_summary(gc)));
+            }
+            line
+        }
+        CommandData::GarbageCollected(response) => {
+            format!("gc for {}: {}", response.namespace_id, gc_summary(response))
+        }
         CommandData::Changes(response) => {
             let mut lines = vec![
                 format!(

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -962,7 +962,12 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
         ),
         (
             "admin/v0",
-            &[&["admin", "checkpoint"], &["admin", "retention-advance"]],
+            &[
+                &["admin", "checkpoint"],
+                &["admin", "retention-advance"],
+                &["admin", "tick"],
+                &["admin", "gc"],
+            ],
         ),
     ];
     // Advertised feature key -> the CLI command path exercising it. Keys are
@@ -1103,6 +1108,27 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(retention_data["namespace_id"], "demo");
         assert_eq!(retention_data["retention_floor_seq"], 2);
 
+        // The checkpoint above already covers the head, so a tick reports
+        // not-needed identically in both modes.
+        let tick = harness.run(&["--json", "admin", "tick", "--profile", profile]);
+        assert_success(&tick);
+        let tick_data = json_data(&tick);
+        assert_eq!(tick_data["kind"], "maintenance_ticked");
+        assert_eq!(tick_data["namespace_id"], "demo");
+        assert_eq!(tick_data["outcome"]["kind"], "not_needed");
+        assert_eq!(tick_data["status_before"]["namespace_id"], "demo");
+        assert!(tick_data.get("gc").is_none());
+
+        // A fresh namespace has nothing eligible to sweep.
+        let gc = harness.run(&["--json", "admin", "gc", "--profile", profile]);
+        assert_success(&gc);
+        let gc_data = json_data(&gc);
+        assert_eq!(gc_data["kind"], "garbage_collected");
+        assert_eq!(gc_data["namespace_id"], "demo");
+        assert_eq!(gc_data["deleted_wal_segments"], 0);
+        assert_eq!(gc_data["deleted_manifests"], 0);
+        assert_eq!(gc_data["degraded_retention"], false);
+
         // Admin failures surface the registry code in both modes.
         let missing = harness.run(&[
             "--json",
@@ -1120,6 +1146,8 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             sorted_object_keys(&changes_data),
             sorted_object_keys(&checkpoint_data),
             sorted_object_keys(&retention_data),
+            sorted_object_keys(&tick_data),
+            sorted_object_keys(&gc_data),
         ));
     }
 

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -20,8 +20,9 @@ use crate::{Client, ClientError, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
     v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
-    CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode, ListFileRevisionsResponse,
-    MutationResult, NamespaceStatusResponse, NamespaceSummary, RevisionNo,
+    CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode, GcRequest, GcResponse,
+    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, MutationResult,
+    NamespaceStatusResponse, NamespaceSummary, RevisionNo,
 };
 use thiserror::Error;
 
@@ -203,6 +204,20 @@ pub trait Backend {
         &self,
         namespace_id: &str,
     ) -> Result<AdvanceRetentionResponse, BackendError>;
+    /// Runs one bounded maintenance step: a checkpoint once the WAL tail
+    /// reaches the threshold, optionally followed by a GC pass.
+    async fn maintenance_tick(
+        &self,
+        namespace_id: &str,
+        request: MaintenanceTickRequest,
+    ) -> Result<MaintenanceTickResponse, BackendError>;
+    /// Runs one mark-and-sweep garbage-collection pass. Nothing sweeps
+    /// without this explicit call or a maintenance-tick opt-in.
+    async fn gc_namespace(
+        &self,
+        namespace_id: &str,
+        request: GcRequest,
+    ) -> Result<GcResponse, BackendError>;
     /// Reads the ordered change feed after the `after_seq` cursor.
     async fn list_changes(
         &self,
@@ -395,6 +410,26 @@ impl Backend for RemoteBackend {
     ) -> Result<AdvanceRetentionResponse, BackendError> {
         let namespace_id = namespace_id.to_owned();
         self.wire(move |client| client.advance_retention(&namespace_id))
+            .await
+    }
+
+    async fn maintenance_tick(
+        &self,
+        namespace_id: &str,
+        request: MaintenanceTickRequest,
+    ) -> Result<MaintenanceTickResponse, BackendError> {
+        let namespace_id = namespace_id.to_owned();
+        self.wire(move |client| client.maintenance_tick(&namespace_id, &request))
+            .await
+    }
+
+    async fn gc_namespace(
+        &self,
+        namespace_id: &str,
+        request: GcRequest,
+    ) -> Result<GcResponse, BackendError> {
+        let namespace_id = namespace_id.to_owned();
+        self.wire(move |client| client.gc_namespace(&namespace_id, &request))
             .await
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -21,8 +21,9 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, InodeId,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MutationResult, NamespaceId,
+    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickRequest, MaintenanceTickResponse, MutationResult, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
@@ -556,6 +557,35 @@ impl Client {
             self.base_url
         );
         self.request_json::<(), AdvanceRetentionResponse>(self.agent.post(&url), None)
+    }
+
+    /// Runs one bounded maintenance step against a namespace (admin plane).
+    /// Absent request fields use the server's defaults; garbage collection
+    /// runs only when the request opts in.
+    pub fn maintenance_tick(
+        &self,
+        namespace: &str,
+        request: &MaintenanceTickRequest,
+    ) -> Result<MaintenanceTickResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/maintenance/tick",
+            self.base_url
+        );
+        self.request_json(self.agent.post(&url), Some(request))
+    }
+
+    /// Runs one mark-and-sweep garbage-collection pass (admin plane).
+    /// Nothing sweeps without this explicit call or a maintenance-tick
+    /// opt-in.
+    pub fn gc_namespace(
+        &self,
+        namespace: &str,
+        request: &GcRequest,
+    ) -> Result<GcResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!("{}/v0/admin/namespaces/{namespace}/gc", self.base_url);
+        self.request_json(self.agent.post(&url), Some(request))
     }
 
     fn apply_filesystem_operation(

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -11,7 +11,8 @@ use loonfs::{ChangeSeq, CreateNamespaceOptions, DeleteNamespaceOptions};
 use loonfs_api::ApiError;
 use loonfs_api::{
     AdvanceRetentionResponse, CreateCheckpointResponse, CreateNamespaceRequest,
-    ForkNamespaceRequest, GcRequest, GcResponse, FEATURE_UPLOADS_DIRECT_PUT,
+    ForkNamespaceRequest, GcRequest, GcResponse, MaintenanceTickRequest, MaintenanceTickResponse,
+    FEATURE_UPLOADS_DIRECT_PUT,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -285,26 +286,47 @@ pub(super) async fn gc_namespace(
 ) -> Result<Json<GcResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
-    let request = request.unwrap_or_default();
-    let defaults = loonfs::GcConfig::default();
-    let config = loonfs::GcConfig {
-        grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),
-        reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
-    };
+    let config = loonfs::gc_config_from_request(request.unwrap_or_default());
     let report = state
         .admin
         .gc_namespace(&namespace_id, &config)
         .await
         .map_err(ApiResponseError::runtime)?;
-    Ok(Json(GcResponse {
-        namespace_id,
-        deleted_wal_segments: report.deleted_wal_segments,
-        deleted_metadata_tables: report.deleted_metadata_tables,
-        deleted_manifests: report.deleted_manifests,
-        deleted_checkpoint_records: report.deleted_checkpoint_records,
-        released_pins: report.released_pins,
-        reaped_abandoned_objects: report.reaped_abandoned_objects,
-        retained_candidates: report.retained_candidates,
-        degraded_retention: report.degraded_retention,
-    }))
+    Ok(Json(loonfs::gc_response_from_report(namespace_id, report)))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/maintenance/tick",
+        tag = "admin",
+        summary = "Run maintenance tick",
+        description = "Runs one bounded maintenance step: publishes a checkpoint once the visible WAL tail reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing a checkpoint race is an outcome, not an error.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        request_body(content = MaintenanceTickRequest, description = "Optional threshold and GC overrides"),
+        responses(
+            (status = 200, description = "Maintenance tick completed", body = MaintenanceTickResponse),
+            (status = 400, description = "Invalid namespace id or options", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn maintenance_tick(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+    OptionalAppJson(request): OptionalAppJson<MaintenanceTickRequest>,
+) -> Result<Json<MaintenanceTickResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let options = loonfs::MaintenanceTickOptions::from_request(request.unwrap_or_default());
+    let result = state
+        .admin
+        .maintenance_tick_namespace(&namespace_id, options)
+        .await
+        .map_err(ApiResponseError::runtime)?;
+    Ok(Json(result.into_response()))
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -34,7 +34,7 @@ use self::handlers_filesystem::{
 };
 use self::handlers_namespace::{
     advance_retention, create_checkpoint, create_namespace, delete_namespace, fork_namespace,
-    gc_namespace, namespace_status,
+    gc_namespace, maintenance_tick, namespace_status,
 };
 use self::handlers_uploads::{begin_upload, complete_upload, upload_content};
 use crate::config::{ServerConfig, ServerConfigError};
@@ -175,6 +175,10 @@ fn router(state: AppState) -> Router {
         .route(
             "/v0/admin/namespaces/:namespace/retention/advance",
             post(advance_retention),
+        )
+        .route(
+            "/v0/admin/namespaces/:namespace/maintenance/tick",
+            post(maintenance_tick),
         )
         .route("/v0/admin/namespaces/:namespace/gc", post(gc_namespace))
         .with_state(state)

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -17,7 +17,8 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
     CreateNamespaceRequest, FilesystemOperation, FilesystemOperationRequest,
     FilesystemOperationResponse, ForkNamespaceRequest, GcRequest, GcResponse, InodeId,
-    ListFileRevisionsResponse, RestoreFileRevisionRequest, RevisionNo,
+    ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, RestoreFileRevisionRequest, RevisionNo,
 };
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
@@ -57,6 +58,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_filesystem::list_changes,
         crate::http::handlers_namespace::create_checkpoint,
         crate::http::handlers_namespace::advance_retention,
+        crate::http::handlers_namespace::maintenance_tick,
         crate::http::handlers_namespace::gc_namespace
     ),
     components(schemas(
@@ -78,6 +80,9 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         RestoreFileRevisionRequest,
         CreateCheckpointResponse,
         AdvanceRetentionResponse,
+        MaintenanceTickRequest,
+        MaintenanceTickOutcome,
+        MaintenanceTickResponse,
         GcRequest,
         GcResponse,
         ContentRef,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1614,6 +1614,65 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-tick",
+        "http-admin-tick",
+    ))
+    .await;
+    let client = harness.client.clone();
+    let server_url = harness.server_url.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = "demo";
+        client
+            .create_namespace(namespace)
+            .expect("create namespace");
+        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        client
+            .write_file_bytes(&target, b"hello tick\n")
+            .expect("write file");
+
+        // One WAL segment sits far below the default threshold.
+        let idle = post_maintenance_tick(&server_url, namespace).expect("idle tick");
+        assert_eq!(idle.namespace_id.as_str(), namespace);
+        assert_eq!(idle.status_before.wal_tail_segments, 1);
+        assert_eq!(idle.outcome, loonfs_api::MaintenanceTickOutcome::NotNeeded);
+        assert!(idle.gc.is_none());
+
+        // Forcing the threshold to one segment publishes a checkpoint and
+        // runs the opted-in GC pass.
+        let forced: loonfs_api::MaintenanceTickResponse = client
+            .maintenance_tick(
+                namespace,
+                &loonfs_api::MaintenanceTickRequest {
+                    max_wal_tail_segments: Some(1),
+                    gc: Some(loonfs_api::GcRequest::default()),
+                },
+            )
+            .expect("forced tick");
+        assert_eq!(
+            forced.outcome,
+            loonfs_api::MaintenanceTickOutcome::CheckpointPublished {
+                checkpoint_seq: ChangeSeq(1),
+            }
+        );
+        let gc = forced.gc.expect("gc report present when opted in");
+        assert_eq!(gc.deleted_wal_segments, 0);
+        assert!(!gc.degraded_retention);
+
+        let bytes = client.read_file_bytes(&target).expect("read file");
+        assert_eq!(bytes, b"hello tick\n");
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_admin_retention_advance_uses_initial_manifest_after_create() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
@@ -1851,6 +1910,16 @@ fn post_checkpoint(
 fn post_gc(server_url: &str, namespace: &str) -> Result<loonfs_api::GcResponse, ApiError> {
     post_admin_json(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/gc"),
+        "test-token",
+    )
+}
+
+fn post_maintenance_tick(
+    server_url: &str,
+    namespace: &str,
+) -> Result<loonfs_api::MaintenanceTickResponse, ApiError> {
+    post_admin_json(
+        &format!("{server_url}/v0/admin/namespaces/{namespace}/maintenance/tick"),
         "test-token",
     )
 }

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -67,6 +67,8 @@ fn openapi_documents_current_server_paths() {
         ("/v0/namespaces/{namespace}/changes", "get"),
         ("/v0/admin/namespaces/{namespace}/checkpoint", "post"),
         ("/v0/admin/namespaces/{namespace}/retention/advance", "post"),
+        ("/v0/admin/namespaces/{namespace}/maintenance/tick", "post"),
+        ("/v0/admin/namespaces/{namespace}/gc", "post"),
     ] {
         assert_path_method(paths, path, method);
     }

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -7,8 +7,8 @@ use crate::fs::FsCore;
 use crate::{
     AdvanceRetentionResponse, CreateCheckpointResponse, GcConfig, GcReport, MaintenanceTickOptions,
     MaintenanceTickResult, NamespaceId, NamespaceStatusResponse, ObjectStoreMetricsRecorder,
-    Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
-    TraceStoreKind,
+    Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
+    TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -49,6 +49,12 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse> {
         self.core.namespace_status(namespace_id).await
+    }
+
+    /// Snapshots the runtime cache counters, so maintenance work driven
+    /// through this handle is observable alongside writer and reader work.
+    pub fn runtime_cache_stats(&self) -> RuntimeCacheStats {
+        self.core.runtime_cache_stats()
     }
 
     /// Runs one bounded maintenance step against a namespace.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -96,9 +96,10 @@ pub use config::{
 };
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use options::{
-    CopyOptions, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
-    MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions,
+    gc_config_from_request, gc_response_from_report, CopyOptions, CreateDirectoryOptions,
+    CreateNamespaceOptions, DeleteOptions, ListChangesOptions, MaintenanceTickOptions,
+    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, PutFileOptions,
+    RestoreRevisionOptions,
 };
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -1,9 +1,15 @@
-//! Per-operation option and result types for the runtime handle surface.
+//! Per-operation option and result types for the runtime handle surface,
+//! plus the wire conversions the server and embedded hosts share so both
+//! transports report identical maintenance shapes.
 
 use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
-    ChangeSeq, CommitId, DeleteDirectoryBehavior, EffectiveLimit, ManifestId, MoveBehavior,
-    NamespaceId, NamespaceStatusResponse, PutBehavior,
+    ChangeSeq, CommitId, DeleteDirectoryBehavior, EffectiveLimit, GcConfig, GcReport, ManifestId,
+    MoveBehavior, NamespaceId, NamespaceStatusResponse, PutBehavior,
+};
+use loonfs_api::v0::{
+    GcRequest, GcResponse, MaintenanceTickOutcome as WireMaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse,
 };
 
 /// Options for one maintenance tick.
@@ -22,6 +28,43 @@ impl Default for MaintenanceTickOptions {
             max_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
             gc: None,
         }
+    }
+}
+
+impl MaintenanceTickOptions {
+    /// Resolves wire-level tick overrides onto the runtime defaults.
+    pub fn from_request(request: MaintenanceTickRequest) -> Self {
+        let defaults = Self::default();
+        Self {
+            max_wal_tail_segments: request
+                .max_wal_tail_segments
+                .unwrap_or(defaults.max_wal_tail_segments),
+            gc: request.gc.map(gc_config_from_request),
+        }
+    }
+}
+
+/// Resolves wire-level GC window overrides onto the conservative defaults.
+pub fn gc_config_from_request(request: GcRequest) -> GcConfig {
+    let defaults = GcConfig::default();
+    GcConfig {
+        grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),
+        reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
+    }
+}
+
+/// Wire response for one GC report against a namespace.
+pub fn gc_response_from_report(namespace_id: NamespaceId, report: GcReport) -> GcResponse {
+    GcResponse {
+        namespace_id,
+        deleted_wal_segments: report.deleted_wal_segments,
+        deleted_metadata_tables: report.deleted_metadata_tables,
+        deleted_manifests: report.deleted_manifests,
+        deleted_checkpoint_records: report.deleted_checkpoint_records,
+        released_pins: report.released_pins,
+        reaped_abandoned_objects: report.reaped_abandoned_objects,
+        retained_candidates: report.retained_candidates,
+        degraded_retention: report.degraded_retention,
     }
 }
 
@@ -60,6 +103,36 @@ pub struct MaintenanceTickResult {
     pub outcome: MaintenanceTickOutcome,
     /// Garbage-collection report when the tick opted into sweeping.
     pub gc: Option<crate::GcReport>,
+}
+
+impl MaintenanceTickResult {
+    /// Wire response for this tick.
+    pub fn into_response(self) -> MaintenanceTickResponse {
+        let namespace_id = self.namespace_id;
+        MaintenanceTickResponse {
+            gc: self
+                .gc
+                .map(|report| gc_response_from_report(namespace_id.clone(), report)),
+            namespace_id,
+            status_before: self.status_before,
+            outcome: match self.outcome {
+                MaintenanceTickOutcome::NotNeeded => WireMaintenanceTickOutcome::NotNeeded,
+                MaintenanceTickOutcome::CheckpointPublished { checkpoint_seq } => {
+                    WireMaintenanceTickOutcome::CheckpointPublished { checkpoint_seq }
+                }
+                MaintenanceTickOutcome::CheckpointSuperseded {
+                    attempted_seq,
+                    current_manifest_id,
+                } => WireMaintenanceTickOutcome::CheckpointSuperseded {
+                    attempted_seq,
+                    current_manifest_id,
+                },
+                MaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq } => {
+                    WireMaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq }
+                }
+            },
+        }
+    }
 }
 
 /// Options for creating a namespace; feeds core's

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -113,6 +113,9 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
             .expect("namespace status");
         assert_eq!(status.namespace_id, namespace_id);
         assert_eq!(status.wal_tail_segments, 1);
+        // Admin-driven work is observable through the admin handle's own
+        // cache counters, like writer and reader work through theirs.
+        let _ = admin.runtime_cache_stats();
 
         standalone.close().await.expect("close standalone reader");
         derived.close().await.expect("close derived reader");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -25,7 +25,7 @@ within a plane is expressed as **named features** (section 2).
 | Profile | Plane | Ops | Status |
 | --- | --- | --- | --- |
 | `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, explicit commits, the change feed, namespace status by id, `GET /v0/config`, and the standard error contract. Namespace `list`, `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
-| `admin/v0` | Maintenance plane | Trigger checkpoint creation; trigger retention-floor advancement. Future maintenance triggers (compaction, GC, index builds) arrive as features in this plane. | Optional |
+| `admin/v0` | Maintenance plane | Trigger checkpoint creation; trigger retention-floor advancement; run one-shot maintenance ticks; run garbage collection. Future maintenance triggers (compaction, index builds) arrive as features in this plane. | Optional |
 | `query/v0` | Query plane | — | **Reserved name only.** Materializes only if derived indexes introduce endpoints beyond the core ops; until that decision, no ops are specified and no `query.*` feature keys are registered. |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
 
@@ -306,6 +306,7 @@ A representative v0 binding is shown below.
 | Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
 | Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoint` |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
+| Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; checkpoint races surface as outcomes, not errors) |
 | Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; nothing sweeps without an explicit call) |
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile; everything else

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -192,6 +192,90 @@
         }
       }
     },
+    "/v0/admin/namespaces/{namespace}/maintenance/tick": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Run maintenance tick",
+        "description": "Runs one bounded maintenance step: publishes a checkpoint once the visible WAL tail reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing a checkpoint race is an outcome, not an error.",
+        "operationId": "maintenance_tick",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Optional threshold and GC overrides",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MaintenanceTickRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Maintenance tick completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceTickResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id or options",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/admin/namespaces/{namespace}/retention/advance": {
       "post": {
         "tags": [
@@ -1918,6 +2002,7 @@
     "schemas": {
       "AdvanceRetentionResponse": {
         "type": "object",
+        "description": "Result of advancing the retention floor.",
         "required": [
           "namespace_id",
           "retention_floor_seq"
@@ -3191,7 +3276,7 @@
       },
       "GcRequest": {
         "type": "object",
-        "description": "Result of advancing the retention floor.\nOptional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.",
+        "description": "Optional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.",
         "properties": {
           "grace_window_ms": {
             "type": [
@@ -3367,6 +3452,151 @@
               "null"
             ],
             "description": "Cursor for the next page, if more entries remain."
+          }
+        }
+      },
+      "MaintenanceTickOutcome": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "No checkpoint was needed.",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "not_needed"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A checkpoint was published.",
+            "required": [
+              "checkpoint_seq",
+              "kind"
+            ],
+            "properties": {
+              "checkpoint_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence covered by the published checkpoint."
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "checkpoint_published"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Another checkpoint already covered the attempted sequence.",
+            "required": [
+              "attempted_seq",
+              "current_manifest_id",
+              "kind"
+            ],
+            "properties": {
+              "attempted_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence this tick attempted to checkpoint."
+              },
+              "current_manifest_id": {
+                "$ref": "#/components/schemas/ManifestId",
+                "description": "Manifest pointer the head currently records."
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "checkpoint_superseded"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A concurrent head update won the race.",
+            "required": [
+              "observed_head_seq",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "checkpoint_publish_race_lost"
+                ]
+              },
+              "observed_head_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Head sequence observed before the checkpoint attempt."
+              }
+            }
+          }
+        ],
+        "description": "What one maintenance tick did."
+      },
+      "MaintenanceTickRequest": {
+        "type": "object",
+        "description": "Options for one explicit maintenance tick. Absent fields use the\nserver's defaults; garbage collection runs only when `gc` is present.",
+        "properties": {
+          "gc": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GcRequest",
+                "description": "Run the mark-and-sweep garbage collector after the tick's checkpoint\nwork. Nothing sweeps unless this is present."
+              }
+            ]
+          },
+          "max_wal_tail_segments": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Publish a checkpoint when the visible WAL tail reaches this many\nsegments.",
+            "minimum": 0
+          }
+        }
+      },
+      "MaintenanceTickResponse": {
+        "type": "object",
+        "description": "Result of one explicit maintenance tick.",
+        "required": [
+          "namespace_id",
+          "status_before",
+          "outcome"
+        ],
+        "properties": {
+          "gc": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GcResponse",
+                "description": "Garbage-collection report when the tick opted into sweeping."
+              }
+            ]
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the tick ran against."
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/MaintenanceTickOutcome",
+            "description": "What the tick did."
+          },
+          "status_before": {
+            "$ref": "#/components/schemas/NamespaceStatusResponse",
+            "description": "Namespace status observed before the tick acted."
           }
         }
       },


### PR DESCRIPTION
Embedded CLI writes went `ManualOnly` in the handle migration, which makes explicit maintenance the operator's job — but `loon admin` only offered checkpoint and retention-advance, and the server's GC endpoint had no client or CLI reach at all. This completes the explicit-maintenance surface with two-mode parity: `loon admin tick` (one bounded maintenance step, with `--max-wal-tail-segments` and `--gc` opt-in) and `loon admin gc` (window overrides), both reporting identical shapes embedded and remote.

The tick gets a wire pair (`MaintenanceTickRequest`/`MaintenanceTickResponse`) and a `POST /v0/admin/namespaces/{ns}/maintenance/tick` endpoint mirroring the existing gc endpoint; the request→options and result→response conversions live once in the runtime crate so the server handler and embedded backend cannot drift. api.md's admin plane row and ops table now match what the reference implementations serve, and the OpenAPI document is regenerated. Also exposes `runtime_cache_stats()` on `FsAdmin`, closing the observability gap the S3 benchmark adapter hit.