### PR TITLE
feat(core): require ascending row-key order in metadata segments

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -60,45 +60,31 @@ pub(super) struct MetadataTableCacheKey {
 pub(super) struct DecodedSegmentRowSet {
     pub(super) rows: Vec<MetadataRow>,
     /// Stored row keys, parallel to `rows`, validated against
-    /// `row_key_for_family` at decode so scans never recompute them.
+    /// `row_key_for_family` and for ascending order at decode — a format
+    /// requirement — so scans never recompute keys and always binary-search.
     pub(super) row_keys: Vec<String>,
-    /// Whether `row_keys` is non-decreasing. The builder writes sorted
-    /// segments; the flag is verified at decode so scans may binary-search,
-    /// with a linear fallback for segments that decode unsorted.
-    pub(super) sorted_by_row_key: bool,
 }
 
 impl DecodedSegmentRowSet {
-    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order.
-    /// A sorted row set narrows to the matching slice by binary search; an
-    /// unsorted one filters every row. Express a prefix scan as
-    /// `[prefix, string_prefix_upper_bound(prefix))`.
+    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order,
+    /// found by binary search over the decode-validated key order. Express a
+    /// prefix scan as `[prefix, string_prefix_upper_bound(prefix))`.
     pub(super) fn rows_in_key_range<'a>(
         &'a self,
         lower_bound: &'a str,
         upper_bound: Option<&'a str>,
     ) -> impl Iterator<Item = (&'a str, &'a MetadataRow)> + 'a {
-        let range = if self.sorted_by_row_key {
-            let start = self
-                .row_keys
-                .partition_point(|key| key.as_str() < lower_bound);
-            let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
-                self.row_keys
-                    .partition_point(|key| key.as_str() < upper_bound)
-            });
-            start..end.max(start)
-        } else {
-            0..self.row_keys.len()
-        };
+        let start = self
+            .row_keys
+            .partition_point(|key| key.as_str() < lower_bound);
+        let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
+            self.row_keys
+                .partition_point(|key| key.as_str() < upper_bound)
+        });
+        let range = start..end.max(start);
         self.row_keys[range.clone()]
             .iter()
             .zip(&self.rows[range])
-            .filter(move |(key, _)| {
-                key.as_str() >= lower_bound
-                    && upper_bound
-                        .map(|upper_bound| key.as_str() < upper_bound)
-                        .unwrap_or(true)
-            })
             .map(|(key, row)| (key.as_str(), row))
     }
 }
@@ -540,7 +526,6 @@ mod tests {
             row_set: Arc::new(DecodedSegmentRowSet {
                 rows: Vec::new(),
                 row_keys: Vec::new(),
-                sorted_by_row_key: true,
             }),
             segment_seq: ChangeSeq(1),
             family: MetadataTableFamily::Inodes,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2950,6 +2950,83 @@ async fn manifest_rejects_missing_revision_desc_index() {
 }
 
 #[tokio::test]
+async fn manifest_rejects_segment_rows_out_of_row_key_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/other.txt",
+        b"other\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write other");
+
+    let manifest = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let mut manifest = materialized.manifest;
+    let manifest_id = manifest.payload.manifest_id;
+    let mut inode_rows =
+        manifest_rows_for_family(&materialized.metadata_state, ApiMetadataTableFamily::Inodes);
+    // Swap two middle rows: the segment's min/max keys stay truthful, so the
+    // only violation the rewritten segment carries is its row order.
+    assert!(inode_rows.len() >= 3, "need middle rows to disorder");
+    inode_rows.swap(1, 2);
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::Inodes
+        })
+        .expect("inodes metadata file");
+    rewrite_manifest_segment(
+        &store,
+        &namespace_id,
+        manifest.payload.head_seq,
+        ApiMetadataTableFamily::Inodes,
+        descriptor,
+        inode_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id).await {
+        Err(ManifestLoadError::SegmentDescriptorMismatch { message, .. }) => {
+            assert!(
+                message.contains("row-key order"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected out-of-order segment rejection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn manifest_rejects_revision_desc_index_missing_row() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -256,14 +256,21 @@ pub(super) fn validate_manifest_segment(
         });
     }
 
-    // The builder writes segments in row-key order; verifying once here lets
-    // every scan binary-search this block instead of filtering all rows. An
-    // unsorted segment stays valid — scans fall back to a full filter.
-    let sorted_by_row_key = row_keys.windows(2).all(|pair| pair[0] <= pair[1]);
+    // The format requires segment rows in ascending row-key order (format
+    // spec, "Recovery view"): every scan binary-searches this block, so an
+    // out-of-order segment is malformed, not merely slow.
+    if let Some(pair) = row_keys.windows(2).find(|pair| pair[0] > pair[1]) {
+        return Err(ManifestLoadError::SegmentDescriptorMismatch {
+            object_key: descriptor.object_key.clone(),
+            message: format!(
+                "rows out of row-key order: `{}` follows `{}`",
+                pair[1], pair[0]
+            ),
+        });
+    }
     Ok(DecodedSegmentRowSet {
         rows: collected_rows,
         row_keys,
-        sorted_by_row_key,
     })
 }
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -618,8 +618,10 @@ It may reference one or more immutable metadata runs and may include
 standalone checkpoint records under `checkpoints/` pin manifest versions for
 retention, fork, or stable read workflows. Each run is internally segmented without overlapping segment
 key ranges; different runs may overlap and readers apply the normal metadata
-visibility rules across all referenced runs. Readers load the referenced runs,
-then replay only the visible WAL chain after the manifest's `head_seq`.
+visibility rules across all referenced runs. Within a segment, rows are stored
+in ascending row-key order (adjacent equal keys permitted); readers reject a
+segment whose rows are out of order as malformed. Readers load the referenced
+runs, then replay only the visible WAL chain after the manifest's `head_seq`.
 
 The WAL preserves ordered history even when multiple logical commits are
 stored in one segment. Each logical commit records the commit identity, optional


### PR DESCRIPTION
Follow-up to #214, which made every metadata lookup binary-search a segment's stored row keys — and, because sorted order was only "how the builder happens to write segments," kept a fallback that silently walks every row if a segment ever decodes unsorted.

That fallback is the wrong shape for a failure: an unsorted segment wouldn't error, it would just make reads ~100× slower, and nothing would tell you why. Segments are also only ever written by our own builder, which always writes them sorted — so the fallback is dead code that still has to be maintained and reasoned about.

This makes sorted order part of the format instead:

- The format spec now says rows in a segment are stored in ascending row-key order, and readers reject out-of-order segments as malformed.
- Segment validation enforces it at decode, using the same error class as the other malformed-segment checks (no new error code), with a message naming the two keys that are out of order.
- The fallback and the `sorted_by_row_key` flag are deleted; scans always binary-search.

There is nothing to migrate: the builder has always written sorted segments, so every existing segment already satisfies the rule.

Test: a checkpoint segment rewritten with two middle rows swapped (min/max keys stay truthful, so only the ordering rule can fire) is rejected at load with an "out of row-key order" error.
