### PR TITLE
feat(server,client): explicit upload size limit, open-bind guard, and client io timeouts

### DIFF
--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -2,20 +2,28 @@ bind = "127.0.0.1:9400"
 # auth_token and content_token_secret may instead come from the
 # LOONFS_AUTH_TOKEN and LOONFS_CONTENT_TOKEN_SECRET environment variables;
 # a non-blank value in this file takes precedence over the environment.
+# A non-loopback bind refuses to load without auth_token unless
+# allow_unauthenticated_remote = true is set explicitly.
 auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-local"
 writer_version = "loonfs-server/0.1.0"
 
+# Whether this server schedules background maintenance (checkpoints and
+# reorganization folds) after writes; on by default. Set false on
+# write-serving nodes when a dedicated maintenance process owns ticks.
+#background_maintenance = true
+
+# Largest request body accepted for service-proxied upload content, in
+# bytes; the server buffers each upload in memory. Advertised to clients as
+# the `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
+#max_upload_bytes = 268435456
+
 # Optional runtime cache overrides; omitted fields keep the runtime defaults.
 #[runtime_cache]
-#wal_tail_projection_cache_enabled = true
-#control_cache_enabled = true
 #max_cached_namespaces = 64
 #max_cached_wal_tail_projection_rows = 1000000
 #max_cached_wal_tail_projection_decoded_bytes = 268435456
-#metadata_table_cache_enabled = true
-#metadata_table_cache_max_blocks = 256
 # Decoded-byte budget for the metadata table cache; unlimited by default.
 #metadata_table_cache_max_decoded_bytes = 268435456
 

--- a/crates/loonfs-api/src/capability.rs
+++ b/crates/loonfs-api/src/capability.rs
@@ -19,6 +19,10 @@ pub const FEATURE_NAMESPACES_DELETE: &str = "core.namespaces.delete";
 /// Gates direct upload sessions that are authorized with short-lived presigned URLs.
 pub const FEATURE_UPLOADS_DIRECT_PUT: &str = "core.uploads.direct_put";
 
+/// Advisory limit: the largest request body accepted for service-proxied
+/// upload content requests.
+pub const LIMIT_UPLOAD_MAX_CONTENT_BYTES: &str = "upload.max_content_bytes";
+
 /// A deployment's self-description (API spec, "Capability discovery").
 ///
 /// A remote client fetches this from `GET /v0/config` and caches it; an

--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -13,6 +13,10 @@ pub enum ErrorKind {
     InvalidRequest,
     /// The request was not authorized. Fix credentials before retrying.
     Unauthorized,
+    /// The request body exceeds the deployment's size limit for this
+    /// operation. Send a smaller payload (for uploads, prefer `direct_put`);
+    /// retrying unchanged will not succeed.
+    ContentTooLarge,
     /// The caller may not perform this operation. Request access; retrying
     /// unchanged will not succeed.
     PermissionDenied,
@@ -110,6 +114,7 @@ macro_rules! error_codes {
 error_codes! {
     InvalidRequest => "invalid_request",
     Unauthorized => "unauthorized",
+    ContentTooLarge => "content_too_large",
     NotSupported => "not_supported",
     NamespaceNotFound => "namespace_not_found",
     NamespaceDeleted => "namespace_deleted",
@@ -146,6 +151,7 @@ impl ErrorCode {
         match self {
             ErrorCode::InvalidRequest => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
+            ErrorCode::ContentTooLarge => ErrorKind::ContentTooLarge,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound
             | ErrorCode::PathNotFound

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -47,7 +47,7 @@ pub mod wire {
 pub use capability::{
     CapabilityDocument, CapabilityDocumentError, FEATURE_NAMESPACES_CREATE,
     FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT,
-    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use content::{ContentRef, ContentRefKind};
 pub use digest::sha256_digest;

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -527,6 +527,7 @@ impl RemoteTarget {
         let client = Client::new(ClientConfig {
             server_url: server_url.to_owned(),
             auth_token: auth_token.map(ToOwned::to_owned),
+            request_timeout_ms: None,
         });
         Ok(Self {
             backend: RemoteBackend::new(client),

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -39,7 +39,18 @@ pub struct ClientConfig {
     pub server_url: String,
     /// Optional bearer token.
     pub auth_token: Option<String>,
+    /// Optional overall per-request deadline in milliseconds. Unset means no
+    /// whole-request deadline: requests are bounded only by the built-in
+    /// 60-second socket inactivity timeouts, so slow-but-progressing large
+    /// transfers are not cut off while a stalled connection still fails.
+    #[serde(default)]
+    pub request_timeout_ms: Option<u64>,
 }
+
+/// Socket read/write inactivity timeout applied to every request. A
+/// connection that makes no progress for this long fails instead of hanging
+/// the caller forever.
+const IO_INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Synchronous HTTP client for LoonFS.
 #[derive(Debug, Clone)]
@@ -164,6 +175,12 @@ impl ClientConfig {
                 });
             }
         }
+        if self.request_timeout_ms == Some(0) {
+            return Err(ClientError::ConfigValidation {
+                field: "request_timeout_ms",
+                reason: "must be greater than zero; omit it for no deadline".to_owned(),
+            });
+        }
         Ok(())
     }
 }
@@ -197,10 +214,16 @@ impl MutationOptions {
 impl Client {
     /// Creates a client from validated config.
     pub fn new(config: ClientConfig) -> Self {
+        let mut agent = ureq::AgentBuilder::new()
+            .timeout_read(IO_INACTIVITY_TIMEOUT)
+            .timeout_write(IO_INACTIVITY_TIMEOUT);
+        if let Some(timeout_ms) = config.request_timeout_ms {
+            agent = agent.timeout(std::time::Duration::from_millis(timeout_ms));
+        }
         Self {
             base_url: config.server_url.trim().trim_end_matches('/').to_owned(),
             auth_token: config.auth_token,
-            agent: ureq::AgentBuilder::new().build(),
+            agent: agent.build(),
             capabilities: Arc::new(OnceLock::new()),
         }
     }
@@ -1127,6 +1150,7 @@ auth_token = "   "
         let client = Client::new(ClientConfig {
             server_url: "http://127.0.0.1:9".to_owned(),
             auth_token: None,
+            request_timeout_ms: None,
         });
 
         for result in [

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -42,11 +42,28 @@ pub struct ServerConfig {
     /// dedicated maintenance process owns ticks for these namespaces.
     #[serde(default = "default_background_maintenance")]
     pub background_maintenance: bool,
+    /// Largest request body accepted for service-proxied upload content
+    /// requests (`PUT .../uploads/{upload_id}/content`). The server buffers
+    /// each upload body in memory, so this bounds per-request memory;
+    /// larger transfers should use `direct_put` uploads. Advertised to
+    /// clients as the `upload.max_content_bytes` capability limit.
+    #[serde(default = "default_max_upload_bytes")]
+    pub max_upload_bytes: u64,
+    /// Allows serving on a non-loopback address with `auth_token` unset.
+    /// Off by default: exposing every endpoint unauthenticated is almost
+    /// always a misconfiguration, so validation rejects it unless this is
+    /// explicitly set.
+    #[serde(default)]
+    pub allow_unauthenticated_remote: bool,
     pub store: StoreConfig,
 }
 
 fn default_background_maintenance() -> bool {
     true
+}
+
+fn default_max_upload_bytes() -> u64 {
+    256 * 1024 * 1024
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -125,7 +142,7 @@ impl ServerConfig {
     }
 
     fn validate(&self) -> Result<(), ServerConfigError> {
-        validate_socket_addr("bind", &self.bind)?;
+        let bind = validate_socket_addr("bind", &self.bind)?;
         require_non_empty("writer_id", &self.writer_id)?;
         require_non_empty("writer_version", &self.writer_version)?;
 
@@ -136,6 +153,22 @@ impl ServerConfig {
                     reason: "must not be empty".to_owned(),
                 });
             }
+        } else if bind_serves_beyond_localhost(&bind) && !self.allow_unauthenticated_remote {
+            return Err(ServerConfigError::InvalidField {
+                field: "auth_token",
+                reason: format!(
+                    "bind `{bind}` serves every endpoint to the network without \
+                     authentication; set `auth_token` (or `LOONFS_AUTH_TOKEN`), \
+                     or set `allow_unauthenticated_remote = true` to serve open \
+                     on purpose"
+                ),
+            });
+        }
+        if self.max_upload_bytes == 0 {
+            return Err(ServerConfigError::InvalidField {
+                field: "max_upload_bytes",
+                reason: "must be greater than zero".to_owned(),
+            });
         }
         require_non_empty("content_token_secret", self.content_token_secret.expose())?;
         self.store.validate().map_err(ServerConfigError::from)?;
@@ -182,18 +215,24 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<(), ServerConfi
     }
 }
 
-fn validate_socket_addr(field: &'static str, value: &str) -> Result<(), ServerConfigError> {
+fn validate_socket_addr(field: &'static str, value: &str) -> Result<SocketAddr, ServerConfigError> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err(ServerConfigError::MissingField { field });
     }
     trimmed
         .parse::<SocketAddr>()
-        .map(|_| ())
         .map_err(|err| ServerConfigError::InvalidField {
             field,
             reason: err.to_string(),
         })
+}
+
+/// Whether a bind address accepts connections from other hosts: any
+/// non-loopback ip, including the unspecified addresses (`0.0.0.0`, `[::]`)
+/// that bind every interface.
+fn bind_serves_beyond_localhost(addr: &SocketAddr) -> bool {
+    !addr.ip().is_loopback()
 }
 
 #[cfg(test)]
@@ -479,6 +518,102 @@ root = "/tmp/loonfs-server"
         let error = load_server_config(&path).expect_err("blank auth token");
 
         assert_invalid_field(error, "auth_token");
+    }
+
+    #[test]
+    fn load_rejects_non_loopback_bind_without_auth_token() {
+        // LOONFS_AUTH_TOKEN in the environment would legitimately fill the
+        // token and make this config valid; only assert when it is unset.
+        if std::env::var("LOONFS_AUTH_TOKEN").is_ok() {
+            return;
+        }
+        for bind in ["0.0.0.0:9400", "[::]:9400", "10.1.2.3:9400"] {
+            let path = write_config(&format!(
+                r#"
+bind = "{bind}"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+
+            let error = load_server_config(&path).expect_err("open network bind");
+
+            assert_invalid_field(error, "auth_token");
+        }
+    }
+
+    #[test]
+    fn allow_unauthenticated_remote_permits_an_open_bind() {
+        let path = write_config(
+            r#"
+bind = "0.0.0.0:9400"
+allow_unauthenticated_remote = true
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        load_server_config(&path).expect("explicitly-open config loads");
+    }
+
+    #[test]
+    fn loopback_bind_without_auth_token_is_allowed() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        load_server_config(&path).expect("loopback-only config loads");
+    }
+
+    #[test]
+    fn max_upload_bytes_defaults_and_rejects_zero() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("valid config");
+        assert_eq!(config.max_upload_bytes, 256 * 1024 * 1024);
+        assert!(!config.allow_unauthenticated_remote);
+
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+max_upload_bytes = 0
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let error = load_server_config(&path).expect_err("zero upload limit");
+        assert_invalid_field(error, "max_upload_bytes");
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -108,6 +108,7 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
     match kind {
         ErrorKind::InvalidRequest => StatusCode::BAD_REQUEST,
         ErrorKind::Unauthorized => StatusCode::UNAUTHORIZED,
+        ErrorKind::ContentTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
         ErrorKind::PermissionDenied => StatusCode::FORBIDDEN,
         ErrorKind::NotFound => StatusCode::NOT_FOUND,
         ErrorKind::Gone => StatusCode::GONE,

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -12,7 +12,7 @@ use loonfs_api::ApiError;
 use loonfs_api::{
     AdvanceRetentionResponse, CreateCheckpointResponse, CreateNamespaceRequest,
     ForkNamespaceRequest, GcRequest, GcResponse, MaintenanceTickRequest, MaintenanceTickResponse,
-    FEATURE_UPLOADS_DIRECT_PUT,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -45,6 +45,10 @@ pub(super) async fn config(
     capabilities.features.insert(
         FEATURE_UPLOADS_DIRECT_PUT.to_owned(),
         state.transfer_issuer.is_some(),
+    );
+    capabilities.limits.insert(
+        LIMIT_UPLOAD_MAX_CONTENT_BYTES.to_owned(),
+        state.config.max_upload_bytes,
     );
     Ok(Json(capabilities))
 }

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -2,9 +2,8 @@
 //! backing them.
 
 use super::error::ApiResponseError;
-use super::{authorize, AppJson, AppState, NamespaceIdPath, OptionalAppJson};
+use super::{authorize, AppBytes, AppJson, AppState, NamespaceIdPath, OptionalAppJson};
 use crate::config::ServerConfig;
-use axum::body::Bytes;
 use axum::extract::{Path as AxumPath, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
@@ -207,7 +206,8 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 409, description = "Upload content conflict", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 413, description = "Body exceeds the advertised `upload.max_content_bytes` limit", body = ApiError)
         )
     )
 )]
@@ -216,7 +216,7 @@ pub(super) async fn upload_content(
     namespace: NamespaceIdPath,
     AxumPath(UploadPathParams { upload_id }): AxumPath<UploadPathParams>,
     headers: HeaderMap,
-    body: Bytes,
+    AppBytes(body): AppBytes,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -39,8 +39,9 @@ use self::handlers_namespace::{
 use self::handlers_uploads::{begin_upload, complete_upload, upload_content};
 use crate::config::{ServerConfig, ServerConfigError};
 use axum::async_trait;
+use axum::body::Bytes;
 use axum::extract::rejection::PathRejection;
-use axum::extract::{FromRequest, FromRequestParts, Path as AxumPath};
+use axum::extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath};
 use axum::http::request::Parts;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::{get, post, put};
@@ -117,6 +118,10 @@ async fn app_with_store_and_transfer_issuer(
 }
 
 fn router(state: AppState) -> Router {
+    // The upload-content route carries raw file bytes and gets the
+    // configured budget; every other route keeps axum's conservative
+    // default JSON body limit.
+    let max_upload_bytes = usize::try_from(state.config.max_upload_bytes).unwrap_or(usize::MAX);
     Router::new()
         .route("/health", get(health))
         // Module-qualified because handler modules also export a bare
@@ -160,7 +165,7 @@ fn router(state: AppState) -> Router {
         .route("/v0/namespaces/:namespace/uploads", post(begin_upload))
         .route(
             "/v0/namespaces/:namespace/uploads/:upload_id/content",
-            put(upload_content),
+            put(upload_content).layer(DefaultBodyLimit::max(max_upload_bytes)),
         )
         .route(
             "/v0/namespaces/:namespace/uploads/:upload_id/complete",
@@ -372,7 +377,8 @@ fn authorize(config: &ServerConfig, headers: &HeaderMap) -> Result<(), ApiRespon
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .unwrap_or_default();
-    if actual == format!("Bearer {}", expected.expose()) {
+    let expected = format!("Bearer {}", expected.expose());
+    if constant_time_eq(actual.as_bytes(), expected.as_bytes()) {
         Ok(())
     } else {
         Err(ApiResponseError::new(
@@ -381,6 +387,16 @@ fn authorize(config: &ServerConfig, headers: &HeaderMap) -> Result<(), ApiRespon
             "missing or invalid bearer token",
         ))
     }
+}
+
+/// Compares token bytes without short-circuiting on the first mismatch, so
+/// response timing does not narrow down the token byte by byte. Length is
+/// still observable; token values are not.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
 fn parse_namespace_id(value: String) -> Result<NamespaceId, ApiResponseError> {
@@ -442,6 +458,9 @@ where
     async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
         match Json::<T>::from_request(req, state).await {
             Ok(Json(value)) => Ok(AppJson(value)),
+            Err(rejection) if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE => {
+                Err(body_too_large_error())
+            }
             Err(rejection) => Err(ApiResponseError::new(
                 StatusCode::BAD_REQUEST,
                 ErrorCode::InvalidRequest,
@@ -449,6 +468,44 @@ where
             )),
         }
     }
+}
+
+/// A raw-bytes extractor whose rejections stay inside the error contract: a
+/// body over the route's limit answers 413 with a `content_too_large`
+/// `ApiError` body, and other unreadable bodies answer 400, instead of the
+/// raw framework rejection.
+struct AppBytes(Bytes);
+
+#[async_trait]
+impl<S> FromRequest<S> for AppBytes
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiResponseError;
+
+    async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Bytes::from_request(req, state).await {
+            Ok(bytes) => Ok(AppBytes(bytes)),
+            Err(rejection) if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE => {
+                Err(body_too_large_error())
+            }
+            Err(rejection) => Err(ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &rejection.body_text(),
+            )),
+        }
+    }
+}
+
+fn body_too_large_error() -> ApiResponseError {
+    ApiResponseError::new(
+        StatusCode::PAYLOAD_TOO_LARGE,
+        ErrorCode::ContentTooLarge,
+        "request body exceeds this deployment's limit; check the \
+         `upload.max_content_bytes` capability limit, and prefer `direct_put` \
+         uploads for large content",
+    )
 }
 
 /// Like [`AppJson`], but an absent (empty) body is `None` rather than an

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -191,6 +191,7 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
     let client = Client::new(ClientConfig {
         server_url: format!("http://{addr}"),
         auth_token: Some("test-token".to_owned()),
+        request_timeout_ms: None,
     });
     tokio::task::spawn_blocking(move || {
         client
@@ -544,6 +545,103 @@ struct TestHarness {
     server: tokio::task::JoinHandle<()>,
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let config = test_config(temp_dir.path(), "server-writer");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let router = app_with_store(config, store).await.expect("build app");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve app");
+    });
+
+    tokio::task::spawn_blocking(move || {
+        for auth_token in [None, Some("wrong-token".to_owned())] {
+            let client = Client::new(ClientConfig {
+                server_url: format!("http://{addr}"),
+                auth_token,
+                request_timeout_ms: None,
+            });
+            assert_api_error(
+                client.namespace_status("demo"),
+                401,
+                "unauthorized",
+                Some("missing or invalid bearer token"),
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_upload_body_over_the_limit_answers_content_too_large() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
+    let mut config = test_config(temp_dir.path(), "server-writer");
+    config.max_upload_bytes = 1024;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let router = app_with_store(config, store).await.expect("build app");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve app");
+    });
+
+    tokio::task::spawn_blocking(move || {
+        let client = Client::new(ClientConfig {
+            server_url: format!("http://{addr}"),
+            auth_token: Some("test-token".to_owned()),
+            request_timeout_ms: None,
+        });
+        let target = NamespacePath::parse("demo:/big.bin").expect("target");
+        assert_api_error(
+            client.write_file_bytes(&target, &[0u8; 4096], &MutationOptions::default()),
+            413,
+            "content_too_large",
+            None,
+        );
+        // A body inside the limit still goes through on the same route.
+        client
+            .write_file_bytes(&target, &[0u8; 512], &MutationOptions::default())
+            .expect("small upload fits under the limit");
+    })
+    .await
+    .expect("join blocking task");
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capability_document_advertises_the_upload_limit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let harness = start_server(store, temp_dir.path(), "server-writer").await;
+
+    tokio::task::spawn_blocking(move || {
+        let capabilities = harness
+            .client
+            .capabilities()
+            .expect("fetch capability document");
+        assert_eq!(
+            capabilities.limits.get("upload.max_content_bytes").copied(),
+            Some(256 * 1024 * 1024)
+        );
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
+
 async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestHarness {
     let config = test_config(root, writer_id);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -559,6 +657,7 @@ async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestH
         client: Client::new(ClientConfig {
             server_url: format!("http://{}", addr),
             auth_token: Some("test-token".to_owned()),
+            request_timeout_ms: None,
         }),
         server,
     }
@@ -584,6 +683,8 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         background_maintenance: true,
+        max_upload_bytes: 256 * 1024 * 1024,
+        allow_unauthenticated_remote: false,
         store: StoreConfig::LocalFs {
             root: root.display().to_string(),
             key_prefix: Some("http-tests".to_owned()),

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -27,6 +27,8 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
         writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         background_maintenance: true,
+        max_upload_bytes: 256 * 1024 * 1024,
+        allow_unauthenticated_remote: false,
         store: StoreConfig::AwsS3 {
             bucket: config.bucket,
             region: config.region,
@@ -54,6 +56,8 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
         writer_version: "direct-put-r2/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         background_maintenance: true,
+        max_upload_bytes: 256 * 1024 * 1024,
+        allow_unauthenticated_remote: false,
         store: StoreConfig::CloudflareR2 {
             bucket: config.bucket,
             account_id: config.account_id,
@@ -279,6 +283,7 @@ async fn start_server(config: ServerConfig) -> TestServer {
         client: Client::new(ClientConfig {
             server_url: server_url.clone(),
             auth_token: Some(AUTH_TOKEN.to_owned()),
+            request_timeout_ms: None,
         }),
         server_url,
         server,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1913,6 +1913,7 @@ async fn start_server(config: ServerConfig) -> TestServer {
         client: Client::new(ClientConfig {
             server_url: format!("http://{}", addr),
             auth_token: Some("test-token".to_owned()),
+            request_timeout_ms: None,
         }),
         server_url: format!("http://{}", addr),
         store_root,
@@ -1930,6 +1931,8 @@ fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         background_maintenance: true,
+        max_upload_bytes: 256 * 1024 * 1024,
+        allow_unauthenticated_remote: false,
         store: StoreConfig::LocalFs {
             root: store_root.display().to_string(),
             key_prefix: Some(key_prefix.to_owned()),

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -107,6 +107,7 @@ Registered limit keys:
 | --- | --- |
 | `pagination.default_limit` | Default page size applied when a paged request omits `limit`. |
 | `pagination.max_limit` | Largest accepted page size for paged requests. |
+| `upload.max_content_bytes` | Largest request body accepted for service-proxied upload content (`PUT .../uploads/{upload_id}/content`). Larger content should use `direct_put` uploads. |
 
 ### 2.2 Feature registry
 
@@ -169,6 +170,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | --- | --- | --- |
 | `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, or configuration value fails validation. The message names the offending field. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
+| `content_too_large` | 413 | The request body exceeds the deployment's `upload.max_content_bytes` limit. Send a smaller payload or use a `direct_put` upload. |
 | `namespace_not_found` | 404 | The namespace does not exist. |
 | `namespace_deleted` | 410 | The namespace existed and was deleted. The id is permanently retired. |
 | `path_not_found` | 404 | No visible entry at the path. |

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1993,6 +1993,16 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "Body exceeds the advertised `upload.max_content_bytes` limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Remote uploads were silently capped at ~2 MiB by axum's default body limit, and the failure was a plain-text 413 outside the JSON error envelope. This makes the limit an explicit config knob (`max_upload_bytes`, default 256 MiB since the server buffers each upload in memory), keeps the 413 inside the envelope as a new spec-locked `content_too_large` code, and advertises it to clients as the `upload.max_content_bytes` capability limit.

Two more floor fixes ride along: the client gets 60-second socket inactivity timeouts (it could previously hang forever on a stalled server) plus an optional overall `request_timeout_ms`; the server now refuses a non-loopback bind with no auth token unless `allow_unauthenticated_remote = true` is set, and compares bearer tokens in constant time. The local-fs example config also dropped four cache keys that the config schema rejects and documents the maintenance/upload knobs.

Wire format change: error registry, api.md tables, and openapi.json regenerated deliberately.