### PR TITLE
feat(loonfs): drain the fold backlog in background ticks, add server maintenance switch

### DIFF
--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -36,7 +36,17 @@ pub struct ServerConfig {
     pub writer_version: String,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
+    /// Whether the server writer schedules maintenance (checkpoints and
+    /// reorganization folds) after writes that cross the WAL-tail
+    /// threshold. On by default; set `false` on write-serving nodes when a
+    /// dedicated maintenance process owns ticks for these namespaces.
+    #[serde(default = "default_background_maintenance")]
+    pub background_maintenance: bool,
     pub store: StoreConfig,
+}
+
+fn default_background_maintenance() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -197,6 +207,46 @@ mod tests {
 
     const AZURITE_ACCOUNT_KEY: &str =
         "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    #[test]
+    fn background_maintenance_defaults_on_and_accepts_false() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("valid config");
+        assert!(
+            config.background_maintenance,
+            "background maintenance defaults on"
+        );
+
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+background_maintenance = false
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("valid config");
+        assert!(
+            !config.background_maintenance,
+            "write-serving nodes can hand maintenance to a dedicated process"
+        );
+    }
 
     #[test]
     fn load_rejects_invalid_bind() {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -218,7 +218,11 @@ async fn build_handles_with_metrics_jsonl_path(
     let mut writer_builder = FsWriter::builder_with_store(store.clone())
         .writer_id(config.writer_id.clone())
         .writer_version(config.writer_version.clone())
-        .background_work(FsBackgroundWork::Enabled)
+        .background_work(if config.background_maintenance {
+            FsBackgroundWork::Enabled
+        } else {
+            FsBackgroundWork::ManualOnly
+        })
         .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -583,6 +583,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        background_maintenance: true,
         store: StoreConfig::LocalFs {
             root: root.display().to_string(),
             key_prefix: Some("http-tests".to_owned()),

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -26,6 +26,7 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-aws-s3".to_owned(),
         writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        background_maintenance: true,
         store: StoreConfig::AwsS3 {
             bucket: config.bucket,
             region: config.region,
@@ -52,6 +53,7 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-r2".to_owned(),
         writer_version: "direct-put-r2/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        background_maintenance: true,
         store: StoreConfig::CloudflareR2 {
             bucket: config.bucket,
             account_id: config.account_id,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1929,6 +1929,7 @@ fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        background_maintenance: true,
         store: StoreConfig::LocalFs {
             root: store_root.display().to_string(),
             key_prefix: Some(key_prefix.to_owned()),

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -308,9 +308,13 @@ impl FsCore {
 
     /// One bounded reorganization unit per tick: folds one family group of
     /// L0 delta rows into the base when enough L0 runs have piled up (see
-    /// `loonfs-core`'s `reorganize_metadata`). Outcomes are observability,
-    /// not tick results: a superseded unit retries on a later tick.
-    async fn run_tick_reorganization(&self, namespace_id: &NamespaceId) -> Result<()> {
+    /// `loonfs-core`'s `reorganize_metadata`). Explicit ticks stay bounded at
+    /// one unit per call; the returned outcome lets writer-scheduled
+    /// background work keep folding until nothing is left.
+    async fn run_tick_reorganization(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<loonfs_core::MetadataReorganizeOutcome> {
         let report = self
             .namespace_engine(namespace_id)
             .reorganize_metadata()
@@ -332,6 +336,26 @@ impl FsCore {
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
                 tracing::info!("metadata reorganization unit superseded; will retry");
+            }
+        }
+        Ok(report.outcome)
+    }
+
+    /// Folds reorganization units until the trigger reports nothing left to
+    /// do. Only writer-scheduled background ticks drain like this — an
+    /// explicit maintenance tick keeps its one-unit-per-call cost bound —
+    /// so fold debt created by a burst of writes is settled by the burst's
+    /// own background tick instead of waiting for future threshold
+    /// crossings that may never come.
+    async fn drain_reorganization_backlog(&self, namespace_id: &NamespaceId) -> Result<()> {
+        // Four family groups exist today; the bound is a livelock guard,
+        // not a scheduling policy.
+        const MAX_UNITS_PER_DRAIN: usize = 16;
+        for _ in 0..MAX_UNITS_PER_DRAIN {
+            match self.run_tick_reorganization(namespace_id).await? {
+                loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. } => {}
+                loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. }
+                | loonfs_core::MetadataReorganizeOutcome::Superseded => break,
             }
         }
         Ok(())
@@ -1218,11 +1242,20 @@ impl FsCore {
             namespace_id: namespace_id.clone(),
         };
         self.inner.background.spawn(async move {
-            if let Err(error) = claim
+            let tick = claim
                 .fs
                 .maintenance_tick_namespace(&claim.namespace_id, options)
-                .await
-            {
+                .await;
+            let drained = match tick {
+                Ok(_) => {
+                    claim
+                        .fs
+                        .drain_reorganization_backlog(&claim.namespace_id)
+                        .await
+                }
+                Err(error) => Err(error),
+            };
+            if let Err(error) = drained {
                 tracing::info!(
                     phase = "auto_maintenance_tick",
                     result = "error",

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -10,6 +10,11 @@ use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader, FsWriter, MaintenanceTickOptions,
     ManifestId, NamespaceId, PutFileOptions, RuntimeError, StoreConfig,
 };
+use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_core::control::load_namespace_metadata_root_control;
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::ObjectStore;
 use std::future::Future;
 use std::path::Path;
 use tempfile::tempdir;
@@ -324,5 +329,65 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
             .await
             .expect("advance retention");
         assert_eq!(retention.namespace_id, namespace_id);
+    });
+}
+
+/// Eight threshold crossings with background work enabled must both bound
+/// the WAL tail and drain the reorganization backlog: the eighth crossing's
+/// checkpoint reaches the fold trigger (eight L0 runs), and the writer's own
+/// background tick then folds every family group — no admin involvement.
+/// Before the drain, background ticks folded at most one unit per crossing,
+/// so fold debt outlived the burst that created it.
+#[test]
+fn enabled_writer_drains_reorganization_backlog_without_admin() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    block_on(async {
+        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        for round in 0..8u32 {
+            for file in 0..33u32 {
+                writer
+                    .put_file_bytes(
+                        &namespace_id,
+                        &format!("/docs/round-{round}/file-{file}.txt"),
+                        b"body",
+                        PutFileOptions::default(),
+                    )
+                    .await
+                    .expect("put file");
+            }
+            writer
+                .wait_for_background_work()
+                .await
+                .expect("background ticks finish");
+        }
+
+        let store = LocalFsStore::new(temp_dir.path()).expect("open store for inspection");
+        let root = load_namespace_metadata_root_control(&store, &namespace_id)
+            .await
+            .expect("load metadata root");
+        let manifest_key =
+            metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+        let bytes = store
+            .get(&manifest_key, None)
+            .await
+            .expect("read manifest")
+            .expect("manifest exists");
+        let manifest = decode_namespace_manifest_json(&bytes).expect("decode manifest");
+        let l0_files = manifest
+            .payload
+            .metadata_files
+            .iter()
+            .filter(|descriptor| descriptor.level == 0)
+            .count();
+        assert_eq!(
+            l0_files, 0,
+            "background ticks drain the fold backlog to zero L0 runs; \
+             a leftover run means the drain stopped early"
+        );
     });
 }


### PR DESCRIPTION
Two changes, both small:

**Background ticks drain.** After its checkpoint, a writer-scheduled tick now keeps folding units until the trigger reports nothing left, so the burst that created fold debt settles it. Explicit admin ticks keep their one-unit-per-call cost bound — draining is background-only, where nothing waits on it. The loop ends on the trigger's own verdict (or a superseded unit, which a later tick retries) with a generous livelock cap.

**The server gets `background_maintenance` (default `true`).** Setting it `false` on write-serving nodes hands maintenance to a dedicated process — the split-role deployment. No new coordination is needed for that shape: folds land through manifest CAS like every other publication, so a maintenance node is just an admin handle with store credentials running ticks.
