### PR TITLE
fix(runtime): attribute commit window failures to the failing write

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -60,45 +60,31 @@ pub(super) struct MetadataTableCacheKey {
 pub(super) struct DecodedSegmentRowSet {
     pub(super) rows: Vec<MetadataRow>,
     /// Stored row keys, parallel to `rows`, validated against
-    /// `row_key_for_family` at decode so scans never recompute them.
+    /// `row_key_for_family` and for ascending order at decode — a format
+    /// requirement — so scans never recompute keys and always binary-search.
     pub(super) row_keys: Vec<String>,
-    /// Whether `row_keys` is non-decreasing. The builder writes sorted
-    /// segments; the flag is verified at decode so scans may binary-search,
-    /// with a linear fallback for segments that decode unsorted.
-    pub(super) sorted_by_row_key: bool,
 }
 
 impl DecodedSegmentRowSet {
-    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order.
-    /// A sorted row set narrows to the matching slice by binary search; an
-    /// unsorted one filters every row. Express a prefix scan as
-    /// `[prefix, string_prefix_upper_bound(prefix))`.
+    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order,
+    /// found by binary search over the decode-validated key order. Express a
+    /// prefix scan as `[prefix, string_prefix_upper_bound(prefix))`.
     pub(super) fn rows_in_key_range<'a>(
         &'a self,
         lower_bound: &'a str,
         upper_bound: Option<&'a str>,
     ) -> impl Iterator<Item = (&'a str, &'a MetadataRow)> + 'a {
-        let range = if self.sorted_by_row_key {
-            let start = self
-                .row_keys
-                .partition_point(|key| key.as_str() < lower_bound);
-            let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
-                self.row_keys
-                    .partition_point(|key| key.as_str() < upper_bound)
-            });
-            start..end.max(start)
-        } else {
-            0..self.row_keys.len()
-        };
+        let start = self
+            .row_keys
+            .partition_point(|key| key.as_str() < lower_bound);
+        let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
+            self.row_keys
+                .partition_point(|key| key.as_str() < upper_bound)
+        });
+        let range = start..end.max(start);
         self.row_keys[range.clone()]
             .iter()
             .zip(&self.rows[range])
-            .filter(move |(key, _)| {
-                key.as_str() >= lower_bound
-                    && upper_bound
-                        .map(|upper_bound| key.as_str() < upper_bound)
-                        .unwrap_or(true)
-            })
             .map(|(key, row)| (key.as_str(), row))
     }
 }
@@ -540,7 +526,6 @@ mod tests {
             row_set: Arc::new(DecodedSegmentRowSet {
                 rows: Vec::new(),
                 row_keys: Vec::new(),
-                sorted_by_row_key: true,
             }),
             segment_seq: ChangeSeq(1),
             family: MetadataTableFamily::Inodes,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2950,6 +2950,83 @@ async fn manifest_rejects_missing_revision_desc_index() {
 }
 
 #[tokio::test]
+async fn manifest_rejects_segment_rows_out_of_row_key_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/other.txt",
+        b"other\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write other");
+
+    let manifest = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    let materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+            .await
+            .expect("load manifest before corruption");
+    let mut manifest = materialized.manifest;
+    let manifest_id = manifest.payload.manifest_id;
+    let mut inode_rows =
+        manifest_rows_for_family(&materialized.metadata_state, ApiMetadataTableFamily::Inodes);
+    // Swap two middle rows: the segment's min/max keys stay truthful, so the
+    // only violation the rewritten segment carries is its row order.
+    assert!(inode_rows.len() >= 3, "need middle rows to disorder");
+    inode_rows.swap(1, 2);
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::Inodes
+        })
+        .expect("inodes metadata file");
+    rewrite_manifest_segment(
+        &store,
+        &namespace_id,
+        manifest.payload.head_seq,
+        ApiMetadataTableFamily::Inodes,
+        descriptor,
+        inode_rows,
+        &context.writer_version,
+    )
+    .await;
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id).await {
+        Err(ManifestLoadError::SegmentDescriptorMismatch { message, .. }) => {
+            assert!(
+                message.contains("row-key order"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected out-of-order segment rejection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn manifest_rejects_revision_desc_index_missing_row() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -256,14 +256,21 @@ pub(super) fn validate_manifest_segment(
         });
     }
 
-    // The builder writes segments in row-key order; verifying once here lets
-    // every scan binary-search this block instead of filtering all rows. An
-    // unsorted segment stays valid — scans fall back to a full filter.
-    let sorted_by_row_key = row_keys.windows(2).all(|pair| pair[0] <= pair[1]);
+    // The format requires segment rows in ascending row-key order (format
+    // spec, "Recovery view"): every scan binary-searches this block, so an
+    // out-of-order segment is malformed, not merely slow.
+    if let Some(pair) = row_keys.windows(2).find(|pair| pair[0] > pair[1]) {
+        return Err(ManifestLoadError::SegmentDescriptorMismatch {
+            object_key: descriptor.object_key.clone(),
+            message: format!(
+                "rows out of row-key order: `{}` follows `{}`",
+                pair[1], pair[0]
+            ),
+        });
+    }
     Ok(DecodedSegmentRowSet {
         rows: collected_rows,
         row_keys,
-        sorted_by_row_key,
     })
 }
 

--- a/crates/loonfs/src/commit_window.rs
+++ b/crates/loonfs/src/commit_window.rs
@@ -15,16 +15,31 @@
 //! Failure semantics follow the batch they join: if any member's content
 //! durability gate fails — including a submitter cancelled mid-window, which
 //! abandons its content write — the flush aborts before the head CAS and
-//! every member sees the rejection. An opener cancelled before flushing
-//! closes the window and fails the members that joined it.
+//! every member is rejected. Each member's error says what happened to it:
+//! the member whose own content write failed gets that write's error, and
+//! the members whose writes succeeded get a distinct error saying a write
+//! batched with theirs failed, nothing was committed, and a retry is safe.
+//! An opener cancelled before flushing closes the window and fails the
+//! members that joined it.
 
 use crate::publish::NamespaceMutationCandidate;
 use crate::{CommitResponse, CoreError, NamespaceId, Result, RuntimeError};
 use futures::channel::oneshot;
 use loonfs_core::publish::ContentDurabilityGate;
 use std::collections::HashMap;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::time::Duration;
+
+/// Error the combined gate hands the batch when any member's content write
+/// fails. Core stamps it on every aborted member; distribution rewrites it
+/// per member, so callers never see this text — each gets its own write's
+/// error or [`WINDOW_PEER_FAILURE_MESSAGE`].
+const WINDOW_GATE_FAILURE_MESSAGE: &str = "a content write in this commit window failed";
+
+/// Error a member receives when its own content write succeeded but the
+/// flush aborted because another member's failed.
+const WINDOW_PEER_FAILURE_MESSAGE: &str =
+    "a write batched with this one in its commit window failed; nothing was committed; retry";
 
 #[allow(clippy::disallowed_methods)]
 pub(crate) async fn commit_window_delay(window: Duration) {
@@ -132,20 +147,98 @@ impl Drop for OpenerGuard<'_> {
     }
 }
 
-/// Combines the entries' durability gates into the flush's single gate: the
-/// batch's head CAS waits until every member's concurrent content write has
-/// acked, and fails — aborting the whole batch — if any of them fail.
-pub(crate) fn combine_content_gates(
-    gates: Vec<ContentDurabilityGate>,
-) -> Option<ContentDurabilityGate> {
-    let mut gates = gates;
-    match gates.len() {
-        0 => None,
-        1 => gates.pop(),
-        _ => Some(Box::pin(async move {
-            futures::future::try_join_all(gates).await.map(|_| ())
-        })),
+/// Content-write failures the flush's combined gate observed, one slot per
+/// window member. Filled before the gate resolves, so the opener may read
+/// them once the publish returns.
+pub(crate) struct WindowGateFailures {
+    slots: Arc<Mutex<Vec<Option<CoreError>>>>,
+}
+
+impl WindowGateFailures {
+    pub(crate) fn take(&self) -> Vec<Option<CoreError>> {
+        // Poisoning is propagated as a panic, matching the window map: a
+        // half-updated failure record could misattribute members' errors.
+        std::mem::take(
+            &mut *self
+                .slots
+                .lock()
+                .expect("window gate failure slots lock poisoned"),
+        )
     }
+}
+
+/// Combines the members' durability gates into the flush's single gate: the
+/// batch's head CAS waits until every member's concurrent content write has
+/// acked, and fails — aborting the whole batch — if any of them fail. Each
+/// failure is recorded against its member (no fail-fast), so distribution
+/// can tell the failing member its own error and the rest that a batched
+/// peer failed. A solo member keeps its raw gate: its own error already
+/// reaches the right caller, and core traces keep the real failure.
+pub(crate) fn combine_member_content_gates(
+    member_gates: Vec<(usize, ContentDurabilityGate)>,
+    member_count: usize,
+) -> (Option<ContentDurabilityGate>, WindowGateFailures) {
+    let failures = WindowGateFailures {
+        slots: Arc::new(Mutex::new(vec![None; member_count])),
+    };
+    let mut member_gates = member_gates;
+    if member_gates.is_empty() || member_count == 1 {
+        return (member_gates.pop().map(|(_, gate)| gate), failures);
+    }
+    let slots = Arc::clone(&failures.slots);
+    let gate: ContentDurabilityGate = Box::pin(async move {
+        let results = futures::future::join_all(
+            member_gates
+                .into_iter()
+                .map(|(member_index, gate)| async move { (member_index, gate.await) }),
+        )
+        .await;
+        let mut any_failed = false;
+        {
+            let mut slots = slots
+                .lock()
+                .expect("window gate failure slots lock poisoned");
+            for (member_index, result) in results {
+                if let Err(error) = result {
+                    any_failed = true;
+                    if let Some(slot) = slots.get_mut(member_index) {
+                        *slot = Some(error);
+                    }
+                }
+            }
+        }
+        if any_failed {
+            Err(CoreError::Internal(WINDOW_GATE_FAILURE_MESSAGE.to_owned()))
+        } else {
+            Ok(())
+        }
+    });
+    (Some(gate), failures)
+}
+
+/// Rewrites one member's share of an aborted flush: results stamped with the
+/// combined gate's error become the member's own content-write error, or the
+/// batched-peer error when this member's write succeeded. Every other result
+/// — successes, and errors the member earned itself during validation — is
+/// left untouched.
+pub(crate) fn attribute_window_gate_failure(
+    results: WindowResults,
+    own_failure: Option<&CoreError>,
+) -> WindowResults {
+    results
+        .into_iter()
+        .map(|result| match result {
+            Err(RuntimeError::Core(CoreError::Internal(message)))
+                if message == WINDOW_GATE_FAILURE_MESSAGE =>
+            {
+                Err(RuntimeError::Core(match own_failure {
+                    Some(own_failure) => own_failure.clone(),
+                    None => CoreError::Internal(WINDOW_PEER_FAILURE_MESSAGE.to_owned()),
+                }))
+            }
+            other => other,
+        })
+        .collect()
 }
 
 /// Pads a distributed result slice when the publish returned fewer results

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -5,8 +5,8 @@
 use crate::background::BackgroundWork;
 use crate::cache::{CommitEngineCache, RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::commit_window::{
-    combine_content_gates, commit_window_delay, pad_missing_results, CommitWindows, WindowEntry,
-    WindowRole,
+    attribute_window_gate_failure, combine_member_content_gates, commit_window_delay,
+    pad_missing_results, CommitWindows, WindowEntry, WindowRole,
 };
 use crate::config::{validate_config, FsConfig};
 use crate::content_tokens::ContentAdmission;
@@ -1018,9 +1018,9 @@ impl FsCore {
                 commit_window_delay(std::time::Duration::from_millis(window_ms)).await;
                 let entries = guard.take_entries();
                 let mut combined = Vec::new();
-                let mut gates = Vec::new();
+                let mut member_gates = Vec::new();
                 let mut routes = Vec::new();
-                for entry in entries {
+                for (member_index, entry) in entries.into_iter().enumerate() {
                     let WindowEntry {
                         candidates,
                         content_gate,
@@ -1029,19 +1029,22 @@ impl FsCore {
                     routes.push((candidates.len(), result_sender));
                     combined.extend(candidates);
                     if let Some(gate) = content_gate {
-                        gates.push(gate);
+                        member_gates.push((member_index, gate));
                     }
                 }
+                let (combined_gate, gate_failures) =
+                    combine_member_content_gates(member_gates, routes.len());
                 let mut results = self
-                    .publish_namespace_mutations_batch_gated(
-                        namespace_id,
-                        combined,
-                        combine_content_gates(gates),
-                    )
+                    .publish_namespace_mutations_batch_gated(namespace_id, combined, combined_gate)
                     .await
                     .into_iter();
-                for (expected, sender) in routes {
+                let failures = gate_failures.take();
+                for (member_index, (expected, sender)) in routes.into_iter().enumerate() {
                     let slice: Vec<_> = results.by_ref().take(expected).collect();
+                    let slice = attribute_window_gate_failure(
+                        slice,
+                        failures.get(member_index).and_then(Option::as_ref),
+                    );
                     let _ = sender.send(pad_missing_results(slice, expected));
                 }
                 result_receiver

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1697,16 +1697,22 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
 
     let commit_id = CommitId::parse("overlap-put-retry").expect("valid commit id");
     raw_store.fail_next_content_blob_puts(1);
-    fs.put_file_bytes_blocking(
-        &namespace_id,
-        "/docs/report.txt",
-        b"overlap survives",
-        PutFileOptions {
-            behavior: PutBehavior::NoReplace,
-            commit_id: Some(commit_id.clone()),
-        },
-    )
-    .expect_err("put should surface the failed content write");
+    let error = fs
+        .put_file_bytes_blocking(
+            &namespace_id,
+            "/docs/report.txt",
+            b"overlap survives",
+            PutFileOptions {
+                behavior: PutBehavior::NoReplace,
+                commit_id: Some(commit_id.clone()),
+            },
+        )
+        .expect_err("put should surface the failed content write");
+    // A solo put reports its own write's error, not window plumbing.
+    assert!(
+        error.to_string().contains("injected content write failure"),
+        "unexpected error: {error}"
+    );
 
     // The content result gates the head CAS, so the failed write aborted the
     // publish with the head unmoved and nothing visible.
@@ -1876,8 +1882,25 @@ fn commit_window_flush_aborts_every_member_when_one_content_write_fails() {
                 PutFileOptions::default()
             ),
         );
-        a.expect_err("window abort should fail the first member");
-        b.expect_err("window abort should fail the second member");
+        let first = a.expect_err("window abort should fail the first member");
+        let second = b.expect_err("window abort should fail the second member");
+        // Each member's error says what happened to it: whichever upload the
+        // store failed reports the injected write error, and the member whose
+        // upload succeeded is told a batched peer failed and a retry is safe.
+        let messages = [first.to_string(), second.to_string()];
+        let own_failures = messages
+            .iter()
+            .filter(|message| message.contains("injected content write failure"))
+            .count();
+        let peer_failures = messages
+            .iter()
+            .filter(|message| message.contains("batched with this one"))
+            .count();
+        assert_eq!(
+            (own_failures, peer_failures),
+            (1, 1),
+            "unexpected member errors: {messages:?}"
+        );
         for path in ["/docs/a.txt", "/docs/b.txt"] {
             let error = fs
                 .reader

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -618,8 +618,10 @@ It may reference one or more immutable metadata runs and may include
 standalone checkpoint records under `checkpoints/` pin manifest versions for
 retention, fork, or stable read workflows. Each run is internally segmented without overlapping segment
 key ranges; different runs may overlap and readers apply the normal metadata
-visibility rules across all referenced runs. Readers load the referenced runs,
-then replay only the visible WAL chain after the manifest's `head_seq`.
+visibility rules across all referenced runs. Within a segment, rows are stored
+in ascending row-key order (adjacent equal keys permitted); readers reject a
+segment whose rows are out of order as malformed. Readers load the referenced
+runs, then replay only the visible WAL chain after the manifest's `head_seq`.
 
 The WAL preserves ordered history even when multiple logical commits are
 stored in one segment. Each logical commit records the commit identity, optional


### PR DESCRIPTION
Fixes wrong error messages in the commit window (#215).

When concurrent writes share a window and one member's content upload fails, the whole flush aborts before the head moves — that part is intended and unchanged. The bug was in what each caller was told: the abort took the *first* failure it saw and stamped that same error on every member. So if your upload succeeded but your neighbor's didn't, you got an error about someone else's blob, with no hint that your own retry would just work.

Now the flush waits for every member's upload result instead of stopping at the first failure, and remembers which member each failure belongs to. When it hands results back:

- the member whose upload failed gets that upload's actual error;
- members whose uploads succeeded get a distinct error saying a write batched with theirs failed, nothing was committed, and a retry is safe;
- everything else is untouched — successes stay successes (for example a duplicate commit id resolved against an earlier commit), and errors a member earned itself during validation keep their own message.

A solo write skips all of this and reports its own error directly, exactly as before.

Tests: in a two-put window with one injected upload failure, exactly one caller sees the injected error and the other sees the batched-peer error, nothing is visible, and both retries land; a solo put's failure still reports the injected error with no window wording.
