### PR TITLE
fix(loonfs): shut down background work atomically with task registration, rename close to shutdown_background

### DIFF
--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -327,7 +327,10 @@ async fn serve_on(
     // The listener has drained; settle writer-owned maintenance so a
     // checkpoint tick in flight is not torn down mid-write-set. Panicked
     // ticks surface here rather than disappearing with the process.
-    writer.close().await.map_err(ServeError::Shutdown)
+    writer
+        .shutdown_background()
+        .await
+        .map_err(ServeError::Shutdown)
 }
 
 /// Resolves on ctrl-c or, on unix, SIGTERM — the stop signal container

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -44,6 +44,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file = reader.read_file_bytes(&namespace_id, "/hello.txt").await?;
     println!("{}", String::from_utf8_lossy(&file.bytes));
 
-    writer.close().await?;
+    writer.shutdown_background().await?;
     Ok(())
 }

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -8,7 +8,6 @@
 use crate::{NamespaceId, Result, RuntimeError};
 use std::collections::BTreeSet;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -37,9 +36,17 @@ pub(crate) struct BackgroundWork {
     /// they were opened on; `None` resolves the runtime driving the
     /// triggering write at spawn time.
     runtime: Option<tokio::runtime::Handle>,
-    closed: AtomicBool,
-    inflight: Mutex<BTreeSet<NamespaceId>>,
-    tasks: Mutex<Vec<JoinHandle<()>>>,
+    state: Mutex<BackgroundState>,
+}
+
+/// One lock over the shutdown flag, the singleflight claims, and the task
+/// registry. Registration checks the flag inside the same critical section,
+/// so a shutdown that drained an empty registry can never race a spawn into
+/// running unobserved (claimed before shutdown, registered after the drain).
+struct BackgroundState {
+    closed: bool,
+    inflight: BTreeSet<NamespaceId>,
+    tasks: Vec<JoinHandle<()>>,
 }
 
 impl BackgroundWork {
@@ -47,41 +54,43 @@ impl BackgroundWork {
         Self {
             policy,
             runtime,
-            closed: AtomicBool::new(false),
-            inflight: Mutex::new(BTreeSet::new()),
-            tasks: Mutex::new(Vec::new()),
+            state: Mutex::new(BackgroundState {
+                closed: false,
+                inflight: BTreeSet::new(),
+                tasks: Vec::new(),
+            }),
         }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, BackgroundState> {
+        self.state.lock().expect("background state lock poisoned")
     }
 
     /// Claims the namespace's singleflight slot. Returns false when the
     /// policy, a shutdown, or an already in-flight tick for the namespace
     /// forbids scheduling another.
     pub(crate) fn try_claim(&self, namespace_id: &NamespaceId) -> bool {
-        if self.policy != FsBackgroundWork::Enabled || self.closed.load(Ordering::SeqCst) {
+        if self.policy != FsBackgroundWork::Enabled {
             return false;
         }
-        self.inflight
-            .lock()
-            .expect("background inflight lock poisoned")
-            .insert(namespace_id.clone())
+        let mut state = self.lock_state();
+        !state.closed && state.inflight.insert(namespace_id.clone())
     }
 
     /// Releases a namespace's singleflight slot.
     pub(crate) fn release(&self, namespace_id: &NamespaceId) {
-        self.inflight
-            .lock()
-            .expect("background inflight lock poisoned")
-            .remove(namespace_id);
+        self.lock_state().inflight.remove(namespace_id);
     }
 
     /// Rejects any further background scheduling.
     pub(crate) fn shut_down(&self) {
-        self.closed.store(true, Ordering::SeqCst);
+        self.lock_state().closed = true;
     }
 
     /// Spawns claimed work on the owning runtime and registers it for
-    /// shutdown. Dropping the future without running it must release its
-    /// claim, so an unresolvable runtime cleans up by dropping.
+    /// shutdown, or refuses after [`Self::shut_down`]. Dropping the future
+    /// without running it must release its claim, so both refusals here
+    /// clean up by dropping.
     pub(crate) fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
         let handle = match &self.runtime {
             Some(handle) => handle.clone(),
@@ -90,12 +99,18 @@ impl BackgroundWork {
                 Err(_) => return,
             },
         };
-        let mut tasks = self
-            .tasks
-            .lock()
-            .expect("background task registry poisoned");
-        tasks.retain(|task| !task.is_finished());
-        tasks.push(handle.spawn(future));
+        let mut state = self.lock_state();
+        if state.closed {
+            // A shutdown between this work's claim and now must win: the
+            // drain may already have observed an empty registry. Release the
+            // lock before dropping the future — releasing its claim
+            // re-enters this mutex.
+            drop(state);
+            drop(future);
+            return;
+        }
+        state.tasks.retain(|task| !task.is_finished());
+        state.tasks.push(handle.spawn(future));
     }
 
     /// Waits for every scheduled task to finish, surfacing panics. Loops
@@ -104,13 +119,7 @@ impl BackgroundWork {
     pub(crate) async fn drain(&self) -> Result<()> {
         let mut panicked = 0usize;
         loop {
-            let drained = {
-                let mut tasks = self
-                    .tasks
-                    .lock()
-                    .expect("background task registry poisoned");
-                std::mem::take(&mut *tasks)
-            };
+            let drained = std::mem::take(&mut self.lock_state().tasks);
             if drained.is_empty() {
                 break;
             }
@@ -128,5 +137,123 @@ impl BackgroundWork {
             )));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic)]
+    // The drain test injects a task panic to assert it is surfaced.
+
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    fn namespace_id() -> NamespaceId {
+        NamespaceId::parse("demo").expect("valid namespace id")
+    }
+
+    /// Sets its flag when dropped, mimicking the claim guard the auto-tick
+    /// future carries: a refused spawn must drop the future so the guard
+    /// releases the singleflight slot.
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_after_shut_down_refuses_and_drops_the_future() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None);
+        let namespace_id = namespace_id();
+
+        // The racy interleaving a shutdown must win: the claim lands first...
+        assert!(background.try_claim(&namespace_id));
+        // ...then a close (shut_down + drain) completes while the registry
+        // is still empty...
+        background.shut_down();
+        background.drain().await.expect("nothing scheduled");
+
+        // ...and only afterwards does the claimed work reach spawn. It must
+        // be refused and dropped, never registered or run.
+        let ran = Arc::new(AtomicBool::new(false));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard = DropFlag(dropped.clone());
+        let ran_in_task = ran.clone();
+        background.spawn(async move {
+            let _guard = guard;
+            ran_in_task.store(true, Ordering::SeqCst);
+        });
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "a refused future must be dropped so its claim guard releases"
+        );
+        assert!(
+            !ran.load(Ordering::SeqCst),
+            "a refused future must never run"
+        );
+        background.drain().await.expect("registry stays empty");
+    }
+
+    #[tokio::test]
+    async fn tasks_spawned_before_shut_down_are_drained() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None);
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_in_task = ran.clone();
+        background.spawn(async move {
+            tokio::task::yield_now().await;
+            ran_in_task.store(true, Ordering::SeqCst);
+        });
+        background.shut_down();
+        background.drain().await.expect("drain scheduled task");
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "registered task ran to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_surfaces_panicked_tasks_as_an_error() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None);
+        background.spawn(async {
+            panic!("injected background task panic");
+        });
+        background.shut_down();
+        let error = background.drain().await.expect_err("panic must surface");
+        assert!(
+            error.to_string().contains("panicked"),
+            "drain reports panicked tasks: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claims_are_singleflight_and_refused_after_shut_down() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None);
+        let namespace_id = namespace_id();
+        assert!(background.try_claim(&namespace_id));
+        assert!(
+            !background.try_claim(&namespace_id),
+            "one in-flight tick per namespace"
+        );
+        background.release(&namespace_id);
+        assert!(
+            background.try_claim(&namespace_id),
+            "a released slot is claimable again"
+        );
+        background.release(&namespace_id);
+        background.shut_down();
+        assert!(
+            !background.try_claim(&namespace_id),
+            "no new claims after shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_only_policy_never_claims() {
+        let background = BackgroundWork::new(FsBackgroundWork::ManualOnly, None);
+        assert!(!background.try_claim(&namespace_id()));
     }
 }

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -107,10 +107,10 @@ impl FsAdmin {
         self.core.gc_namespace(namespace_id, config).await
     }
 
-    /// Closes the admin handle. Admin calls are one-shot in the caller's
-    /// task, so this settles immediately; it exists so every handle shares
-    /// one shutdown shape.
-    pub async fn close(&self) -> Result<()> {
+    /// Shuts down handle-owned background work. Admin calls are one-shot in
+    /// the caller's task, so this settles immediately; it exists so every
+    /// handle shares one shutdown shape.
+    pub async fn shutdown_background(&self) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -203,9 +203,10 @@ impl FsReader {
             .await
     }
 
-    /// Closes the reader. Readers own no background work, so this settles
-    /// immediately; it exists so every handle shares one shutdown shape.
-    pub async fn close(&self) -> Result<()> {
+    /// Shuts down handle-owned background work. Readers own none, so this
+    /// settles immediately; it exists so every handle shares one shutdown
+    /// shape.
+    pub async fn shutdown_background(&self) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -333,15 +333,17 @@ impl FsWriter {
         self.core.wait_for_background_maintenance().await
     }
 
-    /// Closes the writer: rejects new writer-scheduled background work and
-    /// waits for in-flight maintenance tasks to settle, surfacing panics.
+    /// Shuts down writer-scheduled background work: rejects new scheduling
+    /// and waits for in-flight maintenance tasks to settle, surfacing
+    /// panics. Work that claimed its maintenance slot but has not started
+    /// when the shutdown lands is refused, never left running unobserved.
     ///
-    /// Foreground calls remain usable afterward; `close` only settles
+    /// Foreground calls remain usable afterward; this settles only
     /// handle-owned background work, and with
     /// [`FsBackgroundWork::ManualOnly`] it is nearly trivial. Dropping the
-    /// handle without closing is best-effort cleanup, not the documented
-    /// graceful shutdown path.
-    pub async fn close(&self) -> Result<()> {
+    /// handle without calling this is best-effort cleanup, not the
+    /// documented graceful shutdown path.
+    pub async fn shutdown_background(&self) -> Result<()> {
         self.core.shut_down_background();
         self.core.wait_for_background_maintenance().await
     }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! LoonFS never creates a hidden maintenance runtime: any background work a
 //! handle starts is spawned on that handle's owning runtime, and each handle
-//! has an async `close()` that settles what it owns.
+//! has an async `shutdown_background()` that settles what it owns.
 #![warn(missing_docs)]
 
 mod background;

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -2,7 +2,7 @@
 // Handle integration tests use panic in helper assertions for precise diagnostics.
 
 //! Purpose-specific handle coverage: builder contracts, the background-work
-//! policy, close semantics, and cross-handle reads. Each test drives every
+//! policy, background-shutdown semantics, and cross-handle reads. Each test drives every
 //! handle from one runtime fixture, matching the runtime-ownership contract
 //! the handles document.
 
@@ -122,10 +122,22 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
         // cache counters, like writer and reader work through theirs.
         let _ = admin.runtime_cache_stats();
 
-        standalone.close().await.expect("close standalone reader");
-        derived.close().await.expect("close derived reader");
-        admin.close().await.expect("close admin");
-        writer.close().await.expect("close writer");
+        standalone
+            .shutdown_background()
+            .await
+            .expect("shut down standalone reader background work");
+        derived
+            .shutdown_background()
+            .await
+            .expect("shut down derived reader background work");
+        admin
+            .shutdown_background()
+            .await
+            .expect("shut down admin background work");
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
     });
 }
 
@@ -222,12 +234,15 @@ fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
             status.wal_tail_segments < 32,
             "auto tick should have bounded the tail: {status:?}"
         );
-        writer.close().await.expect("close writer");
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
     });
 }
 
 #[test]
-fn closed_writer_rejects_new_background_work_but_keeps_writing() {
+fn shut_down_writer_rejects_new_background_work_but_keeps_writing() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     block_on(async {
@@ -236,15 +251,18 @@ fn closed_writer_rejects_new_background_work_but_keeps_writing() {
             .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
             .expect("create namespace");
-        writer.close().await.expect("close writer");
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
 
-        // Foreground writes still work after close; only handle-owned
-        // background scheduling is rejected.
+        // Foreground writes still work after the background shutdown; only
+        // handle-owned background scheduling is rejected.
         fill_wal_tail_past_threshold(&writer, &namespace_id).await;
         writer
             .wait_for_background_work()
             .await
-            .expect("nothing scheduled after close");
+            .expect("nothing scheduled after background shutdown");
 
         let admin = FsAdmin::builder(store_config(temp_dir.path()))
             .actor_id("handle-test-admin")
@@ -254,15 +272,15 @@ fn closed_writer_rejects_new_background_work_but_keeps_writing() {
         let status = admin
             .namespace_status(&namespace_id)
             .await
-            .expect("status after post-close writes");
+            .expect("status after post-shutdown writes");
         assert_eq!(
             status.current_manifest_id,
             Some(ManifestId(0)),
-            "closed writer must not schedule checkpoints: {status:?}"
+            "shut-down writer must not schedule checkpoints: {status:?}"
         );
         assert!(
             status.wal_tail_segments >= 33,
-            "closed writer must leave the tail alone: {status:?}"
+            "shut-down writer must leave the tail alone: {status:?}"
         );
     });
 }


### PR DESCRIPTION
FsWriter::close() promised to settle handle-owned background work, but a maintenance tick could slip through it: a publish claims its per-namespace slot, close() sets the shutdown flag and drains an empty task list, and only then does the claimed tick spawn — running after close() already returned. The window is a few instructions wide, but the docs explicitly allow foreground writes concurrent with close(), so it is reachable in documented use.

The shutdown flag, the singleflight claims, and the task list now live under one lock, and spawn refuses once shutdown has begun — the refused future is dropped, which releases its claim through the existing guard. A drain that observed an empty registry can no longer miss work.

Since close() never closed the writer (foreground calls stay usable; it only settles background work), it is renamed to shutdown_background() on all three handles while the API can still change. New unit tests pin the contract, including the exact claim/shutdown/spawn interleaving.