### PR TITLE
refactor(loonfs): one cache entry per namespace and a plain read context

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -281,6 +281,133 @@ pub fn hex_encode_row_key_component(value: &str) -> String {
     encoded
 }
 
+/// Reader-side lookup grammar: the probes, prefixes, and resume keys that
+/// point lookups and scans build per family. Defined beside
+/// `row_key_for_family` and `filter_key_for_family` because the pairing is
+/// byte-for-byte — a probe must equal the filter key the writer stored, and
+/// a prefix must be a prefix of the row keys it selects. Change a key
+/// format and its lookup grammar together, here.
+pub mod lookup_keys {
+    use super::hex_encode_row_key_component;
+    use crate::{ChangeSeq, InodeId, RevisionNo};
+
+    pub fn inode_key(inode_id: InodeId) -> String {
+        format!("inode-{:020}", inode_id.0)
+    }
+
+    pub fn direntry_parent_prefix(parent_inode_id: InodeId) -> String {
+        format!("direntry-{:020}-", parent_inode_id.0)
+    }
+
+    pub fn direntry_bind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "direntry-{:020}-{}",
+            parent_inode_id.0,
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    pub fn direntry_bind_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!("{}-", direntry_bind_probe(parent_inode_id, name_key))
+    }
+
+    pub fn direntry_child_probe(child_inode_id: InodeId) -> String {
+        format!("direntry-child-{:020}", child_inode_id.0)
+    }
+
+    pub fn direntry_child_prefix(child_inode_id: InodeId) -> String {
+        format!("{}-", direntry_child_probe(child_inode_id))
+    }
+
+    pub fn direntry_unbind_probe(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "direntry-unbind-{:020}-{}",
+            parent_inode_id.0,
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    /// Rows for one specific binding generation under the unbind probe.
+    pub fn direntry_unbind_binding_prefix(
+        parent_inode_id: InodeId,
+        name_key: &str,
+        bind_seq: ChangeSeq,
+        bind_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}-{:020}-{:010}-",
+            direntry_unbind_probe(parent_inode_id, name_key),
+            bind_seq.0,
+            bind_delta_index
+        )
+    }
+
+    pub fn direntry_unbind_parent_prefix(parent_inode_id: InodeId) -> String {
+        format!("direntry-unbind-{:020}-", parent_inode_id.0)
+    }
+
+    pub fn direntry_unbind_name_prefix(parent_inode_id: InodeId, name_key: &str) -> String {
+        format!(
+            "{}{}-",
+            direntry_unbind_parent_prefix(parent_inode_id),
+            hex_encode_row_key_component(name_key)
+        )
+    }
+
+    pub fn tombstone_probe(root_inode_id: InodeId) -> String {
+        format!("tombstone-{:020}", root_inode_id.0)
+    }
+
+    pub fn tombstone_prefix(root_inode_id: InodeId) -> String {
+        format!("{}-", tombstone_probe(root_inode_id))
+    }
+
+    pub fn commit_receipt_probe(commit_id: &str) -> String {
+        format!("commit-receipt-{}", hex_encode_row_key_component(commit_id))
+    }
+
+    pub fn commit_receipt_prefix(commit_id: &str) -> String {
+        format!("{}-", commit_receipt_probe(commit_id))
+    }
+
+    pub fn revision_by_inode_desc_probe(inode_id: InodeId) -> String {
+        format!("revision-by-inode-desc-{:020}", inode_id.0)
+    }
+
+    pub fn revision_by_inode_desc_prefix(inode_id: InodeId) -> String {
+        format!("{}-", revision_by_inode_desc_probe(inode_id))
+    }
+
+    /// Revision numbers are stored inverted so newest sorts first.
+    pub fn revision_by_inode_desc_revision_prefix(
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> String {
+        format!(
+            "{}{:020}-",
+            revision_by_inode_desc_prefix(inode_id),
+            u64::MAX - revision_no.0
+        )
+    }
+
+    /// The full descending-index row key: revision number, commit seq, and
+    /// delta index all inverted so newest sorts first.
+    pub fn revision_by_inode_desc_row_key(
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        committed_seq: ChangeSeq,
+        revision_delta_index: u32,
+    ) -> String {
+        format!(
+            "{}{:020}-{:020}-{:010}",
+            revision_by_inode_desc_prefix(inode_id),
+            u64::MAX - revision_no.0,
+            u64::MAX - committed_seq.0,
+            u32::MAX - revision_delta_index
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NamespaceManifestPayload {
     pub namespace_id: NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -150,9 +150,23 @@ pub struct MetadataTableCache {
 
 #[derive(Debug, Default)]
 struct MetadataTableCacheInner {
-    entries: HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>,
-    order: VecDeque<MetadataTableCacheKey>,
+    entries: HashMap<MetadataTableCacheKey, CacheSlot>,
+    /// Recency queue with lazy deletion: a hit appends its key with a fresh
+    /// stamp in constant time and leaves its old position behind as a
+    /// ghost; eviction skips ghosts (stale stamps) as it pops. Nothing is
+    /// scheduled — the queue is compacted inline when ghosts outnumber live
+    /// entries, amortized constant like a vector reallocation.
+    order: VecDeque<(MetadataTableCacheKey, u64)>,
     decoded_byte_len: usize,
+    touch_counter: u64,
+}
+
+#[derive(Debug)]
+struct CacheSlot {
+    block: DecodedMetadataTableBlock,
+    /// Stamp of this entry's newest queue position; older positions for the
+    /// same key are ghosts.
+    last_touch: u64,
 }
 
 #[derive(Debug, Default)]
@@ -254,7 +268,7 @@ impl MetadataTableCache {
             .inner
             .lock()
             .expect("metadata table cache lock poisoned");
-        let Some(block) = inner.entries.get(key).cloned() else {
+        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
             return None;
         };
@@ -271,24 +285,36 @@ impl MetadataTableCache {
             .inner
             .lock()
             .expect("metadata table cache lock poisoned");
-        if let Some(previous) = inner.entries.insert(key.clone(), block.clone()) {
+        let decoded_byte_len = block.decoded_byte_len();
+        if let Some(previous) = inner.entries.insert(
+            key.clone(),
+            CacheSlot {
+                block,
+                last_touch: 0,
+            },
+        ) {
             inner.decoded_byte_len = inner
                 .decoded_byte_len
-                .saturating_sub(previous.decoded_byte_len());
+                .saturating_sub(previous.block.decoded_byte_len());
         }
-        inner.decoded_byte_len = inner
-            .decoded_byte_len
-            .saturating_add(block.decoded_byte_len());
+        inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
         while inner.decoded_byte_len > self.config.max_decoded_bytes {
-            let Some(evicted) = inner.order.pop_front() else {
+            let Some((candidate, stamp)) = inner.order.pop_front() else {
                 break;
             };
-            if let Some(block) = inner.entries.remove(&evicted) {
+            let live = inner
+                .entries
+                .get(&candidate)
+                .is_some_and(|slot| slot.last_touch == stamp);
+            if !live {
+                continue;
+            }
+            if let Some(slot) = inner.entries.remove(&candidate) {
                 inner.decoded_byte_len = inner
                     .decoded_byte_len
-                    .saturating_sub(block.decoded_byte_len());
+                    .saturating_sub(slot.block.decoded_byte_len());
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
             }
         }
@@ -297,8 +323,26 @@ impl MetadataTableCache {
 
 impl MetadataTableCacheInner {
     fn touch(&mut self, key: &MetadataTableCacheKey) {
-        self.order.retain(|candidate| candidate != key);
-        self.order.push_back(key.clone());
+        self.touch_counter += 1;
+        let stamp = self.touch_counter;
+        if let Some(slot) = self.entries.get_mut(key) {
+            slot.last_touch = stamp;
+        }
+        self.order.push_back((key.clone(), stamp));
+        if self.order.len() > (self.entries.len() * 2).max(16) {
+            self.compact_order();
+        }
+    }
+
+    /// Drops ghost queue positions. Runs inline when ghosts outnumber live
+    /// entries, so its cost is amortized over the touches that created them.
+    fn compact_order(&mut self) {
+        let entries = &self.entries;
+        self.order.retain(|(key, stamp)| {
+            entries
+                .get(key)
+                .is_some_and(|slot| slot.last_touch == *stamp)
+        });
     }
 }
 
@@ -587,6 +631,27 @@ mod tests {
         assert!(cache.get(&key("a")).is_some());
         assert!(cache.get(&key("b")).is_some());
         assert_eq!(cache.stats().evictions, 0);
+    }
+
+    #[test]
+    fn recency_queue_stays_bounded_under_repeated_hits() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+            max_decoded_bytes: 10_000,
+        });
+        for index in 0..8 {
+            cache.insert(key(&format!("k{index}")), block(10));
+        }
+        for _ in 0..10_000 {
+            cache.get(&key("k0"));
+            cache.get(&key("k3"));
+        }
+        let inner = cache.inner.lock().expect("cache lock");
+        assert_eq!(inner.entries.len(), 8);
+        assert!(
+            inner.order.len() <= (inner.entries.len() * 2).max(16),
+            "hits must not grow the recency queue unboundedly, queue = {}",
+            inner.order.len()
+        );
     }
 
     #[test]

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -24,39 +24,19 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
+/// The pinned inputs the runtime resolves once per read: the head anchored
+/// to its manifest, the shared caches, and (when the runtime has it) the
+/// namespace's immutable catalog pair.
 #[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct RuntimeReadContext {
-    head: HeadState,
-    head_etag: String,
-    manifest_id: ManifestId,
-    manifest_object_id: ManifestObjectId,
-    table_cache: Option<Arc<MetadataTableCache>>,
-    tail_cache: Option<Arc<WalTailProjectionCache>>,
-    catalog: Option<VerifiedNamespaceCatalogEntry>,
-}
-
-impl RuntimeReadContext {
-    #[doc(hidden)]
-    pub fn pinned_head(
-        head: HeadState,
-        head_etag: String,
-        manifest_id: ManifestId,
-        manifest_object_id: ManifestObjectId,
-        table_cache: Option<Arc<MetadataTableCache>>,
-        tail_cache: Option<Arc<WalTailProjectionCache>>,
-        catalog: Option<VerifiedNamespaceCatalogEntry>,
-    ) -> Self {
-        Self {
-            head,
-            head_etag,
-            manifest_id,
-            manifest_object_id,
-            table_cache,
-            tail_cache,
-            catalog,
-        }
-    }
+    pub head: HeadState,
+    pub head_etag: String,
+    pub manifest_id: ManifestId,
+    pub manifest_object_id: ManifestObjectId,
+    pub table_cache: Arc<MetadataTableCache>,
+    pub tail_cache: Arc<WalTailProjectionCache>,
+    pub catalog: Option<VerifiedNamespaceCatalogEntry>,
 }
 
 fn runtime_read_load_context(options: &RuntimeReadContext) -> ReadLoadContext<'_> {
@@ -65,8 +45,8 @@ fn runtime_read_load_context(options: &RuntimeReadContext) -> ReadLoadContext<'_
         Some(options.head_etag.as_str()),
         options.manifest_id,
         &options.manifest_object_id,
-        options.table_cache.as_deref(),
-        options.tail_cache.as_deref(),
+        Some(&options.table_cache),
+        Some(&options.tail_cache),
         options.catalog.as_ref(),
     )
 }

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -10,7 +10,8 @@ use crate::metadata::{
     unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
     InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loonfs_api::wire::manifest::{hex_encode_row_key_component, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::lookup_keys;
+use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
 use loonfs_objectstore::ObjectStore;
 
@@ -22,7 +23,7 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     inode_id: InodeId,
 ) -> Result<Option<InodeRecord>> {
-    let key = format!("inode-{:020}", inode_id.0);
+    let key = lookup_keys::inode_key(inode_id);
     Ok(tables
         .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
@@ -34,7 +35,7 @@ pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     parent_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = format!("direntry-{:020}-", parent_inode_id.0);
+    let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
     Ok(tables
         .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
         .await
@@ -56,12 +57,11 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
     start_after_row_key: Option<&str>,
     limit: usize,
 ) -> Result<Vec<ManifestDirentryBindCandidate>> {
-    let parent_prefix = format!("direntry-{:020}-", parent_inode_id.0);
+    let parent_prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
     let lower_bound = if let Some(row_key) = start_after_row_key {
         resume_after_row_key(row_key)
     } else if let Some(name_key) = start_after_name_key {
-        let encoded_name_key = hex_encode_row_key_component(name_key);
-        let exact_name_prefix = format!("{parent_prefix}{encoded_name_key}-");
+        let exact_name_prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
         string_prefix_upper_bound(&exact_name_prefix).unwrap_or(exact_name_prefix)
     } else {
         parent_prefix.clone()
@@ -86,9 +86,8 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
     parent_inode_id: InodeId,
     name_key: &str,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let encoded_name_key = hex_encode_row_key_component(name_key);
-    let filter_probe = format!("direntry-{:020}-{encoded_name_key}", parent_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::direntry_bind_probe(parent_inode_id, name_key);
+    let prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryBinds,
@@ -107,8 +106,8 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     child_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
-    let filter_probe = format!("direntry-child-{:020}", child_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::direntry_child_probe(child_inode_id);
+    let prefix = lookup_keys::direntry_child_prefix(child_inode_id);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryChildBinds,
@@ -127,14 +126,13 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     direntry: &DirentryBindRecord,
 ) -> Result<Vec<DirentryUnbindRecord>> {
-    let encoded_name_key = hex_encode_row_key_component(&direntry.name_key);
-    let filter_probe = format!(
-        "direntry-unbind-{:020}-{encoded_name_key}",
-        direntry.parent_inode_id.0
-    );
-    let prefix = format!(
-        "{filter_probe}-{:020}-{:010}-",
-        direntry.bind_seq.0, direntry.bind_delta_index
+    let filter_probe =
+        lookup_keys::direntry_unbind_probe(direntry.parent_inode_id, &direntry.name_key);
+    let prefix = lookup_keys::direntry_unbind_binding_prefix(
+        direntry.parent_inode_id,
+        &direntry.name_key,
+        direntry.bind_seq,
+        direntry.bind_delta_index,
     );
     Ok(tables
         .scan_prefix_for_lookup(
@@ -162,11 +160,8 @@ pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Siz
     last_name_key: &str,
 ) -> Result<Vec<DirentryUnbindRecord>> {
     const UNBIND_RANGE_SCAN_LIMIT: usize = 512;
-    let parent_prefix = format!("direntry-unbind-{:020}-", parent_inode_id.0);
-    let first_encoded = hex_encode_row_key_component(first_name_key);
-    let last_encoded = hex_encode_row_key_component(last_name_key);
-    let mut lower_bound = format!("{parent_prefix}{first_encoded}-");
-    let last_name_prefix = format!("{parent_prefix}{last_encoded}-");
+    let mut lower_bound = lookup_keys::direntry_unbind_name_prefix(parent_inode_id, first_name_key);
+    let last_name_prefix = lookup_keys::direntry_unbind_name_prefix(parent_inode_id, last_name_key);
     let upper_bound = string_prefix_upper_bound(&last_name_prefix);
 
     let mut unbinds = Vec::new();
@@ -285,8 +280,8 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     root_inode_id: InodeId,
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
-    let filter_probe = format!("tombstone-{:020}", root_inode_id.0);
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::tombstone_probe(root_inode_id);
+    let prefix = lookup_keys::tombstone_prefix(root_inode_id);
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::Tombstones,
@@ -305,9 +300,8 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     commit_id: &CommitId,
 ) -> Result<Option<CommitReceiptRecord>> {
-    let encoded_commit_id = hex_encode_row_key_component(commit_id.as_str());
-    let filter_probe = format!("commit-receipt-{encoded_commit_id}");
-    let prefix = format!("{filter_probe}-");
+    let filter_probe = lookup_keys::commit_receipt_probe(commit_id.as_str());
+    let prefix = lookup_keys::commit_receipt_prefix(commit_id.as_str());
     Ok(tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::CommitReceipts,
@@ -338,32 +332,25 @@ fn resume_after_row_key(row_key: &str) -> String {
 }
 
 fn revision_by_inode_desc_inode_prefix(inode_id: InodeId) -> String {
-    format!("revision-by-inode-desc-{:020}-", inode_id.0)
+    lookup_keys::revision_by_inode_desc_prefix(inode_id)
 }
 
-/// The filter key for revision-by-inode lookups; must match
-/// `MetadataRow::filter_key_for_family` for the family byte-for-byte.
 fn revision_by_inode_desc_filter_probe(inode_id: InodeId) -> String {
-    format!("revision-by-inode-desc-{:020}", inode_id.0)
+    lookup_keys::revision_by_inode_desc_probe(inode_id)
 }
 
 fn revision_by_inode_desc_exact_revision_prefix(
     inode_id: InodeId,
     revision_no: RevisionNo,
 ) -> String {
-    format!(
-        "{}{:020}-",
-        revision_by_inode_desc_inode_prefix(inode_id),
-        u64::MAX - revision_no.0
-    )
+    lookup_keys::revision_by_inode_desc_revision_prefix(inode_id, revision_no)
 }
 
 fn revision_by_inode_desc_row_key(inode_id: InodeId, position: RevisionPagePosition) -> String {
-    format!(
-        "{}{:020}-{:020}-{:010}",
-        revision_by_inode_desc_inode_prefix(inode_id),
-        u64::MAX - position.revision_no.0,
-        u64::MAX - position.committed_seq.0,
-        u32::MAX - position.revision_delta_index
+    lookup_keys::revision_by_inode_desc_row_key(
+        inode_id,
+        position.revision_no,
+        position.committed_seq,
+        position.revision_delta_index,
     )
 }

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -8,6 +8,11 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::v0::BeginUploadRequest;
 use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
+    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+};
 use loonfs_core::content::store_bytes_as_content;
 use loonfs_core::control::load_namespace_read_anchor;
 use loonfs_core::gc::{gc_namespace, GcConfig};
@@ -19,6 +24,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use tempfile::tempdir;
 
 async fn put_file<S: ObjectStore + ?Sized>(
@@ -58,15 +64,19 @@ async fn read_context<S: ObjectStore + ?Sized>(
     let (head, root) = load_namespace_read_anchor(store, namespace_id)
         .await
         .expect("load read anchor");
-    RuntimeReadContext::pinned_head(
-        head.state,
-        head.identity.etag,
-        root.state.manifest_id,
-        root.state.manifest_object_id,
-        None,
-        None,
-        None,
-    )
+    RuntimeReadContext {
+        head: head.state,
+        head_etag: head.identity.etag,
+        manifest_id: root.state.manifest_id,
+        manifest_object_id: root.state.manifest_object_id,
+        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
+        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+            max_entries: 4,
+            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        })),
+        catalog: None,
+    }
 }
 
 fn page_limit() -> EffectiveLimit {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -27,6 +27,11 @@ use loonfs_api::{
     DeleteDirectoryBehavior, DirectoryPageCursor, EffectiveLimit, InodeId, InodeKind, ManifestId,
     NameKey, NamespaceId, Page, PageRequest, PutBehavior, RevisionNo, UploadId, WriterEpoch,
 };
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
+    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+};
 use loonfs_core::commit::{
     build_commit_plan, materialize_commit, CommitOp, CommitOpResult, CommitRequest,
     CommitValidationContext, CommitValidationError, PreparedCommit,
@@ -51,7 +56,7 @@ use std::future::Future;
 use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
 #[derive(Debug, Clone)]
@@ -234,15 +239,19 @@ fn read_context<S: ObjectStore + ?Sized>(
 ) -> RuntimeReadContext {
     let (head, root) =
         block_on(load_namespace_read_anchor(store, namespace_id)).expect("load read anchor");
-    RuntimeReadContext::pinned_head(
-        head.state,
-        head.identity.etag,
-        root.state.manifest_id,
-        root.state.manifest_object_id,
-        None,
-        None,
-        None,
-    )
+    RuntimeReadContext {
+        head: head.state,
+        head_etag: head.identity.etag,
+        manifest_id: root.state.manifest_id,
+        manifest_object_id: root.state.manifest_object_id,
+        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
+        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+            max_entries: 4,
+            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        })),
+        catalog: None,
+    }
 }
 
 /// Publishes one path intent through the commit engine — the single publish

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -26,73 +26,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Debug, Default)]
-pub(crate) struct CommitEngineCache {
-    entries: HashMap<NamespaceId, Arc<AsyncMutex<NamespaceCommitEngine>>>,
-    order: VecDeque<NamespaceId>,
-}
-
-impl CommitEngineCache {
-    fn get_or_insert(
-        &mut self,
-        namespace_id: &NamespaceId,
-        max_cached_namespaces: usize,
-        table_cache: Arc<MetadataTableCache>,
-        catalog: Option<VerifiedNamespaceCatalogEntry>,
-    ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
-        if let Some(engine) = self.entries.get(namespace_id).cloned() {
-            self.touch(namespace_id);
-            return engine;
-        }
-        let mut engine =
-            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache);
-        if let Some(catalog) = catalog {
-            engine = engine.with_catalog_entry(catalog);
-        }
-        let engine = Arc::new(AsyncMutex::new(engine));
-        self.entries.insert(namespace_id.clone(), engine.clone());
-        self.touch(namespace_id);
-        while self.entries.len() > max_cached_namespaces {
-            let Some(evicted) = self.order.pop_front() else {
-                break;
-            };
-            self.remove_entry(&evicted);
-        }
-        engine
-    }
-
-    fn invalidate(&mut self, namespace_id: &NamespaceId) {
-        // The engine survives invalidation: its acquired epoch and fencing
-        // are session state ("a fenced session stays fenced"), and only its
-        // tail projection goes stale. A held lock means a publish is in
-        // flight; that publish revalidates against the live head itself.
-        if let Some(engine) = self.entries.get(namespace_id) {
-            if let Ok(mut engine) = engine.try_lock() {
-                engine.invalidate();
-            }
-        }
-    }
-
-    fn remove(&mut self, namespace_id: &NamespaceId) {
-        self.remove_entry(namespace_id);
-        self.order.retain(|candidate| candidate != namespace_id);
-    }
-
-    fn remove_entry(&mut self, namespace_id: &NamespaceId) {
-        let Some(engine) = self.entries.remove(namespace_id) else {
-            return;
-        };
-        if let Ok(mut engine) = engine.try_lock() {
-            engine.invalidate();
-        };
-    }
-
-    fn touch(&mut self, namespace_id: &NamespaceId) {
-        self.order.retain(|candidate| candidate != namespace_id);
-        self.order.push_back(namespace_id.clone());
-    }
-}
-
-#[derive(Debug, Default)]
 
 pub(crate) struct RuntimeControlCache {
     namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
@@ -105,6 +38,11 @@ struct NamespaceControlCacheEntry {
     /// The namespace's spec-immutable catalog pair (config plus content-store
     /// binding): loaded once, never revalidated.
     catalog: Option<VerifiedNamespaceCatalogEntry>,
+    /// This process's commit engine for the namespace: writer-session state
+    /// (acquired epoch, fencing, tail projection). Survives invalidation —
+    /// only its tail projection is dropped; removal happens on namespace
+    /// deletion or LRU eviction.
+    engine: Option<Arc<AsyncMutex<NamespaceCommitEngine>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -252,18 +190,56 @@ impl RuntimeControlCache {
     }
 
     fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
-        // The head anchor goes stale on every mutation, but the catalog pair
-        // is immutable for the namespace's lifetime (a deleted namespace id
-        // never rebinds), so it survives invalidation.
+        // The head anchor goes stale on every mutation; the catalog pair is
+        // immutable for the namespace's lifetime (a deleted namespace id
+        // never rebinds), and the engine keeps its session state ("a fenced
+        // session stays fenced") — only its tail projection goes stale. A
+        // held engine lock means a publish is in flight; that publish
+        // revalidates against the live head itself.
         if let Some(entry) = self.namespaces.get_mut(namespace_id) {
             entry.head = None;
+            if let Some(engine) = &entry.engine {
+                if let Ok(mut engine) = engine.try_lock() {
+                    engine.invalidate();
+                }
+            }
         }
     }
 
-    fn invalidate_namespace_head(&mut self, namespace_id: &NamespaceId) {
-        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
-            entry.head = None;
+    /// Namespace-terminal removal: the whole entry goes, engine included.
+    fn remove_namespace(&mut self, namespace_id: &NamespaceId) {
+        if let Some(entry) = self.namespaces.remove(namespace_id) {
+            invalidate_dropped_engine(&entry);
         }
+        self.namespace_order
+            .retain(|candidate| candidate != namespace_id);
+    }
+
+    fn engine(
+        &mut self,
+        namespace_id: &NamespaceId,
+        max_cached_namespaces: usize,
+        table_cache: Arc<MetadataTableCache>,
+    ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
+        if max_cached_namespaces == 0 {
+            // Diagnostic mode: nothing is cached, every publish gets a
+            // throwaway engine.
+            return Arc::new(AsyncMutex::new(
+                NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache),
+            ));
+        }
+        let entry = self.namespace_entry(namespace_id, max_cached_namespaces);
+        if let Some(engine) = &entry.engine {
+            return Arc::clone(engine);
+        }
+        let mut engine =
+            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache);
+        if let Some(catalog) = &entry.catalog {
+            engine = engine.with_catalog_entry(catalog.clone());
+        }
+        let engine = Arc::new(AsyncMutex::new(engine));
+        entry.engine = Some(Arc::clone(&engine));
+        engine
     }
 
     fn namespace_entry(
@@ -277,7 +253,9 @@ impl RuntimeControlCache {
             let Some(evicted) = self.namespace_order.pop_front() else {
                 break;
             };
-            self.namespaces.remove(&evicted);
+            if let Some(entry) = self.namespaces.remove(&evicted) {
+                invalidate_dropped_engine(&entry);
+            }
         }
         self.namespaces
             .get_mut(namespace_id)
@@ -316,11 +294,11 @@ impl FsCore {
                 Ok(false) => self
                     .inner
                     .control_cache()
-                    .invalidate_namespace_head(namespace_id),
+                    .invalidate_namespace(namespace_id),
                 Err(error) => {
                     self.inner
                         .control_cache()
-                        .invalidate_namespace_head(namespace_id);
+                        .invalidate_namespace(namespace_id);
                     return Err(error);
                 }
             }
@@ -331,7 +309,7 @@ impl FsCore {
             Err(error) => {
                 self.inner
                     .control_cache()
-                    .invalidate_namespace_head(namespace_id);
+                    .invalidate_namespace(namespace_id);
                 return Err(error);
             }
         };
@@ -429,12 +407,10 @@ impl FsCore {
         namespace_id: &NamespaceId,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         let cache_config = &self.inner.config.runtime_cache;
-        let catalog = self.inner.control_cache().catalog(namespace_id);
-        self.inner.commit_engines().get_or_insert(
+        self.inner.control_cache().engine(
             namespace_id,
             cache_config.max_cached_namespaces,
             Arc::clone(&self.inner.metadata_table_cache),
-            catalog,
         )
     }
 
@@ -443,17 +419,31 @@ impl FsCore {
         namespace_id: &NamespaceId,
         anchor: &CachedNamespaceAnchor,
     ) -> Result<RuntimeReadContext> {
-        let tail_cache = Some(Arc::clone(&self.inner.wal_tail_projection_cache));
         let catalog = self.load_namespace_catalog_cached(namespace_id).await?;
-        Ok(RuntimeReadContext::pinned_head(
-            anchor.head.state.clone(),
-            anchor.head.identity.etag.clone(),
-            anchor.manifest_id,
-            anchor.manifest_object_id.clone(),
-            Some(Arc::clone(&self.inner.metadata_table_cache)),
-            tail_cache,
+        Ok(RuntimeReadContext {
+            head: anchor.head.state.clone(),
+            head_etag: anchor.head.identity.etag.clone(),
+            manifest_id: anchor.manifest_id,
+            manifest_object_id: anchor.manifest_object_id.clone(),
+            table_cache: Arc::clone(&self.inner.metadata_table_cache),
+            tail_cache: Arc::clone(&self.inner.wal_tail_projection_cache),
             catalog,
-        ))
+        })
+    }
+
+    /// The shared preamble of every pinned read: revalidate or load the head
+    /// anchor, pin the read context to it, and hand back the engine. The
+    /// context's `head` is the anchor the read is pinned to.
+    pub(crate) async fn pinned_read(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<(
+        loonfs_core::NamespaceEngine<crate::SharedObjectStore>,
+        RuntimeReadContext,
+    )> {
+        let head = self.head_for_metadata_read(namespace_id).await?;
+        let read_context = self.runtime_read_context(namespace_id, &head).await?;
+        Ok((self.namespace_engine(namespace_id), read_context))
     }
 
     /// Returns the namespace's immutable catalog pair through the control
@@ -492,14 +482,15 @@ impl FsCore {
     )]
     pub(crate) fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
         self.invalidate_namespace_read_cache(namespace_id);
-        self.inner.commit_engines().invalidate(namespace_id);
     }
 
-    /// Namespace-terminal invalidation: the commit engine is removed rather
-    /// than kept, because the namespace itself is gone.
+    /// Namespace-terminal invalidation: the whole entry is removed, engine
+    /// included, because the namespace itself is gone.
     pub(crate) fn invalidate_namespace_cache_for_delete(&self, namespace_id: &NamespaceId) {
-        self.invalidate_namespace_read_cache(namespace_id);
-        self.inner.commit_engines().remove(namespace_id);
+        self.inner.control_cache().remove_namespace(namespace_id);
+        self.inner
+            .wal_tail_projection_cache
+            .invalidate_namespace(namespace_id);
     }
 
     /// Seeds the read caches with the state one landed publish produced:
@@ -569,6 +560,14 @@ impl FsCore {
     ) {
         if results.iter().any(should_invalidate_after_result) {
             self.invalidate_namespace_read_cache(namespace_id);
+        }
+    }
+}
+
+fn invalidate_dropped_engine(entry: &NamespaceControlCacheEntry) {
+    if let Some(engine) = &entry.engine {
+        if let Ok(mut engine) = engine.try_lock() {
+            engine.invalidate();
         }
     }
 }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -3,7 +3,7 @@
 //! cache-aware delegation to `loonfs-core`.
 
 use crate::background::BackgroundWork;
-use crate::cache::{CommitEngineCache, RuntimeCacheStatsInner, RuntimeControlCache};
+use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::commit_window::{
     attribute_window_gate_failure, combine_member_content_gates, commit_window_delay,
     pad_missing_results, CommitWindows, WindowEntry, WindowRole,
@@ -54,7 +54,6 @@ pub(crate) struct FsInner {
     pub(crate) store: SharedObjectStore,
     pub(crate) config: FsConfig,
     pub(crate) writer_session_id: String,
-    pub(crate) commit_engines: Mutex<CommitEngineCache>,
     pub(crate) control_cache: Mutex<RuntimeControlCache>,
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
@@ -69,12 +68,6 @@ pub(crate) struct FsInner {
 /// panicked mid-update, and serving from it could violate the consistency the
 /// caches promise.
 impl FsInner {
-    pub(crate) fn commit_engines(&self) -> MutexGuard<'_, CommitEngineCache> {
-        self.commit_engines
-            .lock()
-            .expect("commit engine cache lock poisoned")
-    }
-
     pub(crate) fn control_cache(&self) -> MutexGuard<'_, RuntimeControlCache> {
         self.control_cache
             .lock()
@@ -105,7 +98,6 @@ impl FsCore {
                 store,
                 config,
                 writer_session_id: generated_id("wrs"),
-                commit_engines: Mutex::new(CommitEngineCache::default()),
                 control_cache: Mutex::new(RuntimeControlCache::default()),
                 metadata_table_cache,
                 wal_tail_projection_cache,
@@ -396,9 +388,7 @@ impl FsCore {
     ) -> Result<AuthoritativePathEntry> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let engine = self.namespace_engine(namespace_id);
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
         let entry = engine
             .resolve_path_with_runtime_context(absolute_path, &read_context)
             .await?;
@@ -488,10 +478,8 @@ impl FsCore {
     ) -> Result<(ListPathEntriesResponse, Option<DirectoryPageCursor>)> {
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let engine = self.namespace_engine(namespace_id);
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
         let request_head_seq = request.cursor.as_ref().map(|cursor| cursor.head_seq);
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
         let page = engine
             .list_path_page_with_runtime_context(listed_path.as_str(), request, &read_context)
             .await?;
@@ -501,7 +489,7 @@ impl FsCore {
             .first()
             .map(|entry| entry.head_seq)
             .or(request_head_seq)
-            .unwrap_or(head.head.state.seq);
+            .unwrap_or(read_context.head.seq);
         let next_cursor = page.next_cursor;
         let response = ListPathEntriesResponse {
             namespace_id: namespace_id.clone(),
@@ -519,10 +507,8 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let read = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let read = engine
             .read_file_with_runtime_context(absolute_path, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
@@ -535,10 +521,8 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<ListFileRevisionsResponse> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let revisions = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let revisions = engine
             .list_file_revisions_with_runtime_context(absolute_path, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
@@ -552,17 +536,15 @@ impl FsCore {
         absolute_path: &str,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let page = self
-            .namespace_engine(namespace_id)
+        let page = engine
             .list_file_revisions_page_with_runtime_context(absolute_path, request, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
-            head.head.state.seq,
+            read_context.head.seq,
             page,
             fallback_inode_id,
         )?)
@@ -575,10 +557,8 @@ impl FsCore {
         namespace_id: &NamespaceId,
         inode_id: InodeId,
     ) -> Result<ListFileRevisionsResponse> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let revisions = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let revisions = engine
             .list_file_revisions_for_inode_with_runtime_context(inode_id, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
@@ -592,10 +572,8 @@ impl FsCore {
         inode_id: InodeId,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let page = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let page = engine
             .list_file_revisions_for_inode_page_with_runtime_context(
                 inode_id,
                 request,
@@ -605,7 +583,7 @@ impl FsCore {
         self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
-            head.head.state.seq,
+            read_context.head.seq,
             page,
             Some(inode_id),
         )?)
@@ -618,10 +596,8 @@ impl FsCore {
         absolute_path: &str,
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let read = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let read = engine
             .read_file_revision_with_runtime_context(absolute_path, revision_no, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
@@ -635,10 +611,8 @@ impl FsCore {
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
-        let read = self
-            .namespace_engine(namespace_id)
+        let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        let read = engine
             .read_file_revision_for_inode_with_runtime_context(inode_id, revision_no, &read_context)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();


### PR DESCRIPTION
**One cache entry per namespace.** The runtime kept two LRU maps keyed by namespace — the control cache (head anchor + catalog) and a separate `CommitEngineCache` — with five invalidation entry points spread across them, two of which (`invalidate_namespace` and `invalidate_namespace_head`) had become identical. The commit engine now lives as a slot on the namespace's control-cache entry, so one map holds everything the runtime knows about a namespace and the lifecycle reads directly from the code:

- `invalidate_namespace` clears the head anchor and lock-invalidates the engine (fencing survives, per wave 5); the catalog is immutable and stays.
- `remove_namespace` is the delete flavor: the whole entry goes, engine included.
- LRU eviction of an entry invalidates the engine it carries, same as before.

**A plain read context.** `RuntimeReadContext` was built through a 7-positional-argument constructor that mirrored the struct field for field, and its two cache slots were `Option` even though the runtime always passes both. Fields are public now, the caches are non-optional, and construction is a struct literal. The nine read methods in `fs.rs` shared a three-line preamble (load anchor, build context, get engine) that now lives in one `pinned_read` helper; the paging endpoints read the pinned head sequence from the context itself instead of holding the anchor alongside it.
