### PR TITLE
perf(core): seed read caches from landed publishes and preserve fencing

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -7,8 +7,7 @@ use super::build::{
 };
 use super::error::ManifestLoadError;
 use super::load::{
-    head_from_manifest, load_namespace_manifest_envelope_if_present,
-    load_verified_manifest_tables_with_cache,
+    head_from_manifest, load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
 };
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::record::{
@@ -290,16 +289,12 @@ async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
             },
         ));
     }
-    let manifest_tables = load_verified_manifest_tables_with_cache(
-        store,
-        None,
-        namespace_id,
-        &root.manifest_object_id,
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-    })?;
+    let manifest_tables =
+        load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
     if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
         return Err(CoreError::NamespaceCorrupt(format!(
             "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -1,7 +1,7 @@
 //! Manifest load errors, classified as corruption versus store trouble.
 
 use loonfs_api::wire::manifest::MetadataTableFamily;
-use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_api::{ManifestId, ManifestObjectId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -83,14 +83,6 @@ pub enum ManifestLoadError {
         object_key: String,
         expected: NamespaceId,
         actual: NamespaceId,
-    },
-    #[error(
-        "metadata SST seq mismatch for `{object_key}`: expected `{expected}`, actual `{actual}`"
-    )]
-    SegmentSeqMismatch {
-        object_key: String,
-        expected: ChangeSeq,
-        actual: ChangeSeq,
     },
     #[error(
         "metadata SST family mismatch for `{object_key}`: expected `{expected:?}`, actual `{actual:?}`"

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -1,12 +1,12 @@
 //! Read-side manifest loading.
 //!
-//! There are three intentionally separate levels here:
+//! There are two intentionally separate levels:
 //!
 //! 1. `load_namespace_manifest_envelope` validates only the manifest envelope.
 //! 2. `load_verified_manifest_tables` validates the manifest and table
 //!    descriptors without fetching SST row payloads.
-//! 3. `load_manifest_materialization_for_inspection` is the expensive
-//!    inspection/debug path that loads every referenced row into `MetadataState`.
+//!
+//! Full-row inspection materialization exists only for tests.
 
 use super::cache::{
     DecodedMetadataTableBlock, DecodedSegmentRowSet, MetadataTableBlockKind, MetadataTableCache,
@@ -45,7 +45,7 @@ use loonfs_api::wire::sst_blocks::{
 };
 #[cfg(test)]
 use loonfs_api::ManifestId;
-use loonfs_api::{ChangeSeq, ManifestObjectId, NamespaceId};
+use loonfs_api::{ManifestObjectId, NamespaceId};
 #[cfg(test)]
 use loonfs_objectstore::keys::metadata_manifest_prefix;
 use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
@@ -328,12 +328,7 @@ pub(super) async fn load_manifest_metadata_state_for_inspection_from_manifest<
         append_manifest_tables_to_metadata(
             store,
             namespace_id,
-            MetadataTableLoadContext {
-                manifest_object_key,
-                segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                row_seq_min: None,
-                row_seq_max: run.run_seq,
-            },
+            manifest_object_key,
             &run.tables,
             &mut metadata_state,
         )
@@ -353,16 +348,8 @@ fn validate_manifest_table_descriptors(
         let mut direntry_child_bind_rows = 0u64;
         let mut revision_rows = 0u64;
         let mut revision_by_inode_desc_rows = 0u64;
-        let context = MetadataTableLoadContext {
-            manifest_object_key,
-            segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-            row_seq_min: None,
-            row_seq_max: run.run_seq,
-        };
-
         for table in ordered_tables {
             for descriptor in &table.segments {
-                context.expected_segment_seq(descriptor)?;
                 let expected_key = metadata_file_object_key(descriptor);
                 if descriptor.object_key != expected_key {
                     return Err(ManifestLoadError::SegmentObjectKeyMismatch {
@@ -414,45 +401,6 @@ fn validate_manifest_table_descriptors(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-pub(super) struct MetadataTableLoadContext<'a> {
-    pub(super) manifest_object_key: &'a str,
-    pub(super) segment_seq_expectation: MetadataSstSeqExpectation,
-    pub(super) row_seq_min: Option<ChangeSeq>,
-    pub(super) row_seq_max: ChangeSeq,
-}
-
-#[derive(Clone, Copy)]
-pub(super) enum MetadataSstSeqExpectation {
-    Descriptor,
-}
-
-impl MetadataTableLoadContext<'_> {
-    pub(super) fn expected_segment_seq(
-        &self,
-        descriptor: &MetadataFileRef,
-    ) -> Result<ChangeSeq, ManifestLoadError> {
-        match self.segment_seq_expectation {
-            MetadataSstSeqExpectation::Descriptor => {
-                if descriptor.run_seq > self.row_seq_max {
-                    return Err(ManifestLoadError::SegmentSeqMismatch {
-                        object_key: descriptor.object_key.clone(),
-                        expected: self.row_seq_max,
-                        actual: descriptor.run_seq,
-                    });
-                }
-                Ok(descriptor.run_seq)
-            }
-        }
-    }
-
-    pub(super) fn row_seq_max(&self, descriptor: &MetadataFileRef) -> ChangeSeq {
-        match self.segment_seq_expectation {
-            MetadataSstSeqExpectation::Descriptor => descriptor.run_seq,
-        }
-    }
-}
-
 pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
     metadata_table(
         descriptor.owner_namespace_id.as_str(),
@@ -464,14 +412,14 @@ pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
 pub(super) async fn append_manifest_tables_to_metadata<S>(
     store: &S,
     _namespace_id: &NamespaceId,
-    context: MetadataTableLoadContext<'_>,
+    manifest_object_key: &str,
     tables: &[MetadataTableManifest],
     metadata_state: &mut MetadataStateBuilder,
 ) -> Result<(), ManifestLoadError>
 where
     S: ObjectStore + ?Sized,
 {
-    let ordered_tables = ordered_manifest_tables(context.manifest_object_key, tables)?;
+    let ordered_tables = ordered_manifest_tables(manifest_object_key, tables)?;
     let mut direntry_bind_rows = Vec::new();
     let mut direntry_child_bind_rows = Vec::new();
     let mut revision_rows = Vec::new();
@@ -479,7 +427,6 @@ where
     for table in ordered_tables {
         let mut descriptors = Vec::with_capacity(table.segments.len());
         for descriptor in &table.segments {
-            context.expected_segment_seq(descriptor)?;
             let expected_key = metadata_file_object_key(descriptor);
             if descriptor.object_key != expected_key {
                 return Err(ManifestLoadError::SegmentObjectKeyMismatch {
@@ -493,9 +440,11 @@ where
         let mut loaded_segments = Vec::with_capacity(descriptors.len());
         for chunk in descriptors.chunks(MAX_MAINTENANCE_TABLE_IO) {
             loaded_segments.extend(
-                try_join_all(chunk.iter().map(|descriptor| {
-                    load_manifest_segment_rows(store, context, table.family, descriptor)
-                }))
+                try_join_all(
+                    chunk.iter().map(|descriptor| {
+                        load_manifest_segment_rows(store, table.family, descriptor)
+                    }),
+                )
                 .await?,
             );
         }
@@ -526,12 +475,12 @@ where
     }
 
     validate_direntry_child_bind_index(
-        context.manifest_object_key,
+        manifest_object_key,
         direntry_bind_rows,
         direntry_child_bind_rows,
     )?;
     validate_revision_by_inode_desc_index(
-        context.manifest_object_key,
+        manifest_object_key,
         revision_rows,
         revision_by_inode_desc_rows,
     )
@@ -540,11 +489,10 @@ where
 #[cfg(test)]
 pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     store: &S,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
-    load_manifest_segment_rows_with_cache(store, None, context, family, descriptor).await
+    load_manifest_segment_rows_with_cache(store, None, family, descriptor).await
 }
 
 /// Per-view memo of decoded blocks, so one operation never re-fetches or
@@ -592,7 +540,6 @@ const MAX_BULK_FETCH_BYTES: u64 = 4 * 1024 * 1024;
 pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
@@ -600,7 +547,6 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         store,
         table_cache,
         &SessionBlockMemo::default(),
-        context,
         family,
         descriptor,
         "",
@@ -638,14 +584,12 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    context: MetadataTableLoadContext<'_>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     lower_bound: &str,
     upper_bound: Option<&str>,
     readahead: bool,
 ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
-    context.expected_segment_seq(descriptor)?;
     let index = load_segment_index(store, table_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
@@ -679,12 +623,7 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
         row_keys.extend(block.row_keys.iter().cloned());
         rows.extend(block.rows.iter().cloned());
     }
-    validate_manifest_row_seq_range(
-        &descriptor.object_key,
-        &rows,
-        context.row_seq_min,
-        context.row_seq_max(descriptor),
-    )?;
+    validate_manifest_row_seq_range(&descriptor.object_key, &rows, descriptor.run_seq)?;
     Ok(Arc::new(DecodedSegmentRowSet { rows, row_keys }))
 }
 

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -10,9 +10,9 @@
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
 //! - [`publish`] writes manifest objects and advances `current_manifest_id`
 //!   on the head by compare-and-swap.
-//! - [`load`] and [`validate`] provide envelope-only loading, descriptor-only
-//!   table verification, and explicit inspection materialization when callers
-//!   truly need every metadata row.
+//! - [`load`] and [`validate`] provide envelope-only loading and
+//!   descriptor-only table verification (full-row inspection
+//!   materialization is test-only).
 //! - [`scan`] answers verified row scans over loaded manifest tables.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above, and

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -143,12 +143,9 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     // output represents the same head the manifest already describes.
     let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
     for family in group {
-        let mut rows = tables.scan_prefix(*family, "").await.map_err(|error| {
+        let rows = tables.scan_prefix(*family, "").await.map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
-        // The scan yields rows in run order (base, then L0 newest-first);
-        // the merged base must be in row-key order.
-        rows.sort_by_cached_key(|row| row.row_key_for_family(*family));
         rows_by_family.insert(*family, rows);
     }
     // The paired groups exist to preserve index parity; verify it on the

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -4,9 +4,7 @@
 use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
 use super::error::ManifestLoadError;
 use super::load::{
-    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter,
-    metadata_file_object_key, MetadataSstSeqExpectation, MetadataTableLoadContext,
-    SessionBlockMemo,
+    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SessionBlockMemo,
 };
 use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -52,10 +50,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         key: &str,
         filter_probe: &str,
-        readahead: bool,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
         Ok(self
-            .scan_prefix_rows(family, key, Some(filter_probe), readahead)
+            .scan_prefix_rows(family, key, Some(filter_probe), true)
             .await?
             .into_iter()
             .find(|row| row.row_key_for_family(family) == key))
@@ -101,7 +98,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
     /// [`Self::scan_range_page`] for a point lookup within one filter key's
     /// range; see [`Self::scan_prefix_for_lookup`] for the probe contract.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn scan_range_page_for_lookup(
         &self,
         family: MetadataTableFamily,
@@ -109,7 +105,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         upper_bound: Option<&str>,
         limit: usize,
         filter_probe: &str,
-        readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -120,11 +115,13 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             upper_bound,
             limit,
             Some(filter_probe),
-            readahead,
+            true,
         )
         .await
     }
 
+    /// A prefix scan is a range scan over `[prefix, upper_bound(prefix))`
+    /// with no row limit; rows come back in row-key order.
     async fn scan_prefix_rows(
         &self,
         family: MetadataTableFamily,
@@ -132,25 +129,16 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let mut rows = Vec::new();
-        for run in runs_in_scan_order(&self.manifest.payload) {
-            self.scan_manifest_tables(
-                family,
-                prefix,
-                MetadataTableLoadContext {
-                    manifest_object_key: &self.manifest_object_key,
-                    segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                    row_seq_min: None,
-                    row_seq_max: run.run_seq,
-                },
-                &run.tables,
-                &mut rows,
-                filter_probe,
-                readahead,
-            )
-            .await?;
-        }
-        Ok(rows)
+        let upper_bound = string_prefix_upper_bound(prefix);
+        self.scan_range_page_rows(
+            family,
+            prefix,
+            upper_bound.as_deref(),
+            usize::MAX,
+            filter_probe,
+            readahead,
+        )
+        .await
     }
 
     /// Whether a lookup should touch this segment at all: false only when
@@ -193,37 +181,18 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let mut matching_descriptors = Vec::new();
-        for run in runs_in_scan_order(&self.manifest.payload) {
-            let context = MetadataTableLoadContext {
-                manifest_object_key: &self.manifest_object_key,
-                segment_seq_expectation: MetadataSstSeqExpectation::Descriptor,
-                row_seq_min: None,
-                row_seq_max: run.run_seq,
-            };
-            let table =
-                manifest_table_for_family(context.manifest_object_key, &run.tables, family)?;
-            for descriptor in &table.segments {
-                context.expected_segment_seq(descriptor)?;
-                let expected_key = metadata_file_object_key(descriptor);
-                if descriptor.object_key != expected_key {
-                    return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                        object_key: descriptor.object_key.clone(),
-                        expected: expected_key,
-                    });
-                }
-                if !descriptor_may_intersect_range(descriptor, lower_bound, upper_bound) {
-                    continue;
-                }
-                if let Some(filter_probe) = filter_probe {
-                    if !self.segment_filter_admits(descriptor, filter_probe).await? {
-                        continue;
-                    }
-                }
-                matching_descriptors.push((context, descriptor.clone()));
-            }
+        let runs = runs_in_scan_order(&self.manifest.payload);
+        let mut candidates = Vec::new();
+        for run in &runs {
+            let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
+            candidates.extend(table.segments.iter().filter(|descriptor| {
+                descriptor_may_intersect_range(descriptor, lower_bound, upper_bound)
+            }));
         }
-        matching_descriptors.sort_by(|(_, left), (_, right)| {
+        let mut matching_descriptors = self
+            .filter_admitted_descriptors(candidates, filter_probe)
+            .await?;
+        matching_descriptors.sort_by(|left, right| {
             left.min_key
                 .cmp(&right.min_key)
                 .then(left.max_key.cmp(&right.max_key))
@@ -237,7 +206,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 true
             } else {
                 let boundary_key = &rows[limit - 1].0;
-                matching_descriptors[next_descriptor_index].1.min_key <= *boundary_key
+                matching_descriptors[next_descriptor_index].min_key <= *boundary_key
             };
             if !should_load_next {
                 break;
@@ -248,93 +217,29 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             let loaded_segments = try_join_all(
                 matching_descriptors[next_descriptor_index..chunk_end]
                     .iter()
-                    .map(|(context, descriptor)| {
-                        self.segment_rows(
-                            *context,
-                            family,
-                            descriptor,
-                            lower_bound,
-                            upper_bound,
-                            readahead,
-                        )
+                    .map(|descriptor| {
+                        self.segment_rows(family, descriptor, lower_bound, upper_bound, readahead)
                     }),
             )
             .await?;
             next_descriptor_index = chunk_end;
 
-            rows.extend(loaded_segments.iter().flat_map(|segment_rows| {
-                segment_rows
-                    .rows_in_key_range(lower_bound, upper_bound)
-                    .map(|(row_key, row)| (row_key.to_owned(), row.clone()))
-            }));
+            for segment_rows in loaded_segments {
+                let matched_before = rows.len();
+                rows.extend(
+                    segment_rows
+                        .rows_in_key_range(lower_bound, upper_bound)
+                        .map(|(row_key, row)| (row_key.to_owned(), row.clone())),
+                );
+                if filter_probe.is_some() {
+                    self.record_filter_false_positive_if_empty(rows.len() - matched_before);
+                }
+            }
             rows.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         }
 
         rows.truncate(limit);
         Ok(rows.into_iter().map(|(_, row)| row).collect())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn scan_manifest_tables(
-        &self,
-        family: MetadataTableFamily,
-        prefix: &str,
-        context: MetadataTableLoadContext<'_>,
-        tables: &[MetadataTableManifest],
-        rows: &mut Vec<MetadataRow>,
-        filter_probe: Option<&str>,
-        readahead: bool,
-    ) -> Result<(), ManifestLoadError> {
-        let table = manifest_table_for_family(context.manifest_object_key, tables, family)?;
-        let mut matching_descriptors = Vec::new();
-        for descriptor in &table.segments {
-            context.expected_segment_seq(descriptor)?;
-            let expected_key = metadata_file_object_key(descriptor);
-            if descriptor.object_key != expected_key {
-                return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                    object_key: descriptor.object_key.clone(),
-                    expected: expected_key,
-                });
-            }
-            if !descriptor_may_contain_prefix(descriptor, prefix) {
-                continue;
-            }
-            matching_descriptors.push(descriptor);
-        }
-        let matching_descriptors = self
-            .filter_admitted_descriptors(matching_descriptors, filter_probe)
-            .await?;
-
-        let prefix_upper_bound = string_prefix_upper_bound(prefix);
-        let mut loaded_segments = Vec::new();
-        for chunk in matching_descriptors.chunks(MAX_MATERIALIZED_TABLE_FETCHES) {
-            loaded_segments.extend(
-                try_join_all(chunk.iter().map(|descriptor| {
-                    self.segment_rows(
-                        context,
-                        family,
-                        descriptor,
-                        prefix,
-                        prefix_upper_bound.as_deref(),
-                        readahead,
-                    )
-                }))
-                .await?,
-            );
-        }
-
-        for segment_rows in loaded_segments {
-            let matched = rows.len();
-            rows.extend(
-                segment_rows
-                    .rows_in_key_range(prefix, prefix_upper_bound.as_deref())
-                    .map(|(_, row)| row.clone()),
-            );
-            if filter_probe.is_some() {
-                self.record_filter_false_positive_if_empty(rows.len() - matched);
-            }
-        }
-        Ok(())
     }
 
     /// Drops the descriptors whose bloom filter rules the probe out; with no
@@ -368,7 +273,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
     async fn segment_rows(
         &self,
-        context: MetadataTableLoadContext<'_>,
         family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
         lower_bound: &str,
@@ -379,7 +283,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             self.store,
             self.table_cache,
             &self.block_memo,
-            context,
             family,
             descriptor,
             lower_bound,
@@ -419,31 +322,14 @@ pub(super) fn manifest_table_for_family<'a>(
     tables: &'a [MetadataTableManifest],
     family: MetadataTableFamily,
 ) -> Result<&'a MetadataTableManifest, ManifestLoadError> {
-    ordered_manifest_tables(manifest_object_key, tables)?
-        .into_iter()
-        .find(|table| table.family == family)
-        .ok_or(ManifestLoadError::MissingTableFamily {
+    // Family-set integrity is validated once when the tables are loaded;
+    // scans only need the lookup.
+    tables.iter().find(|table| table.family == family).ok_or(
+        ManifestLoadError::MissingTableFamily {
             object_key: manifest_object_key.to_owned(),
             family,
-        })
-}
-
-pub(super) fn descriptor_may_contain_prefix(descriptor: &MetadataFileRef, prefix: &str) -> bool {
-    if descriptor.row_count == 0 {
-        return false;
-    }
-    if prefix.is_empty() {
-        return true;
-    }
-    if descriptor.max_key.as_str() < prefix {
-        return false;
-    }
-    if let Some(upper_bound) = string_prefix_upper_bound(prefix) {
-        if descriptor.min_key >= upper_bound {
-            return false;
-        }
-    }
-    true
+        },
+    )
 }
 
 pub(super) fn descriptor_may_intersect_range(

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -2684,7 +2684,7 @@ async fn metadata_cache_budget_counts_decoded_blocks() {
 
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("get inode")
         .is_some());
@@ -3966,7 +3966,7 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     store.reset_metadata_sst_gets();
     let key = "inode-00000000000000000001";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("first lookup")
         .is_some());
@@ -3974,13 +3974,13 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     assert!(first_lookup_gets > 0, "a cold lookup fetches blocks");
 
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("repeated lookup")
         .is_some());
     let other = "inode-00000000000000000002";
     assert!(tables
-        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other, false)
+        .get_for_lookup(ApiMetadataTableFamily::Inodes, other, other)
         .await
         .expect("second-key lookup")
         .is_some());

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -138,21 +138,10 @@ pub(super) fn validate_manifest_materialization_ranges(
 pub(super) fn validate_manifest_row_seq_range(
     object_key: &str,
     rows: &[MetadataRow],
-    min_seq: Option<ChangeSeq>,
     max_seq: ChangeSeq,
 ) -> Result<(), ManifestLoadError> {
     for (row_index, row) in rows.iter().enumerate() {
         let row_seq = manifest_row_commit_seq(row);
-        if let Some(min_seq) = min_seq {
-            if row_seq < min_seq {
-                return Err(ManifestLoadError::SegmentDescriptorMismatch {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "row {row_index} seq `{row_seq}` is before expected min `{min_seq}`"
-                    ),
-                });
-            }
-        }
         if row_seq > max_seq {
             return Err(ManifestLoadError::SegmentDescriptorMismatch {
                 object_key: object_key.to_owned(),

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -3,6 +3,7 @@ use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIden
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, MetadataViewError, Result};
+use crate::metadata::MetadataState;
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PathMutationIntent};
@@ -11,8 +12,8 @@ use crate::protocol::{
 };
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
-use loonfs_api::wire::control::AcquiredWriter;
-use loonfs_api::{CommitId, NamespaceId};
+use loonfs_api::wire::control::{AcquiredWriter, HeadState};
+use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
 
@@ -66,6 +67,21 @@ pub struct NamespaceCommitEnginePublishResult {
     /// WAL tail length observed by this publish, for opportunistic
     /// maintenance scheduling. Zero when no projection was loaded.
     pub wal_tail_segments: u64,
+    /// The read state this publish produced, present when the head CAS
+    /// landed unambiguously: callers can seed read caches with it instead
+    /// of invalidating them and rebuilding from the store.
+    pub resulting_read_state: Option<ResultingReadState>,
+}
+
+/// A read anchor plus the projected WAL tail as of one landed publish.
+#[derive(Debug, Clone)]
+pub struct ResultingReadState {
+    pub head: HeadState,
+    pub head_etag: String,
+    pub manifest_id: ManifestId,
+    pub manifest_object_id: ManifestObjectId,
+    pub manifest_head_seq: ChangeSeq,
+    pub tail_rows: Arc<MetadataState>,
 }
 
 #[derive(Debug, Clone)]
@@ -154,6 +170,7 @@ impl NamespaceCommitEngine {
             return NamespaceCommitEnginePublishResult {
                 results: Vec::new(),
                 wal_tail_segments: 0,
+                resulting_read_state: None,
             };
         }
 
@@ -162,6 +179,7 @@ impl NamespaceCommitEngine {
             return NamespaceCommitEnginePublishResult {
                 results: repeated_error(candidate_count, CoreError::WriterFenced(message.clone())),
                 wal_tail_segments: 0,
+                resulting_read_state: None,
             };
         }
         let acquired_writer = match &self.acquired_writer {
@@ -175,6 +193,7 @@ impl NamespaceCommitEngine {
                     return NamespaceCommitEnginePublishResult {
                         results: repeated_error(candidate_count, CoreError::WriterEpoch(error)),
                         wal_tail_segments: 0,
+                        resulting_read_state: None,
                     };
                 }
             },
@@ -194,6 +213,7 @@ impl NamespaceCommitEngine {
                             CoreError::MetadataProjection(MetadataProjectionLoadError::from(error)),
                         ),
                         wal_tail_segments: 0,
+                        resulting_read_state: None,
                     };
                 }
             },
@@ -220,6 +240,7 @@ impl NamespaceCommitEngine {
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
                     wal_tail_segments: 0,
+                    resulting_read_state: None,
                 };
             }
         };
@@ -236,6 +257,7 @@ impl NamespaceCommitEngine {
             return NamespaceCommitEnginePublishResult {
                 results: repeated_error(candidate_count, CoreError::from(error)),
                 wal_tail_segments,
+                resulting_read_state: None,
             };
         }
 
@@ -249,11 +271,28 @@ impl NamespaceCommitEngine {
             content_gate,
         )
         .await;
+        let resulting_head = published.resulting_head.clone();
         let wal_tail_segments =
             self.update_publish_tail_projection(projection, &published, tail_options);
+        // Seedable only when the CAS landed unambiguously and the updated
+        // projection survived (it carries the post-publish tail and etag).
+        let resulting_read_state = match (resulting_head, self.publish_tail_projection.as_ref()) {
+            (Some(head), Some(projection)) if projection.head_seq == head.seq => {
+                Some(ResultingReadState {
+                    head,
+                    head_etag: projection.head_etag.clone(),
+                    manifest_id: projection.manifest_id,
+                    manifest_object_id: projection.manifest_object_id.clone(),
+                    manifest_head_seq: projection.manifest_head_seq,
+                    tail_rows: Arc::new(projection.tail_state.clone()),
+                })
+            }
+            _ => None,
+        };
         NamespaceCommitEnginePublishResult {
             results: published.results,
             wal_tail_segments,
+            resulting_read_state,
         }
     }
 

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -102,6 +102,7 @@ pub mod publish {
     pub use crate::commit::{CommitHeadPublishError, SemanticMutationIdentity};
     pub use crate::commit_engine::{
         NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
+        ResultingReadState,
     };
     pub use crate::path::write::PathMutationIntent;
     pub use crate::protocol::{ContentDurabilityGate, PublishTailOptions};

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -24,7 +24,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
 ) -> Result<Option<InodeRecord>> {
     let key = format!("inode-{:020}", inode_id.0);
     Ok(tables
-        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key, true)
+        .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
         .and_then(inode_from_manifest_row))
@@ -244,7 +244,6 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&exact_prefix).as_deref(),
             1,
             &filter_probe,
-            true,
         )
         .await
         .map_err(manifest_error_to_core)?
@@ -274,7 +273,6 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
             string_prefix_upper_bound(&inode_prefix).as_deref(),
             limit,
             &filter_probe,
-            true,
         )
         .await
         .map_err(manifest_error_to_core)?

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -13,7 +13,9 @@ use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceC
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
-use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, ManifestId, NamePolicy, NamespaceId};
+use loonfs_api::{
+    ChangeSeq, CommitId, ContentStoreId, ManifestId, ManifestObjectId, NamePolicy, NamespaceId,
+};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStore;
 
@@ -73,6 +75,7 @@ pub(crate) struct PublishTailProjection {
     pub(crate) head_etag: String,
     pub(crate) head_seq: ChangeSeq,
     pub(crate) manifest_id: ManifestId,
+    pub(crate) manifest_object_id: ManifestObjectId,
     pub(crate) manifest_head_seq: ChangeSeq,
     pub(crate) manifest_payload_checksum: String,
     pub(crate) wal_tail_segments: u64,
@@ -182,6 +185,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             &head,
             &head_etag,
             manifest_id,
+            root.manifest_object_id.clone(),
             &manifest_head,
             manifest_payload_checksum,
         )
@@ -230,6 +234,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     head: &HeadState,
     head_etag: &str,
     manifest_id: ManifestId,
+    manifest_object_id: ManifestObjectId,
     manifest_head: &HeadState,
     manifest_payload_checksum: String,
 ) -> Result<PublishTailProjection> {
@@ -264,6 +269,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         head_etag: head_etag.to_owned(),
         head_seq: head.seq,
         manifest_id,
+        manifest_object_id,
         manifest_head_seq: manifest_head.seq,
         manifest_payload_checksum,
         wal_tail_segments,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1702,13 +1702,25 @@ async fn http_admin_retention_advance_uses_initial_manifest_after_create() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupted() {
     let temp_dir = tempdir().expect("tempdir");
+    let store_root = temp_dir.path().join("store");
     let harness = start_server(test_config(
-        temp_dir.path().join("store"),
+        store_root.clone(),
         "loonfs-server-admin-corrupt",
         "http-admin-corrupt",
     ))
     .await;
+    // A second server on the same store reads cold: it must consume the
+    // manifest and notice the corruption. The first server's reads are
+    // pinned to the head-plus-manifest pair its own publish seeded, which
+    // stays valid without touching the corrupted object.
+    let cold = start_server(test_config(
+        store_root,
+        "loonfs-server-cold-reader",
+        "http-admin-corrupt",
+    ))
+    .await;
     let client = harness.client.clone();
+    let cold_client = cold.client.clone();
     let server_url = harness.server_url.clone();
     let store_root = harness.store_root.clone();
     let store_key_prefix = harness.store_key_prefix.clone();
@@ -1738,15 +1750,21 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         ))
         .expect("corrupt manifest");
 
-        match client.stat_path(&target) {
+        match cold_client.stat_path(&target) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "namespace_corrupt"),
             other => panic!("expected namespace_corrupt, got {other:?}"),
         }
+        // The warm server keeps serving its pinned pair; the corruption is
+        // surfaced by whoever actually consumes the manifest.
+        client
+            .stat_path(&target)
+            .expect("warm server reads from its pinned head-plus-manifest pair");
     })
     .await
     .expect("join blocking task");
 
     harness.server.abort();
+    cold.server.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -61,6 +61,18 @@ impl CommitEngineCache {
     }
 
     fn invalidate(&mut self, namespace_id: &NamespaceId) {
+        // The engine survives invalidation: its acquired epoch and fencing
+        // are session state ("a fenced session stays fenced"), and only its
+        // tail projection goes stale. A held lock means a publish is in
+        // flight; that publish revalidates against the live head itself.
+        if let Some(engine) = self.entries.get(namespace_id) {
+            if let Ok(mut engine) = engine.try_lock() {
+                engine.invalidate();
+            }
+        }
+    }
+
+    fn remove(&mut self, namespace_id: &NamespaceId) {
         self.remove_entry(namespace_id);
         self.order.retain(|candidate| candidate != namespace_id);
     }
@@ -481,6 +493,53 @@ impl FsCore {
     pub(crate) fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
         self.invalidate_namespace_read_cache(namespace_id);
         self.inner.commit_engines().invalidate(namespace_id);
+    }
+
+    /// Namespace-terminal invalidation: the commit engine is removed rather
+    /// than kept, because the namespace itself is gone.
+    pub(crate) fn invalidate_namespace_cache_for_delete(&self, namespace_id: &NamespaceId) {
+        self.invalidate_namespace_read_cache(namespace_id);
+        self.inner.commit_engines().remove(namespace_id);
+    }
+
+    /// Seeds the read caches with the state one landed publish produced:
+    /// the head anchor and the projected WAL tail. Safe by construction —
+    /// the anchor is etag-revalidated against the store on every read, so a
+    /// wrong seed degrades to today's reload instead of a wrong read.
+    pub(crate) fn seed_namespace_read_cache(
+        &self,
+        namespace_id: &NamespaceId,
+        state: loonfs_core::publish::ResultingReadState,
+    ) {
+        if !self.control_cache_enabled() {
+            return;
+        }
+        let max_cached_namespaces = self.inner.config.runtime_cache.max_cached_namespaces;
+        let head_seq = state.head.seq;
+        self.inner.control_cache().insert_namespace_head(
+            namespace_id,
+            CachedNamespaceAnchor {
+                head: CachedControl {
+                    identity: ControlObjectIdentity {
+                        etag: state.head_etag.clone(),
+                    },
+                    state: state.head,
+                },
+                manifest_id: state.manifest_id,
+                manifest_object_id: state.manifest_object_id,
+            },
+            max_cached_namespaces,
+        );
+        self.inner.wal_tail_projection_cache.insert(
+            loonfs_core::cache::WalTailProjectionCacheKey {
+                namespace_id: namespace_id.clone(),
+                manifest_id: state.manifest_id,
+                manifest_head_seq: state.manifest_head_seq,
+                head_seq,
+                head_etag: state.head_etag,
+            },
+            state.tail_rows,
+        );
     }
 
     pub(crate) fn invalidate_namespace_read_cache(&self, namespace_id: &NamespaceId) {

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -187,7 +187,7 @@ impl FsCore {
                 .await
                 .map_err(RuntimeError::from)
         };
-        self.invalidate_namespace_cache(namespace_id);
+        self.invalidate_namespace_cache_for_delete(namespace_id);
         result
     }
 
@@ -1143,7 +1143,7 @@ impl FsCore {
             // as the publish view's own, properly shaped error instead.
             self.load_namespace_catalog_cached(namespace_id).await.ok();
             let engine = self.commit_engine(namespace_id);
-            let publish = {
+            let mut publish = {
                 let context = self.mutation_context();
                 let cache_config = &self.inner.config.runtime_cache;
                 // Boxing erases the engine's deeply nested publish future;
@@ -1177,12 +1177,19 @@ impl FsCore {
                     batch_size
                 )
                 .entered();
-                let runtime_results = publish
-                    .results
-                    .iter()
-                    .map(|result| result.clone().map_err(RuntimeError::Core))
-                    .collect::<Vec<_>>();
-                self.invalidate_namespace_cache_after_batch(namespace_id, &runtime_results);
+                match publish.resulting_read_state.take() {
+                    // A landed publish hands the caches exactly the state a
+                    // rebuild would recompute; use it instead of dropping.
+                    Some(state) => self.seed_namespace_read_cache(namespace_id, state),
+                    None => {
+                        let runtime_results = publish
+                            .results
+                            .iter()
+                            .map(|result| result.clone().map_err(RuntimeError::Core))
+                            .collect::<Vec<_>>();
+                        self.invalidate_namespace_cache_after_batch(namespace_id, &runtime_results);
+                    }
+                }
             }
             let wal_tail_segments = publish.wal_tail_segments;
             let results = publish

--- a/crates/loonfs/tests/invalidation.rs
+++ b/crates/loonfs/tests/invalidation.rs
@@ -1,0 +1,217 @@
+//! Post-publish cache behavior: a landed publish seeds the read caches
+//! instead of dropping them, and cache invalidation never erases writer
+//! fencing.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs::{
+    CreateNamespaceOptions, FsWriter, NamespaceId, PutFileOptions, RuntimeError, SharedObjectStore,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+#[derive(Debug)]
+struct GetRecordingStore {
+    inner: LocalFsStore,
+    gets: Mutex<Vec<String>>,
+}
+
+impl GetRecordingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            gets: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_gets(&self) -> Vec<String> {
+        std::mem::take(&mut *self.gets.lock().expect("get log lock poisoned"))
+    }
+
+    fn record(&self, key: &str) {
+        self.gets
+            .lock()
+            .expect("get log lock poisoned")
+            .push(key.to_owned());
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GetRecordingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record(key);
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record(key);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+async fn writer(store: &SharedObjectStore, writer_id: &str) -> FsWriter {
+    FsWriter::builder_with_store(store.clone())
+        .writer_id(writer_id)
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+/// A fenced writer session must stay fenced: before this fix, the runtime
+/// dropped the commit engine after every successful publish and maintenance
+/// pass, so a superseded writer forgot its fencing and silently re-acquired
+/// the epoch — two live writers would fence each other back and forth
+/// instead of one surfacing `writer_fenced`.
+#[tokio::test]
+async fn fenced_writer_stays_fenced_instead_of_reacquiring() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("create store"));
+    let namespace_id = NamespaceId::parse("fence").expect("valid namespace id");
+
+    let writer_a = writer(&store, "writer-a").await;
+    writer_a
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer_a
+        .put_file_bytes(&namespace_id, "/a1.txt", b"a", PutFileOptions::default())
+        .await
+        .expect("writer a first put");
+
+    let writer_b = writer(&store, "writer-b").await;
+    writer_b
+        .put_file_bytes(&namespace_id, "/b1.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("writer b takes over the epoch");
+
+    let fenced = writer_a
+        .put_file_bytes(&namespace_id, "/a2.txt", b"a", PutFileOptions::default())
+        .await
+        .expect_err("superseded writer surfaces fencing");
+    assert!(
+        matches!(
+            &fenced,
+            RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::WriterFenced
+        ),
+        "unexpected error: {fenced:?}"
+    );
+
+    // The fenced session stays fenced on the next attempt too, and the live
+    // writer keeps publishing undisturbed.
+    let still_fenced = writer_a
+        .put_file_bytes(&namespace_id, "/a3.txt", b"a", PutFileOptions::default())
+        .await
+        .expect_err("fenced session never reacquires on its own");
+    assert!(
+        matches!(
+            &still_fenced,
+            RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::WriterFenced
+        ),
+        "unexpected error: {still_fenced:?}"
+    );
+    writer_b
+        .put_file_bytes(&namespace_id, "/b2.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("live writer is not fenced back");
+}
+
+/// A landed publish seeds the read caches with the state it just produced,
+/// so read-after-write on the same core issues no store GETs at all: the
+/// anchor, catalog, manifest, tail projection, and table blocks are all in
+/// memory.
+#[tokio::test]
+async fn read_after_write_is_served_from_seeded_caches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let namespace_id = NamespaceId::parse("seeded").expect("valid namespace id");
+
+    let writer = writer(&store, "seed-writer").await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let reader = writer.reader();
+    for index in 0..3 {
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/docs/warm-{index}.txt"),
+                b"warm",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("warmup put");
+    }
+    reader
+        .stat_path(&namespace_id, "/docs/warm-0.txt")
+        .await
+        .expect("warmup stat");
+
+    recording.take_gets();
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/fresh.txt",
+            b"fresh",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("steady-state put");
+    // The publish itself must read the live head and root for freshness;
+    // nothing else.
+    let write_gets = recording.take_gets();
+    assert!(
+        write_gets
+            .iter()
+            .all(|key| key.ends_with("/wal/head.json") || key.ends_with("/metadata/root.json")),
+        "a steady-state write reads only the live head and root, got {write_gets:?}"
+    );
+
+    reader
+        .stat_path(&namespace_id, "/docs/fresh.txt")
+        .await
+        .expect("read after write");
+    let read_gets = recording.take_gets();
+    assert_eq!(
+        read_gets,
+        Vec::<String>::new(),
+        "read-after-write must be served from the seeded caches"
+    );
+}

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -740,18 +740,21 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
 
     raw_store.reset_wal_get_count();
     fs.read_file_bytes_blocking(&namespace_id, "/docs/file.txt")
-        .expect("first read should project WAL tail");
-    assert!(raw_store.wal_get_count() > 0);
+        .expect("first read is served from the projection the put seeded");
+    assert_eq!(raw_store.wal_get_count(), 0);
     let after_first = fs.runtime_cache_stats();
-    assert_eq!(after_first.wal_tail_projection_cache_misses, 1);
-    assert_eq!(after_first.wal_tail_projection_cache_inserts, 1);
+    assert_eq!(after_first.wal_tail_projection_cache_misses, 0);
+    assert!(after_first.wal_tail_projection_cache_inserts >= 1);
+    assert!(after_first.wal_tail_projection_cache_hits >= 1);
 
     raw_store.reset_wal_get_count();
     fs.read_file_bytes_blocking(&namespace_id, "/docs/file.txt")
         .expect("second read should reuse cached WAL-tail projection");
     assert_eq!(raw_store.wal_get_count(), 0);
     let after_second = fs.runtime_cache_stats();
-    assert_eq!(after_second.wal_tail_projection_cache_hits, 1);
+    assert!(
+        after_second.wal_tail_projection_cache_hits > after_first.wal_tail_projection_cache_hits
+    );
 
     fs.put_file_bytes_blocking(
         &namespace_id,
@@ -762,13 +765,11 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     .expect("put other");
     raw_store.reset_wal_get_count();
     fs.read_file_bytes_blocking(&namespace_id, "/docs/file.txt")
-        .expect("read after local mutation should rebuild WAL-tail projection");
-    assert!(raw_store.wal_get_count() > 0);
-    let after_write = fs.runtime_cache_stats();
-    assert!(after_write.wal_tail_projection_cache_evictions > 0);
-    assert!(
-        after_write.wal_tail_projection_cache_misses
-            > after_second.wal_tail_projection_cache_misses
+        .expect("read after local mutation reuses the newly seeded projection");
+    assert_eq!(
+        raw_store.wal_get_count(),
+        0,
+        "the put seeds the projection for its own resulting head"
     );
 }
 
@@ -1027,7 +1028,7 @@ fn runtime_read_allows_multi_segment_wal_tail() {
 }
 
 #[test]
-fn stale_head_write_error_invalidates_runtime_cache() {
+fn stale_head_write_error_recovers_and_reseeds_caches() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let raw_store = Arc::new(HeadCasFailureStore::new(
@@ -1051,22 +1052,21 @@ fn stale_head_write_error_invalidates_runtime_cache() {
     );
 
     raw_store.allow_head_cas();
-    raw_store.reset_wal_get_count();
     fs.create_directory_blocking(
         &namespace_id,
         "/after-stale",
         CreateDirectoryOptions::default(),
     )
-    .expect("write after stale head should reload publish tail");
-    assert!(
-        raw_store.wal_get_count() > 0,
-        "failed publish attempt should invalidate cached publish tail"
-    );
+    .expect("write after stale head succeeds (the engine revalidates its projection by etag)");
 
     raw_store.reset_wal_get_count();
-    fs.stat_path_blocking(&namespace_id, "/docs")
-        .expect("read after stale head should reload materialization");
-    assert!(raw_store.wal_get_count() > 0);
+    fs.stat_path_blocking(&namespace_id, "/after-stale")
+        .expect("read after the recovered write");
+    assert_eq!(
+        raw_store.wal_get_count(),
+        0,
+        "the recovered write seeds the read caches like any landed publish"
+    );
 }
 
 #[test]


### PR DESCRIPTION
After every successful write the runtime threw away read-side state the publisher had just computed, and it threw away writer-fencing state it is contractually required to keep.

**Landed publishes now seed the read caches instead of dropping them.** The publish pipeline already knows the exact post-publish state — the resulting head, its store etag, the manifest it is based on, and the projected WAL tail. That now rides out of the commit engine as `ResultingReadState`, and the runtime inserts it into the control cache and the tail-projection cache. Read-after-write on the same core drops from a full cold rebuild (head and root reads plus a WAL chain fetch and replay, forever) to zero store requests — pinned by a new test that records every GET. This is safe by construction: the anchor is etag-revalidated against the store on every read, so a wrong seed degrades to the old reload, never to a wrong read.

**Cache invalidation no longer erases fencing.** Invalidation used to remove the whole commit engine, whose own contract says a fenced session stays fenced and never reacquires. A superseded writer would therefore forget it was fenced after its own maintenance or earlier success, silently re-acquire the epoch, and fence the live writer back — epoch ping-pong instead of one writer surfacing `writer_fenced`. Engines now survive invalidation (only their tail projection is dropped); removal is reserved for namespace deletion and LRU eviction. A new test pins it: a superseded writer surfaces `writer_fenced` on every subsequent attempt while the live writer publishes undisturbed. This is a behavior change for anyone who relied on two long-lived writers implicitly trading the epoch — reacquiring now requires a new handle, which is what the documented contract always said.
