### PR TITLE
perf: overlap content writes with publish and coalesce direct commits

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -8,7 +8,9 @@ use crate::path::write::{
     path_intent_fingerprint_for_path_intent, PathMutationIntent, PlannedPathMutation,
     PublishPlanningSession,
 };
-use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
+use crate::protocol::{
+    load_publish_metadata_view, ContentDurabilityGate, PublishTailOptions, PublishTailProjection,
+};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::wire::control::AcquiredWriter;
@@ -141,6 +143,7 @@ impl NamespaceCommitEngine {
             candidates,
             context,
             &PublishTailOptions::default(),
+            None,
         )
         .await
     }
@@ -151,6 +154,7 @@ impl NamespaceCommitEngine {
         candidates: Vec<NamespaceMutationCandidate>,
         context: &MutationContext,
         tail_options: &PublishTailOptions,
+        content_gate: Option<ContentDurabilityGate>,
     ) -> NamespaceCommitEnginePublishResult {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
@@ -227,6 +231,7 @@ impl NamespaceCommitEngine {
             context,
             &publish_view,
             self.timer.as_ref(),
+            content_gate,
         )
         .await;
         let wal_tail_segments =
@@ -244,12 +249,13 @@ impl NamespaceCommitEngine {
         context: &MutationContext,
         max_tail_rows: usize,
         max_tail_decoded_bytes: Option<usize>,
+        content_gate: Option<ContentDurabilityGate>,
     ) -> NamespaceCommitEnginePublishResult {
         let options = PublishTailOptions {
             max_tail_rows,
             max_tail_decoded_bytes,
         };
-        self.publish_batch_with_tail_options(store, candidates, context, &options)
+        self.publish_batch_with_tail_options(store, candidates, context, &options, content_gate)
             .await
     }
 
@@ -399,9 +405,28 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse>> {
+    publish_namespace_mutations_batch_gated(store, namespace_id, candidates, context, None).await
+}
+
+/// [`publish_namespace_mutations_batch`] with a content durability gate: the
+/// gate is a future, so it rides an explicit parameter instead of an options
+/// struct, and it is awaited between the WAL write and the head CAS.
+pub(crate) async fn publish_namespace_mutations_batch_gated<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    candidates: Vec<NamespaceMutationCandidate>,
+    context: &MutationContext,
+    content_gate: Option<ContentDurabilityGate>,
+) -> Vec<Result<ApiCommitResponse>> {
     let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
     engine
-        .publish_batch(store, candidates, context)
+        .publish_batch_with_tail_options(
+            store,
+            candidates,
+            context,
+            &PublishTailOptions::default(),
+            content_gate,
+        )
         .await
         .results
 }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -690,11 +690,25 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         &self,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<CoreResult<CommitResponse>> {
-        crate::commit_engine::publish_namespace_mutations_batch(
+        self.publish_namespace_mutations_batch_gated(candidates, None)
+            .await
+    }
+
+    /// [`Self::publish_namespace_mutations_batch`] with a content durability
+    /// gate awaited between the WAL write and the head CAS; the gate is a
+    /// future, so it rides an explicit parameter instead of an options
+    /// struct.
+    pub async fn publish_namespace_mutations_batch_gated(
+        &self,
+        candidates: Vec<NamespaceMutationCandidate>,
+        content_gate: Option<crate::publish::ContentDurabilityGate>,
+    ) -> Vec<CoreResult<CommitResponse>> {
+        crate::commit_engine::publish_namespace_mutations_batch_gated(
             &self.store,
             &self.namespace_id,
             candidates,
             &self.mutation_context(),
+            content_gate,
         )
         .await
     }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod publish {
         NamespaceCommitEnginePublishResult, NamespaceMutationCandidate, PublishOptions,
     };
     pub use crate::path::write::PathMutationIntent;
+    pub use crate::protocol::ContentDurabilityGate;
 }
 
 #[cfg(any(test, feature = "inspection"))]

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -21,6 +21,7 @@ use crate::storage::content::ContentValidationTracker;
 use crate::timing::MonotonicTimer;
 use crate::wal::{prepare_wal_segment, PreparedWalSegment};
 use bytes::Bytes;
+use futures::future::BoxFuture;
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
@@ -122,7 +123,7 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
 ) -> Vec<Result<ApiCommitResponse>> {
-    commit_namespace_mutations_batch(store, namespace_id, candidates, context).await
+    commit_namespace_mutations_batch(store, namespace_id, candidates, context, None).await
 }
 
 async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
@@ -130,6 +131,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
+    content_gate: Option<ContentDurabilityGate>,
 ) -> Vec<Result<ApiCommitResponse>> {
     if candidates.is_empty() {
         return Vec::new();
@@ -185,10 +187,18 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
         context,
         &publish_view,
         &timer,
+        content_gate,
     )
     .await
     .results
 }
+
+/// Awaited between the batch's WAL write and its head compare-and-swap:
+/// nothing becomes visible until separately-written content is durable.
+/// Failure aborts the batch through the same path as a failed WAL write —
+/// the orphaned WAL segment is never referenced by the head and is
+/// garbage-collection's to reclaim.
+pub type ContentDurabilityGate = BoxFuture<'static, Result<()>>;
 
 pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     S: ObjectStore + ?Sized,
@@ -199,6 +209,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     context: &MutationContext,
     view: &PublishMetadataView<'_, S>,
     timer: &dyn MonotonicTimer,
+    content_gate: Option<ContentDurabilityGate>,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
         return PublishBatchAgainstViewResult::new(Vec::new());
@@ -388,6 +399,17 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
             return abort_batch(outcomes, &dedup, &accepted, &error);
         }
     };
+    if let Some(content_gate) = content_gate {
+        if let Err(error) = content_gate
+            .instrument(tracing::info_span!(
+                "loon.phase",
+                phase = "await_content_durability"
+            ))
+            .await
+        {
+            return abort_batch(outcomes, &dedup, &accepted, &error);
+        }
+    }
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(put_started_ms);
     if elapsed_ms > PUBLISH_BUDGET_MS {
         let error = CoreError::HeadPublish(CommitHeadPublishError::PublishBudgetExceeded {

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -26,6 +26,7 @@ mod changes;
 mod publish_view;
 mod uploads;
 
+pub use self::batch::ContentDurabilityGate;
 pub(crate) use self::batch::{
     commit_operations, commit_operations_batch,
     publish_namespace_mutations_batch_against_publish_view, PublishBatchAgainstViewResult,

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -17,6 +17,27 @@ pub struct ContentAdmission {
 }
 
 impl ContentAdmission {
+    /// Admits a content ref whose durable write runs as a peer of the publish
+    /// that commits it, so batch validation does not probe object storage for
+    /// a blob that may not have landed yet. Callers must pair this with a
+    /// [`crate::publish::ContentDurabilityGate`] on the same publish: the
+    /// admission removes the probe, and the gate holds the head CAS until the
+    /// write's own ack proves durability.
+    pub fn for_in_flight_content_write(
+        namespace_id: NamespaceId,
+        content_ref: ContentRef,
+        now_ms: u64,
+    ) -> Self {
+        Self {
+            namespace_id,
+            content_ref,
+            // Generous on purpose: it must outlive buffered commit windows
+            // and stale-head retries. The gate, not this clock, is the
+            // durability authority.
+            expires_at_ms: now_ms.saturating_add(DEFAULT_TOKEN_TTL_MS),
+        }
+    }
+
     pub(crate) fn admits(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/commit_window.rs
+++ b/crates/loonfs/src/commit_window.rs
@@ -1,0 +1,161 @@
+//! Per-namespace commit windows for direct publishes.
+//!
+//! A direct publish — a path intent or explicit commit submitted through a
+//! handle — holds its namespace's window open briefly so concurrent
+//! publishes can join, then the opener flushes every buffered submission as
+//! one batch: one WAL segment, one head compare-and-swap. Every submitter
+//! still awaits its own durable, visible result; the window trades a short
+//! wait for shared publication cost, never for weaker semantics.
+//!
+//! The opener drives the flush inside its own future, so the window needs no
+//! spawned task and works on any runtime that drives the callers. The
+//! server's batching publisher has its own coalescer and does not pass
+//! through here.
+//!
+//! Failure semantics follow the batch they join: if any member's content
+//! durability gate fails — including a submitter cancelled mid-window, which
+//! abandons its content write — the flush aborts before the head CAS and
+//! every member sees the rejection. An opener cancelled before flushing
+//! closes the window and fails the members that joined it.
+
+use crate::publish::NamespaceMutationCandidate;
+use crate::{CommitResponse, CoreError, NamespaceId, Result, RuntimeError};
+use futures::channel::oneshot;
+use loonfs_core::publish::ContentDurabilityGate;
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+use tokio::time::Duration;
+
+#[allow(clippy::disallowed_methods)]
+pub(crate) async fn commit_window_delay(window: Duration) {
+    // The commit window intentionally waits a short async timer so
+    // concurrent direct publishes can join before one flush.
+    tokio::time::sleep(window).await;
+}
+
+type WindowResults = Vec<Result<CommitResponse>>;
+
+/// One buffered submission: its candidates, the durability gate covering any
+/// content it is writing concurrently, and the channel its results return on.
+pub(crate) struct WindowEntry {
+    pub(crate) candidates: Vec<NamespaceMutationCandidate>,
+    pub(crate) content_gate: Option<ContentDurabilityGate>,
+    pub(crate) result_sender: oneshot::Sender<WindowResults>,
+}
+
+/// The open commit windows of one runtime core, keyed by namespace.
+#[derive(Default)]
+pub(crate) struct CommitWindows {
+    open: Mutex<HashMap<NamespaceId, Vec<WindowEntry>>>,
+}
+
+/// What a submission became when it entered the window.
+pub(crate) enum WindowRole<'a> {
+    /// First submission for the namespace: the caller now owns the window
+    /// and must wait out the delay, then flush the drained entries —
+    /// including its own — and distribute results.
+    Opener {
+        guard: OpenerGuard<'a>,
+        result_receiver: oneshot::Receiver<WindowResults>,
+    },
+    /// Joined an already-open window; the opener publishes on this
+    /// submission's behalf and the results arrive on the receiver.
+    Joiner(oneshot::Receiver<WindowResults>),
+}
+
+impl CommitWindows {
+    /// Buffers a submission into the namespace's window, opening one if none
+    /// is open.
+    pub(crate) fn enter(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+        content_gate: Option<ContentDurabilityGate>,
+    ) -> WindowRole<'_> {
+        let (result_sender, result_receiver) = oneshot::channel();
+        let entry = WindowEntry {
+            candidates,
+            content_gate,
+            result_sender,
+        };
+        let mut open = self.lock_open();
+        if let Some(entries) = open.get_mut(namespace_id) {
+            entries.push(entry);
+            return WindowRole::Joiner(result_receiver);
+        }
+        open.insert(namespace_id.clone(), vec![entry]);
+        WindowRole::Opener {
+            guard: OpenerGuard {
+                windows: self,
+                namespace_id: namespace_id.clone(),
+                armed: true,
+            },
+            result_receiver,
+        }
+    }
+
+    fn lock_open(&self) -> MutexGuard<'_, HashMap<NamespaceId, Vec<WindowEntry>>> {
+        // Poisoning is propagated as a panic: a poisoned window map means a
+        // thread panicked mid-update, and reusing it could wedge or misroute
+        // buffered publishes.
+        self.open.lock().expect("commit window map lock poisoned")
+    }
+}
+
+/// Closes the opener's window exactly once: normally by draining it for the
+/// flush, or on drop when the opener was cancelled first — dropping the
+/// buffered entries then cancels the joiners' receivers, so an abandoned
+/// window fails its members instead of wedging the namespace.
+pub(crate) struct OpenerGuard<'a> {
+    windows: &'a CommitWindows,
+    namespace_id: NamespaceId,
+    armed: bool,
+}
+
+impl OpenerGuard<'_> {
+    /// Closes the window and returns its buffered entries in submission
+    /// order, the opener's own entry first.
+    pub(crate) fn take_entries(mut self) -> Vec<WindowEntry> {
+        self.armed = false;
+        self.windows
+            .lock_open()
+            .remove(&self.namespace_id)
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for OpenerGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.windows.lock_open().remove(&self.namespace_id);
+        }
+    }
+}
+
+/// Combines the entries' durability gates into the flush's single gate: the
+/// batch's head CAS waits until every member's concurrent content write has
+/// acked, and fails — aborting the whole batch — if any of them fail.
+pub(crate) fn combine_content_gates(
+    gates: Vec<ContentDurabilityGate>,
+) -> Option<ContentDurabilityGate> {
+    let mut gates = gates;
+    match gates.len() {
+        0 => None,
+        1 => gates.pop(),
+        _ => Some(Box::pin(async move {
+            futures::future::try_join_all(gates).await.map(|_| ())
+        })),
+    }
+}
+
+/// Pads a distributed result slice when the publish returned fewer results
+/// than the entry submitted candidates; the batch contract makes this
+/// unreachable, but a routing bug must fail the submitter, not hang it.
+pub(crate) fn pad_missing_results(mut results: WindowResults, expected: usize) -> WindowResults {
+    while results.len() < expected {
+        results.push(Err(RuntimeError::Core(CoreError::Internal(
+            "commit window flush returned fewer results than candidates".to_owned(),
+        ))));
+    }
+    results
+}

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -14,6 +14,10 @@ pub const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
 pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize = 1_000_000;
 /// Default decoded-byte budget for cached WAL-tail projections.
 pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize = 256 * 1024 * 1024;
+/// Default commit window, in milliseconds: how long a direct publish holds
+/// its namespace's window open so concurrent publishes can join the same
+/// flush — one WAL segment, one head CAS. Zero disables coalescing.
+pub const DEFAULT_COMMIT_WINDOW_MS: u64 = 15;
 
 /// Configuration for one runtime core, assembled by the handle builders.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +26,9 @@ pub(crate) struct FsConfig {
     pub writer_id: String,
     /// Writer version reported in mutation context.
     pub writer_version: String,
+    /// Commit window for direct publishes, in milliseconds; zero disables
+    /// coalescing.
+    pub commit_window_ms: u64,
     /// Cache configuration.
     pub runtime_cache: RuntimeCacheConfig,
     /// Tracing mode label.

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -4,6 +4,10 @@
 
 use crate::background::BackgroundWork;
 use crate::cache::{CommitEngineCache, RuntimeCacheStatsInner, RuntimeControlCache};
+use crate::commit_window::{
+    combine_content_gates, commit_window_delay, pad_missing_results, CommitWindows, WindowEntry,
+    WindowRole,
+};
 use crate::config::{validate_config, FsConfig};
 use crate::content_tokens::ContentAdmission;
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
@@ -56,6 +60,7 @@ pub(crate) struct FsInner {
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
     pub(crate) background: BackgroundWork,
+    pub(crate) commit_windows: CommitWindows,
 }
 
 /// Lock accessors for the runtime caches.
@@ -107,6 +112,7 @@ impl FsCore {
                 wal_tail_projection_cache,
                 cache_stats: RuntimeCacheStatsInner::default(),
                 background,
+                commit_windows: CommitWindows::default(),
             }),
         })
     }
@@ -918,9 +924,10 @@ impl FsCore {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_namespace_mutations_batch(
+        self.publish_through_commit_window(
             namespace_id,
             vec![NamespaceMutationCandidate::Commit(request)],
+            None,
         )
         .await
         .into_iter()
@@ -939,12 +946,13 @@ impl FsCore {
         namespace_id: &NamespaceId,
         requests: Vec<CommitRequest>,
     ) -> Vec<Result<CommitResponse>> {
-        self.publish_namespace_mutations_batch(
+        self.publish_through_commit_window(
             namespace_id,
             requests
                 .into_iter()
                 .map(NamespaceMutationCandidate::Commit)
                 .collect(),
+            None,
         )
         .await
     }
@@ -965,7 +973,7 @@ impl FsCore {
         content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
     ) -> Result<MutationResult> {
         let mut results = self
-            .publish_namespace_mutations_batch_gated(namespace_id, vec![candidate], content_gate)
+            .publish_through_commit_window(namespace_id, vec![candidate], content_gate)
             .await;
         let response = results.pop().unwrap_or_else(|| {
             Err(RuntimeError::Core(CoreError::Internal(
@@ -976,6 +984,83 @@ impl FsCore {
             namespace_id: response.namespace_id,
             committed_seq: response.committed_seq,
         })
+    }
+
+    /// Publishes a direct submission through the namespace's commit window
+    /// (see [`crate::commit_window`]): concurrent submissions within the
+    /// window flush as one batch — one WAL segment, one head CAS — and every
+    /// submitter receives its own results. A zero-length window bypasses
+    /// coalescing entirely. The server's batching publisher submits through
+    /// [`Self::publish_namespace_mutations_batch`] instead, which stays
+    /// window-free because it already coalesces.
+    async fn publish_through_commit_window(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
+    ) -> Vec<Result<CommitResponse>> {
+        let window_ms = self.inner.config.commit_window_ms;
+        if window_ms == 0 {
+            return self
+                .publish_namespace_mutations_batch_gated(namespace_id, candidates, content_gate)
+                .await;
+        }
+        let candidate_count = candidates.len();
+        let role = self
+            .inner
+            .commit_windows
+            .enter(namespace_id, candidates, content_gate);
+        let result_receiver = match role {
+            WindowRole::Opener {
+                guard,
+                result_receiver,
+            } => {
+                commit_window_delay(std::time::Duration::from_millis(window_ms)).await;
+                let entries = guard.take_entries();
+                let mut combined = Vec::new();
+                let mut gates = Vec::new();
+                let mut routes = Vec::new();
+                for entry in entries {
+                    let WindowEntry {
+                        candidates,
+                        content_gate,
+                        result_sender,
+                    } = entry;
+                    routes.push((candidates.len(), result_sender));
+                    combined.extend(candidates);
+                    if let Some(gate) = content_gate {
+                        gates.push(gate);
+                    }
+                }
+                let mut results = self
+                    .publish_namespace_mutations_batch_gated(
+                        namespace_id,
+                        combined,
+                        combine_content_gates(gates),
+                    )
+                    .await
+                    .into_iter();
+                for (expected, sender) in routes {
+                    let slice: Vec<_> = results.by_ref().take(expected).collect();
+                    let _ = sender.send(pad_missing_results(slice, expected));
+                }
+                result_receiver
+            }
+            WindowRole::Joiner(result_receiver) => result_receiver,
+        };
+        match result_receiver.await {
+            Ok(results) => results,
+            // The opener was cancelled before distributing results; the
+            // window closed behind it, so the submission failed rather than
+            // committed and the caller may retry.
+            Err(_) => (0..candidate_count)
+                .map(|_| {
+                    Err(RuntimeError::Core(CoreError::Internal(
+                        "commit window abandoned before its flush completed".to_owned(),
+                    )))
+                })
+                .collect(),
+        }
     }
 
     /// Publishes already-classified namespace mutation candidates as one

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -5,6 +5,7 @@
 use crate::background::BackgroundWork;
 use crate::cache::{CommitEngineCache, RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::config::{validate_config, FsConfig};
+use crate::content_tokens::ContentAdmission;
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use crate::time::current_time_ms;
 use crate::{
@@ -636,21 +637,54 @@ impl FsCore {
         // invalid or root path cannot orphan an already-written content blob;
         // core re-checks the same invariant when the intent is planned.
         loonfs_core::path::validate_path_for_mutation(absolute_path)?;
-        let store = self.store();
-        let stored = loonfs_core::content::store_bytes_as_content(&store, namespace_id, bytes)
+        // The content reference derives from the bytes alone, so the durable
+        // content write runs as a peer of publish validation and the WAL
+        // write: both futures are driven together below. The admission tells
+        // batch validation not to probe for a blob that is still in flight;
+        // the head CAS instead gates on the write's own ack through the
+        // channel. A failed content write leaves only a GC-covered orphan
+        // behind an unmoved head.
+        let content_ref = ContentRef::whole_file_v0(bytes);
+        let content_admission = ContentAdmission::for_in_flight_content_write(
+            namespace_id.clone(),
+            content_ref.clone(),
+            current_time_ms(),
+        );
+        let (content_result_sender, content_result_receiver) = futures::channel::oneshot::channel();
+        let content_store = self.inner.store.clone();
+        let content_namespace_id = namespace_id.clone();
+        let content_write = async move {
+            let result = loonfs_core::content::store_bytes_as_content(
+                &content_store,
+                &content_namespace_id,
+                bytes,
+            )
             .await
-            .map_err(RuntimeError::from);
-        let content_ref = stored?.content_ref;
-        self.publish_path_intent(
+            .map(|_| ());
+            // A receiver dropped before the gate point means the publish
+            // failed earlier; the content object is then a GC-covered orphan.
+            let _ = content_result_sender.send(result);
+        };
+        let content_gate: loonfs_core::publish::ContentDurabilityGate = Box::pin(async move {
+            content_result_receiver.await.map_err(|_| {
+                CoreError::Internal("content write finished without a result".to_owned())
+            })?
+        });
+        let publish = self.publish_candidate_gated(
             namespace_id,
-            PathMutationIntent::PutFile {
-                commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: absolute_path.to_owned(),
-                content_ref,
-                behavior: options.behavior,
+            NamespaceMutationCandidate::PathWithContentAdmission {
+                intent: PathMutationIntent::PutFile {
+                    commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                    absolute_path: absolute_path.to_owned(),
+                    content_ref,
+                    behavior: options.behavior,
+                },
+                admissions: vec![content_admission],
             },
-        )
-        .await
+            Some(content_gate),
+        );
+        let ((), published) = futures::join!(content_write, publish);
+        published
     }
 
     /// Publishes a file revision that points at an already-durable content
@@ -920,11 +954,18 @@ impl FsCore {
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
     ) -> Result<MutationResult> {
+        self.publish_candidate_gated(namespace_id, NamespaceMutationCandidate::Path(intent), None)
+            .await
+    }
+
+    async fn publish_candidate_gated(
+        &self,
+        namespace_id: &NamespaceId,
+        candidate: NamespaceMutationCandidate,
+        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
+    ) -> Result<MutationResult> {
         let mut results = self
-            .publish_namespace_mutations_batch(
-                namespace_id,
-                vec![NamespaceMutationCandidate::Path(intent)],
-            )
+            .publish_namespace_mutations_batch_gated(namespace_id, vec![candidate], content_gate)
             .await;
         let response = results.pop().unwrap_or_else(|| {
             Err(RuntimeError::Core(CoreError::Internal(
@@ -947,6 +988,16 @@ impl FsCore {
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<Result<CommitResponse>> {
+        self.publish_namespace_mutations_batch_gated(namespace_id, candidates, None)
+            .await
+    }
+
+    pub(crate) async fn publish_namespace_mutations_batch_gated(
+        &self,
+        namespace_id: &NamespaceId,
+        candidates: Vec<NamespaceMutationCandidate>,
+        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
+    ) -> Vec<Result<CommitResponse>> {
         let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
         let store = self.store();
         if self.commit_engine_cache_enabled() {
@@ -962,6 +1013,7 @@ impl FsCore {
                         &context,
                         cache_config.max_cached_wal_tail_projection_rows,
                         cache_config.max_cached_wal_tail_projection_decoded_bytes,
+                        content_gate,
                     )
                     .await
             };
@@ -993,7 +1045,7 @@ impl FsCore {
 
         let results: Vec<_> = self
             .namespace_engine_with_store(namespace_id, store)
-            .publish_namespace_mutations_batch(candidates)
+            .publish_namespace_mutations_batch_gated(candidates, content_gate)
             .await
             .into_iter()
             .map(|result| result.map_err(RuntimeError::Core))

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -48,6 +48,7 @@ enum StoreSource {
 /// trace/metrics wiring.
 struct HandleBuilderCore {
     source: StoreSource,
+    commit_window_ms: u64,
     runtime_cache: RuntimeCacheConfig,
     trace_mode: TraceMode,
     trace_store_kind: Option<TraceStoreKind>,
@@ -66,6 +67,7 @@ impl HandleBuilderCore {
     fn new(source: StoreSource) -> Self {
         Self {
             source,
+            commit_window_ms: crate::config::DEFAULT_COMMIT_WINDOW_MS,
             runtime_cache: RuntimeCacheConfig::default(),
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
@@ -101,6 +103,7 @@ impl HandleBuilderCore {
             FsConfig {
                 writer_id,
                 writer_version,
+                commit_window_ms: self.commit_window_ms,
                 runtime_cache: self.runtime_cache,
                 trace_mode: self.trace_mode,
                 trace_store_kind,

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -386,6 +386,18 @@ impl FsWriterBuilder {
         self
     }
 
+    /// Sets the commit window for direct publishes, in milliseconds.
+    ///
+    /// A direct publish holds its namespace's window open this long so
+    /// concurrent publishes join the same flush — one WAL segment, one head
+    /// CAS — with each caller still awaiting its own durable, visible
+    /// result. Defaults to [`crate::DEFAULT_COMMIT_WINDOW_MS`]; zero
+    /// disables coalescing and publishes each submission immediately.
+    pub fn commit_window_ms(mut self, commit_window_ms: u64) -> Self {
+        self.core.commit_window_ms = commit_window_ms;
+        self
+    }
+
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -30,6 +30,7 @@
 
 mod background;
 mod cache;
+mod commit_window;
 mod config;
 mod fs;
 mod handle;
@@ -90,7 +91,7 @@ pub use loonfs_objectstore::{ObjectStore, ObjectStoreError, SharedObjectStore, S
 pub use background::FsBackgroundWork;
 pub use cache::RuntimeCacheStats;
 pub use config::{
-    RuntimeCacheConfig, DEFAULT_MAX_CACHED_NAMESPACES,
+    RuntimeCacheConfig, DEFAULT_COMMIT_WINDOW_MS, DEFAULT_MAX_CACHED_NAMESPACES,
     DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES,
     DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS, DEFAULT_MAX_WAL_TAIL_SEGMENTS,
 };

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1226,6 +1226,9 @@ mod tests {
             FsConfig {
                 writer_id: "writer-a".to_owned(),
                 writer_version: "test".to_owned(),
+                // The publisher under test is itself the coalescer; direct
+                // windows would only add latency to these tests.
+                commit_window_ms: 0,
                 runtime_cache: RuntimeCacheConfig::default(),
                 trace_mode: TraceMode::Remote,
                 trace_store_kind: TraceStoreKind::LocalFs,

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1627,7 +1627,7 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 }
 
 #[test]
-fn put_file_bytes_validates_content_ref_before_publish() {
+fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
@@ -1646,8 +1646,65 @@ fn put_file_bytes_validates_content_ref_before_publish() {
     )
     .expect("put file bytes");
 
+    // The put writes the blob exactly once and never reads it back: the
+    // write's own ack is the durability proof the head CAS waits on, so
+    // validation issues no probe for content the put itself is writing.
+    assert_eq!(raw_store.content_blob_put_count(), 1);
     assert_eq!(raw_store.content_blob_get_count(), 0);
-    assert_eq!(raw_store.content_blob_checksum_head_count(), 1);
+    assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
+}
+
+#[test]
+fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = open_runtime(object_store, "content-write-failure-test");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    let commit_id = CommitId::parse("overlap-put-retry").expect("valid commit id");
+    raw_store.fail_content_blob_puts();
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/report.txt",
+        b"overlap survives",
+        PutFileOptions {
+            behavior: PutBehavior::NoReplace,
+            commit_id: Some(commit_id.clone()),
+        },
+    )
+    .expect_err("put should surface the failed content write");
+
+    // The content result gates the head CAS, so the failed write aborted the
+    // publish with the head unmoved and nothing visible.
+    let error = fs
+        .stat_path_blocking(&namespace_id, "/docs/report.txt")
+        .expect_err("failed put should leave the path unbound");
+    assert!(matches!(
+        error,
+        RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
+    ));
+
+    // The failed attempt never committed, so the same commit id retries
+    // cleanly instead of resolving as a duplicate.
+    raw_store.allow_content_blob_puts();
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/report.txt",
+        b"overlap survives",
+        PutFileOptions {
+            behavior: PutBehavior::NoReplace,
+            commit_id: Some(commit_id),
+        },
+    )
+    .expect("same-commit-id retry should land");
+    let read = fs
+        .read_file_bytes_blocking(&namespace_id, "/docs/report.txt")
+        .expect("read retried file");
+    assert_eq!(read.bytes, b"overlap survives");
 }
 
 #[test]
@@ -2514,6 +2571,7 @@ struct ContentBlobGetCountingStore {
     inner: LocalFsStore,
     content_blob_gets: AtomicUsize,
     content_blob_checksum_heads: AtomicUsize,
+    content_blob_puts: AtomicUsize,
 }
 
 impl ContentBlobGetCountingStore {
@@ -2522,12 +2580,14 @@ impl ContentBlobGetCountingStore {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             content_blob_gets: AtomicUsize::new(0),
             content_blob_checksum_heads: AtomicUsize::new(0),
+            content_blob_puts: AtomicUsize::new(0),
         }
     }
 
     fn reset_content_blob_counters(&self) {
         self.content_blob_gets.store(0, Ordering::SeqCst);
         self.content_blob_checksum_heads.store(0, Ordering::SeqCst);
+        self.content_blob_puts.store(0, Ordering::SeqCst);
     }
 
     fn content_blob_get_count(&self) -> usize {
@@ -2536,6 +2596,10 @@ impl ContentBlobGetCountingStore {
 
     fn content_blob_checksum_head_count(&self) -> usize {
         self.content_blob_checksum_heads.load(Ordering::SeqCst)
+    }
+
+    fn content_blob_put_count(&self) -> usize {
+        self.content_blob_puts.load(Ordering::SeqCst)
     }
 }
 
@@ -2580,6 +2644,80 @@ impl ObjectStore for ContentBlobGetCountingStore {
         bytes: Bytes,
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key.starts_with("content-stores/") && key.contains("/blobs/") {
+            self.content_blob_puts.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+#[derive(Debug)]
+struct FailContentBlobPutsStore {
+    inner: LocalFsStore,
+    fail_content_blob_puts: AtomicBool,
+}
+
+impl FailContentBlobPutsStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            fail_content_blob_puts: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_content_blob_puts(&self) {
+        self.fail_content_blob_puts.store(true, Ordering::SeqCst);
+    }
+
+    fn allow_content_blob_puts(&self) {
+        self.fail_content_blob_puts.store(false, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FailContentBlobPutsStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key.starts_with("content-stores/")
+            && key.contains("/blobs/")
+            && self.fail_content_blob_puts.load(Ordering::SeqCst)
+        {
+            return Err(ObjectStoreError::transport(
+                key,
+                "injected content write failure",
+            ));
+        }
         self.inner.put(key, bytes, mode).await
     }
 

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -213,6 +213,19 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
         .block_on(future)
 }
 
+async fn wal_segment_count(store: &SharedObjectStore, namespace_id: &NamespaceId) -> usize {
+    use futures::StreamExt;
+    store
+        .list_prefix_stream(&format!(
+            "namespaces/{}/wal/segments/",
+            namespace_id.as_str()
+        ))
+        .map(|key| key.expect("list wal segments"))
+        .collect::<Vec<_>>()
+        .await
+        .len()
+}
+
 fn page_limit(limit: u32) -> loonfs::EffectiveLimit {
     PaginationPolicy::from_values(limit, limit)
         .expect("valid pagination policy")
@@ -1666,7 +1679,7 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
         .expect("create namespace");
 
     let commit_id = CommitId::parse("overlap-put-retry").expect("valid commit id");
-    raw_store.fail_content_blob_puts();
+    raw_store.fail_next_content_blob_puts(1);
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/report.txt",
@@ -1690,7 +1703,6 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
 
     // The failed attempt never committed, so the same commit id retries
     // cleanly instead of resolving as a duplicate.
-    raw_store.allow_content_blob_puts();
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/report.txt",
@@ -1705,6 +1717,180 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
         .read_file_bytes_blocking(&namespace_id, "/docs/report.txt")
         .expect("read retried file");
     assert_eq!(read.bytes, b"overlap survives");
+}
+
+#[test]
+fn concurrent_puts_coalesce_into_one_wal_segment() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let object_store = store(temp_dir.path());
+    block_on(async {
+        let fs = open_runtime_async(object_store.clone(), "commit-window-test").await;
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let segments_before = wal_segment_count(&object_store, &namespace_id).await;
+
+        let puts = tokio::join!(
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/b.txt",
+                b"beta",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/c.txt",
+                b"gamma",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/d.txt",
+                b"delta",
+                PutFileOptions::default()
+            ),
+        );
+        puts.0.expect("put a");
+        puts.1.expect("put b");
+        puts.2.expect("put c");
+        puts.3.expect("put d");
+
+        // All four submissions entered one commit window and flushed as a
+        // single batch: one WAL segment, one head CAS.
+        let segments_after = wal_segment_count(&object_store, &namespace_id).await;
+        assert_eq!(segments_after - segments_before, 1);
+
+        for (path, bytes) in [
+            ("/docs/a.txt", b"alpha" as &[u8]),
+            ("/docs/b.txt", b"beta"),
+            ("/docs/c.txt", b"gamma"),
+            ("/docs/d.txt", b"delta"),
+        ] {
+            let read = fs
+                .reader
+                .read_file_bytes(&namespace_id, path)
+                .await
+                .expect("read coalesced file");
+            assert_eq!(read.bytes, bytes);
+        }
+    });
+}
+
+#[test]
+fn commit_window_zero_publishes_each_submission_immediately() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let object_store = store(temp_dir.path());
+    block_on(async {
+        let fs = open_runtime_with_async(object_store.clone(), "window-zero-test", |builder| {
+            builder.commit_window_ms(0)
+        })
+        .await;
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let segments_before = wal_segment_count(&object_store, &namespace_id).await;
+
+        let puts = tokio::join!(
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/b.txt",
+                b"beta",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/c.txt",
+                b"gamma",
+                PutFileOptions::default()
+            ),
+        );
+        puts.0.expect("put a");
+        puts.1.expect("put b");
+        puts.2.expect("put c");
+
+        // With coalescing disabled each publish serializes through the
+        // namespace's engine and writes its own WAL segment.
+        let segments_after = wal_segment_count(&object_store, &namespace_id).await;
+        assert_eq!(segments_after - segments_before, 3);
+    });
+}
+
+#[test]
+fn commit_window_flush_aborts_every_member_when_one_content_write_fails() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
+    let object_store: SharedObjectStore = raw_store.clone();
+    block_on(async {
+        let fs = open_runtime_async(object_store, "window-abort-test").await;
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+
+        // Exactly one of the two concurrent content writes fails; the
+        // combined durability gate cannot prove the flush, so the whole
+        // window aborts before the head CAS.
+        raw_store.fail_next_content_blob_puts(1);
+        let (a, b) = tokio::join!(
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/b.txt",
+                b"beta",
+                PutFileOptions::default()
+            ),
+        );
+        a.expect_err("window abort should fail the first member");
+        b.expect_err("window abort should fail the second member");
+        for path in ["/docs/a.txt", "/docs/b.txt"] {
+            let error = fs
+                .reader
+                .stat_path(&namespace_id, path)
+                .await
+                .expect_err("aborted put should leave the path unbound");
+            assert!(matches!(
+                error,
+                RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
+            ));
+        }
+
+        // Both members retry cleanly once the store recovers.
+        let (a, b) = tokio::join!(
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions::default()
+            ),
+            fs.put_file_bytes(
+                &namespace_id,
+                "/docs/b.txt",
+                b"beta",
+                PutFileOptions::default()
+            ),
+        );
+        a.expect("retried put a");
+        b.expect("retried put b");
+    });
 }
 
 #[test]
@@ -2665,23 +2851,29 @@ impl ObjectStore for ContentBlobGetCountingStore {
 #[derive(Debug)]
 struct FailContentBlobPutsStore {
     inner: LocalFsStore,
-    fail_content_blob_puts: AtomicBool,
+    fail_remaining: AtomicUsize,
 }
 
 impl FailContentBlobPutsStore {
     fn new(root: &Path) -> Self {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
-            fail_content_blob_puts: AtomicBool::new(false),
+            fail_remaining: AtomicUsize::new(0),
         }
     }
 
-    fn fail_content_blob_puts(&self) {
-        self.fail_content_blob_puts.store(true, Ordering::SeqCst);
+    /// Arms the store to fail the next `count` content-blob puts, then
+    /// recover.
+    fn fail_next_content_blob_puts(&self, count: usize) {
+        self.fail_remaining.store(count, Ordering::SeqCst);
     }
 
-    fn allow_content_blob_puts(&self) {
-        self.fail_content_blob_puts.store(false, Ordering::SeqCst);
+    fn should_fail_content_blob_put(&self) -> bool {
+        self.fail_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
     }
 }
 
@@ -2711,7 +2903,7 @@ impl ObjectStore for FailContentBlobPutsStore {
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         if key.starts_with("content-stores/")
             && key.contains("/blobs/")
-            && self.fail_content_blob_puts.load(Ordering::SeqCst)
+            && self.should_fail_content_blob_put()
         {
             return Err(ObjectStoreError::transport(
                 key,


### PR DESCRIPTION
Fifth and final Tier-1 change from the SlateDB-inspired scalability plan, stacked on #212.

A direct put paid three serial object-store round-trips — content PUT, WAL PUT, head CAS — and every concurrent direct publish to a namespace paid all of them separately. Two changes:

**Content ∥ WAL overlap.** `put_file_bytes` now drives its content write as a peer of the publish. The candidate carries a `ContentAdmission` for the in-flight ref, so batch validation stops probing object storage for a blob the put itself is writing (the probe also raced the write); instead a `ContentDurabilityGate` — the write's own ack — is awaited between the WAL write and the head CAS. Nothing becomes visible before content is durable; a failed content write aborts the batch with the head unmoved, leaving only GC-covered orphans, and the same commit id retries cleanly. This also drops the old validation HEAD, so the put path goes from content → probe → WAL → CAS to (content ∥ WAL) → CAS.

**Commit window.** Direct publishes (path intents and explicit commits through a handle) now hold a per-namespace window open briefly — `FsWriterBuilder::commit_window_ms`, default 15ms, zero disables — so concurrent submissions flush as one batch: one WAL segment, one head CAS, with every submitter still awaiting its own durable, visible result. The opener drives the flush inside its own future (no spawned task); an opener cancelled mid-window closes it and fails the joined members rather than wedging the namespace. The server's batching publisher keeps its own coalescer and does not pass through the window.

Semantics deliberately batch-scoped: if any member's content write fails, the whole flush aborts before the CAS and every member sees the rejection — safe, and rare enough that per-member gating wasn't worth the added core surface.

Tests: put issues exactly one content-blob PUT and zero probe reads; an injected content-write failure leaves nothing visible and the same commit id retries; four concurrent puts produce exactly one WAL segment; a zero window publishes each submission immediately; a one-member content failure aborts every member and both retry cleanly.