### PR TITLE
perf(core): borrow scan rows from shared decoded blocks instead of cloning per scan

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,6 +1,6 @@
 use super::runs::MetadataRunManifest;
 use crate::metadata::MetadataState;
-use loonfs_api::wire::manifest::{MetadataRow, NamespaceManifestEnvelope};
+use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
@@ -59,41 +59,6 @@ pub(super) struct MetadataTableCacheKey {
     pub(super) identity: String,
     pub(super) block_kind: MetadataTableBlockKind,
     pub(super) block_offset: u64,
-}
-
-/// One segment's decoded rows with their stored row keys, assembled per
-/// call from the decoded blocks a range read touched.
-#[derive(Debug)]
-pub(super) struct DecodedSegmentRowSet {
-    pub(super) rows: Vec<MetadataRow>,
-    /// Stored row keys, parallel to `rows`, validated against
-    /// `row_key_for_family` and for ascending order at decode — a format
-    /// requirement — so scans never recompute keys and always binary-search.
-    pub(super) row_keys: Vec<String>,
-}
-
-impl DecodedSegmentRowSet {
-    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order,
-    /// found by binary search over the decode-validated key order. Express a
-    /// prefix scan as `[prefix, string_prefix_upper_bound(prefix))`.
-    pub(super) fn rows_in_key_range<'a>(
-        &'a self,
-        lower_bound: &'a str,
-        upper_bound: Option<&'a str>,
-    ) -> impl Iterator<Item = (&'a str, &'a MetadataRow)> + 'a {
-        let start = self
-            .row_keys
-            .partition_point(|key| key.as_str() < lower_bound);
-        let end = upper_bound.map_or(self.row_keys.len(), |upper_bound| {
-            self.row_keys
-                .partition_point(|key| key.as_str() < upper_bound)
-        });
-        let range = start..end.max(start);
-        self.row_keys[range.clone()]
-            .iter()
-            .zip(&self.rows[range])
-            .map(|(key, row)| (key.as_str(), row))
-    }
 }
 
 /// One decoded, verified object the cache holds: a CRC-checked segment

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -9,8 +9,7 @@
 //! Full-row inspection materialization exists only for tests.
 
 use super::cache::{
-    DecodedMetadataTableBlock, DecodedSegmentRowSet, MetadataTableBlockKind, MetadataTableCache,
-    MetadataTableCacheKey,
+    DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
 };
 use super::error::ManifestLoadError;
 #[cfg(test)]
@@ -489,27 +488,23 @@ where
         }
 
         for (descriptor, row_set) in descriptors.into_iter().zip(loaded_segments) {
+            let rows: Vec<MetadataRow> = row_set.rows().cloned().collect();
             match table.family {
                 MetadataTableFamily::DirentryBinds => {
-                    direntry_bind_rows.extend(row_set.rows.iter().cloned());
+                    direntry_bind_rows.extend(rows.iter().cloned());
                 }
                 MetadataTableFamily::DirentryChildBinds => {
-                    direntry_child_bind_rows.extend(row_set.rows.iter().cloned());
+                    direntry_child_bind_rows.extend(rows.iter().cloned());
                 }
                 MetadataTableFamily::Revisions => {
-                    revision_rows.extend(row_set.rows.iter().cloned());
+                    revision_rows.extend(rows.iter().cloned());
                 }
                 MetadataTableFamily::RevisionsByInodeDesc => {
-                    revision_by_inode_desc_rows.extend(row_set.rows.iter().cloned());
+                    revision_by_inode_desc_rows.extend(rows.iter().cloned());
                 }
                 _ => {}
             }
-            append_rows_to_metadata(
-                metadata_state,
-                table.family,
-                &descriptor.object_key,
-                &row_set.rows,
-            )?;
+            append_rows_to_metadata(metadata_state, table.family, &descriptor.object_key, &rows)?;
         }
     }
 
@@ -530,8 +525,54 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     store: &S,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
+) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
     load_manifest_segment_rows_with_cache(store, None, family, descriptor).await
+}
+
+/// The data blocks of one segment that can hold keys in
+/// `[lower_bound, upper_bound)`, shared straight from the decoded-block
+/// memo and caches. Row access borrows from the blocks: assembling an owned
+/// row set here re-cloned every row and key of every touched block on every
+/// scan, which dominated warm-read CPU.
+pub(crate) struct SegmentKeyRangeBlocks {
+    blocks: Vec<Arc<DecodedDataBlock>>,
+}
+
+impl SegmentKeyRangeBlocks {
+    /// Rows whose keys fall in `[lower_bound, upper_bound)`, in row order,
+    /// found by binary search over each block's decode-validated key order.
+    /// Express a prefix scan as `[prefix, string_prefix_upper_bound(prefix))`.
+    pub(super) fn rows_in_key_range<'a>(
+        &'a self,
+        lower_bound: &'a str,
+        upper_bound: Option<&'a str>,
+    ) -> impl Iterator<Item = (&'a str, &'a MetadataRow)> + 'a {
+        self.blocks.iter().flat_map(move |block| {
+            let start = block
+                .row_keys
+                .partition_point(|key| key.as_str() < lower_bound);
+            let end = upper_bound.map_or(block.row_keys.len(), |upper_bound| {
+                block
+                    .row_keys
+                    .partition_point(|key| key.as_str() < upper_bound)
+            });
+            let range = start..end.max(start);
+            block.row_keys[range.clone()]
+                .iter()
+                .zip(&block.rows[range])
+                .map(|(key, row)| (key.as_str(), row))
+        })
+    }
+
+    #[cfg(test)]
+    fn rows(&self) -> impl Iterator<Item = &MetadataRow> {
+        self.blocks.iter().flat_map(|block| block.rows.iter())
+    }
+
+    #[cfg(test)]
+    fn row_keys(&self) -> impl Iterator<Item = &String> {
+        self.blocks.iter().flat_map(|block| block.row_keys.iter())
+    }
 }
 
 /// Per-view memo of decoded blocks, so one operation never re-fetches or
@@ -581,7 +622,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
     table_cache: Option<&MetadataTableCache>,
     family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
-) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
+) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
     let row_set = load_manifest_segment_rows_in_key_range_with_cache(
         store,
         table_cache,
@@ -593,17 +634,17 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
         false,
     )
     .await?;
-    if row_set.rows.len() as u64 != descriptor.row_count {
+    let row_count = row_set.rows().count();
+    if row_count as u64 != descriptor.row_count {
         return Err(ManifestLoadError::SegmentDescriptorMismatch {
             object_key: descriptor.object_key.clone(),
             message: format!(
-                "row count mismatch: expected {}, actual {}",
+                "row count mismatch: expected {}, actual {row_count}",
                 descriptor.row_count,
-                row_set.rows.len()
             ),
         });
     }
-    if let (Some(first), Some(last)) = (row_set.row_keys.first(), row_set.row_keys.last()) {
+    if let (Some(first), Some(last)) = (row_set.row_keys().next(), row_set.row_keys().last()) {
         if descriptor.min_key != *first || descriptor.max_key != *last {
             return Err(ManifestLoadError::SegmentDescriptorMismatch {
                 object_key: descriptor.object_key.clone(),
@@ -617,7 +658,7 @@ pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Size
 /// Loads the rows of one segment whose keys can fall in
 /// `[lower_bound, upper_bound)`: index first, then only the data blocks the
 /// index says can match. Callers trim edge blocks with
-/// [`DecodedSegmentRowSet::rows_in_key_range`].
+/// [`SegmentKeyRangeBlocks::rows_in_key_range`].
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
@@ -628,7 +669,7 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     lower_bound: &str,
     upper_bound: Option<&str>,
     readahead: bool,
-) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
+) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
     let index = load_segment_index(store, table_cache, memo, descriptor).await?;
     let needed = index_blocks_for_key_range(&index, lower_bound, upper_bound);
 
@@ -656,14 +697,12 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
     .take(needed.len())
     .collect();
 
-    let mut rows = Vec::new();
-    let mut row_keys = Vec::new();
-    for block in blocks {
-        row_keys.extend(block.row_keys.iter().cloned());
-        rows.extend(block.rows.iter().cloned());
-    }
-    validate_manifest_row_seq_range(&descriptor.object_key, &rows, descriptor.run_seq)?;
-    Ok(Arc::new(DecodedSegmentRowSet { rows, row_keys }))
+    validate_manifest_row_seq_range(
+        &descriptor.object_key,
+        blocks.iter().flat_map(|block| block.rows.iter()),
+        descriptor.run_seq,
+    )?;
+    Ok(SegmentKeyRangeBlocks { blocks })
 }
 
 fn segment_block_cache_key(
@@ -1037,15 +1076,17 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     entries: &[SegmentIndexEntry],
 ) -> Result<Vec<Arc<DecodedDataBlock>>, ManifestLoadError> {
     let mut blocks: Vec<Option<Arc<DecodedDataBlock>>> = vec![None; entries.len()];
+    // One probe key reused across the span: a fresh key per block would
+    // clone the segment checksum once per block on every warm scan.
+    let mut probe_key = segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, 0);
     for (position, entry) in entries.iter().enumerate() {
-        let cache_key =
-            segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, entry.block.offset);
-        if let Some(DecodedMetadataTableBlock::Data { block, .. }) = memo.get(&cache_key) {
+        probe_key.block_offset = entry.block.offset;
+        if let Some(DecodedMetadataTableBlock::Data { block, .. }) = memo.get(&probe_key) {
             blocks[position] = Some(block);
             continue;
         }
         if let Some(cache) = table_cache {
-            if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&cache_key) {
+            if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&probe_key) {
                 blocks[position] = Some(block);
             }
         }

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -1,10 +1,11 @@
 //! Verified row scans over a loaded manifest's tables, with per-segment
 //! caching and prefix-window pruning.
 
-use super::cache::{DecodedSegmentRowSet, MetadataTableCache};
+use super::cache::MetadataTableCache;
 use super::error::ManifestLoadError;
 use super::load::{
-    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SessionBlockMemo,
+    load_manifest_segment_rows_in_key_range_with_cache, load_segment_filter, SegmentKeyRangeBlocks,
+    SessionBlockMemo,
 };
 use super::runs::{MetadataRunManifest, MetadataTableManifest, CHECKPOINT_TABLE_FAMILIES};
 #[cfg(test)]
@@ -55,11 +56,14 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         key: &str,
         filter_probe: &str,
     ) -> Result<Option<MetadataRow>, ManifestLoadError> {
+        // Matching on the stored row key: the scan already selected the rows
+        // by that key, and recomputing keys from rows allocates per row.
         Ok(self
             .scan_prefix_rows(family, key, Some(filter_probe), true)
             .await?
             .into_iter()
-            .find(|row| row.row_key_for_family(family) == key))
+            .find(|(row_key, _)| row_key == key)
+            .map(|(_, row)| row))
     }
 
     pub(crate) async fn scan_prefix(
@@ -67,7 +71,9 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         family: MetadataTableFamily,
         prefix: &str,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        self.scan_prefix_rows(family, prefix, None, true).await
+        Ok(strip_row_keys(
+            self.scan_prefix_rows(family, prefix, None, true).await?,
+        ))
     }
 
     /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
@@ -82,8 +88,10 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: &str,
         readahead: bool,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        self.scan_prefix_rows(family, prefix, Some(filter_probe), readahead)
-            .await
+        Ok(strip_row_keys(
+            self.scan_prefix_rows(family, prefix, Some(filter_probe), readahead)
+                .await?,
+        ))
     }
 
     pub(crate) async fn scan_range_page(
@@ -93,6 +101,22 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         upper_bound: Option<&str>,
         limit: usize,
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        Ok(strip_row_keys(
+            self.scan_range_page_with_keys(family, lower_bound, upper_bound, limit)
+                .await?,
+        ))
+    }
+
+    /// [`Self::scan_range_page`], returning each row with its stored row
+    /// key, for callers that page by row key and would otherwise recompute
+    /// every key from its row.
+    pub(crate) async fn scan_range_page_with_keys(
+        &self,
+        family: MetadataTableFamily,
+        lower_bound: &str,
+        upper_bound: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -113,15 +137,17 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        self.scan_range_page_rows(
-            family,
-            lower_bound,
-            upper_bound,
-            limit,
-            Some(filter_probe),
-            true,
-        )
-        .await
+        Ok(strip_row_keys(
+            self.scan_range_page_rows(
+                family,
+                lower_bound,
+                upper_bound,
+                limit,
+                Some(filter_probe),
+                true,
+            )
+            .await?,
+        ))
     }
 
     /// A prefix scan is a range scan over `[prefix, upper_bound(prefix))`
@@ -132,7 +158,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         prefix: &str,
         filter_probe: Option<&str>,
         readahead: bool,
-    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let upper_bound = string_prefix_upper_bound(prefix);
         self.scan_range_page_rows(
             family,
@@ -184,7 +210,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         limit: usize,
         filter_probe: Option<&str>,
         readahead: bool,
-    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let mut candidates = Vec::new();
         for run in self.scan_runs.iter() {
             let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
@@ -229,9 +255,14 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
             for segment_rows in loaded_segments {
                 let matched_before = rows.len();
+                // Rows are ascending within a segment, so a row past the
+                // segment's first `limit` matches can never survive the
+                // merged truncation below; stopping there bounds how many
+                // rows a page clones out of the shared blocks.
                 rows.extend(
                     segment_rows
                         .rows_in_key_range(lower_bound, upper_bound)
+                        .take(limit)
                         .map(|(row_key, row)| (row_key.to_owned(), row.clone())),
                 );
                 if filter_probe.is_some() {
@@ -242,7 +273,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
 
         rows.truncate(limit);
-        Ok(rows.into_iter().map(|(_, row)| row).collect())
+        Ok(rows)
     }
 
     /// Drops the descriptors whose bloom filter rules the probe out; with no
@@ -281,7 +312,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         lower_bound: &str,
         upper_bound: Option<&str>,
         readahead: bool,
-    ) -> Result<Arc<DecodedSegmentRowSet>, ManifestLoadError> {
+    ) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
         load_manifest_segment_rows_in_key_range_with_cache(
             self.store,
             self.table_cache,
@@ -294,6 +325,10 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         )
         .await
     }
+}
+
+fn strip_row_keys(rows: Vec<(String, MetadataRow)>) -> Vec<MetadataRow> {
+    rows.into_iter().map(|(_, row)| row).collect()
 }
 
 pub(super) fn ordered_manifest_tables<'a>(

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -135,12 +135,12 @@ pub(super) fn validate_manifest_materialization_ranges(
     Ok(())
 }
 
-pub(super) fn validate_manifest_row_seq_range(
+pub(super) fn validate_manifest_row_seq_range<'a>(
     object_key: &str,
-    rows: &[MetadataRow],
+    rows: impl IntoIterator<Item = &'a MetadataRow>,
     max_seq: ChangeSeq,
 ) -> Result<(), ManifestLoadError> {
-    for (row_index, row) in rows.iter().enumerate() {
+    for (row_index, row) in rows.into_iter().enumerate() {
         let row_seq = manifest_row_commit_seq(row);
         if row_seq > max_seq {
             return Err(ManifestLoadError::SegmentDescriptorMismatch {

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -11,7 +11,7 @@ use crate::metadata::{
     InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::lookup_keys;
-use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::MetadataTableFamily;
 use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
 use loonfs_objectstore::ObjectStore;
 
@@ -68,7 +68,7 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
     };
     let upper_bound = string_prefix_upper_bound(&parent_prefix);
     Ok(tables
-        .scan_range_page(
+        .scan_range_page_with_keys(
             MetadataTableFamily::DirentryBinds,
             &lower_bound,
             upper_bound.as_deref(),
@@ -77,7 +77,10 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_candidate_from_manifest_row)
+        .filter_map(|(row_key, row)| {
+            direntry_bind_from_manifest_row(row)
+                .map(|record| ManifestDirentryBindCandidate { row_key, record })
+        })
         .collect())
 }
 
@@ -314,14 +317,6 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
         .into_iter()
         .filter_map(commit_receipt_from_manifest_row)
         .max_by_key(|receipt| receipt.committed_seq))
-}
-
-fn direntry_bind_candidate_from_manifest_row(
-    row: MetadataRow,
-) -> Option<ManifestDirentryBindCandidate> {
-    let row_key = row.row_key_for_family(MetadataTableFamily::DirentryBinds);
-    direntry_bind_from_manifest_row(row)
-        .map(|record| ManifestDirentryBindCandidate { row_key, record })
 }
 
 fn resume_after_row_key(row_key: &str) -> String {


### PR DESCRIPTION
Warm scans were still allocation-bound after #244: the segment loader assembled a fresh owned row set on every scan call, cloning every row and every row key of every block the range touched, even when every block was already sitting in the per-view memo or shared cache, and the scan then cloned the in-range rows a second time into its result. Point lookups amplified this: they run with readahead, so each probe built a cache key per block across a span of up to 32 blocks (cloning the segment checksum string each time), and `get_for_lookup` recomputed each candidate's row key (a format call plus hex encoding) just to compare it against the probe.

Scans now borrow the decoded blocks instead. The loader returns the blocks behind their existing shared pointers (`SegmentKeyRangeBlocks`), row access binary-searches each block in place, and only the rows a page actually returns are cloned, capped at the page limit per segment (rows ascend within a segment, so a row past the segment's first `limit` matches can never survive the merged truncation). The per-segment seq-range validation walks the same borrowed rows instead of requiring an owned copy. One probe key is reused across a block span, exact-match lookups compare the stored row key the scan already selected by, and the directory list page takes stored keys from the scan instead of recomputing one per child row.

Measured on the lab simulation (fixed seed, release, on top of #244): 400/800 steps went from 19.8s/91.3s to 14.5s/41.6s, and growth per doubling of steps dropped from 4.6x to 2.9x. In a 30-second CPU sample of the run's tail, `String::clone` fell from 581 samples to 33 and the formatting frames left the top of the profile; the remaining hot frames are the simulation harness's own fsync-per-put and content hashing, not metadata-read CPU.