### PR TITLE
perf(core): scale-flat cold stat via inline run filters and a pipelined path walk

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -60,6 +60,13 @@ pub struct MetadataFileRef {
     pub index_block: BlockHandle,
     /// Where the segment's bloom filter block lives and how to verify it.
     pub filter_block: BlockHandle,
+    /// The filter block's stored bytes inlined as hex, present when the
+    /// filter is small (small delta runs). Point lookups consult it to skip
+    /// the segment without any object fetch; `filter_block` still names and
+    /// verifies the same bytes, so the inline copy must decode byte-for-byte
+    /// identical (same length and CRC32C) or the manifest is corrupt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter_inline: Option<String>,
     /// Checksum of the segment object's full bytes, in `sha256:<hex>` form.
     /// The ranged read path verifies per-block CRCs instead; this digest is
     /// the segment's identity in the decoded-block cache.
@@ -272,13 +279,38 @@ impl MetadataRow {
 }
 
 pub fn hex_encode_row_key_component(value: &str) -> String {
+    hex_encode_bytes(value.as_bytes())
+}
+
+pub fn hex_encode_bytes(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value.as_bytes() {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
         encoded.push(char::from(HEX[(byte >> 4) as usize]));
         encoded.push(char::from(HEX[(byte & 0x0f) as usize]));
     }
     encoded
+}
+
+/// Decodes the lowercase hex this module's encoders produce. Errors carry no
+/// input bytes; callers name the field they were decoding.
+pub fn hex_decode_bytes(encoded: &str) -> Result<Vec<u8>, String> {
+    fn nibble(byte: u8) -> Result<u8, String> {
+        match byte {
+            b'0'..=b'9' => Ok(byte - b'0'),
+            b'a'..=b'f' => Ok(byte - b'a' + 10),
+            _ => Err(format!("invalid hex byte {byte:#04x}")),
+        }
+    }
+    let bytes = encoded.as_bytes();
+    if bytes.len() % 2 != 0 {
+        return Err(format!("odd hex length {}", bytes.len()));
+    }
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        decoded.push((nibble(pair[0])? << 4) | nibble(pair[1])?);
+    }
+    Ok(decoded)
 }
 
 /// Reader-side lookup grammar: the probes, prefixes, and resume keys that
@@ -800,6 +832,7 @@ mod tests {
                 decoded_len: 0,
                 crc32c: 0,
             },
+            filter_inline: None,
             payload_checksum: "sha256:unused".to_owned(),
         }
     }

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -266,6 +266,9 @@ fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
                     decoded_len: 100,
                     crc32c: 0x9abc_def0,
                 },
+                // Absent in the golden fixture: the field is skipped when
+                // `None`, so pre-inline manifests decode unchanged.
+                filter_inline: None,
                 payload_checksum: sha256_digest(b"sst payload"),
             }],
         },

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -266,8 +266,8 @@ fn sample_manifest_envelope() -> NamespaceManifestEnvelope {
                     decoded_len: 100,
                     crc32c: 0x9abc_def0,
                 },
-                // Absent in the golden fixture: the field is skipped when
-                // `None`, so pre-inline manifests decode unchanged.
+                // Only small filters are inlined; this descriptor's filter
+                // is read through its handle, so the field is omitted.
                 filter_inline: None,
                 payload_checksum: sha256_digest(b"sst payload"),
             }],

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -10,7 +10,9 @@ use crate::error::{CoreError, Result};
 use crate::metadata::MetadataState;
 use crate::storage::content::write_immutable_object;
 use futures::future::try_join_all;
-use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::{
+    hex_encode_bytes, MetadataFileRef, MetadataRow, MetadataTableFamily,
+};
 use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
 use loonfs_api::{sha256_digest, ChangeSeq, MetadataTableId, NamespaceId};
 use loonfs_objectstore::keys::metadata_table;
@@ -171,6 +173,14 @@ pub(super) struct MetadataSstWriteRequest<'a> {
     object_key: String,
 }
 
+/// Largest filter block inlined into the segment's manifest descriptor, in
+/// stored bytes (hex doubles it in the manifest JSON). Sized for delta-run
+/// segments — the small, key-range-overlapping tables a point lookup must
+/// otherwise fetch one filter block per run to rule out — while keeping big
+/// base-segment filters (which range pruning already narrows to one
+/// candidate) out of the manifest.
+const INLINE_SEGMENT_FILTER_MAX_BYTES: u32 = 1024;
+
 pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,
     request: MetadataSstWriteRequest<'_>,
@@ -193,6 +203,10 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
         ))
     })?;
     write_immutable_object(store, &request.object_key, &built.bytes).await?;
+    let filter_inline = (built.filter.stored_len <= INLINE_SEGMENT_FILTER_MAX_BYTES).then(|| {
+        let start = built.filter.offset as usize;
+        hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])
+    });
     Ok(MetadataFileRef {
         owner_namespace_id: request.namespace_id.clone(),
         table_id: request.table_id,
@@ -206,6 +220,7 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
         max_key: built.max_key,
         index_block: built.index,
         filter_block: built.filter,
+        filter_inline,
         payload_checksum: sha256_digest(&built.bytes),
     })
 }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -42,7 +42,7 @@ pub struct MetadataTableCacheStats {
     pub filter_false_positives: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) enum MetadataTableBlockKind {
     Index,
     Filter,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -36,12 +36,12 @@ use futures::future::try_join_all;
 use loonfs_api::manifest_object_id_manifest_id;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::{
-    decode_namespace_manifest_json, MetadataFileRef, MetadataRow, MetadataTableFamily,
-    NamespaceManifestEnvelope,
+    decode_namespace_manifest_json, hex_decode_bytes, MetadataFileRef, MetadataRow,
+    MetadataTableFamily, NamespaceManifestEnvelope,
 };
 use loonfs_api::wire::sst_blocks::{
     decode_data_block, decode_filter_block, decode_index_block, index_blocks_for_key_range,
-    DecodedDataBlock, SegmentFilter, SegmentIndexEntry,
+    BlockHandle, DecodedDataBlock, SegmentFilter, SegmentIndexEntry,
 };
 #[cfg(test)]
 use loonfs_api::ManifestId;
@@ -680,6 +680,175 @@ fn segment_codec_error(object_key: &str, err: impl std::fmt::Display) -> Manifes
     }
 }
 
+/// Largest segment object fetched whole on first touch, in stored bytes.
+/// Below this, splitting the index and data reads into separate ranged GETs
+/// costs more round-trips than the whole object costs bytes; one GET
+/// publishes every section to the memo and shared cache. Sized to catch
+/// delta-run segments (one or two data blocks) while leaving base segments
+/// on the per-section path.
+const WHOLE_SEGMENT_FETCH_MAX_BYTES: u64 = 128 * 1024;
+
+/// A segment object's total stored length: the index block is the last
+/// section, so it ends the object.
+fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
+    descriptor.index_block.offset + u64::from(descriptor.index_block.stored_len)
+}
+
+/// Whether the filter and index blocks sit back-to-back at the object tail
+/// (the frozen layout). Guarded so a descriptor that violates it degrades to
+/// per-section fetches instead of a misdecoded span.
+fn filter_index_tail_adjacent(descriptor: &MetadataFileRef) -> bool {
+    descriptor.filter_block.offset + u64::from(descriptor.filter_block.stored_len)
+        == descriptor.index_block.offset
+}
+
+/// Fetches the byte span that answers one filter or index load with a single
+/// GET, decoding and publishing every section the span covers: the whole
+/// object when it is small (index, filter, and all data blocks), the
+/// filter+index tail when a filter load would otherwise be followed by an
+/// index fetch one round-trip later, and just the requested section
+/// otherwise. Returns the requested block.
+async fn fetch_and_publish_segment_sections<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
+    descriptor: &MetadataFileRef,
+    want: MetadataTableBlockKind,
+) -> Result<DecodedMetadataTableBlock, ManifestLoadError> {
+    let filter_handle = descriptor.filter_block;
+    let index_handle = descriptor.index_block;
+    let object_len = segment_object_len(descriptor);
+    let wanted_handle = match want {
+        MetadataTableBlockKind::Filter => filter_handle,
+        MetadataTableBlockKind::Index => index_handle,
+        MetadataTableBlockKind::Data | MetadataTableBlockKind::Manifest => {
+            return Err(segment_codec_error(
+                &descriptor.object_key,
+                "segment section fetch supports only filter and index blocks",
+            ));
+        }
+    };
+    let fetch_whole_object = object_len <= WHOLE_SEGMENT_FETCH_MAX_BYTES;
+    let fetch_offset = if fetch_whole_object {
+        0
+    } else if want == MetadataTableBlockKind::Filter && filter_index_tail_adjacent(descriptor) {
+        filter_handle.offset
+    } else {
+        wanted_handle.offset
+    };
+    let fetch_end = if fetch_whole_object || want == MetadataTableBlockKind::Filter {
+        object_len.max(wanted_handle.offset + u64::from(wanted_handle.stored_len))
+    } else {
+        wanted_handle.offset + u64::from(wanted_handle.stored_len)
+    };
+    let bytes = fetch_section_bytes(
+        store,
+        &descriptor.object_key,
+        fetch_offset,
+        fetch_end - fetch_offset,
+    )
+    .await?;
+    let section = |handle: &BlockHandle| -> Option<&[u8]> {
+        let start = usize::try_from(handle.offset.checked_sub(fetch_offset)?).ok()?;
+        bytes.get(start..start + handle.stored_len as usize)
+    };
+
+    let index_entries = match section(&index_handle) {
+        Some(stored) => {
+            let entries = Arc::new(
+                decode_index_block(stored, &index_handle)
+                    .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
+            );
+            let block = DecodedMetadataTableBlock::Index {
+                decoded_byte_len: index_handle.decoded_len as usize,
+                entries: Arc::clone(&entries),
+            };
+            publish_segment_block(
+                table_cache,
+                memo,
+                segment_block_cache_key(
+                    descriptor,
+                    MetadataTableBlockKind::Index,
+                    index_handle.offset,
+                ),
+                &block,
+            );
+            Some(block)
+        }
+        None => None,
+    };
+    let filter_block = match section(&filter_handle) {
+        Some(stored) => {
+            let filter = decode_filter_block(stored, &filter_handle)
+                .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
+            let block = DecodedMetadataTableBlock::Filter {
+                decoded_byte_len: filter_handle.decoded_len as usize,
+                filter: Arc::new(filter),
+            };
+            publish_segment_block(
+                table_cache,
+                memo,
+                segment_block_cache_key(
+                    descriptor,
+                    MetadataTableBlockKind::Filter,
+                    filter_handle.offset,
+                ),
+                &block,
+            );
+            Some(block)
+        }
+        None => None,
+    };
+    if fetch_whole_object {
+        if let Some(DecodedMetadataTableBlock::Index { entries, .. }) = &index_entries {
+            for entry in entries.iter() {
+                let Some(stored) = section(&entry.block) else {
+                    return Err(segment_codec_error(
+                        &descriptor.object_key,
+                        "data block outside the segment object bounds",
+                    ));
+                };
+                let decoded = decode_data_block(stored, &entry.block)
+                    .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
+                let block = decoded_data_cache_block(descriptor.family, decoded);
+                publish_segment_block(
+                    table_cache,
+                    memo,
+                    segment_block_cache_key(
+                        descriptor,
+                        MetadataTableBlockKind::Data,
+                        entry.block.offset,
+                    ),
+                    &block,
+                );
+            }
+        }
+    }
+
+    let wanted = match want {
+        MetadataTableBlockKind::Filter => filter_block,
+        _ => index_entries,
+    };
+    wanted.ok_or_else(|| {
+        segment_codec_error(
+            &descriptor.object_key,
+            "requested section outside the segment object bounds",
+        )
+    })
+}
+
+fn publish_segment_block(
+    table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
+    cache_key: MetadataTableCacheKey,
+    block: &DecodedMetadataTableBlock,
+) {
+    memo.record(&cache_key, block);
+    if let Some(cache) = table_cache {
+        cache.insert(cache_key, block.clone());
+    }
+}
+
 async fn load_segment_index<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -693,19 +862,14 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
         return Ok(entries);
     }
     let fetch = || async {
-        let bytes = fetch_section_bytes(
+        fetch_and_publish_segment_sections(
             store,
-            &descriptor.object_key,
-            handle.offset,
-            handle.stored_len as u64,
+            table_cache,
+            memo,
+            descriptor,
+            MetadataTableBlockKind::Index,
         )
-        .await?;
-        let entries = decode_index_block(&bytes, &handle)
-            .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
-        Ok(DecodedMetadataTableBlock::Index {
-            decoded_byte_len: handle.decoded_len as usize,
-            entries: Arc::new(entries),
-        })
+        .await
     };
     let block = match table_cache {
         Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
@@ -723,8 +887,12 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Loads a segment's bloom filter block through the cache: the cheap
-/// pre-index check a lookup consults to skip the segment entirely.
+/// Loads a segment's bloom filter block: the cheap pre-index check a lookup
+/// consults to skip the segment entirely. A copy inlined in the manifest
+/// descriptor answers without any object fetch; otherwise one ranged GET
+/// covers the filter together with the adjacent index block (and the whole
+/// object when it is small), so an admitted lookup does not pay a second
+/// round-trip for the index.
 pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -737,20 +905,32 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     if let Some(DecodedMetadataTableBlock::Filter { filter, .. }) = memo.get(&cache_key) {
         return Ok(filter);
     }
-    let fetch = || async {
-        let bytes = fetch_section_bytes(
-            store,
-            &descriptor.object_key,
-            handle.offset,
-            handle.stored_len as u64,
-        )
-        .await?;
-        let filter = decode_filter_block(&bytes, &handle)
-            .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
-        Ok(DecodedMetadataTableBlock::Filter {
+    if let Some(inline) = &descriptor.filter_inline {
+        let bytes = hex_decode_bytes(inline).map_err(|err| {
+            segment_codec_error(&descriptor.object_key, format!("inline filter: {err}"))
+        })?;
+        // The handle names and verifies the durable filter block; decoding
+        // the inline copy against it proves the two are byte-identical.
+        let filter = Arc::new(
+            decode_filter_block(&bytes, &handle)
+                .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
+        );
+        let block = DecodedMetadataTableBlock::Filter {
             decoded_byte_len: handle.decoded_len as usize,
-            filter: Arc::new(filter),
-        })
+            filter: Arc::clone(&filter),
+        };
+        publish_segment_block(table_cache, memo, cache_key, &block);
+        return Ok(filter);
+    }
+    let fetch = || async {
+        fetch_and_publish_segment_sections(
+            store,
+            table_cache,
+            memo,
+            descriptor,
+            MetadataTableBlockKind::Filter,
+        )
+        .await
     };
     let block = match table_cache {
         Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -357,6 +357,36 @@ fn validate_manifest_table_descriptors(
                         expected: expected_key,
                     });
                 }
+                // The one segment layout: the filter block sits immediately
+                // before the index block at the object tail. The read path
+                // assumes it (a filter fetch extends through the index; the
+                // index ends the object), so a descriptor that disagrees is
+                // rejected here rather than tolerated with slower fetches.
+                let filter_end =
+                    descriptor.filter_block.offset + u64::from(descriptor.filter_block.stored_len);
+                if filter_end != descriptor.index_block.offset {
+                    return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                        object_key: descriptor.object_key.clone(),
+                        message: format!(
+                            "filter block ends at {filter_end} but the index block starts at {}; \
+                             the filter must directly precede the index",
+                            descriptor.index_block.offset
+                        ),
+                    });
+                }
+                if let Some(inline) = &descriptor.filter_inline {
+                    let expected_hex_len = 2 * descriptor.filter_block.stored_len as usize;
+                    if inline.len() != expected_hex_len {
+                        return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                            object_key: descriptor.object_key.clone(),
+                            message: format!(
+                                "inline filter is {} hex chars but the filter block stores {} bytes",
+                                inline.len(),
+                                descriptor.filter_block.stored_len
+                            ),
+                        });
+                    }
+                }
                 match table.family {
                     MetadataTableFamily::DirentryBinds => {
                         direntry_bind_rows =
@@ -694,20 +724,13 @@ fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
     descriptor.index_block.offset + u64::from(descriptor.index_block.stored_len)
 }
 
-/// Whether the filter and index blocks sit back-to-back at the object tail
-/// (the frozen layout). Guarded so a descriptor that violates it degrades to
-/// per-section fetches instead of a misdecoded span.
-fn filter_index_tail_adjacent(descriptor: &MetadataFileRef) -> bool {
-    descriptor.filter_block.offset + u64::from(descriptor.filter_block.stored_len)
-        == descriptor.index_block.offset
-}
-
 /// Fetches the byte span that answers one filter or index load with a single
 /// GET, decoding and publishing every section the span covers: the whole
-/// object when it is small (index, filter, and all data blocks), the
-/// filter+index tail when a filter load would otherwise be followed by an
-/// index fetch one round-trip later, and just the requested section
-/// otherwise. Returns the requested block.
+/// object when it is small (index, filter, and all data blocks), otherwise
+/// everything from the requested section to the end of the object — for a
+/// filter that is the filter plus the index that directly follows it
+/// (manifest loading rejects any other layout), and for an index exactly the
+/// index, which ends the object. Returns the requested block.
 async fn fetch_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -718,34 +741,23 @@ async fn fetch_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     let filter_handle = descriptor.filter_block;
     let index_handle = descriptor.index_block;
     let object_len = segment_object_len(descriptor);
-    let wanted_handle = match want {
-        MetadataTableBlockKind::Filter => filter_handle,
-        MetadataTableBlockKind::Index => index_handle,
+    let fetch_whole_object = object_len <= WHOLE_SEGMENT_FETCH_MAX_BYTES;
+    let fetch_offset = match want {
         MetadataTableBlockKind::Data | MetadataTableBlockKind::Manifest => {
             return Err(segment_codec_error(
                 &descriptor.object_key,
                 "segment section fetch supports only filter and index blocks",
             ));
         }
-    };
-    let fetch_whole_object = object_len <= WHOLE_SEGMENT_FETCH_MAX_BYTES;
-    let fetch_offset = if fetch_whole_object {
-        0
-    } else if want == MetadataTableBlockKind::Filter && filter_index_tail_adjacent(descriptor) {
-        filter_handle.offset
-    } else {
-        wanted_handle.offset
-    };
-    let fetch_end = if fetch_whole_object || want == MetadataTableBlockKind::Filter {
-        object_len.max(wanted_handle.offset + u64::from(wanted_handle.stored_len))
-    } else {
-        wanted_handle.offset + u64::from(wanted_handle.stored_len)
+        _ if fetch_whole_object => 0,
+        MetadataTableBlockKind::Filter => filter_handle.offset,
+        MetadataTableBlockKind::Index => index_handle.offset,
     };
     let bytes = fetch_section_bytes(
         store,
         &descriptor.object_key,
         fetch_offset,
-        fetch_end - fetch_offset,
+        object_len - fetch_offset,
     )
     .await?;
     let section = |handle: &BlockHandle| -> Option<&[u8]> {

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -4164,6 +4164,78 @@ async fn corrupt_inline_filter_fails_the_lookup() {
 }
 
 #[tokio::test]
+async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    let payload = tables.manifest().payload.clone();
+
+    // The read path assumes the filter block directly precedes the index
+    // block and that an inline copy matches its handle's length; loading a
+    // manifest that breaks either must fail instead of degrading.
+    type Perturbation = fn(&mut MetadataFileRef);
+    fn misalign_filter(descriptor: &mut MetadataFileRef) {
+        descriptor.filter_block.offset -= 1;
+    }
+    fn truncate_inline(descriptor: &mut MetadataFileRef) {
+        let inline = descriptor.filter_inline.as_mut().expect("inline filter");
+        inline.truncate(inline.len() - 2);
+    }
+    let perturbations: [(&str, Perturbation); 2] = [
+        ("filter not adjacent to index", misalign_filter),
+        ("inline length disagrees with handle", truncate_inline),
+    ];
+    for (index, (label, perturb)) in perturbations.iter().enumerate() {
+        let mut perturbed = payload.clone();
+        perturbed.manifest_id = ManifestId(perturbed.manifest_id.0 + 1 + index as u64);
+        perturbed.manifest_object_id = ManifestObjectId::generate(perturbed.manifest_id);
+        let descriptor = perturbed
+            .metadata_files
+            .iter_mut()
+            .find(|descriptor| descriptor.filter_inline.is_some())
+            .expect("an inline-filtered descriptor");
+        perturb(descriptor);
+        let perturbed_object_id = perturbed.manifest_object_id.clone();
+        let envelope = NamespaceManifestEnvelope::from_payload("test-writer", perturbed)
+            .expect("perturbed manifest envelope");
+        write_namespace_manifest(&store, &envelope)
+            .await
+            .expect("write perturbed manifest");
+        let error = match load_verified_manifest_tables(&store, &namespace_id, &perturbed_object_id)
+            .await
+        {
+            Ok(_) => panic!("{label}: perturbed manifest must not load"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(error, ManifestLoadError::SegmentDescriptorMismatch { .. }),
+            "{label}: unexpected error {error:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     let temp_dir = tempdir().expect("tempdir");
     let store =

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -40,8 +40,8 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::wire::control::{HeadState, MetadataRootState};
 use loonfs_api::wire::manifest::{
-    decode_namespace_manifest_json, encode_namespace_manifest_json, MetadataFileRef, MetadataRow,
-    MetadataTableFamily as ApiMetadataTableFamily, NamespaceManifestEnvelope,
+    decode_namespace_manifest_json, encode_namespace_manifest_json, lookup_keys, MetadataFileRef,
+    MetadataRow, MetadataTableFamily as ApiMetadataTableFamily, NamespaceManifestEnvelope,
     NamespaceManifestPayload,
 };
 use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
@@ -3984,6 +3984,182 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
         store.metadata_sst_gets(),
         first_lookup_gets,
         "later lookups through the same view should reuse decoded blocks"
+    );
+}
+
+#[tokio::test]
+async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store =
+        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    // Three checkpoints append three L0 runs whose direntry key ranges
+    // straddle one another (each run binds names from both ends of the
+    // alphabet), so range pruning alone cannot narrow a name lookup below
+    // several candidate segments — the shape a bulk-loaded directory's
+    // unfolded backlog takes.
+    for names in [["a.txt", "z.txt"], ["b.txt", "y.txt"], ["c.txt", "x.txt"]] {
+        for name in names {
+            write_file_bytes(
+                &store,
+                &namespace_id,
+                &format!("/docs/{name}"),
+                b"content\n",
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+    }
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    let direntry_descriptors: Vec<_> = tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| descriptor.family == ApiMetadataTableFamily::DirentryBinds)
+        .collect();
+    assert!(direntry_descriptors.len() >= 3);
+    assert!(
+        direntry_descriptors
+            .iter()
+            .all(|descriptor| descriptor.filter_inline.is_some()),
+        "small delta-run segments should inline their filters in the manifest"
+    );
+
+    let materialized = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        tables.manifest().payload.manifest_id,
+    )
+    .await
+    .expect("materialize manifest");
+    let binding = materialized
+        .metadata_state
+        .direntry_binds()
+        .iter()
+        .find(|binding| binding.name_key == "x.txt")
+        .expect("binding for x.txt")
+        .clone();
+    let prefix = lookup_keys::direntry_bind_prefix(binding.parent_inode_id, &binding.name_key);
+    let probe = lookup_keys::direntry_bind_probe(binding.parent_inode_id, &binding.name_key);
+
+    store.reset_metadata_sst_gets();
+    let rows = tables
+        .scan_prefix_for_lookup(ApiMetadataTableFamily::DirentryBinds, &prefix, &probe, true)
+        .await
+        .expect("point lookup");
+    assert_eq!(rows.len(), 1, "exactly one bind row for the probed name");
+    assert_eq!(
+        store.metadata_sst_gets(),
+        1,
+        "inline filters reject the other runs without fetches, and the one \
+         admitted small segment loads whole with a single ranged GET"
+    );
+
+    // The same lookup against the same manifest with the inline copies
+    // stripped must return the same rows through fetched filter blocks —
+    // the inline copy is an accelerator, never an answer of its own.
+    let mut stripped_payload = tables.manifest().payload.clone();
+    stripped_payload.manifest_id = ManifestId(stripped_payload.manifest_id.0 + 1);
+    stripped_payload.manifest_object_id = ManifestObjectId::generate(stripped_payload.manifest_id);
+    for descriptor in &mut stripped_payload.metadata_files {
+        descriptor.filter_inline = None;
+    }
+    let stripped_object_id = stripped_payload.manifest_object_id.clone();
+    let stripped = NamespaceManifestEnvelope::from_payload("test-writer", stripped_payload)
+        .expect("stripped manifest envelope");
+    write_namespace_manifest(&store, &stripped)
+        .await
+        .expect("write stripped manifest");
+    let stripped_tables = load_verified_manifest_tables(&store, &namespace_id, &stripped_object_id)
+        .await
+        .expect("load stripped tables");
+    store.reset_metadata_sst_gets();
+    let stripped_rows = stripped_tables
+        .scan_prefix_for_lookup(ApiMetadataTableFamily::DirentryBinds, &prefix, &probe, true)
+        .await
+        .expect("point lookup without inline filters");
+    assert_eq!(stripped_rows, rows);
+    assert!(
+        store.metadata_sst_gets() > 1,
+        "without inline copies the ruled-out runs pay filter fetches"
+    );
+}
+
+#[tokio::test]
+async fn corrupt_inline_filter_fails_the_lookup() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write hello");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    let descriptor = tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| {
+            descriptor.family == ApiMetadataTableFamily::DirentryBinds
+                && descriptor.filter_inline.is_some()
+        })
+        .expect("inline-filtered direntry segment")
+        .clone();
+
+    // Flip one nibble of the inline copy: the handle's CRC no longer
+    // matches, so the read must fail instead of consulting corrupt bits.
+    let mut tampered = descriptor.clone();
+    let mut inline = tampered.filter_inline.take().expect("inline filter");
+    let flipped = if inline.ends_with('0') { '1' } else { '0' };
+    inline.pop();
+    inline.push(flipped);
+    tampered.filter_inline = Some(inline);
+
+    let memo = super::load::SessionBlockMemo::default();
+    super::load::load_segment_filter(&store, None, &memo, &descriptor)
+        .await
+        .expect("intact inline filter decodes");
+    let error = super::load::load_segment_filter(
+        &store,
+        None,
+        &super::load::SessionBlockMemo::default(),
+        &tampered,
+    )
+    .await
+    .expect_err("tampered inline filter must fail");
+    assert!(
+        matches!(error, ManifestLoadError::SegmentCodec { .. }),
+        "unexpected error: {error:?}"
     );
 }
 

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -11,7 +11,9 @@ use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
-use loonfs_api::{AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NamePolicy, RevisionNo};
+use loonfs_api::{
+    AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo,
+};
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
@@ -1204,6 +1206,212 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                 .max_by_key(|tombstone| (tombstone.tombstone_seq, tombstone.tombstone_delta_index));
             self.active_tombstone_cache
                 .insert(child_inode_id, active_tombstone);
+        }
+        Ok(())
+    }
+
+    /// Resolves `absolute_path` with the canonical visibility rules, after a
+    /// pipelined preload of the walk's storage lookups. The preload issues
+    /// each path node's independent probes (inode, tombstone, child-keyed
+    /// binding, previous binding's unbind fact) as one concurrent wave
+    /// alongside the next component's bound-child scan — the only lookup the
+    /// walk truly serializes on — and seeds the session's primitive caches
+    /// with exactly what those primitives would have fetched. The canonical
+    /// rules then decide over cache hits, so a cold resolution costs one
+    /// round-trip wave per path component instead of a strictly sequential
+    /// chain of five-plus lookups each.
+    pub(crate) async fn resolve_visible_path(
+        &mut self,
+        absolute_path: &AbsolutePath,
+        prefetch_leaf_revision: bool,
+    ) -> Result<ResolvedVisiblePath, CoreError> {
+        self.preload_path_walk(absolute_path, prefetch_leaf_revision)
+            .await?;
+        visibility::resolve_visible_path(self, absolute_path, self.base.name_policy()).await
+    }
+
+    /// The preload behind [`Self::resolve_visible_path`]: batches storage
+    /// probes and seeds primitive caches, decides nothing. Seeded values are
+    /// byte-identical to what the corresponding cache-miss paths compute, so
+    /// visibility decisions are unchanged; anything the preload skips (a
+    /// renamed child's foreign binding, an unbound name) falls back to the
+    /// ordinary per-key scans. Stops probing once a component has no bound
+    /// child or its binding is revoked — the canonical walk reports those.
+    async fn preload_path_walk(
+        &mut self,
+        absolute_path: &AbsolutePath,
+        prefetch_leaf_revision: bool,
+    ) -> Result<(), CoreError> {
+        let visible_seq = self.base.visible_seq();
+        let name_policy = self.base.name_policy();
+        let component_name_keys: Vec<String> = absolute_path
+            .components()
+            .iter()
+            .map(|component| {
+                NameKey::for_display_name(name_policy, &component.to_display_name())
+                    .as_str()
+                    .to_owned()
+            })
+            .collect();
+
+        let mut current_inode_id = InodeId(1);
+        let mut pending_binding: Option<DirentryBindRecord> = None;
+        for wave in 0..=component_name_keys.len() {
+            let lookup_name_key = component_name_keys.get(wave);
+            let is_leaf_wave = wave == component_name_keys.len();
+
+            let want_inode = !self.inode_at_seq_cache.contains_key(&current_inode_id);
+            let want_tombstone = !self.active_tombstone_cache.contains_key(&current_inode_id);
+            let want_parent_binding = !self
+                .latest_parent_binding_cache
+                .contains_key(&current_inode_id);
+            let arrived_by_binding = pending_binding.take();
+            let unbind_lookup = arrived_by_binding
+                .as_ref()
+                .filter(|binding| {
+                    !self
+                        .unbind_cache
+                        .contains_key(&BindingCacheKey::from(*binding))
+                })
+                .cloned();
+            let bound_child_lookup = lookup_name_key
+                .filter(|name_key| {
+                    !self.bound_child_cache.contains_key(&ParentNameCacheKey {
+                        parent_inode_id: current_inode_id,
+                        name_key: (*name_key).clone(),
+                    })
+                })
+                .cloned();
+            let want_revision = is_leaf_wave
+                && prefetch_leaf_revision
+                && !self
+                    .latest_revision_head_cache
+                    .contains_key(&current_inode_id);
+
+            let base = &self.base;
+            let (inode, tombstones, child_bindings, unbinds, bound_rows, revision) = futures::try_join!(
+                async {
+                    match want_inode {
+                        true => base.inode_at_seq(current_inode_id).await.map(Some),
+                        false => Ok(None),
+                    }
+                },
+                async {
+                    match want_tombstone {
+                        true => base.tombstones_for_root(current_inode_id).await.map(Some),
+                        false => Ok(None),
+                    }
+                },
+                async {
+                    match want_parent_binding {
+                        true => base
+                            .direntry_binds_for_child(current_inode_id)
+                            .await
+                            .map(Some),
+                        false => Ok(None),
+                    }
+                },
+                async {
+                    match &unbind_lookup {
+                        Some(binding) => base.direntry_unbinds_for_binding(binding).await.map(Some),
+                        None => Ok(None),
+                    }
+                },
+                async {
+                    match &bound_child_lookup {
+                        Some(name_key) => base
+                            .direntry_binds_for_parent_name(current_inode_id, name_key)
+                            .await
+                            .map(Some),
+                        None => Ok(None),
+                    }
+                },
+                async {
+                    match want_revision {
+                        true => base
+                            .latest_revision_record(current_inode_id)
+                            .await
+                            .map(Some),
+                        false => Ok(None),
+                    }
+                },
+            )?;
+
+            if let Some(inode) = inode {
+                self.inode_at_seq_cache.insert(current_inode_id, inode);
+            }
+            if let Some(tombstones) = tombstones {
+                let active = tombstones
+                    .into_iter()
+                    .filter(|tombstone| tombstone.tombstone_seq <= visible_seq)
+                    .max_by_key(|tombstone| {
+                        (tombstone.tombstone_seq, tombstone.tombstone_delta_index)
+                    });
+                self.active_tombstone_cache.insert(current_inode_id, active);
+            }
+            if let Some(bindings) = child_bindings {
+                let latest = bindings
+                    .into_iter()
+                    .filter(|direntry| direntry.bind_seq <= visible_seq)
+                    .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index));
+                self.latest_parent_binding_cache
+                    .insert(current_inode_id, latest);
+            }
+            if let Some(revision) = revision {
+                self.latest_revision_head_cache
+                    .insert(current_inode_id, revision);
+            }
+            if let Some(binding) = &arrived_by_binding {
+                let cache_key = BindingCacheKey::from(binding);
+                let unbound = match unbinds {
+                    Some(rows) => {
+                        let unbound = rows
+                            .into_iter()
+                            .any(|unbind| unbind.unbind_seq <= visible_seq);
+                        self.unbind_cache.insert(cache_key, unbound);
+                        unbound
+                    }
+                    None => self.unbind_cache.get(&cache_key).copied().unwrap_or(false),
+                };
+                if unbound {
+                    // The walk dead-ends at the previous component; probing
+                    // deeper would warm caches for nothing.
+                    break;
+                }
+            }
+
+            let Some(name_key) = lookup_name_key else {
+                break;
+            };
+            let bound = match bound_rows {
+                Some(rows) => {
+                    let latest = rows
+                        .into_iter()
+                        .filter(|direntry| direntry.bind_seq <= visible_seq)
+                        .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index));
+                    self.bound_child_cache.insert(
+                        ParentNameCacheKey {
+                            parent_inode_id: current_inode_id,
+                            name_key: name_key.clone(),
+                        },
+                        latest.clone(),
+                    );
+                    latest
+                }
+                None => self
+                    .bound_child_cache
+                    .get(&ParentNameCacheKey {
+                        parent_inode_id: current_inode_id,
+                        name_key: name_key.clone(),
+                    })
+                    .cloned()
+                    .flatten(),
+            };
+            let Some(binding) = bound else {
+                break;
+            };
+            current_inode_id = binding.child_inode_id;
+            pending_binding = Some(binding);
         }
         Ok(())
     }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -254,8 +254,13 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         absolute_path: &str,
     ) -> Result<AuthoritativePathEntry, CoreError> {
         let absolute_path = parse_absolute_path_for_core(absolute_path)?;
-        let resolved = self.resolve_visible_path(&absolute_path).await?;
-        self.build_authoritative_path_entry(&resolved).await
+        // One session serves the resolution and the entry build: the walk's
+        // preloaded probes (including the leaf's head revision) are exactly
+        // what the entry build reads back as cache hits.
+        let mut session = self.metadata_view().session();
+        let resolved = session.resolve_visible_path(&absolute_path, true).await?;
+        self.build_authoritative_path_entry_with_session(&mut session, &resolved)
+            .await
     }
 
     pub(crate) async fn read_file_bytes(
@@ -470,7 +475,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
 
         let absolute_path = parse_absolute_path_for_core(absolute_path)?;
         let mut session = self.metadata_view().session();
-        let resolved = self.resolve_visible_path(&absolute_path).await?;
+        let resolved = session.resolve_visible_path(&absolute_path, false).await?;
         if let Some(cursor) = request.cursor.as_ref() {
             validate_directory_cursor(cursor, &resolved)?;
         }
@@ -609,24 +614,6 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             items: entries,
             next_cursor,
         })
-    }
-
-    async fn resolve_visible_path(
-        &self,
-        absolute_path: &AbsolutePath,
-    ) -> Result<ResolvedVisiblePath, CoreError> {
-        self.metadata_view()
-            .resolve_visible_path(absolute_path)
-            .await
-    }
-
-    async fn build_authoritative_path_entry(
-        &self,
-        resolved: &ResolvedVisiblePath,
-    ) -> Result<AuthoritativePathEntry, CoreError> {
-        let mut session = self.metadata_view().session();
-        self.build_authoritative_path_entry_with_session(&mut session, resolved)
-            .await
     }
 
     /// `resolved` must come from visible resolution or enumeration at this

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -414,13 +414,12 @@ impl FsCore {
         )
     }
 
-    pub(crate) async fn runtime_read_context(
+    pub(crate) fn runtime_read_context(
         &self,
-        namespace_id: &NamespaceId,
         anchor: &CachedNamespaceAnchor,
-    ) -> Result<RuntimeReadContext> {
-        let catalog = self.load_namespace_catalog_cached(namespace_id).await?;
-        Ok(RuntimeReadContext {
+        catalog: Option<VerifiedNamespaceCatalogEntry>,
+    ) -> RuntimeReadContext {
+        RuntimeReadContext {
             head: anchor.head.state.clone(),
             head_etag: anchor.head.identity.etag.clone(),
             manifest_id: anchor.manifest_id,
@@ -428,12 +427,16 @@ impl FsCore {
             table_cache: Arc::clone(&self.inner.metadata_table_cache),
             tail_cache: Arc::clone(&self.inner.wal_tail_projection_cache),
             catalog,
-        })
+        }
     }
 
     /// The shared preamble of every pinned read: revalidate or load the head
     /// anchor, pin the read context to it, and hand back the engine. The
-    /// context's `head` is the anchor the read is pinned to.
+    /// context's `head` is the anchor the read is pinned to. The anchor and
+    /// the namespace's immutable catalog pair are independent objects, so a
+    /// cold read overlaps the two loads instead of paying the catalog's
+    /// descriptor chain as extra round-trips; the head's result is inspected
+    /// first so error reporting matches the serial order.
     pub(crate) async fn pinned_read(
         &self,
         namespace_id: &NamespaceId,
@@ -441,8 +444,12 @@ impl FsCore {
         loonfs_core::NamespaceEngine<crate::SharedObjectStore>,
         RuntimeReadContext,
     )> {
-        let head = self.head_for_metadata_read(namespace_id).await?;
-        let read_context = self.runtime_read_context(namespace_id, &head).await?;
+        let (head, catalog) = futures::join!(
+            self.head_for_metadata_read(namespace_id),
+            self.load_namespace_catalog_cached(namespace_id)
+        );
+        let head = head?;
+        let read_context = self.runtime_read_context(&head, catalog?);
         Ok((self.namespace_engine(namespace_id), read_context))
     }
 

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -1,0 +1,270 @@
+//! Pins the cold first-stat request shape: a fresh handle resolving a path
+//! over a manifest that carries several unfolded L0 runs must not pay a
+//! per-run filter fetch (the manifest's inline filter copies answer those),
+//! and every metadata-table object it does touch is small enough to load
+//! whole with a single ranged GET.
+//!
+//! This is the regression guard for the cold-stat latency cliff: the run
+//! count multiplying into filter-block round-trips on `DirentryBinds`
+//! lookups was the scale term, and dependent per-section GETs were the
+//! wave count.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use loonfs::{
+    CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
+};
+use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+type RecordedGet = (String, Option<(u64, u64)>);
+
+#[derive(Debug, Default)]
+struct RequestLog {
+    gets: Mutex<Vec<RecordedGet>>,
+}
+
+impl RequestLog {
+    fn record(&self, key: &str, range: Option<&ByteRange>) {
+        self.gets.lock().expect("request log lock poisoned").push((
+            key.to_owned(),
+            range.map(|range| (range.start_inclusive, range.end_exclusive)),
+        ));
+    }
+
+    fn take(&self) -> Vec<RecordedGet> {
+        std::mem::take(&mut *self.gets.lock().expect("request log lock poisoned"))
+    }
+}
+
+#[derive(Debug)]
+struct RecordingStore {
+    inner: LocalFsStore,
+    log: Arc<RequestLog>,
+}
+
+impl RecordingStore {
+    fn new(root: &Path, log: Arc<RequestLog>) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            log,
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for RecordingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.log.record(key, range.as_ref());
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.log.record(key, None);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> futures::stream::BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+#[tokio::test]
+async fn cold_stat_pays_no_per_run_filter_fetches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let log = Arc::new(RequestLog::default());
+    let store: loonfs::SharedObjectStore =
+        Arc::new(RecordingStore::new(temp_dir.path(), Arc::clone(&log)));
+    let namespace_id = NamespaceId::parse("coldstat").expect("valid namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("coldstat-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("coldstat-admin")
+        .build()
+        .await
+        .expect("build admin");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    // Three commit batches, checkpointed one L0 run each, with names
+    // interleaved by stride so every run's direntry key range straddles the
+    // whole directory span: range pruning alone cannot rule any run out of
+    // a name lookup, which is exactly the shape a bulk-loaded backlog takes.
+    const FILES: usize = 180;
+    const RUNS: usize = 3;
+    for run in 0..RUNS {
+        let mut candidates = Vec::new();
+        for index in (0..FILES).filter(|index| index % RUNS == run) {
+            let bytes = format!("body {index}");
+            let content_ref = loonfs_core::content::store_bytes_as_content(
+                &store,
+                &namespace_id,
+                bytes.as_bytes(),
+            )
+            .await
+            .expect("stage content")
+            .content_ref;
+            candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
+                loonfs::publish::PathMutationIntent::PutFile {
+                    commit_id: loonfs::CommitId::generate(),
+                    absolute_path: format!("/tree/dir-000000/file-{index:09}.txt"),
+                    content_ref,
+                    behavior: loonfs::PutBehavior::NoReplace,
+                },
+            ));
+        }
+        for outcome in writer
+            .publish_namespace_mutations_batch(&namespace_id, candidates)
+            .await
+        {
+            outcome.expect("publish batch member");
+        }
+        admin
+            .maintenance_tick_namespace(
+                &namespace_id,
+                MaintenanceTickOptions {
+                    max_wal_tail_segments: 1,
+                    ..MaintenanceTickOptions::default()
+                },
+            )
+            .await
+            .expect("tick");
+    }
+
+    // Confirm the manifest really carries several straddling L0 direntry
+    // runs with inline filters — the premise of the assertions below.
+    let root = loonfs_core::control::load_namespace_metadata_root_control(&store, &namespace_id)
+        .await
+        .expect("load metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read manifest")
+        .expect("manifest exists");
+    let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
+    let direntry_l0_runs: BTreeSet<_> = manifest
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            descriptor.level == 0 && format!("{:?}", descriptor.family) == "DirentryBinds"
+        })
+        .map(|descriptor| descriptor.run_seq)
+        .collect();
+    assert!(
+        direntry_l0_runs.len() >= RUNS,
+        "expected at least {RUNS} unfolded L0 direntry runs, found {}",
+        direntry_l0_runs.len()
+    );
+    assert!(
+        manifest
+            .payload
+            .metadata_files
+            .iter()
+            .filter(|descriptor| descriptor.level == 0)
+            .all(|descriptor| descriptor.filter_inline.is_some()),
+        "every L0 segment should carry an inline filter"
+    );
+    let filter_offsets: BTreeSet<(String, u64)> = manifest
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| {
+            (
+                descriptor.object_key.clone(),
+                descriptor.filter_block.offset,
+            )
+        })
+        .collect();
+    let table_keys: BTreeSet<String> = manifest
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+
+    // The measured operation: first stat on a fresh handle, nothing warm.
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    let _ = log.take();
+    let entry = reader
+        .stat_path(&namespace_id, "/tree/dir-000000/file-000000042.txt")
+        .await
+        .expect("cold stat");
+    assert_eq!(entry.display_name, "file-000000042.txt");
+    assert!(entry.revision_no.is_some(), "file stat carries a revision");
+
+    let gets = log.take();
+    let table_gets: Vec<&RecordedGet> = gets
+        .iter()
+        .filter(|(key, _)| table_keys.contains(key))
+        .collect();
+    assert!(!table_gets.is_empty(), "a cold stat reads metadata tables");
+    for (key, range) in &table_gets {
+        let start = range.map(|(start, _)| start);
+        assert!(
+            !filter_offsets.contains(&(key.clone(), start.unwrap_or(0))),
+            "cold stat fetched a filter block from `{key}`: inline copies \
+             and whole-object reads should answer every filter consultation"
+        );
+        assert_eq!(
+            start,
+            Some(0),
+            "small segments should load whole with one ranged GET, got a \
+             partial read of `{key}` at {start:?}"
+        );
+    }
+    // The wave budget: a handful of control-plane reads plus one
+    // whole-object read per touched segment. The exact count is pinned
+    // loosely so genuine wave regressions (per-run filter sweeps, split
+    // filter/index/data fetches) trip it while block-size tuning does not.
+    assert!(
+        gets.len() <= 16,
+        "cold stat issued {} GETs; expected a bounded, near-flat set: {:?}",
+        gets.len(),
+        gets
+    );
+}

--- a/docs/design/metadata-block-storage.md
+++ b/docs/design/metadata-block-storage.md
@@ -52,6 +52,11 @@ A lookup touches a segment in this order, stopping as early as it can:
 1. Key range in the descriptor — free, already in the manifest.
 2. Filter block — a bloom filter over each row's lookup key. It answers
    "definitely not here" (skip the whole segment) or "maybe" (continue).
+   Small delta-run segments inline the filter's bytes in their manifest
+   descriptor, making this step free for exactly the segments an
+   unfolded delta backlog multiplies: delta-run key ranges overlap on
+   parent-keyed families, so without the inline copy every run would
+   cost one filter fetch just to be ruled out.
 3. Index block — one binary search names the data blocks that can hold
    the key.
 4. Data blocks — one ranged GET per contiguous stretch of needed
@@ -61,7 +66,10 @@ Index, filter, and data blocks are cached decoded, under a byte budget.
 Scans and clustered lookups read some blocks ahead of what they
 strictly need: on an object store a request costs more than a few dozen
 extra kilobytes, so trading bytes for fewer round trips is the right
-side of the exchange.
+side of the exchange. Cold lookups make the same trade across sections:
+a filter fetch pulls the adjacent index block in the same ranged GET,
+and a segment whose whole object costs less to transfer than a second
+round trip is fetched once and decoded section by section.
 
 ## Checkpoints and reorganization
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1164,10 +1164,17 @@ descriptor for the index and filter — so a reader verifies every ranged read
 before decoding it, and the manifest transitively binds the object's exact
 bytes. The descriptor also records a whole-object `sha256` digest for
 publication conflict checks and offline verification; the read path never
-consults it. Readers reject out-of-order rows, out-of-order index entries,
-and checksum failures as malformed. The segment format is versioned by the
-manifest that references it (`namespace_manifest` `format_version`), since a
-segment is unreachable except through a manifest.
+consults it. When the filter block is small (delta-run segments), the
+descriptor additionally inlines the filter's stored bytes as lowercase hex
+(`filter_inline`), so a point lookup can rule the segment out without any
+object fetch. The inline copy is bound by the same filter handle — it must
+decode against the handle's stored length and CRC32C exactly like a fetched
+block, and a mismatch is corruption — and it is additive within manifest
+format version 1: readers ignore the field when absent (or unknown) and
+fetch the filter block by its handle. Readers reject out-of-order rows,
+out-of-order index entries, and checksum failures as malformed. The segment
+format is versioned by the manifest that references it (`namespace_manifest`
+`format_version`), since a segment is unreachable except through a manifest.
 
 ### 4.3 Evolution rules
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1169,9 +1169,12 @@ descriptor additionally inlines the filter's stored bytes as lowercase hex
 (`filter_inline`), so a point lookup can rule the segment out without any
 object fetch. The inline copy is bound by the same filter handle — it must
 decode against the handle's stored length and CRC32C exactly like a fetched
-block, and a mismatch is corruption — and it is additive within manifest
-format version 1: readers ignore the field when absent (or unknown) and
-fetch the filter block by its handle. Readers reject out-of-order rows,
+block, and a mismatch is corruption. When the field is absent (large
+filters are not inlined), readers fetch the filter block by its handle. The
+filter block sits directly before the index block at the end of the object;
+manifest loading rejects a descriptor whose handles disagree with that
+layout, or whose inline copy's length disagrees with its handle, so the
+read path assumes both. Readers reject out-of-order rows,
 out-of-order index entries, and checksum failures as malformed. The segment
 format is versioned by the manifest that references it (`namespace_manifest`
 `format_version`), since a segment is unreachable except through a manifest.


### PR DESCRIPTION
A cold first stat (the first `stat_path` on a fresh handle) regressed from a scale-flat ~1.3s to 1.9s at 10k nodes and 3.1s at 100k (S3, release). The lab analysis (`loonfs_lab/analysis/cold-first-stat-regression-20260710.md`) traced it to two compounding effects of the block-storage stack. First, the walk was one long serial chain: each path component ran its family lookups strictly one after another, and each lookup was itself a filter fetch, then an index fetch, then a data fetch — dependent round-trips all the way down, with almost no overlap left (2,524ms of store time under 1,878ms of wall). Second, a scale term: direntry lookups are keyed by parent id, so the key ranges of unfolded delta runs all cover the probed parent and range pruning cannot rule any of them out. Every run then cost one filter-block fetch just to be rejected, and a bulk-loaded dataset carries an unfolded backlog that grows with size.

Three changes, in the order they matter:

1. Small segments inline their bloom filter's bytes in the manifest descriptor (`filter_inline`, hex). A point lookup now rules delta runs out without touching the object at all. The inline copy still decodes against the filter handle's stored length and CRC32C, so a mismatch is corruption, not a silent fallback. The field is absent only for large filters, which read through their handle; there is no compatibility fallback beyond that — manifest loading rejects a descriptor whose filter block does not directly precede the index block, or whose inline copy's length disagrees with its handle, so the read path assumes the one frozen layout instead of tolerating others with slower fetches.
2. Path resolution (stat, and the resolve step of listings) runs over the caching session view, preceded by a preload that issues each component's independent lookups — inode, tombstone, child bindings, the previous binding's unbind fact, and the leaf's head revision — as one concurrent wave, pipelined with the next component's bound-child scan, the only lookup the walk truly serializes on. The canonical visibility rules then decide over cache hits; the preload seeds exactly what the primitives' miss paths would have fetched, so decisions cannot change.
3. Fewer dependent fetches inside one lookup: a filter fetch pulls the adjacent index block in the same ranged GET, a segment of 128 KiB or less is fetched whole and decoded section by section, and the read preamble loads the namespace catalog pair concurrently with the head anchor instead of before it.

Measured on the lab (S3 us-east-2, release, single iterations):

| | main `04754d6b` | this branch | pre-stack `6eaf12ce` |
|---|---:|---:|---:|
| 10k cold first stat | 1,878 ms / 32 GETs | 967 ms / 22 GETs | 904 ms / 22 GETs |
| 10k cold first list | 2,685 ms / 16 GETs | 1,628 ms / 5 GETs | 4,133 ms / 35 GETs |
| 10k warm stat | 27.8 ms | 31.1 ms | 170 ms |
| 100k cold first stat | 3,129 ms | 1,138 ms / 19 GETs | — |
| 100k warm stat | 170.0 ms | 125.5 ms | — |

Cold stat is scale-flat again: 967 ms at 10k against 1,138 ms at 100k, with the request count flat (22 against 19). The June scale-flat era sat at ~1.3s for both sizes. Nothing regressed at either scale — 100k cold list went 91.3s to 85.1s, warm full list 94.8s to 88.8s, warm read 176.8 ms to 71.8 ms, and total cold-boot bytes stayed flat. Runs `20260710T135446Z` (10k) and `20260710T135924Z` (100k) against `20260710T125405Z`, `20260710T125846Z`, and `20260710T023457Z`.

New tests pin the request shape and the strictness: point lookups over straddling delta runs pay no per-run filter fetches and load the one admitted small segment whole (checkpoint tests), a tampered inline filter fails the lookup instead of consulting corrupt bits, a manifest whose descriptors break the frozen layout is rejected at load, and a cold-stat integration test holds the whole operation to a bounded set of whole-object GETs with zero filter-block reads.
