### PR TITLE
fix(core): reuse decoded blocks per view without a shared cache

### DIFF
--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -35,8 +35,13 @@ use std::io::Read;
 use thiserror::Error;
 use xxhash_rust::xxh64::xxh64;
 
-/// Target uncompressed size of one data block, in bytes.
-pub const DEFAULT_TARGET_BLOCK_BYTES: usize = 8 * 1024;
+/// Target uncompressed size of one data block, in bytes. Sized for direct
+/// object-store reads: request round-trips dominate transfer time at this
+/// scale, so bulk read paths (directory listings read most rows of several
+/// families) want few large ranged GETs, and a lookup fetching one block
+/// still moves trivial bytes. Benchmarked over 8 KiB, which priced a full
+/// listing at one GET per tiny block.
+pub const DEFAULT_TARGET_BLOCK_BYTES: usize = 64 * 1024;
 /// Entries between restart points inside a data block.
 pub const RESTART_INTERVAL: usize = 16;
 /// Bloom filter sizing: bits reserved per inserted filter key.

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -51,8 +51,8 @@ use loonfs_objectstore::keys::metadata_manifest_prefix;
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
 use loonfs_objectstore::ByteRange;
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::collections::{BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
 use tracing::Instrument;
 
 #[cfg(test)]
@@ -185,6 +185,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         table_cache,
         manifest_object_key: manifest_key,
         manifest,
+        block_memo: SessionBlockMemo::default(),
     };
     Ok(tables)
 }
@@ -533,6 +534,33 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     .await
 }
 
+/// Per-view memo of decoded blocks, so one operation never re-fetches or
+/// re-decodes a block it already saw — the reuse that keeps cache-disabled
+/// paths (cold boot, diagnostics) linear in the blocks they touch. Entries
+/// share the decoded allocations with the shared cache and concurrent
+/// readers; the memo retains pointers, not copies, for the view's lifetime.
+#[derive(Debug, Default)]
+pub(super) struct SessionBlockMemo {
+    blocks: Mutex<HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>>,
+}
+
+impl SessionBlockMemo {
+    fn get(&self, cache_key: &MetadataTableCacheKey) -> Option<DecodedMetadataTableBlock> {
+        self.blocks
+            .lock()
+            .expect("session block memo lock poisoned")
+            .get(cache_key)
+            .cloned()
+    }
+
+    fn record(&self, cache_key: &MetadataTableCacheKey, block: &DecodedMetadataTableBlock) {
+        self.blocks
+            .lock()
+            .expect("session block memo lock poisoned")
+            .insert(cache_key.clone(), block.clone());
+    }
+}
+
 /// Widest block selection served by per-block single-flight fetches; wider
 /// selections bulk-fetch their missing spans with coalesced ranged GETs.
 const NARROW_BLOCK_FETCH_LIMIT: usize = 4;
@@ -555,6 +583,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     let row_set = load_manifest_segment_rows_in_key_range_with_cache(
         store,
         table_cache,
+        &SessionBlockMemo::default(),
         context,
         family,
         descriptor,
@@ -592,6 +621,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
 pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
     context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
@@ -600,18 +630,34 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     upper_bound: Option<&str>,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     context.expected_segment_seq(descriptor)?;
-    let index = load_segment_index(store, table_cache, descriptor, cache_mode).await?;
+    let index = load_segment_index(store, table_cache, memo, descriptor, cache_mode).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
     let entries = &index[needed];
 
     let blocks = if entries.len() <= NARROW_BLOCK_FETCH_LIMIT {
         futures::future::try_join_all(entries.iter().map(|entry| {
-            load_segment_data_block(store, table_cache, family, descriptor, entry, cache_mode)
+            load_segment_data_block(
+                store,
+                table_cache,
+                memo,
+                family,
+                descriptor,
+                entry,
+                cache_mode,
+            )
         }))
         .await?
     } else {
-        load_segment_data_block_span(store, table_cache, family, descriptor, entries, cache_mode)
-            .await?
+        load_segment_data_block_span(
+            store,
+            table_cache,
+            memo,
+            family,
+            descriptor,
+            entries,
+            cache_mode,
+        )
+        .await?
     };
 
     let mut rows = Vec::new();
@@ -685,12 +731,16 @@ fn segment_codec_error(object_key: &str, err: impl std::fmt::Display) -> Manifes
 async fn load_segment_index<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
     let handle = descriptor.index_block;
     let cache_key =
         segment_block_cache_key(descriptor, MetadataTableBlockKind::Index, handle.offset);
+    if let Some(DecodedMetadataTableBlock::Index { entries, .. }) = memo.get(&cache_key) {
+        return Ok(entries);
+    }
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -719,6 +769,7 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
         }
         None => fetch().await?,
     };
+    memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
         DecodedMetadataTableBlock::Filter { .. } | DecodedMetadataTableBlock::Data { .. } => {
@@ -735,12 +786,16 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
 pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
     cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<SegmentFilter>, ManifestLoadError> {
     let handle = descriptor.filter_block;
     let cache_key =
         segment_block_cache_key(descriptor, MetadataTableBlockKind::Filter, handle.offset);
+    if let Some(DecodedMetadataTableBlock::Filter { filter, .. }) = memo.get(&cache_key) {
+        return Ok(filter);
+    }
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -769,6 +824,7 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         }
         None => fetch().await?,
     };
+    memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
         DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Data { .. } => Err(
@@ -780,6 +836,7 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
 async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entry: &SegmentIndexEntry,
@@ -788,6 +845,9 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     let handle = entry.block;
     let cache_key =
         segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
+    if let Some(DecodedMetadataTableBlock::Data { block, .. }) = memo.get(&cache_key) {
+        return Ok(block);
+    }
     let fetch = || async {
         let bytes = fetch_section_bytes(
             store,
@@ -815,6 +875,7 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         }
         None => fetch().await?,
     };
+    memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Data { block, .. } => Ok(block),
         DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
@@ -844,6 +905,7 @@ fn decoded_data_cache_block(
 async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entries: &[SegmentIndexEntry],
@@ -852,13 +914,14 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     let consult = cache_mode != MetadataTableCacheMode::Bypass;
     let populate = cache_mode == MetadataTableCacheMode::Populate;
     let mut blocks: Vec<Option<Arc<DecodedDataBlock>>> = vec![None; entries.len()];
-    if let (Some(cache), true) = (table_cache, consult) {
-        for (position, entry) in entries.iter().enumerate() {
-            let cache_key = segment_block_cache_key(
-                descriptor,
-                MetadataTableBlockKind::Data,
-                entry.block.offset,
-            );
+    for (position, entry) in entries.iter().enumerate() {
+        let cache_key =
+            segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, entry.block.offset);
+        if let Some(DecodedMetadataTableBlock::Data { block, .. }) = memo.get(&cache_key) {
+            blocks[position] = Some(block);
+            continue;
+        }
+        if let (Some(cache), true) = (table_cache, consult) {
             if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&cache_key) {
                 blocks[position] = Some(block);
             }
@@ -907,19 +970,15 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 decode_data_block(stored, &handle)
                     .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
             );
+            let cache_key =
+                segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
+            let cache_block = DecodedMetadataTableBlock::Data {
+                decoded_byte_len: decoded_manifest_block_weight(family, &decoded.rows),
+                block: Arc::clone(&decoded),
+            };
+            memo.record(&cache_key, &cache_block);
             if let (Some(cache), true) = (table_cache, populate) {
-                let cache_key = segment_block_cache_key(
-                    descriptor,
-                    MetadataTableBlockKind::Data,
-                    handle.offset,
-                );
-                cache.insert(
-                    cache_key,
-                    DecodedMetadataTableBlock::Data {
-                        decoded_byte_len: decoded_manifest_block_weight(family, &decoded.rows),
-                        block: Arc::clone(&decoded),
-                    },
-                );
+                cache.insert(cache_key, cache_block);
             }
             blocks[start + position] = Some(decoded);
         }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -564,6 +564,13 @@ impl SessionBlockMemo {
 /// Widest block selection served by per-block single-flight fetches; wider
 /// selections bulk-fetch their missing spans with coalesced ranged GETs.
 const NARROW_BLOCK_FETCH_LIMIT: usize = 4;
+/// Blocks a range scan reads ahead within a segment. Paged scans ask for a
+/// couple of blocks at a time while marching through whole segments; without
+/// readahead every page pays its own small GETs, and request counts scale
+/// with pages instead of bytes. Read-ahead blocks land in the per-view memo
+/// and shared cache, so the following pages are memory hits. 32 blocks of
+/// the 8 KiB target is a ~256 KiB ranged GET.
+const RANGE_SCAN_READAHEAD_BLOCKS: usize = 32;
 /// Longest single ranged GET issued while bulk-reading a block span; longer
 /// spans split into consecutive requests.
 const MAX_BULK_FETCH_BYTES: u64 = 4 * 1024 * 1024;
@@ -590,6 +597,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         cache_mode,
         "",
         None,
+        false,
     )
     .await?;
     if row_set.rows.len() as u64 != descriptor.row_count {
@@ -628,13 +636,37 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     cache_mode: MetadataTableCacheMode,
     lower_bound: &str,
     upper_bound: Option<&str>,
+    readahead: bool,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     context.expected_segment_seq(descriptor)?;
     let index = load_segment_index(store, table_cache, memo, descriptor, cache_mode).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
-    let entries = &index[needed];
 
-    let blocks = if entries.len() <= NARROW_BLOCK_FETCH_LIMIT {
+    // A paged scan marches onward through the segment: read ahead so the
+    // following pages are served from the memo instead of their own GETs.
+    let extended_end = if readahead {
+        needed
+            .start
+            .saturating_add(RANGE_SCAN_READAHEAD_BLOCKS)
+            .max(needed.end)
+            .min(index.len())
+    } else {
+        needed.end
+    };
+    let blocks = if extended_end - needed.start > NARROW_BLOCK_FETCH_LIMIT {
+        let fetched = load_segment_data_block_span(
+            store,
+            table_cache,
+            memo,
+            family,
+            descriptor,
+            &index[needed.start..extended_end],
+            cache_mode,
+        )
+        .await?;
+        fetched.into_iter().take(needed.len()).collect()
+    } else if needed.len() <= NARROW_BLOCK_FETCH_LIMIT {
+        let entries = &index[needed];
         futures::future::try_join_all(entries.iter().map(|entry| {
             load_segment_data_block(
                 store,
@@ -654,7 +686,7 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
             memo,
             family,
             descriptor,
-            entries,
+            &index[needed],
             cache_mode,
         )
         .await?
@@ -951,43 +983,106 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         spans.push((start, cursor));
     }
 
-    let fetched = futures::future::try_join_all(spans.iter().map(|(start, end)| {
+    futures::future::try_join_all(spans.iter().map(|(start, end)| {
         let span = &entries[*start..*end];
-        let first = &span[0].block;
-        let last = &span[span.len() - 1].block;
-        let span_len = last.offset + u64::from(last.stored_len) - first.offset;
-        fetch_section_bytes(store, &descriptor.object_key, first.offset, span_len)
+        async move {
+            // Single-flight on the span's first block: the winning fetch
+            // decodes and publishes the whole span, so a concurrent scan
+            // waiting here finds the remaining blocks in the shared cache
+            // instead of re-fetching the span.
+            let first_key = segment_block_cache_key(
+                descriptor,
+                MetadataTableBlockKind::Data,
+                span[0].block.offset,
+            );
+            let fetch = || async {
+                fetch_and_publish_span(store, table_cache, memo, family, descriptor, span, populate)
+                    .await
+            };
+            match table_cache {
+                Some(cache) => {
+                    cache
+                        .get_or_fetch(&first_key, consult, populate, fetch)
+                        .await?;
+                }
+                None => {
+                    fetch().await?;
+                }
+            }
+            Ok::<_, ManifestLoadError>(())
+        }
     }))
     .await?;
 
-    for ((start, end), bytes) in spans.into_iter().zip(fetched) {
-        let base_offset = entries[start].block.offset;
-        for (position, entry) in entries[start..end].iter().enumerate() {
-            let handle = entry.block;
-            let begin = (handle.offset - base_offset) as usize;
-            let stored = &bytes[begin..begin + handle.stored_len as usize];
-            let decoded = Arc::new(
-                decode_data_block(stored, &handle)
-                    .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
-            );
-            let cache_key =
-                segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
-            let cache_block = DecodedMetadataTableBlock::Data {
-                decoded_byte_len: decoded_manifest_block_weight(family, &decoded.rows),
-                block: Arc::clone(&decoded),
-            };
-            memo.record(&cache_key, &cache_block);
-            if let (Some(cache), true) = (table_cache, populate) {
-                cache.insert(cache_key, cache_block);
-            }
-            blocks[start + position] = Some(decoded);
+    // Everything the winner published (or this call fetched) is resolvable
+    // now; blocks a read-only winner could not publish are fetched alone.
+    for (position, entry) in entries.iter().enumerate() {
+        if blocks[position].is_some() {
+            continue;
         }
+        blocks[position] = Some(
+            load_segment_data_block(
+                store,
+                table_cache,
+                memo,
+                family,
+                descriptor,
+                entry,
+                cache_mode,
+            )
+            .await?,
+        );
     }
 
     Ok(blocks
         .into_iter()
-        .map(|block| block.expect("every selected block is either cached or span-fetched"))
+        .map(|block| block.expect("every selected block is resolved above"))
         .collect())
+}
+
+/// Fetches one contiguous span with a single ranged GET, decodes every
+/// block, and publishes them to the per-view memo and (when populating) the
+/// shared cache. Returns the first block's cache entry for the
+/// single-flight cell.
+async fn fetch_and_publish_span<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
+    family: MetadataTableFamily,
+    descriptor: &MetadataFileRef,
+    span: &[SegmentIndexEntry],
+    populate: bool,
+) -> Result<DecodedMetadataTableBlock, ManifestLoadError> {
+    let first = &span[0].block;
+    let last = &span[span.len() - 1].block;
+    let span_len = last.offset + u64::from(last.stored_len) - first.offset;
+    let bytes = fetch_section_bytes(store, &descriptor.object_key, first.offset, span_len).await?;
+    let mut first_block = None;
+    for entry in span {
+        let handle = entry.block;
+        let begin = (handle.offset - first.offset) as usize;
+        let stored = &bytes[begin..begin + handle.stored_len as usize];
+        let decoded = Arc::new(
+            decode_data_block(stored, &handle)
+                .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
+        );
+        let cache_key =
+            segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
+        let cache_block = DecodedMetadataTableBlock::Data {
+            decoded_byte_len: decoded_manifest_block_weight(family, &decoded.rows),
+            block: decoded,
+        };
+        memo.record(&cache_key, &cache_block);
+        if let (Some(cache), true) = (table_cache, populate) {
+            // The first block is what the single-flight cell publishes;
+            // inserting it here too keeps the whole span uniformly cached.
+            cache.insert(cache_key, cache_block.clone());
+        }
+        if first_block.is_none() {
+            first_block = Some(cache_block);
+        }
+    }
+    Ok(first_block.expect("a span always holds at least one block"))
 }
 
 pub(super) fn decoded_manifest_block_weight(

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
-pub(super) const DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT: usize = 4096;
+/// With block-granular reads the segment is no longer the read unit, so
+/// base segments are sized large to amortize their index and filter
+/// sections across many lookups (design doc, "Sizing").
+pub(super) const DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT: usize = 65_536;
 
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 #[cfg(test)]

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -6,7 +6,7 @@ use super::error::ManifestLoadError;
 use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
     metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableCacheMode,
-    MetadataTableLoadContext,
+    MetadataTableLoadContext, SessionBlockMemo,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -41,6 +41,9 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
     pub(super) table_cache: Option<&'a MetadataTableCache>,
     pub(super) manifest_object_key: String,
     pub(super) manifest: NamespaceManifestEnvelope,
+    /// Per-view memo of decoded blocks: one operation never re-fetches a
+    /// block it already saw, with or without a shared cache attached.
+    pub(super) block_memo: SessionBlockMemo,
 }
 
 impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
@@ -181,8 +184,14 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         cache_mode: MetadataTableCacheMode,
         filter_probe: &str,
     ) -> Result<bool, ManifestLoadError> {
-        let filter =
-            load_segment_filter(self.store, self.table_cache, descriptor, cache_mode).await?;
+        let filter = load_segment_filter(
+            self.store,
+            self.table_cache,
+            &self.block_memo,
+            descriptor,
+            cache_mode,
+        )
+        .await?;
         if filter.may_contain(filter_probe) {
             return Ok(true);
         }
@@ -413,6 +422,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         load_manifest_segment_rows_in_key_range_with_cache(
             self.store,
             self.table_cache,
+            &self.block_memo,
             context,
             family,
             descriptor,

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -56,6 +56,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         key: &str,
         filter_probe: &str,
+        readahead: bool,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
             .scan_prefix_with_cache_mode(
@@ -63,6 +64,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 key,
                 MetadataTableCacheMode::Populate,
                 Some(filter_probe),
+                readahead,
             )
             .await?
             .into_iter()
@@ -76,7 +78,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let matching_segment_count = self.matching_segment_count(family, prefix)?;
         let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, None)
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, None, true)
             .await
     }
 
@@ -90,10 +92,11 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         prefix: &str,
         filter_probe: &str,
+        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let matching_segment_count = self.matching_segment_count(family, prefix)?;
         let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, Some(filter_probe))
+        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, Some(filter_probe), readahead)
             .await
     }
 
@@ -123,12 +126,13 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, None)
+        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, None, true)
             .await
     }
 
     /// [`Self::scan_range_page`] for a point lookup within one filter key's
     /// range; see [`Self::scan_prefix_for_lookup`] for the probe contract.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn scan_range_page_for_lookup(
         &self,
         family: MetadataTableFamily,
@@ -136,12 +140,20 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         upper_bound: Option<&str>,
         limit: usize,
         filter_probe: &str,
+        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        self.scan_range_page_rows(family, lower_bound, upper_bound, limit, Some(filter_probe))
-            .await
+        self.scan_range_page_rows(
+            family,
+            lower_bound,
+            upper_bound,
+            limit,
+            Some(filter_probe),
+            readahead,
+        )
+        .await
     }
 
     async fn scan_prefix_with_cache_mode(
@@ -150,6 +162,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         prefix: &str,
         cache_mode: MetadataTableCacheMode,
         filter_probe: Option<&str>,
+        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut rows = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -168,6 +181,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                     cache_mode,
                 },
                 filter_probe,
+                readahead,
             )
             .await?;
         }
@@ -224,6 +238,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         Ok(count)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn scan_range_page_rows(
         &self,
         family: MetadataTableFamily,
@@ -231,6 +246,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         upper_bound: Option<&str>,
         limit: usize,
         filter_probe: Option<&str>,
+        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         let mut matching_descriptors = Vec::new();
         for run in runs_in_scan_order(&self.manifest.payload) {
@@ -303,7 +319,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                             cache_mode,
                             lower_bound,
                             upper_bound,
-                            filter_probe.is_none(),
+                            readahead,
                         )
                     }),
             )
@@ -322,6 +338,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         Ok(rows.into_iter().map(|(_, row)| row).collect())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn scan_manifest_tables(
         &self,
         family: MetadataTableFamily,
@@ -330,6 +347,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         tables: &[MetadataTableManifest],
         output: MetadataTableScanOutput<'_>,
         filter_probe: Option<&str>,
+        readahead: bool,
     ) -> Result<(), ManifestLoadError> {
         let table = manifest_table_for_family(context.manifest_object_key, tables, family)?;
         let mut matching_descriptors = Vec::new();
@@ -363,7 +381,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                         output.cache_mode,
                         prefix,
                         prefix_upper_bound.as_deref(),
-                        filter_probe.is_none(),
+                        readahead,
                     )
                 }))
                 .await?,

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -303,6 +303,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                             cache_mode,
                             lower_bound,
                             upper_bound,
+                            filter_probe.is_none(),
                         )
                     }),
             )
@@ -362,6 +363,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                         output.cache_mode,
                         prefix,
                         prefix_upper_bound.as_deref(),
+                        filter_probe.is_none(),
                     )
                 }))
                 .await?,
@@ -410,6 +412,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         Ok(admitted)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn segment_rows(
         &self,
         context: MetadataTableLoadContext<'_>,
@@ -418,6 +421,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         cache_mode: MetadataTableCacheMode,
         lower_bound: &str,
         upper_bound: Option<&str>,
+        readahead: bool,
     ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
         load_manifest_segment_rows_in_key_range_with_cache(
             self.store,
@@ -429,6 +433,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             cache_mode,
             lower_bound,
             upper_bound,
+            readahead,
         )
         .await
     }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2703,6 +2703,7 @@ async fn lookup_skips_segments_whose_filter_rules_the_name_out() {
             ApiMetadataTableFamily::DirentryBinds,
             &prefix,
             &filter_probe,
+            false,
         )
         .await
         .expect("filtered lookup");
@@ -2754,7 +2755,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
 
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
         .await
         .expect("get inode")
         .is_some());
@@ -4037,7 +4038,7 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     store.reset_metadata_sst_gets();
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
         .await
         .expect("first lookup")
         .is_some());
@@ -4045,13 +4046,13 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     assert!(first_lookup_gets > 0, "a cold lookup fetches blocks");
 
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
         .await
         .expect("repeated lookup")
         .is_some());
     let other = "inode-00000000000000000002";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other, false)
         .await
         .expect("second-key lookup")
         .is_some());

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -3997,6 +3997,72 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
 }
 
 #[tokio::test]
+async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    let manifest_object_id = {
+        checkpoint_then_reorganize(
+            &store,
+            &namespace_id,
+            &context,
+            MetadataLsmPolicy::default(),
+        )
+        .await;
+        current_manifest_object_id(&store, &namespace_id).await
+    };
+
+    // The cold-boot shape: a view with no shared cache attached. Repeating
+    // a lookup must not re-fetch — the per-view memo is the only reuse this
+    // configuration has, and without it a cold list degrades from one fetch
+    // per block to one fetch per lookup.
+    let tables = super::load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    store.reset_metadata_sst_gets();
+    let key = "inode-00000000000000000001";
+    assert!(tables
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
+        .await
+        .expect("first lookup")
+        .is_some());
+    let first_lookup_gets = store.metadata_sst_gets();
+    assert!(first_lookup_gets > 0, "a cold lookup fetches blocks");
+
+    assert!(tables
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
+        .await
+        .expect("repeated lookup")
+        .is_some());
+    let other = "inode-00000000000000000002";
+    assert!(tables
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other)
+        .await
+        .expect("second-key lookup")
+        .is_some());
+    assert_eq!(
+        store.metadata_sst_gets(),
+        first_lookup_gets,
+        "later lookups through the same view should reuse decoded blocks"
+    );
+}
+
+#[tokio::test]
 async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     let temp_dir = tempdir().expect("tempdir");
     let store =

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -24,7 +24,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 ) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
-        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
+        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key, true)
         .await
         .map_err(manifest_error_to_core)?
         .and_then(inode_from_manifest_row))
@@ -90,7 +90,12 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     let filter_probe = format!("direntry-{:020}-{encoded_name_key}", parent_inode_id.0);
     let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix_for_lookup(MetadataTableFamily::DirentryBinds, &prefix, &filter_probe)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::DirentryBinds,
+            &prefix,
+            &filter_probe,
+            false,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -109,6 +114,7 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
             MetadataTableFamily::DirentryChildBinds,
             &prefix,
             &filter_probe,
+            true,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -131,7 +137,12 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         direntry.bind_seq.0, direntry.bind_delta_index
     );
     Ok(tables
-        .scan_prefix_for_lookup(MetadataTableFamily::DirentryUnbinds, &prefix, &filter_probe)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::DirentryUnbinds,
+            &prefix,
+            &filter_probe,
+            false,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -233,6 +244,7 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&exact_prefix).as_deref(),
             1,
             &filter_probe,
+            true,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -262,6 +274,7 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&inode_prefix).as_deref(),
             limit,
             &filter_probe,
+            true,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -277,7 +290,12 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     let filter_probe = format!("tombstone-{:020}", root_inode_id.0);
     let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix_for_lookup(MetadataTableFamily::Tombstones, &prefix, &filter_probe)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::Tombstones,
+            &prefix,
+            &filter_probe,
+            true,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
@@ -293,7 +311,12 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     let filter_probe = format!("commit-receipt-{encoded_commit_id}");
     let prefix = format!("{filter_probe}-");
     Ok(tables
-        .scan_prefix_for_lookup(MetadataTableFamily::CommitReceipts, &prefix, &filter_probe)
+        .scan_prefix_for_lookup(
+            MetadataTableFamily::CommitReceipts,
+            &prefix,
+            &filter_probe,
+            false,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -1,0 +1,325 @@
+//! Diagnostic (ignored): per-section request accounting for the warm-ops
+//! benchmark shape. Builds a bench-like namespace, then runs each warm
+//! phase on a fresh handle while classifying every store GET — by object
+//! class, and for metadata tables by section (index / filter / data),
+//! family, and run level, using the live manifest's own descriptors.
+//!
+//! Run with:
+//!   cargo test -p loonfs --test request_accounting -- --ignored --nocapture
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs::{
+    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
+    PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
+};
+
+use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+const FILES: usize = 10_000;
+const BATCH: usize = 100;
+const TICK_EVERY_BATCHES: usize = 33;
+
+type RecordedGet = (String, Option<(u64, u64)>);
+
+#[derive(Debug, Default)]
+struct RequestLog {
+    gets: Mutex<Vec<RecordedGet>>,
+}
+
+impl RequestLog {
+    fn record(&self, key: &str, range: Option<&ByteRange>) {
+        self.gets.lock().expect("request log lock poisoned").push((
+            key.to_owned(),
+            range.map(|range| (range.start_inclusive, range.end_exclusive)),
+        ));
+    }
+
+    fn take(&self) -> Vec<RecordedGet> {
+        std::mem::take(&mut *self.gets.lock().expect("request log lock poisoned"))
+    }
+}
+
+#[derive(Debug)]
+struct RecordingStore {
+    inner: LocalFsStore,
+    log: Arc<RequestLog>,
+}
+
+impl RecordingStore {
+    fn new(root: &Path, log: Arc<RequestLog>) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            log,
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for RecordingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.log.record(key, range.as_ref());
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.log.record(key, None);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// (family, level, index_offset, filter_offset) per table object key.
+type TableMap = BTreeMap<String, (String, u32, u64, u64)>;
+
+async fn table_map(store: &SharedObjectStore, namespace_id: &NamespaceId) -> TableMap {
+    let root = loonfs_core::control::load_namespace_metadata_root_control(store, namespace_id)
+        .await
+        .expect("load metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read manifest")
+        .expect("manifest exists");
+    let manifest = decode_namespace_manifest_json(&bytes).expect("decode manifest");
+    manifest
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| {
+            (
+                descriptor.object_key.clone(),
+                (
+                    format!("{:?}", descriptor.family),
+                    descriptor.level,
+                    descriptor.index_block.offset,
+                    descriptor.filter_block.offset,
+                ),
+            )
+        })
+        .collect()
+}
+
+#[allow(clippy::print_stdout)]
+fn report(phase: &str, gets: &[RecordedGet], tables: &TableMap) {
+    let mut by_class: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_table: BTreeMap<String, usize> = BTreeMap::new();
+    for (key, range) in gets {
+        let class = if let Some((family, level, index_offset, filter_offset)) = tables.get(key) {
+            let section = match range {
+                Some((start, _)) if start == index_offset => "index",
+                Some((start, _)) if start == filter_offset => "filter",
+                Some(_) => "data",
+                None => "whole",
+            };
+            by_table
+                .entry(format!("L{level} {family} {section}"))
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            format!("table:{section}")
+        } else if key.contains("/wal/segments/") {
+            "wal".to_owned()
+        } else if key.contains("/manifests/") {
+            "manifest".to_owned()
+        } else if key.contains("content-stores/") {
+            "content".to_owned()
+        } else {
+            "control".to_owned()
+        };
+        by_class
+            .entry(class)
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+    }
+    println!("== {phase}: {} GETs", gets.len());
+    for (class, count) in &by_class {
+        println!("   {class:<16} {count}");
+    }
+    for (bucket, count) in &by_table {
+        println!("     {bucket:<44} {count}");
+    }
+}
+
+#[allow(clippy::print_stdout)]
+#[tokio::test]
+#[ignore = "diagnostic: prints warm-phase request accounting"]
+async fn warm_phase_request_accounting() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RequestLog::default());
+    let store: SharedObjectStore = Arc::new(RecordingStore::new(temp_dir.path(), Arc::clone(&log)));
+    let namespace_id = NamespaceId::parse("acct").expect("valid namespace id");
+
+    // Build phase: bench-like shape — one wide hot directory, maintenance
+    // ticks a few times so the manifest ends with a seed base plus a few L0
+    // runs and a WAL tail, like the 10k benchmark build.
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("acct-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("acct-admin")
+        .build()
+        .await
+        .expect("build admin");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    // The bench publishes 100-mutation batches (one WAL segment each) and
+    // ticks a few times across the build; mirror that shape.
+    let mut index = 0usize;
+    while index < FILES {
+        let mut candidates = Vec::with_capacity(BATCH);
+        for _ in 0..BATCH.min(FILES - index) {
+            let bytes = format!("body {index}");
+            let content_ref = loonfs_core::content::store_bytes_as_content(
+                &store,
+                &namespace_id,
+                bytes.as_bytes(),
+            )
+            .await
+            .expect("stage content")
+            .content_ref;
+            candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
+                loonfs::publish::PathMutationIntent::PutFile {
+                    commit_id: loonfs::CommitId::generate(),
+                    absolute_path: format!("/hot/file-{index:05}.txt"),
+                    content_ref,
+                    behavior: loonfs::PutBehavior::NoReplace,
+                },
+            ));
+            index += 1;
+        }
+        for outcome in writer
+            .publish_namespace_mutations_batch(&namespace_id, candidates)
+            .await
+        {
+            outcome.expect("publish batch member");
+        }
+        if (index / BATCH) % TICK_EVERY_BATCHES == 0 {
+            admin
+                .maintenance_tick_namespace(
+                    &namespace_id,
+                    MaintenanceTickOptions {
+                        max_wal_tail_segments: 1,
+                        ..MaintenanceTickOptions::default()
+                    },
+                )
+                .await
+                .expect("tick");
+        }
+    }
+    let tables = table_map(&store, &namespace_id).await;
+    println!(
+        "layout: {} table objects across levels {:?}",
+        tables.len(),
+        tables
+            .values()
+            .map(|(_, level, _, _)| *level)
+            .collect::<std::collections::BTreeSet<_>>()
+    );
+    let _ = log.take();
+
+    // Warm phases, each on the same fresh handle like the bench: a full
+    // paged list, then stat, read, write.
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    let limit = PaginationPolicy::from_values(1_000, 1_000)
+        .expect("valid pagination policy")
+        .resolve_limit(Some(1_000))
+        .expect("valid limit");
+    let mut listed = 0usize;
+    let mut cursor = None;
+    loop {
+        let page = reader
+            .list_path_entries_page(&namespace_id, "/hot", PageRequest { limit, cursor })
+            .await
+            .expect("list page");
+        listed += page.entries.len();
+        match page.next_cursor.as_deref() {
+            Some(encoded) => {
+                cursor = Some(
+                    loonfs_api::decode_directory_cursor(encoded).expect("valid directory cursor"),
+                );
+            }
+            None => break,
+        }
+    }
+    assert_eq!(listed, FILES);
+    report("warm full list", &log.take(), &tables);
+
+    reader
+        .stat_path(&namespace_id, "/hot/file-04999.txt")
+        .await
+        .expect("stat");
+    report("warm stat", &log.take(), &tables);
+
+    reader
+        .read_file_bytes(&namespace_id, "/hot/file-05000.txt")
+        .await
+        .expect("read");
+    report("warm read", &log.take(), &tables);
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("acct-writer-2")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build second writer");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/hot/file-05001.txt",
+            b"replaced",
+            PutFileOptions {
+                behavior: loonfs::PutBehavior::Replace,
+                commit_id: None,
+            },
+        )
+        .await
+        .expect("warm write");
+    report("warm write", &log.take(), &tables);
+}


### PR DESCRIPTION
Fixes a severe cold-path regression the pre-merge benchmark caught, stacked on #222.

#220 deleted the per-view segment memo, reasoning that the shared block cache covers reuse. That's true whenever a cache is attached — but the cold-boot benchmark phase (and any diagnostics configuration) runs with caches disabled, and there the memo was the *only* reuse. Without it, every lookup in a cold list re-fetched its index and data blocks from scratch: the 10k cold list went from about two minutes to still-running-after-two-hours, at ~100k+ serial ranged GETs.

The fix restores per-view reuse at block granularity, which is correct in the block world where the old per-segment memo wasn't (a per-segment memo could serve a partial range as if it were the whole segment; a block is always whole). Each view now carries a memo of the decoded blocks it has seen — index, filter, and data — consulted before the shared cache and populated on every fetch. Entries are pointers into the same allocations the cache shares, held for the view's lifetime, so the memory story is unchanged from the old memo.

Regression test: in the cache-disabled configuration, a repeated lookup and a different-key lookup through the same view issue zero additional GETs after the first.

A second commit applies the design's segment sizing, which the format PRs never actually landed: base segments grow from 4,096 to 65,536 rows. With block-granular reads the segment is no longer the read unit, and the first post-fix benchmark showed why the constant matters — at 4,096 rows a 10k namespace shards every family into several small segments, and each consulted segment pays its own index and filter fetches, inflating request counts ~9x over the old one-GET-per-segment world. Fewer, larger segments amortize those sections the way the design intended.

A third commit adds read-ahead for range scans, the structural fix for the request-count inflation the second benchmark run measured (warm GETs 85 → 789 versus the old format). A paged listing marches through segments a couple of blocks at a time; without read-ahead every page pays its own small GETs, so request counts scale with pages instead of bytes. Range scans (which carry no filter probe — the probe doubles as the point-lookup marker) now fetch ~32 blocks (~256 KiB) ahead in one ranged GET, landing them in the per-view memo so the following pages are memory hits. Point lookups are unchanged. Span fetches also go through single-flight now, keyed on the span's first block, so concurrent scans share one fetch — with one carve-out kept deliberately: selections small enough for the per-block path stay on it, because only value-carrying per-block cells can share results under a read-only (count-bounded) cache, which is exactly the property the concurrent-scan test pins.

The last two commits came from chasing the remaining request-count inflation with a request-accounting probe (kept in the tree as an ignored diagnostic test) instead of more guesswork. It showed the warm list's ~790 GETs were per-child point lookups — revisions, child bindings, inodes — each fetching its own scattered 8 KiB block, while page scans, filters, and indexes were all cheap. So: per-child lookups now read ahead too (they are point-shaped but neighborhood-clustered; readahead is decoupled from the filter probe, which they keep), and blocks grow from 8 KiB to 64 KiB — the design doc explicitly deferred block size to first-benchmark tuning, and on a store where round-trips dominate, a full listing priced at one GET per tiny block was the wrong side of the trade.
