### PR TITLE
feat(core): split wal flushing from checkpoint records

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -75,10 +75,11 @@ pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
     CreateCheckpointResponse, CreateNamespaceRequest, DeleteDirectoryBehavior,
     DeleteNamespaceResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, ForkNamespaceRequest, GcRequest, GcResponse,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOutcome,
-    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
+    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest,
+    GcRequest, GcResponse, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
+    MutationResult, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
+    RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -25,10 +25,10 @@ pub use commits::{
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
-    GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
-    MaintenanceTickResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
-    PutBehavior, RestoreFileRevisionRequest,
+    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse,
+    ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse, MutationResult, NamespaceStatusResponse,
+    NamespaceSummary, PutBehavior, RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use uploads::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -240,6 +240,36 @@ pub struct CreateCheckpointResponse {
     pub current_manifest_id: Option<ManifestId>,
 }
 
+/// How one WAL flush satisfied its goal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum FlushWalOutcome {
+    /// The root already covered the head; nothing was published.
+    AlreadyCurrent,
+    /// This call published a new manifest and advanced the root to it.
+    Published,
+    /// This call published a manifest, but a newer root already covered
+    /// the attempted sequence.
+    Superseded,
+}
+
+/// Result of one WAL flush: how the metadata root covers the head.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct FlushWalResponse {
+    /// Namespace whose WAL tail was flushed.
+    pub namespace_id: NamespaceId,
+    /// Head sequence the flush attempted to cover.
+    pub target_head_seq: ChangeSeq,
+    /// Manifest `metadata/root.json` references after the operation.
+    pub manifest_id: ManifestId,
+    /// Sequence covered by that manifest.
+    pub manifest_head_seq: ChangeSeq,
+    /// How the root came to cover the head.
+    pub outcome: FlushWalOutcome,
+}
+
 /// Optional overrides for one garbage-collection pass. Absent fields use
 /// the server's conservative defaults.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -293,12 +323,12 @@ pub struct AdvanceRetentionResponse {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MaintenanceTickRequest {
-    /// Publish a checkpoint when the visible WAL tail reaches this many
-    /// segments.
+    /// Flush the visible WAL tail into metadata tables when it reaches this
+    /// many segments.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_wal_tail_segments: Option<u64>,
-    /// Run the mark-and-sweep garbage collector after the tick's checkpoint
-    /// work. Nothing sweeps unless this is present.
+    /// Run the mark-and-sweep garbage collector after the tick's
+    /// flush work. Nothing sweeps unless this is present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gc: Option<GcRequest>,
 }
@@ -308,23 +338,24 @@ pub struct MaintenanceTickRequest {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MaintenanceTickOutcome {
-    /// No checkpoint was needed.
+    /// The WAL tail was below the threshold; the root was left alone.
     NotNeeded,
-    /// A checkpoint was published.
-    CheckpointPublished {
-        /// Sequence covered by the published checkpoint.
-        checkpoint_seq: ChangeSeq,
+    /// The tick flushed the WAL tail and advanced the metadata root.
+    WalFlushed {
+        /// Sequence covered by the published manifest.
+        manifest_head_seq: ChangeSeq,
     },
-    /// Another checkpoint already covered the attempted sequence.
-    CheckpointSuperseded {
-        /// Sequence this tick attempted to checkpoint.
+    /// The root already covered the attempted sequence — another publisher
+    /// got there first.
+    WalFlushSuperseded {
+        /// Sequence this tick attempted to flush through.
         attempted_seq: ChangeSeq,
-        /// Manifest pointer the head currently records.
+        /// Manifest the root currently references.
         current_manifest_id: ManifestId,
     },
     /// A concurrent head update won the race.
-    CheckpointPublishRaceLost {
-        /// Head sequence observed before the checkpoint attempt.
+    WalFlushRaceLost {
+        /// Head sequence observed before the advance attempt.
         observed_head_seq: ChangeSeq,
     },
 }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -324,6 +324,7 @@ pub(crate) struct ChangesArgs {
 #[derive(Debug, Subcommand)]
 pub(crate) enum AdminCommand {
     Checkpoint(AdminNamespaceArgs),
+    Flush(AdminNamespaceArgs),
     RetentionAdvance(AdminNamespaceArgs),
     Tick(AdminTickArgs),
     Gc(AdminGcArgs),
@@ -339,11 +340,11 @@ pub(crate) struct AdminNamespaceArgs {
 pub(crate) struct AdminTickArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Publish a checkpoint when the visible WAL tail reaches this many
+    /// Flush the visible WAL tail into metadata tables when it reaches this many
     /// segments (server default when omitted).
     #[arg(long)]
     pub max_wal_tail_segments: Option<u64>,
-    /// Run a garbage-collection pass after the tick's checkpoint work.
+    /// Run a garbage-collection pass after the tick's flush work.
     #[arg(long)]
     pub gc: bool,
 }
@@ -416,6 +417,7 @@ pub(crate) enum CommandKind {
     FilesystemCp,
     Changes,
     AdminCheckpoint,
+    AdminFlush,
     AdminRetentionAdvance,
     AdminTick,
     AdminGc,
@@ -452,6 +454,7 @@ impl CommandKind {
             CommandKind::FilesystemCp => "filesystem_cp",
             CommandKind::Changes => "changes",
             CommandKind::AdminCheckpoint => "admin_checkpoint",
+            CommandKind::AdminFlush => "admin_flush",
             CommandKind::AdminRetentionAdvance => "admin_retention_advance",
             CommandKind::AdminTick => "admin_tick",
             CommandKind::AdminGc => "admin_gc",
@@ -499,6 +502,7 @@ impl Cli {
             Command::Changes(_) => CommandKind::Changes,
             Command::Admin { command } => match command {
                 AdminCommand::Checkpoint(_) => CommandKind::AdminCheckpoint,
+                AdminCommand::Flush(_) => CommandKind::AdminFlush,
                 AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
                 AdminCommand::Tick(_) => CommandKind::AdminTick,
                 AdminCommand::Gc(_) => CommandKind::AdminGc,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -17,10 +17,10 @@ use loonfs::{
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CommitId,
-    CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit, GcRequest, GcResponse,
-    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
-    MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary, PaginationPolicy,
-    PutBehavior, RevisionNo,
+    CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit, FlushWalResponse, GcRequest,
+    GcResponse, ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse,
+    MoveBehavior, MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    PaginationPolicy, PutBehavior, RevisionNo,
 };
 use loonfs_client::{Client, ClientConfig, NamespacePath};
 use std::sync::Arc;
@@ -287,6 +287,14 @@ impl Backend for EmbeddedBackend {
         let parsed = parse_namespace_id(namespace_id)?;
         self.admin
             .create_checkpoint(&parsed)
+            .await
+            .map_err(map_runtime_error)
+    }
+
+    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        self.admin
+            .flush_wal(&parsed)
             .await
             .map_err(map_runtime_error)
     }

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -13,6 +13,7 @@ pub(crate) async fn run_admin_command(
 ) -> Result<CommandOutput, CommandFailure> {
     match command {
         AdminCommand::Checkpoint(args) => run_admin_checkpoint(kind, args).await,
+        AdminCommand::Flush(args) => run_admin_flush(kind, args).await,
         AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
         AdminCommand::Tick(args) => run_admin_tick(kind, args).await,
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
@@ -105,6 +106,33 @@ async fn run_admin_checkpoint(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::CheckpointCreated(response),
+    })
+}
+
+async fn run_admin_flush(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let response = context
+        .target
+        .backend()
+        .flush_wal(&context.namespace)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::WalFlushed(response),
     })
 }
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -5,7 +5,8 @@ use crate::profiles::ProfileSummary;
 use loonfs_api::v0::ChangesResponse;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, CreateCheckpointResponse,
-    DeleteNamespaceResponse, FileRevision, GcResponse, MaintenanceTickResponse, NamespaceSummary,
+    DeleteNamespaceResponse, FileRevision, FlushWalResponse, GcResponse, MaintenanceTickResponse,
+    NamespaceSummary,
 };
 use serde::Serialize;
 
@@ -46,6 +47,7 @@ pub(crate) enum CommandData {
     NamespaceSummary(NamespaceSummary),
     NamespaceDeleted(DeleteNamespaceResponse),
     CheckpointCreated(CreateCheckpointResponse),
+    WalFlushed(FlushWalResponse),
     RetentionAdvanced(AdvanceRetentionResponse),
     MaintenanceTicked(MaintenanceTickResponse),
     GarbageCollected(GcResponse),

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -1,7 +1,7 @@
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput};
 use crate::error::CliError;
-use loonfs_api::{GcResponse, MaintenanceTickOutcome};
+use loonfs_api::{FlushWalOutcome, GcResponse, MaintenanceTickOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
 
@@ -168,6 +168,17 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             response.checkpoint_id,
             response.manifest_id
         ),
+        CommandData::WalFlushed(response) => {
+            let outcome = match response.outcome {
+                FlushWalOutcome::AlreadyCurrent => "already current",
+                FlushWalOutcome::Published => "published",
+                FlushWalOutcome::Superseded => "superseded",
+            };
+            format!(
+                "flushed wal for {} to manifest {} @ seq {} ({outcome})",
+                response.namespace_id, response.manifest_id, response.manifest_head_seq.0
+            )
+        }
         CommandData::RetentionAdvanced(response) => format!(
             "advanced retention floor for {} to seq {}; changes before this floor are no longer replayable",
             response.namespace_id, response.retention_floor_seq.0
@@ -178,19 +189,19 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     "not needed (wal tail {} segments)",
                     response.status_before.wal_tail_segments
                 ),
-                MaintenanceTickOutcome::CheckpointPublished { checkpoint_seq } => {
-                    format!("checkpoint published @ seq {}", checkpoint_seq.0)
+                MaintenanceTickOutcome::WalFlushed { manifest_head_seq } => {
+                    format!("wal flushed @ seq {}", manifest_head_seq.0)
                 }
-                MaintenanceTickOutcome::CheckpointSuperseded {
+                MaintenanceTickOutcome::WalFlushSuperseded {
                     attempted_seq,
                     current_manifest_id,
                 } => format!(
-                    "checkpoint @ seq {} superseded (current manifest {})",
+                    "wal flush @ seq {} superseded (current manifest {})",
                     attempted_seq.0, current_manifest_id
                 ),
-                MaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq } => {
+                MaintenanceTickOutcome::WalFlushRaceLost { observed_head_seq } => {
                     format!(
-                        "checkpoint race lost (head moved past seq {})",
+                        "wal flush race lost (head moved past seq {})",
                         observed_head_seq.0
                     )
                 }

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -20,9 +20,9 @@ use crate::{Client, ClientError, MutationOptions, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
     v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
-    CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode, GcRequest, GcResponse,
-    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, MutationResult,
-    NamespaceStatusResponse, NamespaceSummary, RevisionNo,
+    CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode, FlushWalResponse, GcRequest,
+    GcResponse, ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse,
+    MutationResult, NamespaceStatusResponse, NamespaceSummary, RevisionNo,
 };
 use thiserror::Error;
 
@@ -198,14 +198,17 @@ pub trait Backend {
         &self,
         namespace_id: &str,
     ) -> Result<CreateCheckpointResponse, BackendError>;
+    /// Flushes the WAL tail and advances the metadata root, creating no
+    /// checkpoint record.
+    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError>;
     /// Advances the namespace retention floor. Irreversible: WAL history
     /// before the floor stops being replayable.
     async fn advance_retention(
         &self,
         namespace_id: &str,
     ) -> Result<AdvanceRetentionResponse, BackendError>;
-    /// Runs one bounded maintenance step: a checkpoint once the WAL tail
-    /// reaches the threshold, optionally followed by a GC pass.
+    /// Runs one bounded maintenance step: a root advancement once the WAL
+    /// tail reaches the threshold, optionally followed by a GC pass.
     async fn maintenance_tick(
         &self,
         namespace_id: &str,
@@ -408,6 +411,12 @@ impl Backend for RemoteBackend {
     ) -> Result<CreateCheckpointResponse, BackendError> {
         let namespace_id = namespace_id.to_owned();
         self.wire(move |client| client.create_checkpoint(&namespace_id))
+            .await
+    }
+
+    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError> {
+        let namespace_id = namespace_id.to_owned();
+        self.wire(move |client| client.flush_wal(&namespace_id))
             .await
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -21,10 +21,11 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, ForkNamespaceRequest, GcRequest,
-    GcResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, MutationResult, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, RestoreFileRevisionRequest, RevisionNo,
+    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalResponse,
+    ForkNamespaceRequest, GcRequest, GcResponse, InodeId, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickRequest, MaintenanceTickResponse, MutationResult,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -591,6 +592,18 @@ impl Client {
             self.base_url
         );
         self.request_json::<(), CreateCheckpointResponse>(self.agent.post(&url), None)
+    }
+
+    /// Flushes the WAL tail and advances the metadata root to a manifest
+    /// covering the current head (admin plane). The latest-state maintenance operation: no checkpoint
+    /// record is created. The request carries no body.
+    pub fn flush_wal(&self, namespace: &str) -> Result<FlushWalResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/wal/flush",
+            self.base_url
+        );
+        self.request_json::<(), FlushWalResponse>(self.agent.post(&url), None)
     }
 
     /// Advances the namespace retention floor to what checkpoint state allows

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -1,15 +1,8 @@
-//! Checkpoint creation: project a manifest from the current manifest plus WAL
-//! tail, write its tables, and publish it under one checkpoint record.
+//! Checkpoint creation: advance the metadata root to cover the current head,
+//! then pin the resulting manifest under one durable checkpoint record.
 
-use super::build::{
-    build_manifest_l0_run_tables, build_manifest_tables,
-    debug_assert_manifest_table_segments_do_not_overlap,
-};
-use super::error::ManifestLoadError;
-use super::load::{
-    head_from_manifest, load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
-};
-use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
+use super::build::{build_manifest_tables, debug_assert_manifest_table_segments_do_not_overlap};
+use super::flush::{try_flush_wal, TryFlushWal};
 use super::record::{
     deterministic_checkpoint_id, set_checkpoint_record_state, verify_checkpoint_basis,
     write_checkpoint_record, CheckpointRecordWrite,
@@ -19,49 +12,30 @@ use super::row::manifest_rows_for_family;
 #[cfg(test)]
 use super::runs::CHECKPOINT_TABLE_FAMILIES;
 use super::runs::{flatten_manifest_tables, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL};
-use super::scan::VerifiedMetadataTables;
 use crate::commit::CommitHeadPublishError;
 use crate::context::MutationContext;
 use crate::error::CoreError;
-use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
-use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_metadata_state;
-use crate::namespace::catalog::load_namespace_catalog_entry;
-use crate::namespace::control::{read_head_and_metadata_root, read_wal_floor_seq_or_zero};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
-use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
-use loonfs_api::wire::control::NamespaceState;
+use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::control::{CheckpointRecordLifecycle, CheckpointRecordState};
-use loonfs_api::wire::control::{HeadState, MetadataRootState};
 use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
 use loonfs_api::{ChangeSeq, CreateCheckpointResponse, ManifestId, ManifestObjectId, NamespaceId};
-use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeMap;
-use tracing::Instrument;
 
 #[cfg(test)]
 use super::load::append_rows_to_metadata;
 #[cfg(test)]
 use crate::metadata::MetadataStateBuilder;
 
-// Manifest id allocation can race with other manifest publishers. Exhausting
-// this loop means the candidate id range was already occupied.
-pub(super) const MANIFEST_ALLOCATION_RETRY_LIMIT: usize = 8;
 // Checkpoint publication can race with another manifest update. Retrying here
 // preserves one checkpoint id while rebasing its checkpoint record onto the
 // newest current manifest.
 pub(super) const CHECKPOINT_PUBLICATION_RETRY_LIMIT: usize = 8;
 
 pub(crate) const CHECKPOINT_VERIFY_BUDGET_MS: u64 = 60_000;
-
-struct CheckpointBasis {
-    manifest_id: ManifestId,
-    manifest_object_id: ManifestObjectId,
-    manifest_head_seq: ChangeSeq,
-    manifest_payload_checksum: String,
-}
 
 pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     store: &S,
@@ -72,7 +46,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     // under `checkpoints/`, write-then-verify (format spec, "Checkpoints"):
     //
     // 1. Choose a basis manifest that the metadata root references,
-    //    materializing and publishing one first when the root lags the head.
+    //    flushing the WAL tail first when it lags the head (`flush.rs`).
     // 2. Write `checkpoints/{id}.json` with state = active.
     // 3. Verify, after the write is durable, that the floor has not passed
     //    the basis and the basis manifest still loads, under the verify
@@ -81,103 +55,11 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     //    a newer basis.
     let mut saw_root_cas_race = false;
     for _publication_attempt in 0..CHECKPOINT_PUBLICATION_RETRY_LIMIT {
-        let projection = load_checkpoint_projection(store, namespace_id)
-            .instrument(tracing::info_span!(
-                "loon.phase",
-                phase = "scan_namespace_state"
-            ))
-            .await?;
-        let head_seq = projection.head.seq;
-
-        let basis = if projection.root.manifest_head_seq == head_seq {
-            CheckpointBasis {
-                manifest_id: projection.root.manifest_id,
-                manifest_object_id: projection.root.manifest_object_id.clone(),
-                manifest_head_seq: projection.root.manifest_head_seq,
-                manifest_payload_checksum: projection.root.manifest_payload_checksum.clone(),
-            }
-        } else {
-            let manifest_id = next_manifest_id_after(projection.root.manifest_id)?;
-            let mut written_manifest = None;
-            for _allocation_attempt in 0..MANIFEST_ALLOCATION_RETRY_LIMIT {
-                let manifest_object_id = ManifestObjectId::generate(manifest_id);
-                let manifest_key =
-                    metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
-                match load_namespace_manifest_envelope_if_present(
-                    store,
-                    namespace_id,
-                    &manifest_object_id,
-                    &manifest_key,
-                )
-                .await
-                {
-                    Ok(Some(_existing)) => {
-                        // Physical-id collision or retry; keep the logical
-                        // slot and generate another object id.
-                        continue;
-                    }
-                    Ok(None) => {
-                        let manifest = build_namespace_manifest_for_checkpoint_projection(
-                            store,
-                            namespace_id,
-                            &projection,
-                            &context.writer_version,
-                            manifest_id,
-                            manifest_object_id,
-                        )
-                        .await?;
-                        // `write_namespace_manifest` owns the idempotent
-                        // "manifest already exists" path. A same-id/
-                        // different-payload conflict means another writer won
-                        // this slot, so try the next manifest id.
-                        match write_namespace_manifest(store, &manifest).await {
-                            Ok(()) => {}
-                            Err(MetadataProjectionLoadError::ManifestLoad(
-                                ManifestLoadError::ManifestConflict { .. },
-                            )) => {
-                                continue;
-                            }
-                            Err(error) => return Err(CoreError::MetadataProjection(error)),
-                        }
-                        written_manifest = Some(manifest);
-                        break;
-                    }
-                    Err(error) => {
-                        return Err(CoreError::MetadataProjection(
-                            MetadataProjectionLoadError::ManifestLoad(error),
-                        ))
-                    }
-                }
-            }
-            let Some(manifest) = written_manifest else {
-                return Err(CoreError::Internal(
-                    "manifest id allocation retry exhausted".to_owned(),
-                ));
-            };
-            // Advance the root for readers. A superseded outcome is fine:
-            // the manifest we wrote stays durable and valid as a checkpoint
-            // basis even when a newer root already won.
-            match publish_metadata_root(
-                store,
-                namespace_id,
-                &manifest,
-                context.now_ms,
-                &context.writer_version,
-            )
-            .await?
-            {
-                ManifestPublicationOutcome::Published(_)
-                | ManifestPublicationOutcome::Superseded(_) => {}
-                ManifestPublicationOutcome::RootCasRaceLost => {
-                    saw_root_cas_race = true;
-                    continue;
-                }
-            }
-            CheckpointBasis {
-                manifest_id: manifest.payload.manifest_id,
-                manifest_object_id: manifest.payload.manifest_object_id.clone(),
-                manifest_head_seq: manifest.payload.head_seq,
-                manifest_payload_checksum: manifest.payload_checksum.clone(),
+        let basis = match try_flush_wal(store, namespace_id, context).await? {
+            TryFlushWal::Flushed(basis) => basis,
+            TryFlushWal::RaceLost => {
+                saw_root_cas_race = true;
+                continue;
             }
         };
 
@@ -194,7 +76,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
             manifest_object_id: basis.manifest_object_id.clone(),
             manifest_head_seq: basis.manifest_head_seq,
             manifest_payload_checksum: basis.manifest_payload_checksum.clone(),
-            head_commit_id: projection.head.head_commit_id.clone(),
+            head_commit_id: basis.head_commit_id.clone(),
             created_at_ms: context.now_ms,
             expires_at_ms: None,
             name: None,
@@ -228,7 +110,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
                 checkpoint_id,
                 checkpoint_seq: basis.manifest_head_seq,
                 manifest_id: basis.manifest_id,
-                current_manifest_id: Some(basis.manifest_id.max(projection.root.manifest_id)),
+                current_manifest_id: Some(basis.manifest_id.max(basis.root_manifest_id_at_load)),
             });
         }
 
@@ -253,98 +135,14 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     }
 }
 
-struct CheckpointProjection<'a, S: ObjectStore + ?Sized> {
-    head: HeadState,
-    root: MetadataRootState,
-    floor_seq: ChangeSeq,
-    manifest_tables: VerifiedMetadataTables<'a, S>,
-    tail_state: MetadataState,
-}
-
-async fn load_checkpoint_projection<'a, S: ObjectStore + ?Sized>(
-    store: &'a S,
-    namespace_id: &NamespaceId,
-) -> Result<CheckpointProjection<'a, S>> {
-    load_namespace_catalog_entry(store, namespace_id)
-        .await
-        .map_err(|error| CoreError::MetadataProjection(error.into()))?;
-    let (loaded_head, loaded_root) = read_head_and_metadata_root(store, namespace_id)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
-    let floor_seq = read_wal_floor_seq_or_zero(store, namespace_id)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
-    let head = loaded_head.envelope.state;
-    let root = loaded_root.envelope.state;
-    if head.state == NamespaceState::Deleted {
-        return Err(CoreError::MetadataProjection(
-            MetadataProjectionLoadError::NamespaceDeleted {
-                namespace_id: namespace_id.clone(),
-            },
-        ));
-    }
-    let manifest_tables =
-        load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-            })?;
-    if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
-        return Err(CoreError::NamespaceCorrupt(format!(
-            "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",
-            namespace_id.as_str(),
-            root.manifest_id,
-            root.manifest_payload_checksum,
-            manifest_tables.manifest().payload_checksum,
-        )));
-    }
-    let manifest_head = head_from_manifest(&head, manifest_tables.manifest());
-    let wal_chain = load_validated_wal_chain(
-        store,
-        WalChainLoadRequest {
-            namespace_id,
-            chain_base_seq: manifest_head.seq,
-            head_seq: head.seq,
-            visible_tip: head.visible_wal_tip.clone(),
-            stop_after_seq: None,
-            recent_segments: &head.recent_segments,
-        },
-    )
-    .await
-    .map_err(|error| {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
-    })?;
-    let replayed = {
-        let _span = tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
-        project_validated_wal_tail(
-            &manifest_head,
-            &MetadataState::default(),
-            Some(head.writer_epoch),
-            &wal_chain,
-        )
-        .map_err(MetadataProjectionLoadError::WalReplay)
-        .map_err(CoreError::MetadataProjection)?
-    };
-    ensure_checkpoint_reconstructed_head_matches(&head, &replayed.resulting_head)?;
-    Ok(CheckpointProjection {
-        head,
-        root,
-        floor_seq,
-        manifest_tables,
-        tail_state: replayed.resulting_metadata_state,
-    })
-}
-
 #[cfg(test)]
 pub(super) async fn load_checkpoint_projection_metadata_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<(HeadState, MetadataState)> {
-    let projection = load_checkpoint_projection(store, namespace_id).await?;
+) -> Result<(HeadState, crate::metadata::MetadataState)> {
+    use crate::error::MetadataProjectionLoadError;
+
+    let projection = super::flush::load_root_projection(store, namespace_id).await?;
     let mut metadata_state = MetadataStateBuilder::default();
     for family in CHECKPOINT_TABLE_FAMILIES {
         let mut rows = projection
@@ -362,35 +160,6 @@ pub(super) async fn load_checkpoint_projection_metadata_state<S: ObjectStore + ?
             })?;
     }
     Ok((projection.head, metadata_state.finish()))
-}
-
-fn ensure_checkpoint_reconstructed_head_matches(
-    current_head: &HeadState,
-    reconstructed: &HeadState,
-) -> Result<()> {
-    if current_head.namespace_id != reconstructed.namespace_id
-        || current_head.seq != reconstructed.seq
-        || current_head.head_commit_id != reconstructed.head_commit_id
-        || current_head.next_inode_id != reconstructed.next_inode_id
-        || (reconstructed.visible_wal_tip.is_some()
-            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
-    {
-        return Err(CoreError::MetadataProjection(
-            MetadataProjectionLoadError::ReplayedHeadMismatch {
-                expected: Box::new(current_head.clone()),
-                actual: Box::new(reconstructed.clone()),
-            },
-        ));
-    }
-    Ok(())
-}
-
-pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> {
-    current
-        .0
-        .checked_add(1)
-        .map(ManifestId)
-        .ok_or_else(|| CoreError::Internal("manifest id overflow".to_owned()))
 }
 
 pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
@@ -432,63 +201,6 @@ pub(crate) async fn build_initial_namespace_manifest<S: ObjectStore + ?Sized>(
             fork: None,
             features: BTreeMap::new(),
             metadata_files: flatten_manifest_tables(run_tables),
-        },
-    )
-    .map_err(|err| {
-        CoreError::Internal(format!(
-            "failed to build namespace manifest envelope: {err}"
-        ))
-    })
-}
-
-async fn build_namespace_manifest_for_checkpoint_projection<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    projection: &CheckpointProjection<'_, S>,
-    writer_version: &str,
-    manifest_id: ManifestId,
-    manifest_object_id: ManifestObjectId,
-) -> Result<NamespaceManifestEnvelope> {
-    let head_seq = projection.head.seq;
-    let previous_manifest = projection.manifest_tables.manifest();
-
-    // Checkpoint publication is manifest-only: every prior run is
-    // referenced unchanged and the WAL delta lands as one new L0 run, so
-    // the cost follows the delta, never the namespace. Folding L0 runs
-    // back into the base is reorganization's job (`reorganize.rs`), off
-    // this path.
-    let base_seq = previous_manifest.payload.base_seq;
-    let mut metadata_files = previous_manifest.payload.metadata_files.clone();
-    if previous_manifest.payload.head_seq < head_seq {
-        metadata_files.extend(flatten_manifest_tables(
-            build_manifest_l0_run_tables(
-                store,
-                namespace_id,
-                head_seq,
-                previous_manifest.payload.head_seq,
-                &projection.tail_state,
-            )
-            .await?,
-        ));
-    }
-
-    NamespaceManifestEnvelope::from_payload(
-        writer_version,
-        NamespaceManifestPayload {
-            namespace_id: namespace_id.clone(),
-            manifest_id,
-            manifest_object_id,
-            head_seq,
-            head_commit_id: projection.head.head_commit_id.clone(),
-            base_seq,
-            writer_epoch: projection.head.writer_epoch,
-            next_inode_id: projection.head.next_inode_id,
-            retention_floor_seq: projection.floor_seq,
-            initialized: true,
-            verified: true,
-            fork: None,
-            features: BTreeMap::new(),
-            metadata_files,
         },
     )
     .map_err(|err| {

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -1,0 +1,397 @@
+//! The WAL flush: fold the visible WAL tail into metadata tables under a
+//! manifest covering the current head and advance `metadata/root.json` by
+//! compare-and-swap, creating no durable checkpoint record.
+//!
+//! This is the latest-state maintenance path: superseded manifests become
+//! garbage-collection candidates once nothing pins them. Pinning a manifest
+//! version for retention is a separate concern layered on top by
+//! [`create`](super::create).
+
+use super::build::build_manifest_l0_run_tables;
+use super::error::ManifestLoadError;
+use super::load::{
+    head_from_manifest, load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
+};
+use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
+use super::runs::flatten_manifest_tables;
+use super::scan::VerifiedMetadataTables;
+use crate::commit::CommitHeadPublishError;
+use crate::context::MutationContext;
+use crate::error::CoreError;
+use crate::error::MetadataProjectionLoadError;
+use crate::error::Result;
+use crate::metadata::MetadataState;
+use crate::namespace::catalog::load_namespace_catalog_entry;
+use crate::namespace::control::{read_head_and_metadata_root, read_wal_floor_seq_or_zero};
+use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use loonfs_api::wire::control::{HeadState, MetadataRootState, NamespaceState};
+use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
+use loonfs_api::{
+    ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestId, ManifestObjectId,
+    NamespaceId,
+};
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeMap;
+use tracing::Instrument;
+
+// Manifest id allocation can race with other manifest publishers. Exhausting
+// this loop means the candidate id range was already occupied.
+pub(super) const MANIFEST_ALLOCATION_RETRY_LIMIT: usize = 8;
+// A WAL flush can race with another manifest publisher. Each retry
+// rebases onto a fresh projection of the newest head and root.
+const WAL_FLUSH_RETRY_LIMIT: usize = 8;
+
+/// The basis one flush attempt settled on: the manifest this attempt
+/// published, or the one already covering the head.
+pub(super) struct FlushedBasis {
+    pub(super) manifest_id: ManifestId,
+    pub(super) manifest_object_id: ManifestObjectId,
+    pub(super) manifest_head_seq: ChangeSeq,
+    pub(super) manifest_payload_checksum: String,
+    /// Head commit the basis covers.
+    pub(super) head_commit_id: CommitId,
+    /// Head sequence the attempt targeted.
+    pub(super) target_head_seq: ChangeSeq,
+    /// Root manifest observed when the projection loaded, for callers that
+    /// report the newest manifest id they saw.
+    pub(super) root_manifest_id_at_load: ManifestId,
+    /// Manifest `metadata/root.json` references after the attempt — the
+    /// basis itself, or the newer root that superseded it.
+    pub(super) root_after_manifest_id: ManifestId,
+    /// Sequence covered by `root_after_manifest_id`.
+    pub(super) root_after_head_seq: ChangeSeq,
+    pub(super) outcome: FlushWalOutcome,
+}
+
+pub(super) enum TryFlushWal {
+    Flushed(Box<FlushedBasis>),
+    /// The root compare-and-swap raced another publisher to exhaustion;
+    /// retry against a fresh projection.
+    RaceLost,
+}
+
+/// Flushes the visible WAL tail into metadata tables and advances
+/// `metadata/root.json` to a manifest covering the current head.
+///
+/// The WAL delta lands as one new L0 run when the root lags the head; the
+/// manifest publishes and the root advances. No checkpoint record is
+/// created. Returns `StaleHead` when every attempt lost the root race.
+pub(crate) async fn flush_wal<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<FlushWalResponse> {
+    for _attempt in 0..WAL_FLUSH_RETRY_LIMIT {
+        match try_flush_wal(store, namespace_id, context).await? {
+            TryFlushWal::Flushed(basis) => {
+                return Ok(FlushWalResponse {
+                    namespace_id: namespace_id.clone(),
+                    target_head_seq: basis.target_head_seq,
+                    manifest_id: basis.root_after_manifest_id,
+                    manifest_head_seq: basis.root_after_head_seq,
+                    outcome: basis.outcome,
+                });
+            }
+            TryFlushWal::RaceLost => continue,
+        }
+    }
+    Err(CoreError::HeadPublish(CommitHeadPublishError::StaleHead))
+}
+
+/// One flush attempt against one fresh projection.
+pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<TryFlushWal> {
+    let projection = load_root_projection(store, namespace_id)
+        .instrument(tracing::info_span!(
+            "loon.phase",
+            phase = "scan_namespace_state"
+        ))
+        .await?;
+    let head_seq = projection.head.seq;
+    let root_manifest_id_at_load = projection.root.manifest_id;
+
+    if projection.root.manifest_head_seq == head_seq {
+        return Ok(TryFlushWal::Flushed(Box::new(FlushedBasis {
+            manifest_id: projection.root.manifest_id,
+            manifest_object_id: projection.root.manifest_object_id.clone(),
+            manifest_head_seq: projection.root.manifest_head_seq,
+            manifest_payload_checksum: projection.root.manifest_payload_checksum.clone(),
+            head_commit_id: projection.head.head_commit_id.clone(),
+            target_head_seq: head_seq,
+            root_manifest_id_at_load,
+            root_after_manifest_id: projection.root.manifest_id,
+            root_after_head_seq: projection.root.manifest_head_seq,
+            outcome: FlushWalOutcome::AlreadyCurrent,
+        })));
+    }
+
+    let manifest_id = next_manifest_id_after(projection.root.manifest_id)?;
+    let mut written_manifest = None;
+    for _allocation_attempt in 0..MANIFEST_ALLOCATION_RETRY_LIMIT {
+        let manifest_object_id = ManifestObjectId::generate(manifest_id);
+        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        match load_namespace_manifest_envelope_if_present(
+            store,
+            namespace_id,
+            &manifest_object_id,
+            &manifest_key,
+        )
+        .await
+        {
+            Ok(Some(_existing)) => {
+                // Physical-id collision or retry; keep the logical slot and
+                // generate another object id.
+                continue;
+            }
+            Ok(None) => {
+                let manifest = build_namespace_manifest_for_projection(
+                    store,
+                    namespace_id,
+                    &projection,
+                    &context.writer_version,
+                    manifest_id,
+                    manifest_object_id,
+                )
+                .await?;
+                // `write_namespace_manifest` owns the idempotent "manifest
+                // already exists" path. A same-id/different-payload conflict
+                // means another writer won this slot, so try the next
+                // manifest id.
+                match write_namespace_manifest(store, &manifest).await {
+                    Ok(()) => {}
+                    Err(MetadataProjectionLoadError::ManifestLoad(
+                        ManifestLoadError::ManifestConflict { .. },
+                    )) => {
+                        continue;
+                    }
+                    Err(error) => return Err(CoreError::MetadataProjection(error)),
+                }
+                written_manifest = Some(manifest);
+                break;
+            }
+            Err(error) => {
+                return Err(CoreError::MetadataProjection(
+                    MetadataProjectionLoadError::ManifestLoad(error),
+                ))
+            }
+        }
+    }
+    let Some(manifest) = written_manifest else {
+        return Err(CoreError::Internal(
+            "manifest id allocation retry exhausted".to_owned(),
+        ));
+    };
+    // Advance the root for readers. A superseded outcome is fine: the
+    // manifest we wrote stays durable and valid as a basis even when a
+    // newer root already won.
+    let (outcome, root_after_manifest_id, root_after_head_seq) = match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        context.now_ms,
+        &context.writer_version,
+    )
+    .await?
+    {
+        ManifestPublicationOutcome::Published(_) => (
+            FlushWalOutcome::Published,
+            manifest.payload.manifest_id,
+            manifest.payload.head_seq,
+        ),
+        ManifestPublicationOutcome::Superseded(current) => (
+            FlushWalOutcome::Superseded,
+            current.manifest_id,
+            current.manifest_head_seq,
+        ),
+        ManifestPublicationOutcome::RootCasRaceLost => {
+            return Ok(TryFlushWal::RaceLost);
+        }
+    };
+    Ok(TryFlushWal::Flushed(Box::new(FlushedBasis {
+        manifest_id: manifest.payload.manifest_id,
+        manifest_object_id: manifest.payload.manifest_object_id.clone(),
+        manifest_head_seq: manifest.payload.head_seq,
+        manifest_payload_checksum: manifest.payload_checksum.clone(),
+        head_commit_id: projection.head.head_commit_id.clone(),
+        target_head_seq: head_seq,
+        root_manifest_id_at_load,
+        root_after_manifest_id,
+        root_after_head_seq,
+        outcome,
+    })))
+}
+
+pub(super) struct RootProjection<'a, S: ObjectStore + ?Sized> {
+    pub(super) head: HeadState,
+    pub(super) root: MetadataRootState,
+    pub(super) floor_seq: ChangeSeq,
+    pub(super) manifest_tables: VerifiedMetadataTables<'a, S>,
+    pub(super) tail_state: MetadataState,
+}
+
+pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    namespace_id: &NamespaceId,
+) -> Result<RootProjection<'a, S>> {
+    load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .map_err(|error| CoreError::MetadataProjection(error.into()))?;
+    let (loaded_head, loaded_root) = read_head_and_metadata_root(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    let floor_seq = read_wal_floor_seq_or_zero(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    let head = loaded_head.envelope.state;
+    let root = loaded_root.envelope.state;
+    if head.state == NamespaceState::Deleted {
+        return Err(CoreError::MetadataProjection(
+            MetadataProjectionLoadError::NamespaceDeleted {
+                namespace_id: namespace_id.clone(),
+            },
+        ));
+    }
+    let manifest_tables =
+        load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
+    if manifest_tables.manifest().payload_checksum != root.manifest_payload_checksum {
+        return Err(CoreError::NamespaceCorrupt(format!(
+            "metadata root for `{}` references manifest `{}` with checksum {} but the manifest carries {}",
+            namespace_id.as_str(),
+            root.manifest_id,
+            root.manifest_payload_checksum,
+            manifest_tables.manifest().payload_checksum,
+        )));
+    }
+    let manifest_head = head_from_manifest(&head, manifest_tables.manifest());
+    let wal_chain = load_validated_wal_chain(
+        store,
+        WalChainLoadRequest {
+            namespace_id,
+            chain_base_seq: manifest_head.seq,
+            head_seq: head.seq,
+            visible_tip: head.visible_wal_tip.clone(),
+            stop_after_seq: None,
+            recent_segments: &head.recent_segments,
+        },
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+    })?;
+    let replayed = {
+        let _span = tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
+        project_validated_wal_tail(
+            &manifest_head,
+            &MetadataState::default(),
+            Some(head.writer_epoch),
+            &wal_chain,
+        )
+        .map_err(MetadataProjectionLoadError::WalReplay)
+        .map_err(CoreError::MetadataProjection)?
+    };
+    ensure_reconstructed_head_matches(&head, &replayed.resulting_head)?;
+    Ok(RootProjection {
+        head,
+        root,
+        floor_seq,
+        manifest_tables,
+        tail_state: replayed.resulting_metadata_state,
+    })
+}
+
+fn ensure_reconstructed_head_matches(
+    current_head: &HeadState,
+    reconstructed: &HeadState,
+) -> Result<()> {
+    if current_head.namespace_id != reconstructed.namespace_id
+        || current_head.seq != reconstructed.seq
+        || current_head.head_commit_id != reconstructed.head_commit_id
+        || current_head.next_inode_id != reconstructed.next_inode_id
+        || (reconstructed.visible_wal_tip.is_some()
+            && current_head.visible_wal_tip != reconstructed.visible_wal_tip)
+    {
+        return Err(CoreError::MetadataProjection(
+            MetadataProjectionLoadError::ReplayedHeadMismatch {
+                expected: Box::new(current_head.clone()),
+                actual: Box::new(reconstructed.clone()),
+            },
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> {
+    current
+        .0
+        .checked_add(1)
+        .map(ManifestId)
+        .ok_or_else(|| CoreError::Internal("manifest id overflow".to_owned()))
+}
+
+async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    projection: &RootProjection<'_, S>,
+    writer_version: &str,
+    manifest_id: ManifestId,
+    manifest_object_id: ManifestObjectId,
+) -> Result<NamespaceManifestEnvelope> {
+    let head_seq = projection.head.seq;
+    let previous_manifest = projection.manifest_tables.manifest();
+
+    // A WAL flush is manifest-only: every prior run is referenced
+    // unchanged and the WAL delta lands as one new L0 run, so the cost
+    // follows the delta, never the namespace. Folding L0 runs back into the
+    // base is reorganization's job (`reorganize.rs`), off this path.
+    let base_seq = previous_manifest.payload.base_seq;
+    let mut metadata_files = previous_manifest.payload.metadata_files.clone();
+    if previous_manifest.payload.head_seq < head_seq {
+        metadata_files.extend(flatten_manifest_tables(
+            build_manifest_l0_run_tables(
+                store,
+                namespace_id,
+                head_seq,
+                previous_manifest.payload.head_seq,
+                &projection.tail_state,
+            )
+            .await?,
+        ));
+    }
+
+    NamespaceManifestEnvelope::from_payload(
+        writer_version,
+        NamespaceManifestPayload {
+            namespace_id: namespace_id.clone(),
+            manifest_id,
+            manifest_object_id,
+            head_seq,
+            head_commit_id: projection.head.head_commit_id.clone(),
+            base_seq,
+            writer_epoch: projection.head.writer_epoch,
+            next_inode_id: projection.head.next_inode_id,
+            retention_floor_seq: projection.floor_seq,
+            initialized: true,
+            verified: true,
+            fork: None,
+            features: BTreeMap::new(),
+            metadata_files,
+        },
+    )
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace manifest envelope: {err}"
+        ))
+    })
+}

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -5,8 +5,11 @@
 //! version for retention, forks, stable reads, and restore. Submodules follow
 //! the manifest lifecycle:
 //!
-//! - [`create`] orchestrates checkpoint creation: project a manifest from the
-//!   current materialization, then publish it.
+//! - [`flush`] folds the visible WAL tail into metadata tables and
+//!   advances `metadata/root.json` — the record-less latest-state
+//!   maintenance path.
+//! - [`create`] orchestrates checkpoint creation: flush, then pin
+//!   the resulting manifest under one durable record.
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
 //! - [`publish`] writes manifest objects and advances `current_manifest_id`
 //!   on the head by compare-and-swap.
@@ -22,6 +25,7 @@ mod build;
 mod cache;
 mod create;
 mod error;
+mod flush;
 mod load;
 mod publish;
 pub(crate) mod record;
@@ -45,6 +49,7 @@ pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::{build_initial_namespace_manifest, create_checkpoint};
+pub(crate) use self::flush::flush_wal;
 pub(crate) use self::load::{
     head_from_manifest, load_namespace_manifest_envelope, load_verified_manifest_tables,
     load_verified_manifest_tables_with_cache,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -24,7 +24,7 @@ use super::build::{
     build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
     MetadataTableSegmentation,
 };
-use super::create::{next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT};
+use super::flush::{next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT};
 use super::load::{
     load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
     validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -16,8 +16,8 @@ use loonfs_api::EffectiveLimit;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     ContentRef, CreateCheckpointResponse, DirectoryPageCursor, FileRevision,
-    FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, ManifestId, ManifestObjectId,
-    NamespaceId, NamespaceSummary, Page, PageRequest, RevisionNo, UploadId,
+    FileRevisionsPageCursor, FlushWalResponse, InodeId, ListFileRevisionsResponse, ManifestId,
+    ManifestObjectId, NamespaceId, NamespaceSummary, Page, PageRequest, RevisionNo, UploadId,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -465,6 +465,18 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.mutation_context(),
         )
         .await
+    }
+
+    /// Flushes the visible WAL tail and advances `metadata/root.json` to a
+    /// manifest covering the current head.
+    ///
+    /// This is the latest-state maintenance operation: it absorbs the visible
+    /// WAL tail into a published manifest and advances the root, creating no
+    /// checkpoint record. Superseded manifests become garbage-collection
+    /// candidates once nothing pins them.
+    pub async fn flush_wal(&self) -> CoreResult<FlushWalResponse> {
+        crate::checkpoint::flush_wal(&self.store, &self.namespace_id, &self.mutation_context())
+            .await
     }
 
     /// Runs at most one metadata reorganization unit: folds one family

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -907,6 +907,100 @@ mod tests {
         stat_root(&store, &namespace_id).await;
     }
 
+    /// The maintenance-retention property: repeated record-less WAL
+    /// flushes leave superseded manifests unpinned, so GC reclaims
+    /// them once aged — retained metadata stays bounded under maintenance.
+    #[tokio::test]
+    async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        for round in 0..3 {
+            write_file(
+                &store,
+                &namespace_id,
+                &format!("/docs/file-{round}.txt"),
+                &format!("gc-adv-{round}"),
+                &setup,
+            )
+            .await;
+            crate::checkpoint::flush_wal(&store, &namespace_id, &setup)
+                .await
+                .expect("flush wal");
+        }
+
+        // Record-less maintenance: nothing accumulates under `checkpoints/`.
+        assert!(
+            store
+                .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+                .await
+                .expect("list checkpoint records")
+                .is_empty(),
+            "a wal flush must not create checkpoint records"
+        );
+
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass");
+
+        // Three flushes superseded the bootstrap manifest and two
+        // intermediates; only the root's manifest is reachable. Its tables
+        // are all still referenced (a flush only appends L0 runs).
+        assert_eq!(report.deleted_manifests, 3);
+        assert!(!report.degraded_retention);
+        let manifests_left = list_prefix(&store, &metadata_manifest_prefix(namespace_id.as_str()))
+            .await
+            .expect("list manifests");
+        assert_eq!(manifests_left.len(), 1, "only the live root manifest stays");
+
+        // Reorganization folds the L0 runs into fresh base segments; the
+        // superseded run tables then age out on the next pass.
+        let fold_policy = crate::checkpoint::MetadataLsmPolicy {
+            max_l0_runs: 1,
+            ..Default::default()
+        };
+        for _ in 0..16 {
+            let report = crate::checkpoint::reorganize_metadata_step(
+                &store,
+                &namespace_id,
+                &setup,
+                fold_policy,
+            )
+            .await
+            .expect("reorganize step");
+            if matches!(
+                report.outcome,
+                crate::checkpoint::MetadataReorganizeOutcome::NotNeeded { .. }
+            ) {
+                break;
+            }
+        }
+        let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+        let after_fold = gc_namespace(&store, &namespace_id, &config(), &aged)
+            .await
+            .expect("gc pass after reorganization");
+        assert!(
+            after_fold.deleted_metadata_tables > 0,
+            "folded-away run tables become collectable"
+        );
+        assert!(!after_fold.degraded_retention);
+
+        stat_root(&store, &namespace_id).await;
+        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("load view");
+        for round in 0..3 {
+            view.resolve_path(&format!("/docs/file-{round}.txt"))
+                .await
+                .expect("file readable after sweep");
+        }
+    }
+
     #[tokio::test]
     async fn gc_retains_active_checkpoint_bases() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -10,7 +10,7 @@ use loonfs::{ChangeSeq, CreateNamespaceOptions, DeleteNamespaceOptions};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::{
-    AdvanceRetentionResponse, CreateCheckpointResponse, CreateNamespaceRequest,
+    AdvanceRetentionResponse, CreateCheckpointResponse, CreateNamespaceRequest, FlushWalResponse,
     ForkNamespaceRequest, GcRequest, GcResponse, MaintenanceTickRequest, MaintenanceTickResponse,
     FEATURE_UPLOADS_DIRECT_PUT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
@@ -204,7 +204,7 @@ pub(super) async fn fork_namespace(
         path = "/v0/admin/namespaces/{namespace}/checkpoint",
         tag = "admin",
         summary = "Create checkpoint",
-        description = "Records a checkpoint of the current namespace view. Unnamed checkpoints are maintenance bookkeeping: a manifest retains only the four newest, so this is not a durable pin with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
+        description = "Creates or reuses a durable checkpoint record pinning the current namespace view. The record is a garbage-collection root until it is retired, so routine maintenance should flush the WAL instead. This is a maintenance/admin operation, not a file mutation.",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Checkpoint created or reused", body = CreateCheckpointResponse),
@@ -226,6 +226,40 @@ pub(super) async fn create_checkpoint(
     let response = state
         .admin
         .create_checkpoint(&namespace_id)
+        .await
+        .map_err(ApiResponseError::runtime)?;
+    Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/wal/flush",
+        tag = "admin",
+        summary = "Flush WAL",
+        description = "Folds the visible WAL tail into metadata tables, publishes a manifest, and advances the metadata root to cover the current head. No checkpoint record is created; superseded manifests become garbage-collection candidates once nothing pins them. This is the routine latest-state maintenance operation.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Metadata root covers the current head", body = FlushWalResponse),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Lost the root race", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn flush_wal(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+) -> Result<Json<FlushWalResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let response = state
+        .admin
+        .flush_wal(&namespace_id)
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(response))
@@ -306,7 +340,7 @@ pub(super) async fn gc_namespace(
         path = "/v0/admin/namespaces/{namespace}/maintenance/tick",
         tag = "admin",
         summary = "Run maintenance tick",
-        description = "Runs one bounded maintenance step: publishes a checkpoint once the visible WAL tail reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing a checkpoint race is an outcome, not an error.",
+        description = "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing the root race is an outcome, not an error.",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body(content = MaintenanceTickRequest, description = "Optional threshold and GC overrides"),
         responses(

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -33,8 +33,8 @@ use self::handlers_filesystem::{
     list_entries, list_inode_revisions, list_path_revisions, restore_inode_revision, stat_entry,
 };
 use self::handlers_namespace::{
-    advance_retention, create_checkpoint, create_namespace, delete_namespace, fork_namespace,
-    gc_namespace, maintenance_tick, namespace_status,
+    advance_retention, create_checkpoint, create_namespace, delete_namespace, flush_wal,
+    fork_namespace, gc_namespace, maintenance_tick, namespace_status,
 };
 use self::handlers_uploads::{begin_upload, complete_upload, upload_content};
 use crate::config::{ServerConfig, ServerConfigError};
@@ -202,6 +202,7 @@ fn router(state: AppState) -> Router {
             "/v0/admin/namespaces/:namespace/checkpoint",
             post(create_checkpoint),
         )
+        .route("/v0/admin/namespaces/:namespace/wal/flush", post(flush_wal))
         .route(
             "/v0/admin/namespaces/:namespace/retention/advance",
             post(advance_retention),

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -16,9 +16,9 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointResponse,
     CreateNamespaceRequest, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, ForkNamespaceRequest, GcRequest, GcResponse, InodeId,
-    ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
-    MaintenanceTickResponse, RestoreFileRevisionRequest, RevisionNo,
+    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest,
+    GcRequest, GcResponse, InodeId, ListFileRevisionsResponse, MaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse, RestoreFileRevisionRequest, RevisionNo,
 };
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
@@ -57,6 +57,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_filesystem::commit_operations,
         crate::http::handlers_filesystem::list_changes,
         crate::http::handlers_namespace::create_checkpoint,
+        crate::http::handlers_namespace::flush_wal,
         crate::http::handlers_namespace::advance_retention,
         crate::http::handlers_namespace::maintenance_tick,
         crate::http::handlers_namespace::gc_namespace
@@ -79,6 +80,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         ListFileRevisionsResponse,
         RestoreFileRevisionRequest,
         CreateCheckpointResponse,
+        FlushWalOutcome,
+        FlushWalResponse,
         AdvanceRetentionResponse,
         MaintenanceTickRequest,
         MaintenanceTickOutcome,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1691,8 +1691,8 @@ async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
         assert_eq!(idle.outcome, loonfs_api::MaintenanceTickOutcome::NotNeeded);
         assert!(idle.gc.is_none());
 
-        // Forcing the threshold to one segment publishes a checkpoint and
-        // runs the opted-in GC pass.
+        // Forcing the threshold to one segment flushes the WAL tail
+        // and runs the opted-in GC pass.
         let forced: loonfs_api::MaintenanceTickResponse = client
             .maintenance_tick(
                 namespace,
@@ -1704,8 +1704,8 @@ async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
             .expect("forced tick");
         assert_eq!(
             forced.outcome,
-            loonfs_api::MaintenanceTickOutcome::CheckpointPublished {
-                checkpoint_seq: ChangeSeq(1),
+            loonfs_api::MaintenanceTickOutcome::WalFlushed {
+                manifest_head_seq: ChangeSeq(1),
             }
         );
         let gc = forced.gc.expect("gc report present when opted in");

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -17,11 +17,12 @@ use crate::{
     ChangesResponse, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions, CoreError,
     CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions,
-    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, InodeId,
-    ListChangesOptions, ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, ObjectStore, PutFileOptions, RestoreRevisionOptions,
-    RevisionNo, RuntimeCacheStats, UploadContentResponse,
+    DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions, ErrorCode, FlushWalOutcome,
+    FlushWalResponse, InodeId, ListChangesOptions, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult,
+    MoveOptions, MutationResult, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    ObjectStore, PutFileOptions, RestoreRevisionOptions, RevisionNo, RuntimeCacheStats,
+    UploadContentResponse,
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
@@ -262,17 +263,15 @@ impl FsCore {
             });
         }
 
-        let checkpoint = match self.create_checkpoint(namespace_id).await {
-            Ok(checkpoint) => checkpoint,
+        let flush = match self.flush_wal(namespace_id).await {
+            Ok(flush) => flush,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
                 self.run_tick_reorganization(namespace_id).await?;
                 let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
                 return Ok(MaintenanceTickResult {
                     namespace_id: namespace_id.clone(),
                     status_before,
-                    outcome: MaintenanceTickOutcome::CheckpointPublishRaceLost {
-                        observed_head_seq,
-                    },
+                    outcome: MaintenanceTickOutcome::WalFlushRaceLost { observed_head_seq },
                     gc,
                 });
             }
@@ -280,19 +279,15 @@ impl FsCore {
         };
         self.run_tick_reorganization(namespace_id).await?;
 
-        let outcome = if checkpoint.current_manifest_id == Some(checkpoint.manifest_id) {
-            MaintenanceTickOutcome::CheckpointPublished {
-                checkpoint_seq: checkpoint.checkpoint_seq,
-            }
-        } else {
-            let Some(current_manifest_id) = checkpoint.current_manifest_id else {
-                return Err(RuntimeError::Core(CoreError::Internal(
-                    "checkpoint publication returned no current manifest id".to_owned(),
-                )));
-            };
-            MaintenanceTickOutcome::CheckpointSuperseded {
-                attempted_seq: checkpoint.checkpoint_seq,
-                current_manifest_id,
+        let outcome = match flush.outcome {
+            FlushWalOutcome::Published => MaintenanceTickOutcome::WalFlushed {
+                manifest_head_seq: flush.manifest_head_seq,
+            },
+            FlushWalOutcome::AlreadyCurrent | FlushWalOutcome::Superseded => {
+                MaintenanceTickOutcome::WalFlushSuperseded {
+                    attempted_seq: flush.target_head_seq,
+                    current_manifest_id: flush.manifest_id,
+                }
             }
         };
 
@@ -1279,6 +1274,30 @@ impl FsCore {
         let result = self
             .namespace_engine(namespace_id)
             .create_checkpoint()
+            .await
+            .map_err(RuntimeError::from);
+        self.finish_namespace_mutation(namespace_id, result)
+    }
+
+    /// Flushes the WAL tail and advances the metadata root, creating no
+    /// checkpoint record.
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.compaction",
+        err,
+        skip_all,
+        fields(
+            operation = "compaction",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn flush_wal(&self, namespace_id: &NamespaceId) -> Result<FlushWalResponse> {
+        let span = tracing::Span::current();
+        self.record_trace_context(&span);
+        let result = self
+            .namespace_engine(namespace_id)
+            .flush_wal()
             .await
             .map_err(RuntimeError::from);
         self.finish_namespace_mutation(namespace_id, result)

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -5,10 +5,10 @@ use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
 use crate::fs::FsCore;
 use crate::{
-    AdvanceRetentionResponse, CreateCheckpointResponse, GcConfig, GcReport, MaintenanceTickOptions,
-    MaintenanceTickResult, NamespaceId, NamespaceStatusResponse, ObjectStoreMetricsRecorder,
-    Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
-    TraceMode, TraceStoreKind,
+    AdvanceRetentionResponse, CreateCheckpointResponse, FlushWalResponse, GcConfig, GcReport,
+    MaintenanceTickOptions, MaintenanceTickResult, NamespaceId, NamespaceStatusResponse,
+    ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError,
+    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -84,6 +84,18 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<CreateCheckpointResponse> {
         self.core.create_checkpoint(namespace_id).await
+    }
+
+    /// Flushes the WAL tail and advances the metadata root to a manifest
+    /// covering the current head.
+    ///
+    /// This is the latest-state maintenance operation: it absorbs the
+    /// visible WAL tail into a published manifest and advances
+    /// `metadata/root.json`, creating no checkpoint record. Superseded
+    /// manifests become garbage-collection candidates once nothing pins
+    /// them.
+    pub async fn flush_wal(&self, namespace_id: &NamespaceId) -> Result<FlushWalResponse> {
+        self.core.flush_wal(namespace_id).await
     }
 
     /// Advances the namespace retention floor when a verified checkpoint

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -51,12 +51,13 @@ pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
     ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointResponse,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DirectoryPageCursor, DisplayName,
-    EffectiveLimit, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse, InodeId,
-    InodeKind, ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult,
-    NameKey, NamePolicy, NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest,
-    PaginationPolicy, PutBehavior, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT,
-    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    EffectiveLimit, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse,
+    FlushWalOutcome, FlushWalResponse, InodeId, InodeKind, ListFileRevisionsResponse,
+    ListPathEntriesResponse, ManifestId, MutationResult, NameKey, NamePolicy, NamespaceId,
+    NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy, PutBehavior,
+    RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -15,10 +15,11 @@ use loonfs_api::v0::{
 /// Options for one maintenance tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaintenanceTickOptions {
-    /// Publish a checkpoint when the visible WAL tail reaches this many segments.
+    /// Flush the visible WAL tail into metadata tables when it reaches this many
+    /// segments.
     pub max_wal_tail_segments: u64,
-    /// Run the mark-and-sweep garbage collector after the tick's checkpoint
-    /// and retention work. Nothing sweeps unless this is set.
+    /// Run the mark-and-sweep garbage collector after the tick's
+    /// flush work. Nothing sweeps unless this is set.
     pub gc: Option<crate::GcConfig>,
 }
 
@@ -71,23 +72,24 @@ pub fn gc_response_from_report(namespace_id: NamespaceId, report: GcReport) -> G
 /// Outcome of one maintenance tick.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MaintenanceTickOutcome {
-    /// No checkpoint was needed.
+    /// The WAL tail was below the threshold; the root was left alone.
     NotNeeded,
-    /// A checkpoint was published.
-    CheckpointPublished {
-        /// Sequence covered by the published checkpoint.
-        checkpoint_seq: ChangeSeq,
+    /// The tick flushed the WAL tail and advanced the metadata root.
+    WalFlushed {
+        /// Sequence covered by the published manifest.
+        manifest_head_seq: ChangeSeq,
     },
-    /// Another checkpoint already covered the attempted sequence.
-    CheckpointSuperseded {
-        /// Sequence this tick attempted to checkpoint.
+    /// The root already covered the attempted sequence — another publisher
+    /// got there first.
+    WalFlushSuperseded {
+        /// Sequence this tick attempted to flush through.
         attempted_seq: ChangeSeq,
-        /// Manifest pointer the head currently records.
+        /// Manifest the root currently references.
         current_manifest_id: ManifestId,
     },
     /// A concurrent head update won the race.
-    CheckpointPublishRaceLost {
-        /// Head sequence observed before the checkpoint attempt.
+    WalFlushRaceLost {
+        /// Head sequence observed before the advance attempt.
         observed_head_seq: ChangeSeq,
     },
 }
@@ -117,18 +119,18 @@ impl MaintenanceTickResult {
             status_before: self.status_before,
             outcome: match self.outcome {
                 MaintenanceTickOutcome::NotNeeded => WireMaintenanceTickOutcome::NotNeeded,
-                MaintenanceTickOutcome::CheckpointPublished { checkpoint_seq } => {
-                    WireMaintenanceTickOutcome::CheckpointPublished { checkpoint_seq }
+                MaintenanceTickOutcome::WalFlushed { manifest_head_seq } => {
+                    WireMaintenanceTickOutcome::WalFlushed { manifest_head_seq }
                 }
-                MaintenanceTickOutcome::CheckpointSuperseded {
+                MaintenanceTickOutcome::WalFlushSuperseded {
                     attempted_seq,
                     current_manifest_id,
-                } => WireMaintenanceTickOutcome::CheckpointSuperseded {
+                } => WireMaintenanceTickOutcome::WalFlushSuperseded {
                     attempted_seq,
                     current_manifest_id,
                 },
-                MaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq } => {
-                    WireMaintenanceTickOutcome::CheckpointPublishRaceLost { observed_head_seq }
+                MaintenanceTickOutcome::WalFlushRaceLost { observed_head_seq } => {
+                    WireMaintenanceTickOutcome::WalFlushRaceLost { observed_head_seq }
                 }
             },
         }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2372,7 +2372,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
 }
 
 #[test]
-fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
+fn maintenance_tick_at_segment_threshold_flushes_the_wal() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-publish-test");
     let namespace_id = namespace_id();
@@ -2399,20 +2399,34 @@ fn maintenance_tick_at_segment_threshold_publishes_checkpoint() {
     assert_eq!(tick.status_before.head_seq, ChangeSeq(1));
     assert_eq!(
         tick.outcome,
-        MaintenanceTickOutcome::CheckpointPublished {
-            checkpoint_seq: ChangeSeq(1)
+        MaintenanceTickOutcome::WalFlushed {
+            manifest_head_seq: ChangeSeq(1)
         }
     );
 
     let status = fs
         .namespace_status_blocking(&namespace_id)
-        .expect("status after checkpoint");
+        .expect("status after wal flush");
     assert_eq!(status.current_manifest_id, Some(ManifestId(1)));
     assert_eq!(status.wal_tail_segments, 0);
+
+    // Maintenance is record-less: flushing the WAL must leave nothing
+    // under `checkpoints/`.
+    let raw_store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let records = block_on(
+        raw_store.list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(
+            namespace_id.as_str(),
+        )),
+    )
+    .expect("list checkpoint records");
+    assert!(
+        records.is_empty(),
+        "maintenance tick created checkpoint records: {records:?}"
+    );
 }
 
 #[test]
-fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
+fn maintenance_tick_after_existing_manifest_writes_l0_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-l0-run-publish-test");
     let namespace_id = namespace_id();
@@ -2453,14 +2467,14 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
         .expect("second maintenance tick");
     assert_eq!(
         tick.outcome,
-        MaintenanceTickOutcome::CheckpointPublished {
-            checkpoint_seq: ChangeSeq(2)
+        MaintenanceTickOutcome::WalFlushed {
+            manifest_head_seq: ChangeSeq(2)
         }
     );
 
     let status = fs
         .namespace_status_blocking(&namespace_id)
-        .expect("status after l0 checkpoint");
+        .expect("status after l0 wal flush");
     assert_eq!(status.current_manifest_id, Some(ManifestId(2)));
     assert_eq!(status.wal_tail_segments, 0);
 
@@ -2476,7 +2490,7 @@ fn maintenance_tick_after_existing_checkpoint_writes_l0_manifest() {
         .expect("read namespace manifest")
         .expect("namespace manifest exists");
     let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
-    // Checkpoints only append: the base marker stays the seed's until
+    // A WAL flush only appends: the base marker stays the seed's until
     // reorganization folds the delta runs.
     assert_eq!(manifest.payload.base_seq, ChangeSeq(0));
     let l0_files = manifest
@@ -2568,8 +2582,8 @@ fn maintenance_tick_counts_segments_not_commits() {
     assert_eq!(tick.status_before.wal_tail_segments, 2);
     assert_eq!(
         tick.outcome,
-        MaintenanceTickOutcome::CheckpointPublished {
-            checkpoint_seq: ChangeSeq(3)
+        MaintenanceTickOutcome::WalFlushed {
+            manifest_head_seq: ChangeSeq(3)
         }
     );
 }
@@ -2631,7 +2645,7 @@ fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
 
     assert_eq!(
         tick.outcome,
-        MaintenanceTickOutcome::CheckpointPublishRaceLost {
+        MaintenanceTickOutcome::WalFlushRaceLost {
             observed_head_seq: ChangeSeq(1)
         }
     );

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -25,7 +25,7 @@ within a plane is expressed as **named features** (section 2).
 | Profile | Plane | Ops | Status |
 | --- | --- | --- | --- |
 | `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, explicit commits, the change feed, namespace status by id, `GET /v0/config`, and the standard error contract. Namespace `list`, `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
-| `admin/v0` | Maintenance plane | Trigger checkpoint creation; trigger retention-floor advancement; run one-shot maintenance ticks; run garbage collection. Future maintenance triggers (compaction, index builds) arrive as features in this plane. | Optional |
+| `admin/v0` | Maintenance plane | Trigger WAL flushes; trigger checkpoint creation; trigger retention-floor advancement; run one-shot maintenance ticks; run garbage collection. Future maintenance triggers (compaction, index builds) arrive as features in this plane. | Optional |
 | `query/v0` | Query plane | — | **Reserved name only.** Materializes only if derived indexes introduce endpoints beyond the core ops; until that decision, no ops are specified and no `query.*` feature keys are registered. |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
 
@@ -308,8 +308,9 @@ A representative v0 binding is shown below.
 | Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
 | Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
 | Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoint` |
+| Flush the WAL tail | `POST /v0/admin/namespaces/{ns}/wal/flush` (folds the visible WAL tail into metadata tables and advances the metadata root; creates no checkpoint record) |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
-| Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; checkpoint races surface as outcomes, not errors) |
+| Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; flush races surface as outcomes, not errors) |
 | Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; nothing sweeps without an explicit call) |
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile; everything else

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -614,9 +614,9 @@ re-verification, this closes the create-vs-collect race: within the grace
 window any record is protected unconditionally by age.
 
 A namespace manifest is the durable object for one namespace file-set version.
-It may reference one or more immutable metadata runs and may include
-standalone checkpoint records under `checkpoints/` pin manifest versions for
-retention, fork, or stable read workflows. Each run is internally segmented without overlapping segment
+It may reference one or more immutable metadata runs; standalone checkpoint
+records under `checkpoints/` pin manifest versions for retention, fork, or
+stable read workflows. Each run is internally segmented without overlapping segment
 key ranges; different runs may overlap and readers apply the normal metadata
 visibility rules across all referenced runs. Within a segment, rows are stored
 in ascending row-key order (adjacent equal keys permitted); readers reject a
@@ -1026,15 +1026,21 @@ candidate; actual deletion additionally requires delete-time re-verification,
 and if the floor ever observably passes an active checkpoint's basis,
 retention wins ("Garbage collection").
 
-Creating a checkpoint pins the current durable namespace file-set version. If
-there is no manifest for the current head, the implementation first writes one
-and publishes it by monotonic CAS on `metadata/root.json` — never by touching
-the WAL head, so head watchers observe only commits. It then writes
-`checkpoints/{id}.json` (id derived deterministically from the basis identity,
-so repeating creation for the same pinned manifest returns the existing record
-without listing) and verifies the basis after the write, flipping the record
-to dead on failure. A live manifest does not need to be checkpoint-pinned;
-checkpoint records explain why a manifest version must be retained.
+A WAL flush materializes the current durable namespace
+file-set version: if there is no manifest for the current head, the
+implementation writes one absorbing the visible WAL tail and publishes it by
+monotonic CAS on `metadata/root.json` — never by touching the WAL head, so
+head watchers observe only commits. The flush is the latest-state
+maintenance operation and creates no checkpoint record; a superseded manifest
+becomes a garbage-collection candidate once nothing pins it.
+
+Creating a checkpoint pins one such manifest version deliberately. It first
+flushes the WAL tail as above, then writes `checkpoints/{id}.json` (id derived
+deterministically from the basis identity, so repeating creation for the same
+pinned manifest returns the existing record without listing) and verifies the
+basis after the write, flipping the record to dead on failure. A live
+manifest does not need to be checkpoint-pinned; checkpoint records explain
+why a manifest version must be retained after the root moves on.
 
 ### 3.9 Namespace forks
 
@@ -1244,7 +1250,7 @@ Maintenance **effects** are normative format semantics; maintenance
 **scheduling and triggering** are not. Two behaviors keep an un-administered
 deployment's read costs bounded regardless of scheduling: the reference
 implementation schedules a background maintenance tick after any runtime
-publish that observes the WAL tail at or past the checkpoint threshold
+publish that observes the WAL tail at or past the WAL-flush threshold
 (32 segments at defaults), and every publish surface rejects with
 `maintenance_required` once the tail exceeds four times that threshold
 (128 at defaults). Reads never gate on tail length. Bounded reads are the
@@ -1289,7 +1295,7 @@ A base rebuild drops rows that no retained sequence can observe: revisions
 superseded at or below the retention floor, bindings superseded or unbound at
 or below the floor, spent unbind markers, and commit receipts below the
 floor. The floor is the single retention policy: history below it — including
-file revision history — is reclaimed, except where a named checkpoint record
+file revision history — is reclaimed, except where an active checkpoint record
 still pins an older manifest that can serve it. Tombstone and inode rows are always
 retained for now; reachability-based dropping for them is future work.
 
@@ -1302,12 +1308,12 @@ Invariants:
 - Compacted inputs MUST remain available until no retained manifest version,
   checkpoint record, or fork GC pin references them.
 
-Checkpoint records are standalone files under `checkpoints/`. Records for
-superseded bases are reaped by garbage collection under the grace-window and
-delete-time re-verification rules ("Garbage collection"); named or owned
-records persist until explicitly released. Fork sources are protected by
-their GC pins independently of maintenance records, so record cleanup never
-affects fork safety.
+Checkpoint records are standalone files under `checkpoints/`. Maintenance
+never creates one: automatic root advancement leaves superseded manifests and
+folded-away tables unpinned, and garbage collection reaps them under the
+grace-window and delete-time re-verification rules ("Garbage collection").
+A checkpoint record is a deliberate pin — fork sources and explicit admin
+checkpoints — and roots its basis for as long as the record exists.
 
 ### 6.3 Retention management
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -41,7 +41,7 @@
           "admin"
         ],
         "summary": "Create checkpoint",
-        "description": "Records a checkpoint of the current namespace view. Unnamed checkpoints are maintenance bookkeeping: a manifest retains only the four newest, so this is not a durable pin with a checkpoint. This is a maintenance/admin operation, not a file mutation.",
+        "description": "Creates or reuses a durable checkpoint record pinning the current namespace view. The record is a garbage-collection root until it is retired, so routine maintenance should flush the WAL instead. This is a maintenance/admin operation, not a file mutation.",
         "operationId": "create_checkpoint",
         "parameters": [
           {
@@ -198,7 +198,7 @@
           "admin"
         ],
         "summary": "Run maintenance tick",
-        "description": "Runs one bounded maintenance step: publishes a checkpoint once the visible WAL tail reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing a checkpoint race is an outcome, not an error.",
+        "description": "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing the root race is an outcome, not an error.",
         "operationId": "maintenance_tick",
         "parameters": [
           {
@@ -328,6 +328,89 @@
           },
           "404": {
             "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/admin/namespaces/{namespace}/wal/flush": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Flush WAL",
+        "description": "Folds the visible WAL tail into metadata tables, publishes a manifest, and advances the metadata root to cover the current head. No checkpoint record is created; superseded manifests become garbage-collection candidates once nothing pins them. This is the routine latest-state maintenance operation.",
+        "operationId": "flush_wal",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metadata root covers the current head",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlushWalResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Lost the root race",
             "content": {
               "application/json": {
                 "schema": {
@@ -3271,6 +3354,48 @@
           }
         }
       },
+      "FlushWalOutcome": {
+        "type": "string",
+        "description": "How one WAL flush satisfied its goal.",
+        "enum": [
+          "already_current",
+          "published",
+          "superseded"
+        ]
+      },
+      "FlushWalResponse": {
+        "type": "object",
+        "description": "Result of one WAL flush: how the metadata root covers the head.",
+        "required": [
+          "namespace_id",
+          "target_head_seq",
+          "manifest_id",
+          "manifest_head_seq",
+          "outcome"
+        ],
+        "properties": {
+          "manifest_head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence covered by that manifest."
+          },
+          "manifest_id": {
+            "$ref": "#/components/schemas/ManifestId",
+            "description": "Manifest `metadata/root.json` references after the operation."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace whose WAL tail was flushed."
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/FlushWalOutcome",
+            "description": "How the root came to cover the head."
+          },
+          "target_head_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Head sequence the flush attempted to cover."
+          }
+        }
+      },
       "ForkNamespaceRequest": {
         "type": "object",
         "description": "Request to fork a namespace.",
@@ -3469,7 +3594,7 @@
         "oneOf": [
           {
             "type": "object",
-            "description": "No checkpoint was needed.",
+            "description": "The WAL tail was below the threshold; the root was left alone.",
             "required": [
               "kind"
             ],
@@ -3484,27 +3609,27 @@
           },
           {
             "type": "object",
-            "description": "A checkpoint was published.",
+            "description": "The tick flushed the WAL tail and advanced the metadata root.",
             "required": [
-              "checkpoint_seq",
+              "manifest_head_seq",
               "kind"
             ],
             "properties": {
-              "checkpoint_seq": {
-                "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Sequence covered by the published checkpoint."
-              },
               "kind": {
                 "type": "string",
                 "enum": [
-                  "checkpoint_published"
+                  "wal_flushed"
                 ]
+              },
+              "manifest_head_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence covered by the published manifest."
               }
             }
           },
           {
             "type": "object",
-            "description": "Another checkpoint already covered the attempted sequence.",
+            "description": "The root already covered the attempted sequence — another publisher\ngot there first.",
             "required": [
               "attempted_seq",
               "current_manifest_id",
@@ -3513,16 +3638,16 @@
             "properties": {
               "attempted_seq": {
                 "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Sequence this tick attempted to checkpoint."
+                "description": "Sequence this tick attempted to flush through."
               },
               "current_manifest_id": {
                 "$ref": "#/components/schemas/ManifestId",
-                "description": "Manifest pointer the head currently records."
+                "description": "Manifest the root currently references."
               },
               "kind": {
                 "type": "string",
                 "enum": [
-                  "checkpoint_superseded"
+                  "wal_flush_superseded"
                 ]
               }
             }
@@ -3538,12 +3663,12 @@
               "kind": {
                 "type": "string",
                 "enum": [
-                  "checkpoint_publish_race_lost"
+                  "wal_flush_race_lost"
                 ]
               },
               "observed_head_seq": {
                 "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Head sequence observed before the checkpoint attempt."
+                "description": "Head sequence observed before the advance attempt."
               }
             }
           }
@@ -3561,7 +3686,7 @@
               },
               {
                 "$ref": "#/components/schemas/GcRequest",
-                "description": "Run the mark-and-sweep garbage collector after the tick's checkpoint\nwork. Nothing sweeps unless this is present."
+                "description": "Run the mark-and-sweep garbage collector after the tick's\nflush work. Nothing sweeps unless this is present."
               }
             ]
           },
@@ -3571,7 +3696,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Publish a checkpoint when the visible WAL tail reaches this many\nsegments.",
+            "description": "Flush the visible WAL tail into metadata tables when it reaches this\nmany segments.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
Automatic maintenance called create_checkpoint on every WAL-threshold crossing, and each unnamed record it wrote was a permanent GC root — retained metadata grew without bound under normal operation, contradicting both format.md and the endpoint description. This extracts the latest-state half into flush_wal (project the namespace state, fold the visible WAL tail into metadata tables as one L0 run, publish a manifest, and advance metadata/root.json by monotonic CAS — no record) and routes the maintenance tick and auto-tick through it, so superseded manifests become ordinary GC candidates; checkpoint creation now composes a flush plus the durable pin. The operation is named for the LSM flush it is: new admin endpoint POST /v0/admin/namespaces/{ns}/wal/flush, FsAdmin::flush_wal, loon admin flush, and tick outcomes reporting wal_flushed instead of checkpoint publication (flush joins the STYLE.md verb registry). First of a five-PR stack fixing the pre-v0 checkpoint-lifecycle and GC-safety blockers; openapi.json regenerated, format.md/api.md updated to match.