### PR TITLE
refactor(loonfs,core): stage put content before publish, drop the content durability gate

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -7,9 +7,7 @@ use crate::metadata::MetadataState;
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PathMutationIntent};
-use crate::protocol::{
-    load_publish_metadata_view, ContentDurabilityGate, PublishTailOptions, PublishTailProjection,
-};
+use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};
@@ -153,7 +151,6 @@ impl NamespaceCommitEngine {
             candidates,
             context,
             &PublishTailOptions::default(),
-            None,
         )
         .await
     }
@@ -164,7 +161,6 @@ impl NamespaceCommitEngine {
         candidates: Vec<NamespaceMutationCandidate>,
         context: &MutationContext,
         tail_options: &PublishTailOptions,
-        content_gate: Option<ContentDurabilityGate>,
     ) -> NamespaceCommitEnginePublishResult {
         if candidates.is_empty() {
             return NamespaceCommitEnginePublishResult {
@@ -268,7 +264,6 @@ impl NamespaceCommitEngine {
             context,
             &publish_view,
             self.timer.as_ref(),
-            content_gate,
         )
         .await;
         let resulting_head = published.resulting_head.clone();
@@ -343,25 +338,16 @@ fn repeated_error(count: usize, error: CoreError) -> Vec<Result<ApiCommitRespons
     (0..count).map(|_| Err(error.clone())).collect()
 }
 
-/// [`publish_namespace_mutations_batch`] with a content durability gate: the
-/// gate is a future, so it rides an explicit parameter instead of an options
-/// struct, and it is awaited between the WAL write and the head CAS.
-pub(crate) async fn publish_namespace_mutations_batch_gated<S: ObjectStore + ?Sized>(
+/// Publishes one batch through a fresh, uncached commit engine.
+pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     candidates: Vec<NamespaceMutationCandidate>,
     context: &MutationContext,
-    content_gate: Option<ContentDurabilityGate>,
 ) -> Vec<Result<ApiCommitResponse>> {
     let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
     engine
-        .publish_batch_with_tail_options(
-            store,
-            candidates,
-            context,
-            &PublishTailOptions::default(),
-            content_gate,
-        )
+        .publish_batch(store, candidates, context)
         .await
         .results
 }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -369,21 +369,17 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    /// [`Self::publish_namespace_mutations_batch`] with a content durability
-    /// gate awaited between the WAL write and the head CAS; the gate is a
-    /// future, so it rides an explicit parameter instead of an options
-    /// struct.
-    pub async fn publish_namespace_mutations_batch_gated(
+    /// Publishes already-classified mutation candidates as one batch: one WAL
+    /// segment, one head compare-and-swap, one result per candidate in order.
+    pub async fn publish_namespace_mutations_batch(
         &self,
         candidates: Vec<NamespaceMutationCandidate>,
-        content_gate: Option<crate::publish::ContentDurabilityGate>,
     ) -> Vec<CoreResult<CommitResponse>> {
-        crate::commit_engine::publish_namespace_mutations_batch_gated(
+        crate::commit_engine::publish_namespace_mutations_batch(
             &self.store,
             &self.namespace_id,
             candidates,
             &self.mutation_context(),
-            content_gate,
         )
         .await
     }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -102,7 +102,7 @@ pub mod publish {
         ResultingReadState,
     };
     pub use crate::path::write::PathMutationIntent;
-    pub use crate::protocol::{ContentDurabilityGate, PublishTailOptions};
+    pub use crate::protocol::PublishTailOptions;
 }
 
 pub use checkpoint::{MetadataReorganizeOutcome, MetadataReorganizeReport};

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -19,12 +19,11 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
     intent: PathMutationIntent,
     context: &MutationContext,
 ) -> Result<MutationResult, CoreError> {
-    let mut results = crate::commit_engine::publish_namespace_mutations_batch_gated(
+    let mut results = crate::commit_engine::publish_namespace_mutations_batch(
         store,
         namespace_id,
         vec![NamespaceMutationCandidate::Path(intent)],
         context,
-        None,
     )
     .await;
     let response = results

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -73,19 +73,7 @@ impl PublishPlanningSession {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit_engine::{
-        publish_namespace_mutations_batch_gated, NamespaceMutationCandidate,
-    };
-
-    async fn publish_namespace_mutations_batch<S: loonfs_objectstore::ObjectStore + ?Sized>(
-        store: &S,
-        namespace_id: &loonfs_api::NamespaceId,
-        candidates: Vec<NamespaceMutationCandidate>,
-        context: &MutationContext,
-    ) -> Vec<crate::error::Result<loonfs_api::v0::CommitResponse>> {
-        publish_namespace_mutations_batch_gated(store, namespace_id, candidates, context, None)
-            .await
-    }
+    use crate::commit_engine::{publish_namespace_mutations_batch, NamespaceMutationCandidate};
     use crate::context::MutationContext;
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -20,7 +20,6 @@ use crate::storage::content::ContentValidationTracker;
 use crate::timing::MonotonicTimer;
 use crate::wal::{prepare_wal_segment, PreparedWalSegment};
 use bytes::Bytes;
-use futures::future::BoxFuture;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
@@ -81,13 +80,6 @@ impl PublishBatchAgainstViewResult {
     }
 }
 
-/// Awaited between the batch's WAL write and its head compare-and-swap:
-/// nothing becomes visible until separately-written content is durable.
-/// Failure aborts the batch through the same path as a failed WAL write —
-/// the orphaned WAL segment is never referenced by the head and is
-/// garbage-collection's to reclaim.
-pub type ContentDurabilityGate = BoxFuture<'static, Result<()>>;
-
 pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     S: ObjectStore + ?Sized,
 >(
@@ -97,7 +89,6 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     context: &MutationContext,
     view: &PublishMetadataView<'_, S>,
     timer: &dyn MonotonicTimer,
-    content_gate: Option<ContentDurabilityGate>,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
         return PublishBatchAgainstViewResult::new(Vec::new());
@@ -287,17 +278,6 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
             return abort_batch(outcomes, &dedup, &accepted, &error);
         }
     };
-    if let Some(content_gate) = content_gate {
-        if let Err(error) = content_gate
-            .instrument(tracing::info_span!(
-                "loon.phase",
-                phase = "await_content_durability"
-            ))
-            .await
-        {
-            return abort_batch(outcomes, &dedup, &accepted, &error);
-        }
-    }
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(put_started_ms);
     if elapsed_ms > PUBLISH_BUDGET_MS {
         let error = CoreError::HeadPublish(CommitHeadPublishError::PublishBudgetExceeded {

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -26,7 +26,6 @@ mod changes;
 mod publish_view;
 mod uploads;
 
-pub use self::batch::ContentDurabilityGate;
 pub(crate) use self::batch::{
     publish_namespace_mutations_batch_against_publish_view, PublishBatchAgainstViewResult,
 };

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -17,13 +17,12 @@ pub struct ContentAdmission {
 }
 
 impl ContentAdmission {
-    /// Admits a content ref whose durable write runs as a peer of the publish
-    /// that commits it, so batch validation does not probe object storage for
-    /// a blob that may not have landed yet. Callers must pair this with a
-    /// [`crate::publish::ContentDurabilityGate`] on the same publish: the
-    /// admission removes the probe, and the gate holds the head CAS until the
-    /// write's own ack proves durability.
-    pub fn for_in_flight_content_write(
+    /// Admits a content ref the caller itself wrote durably (and had acked)
+    /// before submitting the publish, so batch validation does not re-probe
+    /// object storage for a blob this process just stored. The caller's own
+    /// completed write is the durability authority, exactly like a token
+    /// minted after upload validation.
+    pub fn for_durable_content_write(
         namespace_id: NamespaceId,
         content_ref: ContentRef,
         now_ms: u64,
@@ -32,8 +31,8 @@ impl ContentAdmission {
             namespace_id,
             content_ref,
             // Generous on purpose: it must outlive buffered commit windows
-            // and stale-head retries. The gate, not this clock, is the
-            // durability authority.
+            // and stale-head retries. An expired admission only downgrades
+            // to a durable-validation probe, never to a weaker check.
             expires_at_ms: now_ms.saturating_add(DEFAULT_TOKEN_TTL_MS),
         }
     }

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1962,22 +1962,19 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
     ))
     .expect("stage recreated content");
     let results = block_on(
-        namespace_engine(&store, &namespace_id, &context).publish_namespace_mutations_batch_gated(
-            vec![
-                NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
-                    commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
-                    absolute_path: "/docs/cycled.txt".to_owned(),
-                    behavior: DeleteDirectoryBehavior::NonRecursive,
-                }),
-                NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                    commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
-                    absolute_path: "/docs/cycled.txt".to_owned(),
-                    content_ref: staged.content_ref,
-                    behavior: PutBehavior::NoReplace,
-                }),
-            ],
-            None,
-        ),
+        namespace_engine(&store, &namespace_id, &context).publish_namespace_mutations_batch(vec![
+            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
+                absolute_path: "/docs/cycled.txt".to_owned(),
+                behavior: DeleteDirectoryBehavior::NonRecursive,
+            }),
+            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
+                absolute_path: "/docs/cycled.txt".to_owned(),
+                content_ref: staged.content_ref,
+                behavior: PutBehavior::NoReplace,
+            }),
+        ]),
     );
     results[0]
         .as_ref()

--- a/crates/loonfs/src/commit_window.rs
+++ b/crates/loonfs/src/commit_window.rs
@@ -12,34 +12,18 @@
 //! server's batching publisher has its own coalescer and does not pass
 //! through here.
 //!
-//! Failure semantics follow the batch they join: if any member's content
-//! durability gate fails — including a submitter cancelled mid-window, which
-//! abandons its content write — the flush aborts before the head CAS and
-//! every member is rejected. Each member's error says what happened to it:
-//! the member whose own content write failed gets that write's error, and
-//! the members whose writes succeeded get a distinct error saying a write
-//! batched with theirs failed, nothing was committed, and a retry is safe.
-//! An opener cancelled before flushing closes the window and fails the
-//! members that joined it.
+//! Submissions buffer metadata only — content a submission references is
+//! already durable before it enters the window — so members share the
+//! flush's publication fate (a failed WAL write or head CAS rejects the
+//! batch) but never each other's uploads. An opener cancelled before
+//! flushing closes the window and fails the members that joined it.
 
 use crate::publish::NamespaceMutationCandidate;
 use crate::{CommitResponse, CoreError, NamespaceId, Result, RuntimeError};
 use futures::channel::oneshot;
-use loonfs_core::publish::ContentDurabilityGate;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard};
 use tokio::time::Duration;
-
-/// Error the combined gate hands the batch when any member's content write
-/// fails. Core stamps it on every aborted member; distribution rewrites it
-/// per member, so callers never see this text — each gets its own write's
-/// error or [`WINDOW_PEER_FAILURE_MESSAGE`].
-const WINDOW_GATE_FAILURE_MESSAGE: &str = "a content write in this commit window failed";
-
-/// Error a member receives when its own content write succeeded but the
-/// flush aborted because another member's failed.
-const WINDOW_PEER_FAILURE_MESSAGE: &str =
-    "a write batched with this one in its commit window failed; nothing was committed; retry";
 
 #[allow(clippy::disallowed_methods)]
 pub(crate) async fn commit_window_delay(window: Duration) {
@@ -50,11 +34,10 @@ pub(crate) async fn commit_window_delay(window: Duration) {
 
 type WindowResults = Vec<Result<CommitResponse>>;
 
-/// One buffered submission: its candidates, the durability gate covering any
-/// content it is writing concurrently, and the channel its results return on.
+/// One buffered submission: its candidates and the channel its results
+/// return on.
 pub(crate) struct WindowEntry {
     pub(crate) candidates: Vec<NamespaceMutationCandidate>,
-    pub(crate) content_gate: Option<ContentDurabilityGate>,
     pub(crate) result_sender: oneshot::Sender<WindowResults>,
 }
 
@@ -85,12 +68,10 @@ impl CommitWindows {
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
-        content_gate: Option<ContentDurabilityGate>,
     ) -> WindowRole<'_> {
         let (result_sender, result_receiver) = oneshot::channel();
         let entry = WindowEntry {
             candidates,
-            content_gate,
             result_sender,
         };
         let mut open = self.lock_open();
@@ -145,100 +126,6 @@ impl Drop for OpenerGuard<'_> {
             self.windows.lock_open().remove(&self.namespace_id);
         }
     }
-}
-
-/// Content-write failures the flush's combined gate observed, one slot per
-/// window member. Filled before the gate resolves, so the opener may read
-/// them once the publish returns.
-pub(crate) struct WindowGateFailures {
-    slots: Arc<Mutex<Vec<Option<CoreError>>>>,
-}
-
-impl WindowGateFailures {
-    pub(crate) fn take(&self) -> Vec<Option<CoreError>> {
-        // Poisoning is propagated as a panic, matching the window map: a
-        // half-updated failure record could misattribute members' errors.
-        std::mem::take(
-            &mut *self
-                .slots
-                .lock()
-                .expect("window gate failure slots lock poisoned"),
-        )
-    }
-}
-
-/// Combines the members' durability gates into the flush's single gate: the
-/// batch's head CAS waits until every member's concurrent content write has
-/// acked, and fails — aborting the whole batch — if any of them fail. Each
-/// failure is recorded against its member (no fail-fast), so distribution
-/// can tell the failing member its own error and the rest that a batched
-/// peer failed. A solo member keeps its raw gate: its own error already
-/// reaches the right caller, and core traces keep the real failure.
-pub(crate) fn combine_member_content_gates(
-    member_gates: Vec<(usize, ContentDurabilityGate)>,
-    member_count: usize,
-) -> (Option<ContentDurabilityGate>, WindowGateFailures) {
-    let failures = WindowGateFailures {
-        slots: Arc::new(Mutex::new(vec![None; member_count])),
-    };
-    let mut member_gates = member_gates;
-    if member_gates.is_empty() || member_count == 1 {
-        return (member_gates.pop().map(|(_, gate)| gate), failures);
-    }
-    let slots = Arc::clone(&failures.slots);
-    let gate: ContentDurabilityGate = Box::pin(async move {
-        let results = futures::future::join_all(
-            member_gates
-                .into_iter()
-                .map(|(member_index, gate)| async move { (member_index, gate.await) }),
-        )
-        .await;
-        let mut any_failed = false;
-        {
-            let mut slots = slots
-                .lock()
-                .expect("window gate failure slots lock poisoned");
-            for (member_index, result) in results {
-                if let Err(error) = result {
-                    any_failed = true;
-                    if let Some(slot) = slots.get_mut(member_index) {
-                        *slot = Some(error);
-                    }
-                }
-            }
-        }
-        if any_failed {
-            Err(CoreError::Internal(WINDOW_GATE_FAILURE_MESSAGE.to_owned()))
-        } else {
-            Ok(())
-        }
-    });
-    (Some(gate), failures)
-}
-
-/// Rewrites one member's share of an aborted flush: results stamped with the
-/// combined gate's error become the member's own content-write error, or the
-/// batched-peer error when this member's write succeeded. Every other result
-/// — successes, and errors the member earned itself during validation — is
-/// left untouched.
-pub(crate) fn attribute_window_gate_failure(
-    results: WindowResults,
-    own_failure: Option<&CoreError>,
-) -> WindowResults {
-    results
-        .into_iter()
-        .map(|result| match result {
-            Err(RuntimeError::Core(CoreError::Internal(message)))
-                if message == WINDOW_GATE_FAILURE_MESSAGE =>
-            {
-                Err(RuntimeError::Core(match own_failure {
-                    Some(own_failure) => own_failure.clone(),
-                    None => CoreError::Internal(WINDOW_PEER_FAILURE_MESSAGE.to_owned()),
-                }))
-            }
-            other => other,
-        })
-        .collect()
 }
 
 /// Pads a distributed result slice when the publish returned fewer results

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -5,8 +5,7 @@
 use crate::background::BackgroundWork;
 use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::commit_window::{
-    attribute_window_gate_failure, combine_member_content_gates, commit_window_delay,
-    pad_missing_results, CommitWindows, WindowEntry, WindowRole,
+    commit_window_delay, pad_missing_results, CommitWindows, WindowEntry, WindowRole,
 };
 use crate::config::{validate_config, FsConfig};
 use crate::content_tokens::ContentAdmission;
@@ -674,70 +673,48 @@ impl FsCore {
         // invalid or root path cannot orphan an already-written content blob;
         // core re-checks the same invariant when the intent is planned.
         loonfs_core::path::validate_path_for_mutation(absolute_path)?;
-        // The content reference derives from the bytes alone, so the durable
-        // content write runs as a peer of publish validation and the WAL
-        // write: both futures are driven together below. The admission tells
-        // batch validation not to probe for a blob that is still in flight;
-        // the head CAS instead gates on the write's own ack through the
-        // channel. A failed content write leaves only a GC-covered orphan
-        // behind an unmoved head.
-        let content_ref = ContentRef::whole_file_v0(bytes);
-        let content_admission = ContentAdmission::for_in_flight_content_write(
-            namespace_id.clone(),
-            content_ref.clone(),
-            current_time_ms(),
-        );
-        let (content_result_sender, content_result_receiver) = futures::channel::oneshot::channel();
-        let content_store = self.inner.store.clone();
-        let content_namespace_id = namespace_id.clone();
+        // The bytes become durable content before the publish is submitted,
+        // so the commit window never waits on a content upload and an upload
+        // failure surfaces here with nothing published. A publish that fails
+        // afterward leaves only a GC-covered orphan behind an unmoved head.
         let cached_content_store_id = self
             .load_namespace_catalog_cached(namespace_id)
             .await?
             .map(|catalog| catalog.content_store_id().clone());
-        let content_write = async move {
-            let result = match cached_content_store_id {
-                Some(content_store_id) => {
-                    loonfs_core::content::store_bytes_as_content_with_store_id(
-                        &content_store,
-                        content_store_id,
-                        bytes,
-                    )
-                    .await
-                }
-                None => {
-                    loonfs_core::content::store_bytes_as_content(
-                        &content_store,
-                        &content_namespace_id,
-                        bytes,
-                    )
-                    .await
-                }
+        let stored = match cached_content_store_id {
+            Some(content_store_id) => {
+                loonfs_core::content::store_bytes_as_content_with_store_id(
+                    &self.inner.store,
+                    content_store_id,
+                    bytes,
+                )
+                .await?
             }
-            .map(|_| ());
-            // A receiver dropped before the gate point means the publish
-            // failed earlier; the content object is then a GC-covered orphan.
-            let _ = content_result_sender.send(result);
+            None => {
+                loonfs_core::content::store_bytes_as_content(&self.inner.store, namespace_id, bytes)
+                    .await?
+            }
         };
-        let content_gate: loonfs_core::publish::ContentDurabilityGate = Box::pin(async move {
-            content_result_receiver.await.map_err(|_| {
-                CoreError::Internal("content write finished without a result".to_owned())
-            })?
-        });
-        let publish = self.publish_candidate_gated(
+        // The admission tells batch validation not to re-probe for the blob
+        // whose acked write this handle just observed.
+        let content_admission = ContentAdmission::for_durable_content_write(
+            namespace_id.clone(),
+            stored.content_ref.clone(),
+            current_time_ms(),
+        );
+        self.publish_candidate(
             namespace_id,
             NamespaceMutationCandidate::PathWithContentAdmission {
                 intent: PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
                     absolute_path: absolute_path.to_owned(),
-                    content_ref,
+                    content_ref: stored.content_ref,
                     behavior: options.behavior,
                 },
                 admissions: vec![content_admission],
             },
-            Some(content_gate),
-        );
-        let ((), published) = futures::join!(content_write, publish);
-        published
+        )
+        .await
     }
 
     /// Publishes a file revision that points at an already-durable content
@@ -974,7 +951,6 @@ impl FsCore {
         self.publish_through_commit_window(
             namespace_id,
             vec![NamespaceMutationCandidate::Commit(request)],
-            None,
         )
         .await
         .into_iter()
@@ -999,7 +975,6 @@ impl FsCore {
                 .into_iter()
                 .map(NamespaceMutationCandidate::Commit)
                 .collect(),
-            None,
         )
         .await
     }
@@ -1009,18 +984,17 @@ impl FsCore {
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
     ) -> Result<MutationResult> {
-        self.publish_candidate_gated(namespace_id, NamespaceMutationCandidate::Path(intent), None)
+        self.publish_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
             .await
     }
 
-    async fn publish_candidate_gated(
+    async fn publish_candidate(
         &self,
         namespace_id: &NamespaceId,
         candidate: NamespaceMutationCandidate,
-        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
     ) -> Result<MutationResult> {
         let mut results = self
-            .publish_through_commit_window(namespace_id, vec![candidate], content_gate)
+            .publish_through_commit_window(namespace_id, vec![candidate])
             .await;
         let response = results.pop().unwrap_or_else(|| {
             Err(RuntimeError::Core(CoreError::Internal(
@@ -1044,19 +1018,15 @@ impl FsCore {
         &self,
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
-        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
     ) -> Vec<Result<CommitResponse>> {
         let window_ms = self.inner.config.commit_window_ms;
         if window_ms == 0 {
             return self
-                .publish_namespace_mutations_batch_gated(namespace_id, candidates, content_gate)
+                .publish_namespace_mutations_batch(namespace_id, candidates)
                 .await;
         }
         let candidate_count = candidates.len();
-        let role = self
-            .inner
-            .commit_windows
-            .enter(namespace_id, candidates, content_gate);
+        let role = self.inner.commit_windows.enter(namespace_id, candidates);
         let result_receiver = match role {
             WindowRole::Opener {
                 guard,
@@ -1065,33 +1035,21 @@ impl FsCore {
                 commit_window_delay(std::time::Duration::from_millis(window_ms)).await;
                 let entries = guard.take_entries();
                 let mut combined = Vec::new();
-                let mut member_gates = Vec::new();
                 let mut routes = Vec::new();
-                for (member_index, entry) in entries.into_iter().enumerate() {
+                for entry in entries {
                     let WindowEntry {
                         candidates,
-                        content_gate,
                         result_sender,
                     } = entry;
                     routes.push((candidates.len(), result_sender));
                     combined.extend(candidates);
-                    if let Some(gate) = content_gate {
-                        member_gates.push((member_index, gate));
-                    }
                 }
-                let (combined_gate, gate_failures) =
-                    combine_member_content_gates(member_gates, routes.len());
                 let mut results = self
-                    .publish_namespace_mutations_batch_gated(namespace_id, combined, combined_gate)
+                    .publish_namespace_mutations_batch(namespace_id, combined)
                     .await
                     .into_iter();
-                let failures = gate_failures.take();
-                for (member_index, (expected, sender)) in routes.into_iter().enumerate() {
+                for (expected, sender) in routes {
                     let slice: Vec<_> = results.by_ref().take(expected).collect();
-                    let slice = attribute_window_gate_failure(
-                        slice,
-                        failures.get(member_index).and_then(Option::as_ref),
-                    );
                     let _ = sender.send(pad_missing_results(slice, expected));
                 }
                 result_receiver
@@ -1123,16 +1081,6 @@ impl FsCore {
         namespace_id: &NamespaceId,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<Result<CommitResponse>> {
-        self.publish_namespace_mutations_batch_gated(namespace_id, candidates, None)
-            .await
-    }
-
-    pub(crate) async fn publish_namespace_mutations_batch_gated(
-        &self,
-        namespace_id: &NamespaceId,
-        candidates: Vec<NamespaceMutationCandidate>,
-        content_gate: Option<loonfs_core::publish::ContentDurabilityGate>,
-    ) -> Vec<Result<CommitResponse>> {
         let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
         let store = self.store();
         if self.commit_engine_cache_enabled() {
@@ -1160,7 +1108,6 @@ impl FsCore {
                             candidates,
                             &context,
                             &tail_options,
-                            content_gate,
                         )
                         .await
                 })
@@ -1201,12 +1148,11 @@ impl FsCore {
 
         let engine = self.namespace_engine_with_store(namespace_id, store);
         // Boxed for the same type-recursion reason as the cached-engine path.
-        let results: Vec<_> =
-            Box::pin(engine.publish_namespace_mutations_batch_gated(candidates, content_gate))
-                .await
-                .into_iter()
-                .map(|result| result.map_err(RuntimeError::Core))
-                .collect();
+        let results: Vec<_> = Box::pin(engine.publish_namespace_mutations_batch(candidates))
+            .await
+            .into_iter()
+            .map(|result| result.map_err(RuntimeError::Core))
+            .collect();
         {
             let _span = tracing::info_span!(
                 "publisher.batch_update_cache",

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -1708,14 +1708,14 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
             },
         )
         .expect_err("put should surface the failed content write");
-    // A solo put reports its own write's error, not window plumbing.
+    // A put reports its own write's error, not publish plumbing.
     assert!(
         error.to_string().contains("injected content write failure"),
         "unexpected error: {error}"
     );
 
-    // The content result gates the head CAS, so the failed write aborted the
-    // publish with the head unmoved and nothing visible.
+    // Content is staged before the publish is submitted, so the failed write
+    // stopped the put with the head unmoved and nothing visible.
     let error = fs
         .stat_path_blocking(&namespace_id, "/docs/report.txt")
         .expect_err("failed put should leave the path unbound");
@@ -1752,31 +1752,61 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
+
+        // Stage every file's content first: a put publishes only after its
+        // bytes are durable, so racing already-staged publishes is what
+        // reaches the commit window together deterministically.
+        let mut content_refs = Vec::new();
+        for bytes in [b"alpha" as &[u8], b"beta", b"gamma", b"delta"] {
+            let begin = fs
+                .writer
+                .begin_upload(&namespace_id, BeginUploadRequest::default())
+                .await
+                .expect("begin upload");
+            let staged = fs
+                .writer
+                .upload_content(&namespace_id, &begin.upload_id, bytes)
+                .await
+                .expect("upload content");
+            let completed = fs
+                .writer
+                .complete_upload(
+                    &namespace_id,
+                    &begin.upload_id,
+                    &CompleteUploadRequest {
+                        content_ref: staged.content_ref,
+                    },
+                )
+                .await
+                .expect("complete upload");
+            content_refs.push(completed.content_ref);
+        }
+        let [ref_a, ref_b, ref_c, ref_d] = content_refs.try_into().expect("four staged refs");
         let segments_before = wal_segment_count(&object_store, &namespace_id).await;
 
         let puts = tokio::join!(
-            fs.put_file_bytes(
+            fs.put_file_content_ref(
                 &namespace_id,
                 "/docs/a.txt",
-                b"alpha",
+                ref_a,
                 PutFileOptions::default()
             ),
-            fs.put_file_bytes(
+            fs.put_file_content_ref(
                 &namespace_id,
                 "/docs/b.txt",
-                b"beta",
+                ref_b,
                 PutFileOptions::default()
             ),
-            fs.put_file_bytes(
+            fs.put_file_content_ref(
                 &namespace_id,
                 "/docs/c.txt",
-                b"gamma",
+                ref_c,
                 PutFileOptions::default()
             ),
-            fs.put_file_bytes(
+            fs.put_file_content_ref(
                 &namespace_id,
                 "/docs/d.txt",
-                b"delta",
+                ref_d,
                 PutFileOptions::default()
             ),
         );
@@ -1853,7 +1883,7 @@ fn commit_window_zero_publishes_each_submission_immediately() {
 }
 
 #[test]
-fn commit_window_flush_aborts_every_member_when_one_content_write_fails() {
+fn concurrent_put_content_write_failure_leaves_the_other_put_committed() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
@@ -1864,9 +1894,9 @@ fn commit_window_flush_aborts_every_member_when_one_content_write_fails() {
             .await
             .expect("create namespace");
 
-        // Exactly one of the two concurrent content writes fails; the
-        // combined durability gate cannot prove the flush, so the whole
-        // window aborts before the head CAS.
+        // Exactly one of the two concurrent content writes fails. Content is
+        // staged before a submission enters the commit window, so only the
+        // put whose own upload failed errors; the other publishes normally.
         raw_store.fail_next_content_blob_puts(1);
         let (a, b) = tokio::join!(
             fs.put_file_bytes(
@@ -1882,54 +1912,60 @@ fn commit_window_flush_aborts_every_member_when_one_content_write_fails() {
                 PutFileOptions::default()
             ),
         );
-        let first = a.expect_err("window abort should fail the first member");
-        let second = b.expect_err("window abort should fail the second member");
-        // Each member's error says what happened to it: whichever upload the
-        // store failed reports the injected write error, and the member whose
-        // upload succeeded is told a batched peer failed and a retry is safe.
-        let messages = [first.to_string(), second.to_string()];
-        let own_failures = messages
-            .iter()
-            .filter(|message| message.contains("injected content write failure"))
-            .count();
-        let peer_failures = messages
-            .iter()
-            .filter(|message| message.contains("batched with this one"))
-            .count();
-        assert_eq!(
-            (own_failures, peer_failures),
-            (1, 1),
-            "unexpected member errors: {messages:?}"
-        );
-        for path in ["/docs/a.txt", "/docs/b.txt"] {
-            let error = fs
-                .reader
-                .stat_path(&namespace_id, path)
-                .await
-                .expect_err("aborted put should leave the path unbound");
-            assert!(matches!(
-                error,
-                RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
-            ));
-        }
 
-        // Both members retry cleanly once the store recovers.
-        let (a, b) = tokio::join!(
-            fs.put_file_bytes(
-                &namespace_id,
-                "/docs/a.txt",
-                b"alpha",
-                PutFileOptions::default()
-            ),
-            fs.put_file_bytes(
-                &namespace_id,
-                "/docs/b.txt",
-                b"beta",
-                PutFileOptions::default()
-            ),
-        );
-        a.expect("retried put a");
-        b.expect("retried put b");
+        let mut failed = Vec::new();
+        for (path, bytes, result) in [
+            ("/docs/a.txt", b"alpha" as &[u8], a),
+            ("/docs/b.txt", b"beta" as &[u8], b),
+        ] {
+            match result {
+                Ok(_) => {
+                    let read = fs
+                        .reader
+                        .read_file_bytes(&namespace_id, path)
+                        .await
+                        .expect("read the committed peer");
+                    assert_eq!(read.bytes, bytes);
+                }
+                Err(error) => {
+                    // The failing member reports its own write's error, and
+                    // its path stays unbound behind an unmoved head.
+                    assert!(
+                        error.to_string().contains("injected content write failure"),
+                        "unexpected error: {error}"
+                    );
+                    let error = fs
+                        .reader
+                        .stat_path(&namespace_id, path)
+                        .await
+                        .expect_err("failed put should leave the path unbound");
+                    assert!(matches!(
+                        error,
+                        RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
+                    ));
+                    failed.push((path, bytes));
+                }
+            }
+        }
+        let [(failed_path, failed_bytes)] = failed[..] else {
+            panic!("exactly one put should fail its own content write");
+        };
+
+        // The failed member retries cleanly; its peer never needed one.
+        fs.put_file_bytes(
+            &namespace_id,
+            failed_path,
+            failed_bytes,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("retried put");
+        let read = fs
+            .reader
+            .read_file_bytes(&namespace_id, failed_path)
+            .await
+            .expect("read retried file");
+        assert_eq!(read.bytes, failed_bytes);
     });
 }
 


### PR DESCRIPTION
`FsWriter::put_file_bytes` was the only writer in the system that coupled the content upload to the publish: the upload ran as a peer of the publish, and the batch's head CAS waited on a durability gate between the WAL write and the CAS. Everything else — the remote client, the server's wire surface, and core's own `path::write` ops — already stages content first and publishes metadata that points at durable bytes.

The coupling bought one overlapped store round trip on a solo put, and paid for it three ways. The per-namespace engine lock was held while the gate waited, so one slow upload blocked every other publish to the namespace, including metadata-only ones. All members of a commit window shared upload fate: one failed or cancelled content write rejected every member, which is what the per-member failure attribution machinery existed to explain. And an upload slower than the publish budget aborted the batch after the bytes had landed — a retry re-uploads and hits the same ceiling, so a large enough put could never succeed.

This makes `put_file_bytes` upload-first: stage the bytes, then publish the content ref with an admission saying this handle just wrote the blob, so validation does not re-probe and per-put request counts are unchanged. The gate type, its threading through the engine and batch publisher, and the window's gate-combination and failure-attribution code are deleted. The commit window now buffers metadata only: an upload failure surfaces to its own caller with nothing published, and its peers commit normally.

One behavior note: racing `put_file_bytes` calls now reach the window skewed by their upload times, so they are not guaranteed to coalesce into one WAL segment (the window was always opportunistic; the server's batching publisher is unaffected). The coalescing test now stages content first and races `put_file_content_ref`, which enters the window deterministically.
