### PR TITLE
refactor(core): one budget and one disable switch per cache

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -494,6 +494,9 @@ impl EmbeddedTarget {
             .writer_id(writer_id.clone())
             .writer_version(writer_version.clone())
             .background_work(FsBackgroundWork::ManualOnly)
+            // A CLI invocation is one solo mutation: holding the commit
+            // window open would only add its full delay to every command.
+            .commit_window_ms(0)
             .trace_store_kind(trace_store_kind)
             .build()
             .await

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -9,25 +9,19 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::OnceCell;
 
 /// Default decoded-byte budget for cached metadata table blocks. The byte
-/// budget is the primary limit: one wide directory's segment working set
-/// must fit, or warm listings re-fetch segments superlinearly.
+/// budget is the only limit — one wide directory's segment working set must
+/// fit, or warm listings re-fetch segments superlinearly — and zero
+/// disables the cache.
 pub const DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
-/// Secondary block-count bound behind the byte budget; it only binds under
-/// pathological many-tiny-block shapes.
-pub const DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS: usize = 8192;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataTableCacheConfig {
-    pub enabled: bool,
-    pub max_blocks: usize,
     pub max_decoded_bytes: usize,
 }
 
 impl Default for MetadataTableCacheConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
-            max_blocks: DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
             max_decoded_bytes: DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES,
         }
     }
@@ -252,7 +246,7 @@ impl MetadataTableCache {
     }
 
     pub(super) fn get(&self, key: &MetadataTableCacheKey) -> Option<DecodedMetadataTableBlock> {
-        if !self.config.enabled || self.config.max_blocks == 0 {
+        if self.config.max_decoded_bytes == 0 {
             return None;
         }
         let mut inner = self
@@ -269,7 +263,7 @@ impl MetadataTableCache {
     }
 
     pub(super) fn insert(&self, key: MetadataTableCacheKey, block: DecodedMetadataTableBlock) {
-        if !self.config.enabled || self.config.max_blocks == 0 {
+        if self.config.max_decoded_bytes == 0 {
             return;
         }
         let mut inner = self
@@ -286,9 +280,7 @@ impl MetadataTableCache {
             .saturating_add(block.decoded_byte_len());
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        while inner.entries.len() > self.config.max_blocks
-            || inner.decoded_byte_len > self.config.max_decoded_bytes
-        {
+        while inner.decoded_byte_len > self.config.max_decoded_bytes {
             let Some(evicted) = inner.order.pop_front() else {
                 break;
             };
@@ -309,23 +301,18 @@ impl MetadataTableCacheInner {
     }
 }
 
+/// Default bounds for WAL-tail projections, shared by the read-side
+/// projection cache and the publish-side tail reuse check.
+pub const DEFAULT_WAL_TAIL_PROJECTION_ROWS: usize = 1_000_000;
+pub const DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES: usize = 256 * 1024 * 1024;
+
+/// Zero entries disables the cache; the row and byte limits bound what one
+/// entry may hold and what the cache may retain in total.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WalTailProjectionCacheConfig {
-    pub enabled: bool,
     pub max_entries: usize,
     pub max_rows: usize,
-    pub max_decoded_bytes: Option<usize>,
-}
-
-impl Default for WalTailProjectionCacheConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            max_entries: 64,
-            max_rows: 1_000_000,
-            max_decoded_bytes: Some(256 * 1024 * 1024),
-        }
-    }
+    pub max_decoded_bytes: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -435,7 +422,7 @@ impl WalTailProjectionCache {
     }
 
     pub fn get(&self, key: &WalTailProjectionCacheKey) -> Option<Arc<MetadataState>> {
-        if !self.config.enabled || self.config.max_entries == 0 {
+        if self.config.max_entries == 0 {
             return None;
         }
         let mut inner = self
@@ -452,18 +439,12 @@ impl WalTailProjectionCache {
     }
 
     pub fn insert(&self, key: WalTailProjectionCacheKey, rows: Arc<MetadataState>) {
-        if !self.config.enabled || self.config.max_entries == 0 {
+        if self.config.max_entries == 0 {
             return;
         }
         let cached = CachedWalTailProjection::new(rows);
         let (row_count, decoded_bytes) = cached.weight();
-        if row_count > self.config.max_rows
-            || self
-                .config
-                .max_decoded_bytes
-                .map(|max| decoded_bytes > max)
-                .unwrap_or(false)
-        {
+        if row_count > self.config.max_rows || decoded_bytes > self.config.max_decoded_bytes {
             self.stats.uncacheable_count.fetch_add(1, Ordering::SeqCst);
             self.stats
                 .uncacheable_rows
@@ -490,11 +471,7 @@ impl WalTailProjectionCache {
 
         while inner.entries.len() > self.config.max_entries
             || inner.cached_rows > self.config.max_rows
-            || self
-                .config
-                .max_decoded_bytes
-                .map(|max| inner.cached_decoded_bytes > max)
-                .unwrap_or(false)
+            || inner.cached_decoded_bytes > self.config.max_decoded_bytes
         {
             let Some(evicted) = inner.order.pop_front() else {
                 break;
@@ -574,23 +551,17 @@ mod tests {
     }
 
     #[test]
-    fn default_config_budgets_bytes_as_the_primary_limit() {
+    fn default_config_budgets_bytes() {
         let config = MetadataTableCacheConfig::default();
         assert_eq!(
             config.max_decoded_bytes,
             super::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES
         );
-        assert_eq!(
-            config.max_blocks,
-            super::DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS
-        );
     }
 
     #[test]
-    fn byte_budget_evicts_before_the_block_bound() {
+    fn byte_budget_evicts_the_oldest_block() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig {
-            enabled: true,
-            max_blocks: 100,
             max_decoded_bytes: 1000,
         });
         cache.insert(key("a"), block(600));
@@ -606,8 +577,6 @@ mod tests {
     #[test]
     fn replacing_a_block_reaccounts_its_decoded_bytes() {
         let cache = MetadataTableCache::new(MetadataTableCacheConfig {
-            enabled: true,
-            max_blocks: 100,
             max_decoded_bytes: 1000,
         });
         cache.insert(key("a"), block(600));

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -37,11 +37,12 @@ mod validate;
 pub use self::cache::{
     MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
     WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
-    DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
+    DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
-pub use self::runs::MetadataLsmPolicy;
+pub(crate) use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::{
     build_initial_namespace_manifest, create_checkpoint, create_checkpoint_with_owner,

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -13,8 +13,6 @@ pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
 pub(super) const DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT: usize = 65_536;
 
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
-#[cfg(test)]
-pub(super) const MAX_CHECKPOINT_L0_RUNS: usize = DEFAULT_MAX_CHECKPOINT_L0_RUNS;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
 pub(super) const CHECKPOINT_BASE_RUN_LEVEL: u32 = 1;
 pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 8] = [
@@ -42,7 +40,7 @@ pub(super) struct MetadataRunManifest {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MetadataLsmPolicy {
+pub(crate) struct MetadataLsmPolicy {
     pub max_l0_runs: usize,
     pub max_rows_per_segment: usize,
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -25,7 +25,7 @@ use super::row::{manifest_rows_for_family, metadata_states_equivalent};
 use super::runs::{
     flatten_manifest_tables, runs_from_metadata_files, MetadataLsmPolicy, MetadataRunManifest,
     CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
-    DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT, MAX_CHECKPOINT_L0_RUNS,
+    DEFAULT_MAX_CHECKPOINT_L0_RUNS,
 };
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
@@ -2024,18 +2024,6 @@ async fn manifest_l0_runs_chain_across_successive_manifests() {
 }
 
 #[tokio::test]
-async fn metadata_lsm_policy_default_matches_l0_run_cap() {
-    assert_eq!(
-        MetadataLsmPolicy::default().max_l0_runs,
-        MAX_CHECKPOINT_L0_RUNS
-    );
-    assert_eq!(
-        MetadataLsmPolicy::default().max_rows_per_segment,
-        DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT
-    );
-}
-
-#[tokio::test]
 async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -2697,8 +2685,6 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
         .expect("checkpoint");
     let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
     let cache = MetadataTableCache::new(MetadataTableCacheConfig {
-        enabled: true,
-        max_blocks: 256,
         max_decoded_bytes: 1,
     });
     let tables = super::load_verified_manifest_tables_with_cache(
@@ -3555,7 +3541,7 @@ async fn checkpoints_chain_l0_runs_past_the_default_cap() {
     )
     .await
     .expect("load appended manifest");
-    assert!(l0_runs(&appended.manifest).len() > MAX_CHECKPOINT_L0_RUNS);
+    assert!(l0_runs(&appended.manifest).len() > DEFAULT_MAX_CHECKPOINT_L0_RUNS);
     assert_eq!(appended.manifest.payload.base_seq, ChangeSeq(0));
 }
 

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -72,10 +72,11 @@ mod wal;
 
 pub mod cache {
     pub use crate::checkpoint::{
-        ManifestLoadError, ManifestLoadFailureClass, MetadataLsmPolicy, MetadataTableCache,
-        MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
-        WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
-        DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_METADATA_TABLE_CACHE_MAX_BLOCKS,
+        ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
+        MetadataTableCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,
+        WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
     pub use crate::namespace::status::{
         load_namespace_head_summary, probe_namespace_head_etag, NamespaceHeadEtagProbe,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -55,14 +55,14 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublishTailOptions {
     pub max_tail_rows: usize,
-    pub max_tail_decoded_bytes: Option<usize>,
+    pub max_tail_decoded_bytes: usize,
 }
 
 impl Default for PublishTailOptions {
     fn default() -> Self {
         Self {
-            max_tail_rows: 1_000_000,
-            max_tail_decoded_bytes: Some(256 * 1024 * 1024),
+            max_tail_rows: crate::checkpoint::DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_tail_decoded_bytes: crate::checkpoint::DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
         }
     }
 }
@@ -99,10 +99,7 @@ impl PublishTailProjection {
 
     pub(crate) fn within_limits(&self, options: &PublishTailOptions) -> bool {
         self.tail_state.row_count() <= options.max_tail_rows
-            && options
-                .max_tail_decoded_bytes
-                .map(|max| self.tail_state.decoded_bytes() <= max)
-                .unwrap_or(true)
+            && self.tail_state.decoded_bytes() <= options.max_tail_decoded_bytes
     }
 }
 

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -42,13 +42,9 @@ pub struct ServerConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeCacheConfigOverrides {
-    pub wal_tail_projection_cache_enabled: Option<bool>,
-    pub control_cache_enabled: Option<bool>,
     pub max_cached_namespaces: Option<usize>,
     pub max_cached_wal_tail_projection_rows: Option<usize>,
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
-    pub metadata_table_cache_enabled: Option<bool>,
-    pub metadata_table_cache_max_blocks: Option<usize>,
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
 }
 
@@ -91,12 +87,6 @@ impl ServerConfig {
 
     pub fn runtime_cache_config(&self) -> RuntimeCacheConfig {
         let mut config = RuntimeCacheConfig::default();
-        if let Some(value) = self.runtime_cache.wal_tail_projection_cache_enabled {
-            config.wal_tail_projection_cache_enabled = value;
-        }
-        if let Some(value) = self.runtime_cache.control_cache_enabled {
-            config.control_cache_enabled = value;
-        }
         if let Some(value) = self.runtime_cache.max_cached_namespaces {
             config.max_cached_namespaces = value;
         }
@@ -107,13 +97,7 @@ impl ServerConfig {
             .runtime_cache
             .max_cached_wal_tail_projection_decoded_bytes
         {
-            config.max_cached_wal_tail_projection_decoded_bytes = Some(value);
-        }
-        if let Some(value) = self.runtime_cache.metadata_table_cache_enabled {
-            config.metadata_table_cache.enabled = value;
-        }
-        if let Some(value) = self.runtime_cache.metadata_table_cache_max_blocks {
-            config.metadata_table_cache.max_blocks = value;
+            config.max_cached_wal_tail_projection_decoded_bytes = value;
         }
         if let Some(value) = self.runtime_cache.metadata_table_cache_max_decoded_bytes {
             config.metadata_table_cache.max_decoded_bytes = value;
@@ -563,7 +547,7 @@ writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
 [runtime_cache]
-control_cache_enable = true
+max_cached_namespacs = 2
 
 [store]
 kind = "local-fs"
@@ -574,7 +558,7 @@ root = "/tmp/loonfs-server"
         for (path, typo) in [
             (top_level, "lease_duration"),
             (store_level, "key_prefiks"),
-            (runtime_cache_level, "control_cache_enable"),
+            (runtime_cache_level, "max_cached_namespacs"),
         ] {
             let error = load_server_config(&path).expect_err("typo'd key must be rejected");
             match error {
@@ -653,8 +637,6 @@ writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
 [runtime_cache]
-wal_tail_projection_cache_enabled = true
-control_cache_enabled = false
 max_cached_namespaces = 2
 max_cached_wal_tail_projection_rows = 10
 max_cached_wal_tail_projection_decoded_bytes = 4096
@@ -668,14 +650,9 @@ root = "/tmp/loonfs-server"
         let config = load_server_config(&path)
             .expect("load config")
             .runtime_cache_config();
-        assert!(config.wal_tail_projection_cache_enabled);
-        assert!(!config.control_cache_enabled);
         assert_eq!(config.max_cached_namespaces, 2);
         assert_eq!(config.max_cached_wal_tail_projection_rows, 10);
-        assert_eq!(
-            config.max_cached_wal_tail_projection_decoded_bytes,
-            Some(4096)
-        );
+        assert_eq!(config.max_cached_wal_tail_projection_decoded_bytes, 4096);
     }
 
     #[test]
@@ -688,13 +665,9 @@ writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
 [runtime_cache]
-wal_tail_projection_cache_enabled = false
-control_cache_enabled = false
 max_cached_namespaces = 0
 max_cached_wal_tail_projection_rows = 0
 max_cached_wal_tail_projection_decoded_bytes = 0
-metadata_table_cache_enabled = false
-metadata_table_cache_max_blocks = 0
 metadata_table_cache_max_decoded_bytes = 0
 
 [store]

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -405,8 +405,7 @@ impl FsCore {
     }
 
     pub(crate) fn control_cache_enabled(&self) -> bool {
-        let cache_config = &self.inner.config.runtime_cache;
-        cache_config.control_cache_enabled && cache_config.max_cached_namespaces > 0
+        self.inner.config.runtime_cache.max_cached_namespaces > 0
     }
 
     pub(crate) fn commit_engine_cache_enabled(&self) -> bool {
@@ -432,10 +431,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         anchor: &CachedNamespaceAnchor,
     ) -> Result<RuntimeReadContext> {
-        let cache_config = &self.inner.config.runtime_cache;
-        let tail_cache = cache_config
-            .wal_tail_projection_cache_enabled
-            .then(|| Arc::clone(&self.inner.wal_tail_projection_cache));
+        let tail_cache = Some(Arc::clone(&self.inner.wal_tail_projection_cache));
         let catalog = self.load_namespace_catalog_cached(namespace_id).await?;
         Ok(RuntimeReadContext::pinned_head(
             anchor.head.state.clone(),

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -11,9 +11,11 @@ pub const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
 /// Default maximum namespaces retained in runtime caches.
 pub const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
 /// Default maximum metadata rows retained across cached WAL-tail projections.
-pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize = 1_000_000;
+pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize =
+    loonfs_core::cache::DEFAULT_WAL_TAIL_PROJECTION_ROWS;
 /// Default decoded-byte budget for cached WAL-tail projections.
-pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize = 256 * 1024 * 1024;
+pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize =
+    loonfs_core::cache::DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES;
 /// Default commit window, in milliseconds: how long a direct publish holds
 /// its namespace's window open so concurrent publishes can join the same
 /// flush — one WAL segment, one head CAS. Zero disables coalescing.
@@ -37,38 +39,33 @@ pub(crate) struct FsConfig {
     pub trace_store_kind: TraceStoreKind,
 }
 
-/// Cache configuration for the embedded runtime.
+/// Cache configuration for the embedded runtime. Every cache disables the
+/// same way: a zero budget.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
-    /// Enables WAL-tail projection caching.
-    pub wal_tail_projection_cache_enabled: bool,
-    /// Enables namespace control-object caching.
-    pub control_cache_enabled: bool,
-    /// Maximum namespaces retained in runtime caches.
-    /// Setting this to zero disables the commit-engine cache — a diagnostic
-    /// mode that also disables post-publish auto-maintenance, leaving only
-    /// the hard publish backpressure. Not for production use.
+    /// Maximum namespaces retained in runtime caches (control anchors,
+    /// catalogs, commit engines, and WAL-tail projection entries).
+    /// Setting this to zero disables those caches — a diagnostic mode that
+    /// also disables post-publish auto-maintenance, leaving only the hard
+    /// publish backpressure. Not for production use.
     pub max_cached_namespaces: usize,
-    /// Maximum metadata rows retained across cached WAL-tail projections.
+    /// Maximum metadata rows retained across cached WAL-tail projections;
+    /// zero disables the projection cache.
     pub max_cached_wal_tail_projection_rows: usize,
     /// Approximate decoded-byte budget for cached WAL-tail projections.
-    pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
+    pub max_cached_wal_tail_projection_decoded_bytes: usize,
     /// Cache settings for decoded metadata tables.
     pub metadata_table_cache: MetadataTableCacheConfig,
 }
 
 impl RuntimeCacheConfig {
-    /// Disables runtime caches.
+    /// Disables runtime caches by zeroing every budget.
     pub fn disabled() -> Self {
         Self {
-            wal_tail_projection_cache_enabled: false,
-            control_cache_enabled: false,
             max_cached_namespaces: 0,
             max_cached_wal_tail_projection_rows: 0,
-            max_cached_wal_tail_projection_decoded_bytes: Some(0),
+            max_cached_wal_tail_projection_decoded_bytes: 0,
             metadata_table_cache: MetadataTableCacheConfig {
-                enabled: false,
-                max_blocks: 0,
                 max_decoded_bytes: 0,
             },
         }
@@ -78,13 +75,10 @@ impl RuntimeCacheConfig {
 impl Default for RuntimeCacheConfig {
     fn default() -> Self {
         Self {
-            wal_tail_projection_cache_enabled: true,
-            control_cache_enabled: true,
             max_cached_namespaces: DEFAULT_MAX_CACHED_NAMESPACES,
             max_cached_wal_tail_projection_rows: DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS,
-            max_cached_wal_tail_projection_decoded_bytes: Some(
+            max_cached_wal_tail_projection_decoded_bytes:
                 DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES,
-            ),
             metadata_table_cache: MetadataTableCacheConfig::default(),
         }
     }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -94,7 +94,6 @@ impl FsCore {
         ));
         let wal_tail_projection_cache =
             Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-                enabled: config.runtime_cache.wal_tail_projection_cache_enabled,
                 max_entries: config.runtime_cache.max_cached_namespaces,
                 max_rows: config.runtime_cache.max_cached_wal_tail_projection_rows,
                 max_decoded_bytes: config


### PR DESCRIPTION
Before this, each cache had two or three versions of "off" (an enabled flag, a zero count, a zero byte budget), three byte budgets were `Option<usize>` even though nothing ever passed `None`, and the same three default limits were hand-copied across four files. 

- The metadata table cache keeps exactly one field: its decoded-byte budget. The secondary `max_blocks` count bound is gone — at 64 KiB blocks the byte budget always binds first, so the count never did anything at defaults. (Known cost: the LRU touch is linear in entries per hit; unchanged here, noted for later.)
- The WAL-tail projection cache loses its `enabled` flag (zero entries or a zero row budget disables it) and its byte budget becomes plain.
- The runtime config loses `wal_tail_projection_cache_enabled` and `control_cache_enabled` (the tail cache was being gated three times: a config bool, an attach-time check, and the cache's own flag); `max_cached_namespaces = 0` is the single off switch for the per-namespace caches, which is what `RuntimeCacheConfig::disabled()` now zeroes.
- The publish-side tail limits share one pair of default constants with the read-side projection cache instead of duplicating the numbers.
- The server TOML drops the three boolean knobs and the block-count knob; zero budgets express the same configurations.

Two decisions from the audit ride along: the CLI writer now runs with a zero commit window (a CLI invocation is one solo mutation — holding the 15 ms window open only added its full delay to every command), and `MetadataLsmPolicy` leaves the public API (production only ever constructs its default; it stays as the tests' injection point), taking a tautology test with it.
