### PR TITLE
perf(core): memoize durable lookups across a publish batch

### DIFF
--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -41,7 +41,8 @@ pub use self::rows::{
 
 pub(crate) use self::rows::record_name_key;
 pub(crate) use self::view::{
-    InMemoryMetadataView, MetadataView, MetadataViewSession, VisibleChildEntry,
+    DurableVisibilityCache, InMemoryMetadataView, MetadataView, MetadataViewSession,
+    VisibleChildEntry,
 };
 pub(crate) use self::visibility::{unbind_matches_binding, BindingIdentity};
 

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -16,6 +16,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Mutex;
 
 const DIRECTORY_PAGE_RAW_SCAN_LIMIT: usize = 64;
 
@@ -30,6 +31,7 @@ pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
     wal_tail: Option<&'a MetadataState>,
     manifest: Option<&'a VerifiedMetadataTables<'store, S>>,
     in_memory_base: Option<&'a MetadataState>,
+    durable_cache: Option<&'a DurableVisibilityCache>,
 }
 
 pub(crate) struct MetadataView<'a, 'store, S: ObjectStore + ?Sized> {
@@ -124,6 +126,7 @@ impl<'a> InMemoryMetadataView<'a> {
                 wal_tail: None,
                 manifest: None,
                 in_memory_base: Some(base),
+                durable_cache: None,
             },
         }
     }
@@ -146,6 +149,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 wal_tail: Some(wal_tail_rows),
                 manifest: Some(tables),
                 in_memory_base: None,
+                durable_cache: None,
             },
         }
     }
@@ -169,12 +173,25 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 wal_tail: self.sources.wal_tail,
                 manifest: self.sources.manifest,
                 in_memory_base: self.sources.in_memory_base,
+                durable_cache: self.sources.durable_cache,
             },
         }
     }
 
     fn visible_seq(&self) -> ChangeSeq {
         self.snapshot.visible_seq
+    }
+
+    /// Attaches a batch-scoped durable-layer memo. Only attach where every
+    /// composed view's `visible_seq` stays at or above the seq the durable
+    /// layers were loaded at, so memoized durable answers never go stale;
+    /// overlay rows are composed per lookup either way.
+    pub(crate) fn with_durable_cache(
+        mut self,
+        durable_cache: &'a DurableVisibilityCache,
+    ) -> MetadataView<'a, 'store, S> {
+        self.sources.durable_cache = Some(durable_cache);
+        self
     }
 
     fn row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
@@ -185,6 +202,16 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         ]
         .into_iter()
         .flatten()
+    }
+
+    fn overlay_state(&self) -> Option<&'a MetadataState> {
+        self.sources.overlay
+    }
+
+    fn durable_row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
+        [self.sources.wal_tail, self.sources.in_memory_base]
+            .into_iter()
+            .flatten()
     }
 
     fn manifest_tables(&self) -> Option<&'a VerifiedMetadataTables<'store, S>> {
@@ -264,16 +291,28 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
         if let Some(inode) = self
-            .row_states()
-            .find_map(|state| state.inode_at_seq(inode_id, self.visible_seq()))
+            .overlay_state()
+            .and_then(|state| state.inode_at_seq(inode_id, self.visible_seq()))
         {
             return Ok(Some(inode));
         }
-        if let Some(tables) = self.manifest_tables() {
-            manifest_index::inode_at_seq(tables, inode_id).await
-        } else {
-            Ok(None)
+        if let Some(cache) = self.sources.durable_cache {
+            if let Some(cached) = cache.get(|inner| &mut inner.inodes, &inode_id) {
+                return Ok(cached);
+            }
         }
+        let mut durable = self
+            .durable_row_states()
+            .find_map(|state| state.inode_at_seq(inode_id, self.visible_seq()));
+        if durable.is_none() {
+            if let Some(tables) = self.manifest_tables() {
+                durable = manifest_index::inode_at_seq(tables, inode_id).await?;
+            }
+        }
+        if let Some(cache) = self.sources.durable_cache {
+            cache.insert(|inner| &mut inner.inodes, inode_id, durable.clone());
+        }
+        Ok(durable)
     }
 
     pub(crate) async fn latest_revision_head(
@@ -463,12 +502,36 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         parent_inode_id: InodeId,
     ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let mut bindings = if let Some(tables) = self.manifest_tables() {
-            manifest_index::direntry_binds_for_parent(tables, parent_inode_id).await?
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_parent, &parent_inode_id))
+        {
+            cached
         } else {
-            Vec::new()
+            let mut durable = if let Some(tables) = self.manifest_tables() {
+                manifest_index::direntry_binds_for_parent(tables, parent_inode_id).await?
+            } else {
+                Vec::new()
+            };
+            durable.extend(self.durable_row_states().flat_map(|state| {
+                state
+                    .direntry_binds()
+                    .iter()
+                    .filter(move |direntry| direntry.parent_inode_id == parent_inode_id)
+                    .cloned()
+            }));
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(
+                    |inner| &mut inner.binds_for_parent,
+                    parent_inode_id,
+                    durable.clone(),
+                );
+            }
+            durable
         };
-        bindings.extend(self.row_states().flat_map(|state| {
+        let mut bindings = durable;
+        bindings.extend(self.overlay_state().into_iter().flat_map(|state| {
             state
                 .direntry_binds()
                 .iter()
@@ -483,13 +546,43 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         parent_inode_id: InodeId,
         name_key: &str,
     ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let mut bindings = if let Some(tables) = self.manifest_tables() {
-            manifest_index::direntry_binds_for_parent_name(tables, parent_inode_id, name_key)
-                .await?
-        } else {
-            Vec::new()
+        let cache_key = ParentNameCacheKey {
+            parent_inode_id,
+            name_key: name_key.to_owned(),
         };
-        bindings.extend(self.row_states().flat_map(|state| {
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_parent_name, &cache_key))
+        {
+            cached
+        } else {
+            let mut durable = if let Some(tables) = self.manifest_tables() {
+                manifest_index::direntry_binds_for_parent_name(tables, parent_inode_id, name_key)
+                    .await?
+            } else {
+                Vec::new()
+            };
+            durable.extend(self.durable_row_states().flat_map(|state| {
+                state
+                    .direntry_binds()
+                    .iter()
+                    .filter(move |direntry| {
+                        direntry.parent_inode_id == parent_inode_id && direntry.name_key == name_key
+                    })
+                    .cloned()
+            }));
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(
+                    |inner| &mut inner.binds_for_parent_name,
+                    cache_key,
+                    durable.clone(),
+                );
+            }
+            durable
+        };
+        let mut bindings = durable;
+        bindings.extend(self.overlay_state().into_iter().flat_map(|state| {
             state
                 .direntry_binds()
                 .iter()
@@ -505,12 +598,36 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         child_inode_id: InodeId,
     ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let mut bindings = if let Some(tables) = self.manifest_tables() {
-            manifest_index::direntry_binds_for_child(tables, child_inode_id).await?
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_child, &child_inode_id))
+        {
+            cached
         } else {
-            Vec::new()
+            let mut durable = if let Some(tables) = self.manifest_tables() {
+                manifest_index::direntry_binds_for_child(tables, child_inode_id).await?
+            } else {
+                Vec::new()
+            };
+            durable.extend(self.durable_row_states().flat_map(|state| {
+                state
+                    .direntry_binds()
+                    .iter()
+                    .filter(move |direntry| direntry.child_inode_id == child_inode_id)
+                    .cloned()
+            }));
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(
+                    |inner| &mut inner.binds_for_child,
+                    child_inode_id,
+                    durable.clone(),
+                );
+            }
+            durable
         };
-        bindings.extend(self.row_states().flat_map(|state| {
+        let mut bindings = durable;
+        bindings.extend(self.overlay_state().into_iter().flat_map(|state| {
             state
                 .direntry_binds()
                 .iter()
@@ -524,12 +641,37 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         direntry: &DirentryBindRecord,
     ) -> Result<Vec<DirentryUnbindRecord>, CoreError> {
-        let mut unbinds = if let Some(tables) = self.manifest_tables() {
-            manifest_index::direntry_unbinds_for_binding(tables, direntry).await?
+        let cache_key = BindingCacheKey::from(direntry);
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(|inner| &mut inner.unbinds_for_binding, &cache_key))
+        {
+            cached
         } else {
-            Vec::new()
+            let mut durable = if let Some(tables) = self.manifest_tables() {
+                manifest_index::direntry_unbinds_for_binding(tables, direntry).await?
+            } else {
+                Vec::new()
+            };
+            durable.extend(self.durable_row_states().flat_map(|state| {
+                state
+                    .direntry_unbinds()
+                    .iter()
+                    .filter(move |unbind| unbind_matches_binding(unbind, direntry))
+                    .cloned()
+            }));
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(
+                    |inner| &mut inner.unbinds_for_binding,
+                    cache_key,
+                    durable.clone(),
+                );
+            }
+            durable
         };
-        unbinds.extend(self.row_states().flat_map(|state| {
+        let mut unbinds = durable;
+        unbinds.extend(self.overlay_state().into_iter().flat_map(|state| {
             state
                 .direntry_unbinds()
                 .iter()
@@ -590,12 +732,36 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         &self,
         root_inode_id: InodeId,
     ) -> Result<Vec<SubtreeTombstoneRecord>, CoreError> {
-        let mut tombstones = if let Some(tables) = self.manifest_tables() {
-            manifest_index::tombstones_for_root(tables, root_inode_id).await?
+        let durable = if let Some(cached) = self
+            .sources
+            .durable_cache
+            .and_then(|cache| cache.get(|inner| &mut inner.tombstones_for_root, &root_inode_id))
+        {
+            cached
         } else {
-            Vec::new()
+            let mut durable = if let Some(tables) = self.manifest_tables() {
+                manifest_index::tombstones_for_root(tables, root_inode_id).await?
+            } else {
+                Vec::new()
+            };
+            durable.extend(self.durable_row_states().flat_map(|state| {
+                state
+                    .subtree_tombstones()
+                    .iter()
+                    .filter(move |tombstone| tombstone.root_inode_id == root_inode_id)
+                    .cloned()
+            }));
+            if let Some(cache) = self.sources.durable_cache {
+                cache.insert(
+                    |inner| &mut inner.tombstones_for_root,
+                    root_inode_id,
+                    durable.clone(),
+                );
+            }
+            durable
         };
-        tombstones.extend(self.row_states().flat_map(|state| {
+        let mut tombstones = durable;
+        tombstones.extend(self.overlay_state().into_iter().flat_map(|state| {
             state
                 .subtree_tombstones()
                 .iter()
@@ -1289,6 +1455,81 @@ impl<S: ObjectStore + ?Sized> MetadataVisibilityReads for MetadataViewSession<'_
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, Self::Error> {
         MetadataViewSession::visible_inode(self, inode_id).await
+    }
+}
+
+/// Batch-scoped memo of durable-layer lookups: everything except the
+/// mutation overlay (manifest tables, WAL tail, in-memory base). Publish
+/// batches attach one so repeated path walks across candidates scan each
+/// durable key once; the overlay — the only layer that changes between
+/// candidates — is composed per lookup on top.
+///
+/// Cached vectors are raw, unfiltered rows; callers apply their own seq
+/// filters, so answers hold regardless of the composed view's visible seq.
+#[derive(Debug, Default)]
+pub(crate) struct DurableVisibilityCache {
+    inner: Mutex<DurableVisibilityCacheInner>,
+}
+
+#[derive(Debug, Default)]
+struct DurableVisibilityCacheInner {
+    inodes: HashMap<InodeId, Option<InodeRecord>>,
+    binds_for_parent_name: HashMap<ParentNameCacheKey, Vec<DirentryBindRecord>>,
+    binds_for_parent: HashMap<InodeId, Vec<DirentryBindRecord>>,
+    binds_for_child: HashMap<InodeId, Vec<DirentryBindRecord>>,
+    unbinds_for_binding: HashMap<BindingCacheKey, Vec<DirentryUnbindRecord>>,
+    tombstones_for_root: HashMap<InodeId, Vec<SubtreeTombstoneRecord>>,
+    hits: u64,
+    misses: u64,
+}
+
+/// Hit/miss counts, pinning cache engagement in tests.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct DurableVisibilityCacheStats {
+    pub(crate) hits: u64,
+    pub(crate) misses: u64,
+}
+
+impl DurableVisibilityCache {
+    #[cfg(test)]
+    pub(crate) fn stats(&self) -> DurableVisibilityCacheStats {
+        let inner = self.lock();
+        DurableVisibilityCacheStats {
+            hits: inner.hits,
+            misses: inner.misses,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, DurableVisibilityCacheInner> {
+        self.inner
+            .lock()
+            .expect("durable visibility cache lock poisoned")
+    }
+
+    fn get<K: std::hash::Hash + Eq, V: Clone>(
+        &self,
+        map: impl FnOnce(&mut DurableVisibilityCacheInner) -> &mut HashMap<K, V>,
+        key: &K,
+    ) -> Option<V> {
+        let mut inner = self.lock();
+        let hit = map(&mut inner).get(key).cloned();
+        if hit.is_some() {
+            inner.hits += 1;
+        } else {
+            inner.misses += 1;
+        }
+        hit
+    }
+
+    fn insert<K: std::hash::Hash + Eq, V>(
+        &self,
+        map: impl FnOnce(&mut DurableVisibilityCacheInner) -> &mut HashMap<K, V>,
+        key: K,
+        value: V,
+    ) {
+        let mut inner = self.lock();
+        map(&mut inner).insert(key, value);
     }
 }
 

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -2,7 +2,7 @@ use super::intent::PathMutationIntent;
 use super::planner::{plan_path_mutation_against_publish_view, PlannedPathMutation};
 use crate::commit::CommitPlan;
 use crate::error::CoreError;
-use crate::metadata::{MetadataApplyError, MetadataState, MetadataView};
+use crate::metadata::{DurableVisibilityCache, MetadataApplyError, MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::NamespaceId;
@@ -18,6 +18,10 @@ use loonfs_objectstore::ObjectStore;
 pub(crate) struct PublishPlanningSession {
     head: HeadState,
     accepted_rows: MetadataState,
+    /// Durable-layer lookups memoized across the whole batch attempt; the
+    /// accepted-rows overlay is the only layer that changes between
+    /// candidates and is composed per lookup.
+    durable_cache: DurableVisibilityCache,
 }
 
 impl PublishPlanningSession {
@@ -25,6 +29,7 @@ impl PublishPlanningSession {
         Self {
             head: head.clone(),
             accepted_rows: MetadataState::default(),
+            durable_cache: DurableVisibilityCache::default(),
         }
     }
 
@@ -36,13 +41,18 @@ impl PublishPlanningSession {
         &self.accepted_rows
     }
 
+    pub(crate) fn durable_cache(&self) -> &DurableVisibilityCache {
+        &self.durable_cache
+    }
+
     pub(crate) async fn plan_path_mutation<S: ObjectStore + ?Sized>(
         &self,
         namespace_id: &NamespaceId,
         intent: &PathMutationIntent,
         base_view: MetadataView<'_, '_, S>,
     ) -> Result<PlannedPathMutation, CoreError> {
-        let view = base_view.with_overlay(&self.accepted_rows, self.head.seq);
+        let cached_view = base_view.with_durable_cache(&self.durable_cache);
+        let view = cached_view.with_overlay(&self.accepted_rows, self.head.seq);
         plan_path_mutation_against_publish_view(namespace_id, intent, &self.head, &view).await
     }
 
@@ -68,6 +78,7 @@ mod tests {
     use crate::engine::NamespaceEngine;
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, PutBehavior};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -122,6 +133,75 @@ mod tests {
             .writer_version(context.writer_version.clone())
             .build()
             .expect("test engine")
+    }
+
+    /// Two plans through one session share the durable-layer memo: the
+    /// second plan's path walk answers from cache instead of re-scanning
+    /// the manifest for the components both paths share.
+    #[tokio::test]
+    async fn second_plan_in_a_session_hits_the_durable_cache() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+        let staged = store_bytes_as_content(&store, &namespace_id, b"hello")
+            .await
+            .expect("stage");
+        // Durable parent directory so the walks touch manifest-backed state.
+        publish_namespace_mutations_batch(
+            &store,
+            &namespace_id,
+            vec![put_file_candidate(
+                "seed-docs",
+                "/docs/seed.txt",
+                staged.content_ref.clone(),
+            )],
+            &context,
+        )
+        .await
+        .remove(0)
+        .expect("seed publish");
+
+        let (view, _projection) = load_publish_metadata_view(
+            &store,
+            &namespace_id,
+            None,
+            None,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .expect("load publish view");
+        let session = PublishPlanningSession::new(view.head());
+
+        let first_intent = PathMutationIntent::PutFile {
+            commit_id: CommitId::parse("plan-a").expect("valid commit id"),
+            absolute_path: "/docs/a.txt".to_owned(),
+            content_ref: staged.content_ref.clone(),
+            behavior: PutBehavior::NoReplace,
+        };
+        session
+            .plan_path_mutation(&namespace_id, &first_intent, view.metadata_view())
+            .await
+            .expect("first plan");
+        let after_first = session.durable_cache().stats();
+
+        let second_intent = PathMutationIntent::PutFile {
+            commit_id: CommitId::parse("plan-b").expect("valid commit id"),
+            absolute_path: "/docs/b.txt".to_owned(),
+            content_ref: staged.content_ref.clone(),
+            behavior: PutBehavior::NoReplace,
+        };
+        session
+            .plan_path_mutation(&namespace_id, &second_intent, view.metadata_view())
+            .await
+            .expect("second plan");
+        let after_second = session.durable_cache().stats();
+
+        assert!(
+            after_second.hits > after_first.hits,
+            "second plan should reuse durable lookups from the first: {after_first:?} -> {after_second:?}"
+        );
+        assert!(
+            after_second.misses < after_first.misses * 2,
+            "shared path components should not re-scan per plan: {after_first:?} -> {after_second:?}"
+        );
     }
 
     /// The first candidate implicitly creates `/wide`; the second must plan

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -254,7 +254,9 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
             };
             let validation = PublishCommitValidationContext {
                 head: session.head(),
-                metadata_view: view.metadata_view(),
+                metadata_view: view
+                    .metadata_view()
+                    .with_durable_cache(session.durable_cache()),
                 accepted_rows: session.accepted_rows(),
             };
             let request = candidate_request.request;

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1863,6 +1863,63 @@ async fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    let namespace_id = namespace_id();
+
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/cycled.txt",
+        b"durable",
+        PutBehavior::NoReplace,
+        &context,
+        Some("put-durable"),
+    )
+    .expect("put durable file");
+    create_checkpoint(&store, &namespace_id, &context).expect("checkpoint durable state");
+
+    // One batch: delete the checkpointed file, then recreate the same name
+    // with NoReplace. The recreate must observe the batch-local unbind over
+    // the durable binding, and the delete must observe the durable binding
+    // at all — both through the batch's cached durable layer.
+    let staged = block_on(loonfs_core::content::store_bytes_as_content(
+        &store,
+        &namespace_id,
+        b"recreated",
+    ))
+    .expect("stage recreated content");
+    let results = block_on(
+        namespace_engine(&store, &namespace_id, &context).publish_namespace_mutations_batch(vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
+                absolute_path: "/docs/cycled.txt".to_owned(),
+                behavior: DeleteDirectoryBehavior::NonRecursive,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
+                absolute_path: "/docs/cycled.txt".to_owned(),
+                content_ref: staged.content_ref,
+                behavior: PutBehavior::NoReplace,
+            }),
+        ]),
+    );
+    results[0]
+        .as_ref()
+        .expect("delete of durable file succeeds");
+    results[1]
+        .as_ref()
+        .expect("no-replace recreate sees the in-batch unbind over the durable binding");
+
+    let recreated =
+        read_file_bytes(&store, &namespace_id, "/docs/cycled.txt").expect("read recreated file");
+    assert_eq!(recreated.bytes, b"recreated");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wide_directory_listing_resolves_tail_unbinds_cross_directory_renames_and_rebinds() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");


### PR DESCRIPTION
Publish validation re-scanned directory state per mutation: each candidate's planning and precondition checks walked its full path through stateless composites — for 5k-file batches into a filling directory, three-plus walks per candidate re-scanning the same parents, which is the measured 17.5s→55.1s degradation as a directory fills 0→25k.

A batch attempt now owns a `DurableVisibilityCache` on its planning session, attachable to any `MetadataView`. It memoizes the raw row vectors from the durable layers only — manifest, WAL tail, in-memory base — which cannot change for the batch's lifetime; the accepted-rows overlay, the one layer that grows between candidates, stays composed per lookup on top. Both scan surfaces attach it (the path planner and the commit-plan validation view), the canonical visibility rules are untouched, and cached vectors are raw and unfiltered so callers' own seq filters keep working as the batch head advances.

The overlay-correctness edge is pinned two ways: the existing batch-session tests (in-batch creates observed by later candidates, duplicate NoReplace rejection, create-then-delete ordering, preconditions over speculative state) all pass unchanged, and a new guard covers the sharpest case — deleting a checkpointed file and recreating the same name with NoReplace in one batch, where the recreate must see the batch-local unbind layered over the cached durable binding. A session unit test pins cache engagement: the second plan through a session hits where the first missed.