### PR TITLE
perf(core): budget the metadata table cache by bytes and single-flight segment fetches

### DIFF
--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -18,6 +18,8 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+# sync-only: single-flight primitives; core stays executor-agnostic.
+tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing.workspace = true
 
 [features]

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -5,6 +5,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
+
+/// Default decoded-byte budget for cached metadata table blocks. The byte
+/// budget is the primary limit: one wide directory's segment working set
+/// must fit, or warm listings re-fetch segments superlinearly.
+pub const DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
+/// Secondary block-count bound behind the byte budget; it only binds under
+/// pathological many-tiny-block shapes.
+pub const DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS: usize = 8192;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataTableCacheConfig {
@@ -17,8 +26,8 @@ impl Default for MetadataTableCacheConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            max_blocks: 256,
-            max_decoded_bytes: None,
+            max_blocks: DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
+            max_decoded_bytes: Some(DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES),
         }
     }
 }
@@ -61,6 +70,9 @@ pub struct MetadataTableCache {
     config: MetadataTableCacheConfig,
     inner: Mutex<MetadataTableCacheInner>,
     stats: MetadataTableCacheStatsInner,
+    /// One cell per in-flight segment fetch, keyed by object key, so
+    /// concurrent readers share a single store GET per segment.
+    in_flight: Mutex<HashMap<String, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -84,7 +96,46 @@ impl MetadataTableCache {
             config,
             inner: Mutex::new(MetadataTableCacheInner::default()),
             stats: MetadataTableCacheStatsInner::default(),
+            in_flight: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Runs `fetch` once per object key across concurrent callers: waiters
+    /// share the winner's decoded block instead of issuing duplicate store
+    /// GETs. A failed or cancelled fetch leaves the cell empty, so the next
+    /// caller retries.
+    pub(super) async fn fetch_deduplicated<E, F, Fut>(
+        &self,
+        object_key: &str,
+        fetch: F,
+    ) -> Result<DecodedMetadataTableBlock, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<DecodedMetadataTableBlock, E>>,
+    {
+        let cell = {
+            let mut in_flight = self
+                .in_flight
+                .lock()
+                .expect("metadata table cache in-flight lock poisoned");
+            Arc::clone(
+                in_flight
+                    .entry(object_key.to_owned())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let result = cell.get_or_try_init(fetch).await.cloned();
+        let mut in_flight = self
+            .in_flight
+            .lock()
+            .expect("metadata table cache in-flight lock poisoned");
+        if in_flight
+            .get(object_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &cell))
+        {
+            in_flight.remove(object_key);
+        }
+        result
     }
 
     pub fn stats(&self) -> MetadataTableCacheStats {
@@ -392,5 +443,99 @@ impl WalTailProjectionCacheInner {
     fn touch(&mut self, key: &WalTailProjectionCacheKey) {
         self.order.retain(|candidate| candidate != key);
         self.order.push_back(key.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache,
+        MetadataTableCacheConfig, MetadataTableCacheKey,
+    };
+    use loonfs_api::wire::manifest::{MetadataSegmentKey, MetadataTableFamily};
+    use loonfs_api::ChangeSeq;
+
+    fn block(decoded_byte_len: usize) -> DecodedMetadataTableBlock {
+        DecodedMetadataTableBlock {
+            rows: Vec::new(),
+            segment_seq: ChangeSeq(1),
+            family: MetadataTableFamily::Inodes,
+            segment_index: 0,
+            segment_key: MetadataSegmentKey::Full,
+            row_count: 0,
+            min_key: String::new(),
+            max_key: String::new(),
+            decoded_byte_len,
+        }
+    }
+
+    fn key(digest: &str) -> MetadataTableCacheKey {
+        MetadataTableCacheKey {
+            table_digest: digest.to_owned(),
+            block_kind: MetadataTableBlockKind::SegmentPayload,
+            block_offset: 0,
+        }
+    }
+
+    #[test]
+    fn default_config_budgets_bytes_as_the_primary_limit() {
+        let config = MetadataTableCacheConfig::default();
+        assert_eq!(
+            config.max_decoded_bytes,
+            Some(super::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES)
+        );
+        assert_eq!(
+            config.max_blocks,
+            super::DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS
+        );
+    }
+
+    #[test]
+    fn byte_budget_evicts_before_the_block_bound() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            enabled: true,
+            max_blocks: 100,
+            max_decoded_bytes: Some(1000),
+        });
+        cache.insert(key("a"), block(600));
+        cache.insert(key("b"), block(600));
+        assert!(
+            cache.get(&key("a")).is_none(),
+            "oldest block should evict once the byte budget is exceeded"
+        );
+        assert!(cache.get(&key("b")).is_some());
+        assert_eq!(cache.stats().evictions, 1);
+    }
+
+    #[test]
+    fn replacing_a_block_reaccounts_its_decoded_bytes() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            enabled: true,
+            max_blocks: 100,
+            max_decoded_bytes: Some(1000),
+        });
+        cache.insert(key("a"), block(600));
+        cache.insert(key("a"), block(100));
+        // 600 was released on replace: another 600 fits without eviction.
+        cache.insert(key("b"), block(600));
+        assert!(cache.get(&key("a")).is_some());
+        assert!(cache.get(&key("b")).is_some());
+        assert_eq!(cache.stats().evictions, 0);
+    }
+
+    #[tokio::test]
+    async fn fetch_deduplicated_retries_after_a_failed_fetch() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+        let failed: Result<_, String> = cache
+            .fetch_deduplicated("segment-key", || async { Err("transport".to_owned()) })
+            .await;
+        assert!(failed.is_err());
+        let recovered: Result<_, String> = cache
+            .fetch_deduplicated("segment-key", || async { Ok(block(1)) })
+            .await;
+        assert!(
+            recovered.is_ok(),
+            "a failed fetch should leave nothing behind for the next caller"
+        );
     }
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -551,50 +551,62 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         }
     }
 
-    let Some(bytes) = store
-        .get(&descriptor.object_key, None)
-        .await
-        .map_err(|err| ManifestLoadError::ReadSegment {
-            object_key: descriptor.object_key.clone(),
-            message: err.to_string(),
-        })?
-    else {
-        return Err(ManifestLoadError::MissingSegment {
-            object_key: descriptor.object_key.clone(),
-        });
+    let fetch = || async {
+        let Some(bytes) = store
+            .get(&descriptor.object_key, None)
+            .await
+            .map_err(|err| ManifestLoadError::ReadSegment {
+                object_key: descriptor.object_key.clone(),
+                message: err.to_string(),
+            })?
+        else {
+            return Err(ManifestLoadError::MissingSegment {
+                object_key: descriptor.object_key.clone(),
+            });
+        };
+        let segment = decode_metadata_sst_envelope_zstd(&bytes).map_err(|err| {
+            ManifestLoadError::SegmentCodec {
+                object_key: descriptor.object_key.clone(),
+                message: err.to_string(),
+            }
+        })?;
+        let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        Ok(DecodedMetadataTableBlock {
+            decoded_byte_len: decoded_manifest_block_weight(family, &rows),
+            rows,
+            segment_seq: expected_segment_seq,
+            family,
+            segment_index: descriptor.segment_index,
+            segment_key: descriptor.segment_key.clone(),
+            row_count: descriptor.row_count,
+            min_key: descriptor.min_key.clone(),
+            max_key: descriptor.max_key.clone(),
+        })
     };
-    let segment = decode_metadata_sst_envelope_zstd(&bytes).map_err(|err| {
-        ManifestLoadError::SegmentCodec {
-            object_key: descriptor.object_key.clone(),
-            message: err.to_string(),
+    // Waiters may share a block another caller fetched, so every path
+    // re-validates the block against this caller's own expectations, exactly
+    // as the cache-hit path above does.
+    let block = match table_cache {
+        Some(cache) => {
+            cache
+                .fetch_deduplicated(&descriptor.object_key, fetch)
+                .await?
         }
-    })?;
-    let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        None => fetch().await?,
+    };
+    validate_cached_manifest_block(family, expected_segment_seq, descriptor, &block)?;
     validate_manifest_row_seq_range(
         &descriptor.object_key,
-        &rows,
+        &block.rows,
         context.row_seq_min,
         context.row_seq_max(descriptor),
     )?;
     if cache_mode == MetadataTableCacheMode::Populate {
         if let Some(cache) = table_cache {
-            cache.insert(
-                cache_key,
-                DecodedMetadataTableBlock {
-                    rows: rows.clone(),
-                    segment_seq: expected_segment_seq,
-                    family,
-                    segment_index: descriptor.segment_index,
-                    segment_key: descriptor.segment_key.clone(),
-                    row_count: descriptor.row_count,
-                    min_key: descriptor.min_key.clone(),
-                    max_key: descriptor.max_key.clone(),
-                    decoded_byte_len: decoded_manifest_block_weight(family, &rows),
-                },
-            );
+            cache.insert(cache_key, block.clone());
         }
     }
-    Ok(rows)
+    Ok(block.rows)
 }
 
 pub(super) fn validate_cached_manifest_block(

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -36,6 +36,7 @@ mod validate;
 pub use self::cache::{
     MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
     WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+    DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::runs::MetadataLsmPolicy;

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -21,7 +21,10 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 pub(super) const SMALL_SCAN_CACHE_SEGMENT_LIMIT: usize = 4;
-pub(super) const MAX_MATERIALIZED_TABLE_FETCHES: usize = 8;
+/// Segment fetches issued per wave during a scan. Wide directories touch
+/// hundreds of segments per page; deeper waves amortize the per-wave await
+/// without unbounded fan-out.
+pub(super) const MAX_MATERIALIZED_TABLE_FETCHES: usize = 16;
 
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2143,6 +2143,70 @@ async fn large_table_scan_does_not_insert_metadata_cache_blocks() {
 }
 
 #[tokio::test]
+async fn concurrent_scans_share_one_fetch_per_segment() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..8 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    let policy = MetadataLsmPolicy {
+        max_rows_per_segment: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+        .await
+        .expect("manifest");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let cache = super::MetadataTableCache::new(Default::default());
+    let load_tables = || {
+        super::load_verified_manifest_tables_with_cache(
+            &store,
+            Some(&cache),
+            &namespace_id,
+            &manifest_object_id,
+        )
+    };
+
+    // The scan touches more segments than the small-scan populate limit, so
+    // every fresh view re-fetches each segment: a solo pass measures the
+    // true per-scan fetch count.
+    let solo_tables = load_tables().await.expect("load solo tables");
+    store.reset_metadata_sst_gets();
+    let solo = solo_tables
+        .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
+        .await
+        .expect("solo scan");
+    let solo_fetches = store.metadata_sst_gets();
+    assert!(solo.len() >= 8);
+    assert!(solo_fetches >= 8, "solo scan should fetch every segment");
+
+    // Concurrent requests each load their own tables view; only the shared
+    // cache's single-flight can deduplicate their segment fetches.
+    let first_tables = load_tables().await.expect("load first tables");
+    let second_tables = load_tables().await.expect("load second tables");
+    store.reset_metadata_sst_gets();
+    let (first, second) = tokio::join!(
+        first_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
+        second_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
+    );
+    let paired_fetches = store.metadata_sst_gets();
+    assert_eq!(first.expect("first scan"), second.expect("second scan"));
+    assert_eq!(
+        paired_fetches, solo_fetches,
+        "concurrent scans over one shared cache should share one fetch per segment"
+    );
+}
+
+#[tokio::test]
 async fn table_range_page_merges_base_and_l0_in_row_key_order() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -4573,7 +4637,7 @@ impl MetadataSstGetCountingStore {
     }
 
     fn record_if_metadata_sst(&self, key: &str) {
-        if key.contains("/tables/metadata/") && key.ends_with(".sst.zst") {
+        if key.contains("/metadata/tables/") && key.ends_with(".sst.zst") {
             *self
                 .metadata_sst_gets
                 .lock()

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod cache {
         ManifestLoadError, ManifestLoadFailureClass, MetadataLsmPolicy, MetadataTableCache,
         MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
         WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
     };
     pub use crate::namespace::status::{
         load_namespace_head_summary, probe_namespace_head_etag, NamespaceHeadEtagProbe,

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,5 +1,6 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -25,6 +26,9 @@ pub struct AzureAbsStoreConfig {
 #[derive(Debug)]
 pub struct AzureAbsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl AzureAbsStore {
@@ -45,7 +49,9 @@ impl AzureAbsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = MicrosoftAzureBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_account(config.account_name)
             .with_container_name(config.container_name)
             .with_access_key(config.access_key.expose());
@@ -73,7 +79,10 @@ impl AzureAbsStore {
                 sha256_checksum_metadata: false,
             },
         )?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 }
 

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,4 +1,5 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -23,6 +24,9 @@ pub struct GcpGcsStoreConfig {
 #[derive(Debug)]
 pub struct GcpGcsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl GcpGcsStore {
@@ -38,7 +42,9 @@ impl GcpGcsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let builder = GoogleCloudStorageBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_service_account_path(config.service_account_key_path);
 
@@ -53,7 +59,10 @@ impl GcpGcsStore {
             },
         )?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 
     fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -26,6 +26,7 @@ pub mod s3;
 mod s3_compatible;
 mod secret;
 mod store_config;
+mod store_io_runtime;
 
 /// Compatibility alias for [`local_fs_store`], kept so existing imports of
 /// `loonfs_objectstore::fs::LocalFsStore` keep resolving.

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,4 +1,5 @@
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, ProviderObjectStore,
     ProviderObjectStoreConfig, PutMode,
@@ -28,6 +29,9 @@ pub(crate) struct S3CompatibleConfig {
 pub(crate) struct S3CompatibleStore {
     provider_name: &'static str,
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl fmt::Debug for S3CompatibleStore {
@@ -49,7 +53,9 @@ impl S3CompatibleStore {
             })
             .transpose()?;
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = AmazonS3Builder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_region(config.region)
             .with_access_key_id(config.access_key_id.expose())
@@ -83,6 +89,7 @@ impl S3CompatibleStore {
         Ok(Self {
             provider_name: config.provider_name,
             inner,
+            _io_runtime: io_runtime,
         })
     }
 }

--- a/crates/loonfs-objectstore/src/store_io_runtime.rs
+++ b/crates/loonfs-objectstore/src/store_io_runtime.rs
@@ -1,0 +1,102 @@
+//! The per-store HTTP IO runtime: provider requests are driven by a thread
+//! this runtime owns, never by the caller's runtime.
+//!
+//! The default provider connector performs HTTP IO on whichever runtime
+//! issues the request. A store shared across current-thread runtimes then
+//! parks pooled connections until the client's 30s request timeout fires —
+//! reproduced and fixed in the S3 benchmark investigation by routing IO
+//! through a dedicated runtime. Every provider client is constructed with a
+//! connector onto its store's own runtime, so caller runtime topology can
+//! never affect provider IO.
+
+use crate::ObjectStoreError;
+use object_store::client::SpawnedReqwestConnector;
+use std::fmt;
+use std::sync::Arc;
+
+/// Owns the Tokio runtime that drives one configured store's HTTP IO.
+///
+/// The provider connector holds only a runtime `Handle`; this type keeps the
+/// runtime itself alive for as long as the provider client lives. Clones
+/// share one runtime. Dropping the last clone shuts the runtime down in the
+/// background, so a store dropped inside an async context never blocks or
+/// panics.
+#[derive(Clone)]
+pub(crate) struct StoreIoRuntime {
+    inner: Arc<OwnedRuntime>,
+}
+
+struct OwnedRuntime {
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl StoreIoRuntime {
+    /// Starts the IO runtime for one configured store.
+    ///
+    /// One worker thread multiplexes every request for the store; HTTP IO is
+    /// reactor-driven, so request concurrency does not need more threads.
+    pub(crate) fn new() -> Result<Self, ObjectStoreError> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("loonfs-store-io")
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                ObjectStoreError::Configuration(format!(
+                    "failed to start store io runtime: {error}"
+                ))
+            })?;
+        Ok(Self {
+            inner: Arc::new(OwnedRuntime {
+                runtime: Some(runtime),
+            }),
+        })
+    }
+
+    /// Connector that routes a provider client's requests onto this runtime.
+    pub(crate) fn connector(&self) -> SpawnedReqwestConnector {
+        let handle = self
+            .inner
+            .runtime
+            .as_ref()
+            .expect("store io runtime should live until the last store clone drops")
+            .handle()
+            .clone();
+        SpawnedReqwestConnector::new(handle)
+    }
+}
+
+impl fmt::Debug for StoreIoRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoreIoRuntime").finish_non_exhaustive()
+    }
+}
+
+impl Drop for OwnedRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            // A store may be dropped inside an async context, where a
+            // blocking runtime drop panics; background shutdown never blocks.
+            runtime.shutdown_background();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StoreIoRuntime;
+
+    #[tokio::test]
+    async fn store_io_runtime_drops_safely_inside_an_async_context() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let clone = runtime.clone();
+        drop(runtime);
+        drop(clone);
+    }
+
+    #[tokio::test]
+    async fn connector_construction_does_not_touch_the_caller_runtime() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let _connector = runtime.connector();
+    }
+}

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -350,6 +350,67 @@ async fn aws_s3_real_provider_conformance() {
     assert_provider_conformance(&store).await;
 }
 
+#[test]
+#[ignore = "requires real AWS S3 credentials"]
+fn aws_s3_store_survives_alternating_current_thread_runtimes() {
+    // Regression probe for the 30s stall: a provider client driven from two
+    // current-thread runtimes parked pooled connections until the client
+    // timeout fired. The store-owned IO runtime decouples HTTP driving from
+    // caller runtime topology, so alternating runtimes stays fast.
+    let config = AwsS3ConformanceConfig::from_env()
+        .expect("load AWS S3 real-provider conformance environment");
+    let store = AwsS3Store::new(AwsS3StoreConfig {
+        bucket: config.bucket,
+        region: config.region,
+        endpoint_url: config.endpoint,
+        access_key_id: config.access_key_id.into(),
+        secret_access_key: config.secret_access_key.into(),
+        session_token: config.session_token.map(Into::into),
+        key_prefix: Some(config.prefix),
+        force_path_style: false,
+    })
+    .expect("create AWS S3 object store");
+
+    let runtime_a = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime a");
+    let runtime_b = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime b");
+
+    #[allow(clippy::disallowed_methods)]
+    // Wall-clock bounds a live-provider stall check; no protocol time depends on it.
+    let started = std::time::Instant::now();
+    for round in 0..5u32 {
+        let key = format!("runtime-affinity-probe/round-{round}.bin");
+        let bytes = Bytes::from(format!("round {round}"));
+        runtime_a
+            .block_on(store.put_overwrite(&key, bytes))
+            .expect("put on runtime a");
+        let head = runtime_b
+            .block_on(store.head(&key))
+            .expect("head on runtime b");
+        assert!(head.is_some(), "object should exist after put");
+        let body = runtime_a
+            .block_on(store.get(&key, None))
+            .expect("get on runtime a");
+        assert!(body.is_some(), "object body should read back");
+        runtime_b
+            .block_on(store.delete(&key))
+            .expect("delete on runtime b");
+    }
+    #[allow(clippy::disallowed_methods)]
+    // Same wall-clock boundary as above; 20 rounds of small ops complete in
+    // seconds unless a request parks until the 30s client timeout.
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(25),
+        "alternating-runtime ops should never park until the client timeout; took {elapsed:?}"
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires real Cloudflare R2 credentials"]
 async fn cloudflare_r2_real_provider_conformance() {


### PR DESCRIPTION
At 50k children the metadata cache's 256-block default sits below one wide directory's segment working set (~320 segments), so warm-list hit rate degraded 87%→52% and warm GETs grew superlinearly per child. The cache already tracked decoded bytes; this makes the byte budget the primary limit with a real default (256 MiB, matching the WAL-tail projection cache's precedent) and keeps block count as a generous secondary bound (8192) for pathological tiny-block shapes.

Concurrent readers also duplicated segment fetches: two requests listing the same directory each issued their own GET per segment. The cache now single-flights fetches by object key — waiters share the winner's decoded block, a failed or cancelled fetch leaves nothing behind so the next caller retries, and every path (hit, shared, direct) re-validates the block against its own descriptor expectations. The concurrency test drives two views over one shared cache and pins paired fetches to the solo count. Core gains a `sync`-only tokio dependency for the once-cell; it stays executor-agnostic.

Also in passing: the segment fetch wave deepens 8→16 (kept a constant rather than a knob — the byte budget is the real lever), and the GET-counting test store's key matcher was inverted (`/tables/metadata/` vs the actual `metadata/tables/` layout), which had turned three no-SST-reads regression guards vacuous; fixed, and all three still hold.