### PR TITLE
perf(core): derive the scan-order run list once per verified manifest

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,3 +1,4 @@
+use super::runs::MetadataRunManifest;
 use crate::metadata::MetadataState;
 use loonfs_api::wire::manifest::{MetadataRow, NamespaceManifestEnvelope};
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
@@ -115,6 +116,10 @@ pub(super) enum DecodedMetadataTableBlock {
     },
     Manifest {
         manifest: Arc<NamespaceManifestEnvelope>,
+        /// The manifest's `metadata_files` regrouped into scan-order runs,
+        /// derived once when the envelope is validated. Scans walk this list
+        /// on every page; regrouping it per scan dominated warm-read CPU.
+        scan_runs: Arc<Vec<MetadataRunManifest>>,
         decoded_byte_len: usize,
     },
 }

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -15,7 +15,7 @@ use super::cache::{
 use super::error::ManifestLoadError;
 #[cfg(test)]
 use super::row::manifest_row_kind;
-use super::runs::runs_in_materialization_order;
+use super::runs::{runs_in_materialization_order, runs_in_scan_order};
 #[cfg(test)]
 use super::runs::{MetadataTableManifest, MAX_MAINTENANCE_TABLE_IO};
 #[cfg(test)]
@@ -181,9 +181,13 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         )?;
         validate_manifest_materialization_ranges(&manifest_key, &manifest.payload)?;
         validate_manifest_table_descriptors(&manifest_key, &manifest)?;
+        let scan_runs = Arc::new(runs_in_scan_order(&manifest.payload));
         Ok(DecodedMetadataTableBlock::Manifest {
             manifest: Arc::new(manifest),
-            decoded_byte_len: manifest_bytes.len(),
+            scan_runs,
+            // The entry retains the envelope plus its regrouped descriptor
+            // list, which clones every metadata file ref once.
+            decoded_byte_len: manifest_bytes.len().saturating_mul(2),
         })
     };
     let decoded = match table_cache {
@@ -197,8 +201,12 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         }
         None => fetch().await?,
     };
-    let manifest = match decoded {
-        DecodedMetadataTableBlock::Manifest { manifest, .. } => manifest,
+    let (manifest, scan_runs) = match decoded {
+        DecodedMetadataTableBlock::Manifest {
+            manifest,
+            scan_runs,
+            ..
+        } => (manifest, scan_runs),
         DecodedMetadataTableBlock::Index { .. }
         | DecodedMetadataTableBlock::Filter { .. }
         | DecodedMetadataTableBlock::Data { .. } => {
@@ -213,6 +221,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         table_cache,
         manifest_object_key: manifest_key,
         manifest,
+        scan_runs,
         block_memo: SessionBlockMemo::default(),
     };
     Ok(tables)

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -6,7 +6,7 @@ use super::error::ManifestLoadError;
 use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SessionBlockMemo,
 };
-use super::runs::{runs_in_scan_order, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
+use super::runs::{MetadataRunManifest, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
 use crate::metadata::MetadataState;
 use futures::future::try_join_all;
@@ -35,6 +35,10 @@ pub(crate) struct VerifiedMetadataTables<'a, S: ObjectStore + ?Sized> {
     pub(super) table_cache: Option<&'a MetadataTableCache>,
     pub(super) manifest_object_key: String,
     pub(super) manifest: Arc<NamespaceManifestEnvelope>,
+    /// The manifest's runs in scan order, derived once at load validation
+    /// and shared through the manifest cache entry. A run list is immutable
+    /// per manifest object; scans must not regroup it per page.
+    pub(super) scan_runs: Arc<Vec<MetadataRunManifest>>,
     /// Per-view memo of decoded blocks: one operation never re-fetches a
     /// block it already saw, with or without a shared cache attached.
     pub(super) block_memo: SessionBlockMemo,
@@ -181,9 +185,8 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        let runs = runs_in_scan_order(&self.manifest.payload);
         let mut candidates = Vec::new();
-        for run in &runs {
+        for run in self.scan_runs.iter() {
             let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
             candidates.extend(table.segments.iter().filter(|descriptor| {
                 descriptor_may_intersect_range(descriptor, lower_bound, upper_bound)

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -19,9 +19,9 @@ use super::record::read_checkpoint_record;
 use super::retention::advance_retention_floor;
 use super::row::{manifest_rows_for_family, metadata_states_equivalent};
 use super::runs::{
-    flatten_manifest_tables, runs_from_metadata_files, MetadataLsmPolicy, MetadataRunManifest,
-    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, CHECKPOINT_TABLE_FAMILIES,
-    DEFAULT_MAX_CHECKPOINT_L0_RUNS,
+    flatten_manifest_tables, runs_from_metadata_files, runs_in_scan_order, MetadataLsmPolicy,
+    MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
+    CHECKPOINT_TABLE_FAMILIES, DEFAULT_MAX_CHECKPOINT_L0_RUNS,
 };
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
@@ -58,7 +58,7 @@ use loonfs_objectstore::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
 #[derive(Debug)]
@@ -2370,6 +2370,72 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     assert_eq!(
         paired_fetches, solo_fetches,
         "concurrent scans over one shared cache should share one fetch per segment"
+    );
+}
+
+#[tokio::test]
+async fn cached_manifest_carries_its_scan_order_runs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..4 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create first checkpoint");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/tail.txt",
+        b"tail\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write tail file");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create second checkpoint");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+
+    let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let first = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load first tables");
+    let second = super::load_verified_manifest_tables_with_cache(
+        &store,
+        Some(&cache),
+        &namespace_id,
+        &manifest_object_id,
+    )
+    .await
+    .expect("load second tables");
+
+    assert!(
+        first.scan_runs.len() >= 2,
+        "two checkpoints should leave more than one run to order"
+    );
+    assert_eq!(
+        *first.scan_runs,
+        runs_in_scan_order(&first.manifest().payload),
+        "the cached run list must equal the manifest's scan-order grouping"
+    );
+    assert!(
+        Arc::ptr_eq(&first.scan_runs, &second.scan_runs),
+        "views over one cached manifest should share one derived run list"
     );
 }
 


### PR DESCRIPTION
Every row scan rebuilt the manifest's run grouping from the flat `metadata_files` list: `scan_range_page_rows` called `runs_in_scan_order` on each invocation, so every point lookup and every list page re-bucketed and re-cloned every table descriptor (several string allocations each) and dropped the result when the scan returned. On warm reads this was the dominant CPU cost: sampling the lab simulation showed most of the process inside `runs_from_metadata_files`, and per-step cost grew with namespace size because the rebuild is proportional to descriptor count.

The run list is immutable per manifest object, so it is now derived once, when the envelope is fetched and validated, and cached alongside it: the manifest's cache entry carries the scan-order runs behind a shared pointer, `VerifiedMetadataTables` holds that pointer, and scans iterate it in place. The entry's cache weight doubles to account for the retained descriptor clones.

Measured on the lab simulation (fixed seed, release): 200/400/800 steps went from 7.8s/35.7s/233.9s to 7.1s/19.8s/91.3s, and the regroup symbols no longer appear in a 30-second CPU sample. On the s3-10k bench, warm stat halved (92.6ms to 40.8ms). Warm full list on S3 is unchanged, as expected: request and cache counters are identical on both sides (60 gets and the same hit/miss counts at 10k, about 737 gets at 100k), so that path's wall time is fetch-bound, not regroup-bound.

New test pins the contract: two views loaded through one cache share a single derived run list, and it equals a fresh regroup of the manifest.