### PR TITLE
fix(objectstore): drive provider http io on a store-owned runtime

### DIFF
--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,5 +1,6 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -25,6 +26,9 @@ pub struct AzureAbsStoreConfig {
 #[derive(Debug)]
 pub struct AzureAbsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl AzureAbsStore {
@@ -45,7 +49,9 @@ impl AzureAbsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = MicrosoftAzureBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_account(config.account_name)
             .with_container_name(config.container_name)
             .with_access_key(config.access_key.expose());
@@ -73,7 +79,10 @@ impl AzureAbsStore {
                 sha256_checksum_metadata: false,
             },
         )?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 }
 

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,4 +1,5 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -23,6 +24,9 @@ pub struct GcpGcsStoreConfig {
 #[derive(Debug)]
 pub struct GcpGcsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl GcpGcsStore {
@@ -38,7 +42,9 @@ impl GcpGcsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let builder = GoogleCloudStorageBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_service_account_path(config.service_account_key_path);
 
@@ -53,7 +59,10 @@ impl GcpGcsStore {
             },
         )?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 
     fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -26,6 +26,7 @@ pub mod s3;
 mod s3_compatible;
 mod secret;
 mod store_config;
+mod store_io_runtime;
 
 /// Compatibility alias for [`local_fs_store`], kept so existing imports of
 /// `loonfs_objectstore::fs::LocalFsStore` keep resolving.

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,4 +1,5 @@
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, ProviderObjectStore,
     ProviderObjectStoreConfig, PutMode,
@@ -28,6 +29,9 @@ pub(crate) struct S3CompatibleConfig {
 pub(crate) struct S3CompatibleStore {
     provider_name: &'static str,
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl fmt::Debug for S3CompatibleStore {
@@ -49,7 +53,9 @@ impl S3CompatibleStore {
             })
             .transpose()?;
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = AmazonS3Builder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_region(config.region)
             .with_access_key_id(config.access_key_id.expose())
@@ -83,6 +89,7 @@ impl S3CompatibleStore {
         Ok(Self {
             provider_name: config.provider_name,
             inner,
+            _io_runtime: io_runtime,
         })
     }
 }

--- a/crates/loonfs-objectstore/src/store_io_runtime.rs
+++ b/crates/loonfs-objectstore/src/store_io_runtime.rs
@@ -1,0 +1,102 @@
+//! The per-store HTTP IO runtime: provider requests are driven by a thread
+//! this runtime owns, never by the caller's runtime.
+//!
+//! The default provider connector performs HTTP IO on whichever runtime
+//! issues the request. A store shared across current-thread runtimes then
+//! parks pooled connections until the client's 30s request timeout fires —
+//! reproduced and fixed in the S3 benchmark investigation by routing IO
+//! through a dedicated runtime. Every provider client is constructed with a
+//! connector onto its store's own runtime, so caller runtime topology can
+//! never affect provider IO.
+
+use crate::ObjectStoreError;
+use object_store::client::SpawnedReqwestConnector;
+use std::fmt;
+use std::sync::Arc;
+
+/// Owns the Tokio runtime that drives one configured store's HTTP IO.
+///
+/// The provider connector holds only a runtime `Handle`; this type keeps the
+/// runtime itself alive for as long as the provider client lives. Clones
+/// share one runtime. Dropping the last clone shuts the runtime down in the
+/// background, so a store dropped inside an async context never blocks or
+/// panics.
+#[derive(Clone)]
+pub(crate) struct StoreIoRuntime {
+    inner: Arc<OwnedRuntime>,
+}
+
+struct OwnedRuntime {
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl StoreIoRuntime {
+    /// Starts the IO runtime for one configured store.
+    ///
+    /// One worker thread multiplexes every request for the store; HTTP IO is
+    /// reactor-driven, so request concurrency does not need more threads.
+    pub(crate) fn new() -> Result<Self, ObjectStoreError> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("loonfs-store-io")
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                ObjectStoreError::Configuration(format!(
+                    "failed to start store io runtime: {error}"
+                ))
+            })?;
+        Ok(Self {
+            inner: Arc::new(OwnedRuntime {
+                runtime: Some(runtime),
+            }),
+        })
+    }
+
+    /// Connector that routes a provider client's requests onto this runtime.
+    pub(crate) fn connector(&self) -> SpawnedReqwestConnector {
+        let handle = self
+            .inner
+            .runtime
+            .as_ref()
+            .expect("store io runtime should live until the last store clone drops")
+            .handle()
+            .clone();
+        SpawnedReqwestConnector::new(handle)
+    }
+}
+
+impl fmt::Debug for StoreIoRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoreIoRuntime").finish_non_exhaustive()
+    }
+}
+
+impl Drop for OwnedRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            // A store may be dropped inside an async context, where a
+            // blocking runtime drop panics; background shutdown never blocks.
+            runtime.shutdown_background();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StoreIoRuntime;
+
+    #[tokio::test]
+    async fn store_io_runtime_drops_safely_inside_an_async_context() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let clone = runtime.clone();
+        drop(runtime);
+        drop(clone);
+    }
+
+    #[tokio::test]
+    async fn connector_construction_does_not_touch_the_caller_runtime() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let _connector = runtime.connector();
+    }
+}

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -350,6 +350,67 @@ async fn aws_s3_real_provider_conformance() {
     assert_provider_conformance(&store).await;
 }
 
+#[test]
+#[ignore = "requires real AWS S3 credentials"]
+fn aws_s3_store_survives_alternating_current_thread_runtimes() {
+    // Regression probe for the 30s stall: a provider client driven from two
+    // current-thread runtimes parked pooled connections until the client
+    // timeout fired. The store-owned IO runtime decouples HTTP driving from
+    // caller runtime topology, so alternating runtimes stays fast.
+    let config = AwsS3ConformanceConfig::from_env()
+        .expect("load AWS S3 real-provider conformance environment");
+    let store = AwsS3Store::new(AwsS3StoreConfig {
+        bucket: config.bucket,
+        region: config.region,
+        endpoint_url: config.endpoint,
+        access_key_id: config.access_key_id.into(),
+        secret_access_key: config.secret_access_key.into(),
+        session_token: config.session_token.map(Into::into),
+        key_prefix: Some(config.prefix),
+        force_path_style: false,
+    })
+    .expect("create AWS S3 object store");
+
+    let runtime_a = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime a");
+    let runtime_b = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime b");
+
+    #[allow(clippy::disallowed_methods)]
+    // Wall-clock bounds a live-provider stall check; no protocol time depends on it.
+    let started = std::time::Instant::now();
+    for round in 0..5u32 {
+        let key = format!("runtime-affinity-probe/round-{round}.bin");
+        let bytes = Bytes::from(format!("round {round}"));
+        runtime_a
+            .block_on(store.put_overwrite(&key, bytes))
+            .expect("put on runtime a");
+        let head = runtime_b
+            .block_on(store.head(&key))
+            .expect("head on runtime b");
+        assert!(head.is_some(), "object should exist after put");
+        let body = runtime_a
+            .block_on(store.get(&key, None))
+            .expect("get on runtime a");
+        assert!(body.is_some(), "object body should read back");
+        runtime_b
+            .block_on(store.delete(&key))
+            .expect("delete on runtime b");
+    }
+    #[allow(clippy::disallowed_methods)]
+    // Same wall-clock boundary as above; 20 rounds of small ops complete in
+    // seconds unless a request parks until the 30s client timeout.
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(25),
+        "alternating-runtime ops should never park until the client timeout; took {elapsed:?}"
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires real Cloudflare R2 credentials"]
 async fn cloudflare_r2_real_provider_conformance() {


### PR DESCRIPTION
The S3 growth benchmark logged 16 retry-recovered transport timeouts, all ~30.00s — reqwest's default request timeout, not S3 latency. Root cause (probe-reproduced in the runtime-timeout analysis): the default connector performs HTTP IO on whichever runtime issues the request, so a store shared across current-thread runtimes parks pooled connections until the client timeout fires. Routing the same probe through a dedicated-runtime connector dropped 30 alternating-runtime iterations from repeated 30s stalls to 7.2s total.

Each provider store (S3/R2 via the shared S3-compatible adapter, GCS, ABS) now owns a single-threaded IO runtime for its client's HTTP, wired through `object_store`'s `SpawnedReqwestConnector`, so caller runtime topology can never affect provider IO. The store keeps the runtime alive for the client's lifetime and shuts it down in the background on drop, so dropping a store inside an async context never blocks or panics. An ignored live-provider test reproduces the alternating-runtimes pattern as a regression probe.