### PR TITLE
perf(core): resolve list visibility from page-scoped preloads

### DIFF
--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -18,6 +18,8 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+# sync-only: single-flight primitives; core stays executor-agnostic.
+tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing.workspace = true
 
 [features]

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -5,6 +5,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
+
+/// Default decoded-byte budget for cached metadata table blocks. The byte
+/// budget is the primary limit: one wide directory's segment working set
+/// must fit, or warm listings re-fetch segments superlinearly.
+pub const DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
+/// Secondary block-count bound behind the byte budget; it only binds under
+/// pathological many-tiny-block shapes.
+pub const DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS: usize = 8192;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataTableCacheConfig {
@@ -17,8 +26,8 @@ impl Default for MetadataTableCacheConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            max_blocks: 256,
-            max_decoded_bytes: None,
+            max_blocks: DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
+            max_decoded_bytes: Some(DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES),
         }
     }
 }
@@ -61,6 +70,9 @@ pub struct MetadataTableCache {
     config: MetadataTableCacheConfig,
     inner: Mutex<MetadataTableCacheInner>,
     stats: MetadataTableCacheStatsInner,
+    /// One cell per in-flight segment fetch, keyed by object key, so
+    /// concurrent readers share a single store GET per segment.
+    in_flight: Mutex<HashMap<String, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -84,7 +96,46 @@ impl MetadataTableCache {
             config,
             inner: Mutex::new(MetadataTableCacheInner::default()),
             stats: MetadataTableCacheStatsInner::default(),
+            in_flight: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Runs `fetch` once per object key across concurrent callers: waiters
+    /// share the winner's decoded block instead of issuing duplicate store
+    /// GETs. A failed or cancelled fetch leaves the cell empty, so the next
+    /// caller retries.
+    pub(super) async fn fetch_deduplicated<E, F, Fut>(
+        &self,
+        object_key: &str,
+        fetch: F,
+    ) -> Result<DecodedMetadataTableBlock, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<DecodedMetadataTableBlock, E>>,
+    {
+        let cell = {
+            let mut in_flight = self
+                .in_flight
+                .lock()
+                .expect("metadata table cache in-flight lock poisoned");
+            Arc::clone(
+                in_flight
+                    .entry(object_key.to_owned())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let result = cell.get_or_try_init(fetch).await.cloned();
+        let mut in_flight = self
+            .in_flight
+            .lock()
+            .expect("metadata table cache in-flight lock poisoned");
+        if in_flight
+            .get(object_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &cell))
+        {
+            in_flight.remove(object_key);
+        }
+        result
     }
 
     pub fn stats(&self) -> MetadataTableCacheStats {
@@ -392,5 +443,99 @@ impl WalTailProjectionCacheInner {
     fn touch(&mut self, key: &WalTailProjectionCacheKey) {
         self.order.retain(|candidate| candidate != key);
         self.order.push_back(key.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache,
+        MetadataTableCacheConfig, MetadataTableCacheKey,
+    };
+    use loonfs_api::wire::manifest::{MetadataSegmentKey, MetadataTableFamily};
+    use loonfs_api::ChangeSeq;
+
+    fn block(decoded_byte_len: usize) -> DecodedMetadataTableBlock {
+        DecodedMetadataTableBlock {
+            rows: Vec::new(),
+            segment_seq: ChangeSeq(1),
+            family: MetadataTableFamily::Inodes,
+            segment_index: 0,
+            segment_key: MetadataSegmentKey::Full,
+            row_count: 0,
+            min_key: String::new(),
+            max_key: String::new(),
+            decoded_byte_len,
+        }
+    }
+
+    fn key(digest: &str) -> MetadataTableCacheKey {
+        MetadataTableCacheKey {
+            table_digest: digest.to_owned(),
+            block_kind: MetadataTableBlockKind::SegmentPayload,
+            block_offset: 0,
+        }
+    }
+
+    #[test]
+    fn default_config_budgets_bytes_as_the_primary_limit() {
+        let config = MetadataTableCacheConfig::default();
+        assert_eq!(
+            config.max_decoded_bytes,
+            Some(super::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES)
+        );
+        assert_eq!(
+            config.max_blocks,
+            super::DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS
+        );
+    }
+
+    #[test]
+    fn byte_budget_evicts_before_the_block_bound() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            enabled: true,
+            max_blocks: 100,
+            max_decoded_bytes: Some(1000),
+        });
+        cache.insert(key("a"), block(600));
+        cache.insert(key("b"), block(600));
+        assert!(
+            cache.get(&key("a")).is_none(),
+            "oldest block should evict once the byte budget is exceeded"
+        );
+        assert!(cache.get(&key("b")).is_some());
+        assert_eq!(cache.stats().evictions, 1);
+    }
+
+    #[test]
+    fn replacing_a_block_reaccounts_its_decoded_bytes() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            enabled: true,
+            max_blocks: 100,
+            max_decoded_bytes: Some(1000),
+        });
+        cache.insert(key("a"), block(600));
+        cache.insert(key("a"), block(100));
+        // 600 was released on replace: another 600 fits without eviction.
+        cache.insert(key("b"), block(600));
+        assert!(cache.get(&key("a")).is_some());
+        assert!(cache.get(&key("b")).is_some());
+        assert_eq!(cache.stats().evictions, 0);
+    }
+
+    #[tokio::test]
+    async fn fetch_deduplicated_retries_after_a_failed_fetch() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+        let failed: Result<_, String> = cache
+            .fetch_deduplicated("segment-key", || async { Err("transport".to_owned()) })
+            .await;
+        assert!(failed.is_err());
+        let recovered: Result<_, String> = cache
+            .fetch_deduplicated("segment-key", || async { Ok(block(1)) })
+            .await;
+        assert!(
+            recovered.is_ok(),
+            "a failed fetch should leave nothing behind for the next caller"
+        );
     }
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -551,50 +551,62 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         }
     }
 
-    let Some(bytes) = store
-        .get(&descriptor.object_key, None)
-        .await
-        .map_err(|err| ManifestLoadError::ReadSegment {
-            object_key: descriptor.object_key.clone(),
-            message: err.to_string(),
-        })?
-    else {
-        return Err(ManifestLoadError::MissingSegment {
-            object_key: descriptor.object_key.clone(),
-        });
+    let fetch = || async {
+        let Some(bytes) = store
+            .get(&descriptor.object_key, None)
+            .await
+            .map_err(|err| ManifestLoadError::ReadSegment {
+                object_key: descriptor.object_key.clone(),
+                message: err.to_string(),
+            })?
+        else {
+            return Err(ManifestLoadError::MissingSegment {
+                object_key: descriptor.object_key.clone(),
+            });
+        };
+        let segment = decode_metadata_sst_envelope_zstd(&bytes).map_err(|err| {
+            ManifestLoadError::SegmentCodec {
+                object_key: descriptor.object_key.clone(),
+                message: err.to_string(),
+            }
+        })?;
+        let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        Ok(DecodedMetadataTableBlock {
+            decoded_byte_len: decoded_manifest_block_weight(family, &rows),
+            rows,
+            segment_seq: expected_segment_seq,
+            family,
+            segment_index: descriptor.segment_index,
+            segment_key: descriptor.segment_key.clone(),
+            row_count: descriptor.row_count,
+            min_key: descriptor.min_key.clone(),
+            max_key: descriptor.max_key.clone(),
+        })
     };
-    let segment = decode_metadata_sst_envelope_zstd(&bytes).map_err(|err| {
-        ManifestLoadError::SegmentCodec {
-            object_key: descriptor.object_key.clone(),
-            message: err.to_string(),
+    // Waiters may share a block another caller fetched, so every path
+    // re-validates the block against this caller's own expectations, exactly
+    // as the cache-hit path above does.
+    let block = match table_cache {
+        Some(cache) => {
+            cache
+                .fetch_deduplicated(&descriptor.object_key, fetch)
+                .await?
         }
-    })?;
-    let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        None => fetch().await?,
+    };
+    validate_cached_manifest_block(family, expected_segment_seq, descriptor, &block)?;
     validate_manifest_row_seq_range(
         &descriptor.object_key,
-        &rows,
+        &block.rows,
         context.row_seq_min,
         context.row_seq_max(descriptor),
     )?;
     if cache_mode == MetadataTableCacheMode::Populate {
         if let Some(cache) = table_cache {
-            cache.insert(
-                cache_key,
-                DecodedMetadataTableBlock {
-                    rows: rows.clone(),
-                    segment_seq: expected_segment_seq,
-                    family,
-                    segment_index: descriptor.segment_index,
-                    segment_key: descriptor.segment_key.clone(),
-                    row_count: descriptor.row_count,
-                    min_key: descriptor.min_key.clone(),
-                    max_key: descriptor.max_key.clone(),
-                    decoded_byte_len: decoded_manifest_block_weight(family, &rows),
-                },
-            );
+            cache.insert(cache_key, block.clone());
         }
     }
-    Ok(rows)
+    Ok(block.rows)
 }
 
 pub(super) fn validate_cached_manifest_block(

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -36,6 +36,7 @@ mod validate;
 pub use self::cache::{
     MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
     WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+    DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::runs::MetadataLsmPolicy;

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -21,7 +21,10 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 pub(super) const SMALL_SCAN_CACHE_SEGMENT_LIMIT: usize = 4;
-pub(super) const MAX_MATERIALIZED_TABLE_FETCHES: usize = 8;
+/// Segment fetches issued per wave during a scan. Wide directories touch
+/// hundreds of segments per page; deeper waves amortize the per-wave await
+/// without unbounded fan-out.
+pub(super) const MAX_MATERIALIZED_TABLE_FETCHES: usize = 16;
 
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2143,6 +2143,70 @@ async fn large_table_scan_does_not_insert_metadata_cache_blocks() {
 }
 
 #[tokio::test]
+async fn concurrent_scans_share_one_fetch_per_segment() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..8 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    let policy = MetadataLsmPolicy {
+        max_rows_per_segment: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+        .await
+        .expect("manifest");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let cache = super::MetadataTableCache::new(Default::default());
+    let load_tables = || {
+        super::load_verified_manifest_tables_with_cache(
+            &store,
+            Some(&cache),
+            &namespace_id,
+            &manifest_object_id,
+        )
+    };
+
+    // The scan touches more segments than the small-scan populate limit, so
+    // every fresh view re-fetches each segment: a solo pass measures the
+    // true per-scan fetch count.
+    let solo_tables = load_tables().await.expect("load solo tables");
+    store.reset_metadata_sst_gets();
+    let solo = solo_tables
+        .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
+        .await
+        .expect("solo scan");
+    let solo_fetches = store.metadata_sst_gets();
+    assert!(solo.len() >= 8);
+    assert!(solo_fetches >= 8, "solo scan should fetch every segment");
+
+    // Concurrent requests each load their own tables view; only the shared
+    // cache's single-flight can deduplicate their segment fetches.
+    let first_tables = load_tables().await.expect("load first tables");
+    let second_tables = load_tables().await.expect("load second tables");
+    store.reset_metadata_sst_gets();
+    let (first, second) = tokio::join!(
+        first_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
+        second_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
+    );
+    let paired_fetches = store.metadata_sst_gets();
+    assert_eq!(first.expect("first scan"), second.expect("second scan"));
+    assert_eq!(
+        paired_fetches, solo_fetches,
+        "concurrent scans over one shared cache should share one fetch per segment"
+    );
+}
+
+#[tokio::test]
 async fn table_range_page_merges_base_and_l0_in_row_key_order() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -4573,7 +4637,7 @@ impl MetadataSstGetCountingStore {
     }
 
     fn record_if_metadata_sst(&self, key: &str) {
-        if key.contains("/tables/metadata/") && key.ends_with(".sst.zst") {
+        if key.contains("/metadata/tables/") && key.ends_with(".sst.zst") {
             *self
                 .metadata_sst_gets
                 .lock()

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod cache {
         ManifestLoadError, ManifestLoadFailureClass, MetadataLsmPolicy, MetadataTableCache,
         MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
         WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
     };
     pub use crate::namespace::status::{
         load_namespace_head_summary, probe_namespace_head_etag, NamespaceHeadEtagProbe,

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -133,6 +133,54 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         .collect())
 }
 
+/// Every unbind row for `parent_inode_id` whose name key falls in
+/// `[first_name_key, last_name_key]`, paged internally to completeness: the
+/// caller treats absence from the result as "no unbind exists" for names in
+/// the range, so a partial scan would be a correctness bug, not a slow path.
+pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    parent_inode_id: InodeId,
+    first_name_key: &str,
+    last_name_key: &str,
+) -> Result<Vec<DirentryUnbindRecord>> {
+    const UNBIND_RANGE_SCAN_LIMIT: usize = 512;
+    let parent_prefix = format!("direntry-unbind-{:020}-", parent_inode_id.0);
+    let first_encoded = hex_encode_row_key_component(first_name_key);
+    let last_encoded = hex_encode_row_key_component(last_name_key);
+    let mut lower_bound = format!("{parent_prefix}{first_encoded}-");
+    let last_name_prefix = format!("{parent_prefix}{last_encoded}-");
+    let upper_bound = string_prefix_upper_bound(&last_name_prefix);
+
+    let mut unbinds = Vec::new();
+    loop {
+        let page = tables
+            .scan_range_page(
+                MetadataTableFamily::DirentryUnbinds,
+                &lower_bound,
+                upper_bound.as_deref(),
+                UNBIND_RANGE_SCAN_LIMIT,
+            )
+            .await
+            .map_err(manifest_error_to_core)?;
+        let page_len = page.len();
+        let last_row_key = page
+            .last()
+            .map(|row| row.row_key_for_family(MetadataTableFamily::DirentryUnbinds));
+        unbinds.extend(
+            page.into_iter()
+                .filter_map(direntry_unbind_from_manifest_row),
+        );
+        if page_len < UNBIND_RANGE_SCAN_LIMIT {
+            break;
+        }
+        let Some(last_row_key) = last_row_key else {
+            break;
+        };
+        lower_bound = resume_after_row_key(&last_row_key);
+    }
+    Ok(unbinds)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RevisionPagePosition {
     pub(super) revision_no: RevisionNo,

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -15,7 +15,7 @@ use loonfs_api::{AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NamePoli
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 const DIRECTORY_PAGE_RAW_SCAN_LIMIT: usize = 64;
 
@@ -605,6 +605,41 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         Ok(tombstones)
     }
 
+    /// Every unbind for `parent_inode_id` with a name key in
+    /// `[first_name_key, last_name_key]`, merged across manifest tables and
+    /// row states. Complete over the range: callers treat absence as "no
+    /// unbind exists".
+    async fn direntry_unbinds_for_parent_name_range(
+        &self,
+        parent_inode_id: InodeId,
+        first_name_key: &str,
+        last_name_key: &str,
+    ) -> Result<Vec<DirentryUnbindRecord>, CoreError> {
+        let mut unbinds = if let Some(tables) = self.manifest_tables() {
+            manifest_index::direntry_unbinds_for_parent_name_range(
+                tables,
+                parent_inode_id,
+                first_name_key,
+                last_name_key,
+            )
+            .await?
+        } else {
+            Vec::new()
+        };
+        unbinds.extend(self.row_states().flat_map(|state| {
+            state
+                .direntry_unbinds()
+                .iter()
+                .filter(move |unbind| {
+                    unbind.parent_inode_id == parent_inode_id
+                        && unbind.name_key.as_str() >= first_name_key
+                        && unbind.name_key.as_str() <= last_name_key
+                })
+                .cloned()
+        }));
+        Ok(unbinds)
+    }
+
     fn tail_direntry_bind_page_candidates(
         &self,
         parent_inode_id: InodeId,
@@ -693,6 +728,8 @@ pub(crate) struct MetadataViewSessionCounters {
     pub(crate) direntry_child_scan_calls: u64,
     pub(crate) scan_prefix_calls: u64,
     pub(crate) scan_range_page_calls: u64,
+    pub(crate) list_preload_unbind_range_scans: u64,
+    pub(crate) list_preload_child_lookups: u64,
 }
 
 pub(crate) struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
@@ -701,6 +738,7 @@ pub(crate) struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
     visible_inode_cache: HashMap<InodeId, Option<InodeRecord>>,
     bound_child_cache: HashMap<ParentNameCacheKey, Option<DirentryBindRecord>>,
     current_parent_binding_cache: HashMap<InodeId, Option<DirentryBindRecord>>,
+    latest_parent_binding_cache: HashMap<InodeId, Option<DirentryBindRecord>>,
     latest_revision_head_cache: HashMap<InodeId, Option<RevisionRecord>>,
     active_tombstone_cache: HashMap<InodeId, Option<SubtreeTombstoneRecord>>,
     covering_tombstone_cache: HashMap<InodeId, Option<SubtreeTombstoneRecord>>,
@@ -716,6 +754,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             visible_inode_cache: HashMap::new(),
             bound_child_cache: HashMap::new(),
             current_parent_binding_cache: HashMap::new(),
+            latest_parent_binding_cache: HashMap::new(),
             latest_revision_head_cache: HashMap::new(),
             active_tombstone_cache: HashMap::new(),
             covering_tombstone_cache: HashMap::new(),
@@ -745,17 +784,63 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         }
 
         let raw_scan_limit = limit.max(DIRECTORY_PAGE_RAW_SCAN_LIMIT);
-        let mut manifest_after_row_key = None;
-        let mut manifest_exhausted = self.base.manifest_tables().is_none();
-        let mut manifest_candidates = VecDeque::<DirentryBindPageCandidate>::new();
-        let tail_candidates = self
-            .base
-            .tail_direntry_bind_page_candidates(parent_inode_id, start_after_name_key);
-        let mut tail_index = 0;
-        let mut seen_name_keys = BTreeSet::new();
+        let mut stream = DirentryBindNameGroupStream::new(
+            self.base
+                .tail_direntry_bind_page_candidates(parent_inode_id, start_after_name_key),
+            self.base.manifest_tables().is_none(),
+        );
         let mut children = Vec::with_capacity(limit);
-        while children.len() < limit {
-            if manifest_candidates.is_empty() && !manifest_exhausted {
+        'pages: while children.len() < limit {
+            let groups = self
+                .next_candidate_name_groups(
+                    &mut stream,
+                    parent_inode_id,
+                    start_after_name_key,
+                    raw_scan_limit,
+                )
+                .await?;
+            if groups.is_empty() {
+                break;
+            }
+            self.preload_group_visibility(parent_inode_id, &groups)
+                .await?;
+            for group in &groups {
+                // One group per name key: the stream already deduplicated
+                // and ordered candidates, and the preload seeded the caches
+                // the canonical visibility rules read through.
+                let Some(active) = self.visible_child(parent_inode_id, &group.name_key).await?
+                else {
+                    continue;
+                };
+                let Some(inode) = self.visible_inode(active.child_inode_id).await? else {
+                    continue;
+                };
+                children.push(VisibleChildEntry {
+                    binding: active,
+                    inode,
+                });
+                if children.len() == limit {
+                    break 'pages;
+                }
+            }
+        }
+        Ok(children)
+    }
+
+    /// Pulls up to `group_limit` complete name-key groups from the merged
+    /// manifest+tail candidate stream, in row-key order. A group carries
+    /// every bind row for its name, so the group's newest visible row IS the
+    /// latest bound child for that name.
+    async fn next_candidate_name_groups(
+        &mut self,
+        stream: &mut DirentryBindNameGroupStream,
+        parent_inode_id: InodeId,
+        start_after_name_key: Option<&str>,
+        group_limit: usize,
+    ) -> Result<Vec<DirentryBindNameGroup>, CoreError> {
+        let mut groups: Vec<DirentryBindNameGroup> = Vec::new();
+        loop {
+            if stream.manifest_candidates.is_empty() && !stream.manifest_exhausted {
                 self.counters.scan_range_page_calls =
                     self.counters.scan_range_page_calls.saturating_add(1);
                 let page = if let Some(tables) = self.base.manifest_tables() {
@@ -763,62 +848,198 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                         tables,
                         parent_inode_id,
                         start_after_name_key,
-                        manifest_after_row_key.as_deref(),
-                        raw_scan_limit,
+                        stream.manifest_after_row_key.as_deref(),
+                        group_limit.max(DIRECTORY_PAGE_RAW_SCAN_LIMIT),
                     )
                     .await?
                 } else {
                     Vec::new()
                 };
                 if page.is_empty() {
-                    manifest_exhausted = true;
+                    stream.manifest_exhausted = true;
                 } else {
-                    manifest_after_row_key = page.last().map(|candidate| candidate.row_key.clone());
-                    manifest_candidates.extend(page.into_iter().map(|candidate| {
-                        DirentryBindPageCandidate {
+                    stream.manifest_after_row_key =
+                        page.last().map(|candidate| candidate.row_key.clone());
+                    stream
+                        .manifest_candidates
+                        .extend(page.into_iter().map(|candidate| DirentryBindPageCandidate {
                             row_key: candidate.row_key,
                             record: candidate.record,
+                        }));
+                }
+                continue;
+            }
+
+            let candidate = if let Some(pushed_back) = stream.pushed_back.take() {
+                pushed_back
+            } else {
+                let next_manifest = stream.manifest_candidates.front();
+                let next_tail = stream.tail_candidates.get(stream.tail_index);
+                let take_tail = match (next_manifest, next_tail) {
+                    (Some(manifest), Some(tail)) => tail.row_key < manifest.row_key,
+                    (None, Some(_)) => true,
+                    (Some(_), None) => false,
+                    (None, None) => {
+                        if stream.manifest_exhausted {
+                            break;
                         }
-                    }));
+                        continue;
+                    }
+                };
+                if take_tail {
+                    let candidate = stream.tail_candidates[stream.tail_index].clone();
+                    stream.tail_index += 1;
+                    candidate
+                } else {
+                    stream
+                        .manifest_candidates
+                        .pop_front()
+                        .expect("manifest candidate should exist")
+                }
+            };
+
+            match groups.last_mut() {
+                Some(group) if group.name_key == candidate.record.name_key => {
+                    group.rows.push(candidate.record);
+                }
+                _ => {
+                    // A full batch closes only at a name boundary, so the
+                    // finished group is guaranteed complete.
+                    if groups.len() == group_limit {
+                        stream.pushed_back = Some(candidate);
+                        break;
+                    }
+                    groups.push(DirentryBindNameGroup {
+                        name_key: candidate.record.name_key.clone(),
+                        rows: vec![candidate.record],
+                    });
                 }
             }
-
-            let next_manifest = manifest_candidates.front();
-            let next_tail = tail_candidates.get(tail_index);
-            let take_tail = match (next_manifest, next_tail) {
-                (Some(manifest), Some(tail)) => tail.row_key < manifest.row_key,
-                (None, Some(_)) => true,
-                (Some(_), None) => false,
-                (None, None) => break,
-            };
-            let candidate = if take_tail {
-                let candidate = tail_candidates[tail_index].clone();
-                tail_index += 1;
-                candidate
-            } else {
-                manifest_candidates
-                    .pop_front()
-                    .expect("manifest candidate should exist")
-            };
-
-            if !seen_name_keys.insert(candidate.record.name_key.clone()) {
-                continue;
-            }
-            let Some(active) = self
-                .visible_child(parent_inode_id, &candidate.record.name_key)
-                .await?
-            else {
-                continue;
-            };
-            let Some(inode) = self.visible_inode(active.child_inode_id).await? else {
-                continue;
-            };
-            children.push(VisibleChildEntry {
-                binding: active,
-                inode,
-            });
         }
-        Ok(children)
+        Ok(groups)
+    }
+
+    /// Seeds the session caches for one wave of name groups: the latest bind
+    /// per name from rows the stream already carried, unbind facts from one
+    /// range scan, and the child-keyed lookups batched concurrently. The
+    /// canonical visibility rules then decide over cache hits; anything the
+    /// preload cannot answer (cross-directory binding chases) falls back to
+    /// the ordinary per-key scans.
+    async fn preload_group_visibility(
+        &mut self,
+        parent_inode_id: InodeId,
+        groups: &[DirentryBindNameGroup],
+    ) -> Result<(), CoreError> {
+        let visible_seq = self.base.visible_seq();
+        let mut latest_binds = Vec::with_capacity(groups.len());
+        for group in groups {
+            let latest = group
+                .rows
+                .iter()
+                .filter(|direntry| direntry.bind_seq <= visible_seq)
+                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
+                .cloned();
+            self.bound_child_cache.insert(
+                ParentNameCacheKey {
+                    parent_inode_id,
+                    name_key: group.name_key.clone(),
+                },
+                latest.clone(),
+            );
+            if let Some(latest) = latest {
+                latest_binds.push(latest);
+            }
+        }
+        let (Some(first_group), Some(last_group)) = (groups.first(), groups.last()) else {
+            return Ok(());
+        };
+
+        self.counters.list_preload_unbind_range_scans = self
+            .counters
+            .list_preload_unbind_range_scans
+            .saturating_add(1);
+        let unbinds = self
+            .base
+            .direntry_unbinds_for_parent_name_range(
+                parent_inode_id,
+                &first_group.name_key,
+                &last_group.name_key,
+            )
+            .await?;
+        let unbound_identities: HashSet<BindingCacheKey> = unbinds
+            .iter()
+            .filter(|unbind| unbind.unbind_seq <= visible_seq)
+            .map(BindingCacheKey::from)
+            .collect();
+        for direntry in &latest_binds {
+            let cache_key = BindingCacheKey::from(direntry);
+            let unbound = unbound_identities.contains(&cache_key);
+            self.unbind_cache.insert(cache_key, unbound);
+        }
+
+        let mut pending_child_ids: Vec<InodeId> = latest_binds
+            .iter()
+            .map(|direntry| direntry.child_inode_id)
+            .filter(|child_inode_id| {
+                !(self.inode_at_seq_cache.contains_key(child_inode_id)
+                    && self
+                        .latest_parent_binding_cache
+                        .contains_key(child_inode_id)
+                    && self.active_tombstone_cache.contains_key(child_inode_id))
+            })
+            .collect();
+        pending_child_ids.sort_unstable();
+        pending_child_ids.dedup();
+        if pending_child_ids.is_empty() {
+            return Ok(());
+        }
+        self.counters.list_preload_child_lookups = self
+            .counters
+            .list_preload_child_lookups
+            .saturating_add(pending_child_ids.len() as u64);
+
+        let base = &self.base;
+        let lookups = futures::future::try_join_all(pending_child_ids.iter().map(
+            |&child_inode_id| async move {
+                let (inode, bindings, tombstones) = futures::try_join!(
+                    base.inode_at_seq(child_inode_id),
+                    base.direntry_binds_for_child(child_inode_id),
+                    base.tombstones_for_root(child_inode_id),
+                )?;
+                Ok::<_, CoreError>((child_inode_id, inode, bindings, tombstones))
+            },
+        ))
+        .await?;
+
+        for (child_inode_id, inode, bindings, tombstones) in lookups {
+            self.inode_at_seq_cache.insert(child_inode_id, inode);
+            let latest_binding = bindings
+                .into_iter()
+                .filter(|direntry| direntry.bind_seq <= visible_seq)
+                .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index));
+            if let Some(latest_binding) = &latest_binding {
+                // A child bound in this directory within the preloaded name
+                // range gets its unbind fact from the range scan; bindings
+                // elsewhere fall back to the ordinary per-binding scan.
+                if latest_binding.parent_inode_id == parent_inode_id
+                    && latest_binding.name_key.as_str() >= first_group.name_key.as_str()
+                    && latest_binding.name_key.as_str() <= last_group.name_key.as_str()
+                {
+                    let cache_key = BindingCacheKey::from(latest_binding);
+                    let unbound = unbound_identities.contains(&cache_key);
+                    self.unbind_cache.entry(cache_key).or_insert(unbound);
+                }
+            }
+            self.latest_parent_binding_cache
+                .insert(child_inode_id, latest_binding);
+            let active_tombstone = tombstones
+                .into_iter()
+                .filter(|tombstone| tombstone.tombstone_seq <= visible_seq)
+                .max_by_key(|tombstone| (tombstone.tombstone_seq, tombstone.tombstone_delta_index));
+            self.active_tombstone_cache
+                .insert(child_inode_id, active_tombstone);
+        }
+        Ok(())
     }
 
     pub(crate) async fn visible_child(
@@ -910,14 +1131,24 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {
+        if let Some(cached) = self
+            .latest_parent_binding_cache
+            .get(&child_inode_id)
+            .cloned()
+        {
+            return Ok(cached);
+        }
         self.counters.direntry_child_scan_calls =
             self.counters.direntry_child_scan_calls.saturating_add(1);
         self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
         let bindings = self.base.direntry_binds_for_child(child_inode_id).await?;
-        Ok(bindings
+        let latest = bindings
             .into_iter()
             .filter(|direntry| direntry.bind_seq <= self.base.visible_seq())
-            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index)))
+            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index));
+        self.latest_parent_binding_cache
+            .insert(child_inode_id, latest.clone());
+        Ok(latest)
     }
 
     pub(crate) async fn covering_subtree_tombstone(
@@ -1086,6 +1317,50 @@ impl From<&DirentryBindRecord> for BindingCacheKey {
             bind_delta_index: record.bind_delta_index,
         }
     }
+}
+
+/// An unbind carries the identity of the binding event it revokes, so it
+/// keys the same cache slot as that binding.
+impl From<&DirentryUnbindRecord> for BindingCacheKey {
+    fn from(record: &DirentryUnbindRecord) -> Self {
+        Self {
+            parent_inode_id: record.parent_inode_id,
+            name_key: record.name_key.clone(),
+            child_inode_id: record.child_inode_id,
+            bind_seq: record.bind_seq,
+            bind_delta_index: record.bind_delta_index,
+        }
+    }
+}
+
+/// Cursor state for the merged manifest+tail direntry-bind stream, grouped
+/// by name key across calls.
+struct DirentryBindNameGroupStream {
+    manifest_after_row_key: Option<String>,
+    manifest_exhausted: bool,
+    manifest_candidates: VecDeque<DirentryBindPageCandidate>,
+    tail_candidates: Vec<DirentryBindPageCandidate>,
+    tail_index: usize,
+    pushed_back: Option<DirentryBindPageCandidate>,
+}
+
+impl DirentryBindNameGroupStream {
+    fn new(tail_candidates: Vec<DirentryBindPageCandidate>, manifest_exhausted: bool) -> Self {
+        Self {
+            manifest_after_row_key: None,
+            manifest_exhausted,
+            manifest_candidates: VecDeque::new(),
+            tail_candidates,
+            tail_index: 0,
+            pushed_back: None,
+        }
+    }
+}
+
+/// Every bind row the stream carried for one name key, in row-key order.
+struct DirentryBindNameGroup {
+    name_key: String,
+    rows: Vec<DirentryBindRecord>,
 }
 
 #[derive(Clone)]

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -577,6 +577,8 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             list_page_direntry_child_scan_calls = tracing::field::Empty,
             list_page_scan_prefix_calls = tracing::field::Empty,
             list_page_scan_range_page_calls = tracing::field::Empty,
+            list_page_preload_unbind_range_scans = tracing::field::Empty,
+            list_page_preload_child_lookups = tracing::field::Empty,
         );
         let entries = async {
             let mut entries = Vec::with_capacity(children.len());
@@ -623,6 +625,14 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         build_span.record(
             "list_page_scan_range_page_calls",
             counters.scan_range_page_calls,
+        );
+        build_span.record(
+            "list_page_preload_unbind_range_scans",
+            counters.list_preload_unbind_range_scans,
+        );
+        build_span.record(
+            "list_page_preload_child_lookups",
+            counters.list_preload_child_lookups,
         );
 
         Ok(Page {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1863,6 +1863,115 @@ async fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wide_directory_listing_resolves_tail_unbinds_cross_directory_renames_and_rebinds() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    create_directory_path(&store, &namespace_id, "/wide", &context, Some("mkdir-wide"))
+        .expect("create wide");
+    create_directory_path(
+        &store,
+        &namespace_id,
+        "/other",
+        &context,
+        Some("mkdir-other"),
+    )
+    .expect("create other");
+
+    // More names than one raw scan chunk, so group boundaries cross
+    // manifest pages; a few names rebound several times, so groups carry
+    // more than one row.
+    for index in 0..70u32 {
+        let path = format!("/wide/file-{index:03}.txt");
+        put_file_bytes(
+            &store,
+            &namespace_id,
+            &path,
+            b"first",
+            PutBehavior::NoReplace,
+            &context,
+            Some(&format!("put-{index:03}")),
+        )
+        .expect("put file");
+    }
+    for index in [3u32, 35, 68] {
+        let path = format!("/wide/file-{index:03}.txt");
+        put_file_bytes(
+            &store,
+            &namespace_id,
+            &path,
+            b"rebound",
+            PutBehavior::Replace,
+            &context,
+            Some(&format!("rebind-{index:03}")),
+        )
+        .expect("rebind file");
+    }
+    create_checkpoint(&store, &namespace_id, &context).expect("checkpoint wide dir");
+
+    // Tail-only mutations over checkpointed state: a delete whose unbind
+    // lives only in the WAL tail, and a rename into another directory whose
+    // current binding lives outside the listed parent.
+    delete_path(
+        &store,
+        &namespace_id,
+        "/wide/file-010.txt",
+        &context,
+        Some("delete-tail-unbind"),
+    )
+    .expect("delete over checkpointed bind");
+    move_path(
+        &store,
+        &namespace_id,
+        "/wide/file-020.txt",
+        "/other/moved-away.txt",
+        &context,
+        Some("move-cross-directory"),
+    )
+    .expect("move into other directory");
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/wide/file-005.txt",
+        b"tail-rebound",
+        PutBehavior::Replace,
+        &context,
+        Some("tail-rebind-005"),
+    )
+    .expect("tail rebind over checkpointed bind");
+
+    let mut listed = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page =
+            list_path_page(&store, &namespace_id, "/wide", 16, cursor.clone()).expect("list page");
+        listed.extend(page.items.iter().map(|entry| entry.display_name.clone()));
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    let expected: Vec<String> = (0..70u32)
+        .filter(|index| *index != 10 && *index != 20)
+        .map(|index| format!("file-{index:03}.txt"))
+        .collect();
+    assert_eq!(listed, expected);
+
+    // The tail rebind is the visible revision, not the checkpointed one.
+    let rebound = read_file_bytes(&store, &namespace_id, "/wide/file-005.txt")
+        .expect("read tail-rebound file");
+    assert_eq!(rebound.bytes, b"tail-rebound");
+    // The moved child is visible under its new parent only.
+    let moved =
+        read_file_bytes(&store, &namespace_id, "/other/moved-away.txt").expect("read moved file");
+    assert_eq!(moved.bytes, b"first");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_driven_directory_page_merges_manifest_and_tail_visible_children() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,5 +1,6 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -25,6 +26,9 @@ pub struct AzureAbsStoreConfig {
 #[derive(Debug)]
 pub struct AzureAbsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl AzureAbsStore {
@@ -45,7 +49,9 @@ impl AzureAbsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = MicrosoftAzureBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_account(config.account_name)
             .with_container_name(config.container_name)
             .with_access_key(config.access_key.expose());
@@ -73,7 +79,10 @@ impl AzureAbsStore {
                 sha256_checksum_metadata: false,
             },
         )?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 }
 

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,4 +1,5 @@
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -23,6 +24,9 @@ pub struct GcpGcsStoreConfig {
 #[derive(Debug)]
 pub struct GcpGcsStore {
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl GcpGcsStore {
@@ -38,7 +42,9 @@ impl GcpGcsStore {
             ));
         }
 
+        let io_runtime = StoreIoRuntime::new()?;
         let builder = GoogleCloudStorageBuilder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_service_account_path(config.service_account_key_path);
 
@@ -53,7 +59,10 @@ impl GcpGcsStore {
             },
         )?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _io_runtime: io_runtime,
+        })
     }
 
     fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -26,6 +26,7 @@ pub mod s3;
 mod s3_compatible;
 mod secret;
 mod store_config;
+mod store_io_runtime;
 
 /// Compatibility alias for [`local_fs_store`], kept so existing imports of
 /// `loonfs_objectstore::fs::LocalFsStore` keep resolving.

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,4 +1,5 @@
 use crate::secret::SecretString;
+use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, ProviderObjectStore,
     ProviderObjectStoreConfig, PutMode,
@@ -28,6 +29,9 @@ pub(crate) struct S3CompatibleConfig {
 pub(crate) struct S3CompatibleStore {
     provider_name: &'static str,
     inner: ProviderObjectStore,
+    /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
+    /// the connector inside the client holds only a handle onto it.
+    _io_runtime: StoreIoRuntime,
 }
 
 impl fmt::Debug for S3CompatibleStore {
@@ -49,7 +53,9 @@ impl S3CompatibleStore {
             })
             .transpose()?;
 
+        let io_runtime = StoreIoRuntime::new()?;
         let mut builder = AmazonS3Builder::new()
+            .with_http_connector(io_runtime.connector())
             .with_bucket_name(config.bucket)
             .with_region(config.region)
             .with_access_key_id(config.access_key_id.expose())
@@ -83,6 +89,7 @@ impl S3CompatibleStore {
         Ok(Self {
             provider_name: config.provider_name,
             inner,
+            _io_runtime: io_runtime,
         })
     }
 }

--- a/crates/loonfs-objectstore/src/store_io_runtime.rs
+++ b/crates/loonfs-objectstore/src/store_io_runtime.rs
@@ -1,0 +1,102 @@
+//! The per-store HTTP IO runtime: provider requests are driven by a thread
+//! this runtime owns, never by the caller's runtime.
+//!
+//! The default provider connector performs HTTP IO on whichever runtime
+//! issues the request. A store shared across current-thread runtimes then
+//! parks pooled connections until the client's 30s request timeout fires —
+//! reproduced and fixed in the S3 benchmark investigation by routing IO
+//! through a dedicated runtime. Every provider client is constructed with a
+//! connector onto its store's own runtime, so caller runtime topology can
+//! never affect provider IO.
+
+use crate::ObjectStoreError;
+use object_store::client::SpawnedReqwestConnector;
+use std::fmt;
+use std::sync::Arc;
+
+/// Owns the Tokio runtime that drives one configured store's HTTP IO.
+///
+/// The provider connector holds only a runtime `Handle`; this type keeps the
+/// runtime itself alive for as long as the provider client lives. Clones
+/// share one runtime. Dropping the last clone shuts the runtime down in the
+/// background, so a store dropped inside an async context never blocks or
+/// panics.
+#[derive(Clone)]
+pub(crate) struct StoreIoRuntime {
+    inner: Arc<OwnedRuntime>,
+}
+
+struct OwnedRuntime {
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl StoreIoRuntime {
+    /// Starts the IO runtime for one configured store.
+    ///
+    /// One worker thread multiplexes every request for the store; HTTP IO is
+    /// reactor-driven, so request concurrency does not need more threads.
+    pub(crate) fn new() -> Result<Self, ObjectStoreError> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("loonfs-store-io")
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                ObjectStoreError::Configuration(format!(
+                    "failed to start store io runtime: {error}"
+                ))
+            })?;
+        Ok(Self {
+            inner: Arc::new(OwnedRuntime {
+                runtime: Some(runtime),
+            }),
+        })
+    }
+
+    /// Connector that routes a provider client's requests onto this runtime.
+    pub(crate) fn connector(&self) -> SpawnedReqwestConnector {
+        let handle = self
+            .inner
+            .runtime
+            .as_ref()
+            .expect("store io runtime should live until the last store clone drops")
+            .handle()
+            .clone();
+        SpawnedReqwestConnector::new(handle)
+    }
+}
+
+impl fmt::Debug for StoreIoRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoreIoRuntime").finish_non_exhaustive()
+    }
+}
+
+impl Drop for OwnedRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            // A store may be dropped inside an async context, where a
+            // blocking runtime drop panics; background shutdown never blocks.
+            runtime.shutdown_background();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StoreIoRuntime;
+
+    #[tokio::test]
+    async fn store_io_runtime_drops_safely_inside_an_async_context() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let clone = runtime.clone();
+        drop(runtime);
+        drop(clone);
+    }
+
+    #[tokio::test]
+    async fn connector_construction_does_not_touch_the_caller_runtime() {
+        let runtime = StoreIoRuntime::new().expect("start io runtime");
+        let _connector = runtime.connector();
+    }
+}

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -350,6 +350,67 @@ async fn aws_s3_real_provider_conformance() {
     assert_provider_conformance(&store).await;
 }
 
+#[test]
+#[ignore = "requires real AWS S3 credentials"]
+fn aws_s3_store_survives_alternating_current_thread_runtimes() {
+    // Regression probe for the 30s stall: a provider client driven from two
+    // current-thread runtimes parked pooled connections until the client
+    // timeout fired. The store-owned IO runtime decouples HTTP driving from
+    // caller runtime topology, so alternating runtimes stays fast.
+    let config = AwsS3ConformanceConfig::from_env()
+        .expect("load AWS S3 real-provider conformance environment");
+    let store = AwsS3Store::new(AwsS3StoreConfig {
+        bucket: config.bucket,
+        region: config.region,
+        endpoint_url: config.endpoint,
+        access_key_id: config.access_key_id.into(),
+        secret_access_key: config.secret_access_key.into(),
+        session_token: config.session_token.map(Into::into),
+        key_prefix: Some(config.prefix),
+        force_path_style: false,
+    })
+    .expect("create AWS S3 object store");
+
+    let runtime_a = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime a");
+    let runtime_b = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime b");
+
+    #[allow(clippy::disallowed_methods)]
+    // Wall-clock bounds a live-provider stall check; no protocol time depends on it.
+    let started = std::time::Instant::now();
+    for round in 0..5u32 {
+        let key = format!("runtime-affinity-probe/round-{round}.bin");
+        let bytes = Bytes::from(format!("round {round}"));
+        runtime_a
+            .block_on(store.put_overwrite(&key, bytes))
+            .expect("put on runtime a");
+        let head = runtime_b
+            .block_on(store.head(&key))
+            .expect("head on runtime b");
+        assert!(head.is_some(), "object should exist after put");
+        let body = runtime_a
+            .block_on(store.get(&key, None))
+            .expect("get on runtime a");
+        assert!(body.is_some(), "object body should read back");
+        runtime_b
+            .block_on(store.delete(&key))
+            .expect("delete on runtime b");
+    }
+    #[allow(clippy::disallowed_methods)]
+    // Same wall-clock boundary as above; 20 rounds of small ops complete in
+    // seconds unless a request parks until the 30s client timeout.
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(25),
+        "alternating-runtime ops should never park until the client timeout; took {elapsed:?}"
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires real Cloudflare R2 credentials"]
 async fn cloudflare_r2_real_provider_conformance() {


### PR DESCRIPTION
Directory listings paid ~14ms per child at every scale — 7-minute 30k listings, and June's 100k cold boot CPU-hung in this loop. The page enumerator already merge-joins manifest and WAL-tail bind rows in name order, but each surviving candidate then resolved visibility through ~5 serial per-key scans (latest bind, unbind, the child's current binding, inode, tombstone).

The enumerator now pulls candidates as complete per-name groups, so the latest bind per name falls out of rows the stream already carried; unbind facts for the wave come from one range scan per ~64 names (complete over the range, merged with tail unbinds, so absence is a definitive answer); and the remaining child-keyed lookups (inode, child-binding index, tombstone) preload concurrently in one wave instead of serially per child, sharing segment fetches through the byte-budgeted cache underneath. Everything seeds the session caches the canonical visibility rules already read through — the rules in `visibility.rs` are untouched, exactly the override contract that module documents. Cross-directory binding chases still fall back to ordinary per-key scans.

Two new span counters (`list_page_preload_unbind_range_scans`, `list_page_preload_child_lookups`) make the win attributable per page. The existing pagination/rename/tombstone listing tests pass unchanged, and a new wide-directory test pins the subtle seams: a tail unbind over a checkpointed bind, a rename into another directory, rebound names carrying multi-row groups, and 70 names spanning raw-scan chunk boundaries — with exact full-list ordering asserted.