### PR TITLE
refactor(core): one scan engine and no unfalsifiable seq checks

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -7,8 +7,7 @@ use super::build::{
 };
 use super::error::ManifestLoadError;
 use super::load::{
-    head_from_manifest, load_namespace_manifest_envelope_if_present,
-    load_verified_manifest_tables_with_cache,
+    head_from_manifest, load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
 };
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::record::{
@@ -290,16 +289,12 @@ async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
             },
         ));
     }
-    let manifest_tables = load_verified_manifest_tables_with_cache(
-        store,
-        None,
-        namespace_id,
-        &root.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
+    let manifest_tables =
+        load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
     if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
         return Err(CoreError::NamespaceCorrupt(format!(
             "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -1,7 +1,7 @@
 //! Manifest load errors, classified as corruption versus store trouble.
 
 use loonfs_api::wire::manifest::MetadataTableFamily;
-use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_api::{ManifestId, ManifestObjectId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -83,14 +83,6 @@ pub enum ManifestLoadError {
         object_key: String,
         expected: NamespaceId,
         actual: NamespaceId,
-    },
-    #[error(
-        "metadata SST seq mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
-    )]
-    SegmentSeqMismatch {
-        object_key: String,
-        expected: ChangeSeq,
-        actual: ChangeSeq,
     },
     #[error(
         "metadata SST family mismatch for `{object_key}`: expected `{expected:?}`, actual `{actual:?}`"

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -1,12 +1,12 @@
 //! Read-side manifest loading.
 //!
-//! There are three intentionally separate levels here:
+//! There are two intentionally separate levels:
 //!
 //! 1. `load_namespace_manifest_envelope` validates only the manifest envelope.
 //! 2. `load_verified_manifest_tables` validates the manifest and table
 //!    descriptors without fetching SST row payloads.
-//! 3. `load_manifest_materialization_for_inspection` is the expensive
-//!    inspection/debug path that loads every referenced row into `MetadataState`.
+//!
+//! Full-row inspection materialization exists only for tests.
 
 use super::cache::{
     DecodedMetadataTableBlock, DecodedSegmentRowSet, MetadataTableBlockKind, MetadataTableCache,
@@ -45,7 +45,7 @@ use loonfs_api::wire::sst_blocks::{
 };
 #[cfg(test)]
 use loonfs_api::ManifestId;
-use loonfs_api::{ChangeSeq, ManifestObjectId, NamespaceId};
+use loonfs_api::{ManifestObjectId, NamespaceId};
 #[cfg(test)]
 use loonfs_objectstore::keys::metadata_manifest_prefix;
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
@@ -328,12 +328,7 @@ pub(super) async fn load_manifest_metadata_state_for_inspection_from_manifest<
         append_manifest_tables_to_metadata(
             store,
             namespace_id,
-            MetadataTableLoadContext {
-                manifest_object_key,
-                segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                row_seq_min: None,
-                row_seq_max: run.run_seq,
-            },
+            manifest_object_key,
             &run.tables,
             &mut metadata_state,
         )
@@ -353,16 +348,8 @@ fn validate_manifest_table_descriptors(
         let mut direntry_child_bind_rows = 0u64;
         let mut revision_rows = 0u64;
         let mut revision_by_inode_desc_rows = 0u64;
-        let context = MetadataTableLoadContext {
-            manifest_object_key,
-            segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-            row_seq_min: None,
-            row_seq_max: run.run_seq,
-        };
-
         for table in ordered_tables {
             for descriptor in &table.segments {
-                context.expected_segment_seq(descriptor)?;
                 let expected_key = metadata_file_object_key(descriptor);
                 if descriptor.object_key != expected_key {
                     return Err(ManifestLoadError::SegmentObjectKeyMismatch {
@@ -414,45 +401,6 @@ fn validate_manifest_table_descriptors(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-pub(super) struct MetadataTableLoadContext<'a> {
-    pub(super) manifest_object_key: &'a str,
-    pub(super) segment_seq_expectation: MetadataSstSeqExpectation,
-    pub(super) row_seq_min: Option<ChangeSeq>,
-    pub(super) row_seq_max: ChangeSeq,
-}
-
-#[derive(Clone, Copy)]
-pub(super) enum MetadataSstSeqExpectation {
-    Descriptor,
-}
-
-impl MetadataTableLoadContext<'_> {
-    pub(super) fn expected_segment_seq(
-        &self,
-        descriptor: &MetadataFileRef,
-    ) -> Result<ChangeSeq, ManifestLoadError> {
-        match self.segment_seq_expectation {
-            MetadataSstSeqExpectation::Descriptor => {
-                if descriptor.run_seq > self.row_seq_max {
-                    return Err(ManifestLoadError::SegmentSeqMismatch {
-                        object_key: descriptor.object_key.clone(),
-                        expected: self.row_seq_max,
-                        actual: descriptor.run_seq,
-                    });
-                }
-                Ok(descriptor.run_seq)
-            }
-        }
-    }
-
-    pub(super) fn row_seq_max(&self, descriptor: &MetadataFileRef) -> ChangeSeq {
-        match self.segment_seq_expectation {
-            MetadataSstSeqExpectation::Descriptor => descriptor.run_seq,
-        }
-    }
-}
-
 pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
     metadata_table(
         descriptor.owner_namespace_id.as_str(),
@@ -464,14 +412,14 @@ pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
 pub(super) async fn append_manifest_tables_to_metadata<S>(
     store: &S,
     _namespace_id: &NamespaceId,
-    context: MetadataTableLoadContext<'_>,
+    manifest_object_key: &str,
     tables: &[MetadataTableManifest],
     metadata_state: &mut MetadataStateBuilder,
 ) -> Result<(), ManifestLoadError>
 where
     S: ObjectStore + ?Sized,
 {
-    let ordered_tables = ordered_manifest_tables(context.manifest_object_key, tables)?;
+    let ordered_tables = ordered_manifest_tables(manifest_object_key, tables)?;
     let mut direntry_bind_rows = Vec::new();
     let mut direntry_child_bind_rows = Vec::new();
     let mut revision_rows = Vec::new();
@@ -479,7 +427,6 @@ where
     for table in ordered_tables {
         let mut descriptors = Vec::with_capacity(table.segments.len());
         for descriptor in &table.segments {
-            context.expected_segment_seq(descriptor)?;
             let expected_key = metadata_file_object_key(descriptor);
             if descriptor.object_key != expected_key {
                 return Err(ManifestLoadError::SegmentObjectKeyMismatch {
@@ -493,9 +440,11 @@ where
         let mut loaded_segments = Vec::with_capacity(descriptors.len());
         for chunk in descriptors.chunks(MAX_MAINTENANCE_TABLE_IO) {
             loaded_segments.extend(
-                try_join_all(chunk.iter().map(|descriptor| {
-                    load_manifest_segment_rows(store, context, table.family, descriptor)
-                }))
+                try_join_all(
+                    chunk.iter().map(|descriptor| {
+                        load_manifest_segment_rows(store, table.family, descriptor)
+                    }),
+                )
                 .await?,
             );
         }
@@ -526,12 +475,12 @@ where
     }
 
     validate_direntry_child_bind_index(
-        context.manifest_object_key,
+        manifest_object_key,
         direntry_bind_rows,
         direntry_child_bind_rows,
     )?;
     validate_revision_by_inode_desc_index(
-        context.manifest_object_key,
+        manifest_object_key,
         revision_rows,
         revision_by_inode_desc_rows,
     )
@@ -540,11 +489,10 @@ where
 #[cfg(test)]
 pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     store: &S,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
-    load_manifest_segment_rows_with_cache(store, None, context, family, descriptor).await
+    load_manifest_segment_rows_with_cache(store, None, family, descriptor).await
 }
 
 /// Per-view memo of decoded blocks, so one operation never re-fetches or
@@ -592,7 +540,6 @@ const MAX_BULK_FETCH_BYTES: u64 = 4 * 1024 * 1024;
 pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
@@ -600,7 +547,6 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         store,
         table_cache,
         &SessionBlockMemo::default(),
-        context,
         family,
         descriptor,
         "",
@@ -638,14 +584,12 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     lower_bound: &str,
     upper_bound: Option<&str>,
     readahead: bool,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
-    context.expected_segment_seq(descriptor)?;
     let index = load_segment_index(store, table_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
@@ -679,12 +623,7 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
         row_keys.extend(block.row_keys.iter().cloned());
         rows.extend(block.rows.iter().cloned());
     }
-    validate_manifest_row_seq_range(
-        &descriptor.object_key,
-        &rows,
-        context.row_seq_min,
-        context.row_seq_max(descriptor),
-    )?;
+    validate_manifest_row_seq_range(&descriptor.object_key, &rows, descriptor.run_seq)?;
     Ok(Arc::new(DecodedSegmentRowSet { rows, row_keys }))
 }
 

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -10,9 +10,9 @@
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
 //! - [`publish`] writes manifest objects and advances `current_manifest_id`
 //!   on the head by compare-and-swap.
-//! - [`load`] and [`validate`] provide envelope-only loading, descriptor-only
-//!   table verification, and explicit inspection materialization when callers
-//!   truly need every metadata row.
+//! - [`load`] and [`validate`] provide envelope-only loading and
+//!   descriptor-only table verification (full-row inspection
+//!   materialization is test-only).
 //! - [`scan`] answers verified row scans over loaded manifest tables.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above, and

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -143,12 +143,9 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     // output represents the same head the manifest already describes.
     let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
     for family in group {
-        let mut rows = tables.scan_prefix(*family, "").await.map_err(|error| {
+        let rows = tables.scan_prefix(*family, "").await.map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
-        // The scan yields rows in run order (base, then L0 newest-first);
-        // the merged base must be in row-key order.
-        rows.sort_by_cached_key(|row| row.row_key_for_family(*family));
         rows_by_family.insert(*family, rows);
     }
     // The paired groups exist to preserve index parity; verify it on the

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -4,9 +4,7 @@
 use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
-    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
-    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableLoadContext,
-    SessionBlockMemo,
+    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SessionBlockMemo,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -52,10 +50,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         key: &str,
         filter_probe: &str,
-        readahead: bool,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
-            .scan_prefix_rows(family, key, Some(filter_probe), readahead)
+            .scan_prefix_rows(family, key, Some(filter_probe), true)
             .await?
             .into_iter()
             .find(|row| row.row_key_for_family(family) == key))
@@ -101,7 +98,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
     /// [`Self::scan_range_page`] for a point lookup within one filter key's
     /// range; see [`Self::scan_prefix_for_lookup`] for the probe contract.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn scan_range_page_for_lookup(
         &self,
         family: MetadataTableFamily,
@@ -109,7 +105,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         upper_bound: Option<&str>,
         limit: usize,
         filter_probe: &str,
-        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -120,11 +115,13 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             upper_bound,
             limit,
             Some(filter_probe),
-            readahead,
+            true,
         )
         .await
     }
 
+    /// A prefix scan is a range scan over `[prefix, upper_bound(prefix))`
+    /// with no row limit; rows come back in row-key order.
     async fn scan_prefix_rows(
         &self,
         family: MetadataTableFamily,
@@ -132,25 +129,16 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let mut rows = Vec::new();
-        for run in runs_in_scan_order(&self.manifest.payload) {
-            self.scan_manifest_tables(
-                family,
-                prefix,
-                MetadataTableLoadContext {
-                    manifest_object_key: &self.manifest_object_key,
-                    segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                    row_seq_min: None,
-                    row_seq_max: run.run_seq,
-                },
-                &run.tables,
-                &mut rows,
-                filter_probe,
-                readahead,
-            )
-            .await?;
-        }
-        Ok(rows)
+        let upper_bound = string_prefix_upper_bound(prefix);
+        self.scan_range_page_rows(
+            family,
+            prefix,
+            upper_bound.as_deref(),
+            usize::MAX,
+            filter_probe,
+            readahead,
+        )
+        .await
     }
 
     /// Whether a lookup should touch this segment at all: false only when
@@ -193,37 +181,18 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let mut matching_descriptors = Vec::new();
-        for run in runs_in_scan_order(&self.manifest.payload) {
-            let context = MetadataTableLoadContext {
-                manifest_object_key: &self.manifest_object_key,
-                segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                row_seq_min: None,
-                row_seq_max: run.run_seq,
-            };
-            let table =
-                manifest_table_for_family(context.manifest_object_key, &run.tables, family)?;
-            for descriptor in &table.segments {
-                context.expected_segment_seq(descriptor)?;
-                let expected_key = metadata_file_object_key(descriptor);
-                if descriptor.object_key != expected_key {
-                    return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                        object_key: descriptor.object_key.clone(),
-                        expected: expected_key,
-                    });
-                }
-                if !descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
-                    continue;
-                }
-                if let Some(filter_probe) = filter_probe {
-                    if !self.segment_filter_admits(descriptor, filter_probe).await? {
-                        continue;
-                    }
-                }
-                matching_descriptors.push((context, descriptor.clone()));
-            }
+        let runs = runs_in_scan_order(&self.manifest.payload);
+        let mut candidates = Vec::new();
+        for run in &runs {
+            let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
+            candidates.extend(table.segments.iter().filter(|descriptor| {
+                descriptor_may_intersect_range(descriptor, lower_bound, upper_bound)
+            }));
         }
-        matching_descriptors.sort_by(|(_, left), (_, right)| {
+        let mut matching_descriptors = self
+            .filter_admitted_descriptors(candidates, filter_probe)
+            .await?;
+        matching_descriptors.sort_by(|left, right| {
             left.min_key
                 .cmp(&right.min_key)
                 .then(left.max_key.cmp(&right.max_key))
@@ -237,7 +206,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 true
             } else {
                 let boundary_key = &rows[limit - 1].0;
-                matching_descriptors[next_descriptor_index].1.min_key <= *boundary_key
+                matching_descriptors[next_descriptor_index].min_key <= *boundary_key
             };
             if !should_load_next {
                 break;
@@ -248,93 +217,29 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             let loaded_segments = try_join_all(
                 matching_descriptors[next_descriptor_index..chunk_end]
                     .iter()
-                    .map(|(context, descriptor)| {
-                        self.segment_rows(
-                            *context,
-                            family,
-                            descriptor,
-                            lower_bound,
-                            upper_bound,
-                            readahead,
-                        )
+                    .map(|descriptor| {
+                        self.segment_rows(family, descriptor, lower_bound, upper_bound, readahead)
                     }),
             )
             .await?;
             next_descriptor_index = chunk_end;
 
-            rows.extend(loaded_segments.iter().flat_map(|segment_rows| {
-                segment_rows
-                    .rows_in_key_range(lower_bound, upper_bound)
-                    .map(|(row_key, row)| (row_key.to_owned(), row.clone()))
-            }));
+            for segment_rows in loaded_segments {
+                let matched_before = rows.len();
+                rows.extend(
+                    segment_rows
+                        .rows_in_key_range(lower_bound, upper_bound)
+                        .map(|(row_key, row)| (row_key.to_owned(), row.clone())),
+                );
+                if filter_probe.is_some() {
+                    self.record_filter_false_positive_if_empty(rows.len() - matched_before);
+                }
+            }
             rows.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         }
 
         rows.truncate(limit);
         Ok(rows.into_iter().map(|(_, row)| row).collect())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn scan_manifest_tables(
-        &self,
-        family: MetadataTableFamily,
-        prefix: &str,
-        context: MetadataTableLoadContext<'_>,
-        tables: &[MetadataTableManifest],
-        rows: &mut Vec<MetadataRow>,
-        filter_probe: Option<&str>,
-        readahead: bool,
-    ) -> Result<(), ManifestLoadError> {
-        let table = manifest_table_for_family(context.manifest_object_key, tables, family)?;
-        let mut matching_descriptors = Vec::new();
-        for descriptor in &table.segments {
-            context.expected_segment_seq(descriptor)?;
-            let expected_key = metadata_file_object_key(descriptor);
-            if descriptor.object_key != expected_key {
-                return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                    object_key: descriptor.object_key.clone(),
-                    expected: expected_key,
-                });
-            }
-            if !descriptor_may_contain_prefix(descriptor, prefix) {
-                continue;
-            }
-            matching_descriptors.push(descriptor);
-        }
-        let matching_descriptors = self
-            .filter_admitted_descriptors(matching_descriptors, filter_probe)
-            .await?;
-
-        let prefix_upper_bound = string_prefix_upper_bound(prefix);
-        let mut loaded_segments = Vec::new();
-        for chunk in matching_descriptors.chunks(MAX_MATERIALIZED_TABLE_FETCHES) {
-            loaded_segments.extend(
-                try_join_all(chunk.iter().map(|descriptor| {
-                    self.segment_rows(
-                        context,
-                        family,
-                        descriptor,
-                        prefix,
-                        prefix_upper_bound.as_deref(),
-                        readahead,
-                    )
-                }))
-                .await?,
-            );
-        }
-
-        for segment_rows in loaded_segments {
-            let matched = rows.len();
-            rows.extend(
-                segment_rows
-                    .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
-                    .map(|(_, row)| row.clone()),
-            );
-            if filter_probe.is_some() {
-                self.record_filter_false_positive_if_empty(rows.len() - matched);
-            }
-        }
-        Ok(())
     }
 
     /// Drops the descriptors whose bloom filter rules the probe out; with no
@@ -368,7 +273,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
     async fn segment_rows(
         &self,
-        context: MetadataTableLoadContext<'_>,
         family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
         lower_bound: &str,
@@ -379,7 +283,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             self.store,
             self.table_cache,
             &self.block_memo,
-            context,
             family,
             descriptor,
             lower_bound,
@@ -419,31 +322,14 @@ pub(super) fn manifest_table_for_family<'a>(
     tables: &'a [MetadataTableManifest],
     family: MetadataTableFamily,
 ) -> Result<&'a MetadataTableManifest, ManifestLoadError> {
-    ordered_manifest_tables(manifest_object_key, tables)?
-        .into_iter()
-        .find(|table| table.family == family)
-        .ok_or(ManifestLoadError::MissingTableFamily {
+    // Family-set integrity is validated once when the tables are loaded;
+    // scans only need the lookup.
+    tables.iter().find(|table| table.family == family).ok_or(
+        ManifestLoadError::MissingTableFamily {
             object_key: manifest_object_key.to_owned(),
             family,
-        })
-}
-
-pub(super) fn descriptor_may_contain_prefix(descriptor: &MetadataFileRef, prefix: &str) -> bool {
-    if descriptor.row_count == 0 {
-        return false;
-    }
-    if prefix.is_empty() {
-        return true;
-    }
-    if descriptor.max_key.as_str() < prefix {
-        return false;
-    }
-    if let Some(upper_bound) = string_prefix_upper_bound(prefix) {
-        if descriptor.min_key >= upper_bound {
-            return false;
-        }
-    }
-    true
+        },
+    )
 }
 
 pub(super) fn descriptor_may_intersect_range(

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2684,7 +2684,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
 
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("get inode")
         .is_some());
@@ -3966,7 +3966,7 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     store.reset_metadata_sst_gets();
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("first lookup")
         .is_some());
@@ -3974,13 +3974,13 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     assert!(first_lookup_gets > 0, "a cold lookup fetches blocks");
 
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("repeated lookup")
         .is_some());
     let other = "inode-00000000000000000002";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other)
         .await
         .expect("second-key lookup")
         .is_some());

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -138,21 +138,10 @@ pub(super) fn validate_manifest_materialization_ranges(
 pub(super) fn validate_manifest_row_seq_range(
     object_key: &str,
     rows: &[MetadataRow],
-    min_seq: Option<ChangeSeq>,
     max_seq: ChangeSeq,
 ) -> Result<(), ManifestLoadError> {
     for (row_index, row) in rows.iter().enumerate() {
         let row_seq = manifest_row_commit_seq(row);
-        if let Some(min_seq) = min_seq {
-            if row_seq < min_seq {
-                return Err(ManifestLoadError::SegmentDescriptorMismatch {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "row {row_index} seq `{row_seq}` is before expected min `{min_seq}`"
-                    ),
-                });
-            }
-        }
         if row_seq > max_seq {
             return Err(ManifestLoadError::SegmentDescriptorMismatch {
                 object_key: object_key.to_owned(),

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -24,7 +24,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 ) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
-        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key, true)
+        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
         .and_then(inode_from_manifest_row))
@@ -244,7 +244,6 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&exact_prefix).as_deref(),
             1,
             &filter_probe,
-            true,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -274,7 +273,6 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&inode_prefix).as_deref(),
             limit,
             &filter_probe,
-            true,
         )
         .await
         .map_err(manifest_error_to_core)?


### PR DESCRIPTION
Wave 4 of the pre-release audit: the scan layer had two parallel row-collection engines for what is one job, plus a validation layer that provably could never fire. This folds everything onto one engine and deletes the unfalsifiable checks.

**One scan engine.** A prefix scan is exactly a range scan over `[prefix, upper_bound(prefix))` with no row limit, so the prefix engine (~90 lines) is now a two-line wrapper over the range engine. The duplication had already produced two real asymmetries, both of which this fixes by keeping the better half of each path:

- bloom-filter admission was batched 16-way on the prefix path but awaited one segment at a time on the range path — every path now batches;
- the filter false-positive counter was only recorded on the prefix path — it now records on both, so revision lookups count toward the stat.

Scan output is now row-key ordered everywhere (all callers were verified order-insensitive; rows for the same key carry their own sequence fields, which is what every consumer compares), and reorganization drops the re-sort it needed when prefix scans returned run-major order.

**The seq apparatus is gone.** `MetadataSstSeqExpectation` was a one-variant enum whose check compared a descriptor's run seq against a bound that was, at every construction site, that same descriptor's run grouped by that same seq — it could never fire, and its error variant had no reachable constructor. The `row_seq_min` bound was `None` at every site. What remains is the one falsifiable decode-side check: rows in a segment must not exceed the descriptor's run seq. Scans also no longer re-run per-page the descriptor validation (object-key equality, family-set integrity) that the single `VerifiedMetadataTables` constructor already performs once per view.

**Vestigial parameters.** `get_for_lookup` and `scan_range_page_for_lookup` threaded a `readahead` flag that every caller set to true — hardcoded now; the flag stays only on `scan_prefix_for_lookup`, where callers genuinely vary it.

Verified with the request-accounting probe at 10k: request counts are unchanged from the previous stack tip (the merge changes structure, not fetch behavior), and the full workspace suite is green.
