### PR TITLE
refactor(core): move fold-only and test-only code out of create.rs

### DIFF
--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -16,7 +16,7 @@
 //! running each wire call on the runtime's blocking pool instead of stalling
 //! an async worker.
 
-use crate::{Client, ClientError, NamespacePath};
+use crate::{Client, ClientError, MutationOptions, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
     v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
@@ -350,19 +350,22 @@ impl Backend for RemoteBackend {
     ) -> Result<MutationResult, BackendError> {
         let spec = spec.clone();
         let bytes = bytes.to_vec();
-        self.wire(move |client| client.put_file_bytes(&spec, &bytes, force))
-            .await
+        self.wire(move |client| {
+            client.put_file_bytes(&spec, &bytes, force, &MutationOptions::default())
+        })
+        .await
     }
 
     async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| client.create_directory(&spec))
+        self.wire(move |client| client.create_directory(&spec, &MutationOptions::default()))
             .await
     }
 
     async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| client.delete_path(&spec)).await
+        self.wire(move |client| client.delete_path(&spec, &MutationOptions::default()))
+            .await
     }
 
     async fn move_path(
@@ -372,7 +375,8 @@ impl Backend for RemoteBackend {
     ) -> Result<MutationResult, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.move_path(&from, &to)).await
+        self.wire(move |client| client.move_path(&from, &to, &MutationOptions::default()))
+            .await
     }
 
     async fn copy_path(
@@ -382,7 +386,8 @@ impl Backend for RemoteBackend {
     ) -> Result<MutationResult, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.copy_path(&from, &to)).await
+        self.wire(move |client| client.copy_path(&from, &to, &MutationOptions::default()))
+            .await
     }
 
     async fn restore_file_revision(
@@ -391,8 +396,10 @@ impl Backend for RemoteBackend {
         source_revision_no: RevisionNo,
     ) -> Result<MutationResult, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| client.restore_file_revision(&spec, source_revision_no))
-            .await
+        self.wire(move |client| {
+            client.restore_file_revision(&spec, source_revision_no, &MutationOptions::default())
+        })
+        .await
     }
 
     async fn create_checkpoint(

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -168,6 +168,32 @@ impl ClientConfig {
     }
 }
 
+/// Options shared by every client mutation, mirroring the runtime's
+/// per-operation options structs.
+#[derive(Debug, Clone, Default)]
+pub struct MutationOptions {
+    /// Idempotency key for the commit; retrying with the same id replays
+    /// the committed mutation instead of double-committing. A fresh id is
+    /// generated when absent.
+    pub commit_id: Option<String>,
+}
+
+impl MutationOptions {
+    /// Retry with a caller-chosen idempotency key.
+    pub fn with_commit_id(commit_id: impl Into<String>) -> Self {
+        Self {
+            commit_id: Some(commit_id.into()),
+        }
+    }
+
+    fn resolve_commit_id(&self) -> Result<CommitId, ClientError> {
+        match &self.commit_id {
+            Some(value) => parse_commit_id(value),
+            None => parse_commit_id(&generated_commit_id()),
+        }
+    }
+}
+
 impl Client {
     /// Creates a client from validated config.
     pub fn new(config: ClientConfig) -> Self {
@@ -633,18 +659,9 @@ impl Client {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        self.put_file_bytes_with_commit_id(spec, bytes, force, &generated_commit_id())
-    }
-
-    pub fn put_file_bytes_with_commit_id(
-        &self,
-        spec: &NamespacePath,
-        bytes: &[u8],
-        force: bool,
-        commit_id: &str,
-    ) -> Result<MutationResult, ClientError> {
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let staged = self.stage_bytes_as_content_ref(&spec.namespace, bytes)?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -669,29 +686,17 @@ impl Client {
         &self,
         spec: &NamespacePath,
         bytes: &[u8],
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        self.write_file_bytes_with_commit_id(spec, bytes, &generated_commit_id())
+        self.put_file_bytes(spec, bytes, true, options)
     }
 
-    pub fn write_file_bytes_with_commit_id(
+    pub fn create_directory(
         &self,
         spec: &NamespacePath,
-        bytes: &[u8],
-        commit_id: &str,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        self.put_file_bytes_with_commit_id(spec, bytes, true, commit_id)
-    }
-
-    pub fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, ClientError> {
-        self.create_directory_with_commit_id(spec, &generated_commit_id())
-    }
-
-    pub fn create_directory_with_commit_id(
-        &self,
-        spec: &NamespacePath,
-        commit_id: &str,
-    ) -> Result<MutationResult, ClientError> {
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
             &FilesystemOperationRequest {
@@ -705,48 +710,29 @@ impl Client {
         Ok(response.into())
     }
 
-    pub fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, ClientError> {
-        self.delete_path_with_commit_id(spec, &generated_commit_id())
+    pub fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        options: &MutationOptions,
+    ) -> Result<MutationResult, ClientError> {
+        self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::NonRecursive, options)
     }
 
     pub fn delete_path_recursive(
         &self,
         spec: &NamespacePath,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        self.delete_path_recursive_with_commit_id(spec, &generated_commit_id())
+        self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::Recursive, options)
     }
 
-    pub fn delete_path_with_commit_id(
-        &self,
-        spec: &NamespacePath,
-        commit_id: &str,
-    ) -> Result<MutationResult, ClientError> {
-        self.delete_path_with_behavior_and_commit_id(
-            spec,
-            DeleteDirectoryBehavior::NonRecursive,
-            commit_id,
-        )
-    }
-
-    pub fn delete_path_recursive_with_commit_id(
-        &self,
-        spec: &NamespacePath,
-        commit_id: &str,
-    ) -> Result<MutationResult, ClientError> {
-        self.delete_path_with_behavior_and_commit_id(
-            spec,
-            DeleteDirectoryBehavior::Recursive,
-            commit_id,
-        )
-    }
-
-    pub fn delete_path_with_behavior_and_commit_id(
+    fn delete_path_with_behavior(
         &self,
         spec: &NamespacePath,
         behavior: DeleteDirectoryBehavior,
-        commit_id: &str,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
             &FilesystemOperationRequest {
@@ -765,15 +751,7 @@ impl Client {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, ClientError> {
-        self.move_path_with_commit_id(from, to, &generated_commit_id())
-    }
-
-    pub fn move_path_with_commit_id(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-        commit_id: &str,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -781,7 +759,7 @@ impl Client {
                 from.namespace, to.namespace
             )));
         }
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &from.namespace,
             &FilesystemOperationRequest {
@@ -801,15 +779,7 @@ impl Client {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, ClientError> {
-        self.copy_path_with_commit_id(from, to, &generated_commit_id())
-    }
-
-    pub fn copy_path_with_commit_id(
-        &self,
-        from: &NamespacePath,
-        to: &NamespacePath,
-        commit_id: &str,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -817,7 +787,7 @@ impl Client {
                 from.namespace, to.namespace
             )));
         }
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &from.namespace,
             &FilesystemOperationRequest {
@@ -836,17 +806,9 @@ impl Client {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
+        options: &MutationOptions,
     ) -> Result<MutationResult, ClientError> {
-        self.restore_file_revision_with_commit_id(spec, source_revision_no, &generated_commit_id())
-    }
-
-    pub fn restore_file_revision_with_commit_id(
-        &self,
-        spec: &NamespacePath,
-        source_revision_no: RevisionNo,
-        commit_id: &str,
-    ) -> Result<MutationResult, ClientError> {
-        let commit_id = parse_commit_id(commit_id)?;
+        let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
             &FilesystemOperationRequest {

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -16,9 +16,9 @@ use super::record::{
 };
 #[cfg(test)]
 use super::row::manifest_rows_for_family;
-use super::runs::{flatten_manifest_tables, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL};
 #[cfg(test)]
-use super::runs::{l0_run_count, CHECKPOINT_TABLE_FAMILIES};
+use super::runs::CHECKPOINT_TABLE_FAMILIES;
+use super::runs::{flatten_manifest_tables, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL};
 use super::scan::VerifiedMetadataTables;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
@@ -34,17 +34,15 @@ use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainL
 use loonfs_api::wire::control::NamespaceState;
 use loonfs_api::wire::control::{CheckpointRecordLifecycle, CheckpointRecordState};
 use loonfs_api::wire::control::{HeadState, MetadataRootState};
-use loonfs_api::wire::manifest::{
-    MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope, NamespaceManifestPayload,
-};
+use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
 use loonfs_api::{ChangeSeq, CreateCheckpointResponse, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use tracing::Instrument;
 
 #[cfg(test)]
-use super::load::{append_rows_to_metadata, load_manifest_materialization_for_inspection};
+use super::load::append_rows_to_metadata;
 #[cfg(test)]
 use crate::metadata::MetadataStateBuilder;
 
@@ -443,13 +441,6 @@ pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
     })
 }
 
-#[tracing::instrument(
-    level = "info",
-    name = "loon.phase",
-    err,
-    skip_all,
-    fields(phase = "project_manifest")
-)]
 async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -505,327 +496,4 @@ async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Si
             "failed to build namespace manifest envelope: {err}"
         ))
     })
-}
-
-/// Drops rows that no retained sequence can observe (format spec,
-/// "Compaction"). Conservative subset: superseded revisions, superseded or
-/// unbound bindings, and spent unbind markers at or below the retention
-/// floor. Tombstone and inode rows are always retained until
-/// reachability-based dropping is designed.
-pub(super) fn drop_rows_below_retention_floor(
-    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
-    retention_floor_seq: ChangeSeq,
-) -> Result<()> {
-    // The latest revision at or below the floor is what the floor itself
-    // observes; every older one is superseded at every retained sequence.
-    let mut latest_revision_at_floor = BTreeMap::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::Revisions)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::Revision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            ..
-        } = row
-        {
-            if *committed_seq <= retention_floor_seq {
-                let latest = latest_revision_at_floor
-                    .entry(*inode_id)
-                    .or_insert(*revision_no);
-                if *revision_no > *latest {
-                    *latest = *revision_no;
-                }
-            }
-        }
-    }
-    let retain_revision = |row: &MetadataRow| match row {
-        MetadataRow::Revision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            ..
-        } => {
-            *committed_seq > retention_floor_seq
-                || latest_revision_at_floor.get(inode_id) == Some(revision_no)
-        }
-        _ => true,
-    };
-    for family in [
-        MetadataTableFamily::Revisions,
-        MetadataTableFamily::RevisionsByInodeDesc,
-    ] {
-        if let Some(rows) = rows_by_family.get_mut(&family) {
-            rows.retain(retain_revision);
-        }
-    }
-
-    // At the floor only the latest non-unbound bind per (parent, name) slot
-    // is visible; an unbind marker at or below the floor has finished its
-    // work once every bind it covered is gone.
-    // Unbind identity here omits child_inode_id (the read path also matches
-    // it); the 4-tuple is already unique for writer-produced rows, so the
-    // predicates agree on every legal history.
-    let mut unbound_at_floor = BTreeSet::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryUnbinds)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::DirentryUnbind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            unbind_seq,
-            ..
-        } = row
-        {
-            if *unbind_seq <= retention_floor_seq {
-                unbound_at_floor.insert((
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ));
-            }
-        }
-    }
-    let mut latest_bind_at_floor = BTreeMap::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryBinds)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq {
-                let candidate = (*bind_seq, *bind_delta_index);
-                let latest = latest_bind_at_floor
-                    .entry((*parent_inode_id, name_key.clone()))
-                    .or_insert(candidate);
-                if candidate > *latest {
-                    *latest = candidate;
-                }
-            }
-        }
-    }
-    // Load-bearing writer invariant: a bind is only ever superseded by an
-    // operation that also unbinds it, so every non-latest bind at or below
-    // the floor must have a matching unbind at or below the floor. The drop
-    // is only visibility-preserving under that rule; refuse to compact state
-    // that violates it.
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryBinds)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq
-                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
-                    != Some(&(*bind_seq, *bind_delta_index))
-                && !unbound_at_floor.contains(&(
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ))
-            {
-                return Err(CoreError::NamespaceCorrupt(format!(
-                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
-                )));
-            }
-        }
-    }
-
-    let retain_bind = |row: &MetadataRow| match row {
-        MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } => {
-            *bind_seq > retention_floor_seq
-                || (latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
-                    == Some(&(*bind_seq, *bind_delta_index))
-                    && !unbound_at_floor.contains(&(
-                        *parent_inode_id,
-                        name_key.clone(),
-                        *bind_seq,
-                        *bind_delta_index,
-                    )))
-        }
-        _ => true,
-    };
-    for family in [
-        MetadataTableFamily::DirentryBinds,
-        MetadataTableFamily::DirentryChildBinds,
-    ] {
-        if let Some(rows) = rows_by_family.get_mut(&family) {
-            rows.retain(retain_bind);
-        }
-    }
-    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
-        rows.retain(|row| match row {
-            MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq > retention_floor_seq,
-            _ => true,
-        });
-    }
-
-    // The idempotency horizon is the retention floor: a commit retried from
-    // below it re-bootstraps like any sub-floor cursor, so its receipt no
-    // longer needs to be carried forward.
-    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::CommitReceipts) {
-        rows.retain(|row| match row {
-            MetadataRow::CommitReceipt { committed_seq, .. } => {
-                *committed_seq >= retention_floor_seq
-            }
-            _ => true,
-        });
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-pub(super) struct ManifestMetadataSource<'a> {
-    pub(super) head: &'a HeadState,
-    pub(super) basis_manifest_id: Option<ManifestId>,
-    pub(super) retention_floor_seq: ChangeSeq,
-    pub(super) metadata_state: &'a MetadataState,
-}
-
-#[cfg(test)]
-#[tracing::instrument(
-    level = "info",
-    name = "loon.phase",
-    err,
-    skip_all,
-    fields(phase = "project_manifest")
-)]
-#[cfg(test)]
-pub(super) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    source: ManifestMetadataSource<'_>,
-    writer_version: &str,
-    policy: MetadataLsmPolicy,
-    manifest_id: ManifestId,
-) -> Result<NamespaceManifestEnvelope> {
-    let manifest_object_id = ManifestObjectId::generate(manifest_id);
-    let head = source.head;
-    let metadata_state = source.metadata_state;
-    let head_seq = head.seq;
-    let previous_manifest = match source.basis_manifest_id {
-        Some(previous_id) => Some(
-            load_manifest_materialization_for_inspection(store, namespace_id, previous_id)
-                .await
-                .map_err(|error| {
-                    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-                })?,
-        ),
-        _ => None,
-    };
-
-    let (base_seq, metadata_files) = match previous_manifest {
-        Some(previous) if is_bootstrap_seed_manifest(&previous.manifest.payload) => {
-            let run_tables = build_manifest_tables(
-                store,
-                namespace_id,
-                head_seq,
-                CHECKPOINT_BASE_RUN_LEVEL,
-                metadata_state,
-                policy.max_rows_per_segment,
-            )
-            .await?;
-            debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
-            (head_seq, flatten_manifest_tables(run_tables))
-        }
-        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs => {
-            let mut metadata_files = previous.manifest.payload.metadata_files.clone();
-            if previous.manifest.payload.head_seq < head_seq {
-                metadata_files.extend(flatten_manifest_tables(
-                    build_manifest_l0_run_tables(
-                        store,
-                        namespace_id,
-                        head_seq,
-                        previous.manifest.payload.head_seq,
-                        metadata_state,
-                    )
-                    .await?,
-                ));
-            }
-            (previous.manifest.payload.base_seq, metadata_files)
-        }
-        Some(_) => {
-            let run_tables = build_manifest_tables(
-                store,
-                namespace_id,
-                head_seq,
-                CHECKPOINT_BASE_RUN_LEVEL,
-                metadata_state,
-                policy.max_rows_per_segment,
-            )
-            .await?;
-            debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
-            (head_seq, flatten_manifest_tables(run_tables))
-        }
-        _ => {
-            let run_tables = build_manifest_tables(
-                store,
-                namespace_id,
-                head_seq,
-                CHECKPOINT_BASE_RUN_LEVEL,
-                metadata_state,
-                policy.max_rows_per_segment,
-            )
-            .await?;
-            (head_seq, flatten_manifest_tables(run_tables))
-        }
-    };
-
-    NamespaceManifestEnvelope::from_payload(
-        writer_version,
-        NamespaceManifestPayload {
-            namespace_id: namespace_id.clone(),
-            manifest_id,
-            manifest_object_id,
-            head_seq,
-            head_commit_id: head.head_commit_id.clone(),
-            base_seq,
-            writer_epoch: head.writer_epoch,
-            next_inode_id: head.next_inode_id,
-            retention_floor_seq: source.retention_floor_seq,
-            initialized: true,
-            verified: true,
-            fork: None,
-            features: BTreeMap::new(),
-            metadata_files,
-        },
-    )
-    .map_err(|err| {
-        CoreError::Internal(format!(
-            "failed to build namespace manifest envelope: {err}"
-        ))
-    })
-}
-
-#[cfg(test)]
-fn is_bootstrap_seed_manifest(payload: &NamespaceManifestPayload) -> bool {
-    payload.head_seq == ChangeSeq(0) && payload.base_seq == ChangeSeq(0) && payload.fork.is_none()
 }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -24,9 +24,7 @@ use super::build::{
     build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
     MetadataTableSegmentation,
 };
-use super::create::{
-    drop_rows_below_retention_floor, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
-};
+use super::create::{next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT};
 use super::load::{
     load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
     validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,
@@ -45,7 +43,7 @@ use loonfs_api::wire::manifest::{
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Families whose rows merge in one reorganization unit. Groupings follow
 /// the retention rules in `drop_rows_below_retention_floor`: families that
@@ -361,4 +359,199 @@ async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
     Err(CoreError::Internal(
         "reorganized manifest allocation retry exhausted".to_owned(),
     ))
+}
+
+/// Drops rows that no retained sequence can observe (format spec,
+/// "Compaction"). Conservative subset: superseded revisions, superseded or
+/// unbound bindings, and spent unbind markers at or below the retention
+/// floor. Tombstone and inode rows are always retained until
+/// reachability-based dropping is designed.
+pub(super) fn drop_rows_below_retention_floor(
+    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    retention_floor_seq: ChangeSeq,
+) -> Result<()> {
+    // The latest revision at or below the floor is what the floor itself
+    // observes; every older one is superseded at every retained sequence.
+    let mut latest_revision_at_floor = BTreeMap::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::Revisions)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            ..
+        } = row
+        {
+            if *committed_seq <= retention_floor_seq {
+                let latest = latest_revision_at_floor
+                    .entry(*inode_id)
+                    .or_insert(*revision_no);
+                if *revision_no > *latest {
+                    *latest = *revision_no;
+                }
+            }
+        }
+    }
+    let retain_revision = |row: &MetadataRow| match row {
+        MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            ..
+        } => {
+            *committed_seq > retention_floor_seq
+                || latest_revision_at_floor.get(inode_id) == Some(revision_no)
+        }
+        _ => true,
+    };
+    for family in [
+        MetadataTableFamily::Revisions,
+        MetadataTableFamily::RevisionsByInodeDesc,
+    ] {
+        if let Some(rows) = rows_by_family.get_mut(&family) {
+            rows.retain(retain_revision);
+        }
+    }
+
+    // At the floor only the latest non-unbound bind per (parent, name) slot
+    // is visible; an unbind marker at or below the floor has finished its
+    // work once every bind it covered is gone.
+    // Unbind identity here omits child_inode_id (the read path also matches
+    // it); the 4-tuple is already unique for writer-produced rows, so the
+    // predicates agree on every legal history.
+    let mut unbound_at_floor = BTreeSet::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryUnbinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryUnbind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            unbind_seq,
+            ..
+        } = row
+        {
+            if *unbind_seq <= retention_floor_seq {
+                unbound_at_floor.insert((
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ));
+            }
+        }
+    }
+    let mut latest_bind_at_floor = BTreeMap::new();
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryBinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq {
+                let candidate = (*bind_seq, *bind_delta_index);
+                let latest = latest_bind_at_floor
+                    .entry((*parent_inode_id, name_key.clone()))
+                    .or_insert(candidate);
+                if candidate > *latest {
+                    *latest = candidate;
+                }
+            }
+        }
+    }
+    // Load-bearing writer invariant: a bind is only ever superseded by an
+    // operation that also unbinds it, so every non-latest bind at or below
+    // the floor must have a matching unbind at or below the floor. The drop
+    // is only visibility-preserving under that rule; refuse to compact state
+    // that violates it.
+    for row in rows_by_family
+        .get(&MetadataTableFamily::DirentryBinds)
+        .into_iter()
+        .flatten()
+    {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq
+                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
+                    != Some(&(*bind_seq, *bind_delta_index))
+                && !unbound_at_floor.contains(&(
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ))
+            {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
+                )));
+            }
+        }
+    }
+
+    let retain_bind = |row: &MetadataRow| match row {
+        MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } => {
+            *bind_seq > retention_floor_seq
+                || (latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
+                    == Some(&(*bind_seq, *bind_delta_index))
+                    && !unbound_at_floor.contains(&(
+                        *parent_inode_id,
+                        name_key.clone(),
+                        *bind_seq,
+                        *bind_delta_index,
+                    )))
+        }
+        _ => true,
+    };
+    for family in [
+        MetadataTableFamily::DirentryBinds,
+        MetadataTableFamily::DirentryChildBinds,
+    ] {
+        if let Some(rows) = rows_by_family.get_mut(&family) {
+            rows.retain(retain_bind);
+        }
+    }
+    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
+        rows.retain(|row| match row {
+            MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq > retention_floor_seq,
+            _ => true,
+        });
+    }
+
+    // The idempotency horizon is the retention floor: a commit retried from
+    // below it re-bootstraps like any sub-floor cursor, so its receipt no
+    // longer needs to be carried forward.
+    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::CommitReceipts) {
+        rows.retain(|row| match row {
+            MetadataRow::CommitReceipt { committed_seq, .. } => {
+                *committed_seq >= retention_floor_seq
+            }
+            _ => true,
+        });
+    }
+    Ok(())
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -8,11 +8,7 @@ use super::build::{
     build_manifest_tables, build_manifest_tables_from_rows, MetadataTableSegmentation,
 };
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
-use super::create::{
-    build_namespace_manifest_from_metadata_state, create_checkpoint,
-    drop_rows_below_retention_floor, load_checkpoint_projection_metadata_state,
-    ManifestMetadataSource,
-};
+use super::create::{create_checkpoint, load_checkpoint_projection_metadata_state};
 use super::error::ManifestLoadError;
 use super::load::{
     head_from_manifest, load_manifest_materialization_for_inspection,
@@ -988,7 +984,7 @@ fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
         vec![unbind(1, 0, 2)],
     );
 
-    drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+    super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
 
     assert_eq!(rows[&ApiMetadataTableFamily::DirentryBinds].len(), 2);
     assert_eq!(rows[&ApiMetadataTableFamily::DirentryChildBinds].len(), 2);
@@ -1026,7 +1022,7 @@ fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
     );
     rows.insert(ApiMetadataTableFamily::DirentryUnbinds, vec![unbind]);
 
-    drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+    super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
 
     // Only the delta-2 rebind (the slot's latest) survives; the superseded
     // delta-0 bind and its spent unbind marker are gone from both families.
@@ -1064,7 +1060,7 @@ fn drop_pass_refuses_superseded_bind_without_unbind() {
         vec![bind(0), bind(1)],
     );
 
-    let error = drop_rows_below_retention_floor(&mut rows, ChangeSeq(1))
+    let error = super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1))
         .expect_err("superseded live bind must refuse the drop");
     assert!(matches!(error, CoreError::NamespaceCorrupt(_)));
 }
@@ -5193,4 +5189,131 @@ impl ObjectStore for ConflictOnManifestCreateStore {
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         self.inner.list_prefix_stream(prefix)
     }
+}
+
+use super::build::{
+    build_manifest_l0_run_tables, debug_assert_manifest_table_segments_do_not_overlap,
+};
+use super::runs::l0_run_count;
+
+// Test support: a manifest built directly from a MetadataState, used to
+// author arbitrary layouts without driving the full checkpoint pipeline.
+#[cfg(test)]
+pub(crate) struct ManifestMetadataSource<'a> {
+    pub(super) head: &'a HeadState,
+    pub(super) basis_manifest_id: Option<ManifestId>,
+    pub(super) retention_floor_seq: ChangeSeq,
+    pub(super) metadata_state: &'a MetadataState,
+}
+
+#[cfg(test)]
+pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    source: ManifestMetadataSource<'_>,
+    writer_version: &str,
+    policy: MetadataLsmPolicy,
+    manifest_id: ManifestId,
+) -> crate::error::Result<NamespaceManifestEnvelope> {
+    let manifest_object_id = ManifestObjectId::generate(manifest_id);
+    let head = source.head;
+    let metadata_state = source.metadata_state;
+    let head_seq = head.seq;
+    let previous_manifest = match source.basis_manifest_id {
+        Some(previous_id) => Some(
+            load_manifest_materialization_for_inspection(store, namespace_id, previous_id)
+                .await
+                .map_err(|error| {
+                    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+                })?,
+        ),
+        _ => None,
+    };
+
+    let (base_seq, metadata_files) = match previous_manifest {
+        Some(previous) if is_bootstrap_seed_manifest(&previous.manifest.payload) => {
+            let run_tables = build_manifest_tables(
+                store,
+                namespace_id,
+                head_seq,
+                CHECKPOINT_BASE_RUN_LEVEL,
+                metadata_state,
+                policy.max_rows_per_segment,
+            )
+            .await?;
+            debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
+            (head_seq, flatten_manifest_tables(run_tables))
+        }
+        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs => {
+            let mut metadata_files = previous.manifest.payload.metadata_files.clone();
+            if previous.manifest.payload.head_seq < head_seq {
+                metadata_files.extend(flatten_manifest_tables(
+                    build_manifest_l0_run_tables(
+                        store,
+                        namespace_id,
+                        head_seq,
+                        previous.manifest.payload.head_seq,
+                        metadata_state,
+                    )
+                    .await?,
+                ));
+            }
+            (previous.manifest.payload.base_seq, metadata_files)
+        }
+        Some(_) => {
+            let run_tables = build_manifest_tables(
+                store,
+                namespace_id,
+                head_seq,
+                CHECKPOINT_BASE_RUN_LEVEL,
+                metadata_state,
+                policy.max_rows_per_segment,
+            )
+            .await?;
+            debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
+            (head_seq, flatten_manifest_tables(run_tables))
+        }
+        _ => {
+            let run_tables = build_manifest_tables(
+                store,
+                namespace_id,
+                head_seq,
+                CHECKPOINT_BASE_RUN_LEVEL,
+                metadata_state,
+                policy.max_rows_per_segment,
+            )
+            .await?;
+            (head_seq, flatten_manifest_tables(run_tables))
+        }
+    };
+
+    NamespaceManifestEnvelope::from_payload(
+        writer_version,
+        NamespaceManifestPayload {
+            namespace_id: namespace_id.clone(),
+            manifest_id,
+            manifest_object_id,
+            head_seq,
+            head_commit_id: head.head_commit_id.clone(),
+            base_seq,
+            writer_epoch: head.writer_epoch,
+            next_inode_id: head.next_inode_id,
+            retention_floor_seq: source.retention_floor_seq,
+            initialized: true,
+            verified: true,
+            fork: None,
+            features: BTreeMap::new(),
+            metadata_files,
+        },
+    )
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace manifest envelope: {err}"
+        ))
+    })
+}
+
+#[cfg(test)]
+fn is_bootstrap_seed_manifest(payload: &NamespaceManifestPayload) -> bool {
+    payload.head_seq == ChangeSeq(0) && payload.base_seq == ChangeSeq(0) && payload.fork.is_none()
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -72,7 +72,7 @@ use loonfs::{
     CreateNamespaceOptions, DeleteOptions, FsWriter, PutFileOptions, TraceMode, TraceStoreKind,
 };
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
-use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
+use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -264,7 +264,7 @@ async fn http_created_state_is_readable_through_runtime() {
         let target = NamespacePath::parse("demo:/notes/from-http.txt").expect("target");
         harness
             .client
-            .write_file_bytes(&target, b"hello from http")
+            .write_file_bytes(&target, b"hello from http", &MutationOptions::default())
             .expect("write file through http");
     })
     .await
@@ -292,20 +292,26 @@ async fn http_missing_namespace_mutations_return_namespace_not_found() {
     tokio::task::spawn_blocking(move || {
         let target = NamespacePath::parse("missing:/notes/hello.txt").expect("target");
         assert_api_error(
-            harness.client.write_file_bytes(&target, b"hello"),
+            harness
+                .client
+                .write_file_bytes(&target, b"hello", &MutationOptions::default()),
             404,
             "namespace_not_found",
             Some("namespace `missing` does not exist"),
         );
         assert_api_error(
-            harness.client.delete_path(&target),
+            harness
+                .client
+                .delete_path(&target, &MutationOptions::default()),
             404,
             "namespace_not_found",
             Some("namespace `missing` does not exist"),
         );
         let destination = NamespacePath::parse("missing:/notes/renamed.txt").expect("target");
         assert_api_error(
-            harness.client.move_path(&target, &destination),
+            harness
+                .client
+                .move_path(&target, &destination, &MutationOptions::default()),
             404,
             "namespace_not_found",
             Some("namespace `missing` does not exist"),
@@ -348,7 +354,9 @@ async fn http_delete_missing_path_returns_path_not_found() {
     tokio::task::spawn_blocking(move || {
         let target = NamespacePath::parse("demo:/missing.txt").expect("target");
         assert_api_error(
-            harness.client.delete_path(&target),
+            harness
+                .client
+                .delete_path(&target, &MutationOptions::default()),
             404,
             "path_not_found",
             None,
@@ -394,7 +402,11 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
     tokio::task::spawn_blocking(move || {
         let dir_target = NamespacePath::parse("demo:/docs").expect("dir target");
         assert_api_error(
-            harness.client.write_file_bytes(&dir_target, b"not a file"),
+            harness.client.write_file_bytes(
+                &dir_target,
+                b"not a file",
+                &MutationOptions::default(),
+            ),
             409,
             "path_conflict",
             None,
@@ -403,7 +415,9 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
         let from = NamespacePath::parse("demo:/tmp/a.txt").expect("from");
         let to = NamespacePath::parse("demo:/docs/a.txt").expect("to");
         assert_api_error(
-            harness.client.move_path(&from, &to),
+            harness
+                .client
+                .move_path(&from, &to, &MutationOptions::default()),
             409,
             "path_conflict",
             None,
@@ -445,7 +459,7 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         let put_target = NamespacePath::parse("demo:/docs/new.txt").expect("put target");
         harness
             .client
-            .write_file_bytes(&put_target, b"new")
+            .write_file_bytes(&put_target, b"new", &MutationOptions::default())
             .expect("put recreates the subtree");
         let old_child = NamespacePath::parse("demo:/docs/old.txt").expect("old child");
         assert_api_error(
@@ -459,7 +473,7 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         let to = NamespacePath::parse("demo:/docs/source.txt").expect("to");
         harness
             .client
-            .move_path(&from, &to)
+            .move_path(&from, &to, &MutationOptions::default())
             .expect("move lands in the recreated subtree");
     })
     .await
@@ -479,7 +493,7 @@ async fn http_path_mutation_retries_transient_stale_head_cas() {
         let target = NamespacePath::parse("demo:/notes/race.txt").expect("target");
         let result = harness
             .client
-            .write_file_bytes(&target, b"race")
+            .write_file_bytes(&target, b"race", &MutationOptions::default())
             .expect("path write retries stale head");
         assert_eq!(result.committed_seq, ChangeSeq(1));
     })
@@ -503,7 +517,7 @@ async fn http_first_write_takes_over_a_namespace_owned_by_another_writer() {
         let target = NamespacePath::parse("demo:/notes/taken-over.txt").expect("target");
         let result = harness
             .client
-            .write_file_bytes(&target, b"taken over")
+            .write_file_bytes(&target, b"taken over", &MutationOptions::default())
             .expect("first write takes over the namespace");
         assert_eq!(result.committed_seq, ChangeSeq(1));
     })

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -13,7 +13,7 @@ use loonfs_api::{
     NamespaceId, PutBehavior, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
     LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
-use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
+use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::{ConfiguredObjectStore, ObjectStore};
 use loonfs_server::{app, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
@@ -48,7 +48,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         let target = NamespacePath::parse("doomed:/note.txt").expect("parse path");
         harness
             .client
-            .write_file_bytes(&target, b"last words")
+            .write_file_bytes(&target, b"last words", &MutationOptions::default())
             .expect("write file");
 
         // A stale precondition refuses the delete and deletes nothing.
@@ -178,17 +178,17 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
         let other = NamespacePath::parse("demo:/other").expect("other path");
         harness
             .client
-            .create_directory(&docs)
+            .create_directory(&docs, &MutationOptions::default())
             .expect("create docs dir");
         harness
             .client
-            .create_directory(&other)
+            .create_directory(&other, &MutationOptions::default())
             .expect("create other dir");
         for name in ["a.txt", "b.txt", "c.txt"] {
             let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
             harness
                 .client
-                .write_file_bytes(&path, name.as_bytes())
+                .write_file_bytes(&path, name.as_bytes(), &MutationOptions::default())
                 .expect("write file");
         }
 
@@ -274,13 +274,13 @@ async fn http_client_listing_preserves_canonical_name_key_order() {
         let docs = NamespacePath::parse("demo:/docs").expect("docs path");
         harness
             .client
-            .create_directory(&docs)
+            .create_directory(&docs, &MutationOptions::default())
             .expect("create docs dir");
         for name in ["B.txt", "a.txt", "c.txt"] {
             let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
             harness
                 .client
-                .write_file_bytes(&path, name.as_bytes())
+                .write_file_bytes(&path, name.as_bytes(), &MutationOptions::default())
                 .expect("write file");
         }
 
@@ -311,7 +311,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         let directory = NamespacePath::parse("demo:/notes").expect("parse directory path");
         harness
             .client
-            .create_directory(&directory)
+            .create_directory(&directory, &MutationOptions::default())
             .expect("create directory");
         let directory_entry = harness
             .client
@@ -322,7 +322,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         let target = NamespacePath::parse("demo:/notes/hello.txt").expect("parse namespace path");
         harness
             .client
-            .write_file_bytes(&target, b"hello over http\n")
+            .write_file_bytes(&target, b"hello over http\n", &MutationOptions::default())
             .expect("write bytes");
 
         let entry = harness.client.stat_path(&target).expect("stat path");
@@ -476,23 +476,38 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
         let source = NamespacePath::parse("demo:/docs/hello.txt").expect("source");
         harness
             .client
-            .put_file_bytes(&source, b"hello over http\n", false)
+            .put_file_bytes(
+                &source,
+                b"hello over http\n",
+                false,
+                &MutationOptions::default(),
+            )
             .expect("initial create");
 
-        match harness.client.put_file_bytes(&source, b"conflict\n", false) {
+        match harness.client.put_file_bytes(
+            &source,
+            b"conflict\n",
+            false,
+            &MutationOptions::default(),
+        ) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_conflict"),
             other => panic!("expected path_conflict, got {other:?}"),
         }
 
         harness
             .client
-            .put_file_bytes(&source, b"forced overwrite\n", true)
+            .put_file_bytes(
+                &source,
+                b"forced overwrite\n",
+                true,
+                &MutationOptions::default(),
+            )
             .expect("forced overwrite");
 
         let destination = NamespacePath::parse("demo:/docs/copy.txt").expect("destination");
         harness
             .client
-            .copy_path(&source, &destination)
+            .copy_path(&source, &destination, &MutationOptions::default())
             .expect("copy path");
 
         let source_entry = harness.client.stat_path(&source).expect("source stat");
@@ -530,7 +545,7 @@ async fn http_namespace_fork_shares_content_and_diverges() {
         let clone_path = NamespacePath::parse("clone:/docs/shared.txt").expect("clone path");
         harness
             .client
-            .write_file_bytes(&source_path, b"base\n")
+            .write_file_bytes(&source_path, b"base\n", &MutationOptions::default())
             .expect("write source");
 
         let forked = harness
@@ -552,7 +567,11 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
         harness
             .client
-            .write_file_bytes(&source_path, b"source-after-fork\n")
+            .write_file_bytes(
+                &source_path,
+                b"source-after-fork\n",
+                &MutationOptions::default(),
+            )
             .expect("replace source");
         assert_eq!(
             harness
@@ -564,7 +583,11 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
         let clone_write = harness
             .client
-            .write_file_bytes(&clone_path, b"clone-after-fork\n")
+            .write_file_bytes(
+                &clone_path,
+                b"clone-after-fork\n",
+                &MutationOptions::default(),
+            )
             .expect("replace clone");
         assert_eq!(clone_write.committed_seq, ChangeSeq(2));
         assert_eq!(
@@ -977,11 +1000,11 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
         let target = NamespacePath::parse("demo:/docs/rev.txt").expect("target");
         harness
             .client
-            .put_file_bytes(&target, b"one", false)
+            .put_file_bytes(&target, b"one", false, &MutationOptions::default())
             .expect("create file");
         harness
             .client
-            .put_file_bytes(&target, b"two", true)
+            .put_file_bytes(&target, b"two", true, &MutationOptions::default())
             .expect("replace file");
 
         let entry = harness.client.stat_path(&target).expect("stat file");
@@ -1002,7 +1025,7 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
         let moved = NamespacePath::parse("demo:/docs/moved.txt").expect("moved");
         harness
             .client
-            .move_path(&target, &moved)
+            .move_path(&target, &moved, &MutationOptions::default())
             .expect("move path");
         assert!(matches!(
             harness.client.list_file_revisions(&target),
@@ -1023,7 +1046,7 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
 
         harness
             .client
-            .restore_file_revision(&moved, RevisionNo(1))
+            .restore_file_revision(&moved, RevisionNo(1), &MutationOptions::default())
             .expect("path restore");
         assert_eq!(
             harness
@@ -1285,13 +1308,23 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
 
         let first = harness
             .client
-            .put_file_bytes_with_commit_id(&target, b"stable bytes\n", false, commit_id)
+            .put_file_bytes(
+                &target,
+                b"stable bytes\n",
+                false,
+                &MutationOptions::with_commit_id(commit_id),
+            )
             .expect("first put");
         assert!(first.committed_seq.0 >= 1);
 
         let repeated = harness
             .client
-            .put_file_bytes_with_commit_id(&target, b"stable bytes\n", false, commit_id)
+            .put_file_bytes(
+                &target,
+                b"stable bytes\n",
+                false,
+                &MutationOptions::with_commit_id(commit_id),
+            )
             .expect("repeat put");
         assert_eq!(repeated, first);
 
@@ -1300,11 +1333,11 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         let bytes = harness.client.read_file_bytes(&target).expect("read file");
         assert_eq!(bytes, b"stable bytes\n");
 
-        match harness.client.put_file_bytes_with_commit_id(
+        match harness.client.put_file_bytes(
             &target,
             b"different bytes\n",
             false,
-            commit_id,
+            &MutationOptions::with_commit_id(commit_id),
         ) {
             Err(ClientError::Api { code, .. }) => {
                 assert_eq!(code, "commit_id_reuse_conflict")
@@ -1336,17 +1369,25 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         let source = NamespacePath::parse("demo:/docs/source.txt").expect("source");
         harness
             .client
-            .write_file_bytes(&source, b"source bytes\n")
+            .write_file_bytes(&source, b"source bytes\n", &MutationOptions::default())
             .expect("seed source");
 
         let copied = NamespacePath::parse("demo:/docs/copied.txt").expect("copied");
         let copy_first = harness
             .client
-            .copy_path_with_commit_id(&source, &copied, "req-v1-copy")
+            .copy_path(
+                &source,
+                &copied,
+                &MutationOptions::with_commit_id("req-v1-copy"),
+            )
             .expect("copy first");
         let copy_repeated = harness
             .client
-            .copy_path_with_commit_id(&source, &copied, "req-v1-copy")
+            .copy_path(
+                &source,
+                &copied,
+                &MutationOptions::with_commit_id("req-v1-copy"),
+            )
             .expect("copy repeat");
         assert_eq!(copy_repeated, copy_first);
         let source_entry = harness.client.stat_path(&source).expect("source stat");
@@ -1357,11 +1398,19 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         let moved = NamespacePath::parse("demo:/docs/moved.txt").expect("moved");
         let move_first = harness
             .client
-            .move_path_with_commit_id(&copied, &moved, "req-v1-move")
+            .move_path(
+                &copied,
+                &moved,
+                &MutationOptions::with_commit_id("req-v1-move"),
+            )
             .expect("move first");
         let move_repeated = harness
             .client
-            .move_path_with_commit_id(&copied, &moved, "req-v1-move")
+            .move_path(
+                &copied,
+                &moved,
+                &MutationOptions::with_commit_id("req-v1-move"),
+            )
             .expect("move repeat");
         assert_eq!(move_repeated, move_first);
         match harness.client.stat_path(&copied) {
@@ -1373,11 +1422,11 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
 
         let delete_first = harness
             .client
-            .delete_path_with_commit_id(&moved, "req-v1-delete")
+            .delete_path(&moved, &MutationOptions::with_commit_id("req-v1-delete"))
             .expect("delete first");
         let delete_repeated = harness
             .client
-            .delete_path_with_commit_id(&moved, "req-v1-delete")
+            .delete_path(&moved, &MutationOptions::with_commit_id("req-v1-delete"))
             .expect("delete repeat");
         assert_eq!(delete_repeated, delete_first);
         match harness.client.stat_path(&moved) {
@@ -1409,13 +1458,13 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
         let child = NamespacePath::parse("demo:/docs/child.txt").expect("child path");
         harness
             .client
-            .write_file_bytes(&child, b"child")
+            .write_file_bytes(&child, b"child", &MutationOptions::default())
             .expect("write child");
 
         let dir = NamespacePath::parse("demo:/docs").expect("dir path");
         let non_recursive = harness
             .client
-            .delete_path(&dir)
+            .delete_path(&dir, &MutationOptions::default())
             .expect_err("non-recursive delete rejects non-empty dir");
         match non_recursive {
             ClientError::Api { status, code, .. } => {
@@ -1427,7 +1476,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
 
         harness
             .client
-            .delete_path_recursive(&dir)
+            .delete_path_recursive(&dir, &MutationOptions::default())
             .expect("recursive delete succeeds");
         match harness.client.stat_path(&child) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
@@ -1458,7 +1507,7 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
         let source = NamespacePath::parse("demo:/docs/source.txt").expect("source");
         harness
             .client
-            .write_file_bytes(&source, b"source")
+            .write_file_bytes(&source, b"source", &MutationOptions::default())
             .expect("seed source");
 
         // Unknown behaviors are not wire variants; they fail request
@@ -1534,7 +1583,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
             .create_namespace(namespace)
             .expect("create namespace");
         client
-            .write_file_bytes(&target, b"hello admin\n")
+            .write_file_bytes(&target, b"hello admin\n", &MutationOptions::default())
             .expect("write file");
 
         let first = post_checkpoint(&server_url, namespace).expect("first checkpoint");
@@ -1591,7 +1640,7 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
             .expect("create namespace");
         let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
         client
-            .write_file_bytes(&target, b"hello gc\n")
+            .write_file_bytes(&target, b"hello gc\n", &MutationOptions::default())
             .expect("write file");
         post_checkpoint(&server_url, namespace).expect("checkpoint");
 
@@ -1632,7 +1681,7 @@ async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
             .expect("create namespace");
         let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
         client
-            .write_file_bytes(&target, b"hello tick\n")
+            .write_file_bytes(&target, b"hello tick\n", &MutationOptions::default())
             .expect("write file");
 
         // One WAL segment sits far below the default threshold.
@@ -1732,7 +1781,7 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
             .create_namespace(namespace)
             .expect("create namespace");
         client
-            .write_file_bytes(&target, b"hello\n")
+            .write_file_bytes(&target, b"hello\n", &MutationOptions::default())
             .expect("write file");
         post_checkpoint(&server_url, namespace).expect("checkpoint");
 
@@ -1790,14 +1839,14 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
         client_a.create_namespace("demo").expect("create namespace");
         let host_a_target = NamespacePath::parse("demo:/docs/host-a.txt").expect("host a target");
         client_a
-            .write_file_bytes(&host_a_target, b"host a\n")
+            .write_file_bytes(&host_a_target, b"host a\n", &MutationOptions::default())
             .expect("host a write");
 
         // Server B's first semantic write acquires the epoch immediately:
         // there is no lease to wait out, only last-writer-wins fencing.
         let host_b_target = NamespacePath::parse("demo:/docs/host-b.txt").expect("host b target");
         let moved = client_b
-            .move_path(&host_a_target, &host_b_target)
+            .move_path(&host_a_target, &host_b_target, &MutationOptions::default())
             .expect("host b takes over on first write");
         assert!(
             moved.committed_seq.0 >= 2,
@@ -1809,7 +1858,11 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
         // `writer_fenced` and keep failing, with no silent reacquisition.
         let host_c_target = NamespacePath::parse("demo:/docs/host-c.txt").expect("host c target");
         for attempt in 0..2 {
-            match client_a.write_file_bytes(&host_c_target, b"host a again\n") {
+            match client_a.write_file_bytes(
+                &host_c_target,
+                b"host a again\n",
+                &MutationOptions::default(),
+            ) {
                 Err(ClientError::Api { code, .. }) => {
                     assert_eq!(code, "writer_fenced", "attempt {attempt}")
                 }


### PR DESCRIPTION
Two relocations from the audit's deferral list, both moving code to its one consumer with no behavior change.

`drop_rows_below_retention_floor` — the retention-drop invariants, about 190 lines — ran only during reorganization but lived in create.rs, a leftover from when the old full rebuild was the caller. It now lives in reorganize.rs, and create.rs and reorganize.rs no longer import from each other.

The test-only shadow manifest builder (`build_namespace_manifest_from_metadata_state` and friends, about 115 lines) let tests author arbitrary layouts by re-implementing the bootstrap/base/append decision tree next to the production one — two trees that could drift, one of them cfg(test)-invisible in a production file. It now lives in checkpoint/tests.rs as declared test support. The doubled attribute stack it carried (flagged in the audit) came apart during the move and is gone.

create.rs is now only checkpoint creation.