### PR TITLE
perf(core): admit wide scans to the cache and resolve segment scans by stored row keys

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -54,7 +54,10 @@ pub(super) struct MetadataTableCacheKey {
 
 #[derive(Debug, Clone)]
 pub(super) struct DecodedMetadataTableBlock {
-    pub(super) rows: Vec<MetadataRow>,
+    /// Decoded rows are shared, never re-cloned per reader: cache hits,
+    /// single-flight waiters, and per-scan session caches all hold the same
+    /// allocation, so concurrent wide scans cannot multiply resident copies.
+    pub(super) rows: Arc<Vec<MetadataRow>>,
     pub(super) segment_seq: ChangeSeq,
     pub(super) family: MetadataTableFamily,
     pub(super) segment_index: u32,
@@ -145,6 +148,15 @@ impl MetadataTableCache {
             inserts: self.stats.inserts.load(Ordering::SeqCst),
             evictions: self.stats.evictions.load(Ordering::SeqCst),
         }
+    }
+
+    /// Whether inserts are bounded by a decoded-byte budget. A byte-budgeted
+    /// cache admits scans of any width safely: eviction is sized by decoded
+    /// bytes, so one wide scan cannot pin more memory than the budget. Without
+    /// a byte budget only entry count bounds the cache, and wide admissions
+    /// would flush it.
+    pub(super) fn byte_budgeted(&self) -> bool {
+        self.config.max_decoded_bytes.is_some()
     }
 
     pub(super) fn get(&self, key: &MetadataTableCacheKey) -> Option<DecodedMetadataTableBlock> {
@@ -454,10 +466,11 @@ mod tests {
     };
     use loonfs_api::wire::manifest::{MetadataSegmentKey, MetadataTableFamily};
     use loonfs_api::ChangeSeq;
+    use std::sync::Arc;
 
     fn block(decoded_byte_len: usize) -> DecodedMetadataTableBlock {
         DecodedMetadataTableBlock {
-            rows: Vec::new(),
+            rows: Arc::new(Vec::new()),
             segment_seq: ChangeSeq(1),
             family: MetadataTableFamily::Inodes,
             segment_index: 0,
@@ -521,6 +534,19 @@ mod tests {
         assert!(cache.get(&key("a")).is_some());
         assert!(cache.get(&key("b")).is_some());
         assert_eq!(cache.stats().evictions, 0);
+    }
+
+    #[test]
+    fn cache_hits_share_the_decoded_row_allocation() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+        let inserted = block(64);
+        let rows = Arc::clone(&inserted.rows);
+        cache.insert(key("a"), inserted);
+        let hit = cache.get(&key("a")).expect("inserted block should hit");
+        assert!(
+            Arc::ptr_eq(&hit.rows, &rows),
+            "a cache hit should share the decoded rows, not clone them"
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -52,12 +52,60 @@ pub(super) struct MetadataTableCacheKey {
     pub(super) block_offset: u64,
 }
 
+/// One segment's decoded rows with their stored row keys, shared behind one
+/// `Arc`: cache hits, single-flight waiters, and per-scan session caches all
+/// hold the same allocation, so concurrent wide scans cannot multiply
+/// resident copies.
+#[derive(Debug)]
+pub(super) struct DecodedSegmentRowSet {
+    pub(super) rows: Vec<MetadataRow>,
+    /// Stored row keys, parallel to `rows`, validated against
+    /// `row_key_for_family` at decode so scans never recompute them.
+    pub(super) row_keys: Vec<String>,
+    /// Whether `row_keys` is non-decreasing. The builder writes sorted
+    /// segments; the flag is verified at decode so scans may binary-search,
+    /// with a linear fallback for segments that decode unsorted.
+    pub(super) sorted_by_row_key: bool,
+}
+
+impl DecodedSegmentRowSet {
+    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order.
+    /// A sorted row set narrows to the matching slice by binary search; an
+    /// unsorted one filters every row. Express a prefix scan as
+    /// `[prefix, string_prefix_upper_bound(prefix))`.
+    pub(super) fn rows_in_key_range<'a>(
+        &'a self,
+        lower_bound: &'a str,
+        upper_bound: Option<&'a str>,
+    ) -> impl Iterator<Item = (&'a str, &'a MetadataRow)> + 'a {
+        let range = if self.sorted_by_row_key {
+            let start = self
+                .row_keys
+                .partition_point(|key| key.as_str() < lower_bound);
+            let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
+                self.row_keys
+                    .partition_point(|key| key.as_str() < upper_bound)
+            });
+            start..end.max(start)
+        } else {
+            0..self.row_keys.len()
+        };
+        self.row_keys[range.clone()]
+            .iter()
+            .zip(&self.rows[range])
+            .filter(move |(key, _)| {
+                key.as_str() >= lower_bound
+                    && upper_bound
+                        .map(|upper_bound| key.as_str() < upper_bound)
+                        .unwrap_or(true)
+            })
+            .map(|(key, row)| (key.as_str(), row))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct DecodedMetadataTableBlock {
-    /// Decoded rows are shared, never re-cloned per reader: cache hits,
-    /// single-flight waiters, and per-scan session caches all hold the same
-    /// allocation, so concurrent wide scans cannot multiply resident copies.
-    pub(super) rows: Arc<Vec<MetadataRow>>,
+    pub(super) row_set: Arc<DecodedSegmentRowSet>,
     pub(super) segment_seq: ChangeSeq,
     pub(super) family: MetadataTableFamily,
     pub(super) segment_index: u32,
@@ -103,13 +151,18 @@ impl MetadataTableCache {
         }
     }
 
-    /// Runs `fetch` once per object key across concurrent callers: waiters
-    /// share the winner's decoded block instead of issuing duplicate store
-    /// GETs. A failed or cancelled fetch leaves the cell empty, so the next
-    /// caller retries.
-    pub(super) async fn fetch_deduplicated<E, F, Fut>(
+    /// Resolves one segment access through the single-flight cell: the
+    /// winner consults the cache, fetches on a miss, and populates when
+    /// `populate` is set; concurrent waiters share the winner's block
+    /// instead of issuing duplicate lookups, fetches, or inserts, so hit and
+    /// miss counts measure deduplicated accesses. A failed or cancelled
+    /// fetch leaves the cell empty, so the next caller retries.
+    pub(super) async fn get_or_fetch<E, F, Fut>(
         &self,
         object_key: &str,
+        cache_key: &MetadataTableCacheKey,
+        consult: bool,
+        populate: bool,
         fetch: F,
     ) -> Result<DecodedMetadataTableBlock, E>
     where
@@ -127,7 +180,21 @@ impl MetadataTableCache {
                     .or_insert_with(|| Arc::new(OnceCell::new())),
             )
         };
-        let result = cell.get_or_try_init(fetch).await.cloned();
+        let result = cell
+            .get_or_try_init(|| async {
+                if consult {
+                    if let Some(block) = self.get(cache_key) {
+                        return Ok(block);
+                    }
+                }
+                let block = fetch().await?;
+                if populate {
+                    self.insert(cache_key.clone(), block.clone());
+                }
+                Ok(block)
+            })
+            .await
+            .cloned();
         let mut in_flight = self
             .in_flight
             .lock()
@@ -461,8 +528,8 @@ impl WalTailProjectionCacheInner {
 #[cfg(test)]
 mod tests {
     use super::{
-        DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache,
-        MetadataTableCacheConfig, MetadataTableCacheKey,
+        DecodedMetadataTableBlock, DecodedSegmentRowSet, MetadataTableBlockKind,
+        MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheKey,
     };
     use loonfs_api::wire::manifest::{MetadataSegmentKey, MetadataTableFamily};
     use loonfs_api::ChangeSeq;
@@ -470,7 +537,11 @@ mod tests {
 
     fn block(decoded_byte_len: usize) -> DecodedMetadataTableBlock {
         DecodedMetadataTableBlock {
-            rows: Arc::new(Vec::new()),
+            row_set: Arc::new(DecodedSegmentRowSet {
+                rows: Vec::new(),
+                row_keys: Vec::new(),
+                sorted_by_row_key: true,
+            }),
             segment_seq: ChangeSeq(1),
             family: MetadataTableFamily::Inodes,
             segment_index: 0,
@@ -540,28 +611,54 @@ mod tests {
     fn cache_hits_share_the_decoded_row_allocation() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
         let inserted = block(64);
-        let rows = Arc::clone(&inserted.rows);
+        let row_set = Arc::clone(&inserted.row_set);
         cache.insert(key("a"), inserted);
         let hit = cache.get(&key("a")).expect("inserted block should hit");
         assert!(
-            Arc::ptr_eq(&hit.rows, &rows),
+            Arc::ptr_eq(&hit.row_set, &row_set),
             "a cache hit should share the decoded rows, not clone them"
         );
     }
 
     #[tokio::test]
-    async fn fetch_deduplicated_retries_after_a_failed_fetch() {
+    async fn get_or_fetch_retries_after_a_failed_fetch() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
         let failed: Result<_, String> = cache
-            .fetch_deduplicated("segment-key", || async { Err("transport".to_owned()) })
+            .get_or_fetch("segment-key", &key("a"), true, true, || async {
+                Err("transport".to_owned())
+            })
             .await;
         assert!(failed.is_err());
         let recovered: Result<_, String> = cache
-            .fetch_deduplicated("segment-key", || async { Ok(block(1)) })
+            .get_or_fetch("segment-key", &key("a"), true, true, || async {
+                Ok(block(1))
+            })
             .await;
         assert!(
             recovered.is_ok(),
             "a failed fetch should leave nothing behind for the next caller"
         );
+    }
+
+    #[tokio::test]
+    async fn get_or_fetch_counts_one_miss_and_populates_for_later_hits() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+        let fetched: Result<_, String> = cache
+            .get_or_fetch("segment-key", &key("a"), true, true, || async {
+                Ok(block(1))
+            })
+            .await;
+        assert!(fetched.is_ok());
+        let cached: Result<_, String> = cache
+            .get_or_fetch("segment-key", &key("a"), true, true, || async {
+                Err("a populated key must not re-fetch".to_owned())
+            })
+            .await;
+        assert!(cached.is_ok(), "the cached block should answer the access");
+
+        let stats = cache.stats();
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.inserts, 1);
+        assert_eq!(stats.hits, 1);
     }
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -9,7 +9,8 @@
 //!    inspection/debug path that loads every referenced row into `MetadataState`.
 
 use super::cache::{
-    DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
+    DecodedMetadataTableBlock, DecodedSegmentRowSet, MetadataTableBlockKind, MetadataTableCache,
+    MetadataTableCacheKey,
 };
 use super::error::ManifestLoadError;
 #[cfg(test)]
@@ -47,7 +48,8 @@ use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::Semaphore;
 use tracing::Instrument;
 
 #[cfg(test)]
@@ -474,23 +476,28 @@ where
             );
         }
 
-        for (descriptor, rows) in descriptors.into_iter().zip(loaded_segments) {
+        for (descriptor, row_set) in descriptors.into_iter().zip(loaded_segments) {
             match table.family {
                 MetadataTableFamily::DirentryBinds => {
-                    direntry_bind_rows.extend(rows.iter().cloned());
+                    direntry_bind_rows.extend(row_set.rows.iter().cloned());
                 }
                 MetadataTableFamily::DirentryChildBinds => {
-                    direntry_child_bind_rows.extend(rows.iter().cloned());
+                    direntry_child_bind_rows.extend(row_set.rows.iter().cloned());
                 }
                 MetadataTableFamily::Revisions => {
-                    revision_rows.extend(rows.iter().cloned());
+                    revision_rows.extend(row_set.rows.iter().cloned());
                 }
                 MetadataTableFamily::RevisionsByInodeDesc => {
-                    revision_by_inode_desc_rows.extend(rows.iter().cloned());
+                    revision_by_inode_desc_rows.extend(row_set.rows.iter().cloned());
                 }
                 _ => {}
             }
-            append_rows_to_metadata(metadata_state, table.family, &descriptor.object_key, &rows)?;
+            append_rows_to_metadata(
+                metadata_state,
+                table.family,
+                &descriptor.object_key,
+                &row_set.rows,
+            )?;
         }
     }
 
@@ -512,7 +519,7 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
+) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     load_manifest_segment_rows_with_cache(
         store,
         None,
@@ -524,6 +531,16 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     .await
 }
 
+/// Concurrent segment decodes each hold multi-megabyte payload and row
+/// buffers, so wide preload waves are bounded here: store fetches stay fully
+/// concurrent, only the decode step queues.
+const MAX_CONCURRENT_SEGMENT_DECODES: usize = 4;
+
+fn segment_decode_permits() -> &'static Semaphore {
+    static PERMITS: OnceLock<Semaphore> = OnceLock::new();
+    PERMITS.get_or_init(|| Semaphore::new(MAX_CONCURRENT_SEGMENT_DECODES))
+}
+
 pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -531,26 +548,13 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     cache_mode: MetadataTableCacheMode,
-) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
+) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     let expected_segment_seq = context.expected_segment_seq(descriptor)?;
     let cache_key = MetadataTableCacheKey {
         table_digest: descriptor.payload_checksum.clone(),
         block_kind: MetadataTableBlockKind::SegmentPayload,
         block_offset: 0,
     };
-    if cache_mode != MetadataTableCacheMode::Bypass {
-        if let Some(block) = table_cache.and_then(|cache| cache.get(&cache_key)) {
-            validate_cached_manifest_block(family, expected_segment_seq, descriptor, &block)?;
-            validate_manifest_row_seq_range(
-                &descriptor.object_key,
-                &block.rows,
-                context.row_seq_min,
-                context.row_seq_max(descriptor),
-            )?;
-            return Ok(block.rows);
-        }
-    }
-
     let fetch = || async {
         let Some(bytes) = store
             .get(&descriptor.object_key, None)
@@ -564,16 +568,22 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
                 object_key: descriptor.object_key.clone(),
             });
         };
+        let permit = segment_decode_permits()
+            .acquire()
+            .await
+            .expect("segment decode semaphore is never closed");
         let segment = decode_metadata_sst_envelope_zstd(&bytes).map_err(|err| {
             ManifestLoadError::SegmentCodec {
                 object_key: descriptor.object_key.clone(),
                 message: err.to_string(),
             }
         })?;
-        let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        let row_set =
+            validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
+        drop(permit);
         Ok(DecodedMetadataTableBlock {
-            decoded_byte_len: decoded_manifest_block_weight(family, &rows),
-            rows: Arc::new(rows),
+            decoded_byte_len: decoded_manifest_block_weight(family, &row_set.rows),
+            row_set: Arc::new(row_set),
             segment_seq: expected_segment_seq,
             family,
             segment_index: descriptor.segment_index,
@@ -583,13 +593,20 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
             max_key: descriptor.max_key.clone(),
         })
     };
-    // Waiters may share a block another caller fetched, so every path
-    // re-validates the block against this caller's own expectations, exactly
-    // as the cache-hit path above does.
+    // The winner of the single-flight cell consults the cache and populates
+    // it on a miss; waiters share its block. Every path then re-validates the
+    // block against this caller's own expectations, so a shared or cached
+    // block is held to exactly the standard of a freshly fetched one.
     let block = match table_cache {
         Some(cache) => {
             cache
-                .fetch_deduplicated(&descriptor.object_key, fetch)
+                .get_or_fetch(
+                    &descriptor.object_key,
+                    &cache_key,
+                    cache_mode != MetadataTableCacheMode::Bypass,
+                    cache_mode == MetadataTableCacheMode::Populate,
+                    fetch,
+                )
                 .await?
         }
         None => fetch().await?,
@@ -597,16 +614,11 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     validate_cached_manifest_block(family, expected_segment_seq, descriptor, &block)?;
     validate_manifest_row_seq_range(
         &descriptor.object_key,
-        &block.rows,
+        &block.row_set.rows,
         context.row_seq_min,
         context.row_seq_max(descriptor),
     )?;
-    if cache_mode == MetadataTableCacheMode::Populate {
-        if let Some(cache) = table_cache {
-            cache.insert(cache_key, block.clone());
-        }
-    }
-    Ok(block.rows)
+    Ok(block.row_set)
 }
 
 pub(super) fn validate_cached_manifest_block(

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -47,7 +47,7 @@ use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tracing::Instrument;
 
 #[cfg(test)]
@@ -512,7 +512,7 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
     load_manifest_segment_rows_with_cache(
         store,
         None,
@@ -531,7 +531,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     cache_mode: MetadataTableCacheMode,
-) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
     let expected_segment_seq = context.expected_segment_seq(descriptor)?;
     let cache_key = MetadataTableCacheKey {
         table_digest: descriptor.payload_checksum.clone(),
@@ -573,7 +573,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         let rows = validate_manifest_segment(expected_segment_seq, family, descriptor, &segment)?;
         Ok(DecodedMetadataTableBlock {
             decoded_byte_len: decoded_manifest_block_weight(family, &rows),
-            rows,
+            rows: Arc::new(rows),
             segment_seq: expected_segment_seq,
             family,
             segment_index: descriptor.segment_index,

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -1,7 +1,7 @@
 //! Verified row scans over a loaded manifest's tables, with per-segment
 //! caching and prefix-window pruning.
 
-use super::cache::MetadataTableCache;
+use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
     load_manifest_segment_rows_with_cache, metadata_file_object_key, MetadataSstSeqExpectation,
@@ -45,7 +45,7 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
     /// or re-decodes a segment it already saw. Entries share the decoded
     /// allocation with the table cache and with concurrent readers; the memo
     /// itself retains pointers, not copies.
-    pub(super) segment_cache: Mutex<HashMap<String, Arc<Vec<MetadataRow>>>>,
+    pub(super) segment_cache: Mutex<HashMap<String, Arc<DecodedSegmentRowSet>>>,
 }
 
 impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
@@ -211,24 +211,11 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             .await?;
             next_descriptor_index = chunk_end;
 
-            rows.extend(
-                loaded_segments
-                    .iter()
-                    .flat_map(|segment_rows| segment_rows.iter())
-                    .filter_map(|row| {
-                        let row_key = row.row_key_for_family(family);
-                        if row_key.as_str() < lower_bound {
-                            return None;
-                        }
-                        if upper_bound
-                            .map(|upper_bound| row_key.as_str() >= upper_bound)
-                            .unwrap_or(false)
-                        {
-                            return None;
-                        }
-                        Some((row_key, row.clone()))
-                    }),
-            );
+            rows.extend(loaded_segments.iter().flat_map(|segment_rows| {
+                segment_rows
+                    .rows_in_key_range(lower_bound, upper_bound)
+                    .map(|(row_key, row)| (row_key.to_owned(), row.clone()))
+            }));
             rows.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         }
 
@@ -271,12 +258,12 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             );
         }
 
+        let prefix_upper_bound = string_prefix_upper_bound(prefix);
         for segment_rows in loaded_segments {
             output.rows.extend(
                 segment_rows
-                    .iter()
-                    .filter(|row| row.row_key_for_family(family).starts_with(prefix))
-                    .cloned(),
+                    .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
+                    .map(|(_, row)| row.clone()),
             );
         }
         Ok(())
@@ -288,7 +275,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
         cache_mode: MetadataTableCacheMode,
-    ) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
+    ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
         if let Some(rows) = self
             .segment_cache
             .lock()

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -18,8 +18,11 @@ use loonfs_objectstore::ObjectStore;
 #[cfg(test)]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+/// Widest scan a cache without a byte budget may populate. A count-bounded
+/// cache evicts per entry, so admitting a wide scan would flush it; a
+/// byte-budgeted cache ignores this limit and admits every scan.
 pub(super) const SMALL_SCAN_CACHE_SEGMENT_LIMIT: usize = 4;
 /// Segment fetches issued per wave during a scan. Wide directories touch
 /// hundreds of segments per page; deeper waves amortize the per-wave await
@@ -38,7 +41,11 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
     pub(super) table_cache: Option<&'a MetadataTableCache>,
     pub(super) manifest_object_key: String,
     pub(super) manifest: NamespaceManifestEnvelope,
-    pub(super) segment_cache: Mutex<HashMap<String, Vec<MetadataRow>>>,
+    /// Per-view memo of decoded segments, so one operation never re-fetches
+    /// or re-decodes a segment it already saw. Entries share the decoded
+    /// allocation with the table cache and with concurrent readers; the memo
+    /// itself retains pointers, not copies.
+    pub(super) segment_cache: Mutex<HashMap<String, Arc<Vec<MetadataRow>>>>,
 }
 
 impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
@@ -64,13 +71,25 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         prefix: &str,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let matching_segment_count = self.matching_segment_count(family, prefix)?;
-        let cache_mode = if matching_segment_count <= SMALL_SCAN_CACHE_SEGMENT_LIMIT {
+        let cache_mode = self.scan_cache_mode(matching_segment_count);
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode)
+            .await
+    }
+
+    /// Cache admission for a scan matching `matching_segment_count` segments.
+    /// A byte-budgeted table cache admits every scan — byte-based eviction
+    /// makes wide admissions safe, and list preloads are exactly the wide
+    /// scans that must land in the cache. Without a byte budget, wide scans
+    /// stay read-only so they cannot flush a count-bounded cache.
+    fn scan_cache_mode(&self, matching_segment_count: usize) -> MetadataTableCacheMode {
+        let byte_budgeted = self
+            .table_cache
+            .is_some_and(MetadataTableCache::byte_budgeted);
+        if byte_budgeted || matching_segment_count <= SMALL_SCAN_CACHE_SEGMENT_LIMIT {
             MetadataTableCacheMode::Populate
         } else {
             MetadataTableCacheMode::ReadOnly
-        };
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode)
-            .await
+        }
     }
 
     pub(crate) async fn scan_range_page(
@@ -165,11 +184,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 .then(left.max_key.cmp(&right.max_key))
                 .then(left.object_key.cmp(&right.object_key))
         });
-        let cache_mode = if matching_descriptors.len() <= SMALL_SCAN_CACHE_SEGMENT_LIMIT {
-            MetadataTableCacheMode::Populate
-        } else {
-            MetadataTableCacheMode::ReadOnly
-        };
+        let cache_mode = self.scan_cache_mode(matching_descriptors.len());
 
         let mut rows = Vec::<(String, MetadataRow)>::new();
         let mut next_descriptor_index = 0;
@@ -196,19 +211,24 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             .await?;
             next_descriptor_index = chunk_end;
 
-            rows.extend(loaded_segments.into_iter().flatten().filter_map(|row| {
-                let row_key = row.row_key_for_family(family);
-                if row_key.as_str() < lower_bound {
-                    return None;
-                }
-                if upper_bound
-                    .map(|upper_bound| row_key.as_str() >= upper_bound)
-                    .unwrap_or(false)
-                {
-                    return None;
-                }
-                Some((row_key, row))
-            }));
+            rows.extend(
+                loaded_segments
+                    .iter()
+                    .flat_map(|segment_rows| segment_rows.iter())
+                    .filter_map(|row| {
+                        let row_key = row.row_key_for_family(family);
+                        if row_key.as_str() < lower_bound {
+                            return None;
+                        }
+                        if upper_bound
+                            .map(|upper_bound| row_key.as_str() >= upper_bound)
+                            .unwrap_or(false)
+                        {
+                            return None;
+                        }
+                        Some((row_key, row.clone()))
+                    }),
+            );
             rows.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         }
 
@@ -254,8 +274,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         for segment_rows in loaded_segments {
             output.rows.extend(
                 segment_rows
-                    .into_iter()
-                    .filter(|row| row.row_key_for_family(family).starts_with(prefix)),
+                    .iter()
+                    .filter(|row| row.row_key_for_family(family).starts_with(prefix))
+                    .cloned(),
             );
         }
         Ok(())
@@ -267,14 +288,14 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
         cache_mode: MetadataTableCacheMode,
-    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+    ) -> Result<Arc<Vec<MetadataRow>>, ManifestLoadError> {
         if let Some(rows) = self
             .segment_cache
             .lock()
             .expect("manifest segment cache lock poisoned")
             .get(&descriptor.object_key)
         {
-            return Ok(rows.clone());
+            return Ok(Arc::clone(rows));
         }
         let rows = load_manifest_segment_rows_with_cache(
             self.store,
@@ -288,7 +309,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         self.segment_cache
             .lock()
             .expect("manifest segment cache lock poisoned")
-            .insert(descriptor.object_key.clone(), rows.clone());
+            .insert(descriptor.object_key.clone(), Arc::clone(&rows));
         Ok(rows)
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -27,6 +27,7 @@ use super::runs::{
     CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
     DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT, MAX_CHECKPOINT_L0_RUNS,
 };
+use super::scan::SMALL_SCAN_CACHE_SEGMENT_LIMIT;
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
@@ -2098,7 +2099,80 @@ async fn manifest_base_run_tables_have_sorted_segment_coverage() {
 }
 
 #[tokio::test]
-async fn large_table_scan_does_not_insert_metadata_cache_blocks() {
+async fn byte_budgeted_cache_admits_large_table_scans() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..8 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    let policy = MetadataLsmPolicy {
+        max_rows_per_segment: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+        .await
+        .expect("manifest");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    // The default cache config carries a decoded-byte budget, so a scan wider
+    // than the small-scan limit populates the cache instead of reading through.
+    let cache = super::MetadataTableCache::new(Default::default());
+    let tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load tables");
+
+    let revisions = tables
+        .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
+        .await
+        .expect("scan revisions");
+    let after_first = cache.stats();
+    assert!(revisions.len() >= 8);
+    assert!(
+        after_first.inserts >= 8,
+        "a wide scan against a byte-budgeted cache should admit every segment"
+    );
+
+    // A fresh view has no per-view segment memo; only the shared cache can
+    // answer, so the repeated scan must issue no segment fetches.
+    let fresh_tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load fresh tables");
+    store.reset_metadata_sst_gets();
+    let repeated = fresh_tables
+        .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
+        .await
+        .expect("repeated scan");
+    let after_repeat = cache.stats();
+
+    assert_eq!(repeated, revisions);
+    assert_eq!(
+        store.metadata_sst_gets(),
+        0,
+        "a warm wide scan should be served entirely from the cache"
+    );
+    assert!(after_repeat.hits > after_first.hits);
+}
+
+#[tokio::test]
+async fn count_bounded_cache_keeps_large_table_scans_read_only() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -2120,7 +2194,14 @@ async fn large_table_scan_does_not_insert_metadata_cache_blocks() {
         .await
         .expect("manifest");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    let cache = super::MetadataTableCache::new(Default::default());
+    // Without a byte budget only entry count bounds the cache, so one wide
+    // scan admitting all its segments could flush every resident block; wide
+    // scans stay read-only under that configuration.
+    let cache = super::MetadataTableCache::new(MetadataTableCacheConfig {
+        enabled: true,
+        max_blocks: 256,
+        max_decoded_bytes: None,
+    });
     let tables = super::load_verified_manifest_tables_with_cache(
         &store,
         Some(&cache),
@@ -2166,7 +2247,14 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
         .await
         .expect("manifest");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    let cache = super::MetadataTableCache::new(Default::default());
+    // A count-bounded cache keeps wide scans read-only, so nothing is ever
+    // admitted and single-flight deduplication is the only fetch sharing —
+    // exactly the property this test pins.
+    let cache = super::MetadataTableCache::new(MetadataTableCacheConfig {
+        enabled: true,
+        max_blocks: 256,
+        max_decoded_bytes: None,
+    });
     let load_tables = || {
         super::load_verified_manifest_tables_with_cache(
             &store,
@@ -2266,6 +2354,88 @@ async fn table_range_page_merges_base_and_l0_in_row_key_order() {
         .collect::<Vec<_>>();
 
     assert_eq!(display_names, vec!["a.txt", "b.txt"]);
+}
+
+#[tokio::test]
+async fn byte_budgeted_cache_admits_large_range_scans() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..8 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    let policy = MetadataLsmPolicy {
+        max_rows_per_segment: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+        .await
+        .expect("manifest");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let cache = super::MetadataTableCache::new(Default::default());
+    let tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load tables");
+
+    // The list preload path: one page-shaped range scan over a directory
+    // whose bind rows span more segments than the small-scan limit.
+    let docs_inode_id = InodeId(2);
+    let lower_bound = format!("direntry-{:020}-", docs_inode_id.0);
+    let upper_bound = super::string_prefix_upper_bound(&lower_bound);
+    let page = tables
+        .scan_range_page(
+            ApiMetadataTableFamily::DirentryBinds,
+            &lower_bound,
+            upper_bound.as_deref(),
+            8,
+        )
+        .await
+        .expect("scan range page");
+    let after_first = cache.stats();
+    assert_eq!(page.len(), 8);
+    assert!(
+        after_first.inserts > SMALL_SCAN_CACHE_SEGMENT_LIMIT,
+        "a wide range scan against a byte-budgeted cache should admit its segments"
+    );
+
+    let fresh_tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load fresh tables");
+    store.reset_metadata_sst_gets();
+    let repeated = fresh_tables
+        .scan_range_page(
+            ApiMetadataTableFamily::DirentryBinds,
+            &lower_bound,
+            upper_bound.as_deref(),
+            8,
+        )
+        .await
+        .expect("repeated scan range page");
+
+    assert_eq!(repeated, page);
+    assert_eq!(
+        store.metadata_sst_gets(),
+        0,
+        "a warm range scan should be served entirely from the cache"
+    );
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -1,6 +1,7 @@
 //! Pure validation of loaded manifests and SST segments against their
 //! descriptors: identity, checksums, ranges, ordering, and row shape.
 
+use super::cache::DecodedSegmentRowSet;
 use super::error::ManifestLoadError;
 use super::row::{manifest_row_commit_seq, manifest_row_kind, manifest_row_matches_family};
 use loonfs_api::wire::manifest::{
@@ -141,7 +142,7 @@ pub(super) fn validate_manifest_segment(
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     segment: &MetadataSstEnvelope,
-) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+) -> Result<DecodedSegmentRowSet, ManifestLoadError> {
     if segment.payload.namespace_id != descriptor.owner_namespace_id {
         return Err(ManifestLoadError::SegmentNamespaceMismatch {
             object_key: descriptor.object_key.clone(),
@@ -225,6 +226,8 @@ pub(super) fn validate_manifest_segment(
             ),
         });
     }
+    // `validate_manifest_page` pinned every stored row key to its row, so
+    // the collected keys are authoritative and scans can reuse them.
     let row_keys = collected_rows
         .iter()
         .map(|row| row.row_key_for_family(family))
@@ -253,7 +256,15 @@ pub(super) fn validate_manifest_segment(
         });
     }
 
-    Ok(collected_rows)
+    // The builder writes segments in row-key order; verifying once here lets
+    // every scan binary-search this block instead of filtering all rows. An
+    // unsorted segment stays valid — scans fall back to a full filter.
+    let sorted_by_row_key = row_keys.windows(2).all(|pair| pair[0] <= pair[1]);
+    Ok(DecodedSegmentRowSet {
+        rows: collected_rows,
+        row_keys,
+        sorted_by_row_key,
+    })
 }
 
 pub(super) fn validate_manifest_page(

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1665,6 +1665,23 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     assert_eq!(raw_store.content_blob_put_count(), 1);
     assert_eq!(raw_store.content_blob_get_count(), 0);
     assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
+
+    // A replace put rides the same overlapped path: new blob, no probe.
+    raw_store.reset_content_blob_counters();
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/direct.txt",
+        b"replaced bytes",
+        PutFileOptions {
+            behavior: PutBehavior::Replace,
+            commit_id: None,
+        },
+    )
+    .expect("replace file bytes");
+
+    assert_eq!(raw_store.content_blob_put_count(), 1);
+    assert_eq!(raw_store.content_blob_get_count(), 0);
+    assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
The 30k benchmark eval (`loonfs_lab/reports/s3-30k-tier1-eval-20260707.md`) showed the new cache barely helping: the warm list was only 1.2× faster and the cache hit rate read 2%. Digging in found three problems, only one of them where the eval pointed.

**Big scans couldn't use the cache.** An old rule made any scan touching more than 4 segments read-only. It existed to protect the old count-limited cache from being flushed by one big scan — but the cache is now limited by bytes (#210), so the rule only served to block the exact scans directory listing depends on. Big scans now populate the cache whenever a byte budget is set; the read-only behavior stays for caches configured without one. Decoded rows are also shared by pointer (`Arc`) now instead of copied to every reader.

**Every lookup scanned every row — this was the real 340 seconds.** A metadata segment holds ~4,096 rows, and every point lookup walked all of them, building a key string per row just to compare it. A 30k listing makes ~190,000 lookups, so this walk dominated everything else. The fix was nearly free: the wire format already stores each row's key — we were validating those keys at decode time and then throwing them away. Now we keep them (`DecodedSegmentRowSet`), check once at decode that they're sorted, and binary-search instead of walking. If a segment ever isn't sorted we fall back to the old walk rather than failing, since sorted order is how our builder writes segments, not something the format promises. This step alone took the warm list from 298s to 36s.

**Honest stats, bounded memory.** The "2% hit rate" was partly a counting bug: when ~192 readers wanted the same segment at once, each one counted a miss before the single shared download finished. Counting now happens after deduplication, so one downloaded segment is one miss — measured that way, the real hit rate is 90.8%. Separately, segment decoding (which briefly holds several MB per segment) is now limited to 4 at a time; the downloads themselves stay parallel.

Verified with a full 30k S3 rerun (`loonfs_lab/reports/s3-30k-tier1-fix-20260707.md`): warm list 340s → 36s (9.5×), cold list 376s → 66s, warm stat −47%, unchanged GET counts, and the whole run finishes in half the wall clock. One eval finding also turned out to be a false alarm: Replace-mode puts already take the parallel upload path from #215, now pinned by a test.
