### PR TITLE
refactor(core): one block fetch path with an always-on byte budget

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS: usize = 8192;
 pub struct MetadataTableCacheConfig {
     pub enabled: bool,
     pub max_blocks: usize,
-    pub max_decoded_bytes: Option<usize>,
+    pub max_decoded_bytes: usize,
 }
 
 impl Default for MetadataTableCacheConfig {
@@ -28,7 +28,7 @@ impl Default for MetadataTableCacheConfig {
         Self {
             enabled: true,
             max_blocks: DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
-            max_decoded_bytes: Some(DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES),
+            max_decoded_bytes: DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES,
         }
     }
 }
@@ -180,8 +180,6 @@ impl MetadataTableCache {
     pub(super) async fn get_or_fetch<E, F, Fut>(
         &self,
         cache_key: &MetadataTableCacheKey,
-        consult: bool,
-        populate: bool,
         fetch: F,
     ) -> Result<DecodedMetadataTableBlock, E>
     where
@@ -201,15 +199,11 @@ impl MetadataTableCache {
         };
         let result = cell
             .get_or_try_init(|| async {
-                if consult {
-                    if let Some(block) = self.get(cache_key) {
-                        return Ok(block);
-                    }
+                if let Some(block) = self.get(cache_key) {
+                    return Ok(block);
                 }
                 let block = fetch().await?;
-                if populate {
-                    self.insert(cache_key.clone(), block.clone());
-                }
+                self.insert(cache_key.clone(), block.clone());
                 Ok(block)
             })
             .await
@@ -248,15 +242,6 @@ impl MetadataTableCache {
             .fetch_add(1, Ordering::SeqCst);
     }
 
-    /// Whether inserts are bounded by a decoded-byte budget. A byte-budgeted
-    /// cache admits scans of any width safely: eviction is sized by decoded
-    /// bytes, so one wide scan cannot pin more memory than the budget. Without
-    /// a byte budget only entry count bounds the cache, and wide admissions
-    /// would flush it.
-    pub(super) fn byte_budgeted(&self) -> bool {
-        self.config.max_decoded_bytes.is_some()
-    }
-
     pub(super) fn get(&self, key: &MetadataTableCacheKey) -> Option<DecodedMetadataTableBlock> {
         if !self.config.enabled || self.config.max_blocks == 0 {
             return None;
@@ -293,11 +278,7 @@ impl MetadataTableCache {
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
         while inner.entries.len() > self.config.max_blocks
-            || self
-                .config
-                .max_decoded_bytes
-                .map(|max_decoded_bytes| inner.decoded_byte_len > max_decoded_bytes)
-                .unwrap_or(false)
+            || inner.decoded_byte_len > self.config.max_decoded_bytes
         {
             let Some(evicted) = inner.order.pop_front() else {
                 break;
@@ -588,7 +569,7 @@ mod tests {
         let config = MetadataTableCacheConfig::default();
         assert_eq!(
             config.max_decoded_bytes,
-            Some(super::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES)
+            super::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES
         );
         assert_eq!(
             config.max_blocks,
@@ -601,7 +582,7 @@ mod tests {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig {
             enabled: true,
             max_blocks: 100,
-            max_decoded_bytes: Some(1000),
+            max_decoded_bytes: 1000,
         });
         cache.insert(key("a"), block(600));
         cache.insert(key("b"), block(600));
@@ -618,7 +599,7 @@ mod tests {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig {
             enabled: true,
             max_blocks: 100,
-            max_decoded_bytes: Some(1000),
+            max_decoded_bytes: 1000,
         });
         cache.insert(key("a"), block(600));
         cache.insert(key("a"), block(100));
@@ -659,13 +640,11 @@ mod tests {
     async fn get_or_fetch_retries_after_a_failed_fetch() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
         let failed: Result<_, String> = cache
-            .get_or_fetch(&key("a"), true, true, || async {
-                Err("transport".to_owned())
-            })
+            .get_or_fetch(&key("a"), || async { Err("transport".to_owned()) })
             .await;
         assert!(failed.is_err());
         let recovered: Result<_, String> = cache
-            .get_or_fetch(&key("a"), true, true, || async { Ok(block(1)) })
+            .get_or_fetch(&key("a"), || async { Ok(block(1)) })
             .await;
         assert!(
             recovered.is_ok(),
@@ -677,11 +656,11 @@ mod tests {
     async fn get_or_fetch_counts_one_miss_and_populates_for_later_hits() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
         let fetched: Result<_, String> = cache
-            .get_or_fetch(&key("a"), true, true, || async { Ok(block(1)) })
+            .get_or_fetch(&key("a"), || async { Ok(block(1)) })
             .await;
         assert!(fetched.is_ok());
         let cached: Result<_, String> = cache
-            .get_or_fetch(&key("a"), true, true, || async {
+            .get_or_fetch(&key("a"), || async {
                 Err("a populated key must not re-fetch".to_owned())
             })
             .await;

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -399,13 +399,6 @@ pub(super) enum MetadataSstSeqExpectation {
     Descriptor,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum MetadataTableCacheMode {
-    Bypass,
-    Populate,
-    ReadOnly,
-}
-
 impl MetadataTableLoadContext<'_> {
     pub(super) fn expected_segment_seq(
         &self,
@@ -523,15 +516,7 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
-    load_manifest_segment_rows_with_cache(
-        store,
-        None,
-        context,
-        family,
-        descriptor,
-        MetadataTableCacheMode::Bypass,
-    )
-    .await
+    load_manifest_segment_rows_with_cache(store, None, context, family, descriptor).await
 }
 
 /// Per-view memo of decoded blocks, so one operation never re-fetches or
@@ -561,9 +546,6 @@ impl SessionBlockMemo {
     }
 }
 
-/// Widest block selection served by per-block single-flight fetches; wider
-/// selections bulk-fetch their missing spans with coalesced ranged GETs.
-const NARROW_BLOCK_FETCH_LIMIT: usize = 4;
 /// Blocks a range scan reads ahead within a segment. Paged scans ask for a
 /// couple of blocks at a time while marching through whole segments; without
 /// readahead every page pays its own small GETs, and request counts scale
@@ -585,7 +567,6 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-    cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     let row_set = load_manifest_segment_rows_in_key_range_with_cache(
         store,
@@ -594,7 +575,6 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         context,
         family,
         descriptor,
-        cache_mode,
         "",
         None,
         false,
@@ -633,13 +613,12 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-    cache_mode: MetadataTableCacheMode,
     lower_bound: &str,
     upper_bound: Option<&str>,
     readahead: bool,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
     context.expected_segment_seq(descriptor)?;
-    let index = load_segment_index(store, table_cache, memo, descriptor, cache_mode).await?;
+    let index = load_segment_index(store, table_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
     // A paged scan marches onward through the segment: read ahead so the
@@ -653,44 +632,18 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     } else {
         needed.end
     };
-    let blocks = if extended_end - needed.start > NARROW_BLOCK_FETCH_LIMIT {
-        let fetched = load_segment_data_block_span(
-            store,
-            table_cache,
-            memo,
-            family,
-            descriptor,
-            &index[needed.start..extended_end],
-            cache_mode,
-        )
-        .await?;
-        fetched.into_iter().take(needed.len()).collect()
-    } else if needed.len() <= NARROW_BLOCK_FETCH_LIMIT {
-        let entries = &index[needed];
-        futures::future::try_join_all(entries.iter().map(|entry| {
-            load_segment_data_block(
-                store,
-                table_cache,
-                memo,
-                family,
-                descriptor,
-                entry,
-                cache_mode,
-            )
-        }))
-        .await?
-    } else {
-        load_segment_data_block_span(
-            store,
-            table_cache,
-            memo,
-            family,
-            descriptor,
-            &index[needed],
-            cache_mode,
-        )
-        .await?
-    };
+    let blocks: Vec<_> = load_segment_data_block_span(
+        store,
+        table_cache,
+        memo,
+        family,
+        descriptor,
+        &index[needed.start..extended_end],
+    )
+    .await?
+    .into_iter()
+    .take(needed.len())
+    .collect();
 
     let mut rows = Vec::new();
     let mut row_keys = Vec::new();
@@ -765,7 +718,6 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
-    cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
     let handle = descriptor.index_block;
     let cache_key =
@@ -789,16 +741,7 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
         })
     };
     let block = match table_cache {
-        Some(cache) => {
-            cache
-                .get_or_fetch(
-                    &cache_key,
-                    cache_mode != MetadataTableCacheMode::Bypass,
-                    cache_mode == MetadataTableCacheMode::Populate,
-                    fetch,
-                )
-                .await?
-        }
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
@@ -820,7 +763,6 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
-    cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<SegmentFilter>, ManifestLoadError> {
     let handle = descriptor.filter_block;
     let cache_key =
@@ -844,16 +786,7 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         })
     };
     let block = match table_cache {
-        Some(cache) => {
-            cache
-                .get_or_fetch(
-                    &cache_key,
-                    cache_mode != MetadataTableCacheMode::Bypass,
-                    cache_mode == MetadataTableCacheMode::Populate,
-                    fetch,
-                )
-                .await?
-        }
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
@@ -872,7 +805,6 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entry: &SegmentIndexEntry,
-    cache_mode: MetadataTableCacheMode,
 ) -> Result<Arc<DecodedDataBlock>, ManifestLoadError> {
     let handle = entry.block;
     let cache_key =
@@ -895,16 +827,7 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         ))
     };
     let block = match table_cache {
-        Some(cache) => {
-            cache
-                .get_or_fetch(
-                    &cache_key,
-                    cache_mode != MetadataTableCacheMode::Bypass,
-                    cache_mode == MetadataTableCacheMode::Populate,
-                    fetch,
-                )
-                .await?
-        }
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
         None => fetch().await?,
     };
     memo.record(&cache_key, &block);
@@ -941,10 +864,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entries: &[SegmentIndexEntry],
-    cache_mode: MetadataTableCacheMode,
 ) -> Result<Vec<Arc<DecodedDataBlock>>, ManifestLoadError> {
-    let consult = cache_mode != MetadataTableCacheMode::Bypass;
-    let populate = cache_mode == MetadataTableCacheMode::Populate;
     let mut blocks: Vec<Option<Arc<DecodedDataBlock>>> = vec![None; entries.len()];
     for (position, entry) in entries.iter().enumerate() {
         let cache_key =
@@ -953,7 +873,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
             blocks[position] = Some(block);
             continue;
         }
-        if let (Some(cache), true) = (table_cache, consult) {
+        if let Some(cache) = table_cache {
             if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&cache_key) {
                 blocks[position] = Some(block);
             }
@@ -996,14 +916,11 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 span[0].block.offset,
             );
             let fetch = || async {
-                fetch_and_publish_span(store, table_cache, memo, family, descriptor, span, populate)
-                    .await
+                fetch_and_publish_span(store, table_cache, memo, family, descriptor, span).await
             };
             match table_cache {
                 Some(cache) => {
-                    cache
-                        .get_or_fetch(&first_key, consult, populate, fetch)
-                        .await?;
+                    cache.get_or_fetch(&first_key, fetch).await?;
                 }
                 None => {
                     fetch().await?;
@@ -1021,16 +938,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
             continue;
         }
         blocks[position] = Some(
-            load_segment_data_block(
-                store,
-                table_cache,
-                memo,
-                family,
-                descriptor,
-                entry,
-                cache_mode,
-            )
-            .await?,
+            load_segment_data_block(store, table_cache, memo, family, descriptor, entry).await?,
         );
     }
 
@@ -1051,7 +959,6 @@ async fn fetch_and_publish_span<S: ObjectStore + ?Sized>(
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     span: &[SegmentIndexEntry],
-    populate: bool,
 ) -> Result<DecodedMetadataTableBlock, ManifestLoadError> {
     let first = &span[0].block;
     let last = &span[span.len() - 1].block;
@@ -1073,7 +980,7 @@ async fn fetch_and_publish_span<S: ObjectStore + ?Sized>(
             block: decoded,
         };
         memo.record(&cache_key, &cache_block);
-        if let (Some(cache), true) = (table_cache, populate) {
+        if let Some(cache) = table_cache {
             // The first block is what the single-flight cell publishes;
             // inserting it here too keeps the whole span uniformly cached.
             cache.insert(cache_key, cache_block.clone());

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -5,8 +5,8 @@ use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
-    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableCacheMode,
-    MetadataTableLoadContext, SessionBlockMemo,
+    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableLoadContext,
+    SessionBlockMemo,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -20,10 +20,6 @@ use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Widest scan a cache without a byte budget may populate. A count-bounded
-/// cache evicts per entry, so admitting a wide scan would flush it; a
-/// byte-budgeted cache ignores this limit and admits every scan.
-pub(super) const SMALL_SCAN_CACHE_SEGMENT_LIMIT: usize = 4;
 /// Segment fetches issued per wave during a scan. Wide directories touch
 /// hundreds of segments per page; deeper waves amortize the per-wave await
 /// without unbounded fan-out.
@@ -59,13 +55,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         readahead: bool,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
-            .scan_prefix_with_cache_mode(
-                family,
-                key,
-                MetadataTableCacheMode::Populate,
-                Some(filter_probe),
-                readahead,
-            )
+            .scan_prefix_rows(family, key, Some(filter_probe), readahead)
             .await?
             .into_iter()
             .find(|row| row.row_key_for_family(family) == key))
@@ -76,10 +66,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         prefix: &str,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let matching_segment_count = self.matching_segment_count(family, prefix)?;
-        let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, None, true)
-            .await
+        self.scan_prefix_rows(family, prefix, None, true).await
     }
 
     /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
@@ -94,26 +81,8 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: &str,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let matching_segment_count = self.matching_segment_count(family, prefix)?;
-        let cache_mode = self.scan_cache_mode(matching_segment_count);
-        self.scan_prefix_with_cache_mode(family, prefix, cache_mode, Some(filter_probe), readahead)
+        self.scan_prefix_rows(family, prefix, Some(filter_probe), readahead)
             .await
-    }
-
-    /// Cache admission for a scan matching `matching_segment_count` segments.
-    /// A byte-budgeted table cache admits every scan — byte-based eviction
-    /// makes wide admissions safe, and list preloads are exactly the wide
-    /// scans that must land in the cache. Without a byte budget, wide scans
-    /// stay read-only so they cannot flush a count-bounded cache.
-    fn scan_cache_mode(&self, matching_segment_count: usize) -> MetadataTableCacheMode {
-        let byte_budgeted = self
-            .table_cache
-            .is_some_and(MetadataTableCache::byte_budgeted);
-        if byte_budgeted || matching_segment_count <= SMALL_SCAN_CACHE_SEGMENT_LIMIT {
-            MetadataTableCacheMode::Populate
-        } else {
-            MetadataTableCacheMode::ReadOnly
-        }
     }
 
     pub(crate) async fn scan_range_page(
@@ -156,11 +125,10 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         .await
     }
 
-    async fn scan_prefix_with_cache_mode(
+    async fn scan_prefix_rows(
         &self,
         family: MetadataTableFamily,
         prefix: &str,
-        cache_mode: MetadataTableCacheMode,
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
@@ -176,10 +144,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                     row_seq_max: run.run_seq,
                 },
                 &run.tables,
-                MetadataTableScanOutput {
-                    rows: &mut rows,
-                    cache_mode,
-                },
+                &mut rows,
                 filter_probe,
                 readahead,
             )
@@ -195,17 +160,10 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     async fn segment_filter_admits(
         &self,
         descriptor: &MetadataFileRef,
-        cache_mode: MetadataTableCacheMode,
         filter_probe: &str,
     ) -> Result<bool, ManifestLoadError> {
-        let filter = load_segment_filter(
-            self.store,
-            self.table_cache,
-            &self.block_memo,
-            descriptor,
-            cache_mode,
-        )
-        .await?;
+        let filter =
+            load_segment_filter(self.store, self.table_cache, &self.block_memo, descriptor).await?;
         if filter.may_contain(filter_probe) {
             return Ok(true);
         }
@@ -223,19 +181,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 cache.record_filter_false_positive();
             }
         }
-    }
-
-    fn matching_segment_count(
-        &self,
-        family: MetadataTableFamily,
-        prefix: &str,
-    ) -> Result<usize, ManifestLoadError> {
-        let mut count = 0;
-        for run in runs_in_scan_order(&self.manifest.payload) {
-            count +=
-                count_matching_segments(&self.manifest_object_key, &run.tables, family, prefix)?;
-        }
-        Ok(count)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -271,14 +216,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                     continue;
                 }
                 if let Some(filter_probe) = filter_probe {
-                    if !self
-                        .segment_filter_admits(
-                            descriptor,
-                            MetadataTableCacheMode::Populate,
-                            filter_probe,
-                        )
-                        .await?
-                    {
+                    if !self.segment_filter_admits(descriptor, filter_probe).await? {
                         continue;
                     }
                 }
@@ -291,7 +229,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 .then(left.max_key.cmp(&right.max_key))
                 .then(left.object_key.cmp(&right.object_key))
         });
-        let cache_mode = self.scan_cache_mode(matching_descriptors.len());
 
         let mut rows = Vec::<(String, MetadataRow)>::new();
         let mut next_descriptor_index = 0;
@@ -316,7 +253,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                             *context,
                             family,
                             descriptor,
-                            cache_mode,
                             lower_bound,
                             upper_bound,
                             readahead,
@@ -345,7 +281,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         prefix: &str,
         context: MetadataTableLoadContext<'_>,
         tables: &[MetadataTableManifest],
-        output: MetadataTableScanOutput<'_>,
+        rows: &mut Vec<MetadataRow>,
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<(), ManifestLoadError> {
@@ -366,7 +302,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             matching_descriptors.push(descriptor);
         }
         let matching_descriptors = self
-            .filter_admitted_descriptors(matching_descriptors, output.cache_mode, filter_probe)
+            .filter_admitted_descriptors(matching_descriptors, filter_probe)
             .await?;
 
         let prefix_upper_bound = string_prefix_upper_bound(prefix);
@@ -378,7 +314,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                         context,
                         family,
                         descriptor,
-                        output.cache_mode,
                         prefix,
                         prefix_upper_bound.as_deref(),
                         readahead,
@@ -389,14 +324,14 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
 
         for segment_rows in loaded_segments {
-            let matched = output.rows.len();
-            output.rows.extend(
+            let matched = rows.len();
+            rows.extend(
                 segment_rows
                     .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
                     .map(|(_, row)| row.clone()),
             );
             if filter_probe.is_some() {
-                self.record_filter_false_positive_if_empty(output.rows.len() - matched);
+                self.record_filter_false_positive_if_empty(rows.len() - matched);
             }
         }
         Ok(())
@@ -407,7 +342,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     async fn filter_admitted_descriptors<'d>(
         &self,
         descriptors: Vec<&'d MetadataFileRef>,
-        cache_mode: MetadataTableCacheMode,
         filter_probe: Option<&str>,
     ) -> Result<Vec<&'d MetadataFileRef>, ManifestLoadError> {
         let Some(filter_probe) = filter_probe else {
@@ -415,9 +349,11 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         };
         let mut admitted = Vec::with_capacity(descriptors.len());
         for chunk in descriptors.chunks(MAX_MATERIALIZED_TABLE_FETCHES) {
-            let checks = try_join_all(chunk.iter().map(|descriptor| {
-                self.segment_filter_admits(descriptor, cache_mode, filter_probe)
-            }))
+            let checks = try_join_all(
+                chunk
+                    .iter()
+                    .map(|descriptor| self.segment_filter_admits(descriptor, filter_probe)),
+            )
             .await?;
             admitted.extend(
                 chunk
@@ -430,13 +366,11 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         Ok(admitted)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn segment_rows(
         &self,
         context: MetadataTableLoadContext<'_>,
         family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
-        cache_mode: MetadataTableCacheMode,
         lower_bound: &str,
         upper_bound: Option<&str>,
         readahead: bool,
@@ -448,18 +382,12 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             context,
             family,
             descriptor,
-            cache_mode,
             lower_bound,
             upper_bound,
             readahead,
         )
         .await
     }
-}
-
-pub(super) struct MetadataTableScanOutput<'a> {
-    rows: &'a mut Vec<MetadataRow>,
-    cache_mode: MetadataTableCacheMode,
 }
 
 pub(super) fn ordered_manifest_tables<'a>(
@@ -498,20 +426,6 @@ pub(super) fn manifest_table_for_family<'a>(
             object_key: manifest_object_key.to_owned(),
             family,
         })
-}
-
-pub(super) fn count_matching_segments(
-    manifest_object_key: &str,
-    tables: &[MetadataTableManifest],
-    family: MetadataTableFamily,
-    prefix: &str,
-) -> Result<usize, ManifestLoadError> {
-    let table = manifest_table_for_family(manifest_object_key, tables, family)?;
-    Ok(table
-        .segments
-        .iter()
-        .filter(|descriptor| descriptor_may_contain_prefix(descriptor, prefix))
-        .count())
 }
 
 pub(super) fn descriptor_may_contain_prefix(descriptor: &MetadataFileRef, prefix: &str) -> bool {

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -27,7 +27,6 @@ use super::runs::{
     CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
     DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT, MAX_CHECKPOINT_L0_RUNS,
 };
-use super::scan::SMALL_SCAN_CACHE_SEGMENT_LIMIT;
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
@@ -2328,56 +2327,6 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
 }
 
 #[tokio::test]
-async fn count_bounded_cache_keeps_large_table_scans_read_only() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    for index in 0..8 {
-        let path = format!("/docs/file-{index}.txt");
-        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
-            .await
-            .expect("write file");
-    }
-    let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
-        ..MetadataLsmPolicy::default()
-    };
-    checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
-    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    // Without a byte budget only entry count bounds the cache, so one wide
-    // scan admitting all its segments could flush every resident block; wide
-    // scans stay read-only under that configuration.
-    let cache = super::MetadataTableCache::new(MetadataTableCacheConfig {
-        enabled: true,
-        max_blocks: 256,
-        max_decoded_bytes: None,
-    });
-    let tables = super::load_verified_manifest_tables_with_cache(
-        &store,
-        Some(&cache),
-        &namespace_id,
-        &manifest_object_id,
-    )
-    .await
-    .expect("load tables");
-
-    let before = cache.stats();
-    let revisions = tables
-        .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
-        .await
-        .expect("scan revisions");
-    let after = cache.stats();
-
-    assert!(revisions.len() >= 8);
-    assert_eq!(after.inserts, before.inserts);
-    assert!(after.misses > before.misses);
-}
-
-#[tokio::test]
 async fn concurrent_scans_share_one_fetch_per_segment() {
     let temp_dir = tempdir().expect("tempdir");
     let store =
@@ -2399,27 +2348,20 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
-    // A count-bounded cache keeps wide scans read-only, so nothing is ever
-    // admitted and single-flight deduplication is the only fetch sharing —
-    // exactly the property this test pins.
-    let cache = super::MetadataTableCache::new(MetadataTableCacheConfig {
-        enabled: true,
-        max_blocks: 256,
-        max_decoded_bytes: None,
-    });
-    let load_tables = || {
-        super::load_verified_manifest_tables_with_cache(
-            &store,
-            Some(&cache),
-            &namespace_id,
-            &manifest_object_id,
-        )
-    };
-
-    // The scan touches more segments than the small-scan populate limit, so
-    // every fresh view re-fetches each segment: a solo pass measures the
-    // true per-scan fetch count.
-    let solo_tables = load_tables().await.expect("load solo tables");
+    // Concurrent scans over one shared cache must not multiply fetches:
+    // single-flight covers blocks racing before the first insert lands, and
+    // population covers everything after.
+    let cache = super::MetadataTableCache::new(MetadataTableCacheConfig::default());
+    // A solo pass over its own cold cache measures the true per-scan
+    // fetch count.
+    let solo_tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load solo tables");
     store.reset_metadata_sst_gets();
     let solo = solo_tables
         .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
@@ -2429,10 +2371,25 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     assert!(solo.len() >= 8);
     assert!(solo_fetches >= 8, "solo scan should fetch every segment");
 
-    // Concurrent requests each load their own tables view; only the shared
-    // cache's single-flight can deduplicate their segment fetches.
-    let first_tables = load_tables().await.expect("load first tables");
-    let second_tables = load_tables().await.expect("load second tables");
+    // Concurrent requests race over a second cold cache, each with its own
+    // tables view; single-flight is what keeps the pair at the solo count.
+    let paired_cache = super::MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let first_tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&paired_cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load first tables");
+    let second_tables = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&paired_cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load second tables");
     store.reset_metadata_sst_gets();
     let (first, second) = tokio::join!(
         first_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
@@ -2553,8 +2510,8 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
     let after_first = cache.stats();
     assert_eq!(page.len(), 8);
     assert!(
-        after_first.inserts > SMALL_SCAN_CACHE_SEGMENT_LIMIT,
-        "a wide range scan against a byte-budgeted cache should admit its segments"
+        after_first.inserts > 4,
+        "a wide range scan should admit its segments to the cache"
     );
 
     let fresh_tables = super::load_verified_manifest_tables_with_cache(
@@ -2742,7 +2699,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
     let cache = MetadataTableCache::new(MetadataTableCacheConfig {
         enabled: true,
         max_blocks: 256,
-        max_decoded_bytes: Some(1),
+        max_decoded_bytes: 1,
     });
     let tables = super::load_verified_manifest_tables_with_cache(
         &store,

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -116,7 +116,7 @@ impl ServerConfig {
             config.metadata_table_cache.max_blocks = value;
         }
         if let Some(value) = self.runtime_cache.metadata_table_cache_max_decoded_bytes {
-            config.metadata_table_cache.max_decoded_bytes = Some(value);
+            config.metadata_table_cache.max_decoded_bytes = value;
         }
         config
     }

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -69,7 +69,7 @@ impl RuntimeCacheConfig {
             metadata_table_cache: MetadataTableCacheConfig {
                 enabled: false,
                 max_blocks: 0,
-                max_decoded_bytes: Some(0),
+                max_decoded_bytes: 0,
             },
         }
     }


### PR DESCRIPTION
Follow-up to #223, removing the code paths that only existed to protect a cache mode we no longer need.

The metadata table cache used to support a count-only budget (`max_decoded_bytes: None`), a holdover from before the byte budget existed. Protecting that configuration forced three forks through the read path: a `ReadOnly` cache mode so wide scans couldn't flush a count-bounded cache, per-scan admission logic deciding which mode each scan got, and a separate narrow per-block fetch path kept alongside the span path because only value-carrying per-block cells could share fetches between concurrent scans when the winner wasn't allowed to populate.

Pre-release, with the byte budget as the default and nothing deployed on the old knob, the accommodation costs more than it protects. This PR deletes it whole:

- `max_decoded_bytes` is a plain number now — the byte budget is always on, and admission control is the budget's job, not the scan's.
- The cache mode enum is gone (its third variant, `Bypass`, was only ever passed alongside "no cache attached", where it did nothing). An attached cache is always consulted and always populated.
- One fetch path remains: every selection goes through the span loader, which checks the memo and cache per block, coalesces the misses into ranged GETs, and single-flights each span. A one-block point lookup is simply a one-block span — same request, same sharing, no second code path.
- With that, the scan layer loses its admission machinery (`scan_cache_mode`, the small-scan limit, segment counting) and the mode threading through every signature.

Net: about 130 lines gone, one way to fetch a block, and the request-accounting probe actually improved — 74 warm-list GETs versus 83 before, because blocks that read-only wide scans used to throw away now stay cached.

One test was deleted with the mode it pinned (count-bounded scans stay read-only), and the concurrent-scan test was restructured: it now races two views over a second cold cache, since with unconditional population the old structure was serving the paired phase entirely from the solo phase's cache and asserting nothing.
