### PR TITLE
perf(core): stop re-deriving visibility for enumerated list entries

### DIFF
--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -1243,7 +1243,14 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         Ok(inode)
     }
 
-    pub(crate) async fn latest_revision_head(
+    /// The head revision of an inode the caller has already established as
+    /// visible at this session's seq — path resolution and child enumeration
+    /// both do. Skips the per-inode visibility re-derivation the checked
+    /// [`MetadataView::latest_revision_head`] performs: on a wide listing
+    /// that re-check was one full child-binds scan and tombstone probe per
+    /// file entry, and it can never disagree with the enumeration that just
+    /// admitted the entry at the same seq.
+    pub(crate) async fn latest_revision_head_of_visible(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<RevisionRecord>, CoreError> {
@@ -1251,7 +1258,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         if let Some(cached) = self.latest_revision_head_cache.get(&inode_id).cloned() {
             return Ok(cached);
         }
-        let revision = self.base.latest_revision_head(inode_id).await?;
+        let revision = self.base.latest_revision_record(inode_id).await?;
         self.latest_revision_head_cache
             .insert(inode_id, revision.clone());
         Ok(revision)

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -629,13 +629,18 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await
     }
 
+    /// `resolved` must come from visible resolution or enumeration at this
+    /// session's seq (both callers do), so the revision lookup does not
+    /// re-derive the inode's visibility.
     async fn build_authoritative_path_entry_with_session(
         &self,
         session: &mut MetadataViewSession<'_, '_, S>,
         resolved: &ResolvedVisiblePath,
     ) -> Result<AuthoritativePathEntry, CoreError> {
         let revision = if resolved.inode_kind == InodeKind::File {
-            session.latest_revision_head(resolved.inode_id).await?
+            session
+                .latest_revision_head_of_visible(resolved.inode_id)
+                .await?
         } else {
             None
         };

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -5838,3 +5838,79 @@ async fn head_cas_advances_seq(
         })?;
     Ok(candidate.state.seq > existing.state.seq)
 }
+
+/// Listings decide visibility during child enumeration and then look up
+/// revision heads without re-deriving it, so this pins both halves of that
+/// contract: a recursively deleted subtree stays out of listings and
+/// resolution entirely, while entries the enumeration does admit still
+/// surface their real revision data (revision_no, size, content ref).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
+
+    create_directory_path(&store, &namespace_id(), "/live", &context, None)
+        .expect("create live dir");
+    create_directory_path(&store, &namespace_id(), "/dead", &context, None)
+        .expect("create dead dir");
+    put_file_bytes(
+        &store,
+        &namespace_id(),
+        "/live/kept.txt",
+        b"alive",
+        PutBehavior::NoReplace,
+        &context,
+        None,
+    )
+    .expect("put live file");
+    put_file_bytes(
+        &store,
+        &namespace_id(),
+        "/dead/gone.txt",
+        b"doomed",
+        PutBehavior::NoReplace,
+        &context,
+        None,
+    )
+    .expect("put doomed file");
+    delete_path(&store, &namespace_id(), "/dead", &context, None).expect("delete dead subtree");
+
+    let root_entries = list_path(&store, &namespace_id(), "/").expect("list root");
+    let root_names: Vec<&str> = root_entries
+        .iter()
+        .map(|entry| entry.absolute_path.as_str())
+        .collect();
+    assert!(
+        root_names.contains(&"/live"),
+        "live directory must list, got {root_names:?}"
+    );
+    assert!(
+        !root_names.iter().any(|path| path.starts_with("/dead")),
+        "tombstoned directory must not list, got {root_names:?}"
+    );
+
+    let live_entries = list_path(&store, &namespace_id(), "/live").expect("list live dir");
+    assert_eq!(live_entries.len(), 1, "one live child");
+    let kept = &live_entries[0];
+    assert_eq!(kept.absolute_path, "/live/kept.txt");
+    assert_eq!(
+        kept.size_bytes,
+        Some(b"alive".len() as u64),
+        "listed entry carries its revision's size"
+    );
+    assert!(
+        kept.revision_no.is_some(),
+        "listed entry carries its revision number"
+    );
+    assert!(
+        kept.content_ref.is_some(),
+        "listed entry carries its content ref"
+    );
+
+    resolve_path(&store, &namespace_id(), "/dead/gone.txt")
+        .expect_err("file under tombstoned subtree must not resolve");
+    resolve_path(&store, &namespace_id(), "/dead")
+        .expect_err("tombstoned directory must not resolve");
+}


### PR DESCRIPTION
Profiling a warm 100k-child listing (release build, warmed caches, local store) showed 35% of list CPU re-deriving visibility once per file entry. The chain: the entry builder calls the session's `latest_revision_head`, which routed through the view-level checked lookup, whose `visible_inode` gate runs below the session's memo layer — so every listed file paid a full child-binds scan plus tombstone probe to re-answer a question the page enumeration had already answered at the same pinned seq. The enumeration filter (`is_visible_child_direntry`) is the visibility decision for listings; re-deriving it per entry can never disagree with it within one session.

The session method is now `latest_revision_head_of_visible` and routes to `latest_revision_record` — the ungated probe commit validation already uses — with the precondition documented at the method and its one caller. Both paths into the entry builder (path resolution for stat, child enumeration for listings) establish visibility first. The checked `MetadataView::latest_revision_head` is unchanged for the write planner.

Measured on the page-size-sweep harness (100k children, folded layout, local store, release): warm full list 26.9s to ~11-13s at a 1,000-entry page limit, ~10.1s at 5,000. Request counts are unchanged — the request-accounting probe holds at 47/1/1/34/2, confirming the removed work was pure cache-hit CPU. (Probe note: the second-write number can read +2 on rare runs when a random commit id false-positives the receipts bloom filter; a rerun distinguishes that from a real change.)

New test pins the contract seam: a recursively deleted subtree stays out of listings and resolution entirely, while enumerated entries still carry their real revision data (revision number, size, content ref).
