### PR TITLE
perf(core): serve publish-view table reads from the shared block cache

### DIFF
--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -31,7 +31,7 @@ mod row;
 mod runs;
 mod scan;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 mod validate;
 
 pub use self::cache::{

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -5038,27 +5038,27 @@ impl ObjectStore for RootCasTransportAfterCompetingRootStore {
 }
 
 #[derive(Debug)]
-struct MetadataSstGetCountingStore {
+pub(crate) struct MetadataSstGetCountingStore {
     inner: LocalFsStore,
     metadata_sst_gets: Mutex<usize>,
 }
 
 impl MetadataSstGetCountingStore {
-    fn new(inner: LocalFsStore) -> Self {
+    pub(crate) fn new(inner: LocalFsStore) -> Self {
         Self {
             inner,
             metadata_sst_gets: Mutex::new(0),
         }
     }
 
-    fn metadata_sst_gets(&self) -> usize {
+    pub(crate) fn metadata_sst_gets(&self) -> usize {
         *self
             .metadata_sst_gets
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    fn reset_metadata_sst_gets(&self) {
+    pub(crate) fn reset_metadata_sst_gets(&self) {
         *self
             .metadata_sst_gets
             .lock()

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -1,3 +1,4 @@
+use crate::checkpoint::MetadataTableCache;
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
@@ -106,6 +107,10 @@ pub struct NamespaceCommitEngine {
     fenced: Option<String>,
     /// Local monotonic source for the self-enforced publish budget.
     timer: Arc<dyn MonotonicTimer>,
+    /// Shared decoded-block cache for publish-view table reads. Blocks are
+    /// content-addressed by segment digest, so cached entries can never
+    /// serve stale state; freshness stays enforced by the head etag check.
+    table_cache: Option<Arc<MetadataTableCache>>,
 }
 
 impl NamespaceCommitEngine {
@@ -116,12 +121,18 @@ impl NamespaceCommitEngine {
             acquired_writer: None,
             fenced: None,
             timer: Arc::new(StdMonotonicTimer::default()),
+            table_cache: None,
         }
     }
 
     #[doc(hidden)]
     pub fn with_monotonic_timer(mut self, timer: Arc<dyn MonotonicTimer>) -> Self {
         self.timer = timer;
+        self
+    }
+
+    pub fn with_table_cache(mut self, table_cache: Arc<MetadataTableCache>) -> Self {
+        self.table_cache = Some(table_cache);
         self
     }
 
@@ -188,6 +199,7 @@ impl NamespaceCommitEngine {
 
         let (publish_view, projection) = match load_publish_metadata_view(
             store,
+            self.table_cache.as_deref(),
             &self.namespace_id,
             Some(acquired_writer),
             self.publish_tail_projection.as_ref(),
@@ -322,6 +334,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
     ) -> Result<PlannedPathMutation> {
         let (view, _projection) = load_publish_metadata_view(
             self.store,
+            None,
             namespace_id,
             None,
             None,
@@ -603,5 +616,81 @@ mod tests {
             .state;
         assert_eq!(head_final.seq, ChangeSeq(1));
         assert_eq!(head_final.writer_epoch, WriterEpoch(0));
+    }
+
+    #[tokio::test]
+    async fn publish_views_reuse_cached_table_blocks_across_publishes() {
+        use crate::cache::MetadataTableCacheConfig;
+        use crate::checkpoint::tests::MetadataSstGetCountingStore;
+
+        let temp_dir = tempdir().expect("tempdir");
+        let store =
+            MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer = context("writer-a", "session-a");
+        bootstrap_namespace(&store, &namespace_id, &writer, false)
+            .await
+            .expect("bootstrap");
+        let mut seed = NamespaceCommitEngine::new(namespace_id.clone());
+        seed.publish_batch(&store, vec![create_dir("seed-commit", "docs")], &writer)
+            .await
+            .results
+            .remove(0)
+            .expect("seed publish");
+        crate::checkpoint::create_checkpoint(&store, &namespace_id, &writer)
+            .await
+            .expect("checkpoint");
+
+        // Without a cache, every publish view re-fetches the table blocks
+        // its validation walks need.
+        let mut uncached = NamespaceCommitEngine::new(namespace_id.clone());
+        store.reset_metadata_sst_gets();
+        uncached
+            .publish_batch(&store, vec![create_dir("uncached-a", "alpha")], &writer)
+            .await
+            .results
+            .remove(0)
+            .expect("uncached publish a");
+        assert!(
+            store.metadata_sst_gets() > 0,
+            "publish validation should read table blocks"
+        );
+        store.reset_metadata_sst_gets();
+        uncached
+            .publish_batch(&store, vec![create_dir("uncached-b", "beta")], &writer)
+            .await
+            .results
+            .remove(0)
+            .expect("uncached publish b");
+        assert!(
+            store.metadata_sst_gets() > 0,
+            "without a cache the next publish re-fetches the same blocks"
+        );
+
+        let cache = Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default()));
+        let mut cached = NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(cache);
+        store.reset_metadata_sst_gets();
+        cached
+            .publish_batch(&store, vec![create_dir("cached-a", "gamma")], &writer)
+            .await
+            .results
+            .remove(0)
+            .expect("cached publish a");
+        assert!(
+            store.metadata_sst_gets() > 0,
+            "the first cached publish fills the cache"
+        );
+        store.reset_metadata_sst_gets();
+        cached
+            .publish_batch(&store, vec![create_dir("cached-b", "delta")], &writer)
+            .await
+            .results
+            .remove(0)
+            .expect("cached publish b");
+        assert_eq!(
+            store.metadata_sst_gets(),
+            0,
+            "a warm cache serves every publish-view table read"
+        );
     }
 }

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -801,6 +801,7 @@ mod tests {
     ) -> Result<PlannedPathMutation, CoreError> {
         let (view, _projection) = load_publish_metadata_view(
             store,
+            None,
             namespace_id,
             None,
             None,

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -161,6 +161,7 @@ mod tests {
 
         let (view, _projection) = load_publish_metadata_view(
             &store,
+            None,
             &namespace_id,
             None,
             None,

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -147,6 +147,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     let publish_tail_options = PublishTailOptions::default();
     let (publish_view, projection) = match load_publish_metadata_view(
         store,
+        None,
         namespace_id,
         Some(acquired_writer),
         None,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -3,7 +3,8 @@
 //! publishers.
 
 use crate::checkpoint::{
-    head_from_manifest, load_verified_manifest_tables_with_cache, VerifiedMetadataTables,
+    head_from_manifest, load_verified_manifest_tables_with_cache, MetadataTableCache,
+    VerifiedMetadataTables,
 };
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
@@ -104,6 +105,7 @@ impl PublishTailProjection {
 
 pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
+    table_cache: Option<&'a MetadataTableCache>,
     namespace_id: &NamespaceId,
     acquired_writer: Option<AcquiredWriter>,
     cached_projection: Option<&PublishTailProjection>,
@@ -136,7 +138,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     }
     let manifest_tables = load_verified_manifest_tables_with_cache(
         store,
-        None,
+        table_cache,
         namespace_id,
         &root.manifest_object_id,
     )

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -9,7 +9,9 @@ use crate::{CommitResponse, CoreError, NamespaceId};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{ManifestId, ManifestObjectId};
-use loonfs_core::cache::{MetadataTableCacheStats, WalTailProjectionCacheStats};
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheStats, WalTailProjectionCacheStats,
+};
 use loonfs_core::control::{
     load_namespace_read_anchor, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
     LoadedMetadataRootControl,
@@ -33,14 +35,15 @@ impl CommitEngineCache {
         &mut self,
         namespace_id: &NamespaceId,
         max_cached_namespaces: usize,
+        table_cache: Arc<MetadataTableCache>,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         if let Some(engine) = self.entries.get(namespace_id).cloned() {
             self.touch(namespace_id);
             return engine;
         }
-        let engine = Arc::new(AsyncMutex::new(NamespaceCommitEngine::new(
-            namespace_id.clone(),
-        )));
+        let engine = Arc::new(AsyncMutex::new(
+            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache),
+        ));
         self.entries.insert(namespace_id.clone(), engine.clone());
         self.touch(namespace_id);
         while self.entries.len() > max_cached_namespaces {
@@ -385,9 +388,11 @@ impl FsCore {
         namespace_id: &NamespaceId,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         let cache_config = &self.inner.config.runtime_cache;
-        self.inner
-            .commit_engines()
-            .get_or_insert(namespace_id, cache_config.max_cached_namespaces)
+        self.inner.commit_engines().get_or_insert(
+            namespace_id,
+            cache_config.max_cached_namespaces,
+            Arc::clone(&self.inner.metadata_table_cache),
+        )
     }
 
     pub(crate) fn runtime_read_context(

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -322,4 +322,20 @@ async fn warm_phase_request_accounting() {
         .await
         .expect("warm write");
     report("warm write", &log.take(), &tables);
+
+    // A second write on the same handle separates per-handle warmup cost
+    // from per-write cost.
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/hot/file-05002.txt",
+            b"replaced again",
+            PutFileOptions {
+                behavior: loonfs::PutBehavior::Replace,
+                commit_id: None,
+            },
+        )
+        .await
+        .expect("second warm write");
+    report("warm write (same handle, second)", &log.take(), &tables);
 }


### PR DESCRIPTION
The 50k growth run's one regression was warm writes (2.2s to 3.3s at 50k). The cause: every publish loads a metadata view to validate against, and those views never used the shared block cache — each publish re-fetched the same index, filter, and data blocks the previous publish had just read. Reads have shared this cache since Tier 1; the write path was the only consumer left out.

The commit engine (the per-namespace publish state the runtime already keeps) now carries the runtime's block cache and hands it to every publish view it loads. This is safe for the same reason it is on the read path: cache entries are addressed by segment digest, so a cached block can never disagree with the manifest that references it, and publish freshness is still enforced by the head etag re-check.

Embedded one-shot publishes (the core batch API without a runtime) stay uncached, as do maintenance materializations, which deliberately avoid populating the cache.

Measured with the request-accounting probe, which now runs a second write on the same handle to separate per-handle warmup from steady-state cost: the first write on a handle costs 36 GETs, 27 of them table blocks; a second write used to pay the table cost all over again and now costs 7 GETs with zero table reads.

A regression test pins the behavior both ways: with the cache attached, an engine's second publish issues no table GETs; without it, every publish re-fetches.
