### PR TITLE
refactor(core): single-site the lookup key grammar and unlinearize the cache LRU

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -281,6 +281,133 @@ pub fn hex_encode_row_key_component(value: &str) -> String {
     encoded
 }
 
+/// Reader-side lookup grammar: the probes, prefixes, and resume keys that
+/// point lookups and scans build per family. Defined beside
+/// `row_key_for_family` and `filter_key_for_family` because the pairing is
+/// byte-for-byte — a probe must equal the filter key the writer stored, and
+/// a prefix must be a prefix of the row keys it selects. Change a key
+/// format and its lookup grammar together, here.
+pub mod lookup_keys {
+    use super::hex_encode_row_key_component;
+    use crate::{ChangeSeq, InodeId, RevisionNo};
+
+    pub fn inode_key(inode_id: InodeId) -> String {
+        format!("inode-{:020}", inode_id.0)
+    }
+
+    pub fn direntry_parent_prefix(parent_inode_id: InodeId) -> String {
+        format!("direntry-{:020}-", parent_inode_id.0)
+    }
+
+    pub fn direntry_bind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "direntry-{:020}-{}",
+            parent_inode_id.0,
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    pub fn direntry_bind_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!("{}-", direntry_bind_probe(parent_inode_id, name_key))
+    }
+
+    pub fn direntry_child_probe(child_inode_id: InodeId) -> String {
+        format!("direntry-child-{:020}", child_inode_id.0)
+    }
+
+    pub fn direntry_child_prefix(child_inode_id: InodeId) -> String {
+        format!("{}-", direntry_child_probe(child_inode_id))
+    }
+
+    pub fn direntry_unbind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "direntry-unbind-{:020}-{}",
+            parent_inode_id.0,
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    /// Rows for one specific binding generation under the unbind probe.
+    pub fn direntry_unbind_binding_prefix(
+        parent_inode_id: InodeId,
+        name_key: &str,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}-{:020}-{:010}-",
+            direntry_unbind_probe(parent_inode_id, name_key),
+            bind_seq.0,
+            bind_delta_index
+        )
+    }
+
+    pub fn direntry_unbind_parent_prefix(parent_inode_id: InodeId) -> String {
+        format!("direntry-unbind-{:020}-", parent_inode_id.0)
+    }
+
+    pub fn direntry_unbind_name_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "{}{}-",
+            direntry_unbind_parent_prefix(parent_inode_id),
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    pub fn tombstone_probe(root_inode_id: InodeId) -> String {
+        format!("tombstone-{:020}", root_inode_id.0)
+    }
+
+    pub fn tombstone_prefix(root_inode_id: InodeId) -> String {
+        format!("{}-", tombstone_probe(root_inode_id))
+    }
+
+    pub fn commit_receipt_probe(commit_id: &str) -> String {
+        format!("commit-receipt-{}", hex_encode_row_key_component(commit_id))
+    }
+
+    pub fn commit_receipt_prefix(commit_id: &str) -> String {
+        format!("{}-", commit_receipt_probe(commit_id))
+    }
+
+    pub fn revision_by_inode_desc_probe(inode_id: InodeId) -> String {
+        format!("revision-by-inode-desc-{:020}", inode_id.0)
+    }
+
+    pub fn revision_by_inode_desc_prefix(inode_id: InodeId) -> String {
+        format!("{}-", revision_by_inode_desc_probe(inode_id))
+    }
+
+    /// Revision numbers are stored inverted so newest sorts first.
+    pub fn revision_by_inode_desc_revision_prefix(
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> String {
+        format!(
+            "{}{:020}-",
+            revision_by_inode_desc_prefix(inode_id),
+            u64::MAX - revision_no.0
+        )
+    }
+
+    /// The full descending-index row key: revision number, commit seq, and
+    /// delta index all inverted so newest sorts first.
+    pub fn revision_by_inode_desc_row_key(
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        committed_seq: ChangeSeq,
+        revision_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}{:020}-{:020}-{:010}",
+            revision_by_inode_desc_prefix(inode_id),
+            u64::MAX - revision_no.0,
+            u64::MAX - committed_seq.0,
+            u32::MAX - revision_delta_index
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceManifestPayload {
     pub namespace_id: NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -150,9 +150,23 @@ pub struct MetadataTableCache {
 
 #[derive(Debug, Default)]
 struct MetadataTableCacheInner {
-    entries: HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>,
-    order: VecDeque<MetadataTableCacheKey>,
+    entries: HashMap<MetadataTableCacheKey, CacheSlot>,
+    /// Recency queue with lazy deletion: a hit appends its key with a fresh
+    /// stamp in constant time and leaves its old position behind as a
+    /// ghost; eviction skips ghosts (stale stamps) as it pops. Nothing is
+    /// scheduled — the queue is compacted inline when ghosts outnumber live
+    /// entries, amortized constant like a vector reallocation.
+    order: VecDeque<(MetadataTableCacheKey, u64)>,
     decoded_byte_len: usize,
+    touch_counter: u64,
+}
+
+#[derive(Debug)]
+struct CacheSlot {
+    block: DecodedMetadataTableBlock,
+    /// Stamp of this entry's newest queue position; older positions for the
+    /// same key are ghosts.
+    last_touch: u64,
 }
 
 #[derive(Debug, Default)]
@@ -254,7 +268,7 @@ impl MetadataTableCache {
             .inner
             .lock()
             .expect("metadata table cache lock poisoned");
-        let Some(block) = inner.entries.get(key).cloned() else {
+        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
             return None;
         };
@@ -271,24 +285,36 @@ impl MetadataTableCache {
             .inner
             .lock()
             .expect("metadata table cache lock poisoned");
-        if let Some(previous) = inner.entries.insert(key.clone(), block.clone()) {
+        let decoded_byte_len = block.decoded_byte_len();
+        if let Some(previous) = inner.entries.insert(
+            key.clone(),
+            CacheSlot {
+                block,
+                last_touch: 0,
+            },
+        ) {
             inner.decoded_byte_len = inner
                 .decoded_byte_len
-                .saturating_sub(previous.decoded_byte_len());
+                .saturating_sub(previous.block.decoded_byte_len());
         }
-        inner.decoded_byte_len = inner
-            .decoded_byte_len
-            .saturating_add(block.decoded_byte_len());
+        inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
         while inner.decoded_byte_len > self.config.max_decoded_bytes {
-            let Some(evicted) = inner.order.pop_front() else {
+            let Some((candidate, stamp)) = inner.order.pop_front() else {
                 break;
             };
-            if let Some(block) = inner.entries.remove(&evicted) {
+            let live = inner
+                .entries
+                .get(&candidate)
+                .is_some_and(|slot| slot.last_touch == stamp);
+            if !live {
+                continue;
+            }
+            if let Some(slot) = inner.entries.remove(&candidate) {
                 inner.decoded_byte_len = inner
                     .decoded_byte_len
-                    .saturating_sub(block.decoded_byte_len());
+                    .saturating_sub(slot.block.decoded_byte_len());
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
             }
         }
@@ -297,8 +323,26 @@ impl MetadataTableCache {
 
 impl MetadataTableCacheInner {
     fn touch(&mut self, key: &MetadataTableCacheKey) {
-        self.order.retain(|candidate| candidate != key);
-        self.order.push_back(key.clone());
+        self.touch_counter += 1;
+        let stamp = self.touch_counter;
+        if let Some(slot) = self.entries.get_mut(key) {
+            slot.last_touch = stamp;
+        }
+        self.order.push_back((key.clone(), stamp));
+        if self.order.len() > (self.entries.len() * 2).max(16) {
+            self.compact_order();
+        }
+    }
+
+    /// Drops ghost queue positions. Runs inline when ghosts outnumber live
+    /// entries, so its cost is amortized over the touches that created them.
+    fn compact_order(&mut self) {
+        let entries = &self.entries;
+        self.order.retain(|(key, stamp)| {
+            entries
+                .get(key)
+                .is_some_and(|slot| slot.last_touch == *stamp)
+        });
     }
 }
 
@@ -587,6 +631,27 @@ mod tests {
         assert!(cache.get(&key("a")).is_some());
         assert!(cache.get(&key("b")).is_some());
         assert_eq!(cache.stats().evictions, 0);
+    }
+
+    #[test]
+    fn recency_queue_stays_bounded_under_repeated_hits() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            max_decoded_bytes: 10_000,
+        });
+        for index in 0..8 {
+            cache.insert(key(&format!("k{index}")), block(10));
+        }
+        for _ in 0..10_000 {
+            cache.get(&key("k0"));
+            cache.get(&key("k3"));
+        }
+        let inner = cache.inner.lock().expect("cache lock");
+        assert_eq!(inner.entries.len(), 8);
+        assert!(
+            inner.order.len() <= (inner.entries.len() * 2).max(16),
+            "hits must not grow the recency queue unboundedly, queue = {}",
+            inner.order.len()
+        );
     }
 
     #[test]

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -10,7 +10,8 @@ use crate::metadata::{
     unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
     InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loonfs_api::wire::manifest::{hex_encode_row_key_component, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::lookup_keys;
+use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
 use loonfs_objectstore::ObjectStore;
 
@@ -22,7 +23,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
 ) -> Result<Option<InodeRecord>> {
-    let key = format!("inode-{:020}", inode_id.0);
+    let key = lookup_keys::inode_key(inode_id);
     Ok(tables
         .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
@@ -34,7 +35,7 @@ pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     parent_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = format!("direntry-{:020}-", parent_inode_id.0);
+    let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
     Ok(tables
         .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
         .await
@@ -56,12 +57,11 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
     start_after_row_key: Option<&str>,
     limit: usize,
 ) -> Result<Vec<ManifestDirentryBindCandidate>> {
-    let parent_prefix = format!("direntry-{:020}-", parent_inode_id.0);
+    let parent_prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
     let lower_bound = if let Some(row_key) = start_after_row_key {
         resume_after_row_key(row_key)
     } else if let Some(name_key) = start_after_name_key {
-        let encoded_name_key = hex_encode_row_key_component(name_key);
-        let exact_name_prefix = format!("{parent_prefix}{encoded_name_key}-");
+        let exact_name_prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
         string_prefix_upper_bound(&exact_name_prefix).unwrap_or(exact_name_prefix)
     } else {
         parent_prefix.clone()
@@ -86,9 +86,8 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     parent_inode_id: InodeId,
     name_key: &str,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let encoded_name_key = hex_encode_row_key_component(name_key);
-    let filter_probe = format!("direntry-{:020}-{encoded_name_key}", parent_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::direntry_bind_probe(parent_inode_id, name_key);
+    let prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryBinds,
@@ -107,8 +106,8 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     child_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let filter_probe = format!("direntry-child-{:020}", child_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::direntry_child_probe(child_inode_id);
+    let prefix = lookup_keys::direntry_child_prefix(child_inode_id);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryChildBinds,
@@ -127,14 +126,13 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     direntry: &DirentryBindRecord,
 ) -> Result<Vec<DirentryUnbindRecord>> {
-    let encoded_name_key = hex_encode_row_key_component(&direntry.name_key);
-    let filter_probe = format!(
-        "direntry-unbind-{:020}-{encoded_name_key}",
-        direntry.parent_inode_id.0
-    );
-    let prefix = format!(
-        "{filter_probe}-{:020}-{:010}-",
-        direntry.bind_seq.0, direntry.bind_delta_index
+    let filter_probe =
+        lookup_keys::direntry_unbind_probe(direntry.parent_inode_id, &direntry.name_key);
+    let prefix = lookup_keys::direntry_unbind_binding_prefix(
+        direntry.parent_inode_id,
+        &direntry.name_key,
+        direntry.bind_seq,
+        direntry.bind_delta_index,
     );
     Ok(tables
         .scan_prefix_for_lookup(
@@ -162,11 +160,8 @@ pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Siz
     last_name_key: &str,
 ) -> Result<Vec<DirentryUnbindRecord>> {
     const UNBIND_RANGE_SCAN_LIMIT: usize = 512;
-    let parent_prefix = format!("direntry-unbind-{:020}-", parent_inode_id.0);
-    let first_encoded = hex_encode_row_key_component(first_name_key);
-    let last_encoded = hex_encode_row_key_component(last_name_key);
-    let mut lower_bound = format!("{parent_prefix}{first_encoded}-");
-    let last_name_prefix = format!("{parent_prefix}{last_encoded}-");
+    let mut lower_bound = lookup_keys::direntry_unbind_name_prefix(parent_inode_id, first_name_key);
+    let last_name_prefix = lookup_keys::direntry_unbind_name_prefix(parent_inode_id, last_name_key);
     let upper_bound = string_prefix_upper_bound(&last_name_prefix);
 
     let mut unbinds = Vec::new();
@@ -285,8 +280,8 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     root_inode_id: InodeId,
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
-    let filter_probe = format!("tombstone-{:020}", root_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::tombstone_probe(root_inode_id);
+    let prefix = lookup_keys::tombstone_prefix(root_inode_id);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::Tombstones,
@@ -305,9 +300,8 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     commit_id: &CommitId,
 ) -> Result<Option<CommitReceiptRecord>> {
-    let encoded_commit_id = hex_encode_row_key_component(commit_id.as_str());
-    let filter_probe = format!("commit-receipt-{encoded_commit_id}");
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::commit_receipt_probe(commit_id.as_str());
+    let prefix = lookup_keys::commit_receipt_prefix(commit_id.as_str());
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::CommitReceipts,
@@ -338,32 +332,25 @@ fn resume_after_row_key(row_key: &str) -> String {
 }
 
 fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
-    format!("revision-by-inode-desc-{:020}-", inode_id.0)
+    lookup_keys::revision_by_inode_desc_prefix(inode_id)
 }
 
-/// The filter key for revision-by-inode lookups; must match
-/// `MetadataRow::filter_key_for_family` for the family byte-for-byte.
 fn revision_by_inode_desc_filter_probe(inode_id: InodeId) -> String {
-    format!("revision-by-inode-desc-{:020}", inode_id.0)
+    lookup_keys::revision_by_inode_desc_probe(inode_id)
 }
 
 fn revision_by_inode_desc_exact_revision_prefix(
     inode_id: InodeId,
     revision_no: RevisionNo,
 ) -> String {
-    format!(
-        "{}{:020}-",
-        revision_by_inode_desc_inode_prefix(inode_id),
-        u64::MAX - revision_no.0
-    )
+    lookup_keys::revision_by_inode_desc_revision_prefix(inode_id, revision_no)
 }
 
 fn revision_by_inode_desc_row_key(inode_id: InodeId, position: RevisionPagePosition) -> String {
-    format!(
-        "{}{:020}-{:020}-{:010}",
-        revision_by_inode_desc_inode_prefix(inode_id),
-        u64::MAX - position.revision_no.0,
-        u64::MAX - position.committed_seq.0,
-        u32::MAX - position.revision_delta_index
+    lookup_keys::revision_by_inode_desc_row_key(
+        inode_id,
+        position.revision_no,
+        position.committed_seq,
+        position.revision_delta_index,
     )
 }


### PR DESCRIPTION
**The lookup key grammar now lives in one file.** Point lookups and scans build probes and prefixes for row keys whose formats are defined in loonfs-api — but the lookup code built them with about ten hand-written format strings that had to match the api-side definitions byte for byte (a comment admitted as much). A drift would not error: the bloom filter would say "definitely not here" and reads would silently miss rows. The new `lookup_keys` module sits directly beside `row_key_for_family` and `filter_key_for_family`, owns every probe, prefix, and resume-key shape (including the descending-index inversions), and the lookup code calls it. Changing a key format and its lookup grammar is now the same edit in the same file.

**Cache hits stop paying a linear scan.** Every hit on the decoded-block cache walked the whole eviction queue to move its key to the back — a few thousand entries scanned per hit at the default budget, under the global cache mutex, hundreds of times per listing page. The queue now uses lazy deletion: a hit appends its key with a fresh stamp in constant time; eviction skips stale positions as it pops; and when ghost positions outnumber live entries the queue is compacted inline — nothing is scheduled, no timer, no background work, no knob. The compaction is amortized constant per touch, the same argument as a vector reallocation, and eviction order is unchanged (the existing oldest-first eviction tests pass untouched). A new test pins that ten thousand hits leave the queue bounded by twice the entry count.
