### PR TITLE
perf(core): skip segments whose bloom filter rules a lookup out

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,6 +1,6 @@
 use crate::metadata::MetadataState;
 use loonfs_api::wire::manifest::MetadataRow;
-use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentIndexEntry};
+use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -39,12 +39,20 @@ pub struct MetadataTableCacheStats {
     pub misses: usize,
     pub inserts: usize,
     pub evictions: usize,
+    /// Segments a scan skipped because their bloom filter ruled the lookup
+    /// key out before any index or data fetch.
+    pub filter_skips: usize,
+    /// Segments whose filter admitted a lookup that then matched no rows.
+    /// Approximate: a lookup narrower than the filter key (an exact unbind,
+    /// a single revision) can count a true admission here.
+    pub filter_false_positives: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) enum MetadataTableBlockKind {
-    SegmentIndex,
-    SegmentData,
+    Index,
+    Filter,
+    Data,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -100,6 +108,10 @@ pub(super) enum DecodedMetadataTableBlock {
         entries: Arc<Vec<SegmentIndexEntry>>,
         decoded_byte_len: usize,
     },
+    Filter {
+        filter: Arc<SegmentFilter>,
+        decoded_byte_len: usize,
+    },
     Data {
         block: Arc<DecodedDataBlock>,
         decoded_byte_len: usize,
@@ -110,6 +122,9 @@ impl DecodedMetadataTableBlock {
     pub(super) fn decoded_byte_len(&self) -> usize {
         match self {
             Self::Index {
+                decoded_byte_len, ..
+            }
+            | Self::Filter {
                 decoded_byte_len, ..
             }
             | Self::Data {
@@ -142,6 +157,8 @@ struct MetadataTableCacheStatsInner {
     misses: AtomicUsize,
     inserts: AtomicUsize,
     evictions: AtomicUsize,
+    filter_skips: AtomicUsize,
+    filter_false_positives: AtomicUsize,
 }
 
 impl MetadataTableCache {
@@ -216,7 +233,19 @@ impl MetadataTableCache {
             misses: self.stats.misses.load(Ordering::SeqCst),
             inserts: self.stats.inserts.load(Ordering::SeqCst),
             evictions: self.stats.evictions.load(Ordering::SeqCst),
+            filter_skips: self.stats.filter_skips.load(Ordering::SeqCst),
+            filter_false_positives: self.stats.filter_false_positives.load(Ordering::SeqCst),
         }
+    }
+
+    pub(super) fn record_filter_skip(&self) {
+        self.stats.filter_skips.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn record_filter_false_positive(&self) {
+        self.stats
+            .filter_false_positives
+            .fetch_add(1, Ordering::SeqCst);
     }
 
     /// Whether inserts are bounded by a decoded-byte budget. A byte-budgeted
@@ -549,7 +578,7 @@ mod tests {
     fn key(digest: &str) -> MetadataTableCacheKey {
         MetadataTableCacheKey {
             table_digest: digest.to_owned(),
-            block_kind: MetadataTableBlockKind::SegmentData,
+            block_kind: MetadataTableBlockKind::Data,
             block_offset: 0,
         }
     }
@@ -606,7 +635,7 @@ mod tests {
         let inserted = block(64);
         let rows = match &inserted {
             DecodedMetadataTableBlock::Data { block: rows, .. } => Arc::clone(rows),
-            DecodedMetadataTableBlock::Index { .. } => {
+            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
                 unreachable!("fixture builds a data block")
             }
         };
@@ -616,7 +645,9 @@ mod tests {
             DecodedMetadataTableBlock::Data {
                 block: hit_rows, ..
             } => Arc::ptr_eq(hit_rows, &rows),
-            DecodedMetadataTableBlock::Index { .. } => false,
+            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
+                false
+            }
         };
         assert!(
             shares_allocation,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -40,8 +40,8 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope,
 };
 use loonfs_api::wire::sst_blocks::{
-    decode_data_block, decode_index_block, index_blocks_for_key_range, DecodedDataBlock,
-    SegmentIndexEntry,
+    decode_data_block, decode_filter_block, decode_index_block, index_blocks_for_key_range,
+    DecodedDataBlock, SegmentFilter, SegmentIndexEntry,
 };
 #[cfg(test)]
 use loonfs_api::ManifestId;
@@ -689,11 +689,8 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
     let handle = descriptor.index_block;
-    let cache_key = segment_block_cache_key(
-        descriptor,
-        MetadataTableBlockKind::SegmentIndex,
-        handle.offset,
-    );
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Index, handle.offset);
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -724,10 +721,59 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     };
     match block {
         DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
-        DecodedMetadataTableBlock::Data { .. } => Err(segment_codec_error(
+        DecodedMetadataTableBlock::Filter { .. } | DecodedMetadataTableBlock::Data { .. } => {
+            Err(segment_codec_error(
+                &descriptor.object_key,
+                "cache returned a non-index block for an index key",
+            ))
+        }
+    }
+}
+
+/// Loads a segment's bloom filter block through the cache: the cheap
+/// pre-index check a lookup consults to skip the segment entirely.
+pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    descriptor: &MetadataFileRef,
+    cache_mode: MetadataTableCacheMode,
+) -> Result<Arc<SegmentFilter>, ManifestLoadError> {
+    let handle = descriptor.filter_block;
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Filter, handle.offset);
+    let fetch = || async {
+        let bytes = fetch_section_bytes(
+            store,
             &descriptor.object_key,
-            "cache returned a data block for an index key",
-        )),
+            handle.offset,
+            handle.stored_len as u64,
+        )
+        .await?;
+        let filter = decode_filter_block(&bytes, &handle)
+            .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
+        Ok(DecodedMetadataTableBlock::Filter {
+            decoded_byte_len: handle.decoded_len as usize,
+            filter: Arc::new(filter),
+        })
+    };
+    let block = match table_cache {
+        Some(cache) => {
+            cache
+                .get_or_fetch(
+                    &cache_key,
+                    cache_mode != MetadataTableCacheMode::Bypass,
+                    cache_mode == MetadataTableCacheMode::Populate,
+                    fetch,
+                )
+                .await?
+        }
+        None => fetch().await?,
+    };
+    match block {
+        DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
+        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Data { .. } => Err(
+            segment_codec_error(&descriptor.object_key, "cache returned a non-filter block"),
+        ),
     }
 }
 
@@ -740,11 +786,8 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<DecodedDataBlock>, ManifestLoadError> {
     let handle = entry.block;
-    let cache_key = segment_block_cache_key(
-        descriptor,
-        MetadataTableBlockKind::SegmentData,
-        handle.offset,
-    );
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -774,10 +817,12 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     };
     match block {
         DecodedMetadataTableBlock::Data { block, .. } => Ok(block),
-        DecodedMetadataTableBlock::Index { .. } => Err(segment_codec_error(
-            &descriptor.object_key,
-            "cache returned an index block for a data key",
-        )),
+        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
+            Err(segment_codec_error(
+                &descriptor.object_key,
+                "cache returned a non-data block for a data key",
+            ))
+        }
     }
 }
 
@@ -811,7 +856,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         for (position, entry) in entries.iter().enumerate() {
             let cache_key = segment_block_cache_key(
                 descriptor,
-                MetadataTableBlockKind::SegmentData,
+                MetadataTableBlockKind::Data,
                 entry.block.offset,
             );
             if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&cache_key) {
@@ -865,7 +910,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
             if let (Some(cache), true) = (table_cache, populate) {
                 let cache_key = segment_block_cache_key(
                     descriptor,
-                    MetadataTableBlockKind::SegmentData,
+                    MetadataTableBlockKind::Data,
                     handle.offset,
                 );
                 cache.insert(

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -4,8 +4,9 @@
 use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
-    load_manifest_segment_rows_in_key_range_with_cache, metadata_file_object_key,
-    MetadataSstSeqExpectation, MetadataTableCacheMode, MetadataTableLoadContext,
+    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
+    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableCacheMode,
+    MetadataTableLoadContext,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -47,13 +48,19 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         &self.manifest
     }
 
-    pub(crate) async fn get(
+    pub(crate) async fn get_for_lookup(
         &self,
         family: MetadataTableFamily,
         key: &str,
+        filter_probe: &str,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
-            .scan_prefix_with_cache_mode(family, key, MetadataTableCacheMode::Populate)
+            .scan_prefix_with_cache_mode(
+                family,
+                key,
+                MetadataTableCacheMode::Populate,
+                Some(filter_probe),
+            )
             .await?
             .into_iter()
             .find(|row| row.row_key_for_family(family) == key))
@@ -66,7 +73,24 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let matching_segment_count = self.matching_segment_count(family, prefix)?;
         let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode)
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, None)
+            .await
+    }
+
+    /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
+    /// family's exact filter key for the value being looked up, so each
+    /// candidate segment's bloom filter is consulted before its index or
+    /// data — a negative skips the segment without fetching either. Scans
+    /// coarser than the filter key must use [`Self::scan_prefix`] instead.
+    pub(crate) async fn scan_prefix_for_lookup(
+        &self,
+        family: MetadataTableFamily,
+        prefix: &str,
+        filter_probe: &str,
+    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        let matching_segment_count = self.matching_segment_count(family, prefix)?;
+        let cache_mode = self.scan_cache_mode(matching_segment_count);
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, Some(filter_probe))
             .await
     }
 
@@ -96,7 +120,24 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        self.scan_range_page_rows(family, lower_bound, upper_bound, limit)
+        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, None)
+            .await
+    }
+
+    /// [`Self::scan_range_page`] for a point lookup within one filter key's
+    /// range; see [`Self::scan_prefix_for_lookup`] for the probe contract.
+    pub(crate) async fn scan_range_page_for_lookup(
+        &self,
+        family: MetadataTableFamily,
+        lower_bound: &str,
+        upper_bound: Option<&str>,
+        limit: usize,
+        filter_probe: &str,
+    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, Some(filter_probe))
             .await
     }
 
@@ -105,6 +146,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         prefix: &str,
         cache_mode: MetadataTableCacheMode,
+        filter_probe: Option<&str>,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut rows = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -122,10 +164,42 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                     rows: &mut rows,
                     cache_mode,
                 },
+                filter_probe,
             )
             .await?;
         }
         Ok(rows)
+    }
+
+    /// Whether a lookup should touch this segment at all: false only when
+    /// the segment's bloom filter proves the probe key absent. A skipped
+    /// segment costs one tiny cached filter read instead of index and data
+    /// fetches.
+    async fn segment_filter_admits(
+        &self,
+        descriptor: &MetadataFileRef,
+        cache_mode: MetadataTableCacheMode,
+        filter_probe: &str,
+    ) -> Result<bool, ManifestLoadError> {
+        let filter =
+            load_segment_filter(self.store, self.table_cache, descriptor, cache_mode).await?;
+        if filter.may_contain(filter_probe) {
+            return Ok(true);
+        }
+        if let Some(cache) = self.table_cache {
+            cache.record_filter_skip();
+        }
+        Ok(false)
+    }
+
+    /// Counts a segment whose filter admitted the probe but whose rows had
+    /// no match — the filter's false-positive rate as observed by lookups.
+    fn record_filter_false_positive_if_empty(&self, matched_rows: usize) {
+        if matched_rows == 0 {
+            if let Some(cache) = self.table_cache {
+                cache.record_filter_false_positive();
+            }
+        }
     }
 
     fn matching_segment_count(
@@ -147,6 +221,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         lower_bound: &str,
         upper_bound: Option<&str>,
         limit: usize,
+        filter_probe: Option<&str>,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut matching_descriptors = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -167,9 +242,22 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                         expected: expected_key,
                     });
                 }
-                if descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
-                    matching_descriptors.push((context, descriptor.clone()));
+                if !descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
+                    continue;
                 }
+                if let Some(filter_probe) = filter_probe {
+                    if !self
+                        .segment_filter_admits(
+                            descriptor,
+                            MetadataTableCacheMode::Populate,
+                            filter_probe,
+                        )
+                        .await?
+                    {
+                        continue;
+                    }
+                }
+                matching_descriptors.push((context, descriptor.clone()));
             }
         }
         matching_descriptors.sort_by(|(_, left), (_, right)| {
@@ -231,6 +319,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         context: MetadataTableLoadContext<'_>,
         tables: &[MetadataTableManifest],
         output: MetadataTableScanOutput<'_>,
+        filter_probe: Option<&str>,
     ) -> Result<(), ManifestLoadError> {
         let table = manifest_table_for_family(context.manifest_object_key, tables, family)?;
         let mut matching_descriptors = Vec::new();
@@ -248,6 +337,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             }
             matching_descriptors.push(descriptor);
         }
+        let matching_descriptors = self
+            .filter_admitted_descriptors(matching_descriptors, output.cache_mode, filter_probe)
+            .await?;
 
         let prefix_upper_bound = string_prefix_upper_bound(prefix);
         let mut loaded_segments = Vec::new();
@@ -268,13 +360,45 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
 
         for segment_rows in loaded_segments {
+            let matched = output.rows.len();
             output.rows.extend(
                 segment_rows
                     .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
                     .map(|(_, row)| row.clone()),
             );
+            if filter_probe.is_some() {
+                self.record_filter_false_positive_if_empty(output.rows.len() - matched);
+            }
         }
         Ok(())
+    }
+
+    /// Drops the descriptors whose bloom filter rules the probe out; with no
+    /// probe every descriptor is admitted untouched.
+    async fn filter_admitted_descriptors<'d>(
+        &self,
+        descriptors: Vec<&'d MetadataFileRef>,
+        cache_mode: MetadataTableCacheMode,
+        filter_probe: Option<&str>,
+    ) -> Result<Vec<&'d MetadataFileRef>, ManifestLoadError> {
+        let Some(filter_probe) = filter_probe else {
+            return Ok(descriptors);
+        };
+        let mut admitted = Vec::with_capacity(descriptors.len());
+        for chunk in descriptors.chunks(MAX_MATERIALIZED_TABLE_FETCHES) {
+            let checks = try_join_all(chunk.iter().map(|descriptor| {
+                self.segment_filter_admits(descriptor, cache_mode, filter_probe)
+            }))
+            .await?;
+            admitted.extend(
+                chunk
+                    .iter()
+                    .zip(checks)
+                    .filter(|(_, admits)| *admits)
+                    .map(|(descriptor, _)| *descriptor),
+            );
+        }
+        Ok(admitted)
     }
 
     async fn segment_rows(

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2472,6 +2472,104 @@ async fn maintenance_materialization_does_not_populate_metadata_table_cache() {
 }
 
 #[tokio::test]
+async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // "beta" lands in the base run; a second checkpoint puts "alpha" and
+    // "gamma" in an L0 run. The L0 bind segment's key range then straddles
+    // "beta", so min/max pruning cannot exclude it — only its bloom filter
+    // can prove the name absent.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/beta.txt",
+        b"beta\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write beta");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("first checkpoint");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write alpha");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/gamma.txt",
+        b"gamma\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write gamma");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("second checkpoint");
+
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load tables");
+
+    // Resolve /docs, then look up beta's bind under it through the filtered
+    // scan the visibility adapter uses.
+    let docs_binds = tables
+        .scan_prefix(
+            ApiMetadataTableFamily::DirentryBinds,
+            "direntry-00000000000000000001-",
+        )
+        .await
+        .expect("scan root binds");
+    let docs_inode = docs_binds
+        .iter()
+        .find_map(|row| match row {
+            MetadataRow::DirentryBind { child_inode_id, .. } => Some(*child_inode_id),
+            _ => None,
+        })
+        .expect("docs directory bind");
+    let encoded_name = loonfs_api::wire::manifest::hex_encode_row_key_component("beta.txt");
+    let filter_probe = format!("direntry-{:020}-{encoded_name}", docs_inode.0);
+    let prefix = format!("{filter_probe}-");
+    let rows = tables
+        .scan_prefix_for_lookup(
+            ApiMetadataTableFamily::DirentryBinds,
+            &prefix,
+            &filter_probe,
+        )
+        .await
+        .expect("filtered lookup");
+
+    assert_eq!(rows.len(), 1, "beta's bind should still be found");
+    let stats = cache.stats();
+    assert!(
+        stats.filter_skips >= 1,
+        "the L0 bind segment should be skipped by its filter, stats: {stats:?}"
+    );
+}
+
+#[tokio::test]
 async fn metadata_cache_budget_counts_decoded_blocks() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -2510,7 +2608,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
 
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get(ApiMetadataTableFamily::Inodes, key)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("get inode")
         .is_some());

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -24,7 +24,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 ) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
-        .get(MetadataTableFamily::Inodes, &key)
+        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
         .and_then(inode_from_manifest_row))
@@ -87,9 +87,10 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     name_key: &str,
 ) -> Result<Vec<DirentryBindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(name_key);
-    let prefix = format!("direntry-{:020}-{encoded_name_key}-", parent_inode_id.0);
+    let filter_probe = format!("direntry-{:020}-{encoded_name_key}", parent_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::DirentryBinds, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -101,9 +102,14 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     child_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = format!("direntry-child-{:020}-", child_inode_id.0);
+    let filter_probe = format!("direntry-child-{:020}", child_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryChildBinds, &prefix)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::DirentryChildBinds,
+            &prefix,
+            &filter_probe,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -116,15 +122,16 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     direntry: &DirentryBindRecord,
 ) -> Result<Vec<DirentryUnbindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(&direntry.name_key);
+    let filter_probe = format!(
+        "direntry-unbind-{:020}-{encoded_name_key}",
+        direntry.parent_inode_id.0
+    );
     let prefix = format!(
-        "direntry-unbind-{:020}-{}-{:020}-{:010}-",
-        direntry.parent_inode_id.0,
-        encoded_name_key,
-        direntry.bind_seq.0,
-        direntry.bind_delta_index
+        "{filter_probe}-{:020}-{:010}-",
+        direntry.bind_seq.0, direntry.bind_delta_index
     );
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryUnbinds, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::DirentryUnbinds, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -218,12 +225,14 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
     revision_no: RevisionNo,
 ) -> Result<Option<RevisionRecord>> {
     let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
+    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
     Ok(tables
-        .scan_range_page(
+        .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &exact_prefix,
             string_prefix_upper_bound(&exact_prefix).as_deref(),
             1,
+            &filter_probe,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -242,15 +251,17 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
         return Ok(Vec::new());
     }
     let inode_prefix = revision_by_inode_desc_inode_prefix(inode_id);
+    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
     let lower_bound = start_after
         .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
         .unwrap_or_else(|| inode_prefix.clone());
     Ok(tables
-        .scan_range_page(
+        .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &lower_bound,
             string_prefix_upper_bound(&inode_prefix).as_deref(),
             limit,
+            &filter_probe,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -263,9 +274,10 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     root_inode_id: InodeId,
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
-    let prefix = format!("tombstone-{:020}-", root_inode_id.0);
+    let filter_probe = format!("tombstone-{:020}", root_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::Tombstones, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::Tombstones, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -278,9 +290,10 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     commit_id: &CommitId,
 ) -> Result<Option<CommitReceiptRecord>> {
     let encoded_commit_id = hex_encode_row_key_component(commit_id.as_str());
-    let prefix = format!("commit-receipt-{encoded_commit_id}-");
+    let filter_probe = format!("commit-receipt-{encoded_commit_id}");
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::CommitReceipts, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::CommitReceipts, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -305,6 +318,12 @@ fn resume_after_row_key(row_key: &str) -> String {
 
 fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
     format!("revision-by-inode-desc-{:020}-", inode_id.0)
+}
+
+/// The filter key for revision-by-inode lookups; must match
+/// `MetadataRow::filter_key_for_family` for the family byte-for-byte.
+fn revision_by_inode_desc_filter_probe(inode_id: InodeId) -> String {
+    format!("revision-by-inode-desc-{:020}", inode_id.0)
 }
 
 fn revision_by_inode_desc_exact_revision_prefix(

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -139,6 +139,10 @@ pub struct RuntimeCacheStats {
     pub metadata_table_cache_inserts: usize,
     /// Blocks evicted from the decoded metadata-table cache.
     pub metadata_table_cache_evictions: usize,
+    /// Segments skipped by their bloom filter before any index or data read.
+    pub metadata_table_cache_filter_skips: usize,
+    /// Segments whose filter admitted a lookup that matched no rows.
+    pub metadata_table_cache_filter_false_positives: usize,
 }
 
 #[derive(Debug, Default)]
@@ -173,6 +177,9 @@ impl RuntimeCacheStatsInner {
             metadata_table_cache_misses: metadata_table_cache.misses,
             metadata_table_cache_inserts: metadata_table_cache.inserts,
             metadata_table_cache_evictions: metadata_table_cache.evictions,
+            metadata_table_cache_filter_skips: metadata_table_cache.filter_skips,
+            metadata_table_cache_filter_false_positives: metadata_table_cache
+                .filter_false_positives,
         }
     }
 


### PR DESCRIPTION
Third implementation PR of the Tier 2 plan (#218), stacked on the block cutover (#220). The bloom filters have been written into every segment since #220; this PR makes lookups actually consult them.

The rule a lookup follows per candidate segment is now: descriptor key-range check (free, unchanged) → **bloom filter check** (one tiny cached read) → index → data blocks. A negative filter answer proves the key absent, so the segment is skipped without fetching its index or any data — that's the whole win. The filter check matters most for L0 delta runs: their segments hold one checkpoint's writes for a whole family, so their key ranges routinely straddle a name they don't contain, and range pruning alone can't exclude them.

Filters only answer exact-key questions, so only lookups at exactly the filter key's granularity use them: a name under a directory, an inode, a child's parent bindings, a commit receipt, a tombstone root, an inode's revisions. Seven lookup paths in the visibility adapter now pass their probe key alongside the scan prefix (the probe must match the filter key byte-for-byte, so each call site builds both strings from the same parts). Coarser scans — a whole directory, a page, a wave of names — don't consult filters and are unchanged.

Two new counters ride on the existing metadata-cache stats and flow through `runtime_cache_stats` for benchmarking: `filter_skips` (segments a filter excluded) and `filter_false_positives` (a filter said maybe, the rows said no — approximate for lookups narrower than the filter key, and expected to sit near the design's ~1% rate).

Test: a base run holding "beta" plus an L0 run holding "alpha" and "gamma" — the L0 segment's key range straddles "beta" so range pruning cannot exclude it, and the test asserts the lookup still finds beta's bind while the skip counter shows the L0 segment was excluded by its filter. The full workspace suite runs with filters active on every lookup path.
