### PR TITLE
feat(core): split checkpoints from compaction via bounded reorganization

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,6 +1,6 @@
 use crate::metadata::MetadataState;
 use loonfs_api::wire::manifest::MetadataRow;
-use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentIndexEntry};
+use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -39,12 +39,20 @@ pub struct MetadataTableCacheStats {
     pub misses: usize,
     pub inserts: usize,
     pub evictions: usize,
+    /// Segments a scan skipped because their bloom filter ruled the lookup
+    /// key out before any index or data fetch.
+    pub filter_skips: usize,
+    /// Segments whose filter admitted a lookup that then matched no rows.
+    /// Approximate: a lookup narrower than the filter key (an exact unbind,
+    /// a single revision) can count a true admission here.
+    pub filter_false_positives: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) enum MetadataTableBlockKind {
-    SegmentIndex,
-    SegmentData,
+    Index,
+    Filter,
+    Data,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -100,6 +108,10 @@ pub(super) enum DecodedMetadataTableBlock {
         entries: Arc<Vec<SegmentIndexEntry>>,
         decoded_byte_len: usize,
     },
+    Filter {
+        filter: Arc<SegmentFilter>,
+        decoded_byte_len: usize,
+    },
     Data {
         block: Arc<DecodedDataBlock>,
         decoded_byte_len: usize,
@@ -110,6 +122,9 @@ impl DecodedMetadataTableBlock {
     pub(super) fn decoded_byte_len(&self) -> usize {
         match self {
             Self::Index {
+                decoded_byte_len, ..
+            }
+            | Self::Filter {
                 decoded_byte_len, ..
             }
             | Self::Data {
@@ -142,6 +157,8 @@ struct MetadataTableCacheStatsInner {
     misses: AtomicUsize,
     inserts: AtomicUsize,
     evictions: AtomicUsize,
+    filter_skips: AtomicUsize,
+    filter_false_positives: AtomicUsize,
 }
 
 impl MetadataTableCache {
@@ -216,7 +233,19 @@ impl MetadataTableCache {
             misses: self.stats.misses.load(Ordering::SeqCst),
             inserts: self.stats.inserts.load(Ordering::SeqCst),
             evictions: self.stats.evictions.load(Ordering::SeqCst),
+            filter_skips: self.stats.filter_skips.load(Ordering::SeqCst),
+            filter_false_positives: self.stats.filter_false_positives.load(Ordering::SeqCst),
         }
+    }
+
+    pub(super) fn record_filter_skip(&self) {
+        self.stats.filter_skips.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(super) fn record_filter_false_positive(&self) {
+        self.stats
+            .filter_false_positives
+            .fetch_add(1, Ordering::SeqCst);
     }
 
     /// Whether inserts are bounded by a decoded-byte budget. A byte-budgeted
@@ -549,7 +578,7 @@ mod tests {
     fn key(digest: &str) -> MetadataTableCacheKey {
         MetadataTableCacheKey {
             table_digest: digest.to_owned(),
-            block_kind: MetadataTableBlockKind::SegmentData,
+            block_kind: MetadataTableBlockKind::Data,
             block_offset: 0,
         }
     }
@@ -606,7 +635,7 @@ mod tests {
         let inserted = block(64);
         let rows = match &inserted {
             DecodedMetadataTableBlock::Data { block: rows, .. } => Arc::clone(rows),
-            DecodedMetadataTableBlock::Index { .. } => {
+            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
                 unreachable!("fixture builds a data block")
             }
         };
@@ -616,7 +645,9 @@ mod tests {
             DecodedMetadataTableBlock::Data {
                 block: hit_rows, ..
             } => Arc::ptr_eq(hit_rows, &rows),
-            DecodedMetadataTableBlock::Index { .. } => false,
+            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
+                false
+            }
         };
         assert!(
             shares_allocation,

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -2,25 +2,24 @@
 //! tail, write its tables, and publish it under one checkpoint record.
 
 use super::build::{
-    build_manifest_l0_run_tables, build_manifest_tables, build_manifest_tables_from_rows,
-    debug_assert_manifest_table_segments_do_not_overlap, MetadataTableSegmentation,
+    build_manifest_l0_run_tables, build_manifest_tables,
+    debug_assert_manifest_table_segments_do_not_overlap,
 };
 use super::error::ManifestLoadError;
 use super::load::{
     head_from_manifest, load_namespace_manifest_envelope_if_present,
-    load_verified_manifest_tables_with_cache, validate_direntry_child_bind_index,
-    validate_revision_by_inode_desc_index,
+    load_verified_manifest_tables_with_cache,
 };
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::record::{
     deterministic_checkpoint_id, set_checkpoint_record_state, verify_checkpoint_basis,
     write_checkpoint_record, CheckpointRecordWrite,
 };
+#[cfg(test)]
 use super::row::manifest_rows_for_family;
-use super::runs::{
-    flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL,
-    CHECKPOINT_TABLE_FAMILIES,
-};
+use super::runs::{flatten_manifest_tables, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL};
+#[cfg(test)]
+use super::runs::{l0_run_count, CHECKPOINT_TABLE_FAMILIES};
 use super::scan::VerifiedMetadataTables;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
@@ -65,7 +64,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<CreateCheckpointResponse> {
-    create_checkpoint_with_policy(store, namespace_id, context, MetadataLsmPolicy::default()).await
+    create_checkpoint_with_owner(store, namespace_id, context, None).await
 }
 
 pub(crate) const CHECKPOINT_VERIFY_BUDGET_MS: u64 = 60_000;
@@ -77,20 +76,10 @@ struct CheckpointBasis {
     manifest_payload_checksum: String,
 }
 
-pub(crate) async fn create_checkpoint_with_policy<S: ObjectStore + ?Sized>(
+pub(crate) async fn create_checkpoint_with_owner<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
-    policy: MetadataLsmPolicy,
-) -> Result<CreateCheckpointResponse> {
-    create_checkpoint_with_policy_and_owner(store, namespace_id, context, policy, None).await
-}
-
-pub(crate) async fn create_checkpoint_with_policy_and_owner<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    context: &MutationContext,
-    policy: MetadataLsmPolicy,
     owner: Option<CheckpointOwner>,
 ) -> Result<CreateCheckpointResponse> {
     // Checkpoint creation pins a manifest version as a first-class record
@@ -147,7 +136,6 @@ pub(crate) async fn create_checkpoint_with_policy_and_owner<S: ObjectStore + ?Si
                             namespace_id,
                             &projection,
                             &context.writer_version,
-                            policy,
                             manifest_id,
                             manifest_object_id,
                         )
@@ -485,51 +473,31 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
     namespace_id: &NamespaceId,
     projection: &CheckpointProjection<'_, S>,
     writer_version: &str,
-    policy: MetadataLsmPolicy,
     manifest_id: ManifestId,
     manifest_object_id: ManifestObjectId,
 ) -> Result<NamespaceManifestEnvelope> {
     let head_seq = projection.head.seq;
     let previous_manifest = projection.manifest_tables.manifest();
 
-    let (base_seq, metadata_files) = if is_bootstrap_seed_manifest(&previous_manifest.payload) {
-        let run_tables = build_base_manifest_tables_from_projection(
-            store,
-            namespace_id,
-            head_seq,
-            projection,
-            policy.max_rows_per_segment,
-        )
-        .await?;
-        debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
-        (head_seq, flatten_manifest_tables(run_tables))
-    } else if l0_run_count(&previous_manifest.payload) < policy.max_l0_runs {
-        let mut metadata_files = previous_manifest.payload.metadata_files.clone();
-        if previous_manifest.payload.head_seq < head_seq {
-            metadata_files.extend(flatten_manifest_tables(
-                build_manifest_l0_run_tables(
-                    store,
-                    namespace_id,
-                    head_seq,
-                    previous_manifest.payload.head_seq,
-                    &projection.tail_state,
-                )
-                .await?,
-            ));
-        }
-        (previous_manifest.payload.base_seq, metadata_files)
-    } else {
-        let run_tables = build_base_manifest_tables_from_projection(
-            store,
-            namespace_id,
-            head_seq,
-            projection,
-            policy.max_rows_per_segment,
-        )
-        .await?;
-        debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
-        (head_seq, flatten_manifest_tables(run_tables))
-    };
+    // Checkpoint publication is manifest-only: every prior run is
+    // referenced unchanged and the WAL delta lands as one new L0 run, so
+    // the cost follows the delta, never the namespace. Folding L0 runs
+    // back into the base is reorganization's job (`reorganize.rs`), off
+    // this path.
+    let base_seq = previous_manifest.payload.base_seq;
+    let mut metadata_files = previous_manifest.payload.metadata_files.clone();
+    if previous_manifest.payload.head_seq < head_seq {
+        metadata_files.extend(flatten_manifest_tables(
+            build_manifest_l0_run_tables(
+                store,
+                namespace_id,
+                head_seq,
+                previous_manifest.payload.head_seq,
+                &projection.tail_state,
+            )
+            .await?,
+        ));
+    }
 
     NamespaceManifestEnvelope::from_payload(
         writer_version,
@@ -741,94 +709,19 @@ pub(super) fn drop_rows_below_retention_floor(
             _ => true,
         });
     }
-    Ok(())
-}
 
-async fn build_base_manifest_tables_from_projection<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    run_seq: ChangeSeq,
-    projection: &CheckpointProjection<'_, S>,
-    max_rows_per_segment: usize,
-) -> Result<Vec<super::runs::MetadataTableManifest>> {
-    let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
-    for family in CHECKPOINT_TABLE_FAMILIES {
-        let mut rows = projection
-            .manifest_tables
-            .scan_prefix(family, "")
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-            })?;
-        rows.extend(manifest_rows_for_family(&projection.tail_state, family));
-        if family == MetadataTableFamily::CommitReceipts {
-            // The idempotency horizon is the retention floor: a commit
-            // retried from below it re-bootstraps like any sub-floor cursor,
-            // so its receipt no longer needs to be carried forward.
-            let retention_floor_seq = projection.floor_seq;
-            rows.retain(|row| match row {
-                MetadataRow::CommitReceipt { committed_seq, .. } => {
-                    *committed_seq >= retention_floor_seq
-                }
-                _ => true,
-            });
-        }
-        rows.sort_by_key(|row| row.row_key_for_family(family));
-        rows_by_family.insert(family, rows);
+    // The idempotency horizon is the retention floor: a commit retried from
+    // below it re-bootstraps like any sub-floor cursor, so its receipt no
+    // longer needs to be carried forward.
+    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::CommitReceipts) {
+        rows.retain(|row| match row {
+            MetadataRow::CommitReceipt { committed_seq, .. } => {
+                *committed_seq >= retention_floor_seq
+            }
+            _ => true,
+        });
     }
-
-    // The base rebuild is the one production point that holds every row of
-    // every family, so cross-check the index families against their
-    // canonical tables before compacting them forward (format spec,
-    // "Manifest publication and checkpoint verification").
-    let source_manifest_key = metadata_manifest_object(
-        namespace_id.as_str(),
-        &projection
-            .manifest_tables
-            .manifest()
-            .payload
-            .manifest_object_id,
-    );
-    let index_error =
-        |error| CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error));
-    validate_direntry_child_bind_index(
-        &source_manifest_key,
-        rows_by_family
-            .get(&MetadataTableFamily::DirentryBinds)
-            .cloned()
-            .unwrap_or_default(),
-        rows_by_family
-            .get(&MetadataTableFamily::DirentryChildBinds)
-            .cloned()
-            .unwrap_or_default(),
-    )
-    .map_err(index_error)?;
-    validate_revision_by_inode_desc_index(
-        &source_manifest_key,
-        rows_by_family
-            .get(&MetadataTableFamily::Revisions)
-            .cloned()
-            .unwrap_or_default(),
-        rows_by_family
-            .get(&MetadataTableFamily::RevisionsByInodeDesc)
-            .cloned()
-            .unwrap_or_default(),
-    )
-    .map_err(index_error)?;
-
-    drop_rows_below_retention_floor(&mut rows_by_family, projection.floor_seq)?;
-
-    build_manifest_tables_from_rows(
-        store,
-        namespace_id,
-        run_seq,
-        CHECKPOINT_BASE_RUN_LEVEL,
-        |family| rows_by_family.remove(&family).unwrap_or_default(),
-        MetadataTableSegmentation::Base {
-            max_rows_per_segment,
-        },
-    )
-    .await
+    Ok(())
 }
 
 #[cfg(test)]
@@ -847,6 +740,7 @@ pub(super) struct ManifestMetadataSource<'a> {
     skip_all,
     fields(phase = "project_manifest")
 )]
+#[cfg(test)]
 pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -955,6 +849,7 @@ pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
     })
 }
 
+#[cfg(test)]
 fn is_bootstrap_seed_manifest(payload: &NamespaceManifestPayload) -> bool {
     payload.head_seq == ChangeSeq(0) && payload.base_seq == ChangeSeq(0) && payload.fork.is_none()
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -40,8 +40,8 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope,
 };
 use loonfs_api::wire::sst_blocks::{
-    decode_data_block, decode_index_block, index_blocks_for_key_range, DecodedDataBlock,
-    SegmentIndexEntry,
+    decode_data_block, decode_filter_block, decode_index_block, index_blocks_for_key_range,
+    DecodedDataBlock, SegmentFilter, SegmentIndexEntry,
 };
 #[cfg(test)]
 use loonfs_api::ManifestId;
@@ -689,11 +689,8 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
     let handle = descriptor.index_block;
-    let cache_key = segment_block_cache_key(
-        descriptor,
-        MetadataTableBlockKind::SegmentIndex,
-        handle.offset,
-    );
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Index, handle.offset);
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -724,10 +721,59 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     };
     match block {
         DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
-        DecodedMetadataTableBlock::Data { .. } => Err(segment_codec_error(
+        DecodedMetadataTableBlock::Filter { .. } | DecodedMetadataTableBlock::Data { .. } => {
+            Err(segment_codec_error(
+                &descriptor.object_key,
+                "cache returned a non-index block for an index key",
+            ))
+        }
+    }
+}
+
+/// Loads a segment's bloom filter block through the cache: the cheap
+/// pre-index check a lookup consults to skip the segment entirely.
+pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    descriptor: &MetadataFileRef,
+    cache_mode: MetadataTableCacheMode,
+) -> Result<Arc<SegmentFilter>, ManifestLoadError> {
+    let handle = descriptor.filter_block;
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Filter, handle.offset);
+    let fetch = || async {
+        let bytes = fetch_section_bytes(
+            store,
             &descriptor.object_key,
-            "cache returned a data block for an index key",
-        )),
+            handle.offset,
+            handle.stored_len as u64,
+        )
+        .await?;
+        let filter = decode_filter_block(&bytes, &handle)
+            .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
+        Ok(DecodedMetadataTableBlock::Filter {
+            decoded_byte_len: handle.decoded_len as usize,
+            filter: Arc::new(filter),
+        })
+    };
+    let block = match table_cache {
+        Some(cache) => {
+            cache
+                .get_or_fetch(
+                    &cache_key,
+                    cache_mode != MetadataTableCacheMode::Bypass,
+                    cache_mode == MetadataTableCacheMode::Populate,
+                    fetch,
+                )
+                .await?
+        }
+        None => fetch().await?,
+    };
+    match block {
+        DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
+        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Data { .. } => Err(
+            segment_codec_error(&descriptor.object_key, "cache returned a non-filter block"),
+        ),
     }
 }
 
@@ -740,11 +786,8 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<DecodedDataBlock>, ManifestLoadError> {
     let handle = entry.block;
-    let cache_key = segment_block_cache_key(
-        descriptor,
-        MetadataTableBlockKind::SegmentData,
-        handle.offset,
-    );
+    let cache_key =
+        segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -774,10 +817,12 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     };
     match block {
         DecodedMetadataTableBlock::Data { block, .. } => Ok(block),
-        DecodedMetadataTableBlock::Index { .. } => Err(segment_codec_error(
-            &descriptor.object_key,
-            "cache returned an index block for a data key",
-        )),
+        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
+            Err(segment_codec_error(
+                &descriptor.object_key,
+                "cache returned a non-data block for a data key",
+            ))
+        }
     }
 }
 
@@ -811,7 +856,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         for (position, entry) in entries.iter().enumerate() {
             let cache_key = segment_block_cache_key(
                 descriptor,
-                MetadataTableBlockKind::SegmentData,
+                MetadataTableBlockKind::Data,
                 entry.block.offset,
             );
             if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&cache_key) {
@@ -865,7 +910,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
             if let (Some(cache), true) = (table_cache, populate) {
                 let cache_key = segment_block_cache_key(
                     descriptor,
-                    MetadataTableBlockKind::SegmentData,
+                    MetadataTableBlockKind::Data,
                     handle.offset,
                 );
                 cache.insert(

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -25,6 +25,7 @@ mod error;
 mod load;
 mod publish;
 pub(crate) mod record;
+mod reorganize;
 mod retention;
 mod row;
 mod runs;
@@ -39,10 +40,11 @@ pub use self::cache::{
     DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
+pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::{
-    build_initial_namespace_manifest, create_checkpoint, create_checkpoint_with_policy_and_owner,
+    build_initial_namespace_manifest, create_checkpoint, create_checkpoint_with_owner,
 };
 pub(crate) use self::load::{
     head_from_manifest, load_namespace_manifest_envelope, load_verified_manifest_tables,
@@ -50,5 +52,6 @@ pub(crate) use self::load::{
 };
 pub(crate) use self::publish::write_namespace_manifest;
 pub(crate) use self::record::{read_checkpoint_record, verify_checkpoint_basis};
+pub(crate) use self::reorganize::reorganize_metadata_step;
 pub(crate) use self::retention::advance_retention_floor;
 pub(crate) use self::scan::{string_prefix_upper_bound, VerifiedMetadataTables};

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -1,0 +1,369 @@
+//! Bounded metadata reorganization: the background half of the
+//! checkpoint/compaction split.
+//!
+//! Checkpoint publication only ever appends an L0 delta run, so its cost
+//! follows the WAL delta, never the namespace. Folding those L0 runs into
+//! the base happens here instead, one **family group** at a time: the
+//! group's rows are merged from every run it appears in, rows below the
+//! retention floor are dropped, new base segments are written, and a
+//! manifest publishes that swaps just that group's references. Families
+//! whose retention rules read each other compact together — bind, child
+//! bind, and unbind rows form one group; revisions and their descending
+//! index another — so index parity and the drop invariants hold within
+//! every unit.
+//!
+//! There is no progress record: each unit ends in a durable manifest, so a
+//! crashed or interrupted reorganization resumes by reading the live
+//! manifest and picking the next group that still has L0 rows. Unit
+//! selection is deterministic (most L0 rows first, then group order). A
+//! concurrent checkpoint racing a unit wins at the root compare-and-swap;
+//! the unit's segments are left unreferenced for garbage collection and the
+//! next tick retries against the fresh manifest.
+
+use super::build::{
+    build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
+    MetadataTableSegmentation,
+};
+use super::create::{
+    drop_rows_below_retention_floor, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
+};
+use super::load::{
+    load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
+    validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,
+};
+use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
+use super::runs::{
+    flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL,
+    CHECKPOINT_L0_RUN_LEVEL,
+};
+use crate::context::MutationContext;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::namespace::control::{read_metadata_root_object, read_wal_floor_seq_or_zero};
+use loonfs_api::wire::manifest::{
+    MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope, NamespaceManifestPayload,
+};
+use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeMap;
+
+/// Families whose rows merge in one reorganization unit. Groupings follow
+/// the retention rules in `drop_rows_below_retention_floor`: families that
+/// read each other's rows to decide what to drop must compact together, and
+/// a secondary index always travels with its canonical family.
+const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 5] = [
+    &[
+        MetadataTableFamily::DirentryBinds,
+        MetadataTableFamily::DirentryChildBinds,
+        MetadataTableFamily::DirentryUnbinds,
+    ],
+    &[
+        MetadataTableFamily::Revisions,
+        MetadataTableFamily::RevisionsByInodeDesc,
+    ],
+    &[MetadataTableFamily::Inodes],
+    &[MetadataTableFamily::Tombstones],
+    &[MetadataTableFamily::CommitReceipts],
+];
+
+/// What one reorganization step did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataReorganizeOutcome {
+    /// The manifest's L0 run count is below the policy trigger; nothing to
+    /// fold yet.
+    NotNeeded { l0_runs: usize },
+    /// One family group folded into new base segments and the manifest
+    /// advanced.
+    UnitPublished {
+        families: Vec<MetadataTableFamily>,
+        folded_l0_rows: u64,
+        manifest_id: ManifestId,
+    },
+    /// A concurrent publication moved the root while this unit ran; its
+    /// output is unreferenced (garbage collection reclaims it) and the next
+    /// step retries against the fresh manifest.
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetadataReorganizeReport {
+    pub namespace_id: NamespaceId,
+    pub outcome: MetadataReorganizeOutcome,
+}
+
+/// Runs at most one reorganization unit against the namespace's current
+/// manifest. Callers (the maintenance tick) invoke this repeatedly; each
+/// call re-reads durable state, so any two calls compose — including across
+/// process restarts.
+#[tracing::instrument(
+    level = "info",
+    name = "loon.phase",
+    err,
+    skip_all,
+    fields(phase = "reorganize_metadata", key_class = "manifest")
+)]
+pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> Result<MetadataReorganizeReport> {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let previous = tables.manifest();
+
+    let l0_runs = l0_run_count(&previous.payload);
+    if l0_runs < policy.max_l0_runs.max(1) {
+        return Ok(MetadataReorganizeReport {
+            namespace_id: namespace_id.clone(),
+            outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
+        });
+    }
+    let Some(group) = select_family_group(&previous.payload) else {
+        // L0 runs exist but hold no rows (empty families); nothing to fold.
+        return Ok(MetadataReorganizeReport {
+            namespace_id: namespace_id.clone(),
+            outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
+        });
+    };
+    let folded_l0_rows = group_l0_rows(&previous.payload, group);
+
+    // Merge the group's rows from every run it appears in. The scan reads
+    // exactly the manifest's tables — never the WAL tail — so the unit's
+    // output represents the same head the manifest already describes.
+    let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
+    for family in group {
+        let mut rows = tables.scan_prefix(*family, "").await.map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+        // The scan yields rows in run order (base, then L0 newest-first);
+        // the merged base must be in row-key order.
+        rows.sort_by_cached_key(|row| row.row_key_for_family(*family));
+        rows_by_family.insert(*family, rows);
+    }
+    // The paired groups exist to preserve index parity; verify it on the
+    // merged rows before writing anything, exactly as the old full rebuild
+    // did at publication.
+    if group.contains(&MetadataTableFamily::DirentryBinds) {
+        validate_direntry_child_bind_index(
+            root.manifest_object_id.as_ref(),
+            rows_by_family
+                .get(&MetadataTableFamily::DirentryBinds)
+                .cloned()
+                .unwrap_or_default(),
+            rows_by_family
+                .get(&MetadataTableFamily::DirentryChildBinds)
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    }
+    if group.contains(&MetadataTableFamily::Revisions) {
+        validate_revision_by_inode_desc_index(
+            root.manifest_object_id.as_ref(),
+            rows_by_family
+                .get(&MetadataTableFamily::Revisions)
+                .cloned()
+                .unwrap_or_default(),
+            rows_by_family
+                .get(&MetadataTableFamily::RevisionsByInodeDesc)
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    }
+    let floor_seq = read_wal_floor_seq_or_zero(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    drop_rows_below_retention_floor(&mut rows_by_family, floor_seq)?;
+
+    let run_tables = build_manifest_tables_from_rows(
+        store,
+        namespace_id,
+        previous.payload.head_seq,
+        CHECKPOINT_BASE_RUN_LEVEL,
+        |family| rows_by_family.remove(&family).unwrap_or_default(),
+        MetadataTableSegmentation::Base {
+            max_rows_per_segment: policy.max_rows_per_segment,
+        },
+    )
+    .await?;
+    debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
+
+    let mut metadata_files: Vec<_> = previous
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| !group.contains(&descriptor.family))
+        .cloned()
+        .collect();
+    metadata_files.extend(flatten_manifest_tables(run_tables));
+    // `base_seq` is the manifest's oldest-run marker: every referenced run
+    // must sit at or above it, including L0 runs other groups have not
+    // folded yet.
+    let base_seq = metadata_files
+        .iter()
+        .map(|descriptor| descriptor.run_seq)
+        .min()
+        .unwrap_or(previous.payload.base_seq);
+
+    let manifest = write_reorganized_manifest(
+        store,
+        namespace_id,
+        previous,
+        metadata_files,
+        base_seq,
+        {
+            let mut payload_floor = previous.payload.retention_floor_seq;
+            if floor_seq > payload_floor {
+                payload_floor = floor_seq;
+            }
+            payload_floor
+        },
+        &context.writer_version,
+    )
+    .await?;
+
+    match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        context.now_ms,
+        &context.writer_version,
+    )
+    .await?
+    {
+        ManifestPublicationOutcome::Published(_) => Ok(MetadataReorganizeReport {
+            namespace_id: namespace_id.clone(),
+            outcome: MetadataReorganizeOutcome::UnitPublished {
+                families: group.to_vec(),
+                folded_l0_rows,
+                manifest_id: manifest.payload.manifest_id,
+            },
+        }),
+        ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
+            Ok(MetadataReorganizeReport {
+                namespace_id: namespace_id.clone(),
+                outcome: MetadataReorganizeOutcome::Superseded,
+            })
+        }
+    }
+}
+
+/// The family group with the most L0 rows to fold; ties resolve in group
+/// order. `None` when no group has L0 rows.
+fn select_family_group(
+    payload: &NamespaceManifestPayload,
+) -> Option<&'static [MetadataTableFamily]> {
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .map(|group| (group_l0_rows(payload, group), group))
+        .filter(|(rows, _)| *rows > 0)
+        .max_by(|(left_rows, left), (right_rows, right)| {
+            left_rows.cmp(right_rows).then_with(|| {
+                // On ties the EARLIER group must win; comparing positions
+                // reversed makes max_by pick it.
+                position_of(right).cmp(&position_of(left))
+            })
+        })
+        .map(|(_, group)| group)
+}
+
+fn position_of(group: &[MetadataTableFamily]) -> usize {
+    REORGANIZE_FAMILY_GROUPS
+        .iter()
+        .position(|candidate| candidate.as_ptr() == group.as_ptr())
+        .unwrap_or(usize::MAX)
+}
+
+fn group_l0_rows(payload: &NamespaceManifestPayload, group: &[MetadataTableFamily]) -> u64 {
+    payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            descriptor.level == CHECKPOINT_L0_RUN_LEVEL && group.contains(&descriptor.family)
+        })
+        .map(|descriptor| descriptor.row_count)
+        .sum()
+}
+
+async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    previous: &NamespaceManifestEnvelope,
+    metadata_files: Vec<loonfs_api::wire::manifest::MetadataFileRef>,
+    base_seq: ChangeSeq,
+    retention_floor_seq: ChangeSeq,
+    writer_version: &str,
+) -> Result<NamespaceManifestEnvelope> {
+    let manifest_id = next_manifest_id_after(previous.payload.manifest_id)?;
+    for _allocation_attempt in 0..MANIFEST_ALLOCATION_RETRY_LIMIT {
+        let manifest_object_id = ManifestObjectId::generate(manifest_id);
+        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        match load_namespace_manifest_envelope_if_present(
+            store,
+            namespace_id,
+            &manifest_object_id,
+            &manifest_key,
+        )
+        .await
+        {
+            Ok(Some(_existing)) => continue,
+            Ok(None) => {}
+            Err(error) => {
+                return Err(CoreError::MetadataProjection(
+                    MetadataProjectionLoadError::ManifestLoad(error),
+                ))
+            }
+        }
+        let manifest = NamespaceManifestEnvelope::from_payload(
+            writer_version,
+            NamespaceManifestPayload {
+                namespace_id: namespace_id.clone(),
+                manifest_id,
+                manifest_object_id,
+                prev_manifest_id: Some(previous.payload.manifest_id),
+                head_seq: previous.payload.head_seq,
+                head_commit_id: previous.payload.head_commit_id.clone(),
+                base_seq,
+                writer_epoch: previous.payload.writer_epoch,
+                next_inode_id: previous.payload.next_inode_id,
+                retention_floor_seq,
+                initialized: previous.payload.initialized,
+                verified: previous.payload.verified,
+                fork: previous.payload.fork.clone(),
+                features: previous.payload.features.clone(),
+                metadata_files: metadata_files.clone(),
+            },
+        )
+        .map_err(|err| {
+            CoreError::Internal(format!("failed to build reorganized manifest: {err}"))
+        })?;
+        match write_namespace_manifest(store, &manifest).await {
+            Ok(()) => return Ok(manifest),
+            Err(MetadataProjectionLoadError::ManifestLoad(
+                super::error::ManifestLoadError::ManifestConflict { .. },
+            )) => continue,
+            Err(error) => return Err(CoreError::MetadataProjection(error)),
+        }
+    }
+    Err(CoreError::Internal(
+        "reorganized manifest allocation retry exhausted".to_owned(),
+    ))
+}

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -4,8 +4,9 @@
 use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
-    load_manifest_segment_rows_in_key_range_with_cache, metadata_file_object_key,
-    MetadataSstSeqExpectation, MetadataTableCacheMode, MetadataTableLoadContext,
+    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
+    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableCacheMode,
+    MetadataTableLoadContext,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -47,13 +48,19 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         &self.manifest
     }
 
-    pub(crate) async fn get(
+    pub(crate) async fn get_for_lookup(
         &self,
         family: MetadataTableFamily,
         key: &str,
+        filter_probe: &str,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
-            .scan_prefix_with_cache_mode(family, key, MetadataTableCacheMode::Populate)
+            .scan_prefix_with_cache_mode(
+                family,
+                key,
+                MetadataTableCacheMode::Populate,
+                Some(filter_probe),
+            )
             .await?
             .into_iter()
             .find(|row| row.row_key_for_family(family) == key))
@@ -66,7 +73,24 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let matching_segment_count = self.matching_segment_count(family, prefix)?;
         let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode)
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, None)
+            .await
+    }
+
+    /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
+    /// family's exact filter key for the value being looked up, so each
+    /// candidate segment's bloom filter is consulted before its index or
+    /// data — a negative skips the segment without fetching either. Scans
+    /// coarser than the filter key must use [`Self::scan_prefix`] instead.
+    pub(crate) async fn scan_prefix_for_lookup(
+        &self,
+        family: MetadataTableFamily,
+        prefix: &str,
+        filter_probe: &str,
+    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        let matching_segment_count = self.matching_segment_count(family, prefix)?;
+        let cache_mode = self.scan_cache_mode(matching_segment_count);
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, Some(filter_probe))
             .await
     }
 
@@ -96,7 +120,24 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        self.scan_range_page_rows(family, lower_bound, upper_bound, limit)
+        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, None)
+            .await
+    }
+
+    /// [`Self::scan_range_page`] for a point lookup within one filter key's
+    /// range; see [`Self::scan_prefix_for_lookup`] for the probe contract.
+    pub(crate) async fn scan_range_page_for_lookup(
+        &self,
+        family: MetadataTableFamily,
+        lower_bound: &str,
+        upper_bound: Option<&str>,
+        limit: usize,
+        filter_probe: &str,
+    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, Some(filter_probe))
             .await
     }
 
@@ -105,6 +146,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         prefix: &str,
         cache_mode: MetadataTableCacheMode,
+        filter_probe: Option<&str>,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut rows = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -122,10 +164,42 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                     rows: &mut rows,
                     cache_mode,
                 },
+                filter_probe,
             )
             .await?;
         }
         Ok(rows)
+    }
+
+    /// Whether a lookup should touch this segment at all: false only when
+    /// the segment's bloom filter proves the probe key absent. A skipped
+    /// segment costs one tiny cached filter read instead of index and data
+    /// fetches.
+    async fn segment_filter_admits(
+        &self,
+        descriptor: &MetadataFileRef,
+        cache_mode: MetadataTableCacheMode,
+        filter_probe: &str,
+    ) -> Result<bool, ManifestLoadError> {
+        let filter =
+            load_segment_filter(self.store, self.table_cache, descriptor, cache_mode).await?;
+        if filter.may_contain(filter_probe) {
+            return Ok(true);
+        }
+        if let Some(cache) = self.table_cache {
+            cache.record_filter_skip();
+        }
+        Ok(false)
+    }
+
+    /// Counts a segment whose filter admitted the probe but whose rows had
+    /// no match — the filter's false-positive rate as observed by lookups.
+    fn record_filter_false_positive_if_empty(&self, matched_rows: usize) {
+        if matched_rows == 0 {
+            if let Some(cache) = self.table_cache {
+                cache.record_filter_false_positive();
+            }
+        }
     }
 
     fn matching_segment_count(
@@ -147,6 +221,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         lower_bound: &str,
         upper_bound: Option<&str>,
         limit: usize,
+        filter_probe: Option<&str>,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut matching_descriptors = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -167,9 +242,22 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                         expected: expected_key,
                     });
                 }
-                if descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
-                    matching_descriptors.push((context, descriptor.clone()));
+                if !descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
+                    continue;
                 }
+                if let Some(filter_probe) = filter_probe {
+                    if !self
+                        .segment_filter_admits(
+                            descriptor,
+                            MetadataTableCacheMode::Populate,
+                            filter_probe,
+                        )
+                        .await?
+                    {
+                        continue;
+                    }
+                }
+                matching_descriptors.push((context, descriptor.clone()));
             }
         }
         matching_descriptors.sort_by(|(_, left), (_, right)| {
@@ -231,6 +319,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         context: MetadataTableLoadContext<'_>,
         tables: &[MetadataTableManifest],
         output: MetadataTableScanOutput<'_>,
+        filter_probe: Option<&str>,
     ) -> Result<(), ManifestLoadError> {
         let table = manifest_table_for_family(context.manifest_object_key, tables, family)?;
         let mut matching_descriptors = Vec::new();
@@ -248,6 +337,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             }
             matching_descriptors.push(descriptor);
         }
+        let matching_descriptors = self
+            .filter_admitted_descriptors(matching_descriptors, output.cache_mode, filter_probe)
+            .await?;
 
         let prefix_upper_bound = string_prefix_upper_bound(prefix);
         let mut loaded_segments = Vec::new();
@@ -268,13 +360,45 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
 
         for segment_rows in loaded_segments {
+            let matched = output.rows.len();
             output.rows.extend(
                 segment_rows
                     .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
                     .map(|(_, row)| row.clone()),
             );
+            if filter_probe.is_some() {
+                self.record_filter_false_positive_if_empty(output.rows.len() - matched);
+            }
         }
         Ok(())
+    }
+
+    /// Drops the descriptors whose bloom filter rules the probe out; with no
+    /// probe every descriptor is admitted untouched.
+    async fn filter_admitted_descriptors<'d>(
+        &self,
+        descriptors: Vec<&'d MetadataFileRef>,
+        cache_mode: MetadataTableCacheMode,
+        filter_probe: Option<&str>,
+    ) -> Result<Vec<&'d MetadataFileRef>, ManifestLoadError> {
+        let Some(filter_probe) = filter_probe else {
+            return Ok(descriptors);
+        };
+        let mut admitted = Vec::with_capacity(descriptors.len());
+        for chunk in descriptors.chunks(MAX_MATERIALIZED_TABLE_FETCHES) {
+            let checks = try_join_all(chunk.iter().map(|descriptor| {
+                self.segment_filter_admits(descriptor, cache_mode, filter_probe)
+            }))
+            .await?;
+            admitted.extend(
+                chunk
+                    .iter()
+                    .zip(checks)
+                    .filter(|(_, admits)| *admits)
+                    .map(|(descriptor, _)| *descriptor),
+            );
+        }
+        Ok(admitted)
     }
 
     async fn segment_rows(

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2472,6 +2472,104 @@ async fn maintenance_materialization_does_not_populate_metadata_table_cache() {
 }
 
 #[tokio::test]
+async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // "beta" lands in the base run; a second checkpoint puts "alpha" and
+    // "gamma" in an L0 run. The L0 bind segment's key range then straddles
+    // "beta", so min/max pruning cannot exclude it — only its bloom filter
+    // can prove the name absent.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/beta.txt",
+        b"beta\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write beta");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("first checkpoint");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write alpha");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/gamma.txt",
+        b"gamma\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write gamma");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("second checkpoint");
+
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load tables");
+
+    // Resolve /docs, then look up beta's bind under it through the filtered
+    // scan the visibility adapter uses.
+    let docs_binds = tables
+        .scan_prefix(
+            ApiMetadataTableFamily::DirentryBinds,
+            "direntry-00000000000000000001-",
+        )
+        .await
+        .expect("scan root binds");
+    let docs_inode = docs_binds
+        .iter()
+        .find_map(|row| match row {
+            MetadataRow::DirentryBind { child_inode_id, .. } => Some(*child_inode_id),
+            _ => None,
+        })
+        .expect("docs directory bind");
+    let encoded_name = loonfs_api::wire::manifest::hex_encode_row_key_component("beta.txt");
+    let filter_probe = format!("direntry-{:020}-{encoded_name}", docs_inode.0);
+    let prefix = format!("{filter_probe}-");
+    let rows = tables
+        .scan_prefix_for_lookup(
+            ApiMetadataTableFamily::DirentryBinds,
+            &prefix,
+            &filter_probe,
+        )
+        .await
+        .expect("filtered lookup");
+
+    assert_eq!(rows.len(), 1, "beta's bind should still be found");
+    let stats = cache.stats();
+    assert!(
+        stats.filter_skips >= 1,
+        "the L0 bind segment should be skipped by its filter, stats: {stats:?}"
+    );
+}
+
+#[tokio::test]
 async fn metadata_cache_budget_counts_decoded_blocks() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -2510,7 +2608,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
 
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get(ApiMetadataTableFamily::Inodes, key)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("get inode")
         .is_some());

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -9,7 +9,7 @@ use super::build::{
 };
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::create::{
-    build_namespace_manifest_from_metadata_state, create_checkpoint, create_checkpoint_with_policy,
+    build_namespace_manifest_from_metadata_state, create_checkpoint,
     drop_rows_below_retention_floor, load_checkpoint_projection_metadata_state,
     ManifestMetadataSource,
 };
@@ -83,6 +83,65 @@ async fn read_floor_seq<S: ObjectStore + ?Sized>(
         .envelope
         .state
         .floor_seq
+}
+
+/// Checkpoints, then folds every L0 run into the base through
+/// reorganization units, returning the resulting current manifest id. The
+/// old synchronous rebuild produced this shape in one checkpoint call;
+/// tests that need a compacted base with a specific segmentation policy use
+/// this instead.
+async fn checkpoint_then_reorganize<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> ManifestId {
+    create_checkpoint(store, namespace_id, context)
+        .await
+        .expect("create checkpoint");
+    drain_reorganization(store, namespace_id, context, policy).await
+}
+
+/// Runs reorganization units until nothing is left to fold, with the
+/// trigger forced so even one L0 run folds.
+async fn drain_reorganization<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> ManifestId {
+    let fold_policy = MetadataLsmPolicy {
+        max_l0_runs: 1,
+        ..policy
+    };
+    loop {
+        let report = super::reorganize_metadata_step(store, namespace_id, context, fold_policy)
+            .await
+            .expect("reorganization step");
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { .. }
+            | super::MetadataReorganizeOutcome::Superseded => continue,
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+        }
+    }
+    read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state
+        .manifest_id
+}
+
+async fn current_manifest_id<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> ManifestId {
+    read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state
+        .manifest_id
 }
 
 async fn current_manifest_object_id<S: ObjectStore + ?Sized>(
@@ -858,11 +917,21 @@ async fn base_rebuild_drops_commit_receipts_below_retention_floor() {
             .expect("create checkpoint");
         last_manifest_id = Some(checkpoint.manifest_id);
     }
+    // Checkpoints only append; dropping happens when reorganization folds
+    // the runs against the advanced floor.
+    let _ = last_manifest_id.expect("manifest id");
+    let reorganized_manifest_id = drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
 
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
-        last_manifest_id.expect("manifest id"),
+        reorganized_manifest_id,
     )
     .await
     .expect("load manifest");
@@ -1052,6 +1121,15 @@ async fn restore_below_the_floor_fails_with_revision_not_found() {
             .await
             .expect("create checkpoint");
     }
+    // The superseded revision is reclaimed when reorganization folds the
+    // runs against the advanced floor, not at checkpoint time.
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
 
     let error = restore_file_revision(
         &store,
@@ -1119,11 +1197,21 @@ async fn base_rebuild_drops_revisions_superseded_below_floor() {
             .expect("create checkpoint");
         last_manifest_id = Some(checkpoint.manifest_id);
     }
+    // Checkpoints only append; dropping happens when reorganization folds
+    // the runs against the advanced floor.
+    let _ = last_manifest_id.expect("manifest id");
+    let reorganized_manifest_id = drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
 
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
-        last_manifest_id.expect("manifest id"),
+        reorganized_manifest_id,
     )
     .await
     .expect("load manifest");
@@ -1189,11 +1277,21 @@ async fn base_rebuild_drops_bindings_unbound_below_floor() {
             .expect("create checkpoint");
         last_manifest_id = Some(checkpoint.manifest_id);
     }
+    // Checkpoints only append; dropping happens when reorganization folds
+    // the runs against the advanced floor.
+    let _ = last_manifest_id.expect("manifest id");
+    let reorganized_manifest_id = drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
 
     let materialized = load_manifest_materialization_for_inspection(
         &store,
         &namespace_id,
-        last_manifest_id.expect("manifest id"),
+        reorganized_manifest_id,
     )
     .await
     .expect("load manifest");
@@ -1294,29 +1392,40 @@ async fn base_rebuild_rejects_divergent_revision_index() {
     rewrite_revision_index_segment(&store, &namespace_id, &mut manifest, revision_index_rows).await;
     overwrite_manifest(&store, &namespace_id, manifest).await;
 
-    // L0 appends never re-read the base run; the base rebuild that folds
-    // every run back together is the production point that must reject it.
-    let mut rebuild_error = None;
-    for round in 0..12u32 {
-        write_file_bytes(
-            &store,
-            &namespace_id,
-            &format!("/docs/file-{round}.txt"),
-            b"body\n",
-            &context,
-            None,
-        )
+    // L0 appends never re-read the base run; the reorganization merge that
+    // folds every run back together is the production point that must
+    // reject it.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/another.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write");
+    create_checkpoint(&store, &namespace_id, &context)
         .await
-        .expect("write");
-        match create_checkpoint(&store, &namespace_id, &context).await {
-            Ok(_) => {}
+        .expect("l0 checkpoint");
+    let fold_policy = MetadataLsmPolicy {
+        max_l0_runs: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    let mut rebuild_error = None;
+    for _unit in 0..8 {
+        match super::reorganize_metadata_step(&store, &namespace_id, &context, fold_policy).await {
+            Ok(report) => match report.outcome {
+                super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+                _ => continue,
+            },
             Err(error) => {
                 rebuild_error = Some(error);
                 break;
             }
         }
     }
-    match rebuild_error.expect("base rebuild should reject the divergent index") {
+    match rebuild_error.expect("reorganization should reject the divergent index") {
         CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
             ManifestLoadError::RevisionIndexMismatch { .. },
         )) => {}
@@ -1526,11 +1635,21 @@ async fn manifest_materialization_uses_written_segments() {
     create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create checkpoint");
+    let reorganized_manifest_id = drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
 
-    let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(1))
-            .await
-            .expect("load materialized manifest");
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        reorganized_manifest_id,
+    )
+    .await
+    .expect("load materialized manifest");
     let current = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
@@ -1603,18 +1722,23 @@ async fn manifest_l0_run_materialization_matches_checkpoint_projection() {
             .await
             .expect("load second manifest");
 
+    // Checkpoints only append: the base run stays the bootstrap seed's and
+    // each checkpoint contributes one L0 run.
     assert_eq!(
         second_materialized.manifest.payload.base_seq,
-        first.checkpoint_seq
+        first_materialized.manifest.payload.base_seq
     );
     assert_eq!(
         base_run(&second_materialized.manifest).tables,
         base_run(&first_materialized.manifest).tables
     );
     let l0_runs = l0_runs(&second_materialized.manifest);
-    assert_eq!(l0_runs.len(), 1);
-    assert_eq!(l0_runs[0].run_seq, second.checkpoint_seq);
-    assert_eq!(l0_runs[0].level, CHECKPOINT_L0_RUN_LEVEL);
+    assert_eq!(l0_runs.len(), 2);
+    assert_eq!(l0_runs[0].run_seq, first.checkpoint_seq);
+    assert_eq!(l0_runs[1].run_seq, second.checkpoint_seq);
+    assert!(l0_runs
+        .iter()
+        .all(|run| run.level == CHECKPOINT_L0_RUN_LEVEL));
     for response in [&first, &second] {
         let record = read_checkpoint_record(&store, &namespace_id, &response.checkpoint_id)
             .await
@@ -1888,11 +2012,13 @@ async fn manifest_l0_runs_chain_across_successive_manifests() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(4))
             .await
             .expect("load chained manifest");
-    assert_eq!(materialized.manifest.payload.base_seq, ChangeSeq(1));
+    // Always-append checkpoints keep the seed base (seq 0) and chain one
+    // L0 run per checkpoint, the first included.
+    assert_eq!(materialized.manifest.payload.base_seq, ChangeSeq(0));
     let l0_runs = l0_runs(&materialized.manifest);
-    assert_eq!(l0_runs.len(), 3);
+    assert_eq!(l0_runs.len(), 4);
     for (offset, run) in l0_runs.iter().enumerate() {
-        let seq = ChangeSeq(offset as u64 + 2);
+        let seq = ChangeSeq(offset as u64 + 1);
         assert_eq!(run.run_seq, seq);
         assert_eq!(run.level, CHECKPOINT_L0_RUN_LEVEL);
     }
@@ -1911,7 +2037,7 @@ async fn metadata_lsm_policy_default_matches_l0_run_cap() {
 }
 
 #[tokio::test]
-async fn manifest_policy_compacts_when_l0_runs_exceed_threshold() {
+async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1925,31 +2051,60 @@ async fn manifest_policy_compacts_when_l0_runs_exceed_threshold() {
         .expect("bootstrap");
 
     for index in 1..=4 {
-        write_file_and_checkpoint_with_policy(&store, &namespace_id, &context, index, policy).await;
+        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
     }
 
-    let capped = load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(3))
-        .await
-        .expect("load capped manifest");
-    assert_eq!(capped.manifest.payload.base_seq, ChangeSeq(1));
-    assert_eq!(l0_runs(&capped.manifest).len(), 2);
+    // Checkpoints never compact: well past the policy threshold every
+    // delta run is still chained and the base is still the seed's.
+    let appended = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load appended manifest");
+    assert_eq!(l0_runs(&appended.manifest).len(), 4);
+    assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 
-    let compacted =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(4))
+    // Reorganization folds one family group per unit, each publishing its
+    // own manifest — the manifest chain is the progress record.
+    let mut units = 0usize;
+    let mut last_manifest_id = None;
+    loop {
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
             .await
-            .expect("load compacted manifest");
+            .expect("reorganization step");
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { manifest_id, .. } => {
+                units += 1;
+                if let Some(previous) = last_manifest_id {
+                    assert!(manifest_id > previous, "units must advance the manifest");
+                }
+                last_manifest_id = Some(manifest_id);
+            }
+            super::MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+        }
+    }
+    assert!(units >= 2, "several family groups should fold, got {units}");
+
+    let drained = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load drained manifest");
     let materialization_after = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
-    assert_eq!(compacted.manifest.payload.base_seq, ChangeSeq(4));
-    assert!(l0_runs(&compacted.manifest).is_empty());
-    assert_eq!(
-        runs_from_metadata_files(&compacted.manifest.payload).len(),
-        1
-    );
+    assert!(l0_runs(&drained.manifest).is_empty());
+    assert_eq!(drained.manifest.payload.base_seq, ChangeSeq(4));
     assert!(metadata_states_equivalent(
         &materialization_after.metadata_state,
-        &compacted.metadata_state
+        &drained.metadata_state
     ));
 }
 
@@ -1973,13 +2128,20 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     .await
     .expect("write hello");
 
-    let manifest = create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("checkpoint");
-    let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
-            .await
-            .expect("load manifest");
+    let reorganized_manifest_id = checkpoint_then_reorganize(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        reorganized_manifest_id,
+    )
+    .await
+    .expect("load manifest");
     let mut manifest = materialized.manifest;
     let descriptor = manifest
         .payload
@@ -2042,11 +2204,9 @@ async fn manifest_base_run_tables_have_sorted_segment_coverage() {
         .await
         .expect("materialization before checkpoint");
 
-    let manifest = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    let manifest_id = checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id)
             .await
             .expect("load manifest");
 
@@ -2116,9 +2276,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     // The default cache config carries a decoded-byte budget, so a scan wider
     // than the small-scan limit populates the cache instead of reading through.
@@ -2188,9 +2346,7 @@ async fn count_bounded_cache_keeps_large_table_scans_read_only() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     // Without a byte budget only entry count bounds the cache, so one wide
     // scan admitting all its segments could flush every resident block; wide
@@ -2241,9 +2397,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     // A count-bounded cache keeps wide scans read-only, so nothing is ever
     // admitted and single-flight deduplication is the only fetch sharing —
@@ -2312,15 +2466,11 @@ async fn table_range_page_merges_base_and_l0_in_row_key_order() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("first checkpoint");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     write_file_bytes(&store, &namespace_id, "/docs/b.txt", b"b\n", &context, None)
         .await
         .expect("write b");
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("second checkpoint");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let tables = super::load_verified_manifest_tables_with_cache(
         &store,
@@ -2374,9 +2524,7 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let cache = super::MetadataTableCache::new(Default::default());
     let tables = super::load_verified_manifest_tables_with_cache(
@@ -2455,14 +2603,12 @@ async fn maintenance_materialization_does_not_populate_metadata_table_cache() {
         max_rows_per_segment: 1,
         ..MetadataLsmPolicy::default()
     };
-    let manifest = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("manifest");
+    let manifest_id = checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
     let before = cache.stats();
 
     let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id)
             .await
             .expect("load materialized manifest");
     let after = cache.stats();
@@ -2652,11 +2798,10 @@ async fn whole_run_compaction_rewrites_base_segments() {
     .await
     .expect("write cold");
 
-    let first = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("first checkpoint");
+    let first_manifest_id =
+        checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let first_materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, first.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, first_manifest_id)
             .await
             .expect("load first manifest");
     let first_run_keys = run_segment_object_keys(&first_materialized.manifest);
@@ -2671,9 +2816,7 @@ async fn whole_run_compaction_rewrites_base_segments() {
     )
     .await
     .expect("write hot l0");
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("l0 checkpoint");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     write_file_bytes(
         &store,
         &namespace_id,
@@ -2684,11 +2827,12 @@ async fn whole_run_compaction_rewrites_base_segments() {
     )
     .await
     .expect("write hot compact");
-    let compacted = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+    let compacted = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("compacted checkpoint");
+    let compacted_manifest_id = drain_reorganization(&store, &namespace_id, &context, policy).await;
     let compacted_materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, compacted.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, compacted_manifest_id)
             .await
             .expect("load compacted manifest");
     let materialization_after = load_current_projection(&store, &namespace_id)
@@ -2740,11 +2884,10 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
             .expect("write initial file");
     }
 
-    let first = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("first checkpoint");
+    let first_manifest_id =
+        checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let first_materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, first.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, first_manifest_id)
             .await
             .expect("load first manifest");
     let revision_keys_before = base_segment_object_keys_for_family(
@@ -2763,9 +2906,7 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
     )
     .await
     .expect("write l0 revision");
-    create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
-        .await
-        .expect("l0 checkpoint");
+    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     write_file_bytes(
         &store,
         &namespace_id,
@@ -2776,11 +2917,12 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
     )
     .await
     .expect("write compaction revision");
-    let compacted = create_checkpoint_with_policy(&store, &namespace_id, &context, policy)
+    let _compacted = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("compacted checkpoint");
+    let compacted_manifest_id = drain_reorganization(&store, &namespace_id, &context, policy).await;
     let compacted_materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, compacted.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, compacted_manifest_id)
             .await
             .expect("load compacted manifest");
     let revision_keys_after = base_segment_object_keys_for_family(
@@ -2792,9 +2934,12 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
         .expect("materialization");
 
     assert!(l0_runs(&compacted_materialized.manifest).is_empty());
-    assert_eq!(
-        runs_from_metadata_files(&compacted_materialized.manifest.payload).len(),
-        1
+    // Groups untouched since the first fold keep their older base run, so
+    // several base runs may coexist; what matters is that no delta remains.
+    assert!(
+        runs_from_metadata_files(&compacted_materialized.manifest.payload)
+            .iter()
+            .all(|run| run.level == CHECKPOINT_BASE_RUN_LEVEL)
     );
     assert!(revision_keys_after
         .iter()
@@ -2826,11 +2971,15 @@ async fn manifest_writes_and_validates_direntry_child_bind_index() {
     .await
     .expect("write hello");
 
-    let manifest = create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("checkpoint");
+    let manifest_id = checkpoint_then_reorganize(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
     let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id)
             .await
             .expect("load manifest");
     let base = base_run(&materialized.manifest);
@@ -2851,9 +3000,7 @@ async fn manifest_writes_and_validates_direntry_child_bind_index() {
         .delete(&deleted_key)
         .await
         .expect("delete child index");
-    match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
-        .await
-    {
+    match load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id).await {
         Err(ManifestLoadError::MissingSegment { object_key }) => {
             assert_eq!(object_key, deleted_key);
         }
@@ -2891,11 +3038,15 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     .await
     .expect("write other");
 
-    let manifest = create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("checkpoint");
+    let manifest_id = checkpoint_then_reorganize(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
     let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest.manifest_id)
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id)
             .await
             .expect("load manifest before corruption");
     let mut manifest = materialized.manifest;
@@ -3196,11 +3347,13 @@ async fn revision_index_test_materialization(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> (ManifestId, NamespaceManifestEnvelope, Vec<MetadataRow>) {
-    let manifest = create_checkpoint(store, namespace_id, context)
-        .await
-        .expect("checkpoint");
+    // The corruptions below target base-run segments, which only exist
+    // once reorganization has folded the checkpoint's L0 runs.
+    let manifest_id =
+        checkpoint_then_reorganize(store, namespace_id, context, MetadataLsmPolicy::default())
+            .await;
     let materialized =
-        load_manifest_materialization_for_inspection(store, namespace_id, manifest.manifest_id)
+        load_manifest_materialization_for_inspection(store, namespace_id, manifest_id)
             .await
             .expect("load manifest before corruption");
     let revision_index_rows = manifest_rows_for_family(
@@ -3354,7 +3507,76 @@ fn assert_manifest_rows_have_unique_keys(metadata_state: &MetadataState) {
 }
 
 #[tokio::test]
-async fn manifest_l0_run_cap_collapses_back_to_base_manifest() {
+async fn reorganization_resumes_from_the_manifest_after_interruption() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: 1,
+        ..MetadataLsmPolicy::default()
+    };
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 1..=3 {
+        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
+    }
+
+    // One unit runs, then the process "crashes": nothing is carried over
+    // but the published manifest.
+    let first_report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        .await
+        .expect("first unit");
+    let super::MetadataReorganizeOutcome::UnitPublished {
+        families: first_families,
+        ..
+    } = first_report.outcome
+    else {
+        panic!("expected a published unit, got {:?}", first_report.outcome);
+    };
+
+    // A checkpoint lands in between, adding a fresh delta run.
+    write_file_and_checkpoint(&store, &namespace_id, &context, 9).await;
+
+    // A fresh sequence of steps reads the live manifest and finishes the
+    // job, including the delta the interleaved checkpoint added.
+    let mut folded_groups = vec![first_families];
+    loop {
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+            .await
+            .expect("resumed unit");
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { families, .. } => {
+                folded_groups.push(families);
+            }
+            super::MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+        }
+    }
+    assert!(folded_groups.len() >= 2);
+
+    let drained = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load drained manifest");
+    let materialization_after = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("materialization");
+    assert!(l0_runs(&drained.manifest).is_empty());
+    assert!(metadata_states_equivalent(
+        &materialization_after.metadata_state,
+        &drained.metadata_state
+    ));
+}
+
+#[tokio::test]
+async fn checkpoints_chain_l0_runs_past_the_default_cap() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -3362,27 +3584,21 @@ async fn manifest_l0_run_cap_collapses_back_to_base_manifest() {
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
-
     for index in 1..=10 {
         write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
     }
 
-    let capped = load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(9))
-        .await
-        .expect("load capped manifest");
-    assert_eq!(capped.manifest.payload.base_seq, ChangeSeq(1));
-    assert_eq!(l0_runs(&capped.manifest).len(), MAX_CHECKPOINT_L0_RUNS);
-
-    let collapsed =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, ManifestId(10))
-            .await
-            .expect("load collapsed manifest");
-    assert_eq!(collapsed.manifest.payload.base_seq, ChangeSeq(10));
-    assert!(l0_runs(&collapsed.manifest).is_empty());
-    assert_eq!(
-        runs_from_metadata_files(&collapsed.manifest.payload).len(),
-        1
-    );
+    // The default cap is a reorganization trigger, never a checkpoint
+    // behavior: publication keeps appending regardless.
+    let appended = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load appended manifest");
+    assert!(l0_runs(&appended.manifest).len() > MAX_CHECKPOINT_L0_RUNS);
+    assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 }
 
 #[tokio::test]
@@ -3579,14 +3795,9 @@ async fn create_checkpoint_retries_same_id_different_payload_allocation_race() {
         ),
     );
 
-    let checkpoint = create_checkpoint_with_policy(
-        &store,
-        &namespace_id,
-        &context,
-        MetadataLsmPolicy::default(),
-    )
-    .await
-    .expect("create checkpoint should retry allocation");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint should retry allocation");
 
     assert_eq!(checkpoint.manifest_id, ManifestId(1));
     let record = read_checkpoint_record(&store, &namespace_id, &checkpoint.checkpoint_id)
@@ -3765,14 +3976,9 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
     .await
     .expect("publish manifest");
 
-    let checkpoint = create_checkpoint_with_policy(
-        &store,
-        &namespace_id,
-        &context,
-        MetadataLsmPolicy::default(),
-    )
-    .await
-    .expect("create checkpoint");
+    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
 
     // With standalone records, pinning a basis that already covers the head
     // writes a checkpoint file against it instead of building a new
@@ -3840,7 +4046,8 @@ async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
         load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_id)
             .await
             .expect("load checkpoint manifest");
-    assert_eq!(l0_runs(&materialized.manifest).len(), 1);
+    // One L0 run per checkpoint, the first included.
+    assert_eq!(l0_runs(&materialized.manifest).len(), 2);
 }
 
 #[tokio::test]
@@ -4549,24 +4756,6 @@ async fn write_file_and_checkpoint(
         .await
         .expect("write file");
     create_checkpoint(store, namespace_id, context)
-        .await
-        .expect("create checkpoint")
-        .checkpoint_seq
-}
-
-async fn write_file_and_checkpoint_with_policy(
-    store: &LocalFsStore,
-    namespace_id: &NamespaceId,
-    context: &MutationContext,
-    index: u64,
-    policy: MetadataLsmPolicy,
-) -> ChangeSeq {
-    let path = format!("/docs/file-{index}.txt");
-    let bytes = format!("file {index}\n");
-    write_file_bytes(store, namespace_id, &path, bytes.as_bytes(), context, None)
-        .await
-        .expect("write file");
-    create_checkpoint_with_policy(store, namespace_id, context, policy)
         .await
         .expect("create checkpoint")
         .checkpoint_seq

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -796,6 +796,24 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
+    /// Runs at most one metadata reorganization unit: folds one family
+    /// group's L0 delta rows into new base segments and publishes a manifest
+    /// swapping that group's references. Checkpoints only append L0 runs, so
+    /// calling this from maintenance is what keeps read fan-out bounded.
+    /// Repeat until the report says `NotNeeded`; every call re-reads durable
+    /// state, so interrupted reorganizations resume from the live manifest.
+    pub async fn reorganize_metadata(
+        &self,
+    ) -> CoreResult<crate::checkpoint::MetadataReorganizeReport> {
+        crate::checkpoint::reorganize_metadata_step(
+            &self.store,
+            &self.namespace_id,
+            &self.mutation_context(),
+            crate::checkpoint::MetadataLsmPolicy::default(),
+        )
+        .await
+    }
+
     /// Advances the retention floor when a verified checkpoint makes it safe.
     pub async fn advance_retention_floor(&self) -> CoreResult<AdvanceRetentionResponse> {
         crate::checkpoint::advance_retention_floor(

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -85,6 +85,7 @@ pub mod publish {
 #[cfg(any(test, feature = "inspection"))]
 pub mod inspection;
 
+pub use checkpoint::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub use context::MutationContext;
 #[doc(hidden)]
 pub use engine::RuntimeReadContext;

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -24,7 +24,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 ) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
-        .get(MetadataTableFamily::Inodes, &key)
+        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
         .and_then(inode_from_manifest_row))
@@ -87,9 +87,10 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     name_key: &str,
 ) -> Result<Vec<DirentryBindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(name_key);
-    let prefix = format!("direntry-{:020}-{encoded_name_key}-", parent_inode_id.0);
+    let filter_probe = format!("direntry-{:020}-{encoded_name_key}", parent_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::DirentryBinds, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -101,9 +102,14 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     child_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = format!("direntry-child-{:020}-", child_inode_id.0);
+    let filter_probe = format!("direntry-child-{:020}", child_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryChildBinds, &prefix)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::DirentryChildBinds,
+            &prefix,
+            &filter_probe,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -116,15 +122,16 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     direntry: &DirentryBindRecord,
 ) -> Result<Vec<DirentryUnbindRecord>> {
     let encoded_name_key = hex_encode_row_key_component(&direntry.name_key);
+    let filter_probe = format!(
+        "direntry-unbind-{:020}-{encoded_name_key}",
+        direntry.parent_inode_id.0
+    );
     let prefix = format!(
-        "direntry-unbind-{:020}-{}-{:020}-{:010}-",
-        direntry.parent_inode_id.0,
-        encoded_name_key,
-        direntry.bind_seq.0,
-        direntry.bind_delta_index
+        "{filter_probe}-{:020}-{:010}-",
+        direntry.bind_seq.0, direntry.bind_delta_index
     );
     Ok(tables
-        .scan_prefix(MetadataTableFamily::DirentryUnbinds, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::DirentryUnbinds, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -218,12 +225,14 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
     revision_no: RevisionNo,
 ) -> Result<Option<RevisionRecord>> {
     let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
+    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
     Ok(tables
-        .scan_range_page(
+        .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &exact_prefix,
             string_prefix_upper_bound(&exact_prefix).as_deref(),
             1,
+            &filter_probe,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -242,15 +251,17 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
         return Ok(Vec::new());
     }
     let inode_prefix = revision_by_inode_desc_inode_prefix(inode_id);
+    let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
     let lower_bound = start_after
         .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
         .unwrap_or_else(|| inode_prefix.clone());
     Ok(tables
-        .scan_range_page(
+        .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &lower_bound,
             string_prefix_upper_bound(&inode_prefix).as_deref(),
             limit,
+            &filter_probe,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -263,9 +274,10 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     root_inode_id: InodeId,
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
-    let prefix = format!("tombstone-{:020}-", root_inode_id.0);
+    let filter_probe = format!("tombstone-{:020}", root_inode_id.0);
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::Tombstones, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::Tombstones, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -278,9 +290,10 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     commit_id: &CommitId,
 ) -> Result<Option<CommitReceiptRecord>> {
     let encoded_commit_id = hex_encode_row_key_component(commit_id.as_str());
-    let prefix = format!("commit-receipt-{encoded_commit_id}-");
+    let filter_probe = format!("commit-receipt-{encoded_commit_id}");
+    let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix(MetadataTableFamily::CommitReceipts, &prefix)
+        .scan_prefix_for_lookup(MetadataTableFamily::CommitReceipts, &prefix, &filter_probe)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -305,6 +318,12 @@ fn resume_after_row_key(row_key: &str) -> String {
 
 fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
     format!("revision-by-inode-desc-{:020}-", inode_id.0)
+}
+
+/// The filter key for revision-by-inode lookups; must match
+/// `MetadataRow::filter_key_for_family` for the family byte-for-byte.
+fn revision_by_inode_desc_filter_probe(inode_id: InodeId) -> String {
+    format!("revision-by-inode-desc-{:020}", inode_id.0)
 }
 
 fn revision_by_inode_desc_exact_revision_prefix(

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -1,6 +1,6 @@
 use super::bootstrap::BootstrapNamespaceError;
 use crate::checkpoint::{
-    create_checkpoint_with_policy_and_owner, load_verified_manifest_tables, read_checkpoint_record,
+    create_checkpoint_with_owner, load_verified_manifest_tables, read_checkpoint_record,
     write_namespace_manifest,
 };
 use crate::context::MutationContext;
@@ -62,11 +62,10 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
 
     // Fork routes through a fork-owned source checkpoint: the pin will
     // reference the checkpoint only, and reachability resolves through it.
-    let checkpoint = create_checkpoint_with_policy_and_owner(
+    let checkpoint = create_checkpoint_with_owner(
         store,
         source_namespace_id,
         context,
-        crate::checkpoint::MetadataLsmPolicy::default(),
         Some(CheckpointOwner {
             kind: "fork".to_owned(),
             id: Some(new_namespace_id.as_str().to_owned()),

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -139,6 +139,10 @@ pub struct RuntimeCacheStats {
     pub metadata_table_cache_inserts: usize,
     /// Blocks evicted from the decoded metadata-table cache.
     pub metadata_table_cache_evictions: usize,
+    /// Segments skipped by their bloom filter before any index or data read.
+    pub metadata_table_cache_filter_skips: usize,
+    /// Segments whose filter admitted a lookup that matched no rows.
+    pub metadata_table_cache_filter_false_positives: usize,
 }
 
 #[derive(Debug, Default)]
@@ -173,6 +177,9 @@ impl RuntimeCacheStatsInner {
             metadata_table_cache_misses: metadata_table_cache.misses,
             metadata_table_cache_inserts: metadata_table_cache.inserts,
             metadata_table_cache_evictions: metadata_table_cache.evictions,
+            metadata_table_cache_filter_skips: metadata_table_cache.filter_skips,
+            metadata_table_cache_filter_false_positives: metadata_table_cache
+                .filter_false_positives,
         }
     }
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -262,6 +262,7 @@ impl FsCore {
         let status_before = self.namespace_status(namespace_id).await?;
         let observed_head_seq = status_before.head_seq;
         if status_before.wal_tail_segments < options.max_wal_tail_segments {
+            self.run_tick_reorganization(namespace_id).await?;
             let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
             return Ok(MaintenanceTickResult {
                 namespace_id: namespace_id.clone(),
@@ -274,6 +275,7 @@ impl FsCore {
         let checkpoint = match self.create_checkpoint(namespace_id).await {
             Ok(checkpoint) => checkpoint,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
+                self.run_tick_reorganization(namespace_id).await?;
                 let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
                 return Ok(MaintenanceTickResult {
                     namespace_id: namespace_id.clone(),
@@ -286,6 +288,7 @@ impl FsCore {
             }
             Err(error) => return Err(error),
         };
+        self.run_tick_reorganization(namespace_id).await?;
 
         let outcome = if checkpoint.current_manifest_id == Some(checkpoint.manifest_id) {
             MaintenanceTickOutcome::CheckpointPublished {
@@ -310,6 +313,37 @@ impl FsCore {
             outcome,
             gc,
         })
+    }
+
+    /// One bounded reorganization unit per tick: folds one family group of
+    /// L0 delta rows into the base when enough L0 runs have piled up (see
+    /// `loonfs-core`'s `reorganize_metadata`). Outcomes are observability,
+    /// not tick results: a superseded unit retries on a later tick.
+    async fn run_tick_reorganization(&self, namespace_id: &NamespaceId) -> Result<()> {
+        let report = self
+            .namespace_engine(namespace_id)
+            .reorganize_metadata()
+            .await
+            .map_err(RuntimeError::Core)?;
+        match &report.outcome {
+            loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {}
+            loonfs_core::MetadataReorganizeOutcome::UnitPublished {
+                families,
+                folded_l0_rows,
+                ..
+            } => {
+                self.invalidate_namespace_cache(namespace_id);
+                tracing::info!(
+                    families = ?families,
+                    folded_l0_rows,
+                    "metadata reorganization unit published"
+                );
+            }
+            loonfs_core::MetadataReorganizeOutcome::Superseded => {
+                tracing::info!("metadata reorganization unit superseded; will retry");
+            }
+        }
+        Ok(())
     }
 
     async fn run_tick_gc(

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2440,7 +2440,9 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
         .expect("read namespace manifest")
         .expect("namespace manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
-    assert_eq!(manifest.payload.base_seq, ChangeSeq(1));
+    // Checkpoints only append: the base marker stays the seed's until
+    // reorganization folds the delta runs.
+    assert_eq!(manifest.payload.base_seq, ChangeSeq(0));
     let l0_files = manifest
         .payload
         .metadata_files
@@ -2450,7 +2452,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
     assert!(!l0_files.is_empty());
     assert!(l0_files
         .iter()
-        .all(|metadata_file| metadata_file.run_seq == ChangeSeq(2)));
+        .any(|metadata_file| metadata_file.run_seq == ChangeSeq(2)));
 }
 
 #[test]


### PR DESCRIPTION
This delivers the checkpoint/compaction split in one PR — the plan sketched it as two, but deleting the old compaction without shipping its replacement would have left delta runs growing forever in between, so they land together.

**The problem.** A checkpoint used to do two jobs: fold the WAL delta, and — every eighth time — silently re-read and rewrite every metadata table in the namespace, inside whatever maintenance tick happened to trip the threshold. That rewrite is why the first tick cost 5.7s at 10k files and 13.9s at 50k: the bill grew with the namespace, not with what changed.

**Checkpoints now only append.** Every checkpoint references all prior runs unchanged and adds one delta (L0) run built from the WAL — including the first checkpoint, which now builds on the bootstrap seed instead of rebuilding. Cost follows the delta, always.

**Reorganization folds the deltas, in bounded units.** A new maintenance operation merges one *family group* at a time — all its rows from every run, minus rows the retention floor lets us drop — into fresh base segments, and publishes a manifest that swaps just that group's references. Families whose retention rules read each other compact together (binds, child binds, and unbinds are one group; revisions and their index another), so the drop invariants and index parity hold inside every unit. The maintenance tick runs at most one unit per tick, and also when the WAL tail is short, so backlogs fold even under light writes.

**There is no progress record.** Each unit ends in a durable manifest, so a crashed reorganization resumes by reading the live manifest and picking the next group that still has delta rows — a test interrupts after one unit, lands another checkpoint in between, and a fresh sequence of steps finishes everything. If a checkpoint races a unit at the root compare-and-swap, the unit's output is simply left unreferenced for garbage collection and the next tick retries; the root publisher's existing "same-seq replacement is pure compaction" rule was written for exactly this.

Retention dropping (superseded revisions, unbound bindings, spent unbind markers, sub-floor receipts) moves whole from the old rebuild into the unit merge — the receipt rule now lives with the others in `drop_rows_below_retention_floor`. The parity validators the old rebuild ran at publication run on every merged pair before anything is written.

Two data points from porting the tests: the old "compacts at the threshold" tests became "checkpoints append past the threshold, reorganization drains" (plus a divergent-index rejection test now aimed at the merge, the production point that folds runs together), and `base_seq` had to become the minimum over *all* referenced runs, because a partially reorganized manifest legitimately holds older delta runs below the newest base.
