### PR TITLE
perf(core): stop re-reading immutable objects on every view

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,5 +1,5 @@
 use crate::metadata::MetadataState;
-use loonfs_api::wire::manifest::MetadataRow;
+use loonfs_api::wire::manifest::{MetadataRow, NamespaceManifestEnvelope};
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
@@ -53,6 +53,7 @@ pub(super) enum MetadataTableBlockKind {
     Index,
     Filter,
     Data,
+    Manifest,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -99,9 +100,10 @@ impl DecodedSegmentRowSet {
     }
 }
 
-/// One decoded, CRC-verified section of a segment object. Index and data
-/// sections share the cache and its byte budget; the key's `block_kind`
-/// and `block_offset` make collisions between them impossible.
+/// One decoded, verified object the cache holds: a CRC-checked segment
+/// section (index, filter, or data) or a validated namespace manifest.
+/// Everything shares the cache and its byte budget; the key's `block_kind`
+/// and `block_offset` make collisions between kinds impossible.
 #[derive(Debug, Clone)]
 pub(super) enum DecodedMetadataTableBlock {
     Index {
@@ -116,6 +118,10 @@ pub(super) enum DecodedMetadataTableBlock {
         block: Arc<DecodedDataBlock>,
         decoded_byte_len: usize,
     },
+    Manifest {
+        manifest: Arc<NamespaceManifestEnvelope>,
+        decoded_byte_len: usize,
+    },
 }
 
 impl DecodedMetadataTableBlock {
@@ -128,6 +134,9 @@ impl DecodedMetadataTableBlock {
                 decoded_byte_len, ..
             }
             | Self::Data {
+                decoded_byte_len, ..
+            }
+            | Self::Manifest {
                 decoded_byte_len, ..
             } => *decoded_byte_len,
         }
@@ -616,7 +625,9 @@ mod tests {
         let inserted = block(64);
         let rows = match &inserted {
             DecodedMetadataTableBlock::Data { block: rows, .. } => Arc::clone(rows),
-            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
+            DecodedMetadataTableBlock::Index { .. }
+            | DecodedMetadataTableBlock::Filter { .. }
+            | DecodedMetadataTableBlock::Manifest { .. } => {
                 unreachable!("fixture builds a data block")
             }
         };
@@ -626,9 +637,9 @@ mod tests {
             DecodedMetadataTableBlock::Data {
                 block: hit_rows, ..
             } => Arc::ptr_eq(hit_rows, &rows),
-            DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
-                false
-            }
+            DecodedMetadataTableBlock::Index { .. }
+            | DecodedMetadataTableBlock::Filter { .. }
+            | DecodedMetadataTableBlock::Manifest { .. } => false,
         };
         assert!(
             shares_allocation,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -146,7 +146,9 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
     manifest_object_id: &ManifestObjectId,
 ) -> Result<VerifiedMetadataTables<'a, S>, ManifestLoadError> {
     let manifest_key = metadata_manifest_object(namespace_id.as_str(), manifest_object_id);
-    let manifest = {
+    // Manifests are immutable per object key, so the decoded and validated
+    // envelope is cacheable forever under that key.
+    let fetch = || async {
         let Some(manifest_bytes) = store
             .get(&manifest_key, None)
             .instrument(tracing::info_span!(
@@ -164,22 +166,48 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
                 object_key: manifest_key.clone(),
             });
         };
-        decode_namespace_manifest_json(&manifest_bytes).map_err(|err| {
+        let manifest = decode_namespace_manifest_json(&manifest_bytes).map_err(|err| {
             ManifestLoadError::ManifestCodec {
                 object_key: manifest_key.clone(),
                 message: err.to_string(),
             }
+        })?;
+        validate_namespace_manifest(
+            namespace_id,
+            manifest.payload.manifest_id,
+            manifest_object_id,
+            &manifest_key,
+            &manifest,
+        )?;
+        validate_manifest_materialization_ranges(&manifest_key, &manifest.payload)?;
+        validate_manifest_table_descriptors(&manifest_key, &manifest)?;
+        Ok(DecodedMetadataTableBlock::Manifest {
+            manifest: Arc::new(manifest),
+            decoded_byte_len: manifest_bytes.len(),
         })
-    }?;
-    validate_namespace_manifest(
-        namespace_id,
-        manifest.payload.manifest_id,
-        manifest_object_id,
-        &manifest_key,
-        &manifest,
-    )?;
-    validate_manifest_materialization_ranges(&manifest_key, &manifest.payload)?;
-    validate_manifest_table_descriptors(&manifest_key, &manifest)?;
+    };
+    let decoded = match table_cache {
+        Some(cache) => {
+            let cache_key = MetadataTableCacheKey {
+                table_digest: manifest_key.clone(),
+                block_kind: MetadataTableBlockKind::Manifest,
+                block_offset: 0,
+            };
+            cache.get_or_fetch(&cache_key, fetch).await?
+        }
+        None => fetch().await?,
+    };
+    let manifest = match decoded {
+        DecodedMetadataTableBlock::Manifest { manifest, .. } => manifest,
+        DecodedMetadataTableBlock::Index { .. }
+        | DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::Data { .. } => {
+            return Err(segment_codec_error(
+                &manifest_key,
+                "cache returned a non-manifest entry for a manifest key",
+            ));
+        }
+    };
     let tables = VerifiedMetadataTables {
         store,
         table_cache,
@@ -747,12 +775,12 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
-        DecodedMetadataTableBlock::Filter { .. } | DecodedMetadataTableBlock::Data { .. } => {
-            Err(segment_codec_error(
-                &descriptor.object_key,
-                "cache returned a non-index block for an index key",
-            ))
-        }
+        DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
+            &descriptor.object_key,
+            "cache returned a non-index block for an index key",
+        )),
     }
 }
 
@@ -792,9 +820,12 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
-        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Data { .. } => Err(
-            segment_codec_error(&descriptor.object_key, "cache returned a non-filter block"),
-        ),
+        DecodedMetadataTableBlock::Index { .. }
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
+            &descriptor.object_key,
+            "cache returned a non-filter block",
+        )),
     }
 }
 
@@ -833,12 +864,12 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     memo.record(&cache_key, &block);
     match block {
         DecodedMetadataTableBlock::Data { block, .. } => Ok(block),
-        DecodedMetadataTableBlock::Index { .. } | DecodedMetadataTableBlock::Filter { .. } => {
-            Err(segment_codec_error(
-                &descriptor.object_key,
-                "cache returned a non-data block for a data key",
-            ))
-        }
+        DecodedMetadataTableBlock::Index { .. }
+        | DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
+            &descriptor.object_key,
+            "cache returned a non-data block for a data key",
+        )),
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -36,7 +36,7 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
     pub(super) store: &'a S,
     pub(super) table_cache: Option<&'a MetadataTableCache>,
     pub(super) manifest_object_key: String,
-    pub(super) manifest: NamespaceManifestEnvelope,
+    pub(super) manifest: Arc<NamespaceManifestEnvelope>,
     /// Per-view memo of decoded blocks: one operation never re-fetches a
     /// block it already saw, with or without a shared cache attached.
     pub(super) block_memo: SessionBlockMemo,
@@ -44,7 +44,7 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
 
 impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     pub(crate) fn manifest(&self) -> &NamespaceManifestEnvelope {
-        &self.manifest
+        self.manifest.as_ref()
     }
 
     pub(crate) async fn get_for_lookup(

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -2,7 +2,8 @@ use crate::checkpoint::MetadataTableCache;
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
-use crate::error::{CoreError, ErrorCode, MetadataViewError, Result};
+use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError, MetadataViewError, Result};
+use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::planner::plan_path_mutation_against_publish_view;
 use crate::path::write::{
@@ -111,6 +112,9 @@ pub struct NamespaceCommitEngine {
     /// content-addressed by segment digest, so cached entries can never
     /// serve stale state; freshness stays enforced by the head etag check.
     table_cache: Option<Arc<MetadataTableCache>>,
+    /// The namespace's immutable catalog pair, loaded on this session's
+    /// first publish and reused for its lifetime.
+    catalog_entry: Option<VerifiedNamespaceCatalogEntry>,
 }
 
 impl NamespaceCommitEngine {
@@ -122,6 +126,7 @@ impl NamespaceCommitEngine {
             fenced: None,
             timer: Arc::new(StdMonotonicTimer::default()),
             table_cache: None,
+            catalog_entry: None,
         }
     }
 
@@ -133,6 +138,11 @@ impl NamespaceCommitEngine {
 
     pub fn with_table_cache(mut self, table_cache: Arc<MetadataTableCache>) -> Self {
         self.table_cache = Some(table_cache);
+        self
+    }
+
+    pub fn with_catalog_entry(mut self, catalog_entry: VerifiedNamespaceCatalogEntry) -> Self {
+        self.catalog_entry = Some(catalog_entry);
         self
     }
 
@@ -197,9 +207,29 @@ impl NamespaceCommitEngine {
             },
         };
 
+        let catalog_entry = match &self.catalog_entry {
+            Some(value) => value.clone(),
+            None => match load_namespace_catalog_entry(store, &self.namespace_id).await {
+                Ok(value) => {
+                    self.catalog_entry = Some(value.clone());
+                    value
+                }
+                Err(error) => {
+                    return NamespaceCommitEnginePublishResult {
+                        results: repeated_error(
+                            candidate_count,
+                            CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)),
+                        ),
+                        wal_tail_segments: 0,
+                    };
+                }
+            },
+        };
+
         let (publish_view, projection) = match load_publish_metadata_view(
             store,
             self.table_cache.as_deref(),
+            Some(catalog_entry),
             &self.namespace_id,
             Some(acquired_writer),
             self.publish_tail_projection.as_ref(),
@@ -334,6 +364,7 @@ impl<'a, S: ObjectStore + ?Sized> DirectObjectStorePublisher<'a, S> {
     ) -> Result<PlannedPathMutation> {
         let (view, _projection) = load_publish_metadata_view(
             self.store,
+            None,
             None,
             namespace_id,
             None,

--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -1,6 +1,7 @@
 pub use crate::storage::content::{
-    read_durable_content_bytes, store_bytes_as_content, validate_durable_content_reference,
-    DurableContentValidationError, ReadDurableContent, StoredContent, ValidatedDurableContent,
+    read_durable_content_bytes, store_bytes_as_content, store_bytes_as_content_with_store_id,
+    validate_durable_content_reference, DurableContentValidationError, ReadDurableContent,
+    StoredContent, ValidatedDurableContent,
 };
 pub use crate::storage::content_admission::{
     mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -2,6 +2,7 @@ use crate::cache::{MetadataTableCache, WalTailProjectionCache};
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::Result as CoreResult;
+use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::{bootstrap, delete, fork, BootstrapNamespaceError};
 use crate::options::{BootstrapOptions, DeleteNamespaceOptions, WriteOptions};
 use crate::path::query::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
@@ -33,6 +34,7 @@ pub struct RuntimeReadContext {
     manifest_object_id: ManifestObjectId,
     table_cache: Option<Arc<MetadataTableCache>>,
     tail_cache: Option<Arc<WalTailProjectionCache>>,
+    catalog: Option<VerifiedNamespaceCatalogEntry>,
 }
 
 impl RuntimeReadContext {
@@ -44,6 +46,7 @@ impl RuntimeReadContext {
         manifest_object_id: ManifestObjectId,
         table_cache: Option<Arc<MetadataTableCache>>,
         tail_cache: Option<Arc<WalTailProjectionCache>>,
+        catalog: Option<VerifiedNamespaceCatalogEntry>,
     ) -> Self {
         Self {
             head,
@@ -52,6 +55,7 @@ impl RuntimeReadContext {
             manifest_object_id,
             table_cache,
             tail_cache,
+            catalog,
         }
     }
 }
@@ -64,6 +68,7 @@ fn runtime_read_load_context(options: &RuntimeReadContext) -> ReadLoadContext<'_
         &options.manifest_object_id,
         options.table_cache.as_deref(),
         options.tail_cache.as_deref(),
+        options.catalog.as_ref(),
     )
 }
 

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -62,6 +62,9 @@ pub mod cache {
 }
 
 pub mod control {
+    pub use crate::namespace::catalog::{
+        load_namespace_catalog_entry, NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,
+    };
     pub use crate::namespace::control::{
         load_content_store_descriptor_control, load_namespace_checkpoint_record_control,
         load_namespace_descriptor_control, load_namespace_head_control,

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -10,17 +10,26 @@ use thiserror::Error;
 // Both variants share ControlObjectLoadError; conversion stays explicit so
 // `?` cannot pick a variant silently.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub(crate) enum NamespaceCatalogLoadError {
+pub enum NamespaceCatalogLoadError {
     #[error("failed to load namespace descriptor: {0}")]
     LoadNamespaceDescriptor(ControlObjectLoadError),
     #[error("failed to load content store descriptor: {0}")]
     LoadContentStoreDescriptor(ControlObjectLoadError),
 }
 
+/// The namespace's spec-immutable identity pair: its config and the
+/// content-store binding it was created with. Loaded once and reusable for
+/// the life of a process; neither object can change after creation.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct VerifiedNamespaceCatalogEntry {
+pub struct VerifiedNamespaceCatalogEntry {
     pub(crate) namespace_config: NamespaceConfigState,
     pub(crate) content_store_id: ContentStoreId,
+}
+
+impl VerifiedNamespaceCatalogEntry {
+    pub fn content_store_id(&self) -> &ContentStoreId {
+        &self.content_store_id
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,7 +65,7 @@ pub(crate) async fn load_namespace_descriptor<S: ObjectStore + ?Sized>(
     Ok(loaded_descriptor.envelope.state)
 }
 
-pub(crate) async fn load_namespace_catalog_entry<S: ObjectStore + ?Sized>(
+pub async fn load_namespace_catalog_entry<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<VerifiedNamespaceCatalogEntry, NamespaceCatalogLoadError> {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -9,7 +9,7 @@ use crate::metadata::{
     DirentryBindRecord, InodeRecord, MetadataState, MetadataView, MetadataViewSession,
     ResolvedVisiblePath, RevisionRecord, VisibleChildEntry,
 };
-use crate::namespace::catalog::load_namespace_catalog_entry;
+use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::read_head_and_metadata_root;
 use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::read_durable_content_bytes;
@@ -46,6 +46,9 @@ pub(crate) struct ReadLoadContext<'a> {
     view: ReadViewContext<'a>,
     table_cache: Option<&'a MetadataTableCache>,
     tail_cache: Option<&'a WalTailProjectionCache>,
+    /// The namespace's immutable catalog pair, when the caller has already
+    /// loaded it; a view load without one reads it from the store.
+    catalog: Option<&'a VerifiedNamespaceCatalogEntry>,
 }
 
 impl<'a> ReadLoadContext<'a> {
@@ -54,6 +57,7 @@ impl<'a> ReadLoadContext<'a> {
             view: ReadViewContext::Latest,
             table_cache: None,
             tail_cache: None,
+            catalog: None,
         }
     }
 
@@ -64,6 +68,7 @@ impl<'a> ReadLoadContext<'a> {
         manifest_object_id: &'a ManifestObjectId,
         table_cache: Option<&'a MetadataTableCache>,
         tail_cache: Option<&'a WalTailProjectionCache>,
+        catalog: Option<&'a VerifiedNamespaceCatalogEntry>,
     ) -> Self {
         Self {
             view: ReadViewContext::PinnedHead {
@@ -74,6 +79,7 @@ impl<'a> ReadLoadContext<'a> {
             },
             table_cache,
             tail_cache,
+            catalog,
         }
     }
 }
@@ -146,9 +152,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 namespace_id: namespace_id.clone(),
             });
         }
-        let catalog_entry = load_namespace_catalog_entry(store, namespace_id)
-            .await
-            .map_err(MetadataProjectionLoadError::from)?;
+        let catalog_entry = match load_context.catalog {
+            Some(entry) => entry.clone(),
+            None => load_namespace_catalog_entry(store, namespace_id)
+                .await
+                .map_err(MetadataProjectionLoadError::from)?,
+        };
         let tables = load_verified_manifest_tables_with_cache(
             store,
             load_context.table_cache,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -802,6 +802,7 @@ mod tests {
         let (view, _projection) = load_publish_metadata_view(
             store,
             None,
+            None,
             namespace_id,
             None,
             None,

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -162,6 +162,7 @@ mod tests {
         let (view, _projection) = load_publish_metadata_view(
             &store,
             None,
+            None,
             &namespace_id,
             None,
             None,

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -148,6 +148,7 @@ async fn commit_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     let (publish_view, projection) = match load_publish_metadata_view(
         store,
         None,
+        None,
         namespace_id,
         Some(acquired_writer),
         None,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -9,7 +9,7 @@ use crate::checkpoint::{
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
-use crate::namespace::catalog::load_namespace_catalog_entry;
+use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
@@ -106,14 +106,20 @@ impl PublishTailProjection {
 pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     table_cache: Option<&'a MetadataTableCache>,
+    catalog: Option<VerifiedNamespaceCatalogEntry>,
     namespace_id: &NamespaceId,
     acquired_writer: Option<AcquiredWriter>,
     cached_projection: Option<&PublishTailProjection>,
     options: &PublishTailOptions,
 ) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection)> {
-    let catalog_entry = load_namespace_catalog_entry(store, namespace_id)
-        .await
-        .map_err(|error| CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)))?;
+    let catalog_entry = match catalog {
+        Some(entry) => entry,
+        None => load_namespace_catalog_entry(store, namespace_id)
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::from(error))
+            })?,
+    };
     let (loaded_head, loaded_root) = read_head_and_metadata_root(store, namespace_id)
         .await
         .map_err(|error| {

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -235,6 +235,16 @@ pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     bytes: &[u8],
 ) -> Result<StoredContent, CoreError> {
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
+    store_bytes_as_content_with_store_id(store, content_store_id, bytes).await
+}
+
+/// Stages bytes when the caller already knows the namespace's content-store
+/// binding (it is immutable, so a handle can resolve it once).
+pub async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: ContentStoreId,
+    bytes: &[u8],
+) -> Result<StoredContent, CoreError> {
     let content_ref = ContentRef::whole_file_v0(bytes);
     let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
         .map_err(|err| CoreError::Internal(format!("failed to derive content blob key: {err}")))?;

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -13,8 +13,9 @@ use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheStats, WalTailProjectionCacheStats,
 };
 use loonfs_core::control::{
-    load_namespace_read_anchor, ControlObjectIdentity, ControlObjectLoadError, LoadedHeadControl,
-    LoadedMetadataRootControl,
+    load_namespace_catalog_entry, load_namespace_read_anchor, ControlObjectIdentity,
+    ControlObjectLoadError, LoadedHeadControl, LoadedMetadataRootControl,
+    VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::publish::NamespaceCommitEngine;
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext};
@@ -36,14 +37,18 @@ impl CommitEngineCache {
         namespace_id: &NamespaceId,
         max_cached_namespaces: usize,
         table_cache: Arc<MetadataTableCache>,
+        catalog: Option<VerifiedNamespaceCatalogEntry>,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         if let Some(engine) = self.entries.get(namespace_id).cloned() {
             self.touch(namespace_id);
             return engine;
         }
-        let engine = Arc::new(AsyncMutex::new(
-            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache),
-        ));
+        let mut engine =
+            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache);
+        if let Some(catalog) = catalog {
+            engine = engine.with_catalog_entry(catalog);
+        }
+        let engine = Arc::new(AsyncMutex::new(engine));
         self.entries.insert(namespace_id.clone(), engine.clone());
         self.touch(namespace_id);
         while self.entries.len() > max_cached_namespaces {
@@ -85,6 +90,9 @@ pub(crate) struct RuntimeControlCache {
 #[derive(Debug, Default)]
 struct NamespaceControlCacheEntry {
     head: Option<CachedNamespaceAnchor>,
+    /// The namespace's spec-immutable catalog pair (config plus content-store
+    /// binding): loaded once, never revalidated.
+    catalog: Option<VerifiedNamespaceCatalogEntry>,
 }
 
 #[derive(Debug, Clone)]
@@ -212,10 +220,32 @@ impl RuntimeControlCache {
             .head = Some(head);
     }
 
+    fn catalog(&mut self, namespace_id: &NamespaceId) -> Option<VerifiedNamespaceCatalogEntry> {
+        let catalog = self.namespaces.get(namespace_id)?.catalog.clone()?;
+        self.touch_namespace(namespace_id);
+        Some(catalog)
+    }
+
+    fn insert_catalog(
+        &mut self,
+        namespace_id: &NamespaceId,
+        catalog: VerifiedNamespaceCatalogEntry,
+        max_cached_namespaces: usize,
+    ) {
+        if max_cached_namespaces == 0 {
+            return;
+        }
+        self.namespace_entry(namespace_id, max_cached_namespaces)
+            .catalog = Some(catalog);
+    }
+
     fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
-        self.namespaces.remove(namespace_id);
-        self.namespace_order
-            .retain(|candidate| candidate != namespace_id);
+        // The head anchor goes stale on every mutation, but the catalog pair
+        // is immutable for the namespace's lifetime (a deleted namespace id
+        // never rebinds), so it survives invalidation.
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.head = None;
+        }
     }
 
     fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
@@ -388,29 +418,62 @@ impl FsCore {
         namespace_id: &NamespaceId,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         let cache_config = &self.inner.config.runtime_cache;
+        let catalog = self.inner.control_cache().catalog(namespace_id);
         self.inner.commit_engines().get_or_insert(
             namespace_id,
             cache_config.max_cached_namespaces,
             Arc::clone(&self.inner.metadata_table_cache),
+            catalog,
         )
     }
 
-    pub(crate) fn runtime_read_context(
+    pub(crate) async fn runtime_read_context(
         &self,
+        namespace_id: &NamespaceId,
         anchor: &CachedNamespaceAnchor,
-    ) -> RuntimeReadContext {
+    ) -> Result<RuntimeReadContext> {
         let cache_config = &self.inner.config.runtime_cache;
         let tail_cache = cache_config
             .wal_tail_projection_cache_enabled
             .then(|| Arc::clone(&self.inner.wal_tail_projection_cache));
-        RuntimeReadContext::pinned_head(
+        let catalog = self.load_namespace_catalog_cached(namespace_id).await?;
+        Ok(RuntimeReadContext::pinned_head(
             anchor.head.state.clone(),
             anchor.head.identity.etag.clone(),
             anchor.manifest_id,
             anchor.manifest_object_id.clone(),
             Some(Arc::clone(&self.inner.metadata_table_cache)),
             tail_cache,
-        )
+            catalog,
+        ))
+    }
+
+    /// Returns the namespace's immutable catalog pair through the control
+    /// cache, loading it once per cached namespace. With the control cache
+    /// disabled this returns `None` and view loads read it per operation.
+    pub(crate) async fn load_namespace_catalog_cached(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<Option<VerifiedNamespaceCatalogEntry>> {
+        if !self.control_cache_enabled() {
+            return Ok(None);
+        }
+        if let Some(catalog) = self.inner.control_cache().catalog(namespace_id) {
+            return Ok(Some(catalog));
+        }
+        let loaded = load_namespace_catalog_entry(self.store(), namespace_id)
+            .await
+            .map_err(|error| {
+                RuntimeError::Core(CoreError::MetadataProjection(
+                    MetadataProjectionLoadError::from(error),
+                ))
+            })?;
+        self.inner.control_cache().insert_catalog(
+            namespace_id,
+            loaded.clone(),
+            self.inner.config.runtime_cache.max_cached_namespaces,
+        );
+        Ok(Some(loaded))
     }
 
     #[tracing::instrument(

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -399,7 +399,7 @@ impl FsCore {
         self.record_trace_context(&span);
         let head = self.head_for_metadata_read(namespace_id).await?;
         let engine = self.namespace_engine(namespace_id);
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let entry = engine
             .resolve_path_with_runtime_context(absolute_path, &read_context)
             .await?;
@@ -492,7 +492,7 @@ impl FsCore {
         let head = self.head_for_metadata_read(namespace_id).await?;
         let engine = self.namespace_engine(namespace_id);
         let request_head_seq = request.cursor.as_ref().map(|cursor| cursor.head_seq);
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let page = engine
             .list_path_page_with_runtime_context(listed_path.as_str(), request, &read_context)
             .await?;
@@ -521,7 +521,7 @@ impl FsCore {
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let read = self
             .namespace_engine(namespace_id)
             .read_file_with_runtime_context(absolute_path, &read_context)
@@ -537,7 +537,7 @@ impl FsCore {
         absolute_path: &str,
     ) -> Result<ListFileRevisionsResponse> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let revisions = self
             .namespace_engine(namespace_id)
             .list_file_revisions_with_runtime_context(absolute_path, &read_context)
@@ -555,7 +555,7 @@ impl FsCore {
     ) -> Result<ListFileRevisionsResponse> {
         let head = self.head_for_metadata_read(namespace_id).await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let page = self
             .namespace_engine(namespace_id)
             .list_file_revisions_page_with_runtime_context(absolute_path, request, &read_context)
@@ -577,7 +577,7 @@ impl FsCore {
         inode_id: InodeId,
     ) -> Result<ListFileRevisionsResponse> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let revisions = self
             .namespace_engine(namespace_id)
             .list_file_revisions_for_inode_with_runtime_context(inode_id, &read_context)
@@ -594,7 +594,7 @@ impl FsCore {
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let page = self
             .namespace_engine(namespace_id)
             .list_file_revisions_for_inode_page_with_runtime_context(
@@ -620,7 +620,7 @@ impl FsCore {
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let read = self
             .namespace_engine(namespace_id)
             .read_file_revision_with_runtime_context(absolute_path, revision_no, &read_context)
@@ -637,7 +637,7 @@ impl FsCore {
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
         let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(&head);
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let read = self
             .namespace_engine(namespace_id)
             .read_file_revision_for_inode_with_runtime_context(inode_id, revision_no, &read_context)
@@ -693,13 +693,29 @@ impl FsCore {
         let (content_result_sender, content_result_receiver) = futures::channel::oneshot::channel();
         let content_store = self.inner.store.clone();
         let content_namespace_id = namespace_id.clone();
+        let cached_content_store_id = self
+            .load_namespace_catalog_cached(namespace_id)
+            .await?
+            .map(|catalog| catalog.content_store_id().clone());
         let content_write = async move {
-            let result = loonfs_core::content::store_bytes_as_content(
-                &content_store,
-                &content_namespace_id,
-                bytes,
-            )
-            .await
+            let result = match cached_content_store_id {
+                Some(content_store_id) => {
+                    loonfs_core::content::store_bytes_as_content_with_store_id(
+                        &content_store,
+                        content_store_id,
+                        bytes,
+                    )
+                    .await
+                }
+                None => {
+                    loonfs_core::content::store_bytes_as_content(
+                        &content_store,
+                        &content_namespace_id,
+                        bytes,
+                    )
+                    .await
+                }
+            }
             .map(|_| ());
             // A receiver dropped before the gate point means the publish
             // failed earlier; the content object is then a GC-covered orphan.
@@ -1123,6 +1139,10 @@ impl FsCore {
         let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
         let store = self.store();
         if self.commit_engine_cache_enabled() {
+            // Warm the immutable catalog through the control cache so a
+            // recreated engine starts seeded; a load failure here surfaces
+            // as the publish view's own, properly shaped error instead.
+            self.load_namespace_catalog_cached(namespace_id).await.ok();
             let engine = self.commit_engine(namespace_id);
             let publish = {
                 let context = self.mutation_context();

--- a/crates/loonfs/tests/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/immutable_view_inputs.rs
@@ -1,0 +1,218 @@
+//! A namespace's immutable view inputs — its config, its content-store
+//! descriptor, and the manifest object — are loaded once per handle, not
+//! once per operation. These tests pin that a warm handle stops re-fetching
+//! them entirely.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs::{
+    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
+    PutFileOptions, SharedObjectStore,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+#[derive(Debug)]
+struct GetRecordingStore {
+    inner: LocalFsStore,
+    gets: Mutex<Vec<String>>,
+}
+
+impl GetRecordingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            gets: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_gets(&self) -> Vec<String> {
+        std::mem::take(&mut *self.gets.lock().expect("get log lock poisoned"))
+    }
+
+    fn record(&self, key: &str) {
+        self.gets
+            .lock()
+            .expect("get log lock poisoned")
+            .push(key.to_owned());
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GetRecordingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record(key);
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record(key);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+fn immutable_input_gets(gets: &[String]) -> Vec<String> {
+    gets.iter()
+        .filter(|key| {
+            key.ends_with("/namespace.json")
+                || key.ends_with("/descriptor.json")
+                || key.ends_with(".manifest.json")
+        })
+        .cloned()
+        .collect()
+}
+
+async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) {
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("seed-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("seed-admin")
+        .build()
+        .await
+        .expect("build admin");
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for index in 0..4 {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/docs/file-{index}.txt"),
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("seed file");
+    }
+    admin
+        .maintenance_tick_namespace(
+            namespace_id,
+            MaintenanceTickOptions {
+                max_wal_tail_segments: 1,
+                ..MaintenanceTickOptions::default()
+            },
+        )
+        .await
+        .expect("tick");
+}
+
+#[tokio::test]
+async fn warm_reader_stops_fetching_immutable_view_inputs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
+    build_namespace(&store, &namespace_id).await;
+
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    reader
+        .stat_path(&namespace_id, "/docs/file-0.txt")
+        .await
+        .expect("first stat");
+    let warmup = immutable_input_gets(&recording.take_gets());
+    assert!(
+        !warmup.is_empty(),
+        "the first read on a handle loads the immutable inputs"
+    );
+
+    reader
+        .stat_path(&namespace_id, "/docs/file-1.txt")
+        .await
+        .expect("second stat");
+    let repeats = immutable_input_gets(&recording.take_gets());
+    assert_eq!(
+        repeats,
+        Vec::<String>::new(),
+        "a warm handle must not re-fetch the namespace config, the \
+         content-store descriptor, or the manifest object"
+    );
+}
+
+#[tokio::test]
+async fn warm_writer_stops_fetching_immutable_view_inputs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
+    build_namespace(&store, &namespace_id).await;
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("warm-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/file-5.txt",
+            b"body",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("first write");
+    let warmup = immutable_input_gets(&recording.take_gets());
+    assert!(
+        !warmup.is_empty(),
+        "the first write on a handle loads the immutable inputs"
+    );
+
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/file-6.txt",
+            b"body",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("second write");
+    let repeats = immutable_input_gets(&recording.take_gets());
+    assert_eq!(
+        repeats,
+        Vec::<String>::new(),
+        "a warm writer must not re-fetch the namespace config, the \
+         content-store descriptor, or the manifest object"
+    );
+}


### PR DESCRIPTION
Follow-up to #225. Three of a namespace's view inputs are spec-immutable — the manifest object, the namespace config, and the content-store descriptor (format spec, section 1.2) — but every view load re-fetched all three. At 10k that put three constant GETs on every list page and every write: about 30 of the warm list's 74 requests were re-reads of objects that cannot change.

Two commits:

1. **Decoded manifests join the block cache.** The manifest is immutable per object key, so the decoded and validated envelope is cached under that key in the same byte-budgeted cache the blocks live in, with the same single-flight. Views that share a cache now share one manifest fetch; maintenance and other cache-less paths are unchanged.

2. **The namespace catalog loads once per handle.** The runtime's control cache keeps the config-plus-content-store pair alongside the head anchor and hands it to read views, publish views, and content staging. The pair survives the post-write cache invalidation (the head anchor legitimately goes stale on every write; the catalog cannot change), and recreated commit engines start seeded from it. With the control cache disabled everything loads per view, as before.

Measured with the request-accounting probe at 10k: warm full list 74 to 47 GETs (the ten pages stop paying one manifest, one config, and one descriptor read each — what remains is table blocks plus a per-handle warmup), warm stat 4 to 1, warm read 4 to 1, and a second write on the same handle 7 to 2. Combined with #225 that takes steady-state writes from 36 GETs down to 2 — the head and root reads that anchor publish freshness, which are the only inputs that can actually change between writes.