### PR TITLE
feat(core): consolidate publication budgets and enforce the derived gc grace floor

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -305,10 +305,13 @@ pub struct FlushWalResponse {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GcRequest {
-    /// Objects younger than this are never deleted, reachable or not.
+    /// Objects younger than this are never deleted, reachable or not. The
+    /// window has a derived safety floor (publication budgets plus provider
+    /// deadlines); a smaller value is rejected as `invalid_request`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grace_window_ms: Option<u64>,
-    /// Abandoned bootstrap trees older than this may be reaped.
+    /// Abandoned bootstrap trees older than this may be reaped. Must be at
+    /// least the grace window.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reap_window_ms: Option<u64>,
 }

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -37,7 +37,7 @@ use crate::metadata::MetadataStateBuilder;
 // newest current manifest.
 pub(super) const CHECKPOINT_PUBLICATION_RETRY_LIMIT: usize = 8;
 
-pub(crate) const CHECKPOINT_VERIFY_BUDGET_MS: u64 = 60_000;
+pub(crate) use crate::limits::CHECKPOINT_VERIFY_BUDGET_MS;
 
 /// Longest accepted user checkpoint name. A label bound, not a durable
 /// format limit.
@@ -62,9 +62,10 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
     // 4. On verification failure, flip the record to released and retry
     //    against a newer basis.
     validate_checkpoint_owner(&owner, expires_at_ms)?;
+    let timer = StdMonotonicTimer::default();
     let mut saw_root_cas_race = false;
     for _publication_attempt in 0..CHECKPOINT_PUBLICATION_RETRY_LIMIT {
-        let basis = match try_flush_wal(store, namespace_id, context).await? {
+        let basis = match try_flush_wal(store, namespace_id, context, &timer).await? {
             TryFlushWal::Flushed(basis) => basis,
             TryFlushWal::RaceLost => {
                 saw_root_cas_race = true;
@@ -92,7 +93,6 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
             owner: owner.clone(),
             state: CheckpointRecordLifecycle::Active,
         };
-        let timer = StdMonotonicTimer::default();
         let verify_started_ms = timer.monotonic_now_ms();
         let written = write_checkpoint_record(store, &record, &context.writer_version).await?;
 

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -20,9 +20,11 @@ use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::Result;
+use crate::limits::METADATA_PUBLICATION_BUDGET_MS;
 use crate::metadata::MetadataState;
 use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::{read_head_and_metadata_root, read_wal_floor_seq_or_zero};
+use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, MetadataRootState, NamespaceState};
 use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
@@ -82,8 +84,18 @@ pub(crate) async fn flush_wal<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<FlushWalResponse> {
+    let timer = StdMonotonicTimer::default();
+    flush_wal_with_timer(store, namespace_id, context, &timer).await
+}
+
+pub(super) async fn flush_wal_with_timer<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<FlushWalResponse> {
     for _attempt in 0..WAL_FLUSH_RETRY_LIMIT {
-        match try_flush_wal(store, namespace_id, context).await? {
+        match try_flush_wal(store, namespace_id, context, timer).await? {
             TryFlushWal::Flushed(basis) => {
                 return Ok(FlushWalResponse {
                     namespace_id: namespace_id.clone(),
@@ -100,11 +112,18 @@ pub(crate) async fn flush_wal<S: ObjectStore + ?Sized>(
 }
 
 /// One flush attempt against one fresh projection.
+///
+/// The metadata publication budget covers this attempt end to end: the
+/// measurement starts before any table object is written and gates the root
+/// compare-and-swap, so an over-budget build aborts with only unreachable
+/// immutable outputs behind it.
 pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
+    timer: &dyn MonotonicTimer,
 ) -> Result<TryFlushWal> {
+    let publication_started_ms = timer.monotonic_now_ms();
     let projection = load_root_projection(store, namespace_id)
         .instrument(tracing::info_span!(
             "loon.phase",
@@ -185,6 +204,11 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
             "manifest id allocation retry exhausted".to_owned(),
         ));
     };
+    // The publication budget gates the root compare-and-swap: past it, the
+    // written tables and manifest may have aged into the GC grace window,
+    // so this attempt must abort without publishing (format spec, "Garbage
+    // collection", rule 1). The orphans are reclaimed by a later pass.
+    ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
     // Advance the root for readers. A superseded outcome is fine: the
     // manifest we wrote stays durable and valid as a basis even when a
     // newer root already won.
@@ -338,6 +362,31 @@ pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> 
         .checked_add(1)
         .map(ManifestId)
         .ok_or_else(|| CoreError::Internal("manifest id overflow".to_owned()))
+}
+
+/// Refuses to initiate a root compare-and-swap once the publication budget
+/// is spent (format spec, "Garbage collection", rule 1).
+pub(super) fn ensure_metadata_publication_budget(
+    timer: &dyn MonotonicTimer,
+    publication_started_ms: u64,
+    namespace_id: &NamespaceId,
+) -> Result<()> {
+    let elapsed_ms = timer
+        .monotonic_now_ms()
+        .saturating_sub(publication_started_ms);
+    if elapsed_ms <= METADATA_PUBLICATION_BUDGET_MS {
+        return Ok(());
+    }
+    tracing::error!(
+        namespace_id = namespace_id.as_str(),
+        elapsed_ms,
+        budget_ms = METADATA_PUBLICATION_BUDGET_MS,
+        "metadata publication overran its budget; aborting before the root compare-and-swap",
+    );
+    Err(CoreError::MetadataPublicationBudgetExceeded {
+        elapsed_ms,
+        budget_ms: METADATA_PUBLICATION_BUDGET_MS,
+    })
 }
 
 async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -24,7 +24,9 @@ use super::build::{
     build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
     MetadataTableSegmentation,
 };
-use super::flush::{next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT};
+use super::flush::{
+    ensure_metadata_publication_budget, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
+};
 use super::load::{
     load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
     validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,
@@ -37,6 +39,7 @@ use super::runs::{
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::control::{read_metadata_root_object, read_wal_floor_seq_or_zero};
+use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{
     MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
@@ -106,6 +109,21 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     policy: MetadataLsmPolicy,
 ) -> Result<MetadataReorganizeReport> {
+    let timer = StdMonotonicTimer::default();
+    reorganize_metadata_step_with_timer(store, namespace_id, context, policy, &timer).await
+}
+
+pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+    timer: &dyn MonotonicTimer,
+) -> Result<MetadataReorganizeReport> {
+    // The publication budget covers the whole unit: measurement starts
+    // before any table object is written and gates the root
+    // compare-and-swap below.
+    let publication_started_ms = timer.monotonic_now_ms();
     let root = read_metadata_root_object(store, namespace_id)
         .await
         .map_err(|error| {
@@ -234,6 +252,7 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     )
     .await?;
 
+    ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
     match publish_metadata_root(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -5653,3 +5653,166 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
 fn is_bootstrap_seed_manifest(payload: &NamespaceManifestPayload) -> bool {
     payload.head_seq == ChangeSeq(0) && payload.base_seq == ChangeSeq(0) && payload.fork.is_none()
 }
+
+/// Deterministic timer advancing a fixed step per reading, so publication
+/// budgets are consumed by observations instead of wall time.
+#[derive(Debug)]
+struct SteppingTimer {
+    now_ms: std::sync::atomic::AtomicU64,
+    step_ms: u64,
+}
+
+impl SteppingTimer {
+    fn new(step_ms: u64) -> Self {
+        Self {
+            now_ms: std::sync::atomic::AtomicU64::new(0),
+            step_ms,
+        }
+    }
+}
+
+impl crate::timing::MonotonicTimer for SteppingTimer {
+    fn monotonic_now_ms(&self) -> u64 {
+        self.now_ms
+            .fetch_add(self.step_ms, std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+/// An over-budget WAL flush aborts before the root compare-and-swap:
+/// the root keeps its previous basis, the orphan outputs are harmless GC
+/// candidates, and an in-budget retry succeeds.
+#[tokio::test]
+async fn over_budget_wal_flush_aborts_without_publishing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = MutationContext {
+        writer_id: "budget-test".to_owned(),
+        writer_session_id: "wrs_budget_test".to_owned(),
+        writer_version: "budget-test/0.1.0".to_owned(),
+        now_ms: 1_000,
+    };
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/budget.txt",
+        b"body",
+        PutBehavior::NoReplace,
+        &context,
+        None,
+    )
+    .await
+    .expect("seed file");
+    let root_before = read_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("read root")
+        .envelope
+        .state;
+
+    // Every reading advances 20 minutes against the 15-minute budget: the
+    // pre-CAS check observes the publication as over budget.
+    let overrun = SteppingTimer::new(20 * 60 * 1000);
+    let error = super::flush::flush_wal_with_timer(&store, &namespace_id, &context, &overrun)
+        .await
+        .expect_err("over-budget publication must abort");
+    assert!(
+        matches!(error, CoreError::MetadataPublicationBudgetExceeded { .. }),
+        "expected budget error, got {error:?}"
+    );
+
+    let root_after = read_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("read root")
+        .envelope
+        .state;
+    assert_eq!(
+        root_after, root_before,
+        "an aborted publication must not move the root"
+    );
+
+    // The in-budget retry publishes normally over fresh outputs.
+    let advanced = super::flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("in-budget retry succeeds");
+    assert_eq!(advanced.outcome, loonfs_api::FlushWalOutcome::Published);
+    assert!(advanced.manifest_id > root_before.manifest_id);
+}
+
+/// An over-budget reorganization unit aborts the same way: no root motion,
+/// orphan tables left for garbage collection.
+#[tokio::test]
+async fn over_budget_reorganization_aborts_without_publishing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = MutationContext {
+        writer_id: "budget-test".to_owned(),
+        writer_session_id: "wrs_budget_test".to_owned(),
+        writer_version: "budget-test/0.1.0".to_owned(),
+        now_ms: 1_000,
+    };
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    put_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/fold.txt",
+        b"body",
+        PutBehavior::NoReplace,
+        &context,
+        None,
+    )
+    .await
+    .expect("seed file");
+    super::flush::flush_wal(&store, &namespace_id, &context)
+        .await
+        .expect("publish an L0 run to fold");
+    let root_before = read_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("read root")
+        .envelope
+        .state;
+
+    let fold_everything = MetadataLsmPolicy {
+        max_l0_runs: 1,
+        ..Default::default()
+    };
+    let overrun = SteppingTimer::new(20 * 60 * 1000);
+    let error = super::reorganize::reorganize_metadata_step_with_timer(
+        &store,
+        &namespace_id,
+        &context,
+        fold_everything,
+        &overrun,
+    )
+    .await
+    .expect_err("over-budget reorganization must abort");
+    assert!(
+        matches!(error, CoreError::MetadataPublicationBudgetExceeded { .. }),
+        "expected budget error, got {error:?}"
+    );
+
+    let root_after = read_metadata_root_object(&store, &namespace_id)
+        .await
+        .expect("read root")
+        .envelope
+        .state;
+    assert_eq!(root_after, root_before);
+
+    let report = super::reorganize::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        fold_everything,
+    )
+    .await
+    .expect("in-budget retry folds the unit");
+    assert!(matches!(
+        report.outcome,
+        super::MetadataReorganizeOutcome::UnitPublished { .. }
+    ));
+}

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -96,6 +96,13 @@ pub enum CoreError {
     CheckpointUnavailable(String),
     #[error("invalid checkpoint request: {0}")]
     InvalidCheckpointRequest(String),
+    #[error(
+        "metadata publication budget exceeded after {elapsed_ms}ms (budget {budget_ms}ms); \
+         the root was not published"
+    )]
+    MetadataPublicationBudgetExceeded { elapsed_ms: u64, budget_ms: u64 },
+    #[error("invalid gc configuration: {0}")]
+    InvalidGcConfig(String),
     #[error("upload session `{upload_id}` was not found")]
     UploadNotFound { upload_id: UploadId },
     #[error("upload session `{upload_id}` is already completed")]
@@ -299,6 +306,10 @@ impl CoreError {
             CoreError::ShuttingDown => ErrorCode::ShuttingDown,
             CoreError::CheckpointUnavailable(_) => ErrorCode::CheckpointUnavailable,
             CoreError::InvalidCheckpointRequest(_) => ErrorCode::InvalidRequest,
+            // An over-budget publication aborts pre-CAS and is retryable
+            // after maintenance, exactly the checkpoint_unavailable contract.
+            CoreError::MetadataPublicationBudgetExceeded { .. } => ErrorCode::CheckpointUnavailable,
+            CoreError::InvalidGcConfig(_) => ErrorCode::InvalidRequest,
             CoreError::UploadNotFound { .. } => ErrorCode::UploadNotFound,
             CoreError::UploadAlreadyCompleted { .. } => ErrorCode::UploadAlreadyCompleted,
             CoreError::UploadContentConflict { .. } => ErrorCode::UploadContentConflict,

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -11,6 +11,7 @@
 use crate::checkpoint::load_namespace_manifest_envelope;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError};
+use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use crate::namespace::control::{
     read_head_object, read_metadata_root_object, read_wal_floor_object, ControlObjectLoadError,
 };
@@ -51,14 +52,19 @@ impl Default for GcConfig {
 
 impl GcConfig {
     fn validate(&self) -> Result<(), CoreError> {
-        if self.grace_window_ms == 0 {
-            return Err(CoreError::Internal(
-                "gc grace_window_ms must be greater than zero".to_owned(),
-            ));
+        // The grace window's floor is derived from the enforced publication
+        // budgets and provider deadlines (`limits`), never tuned per pass:
+        // below it, the publish-in-flight safety proof does not hold, so the
+        // configuration is rejected as an invalid request.
+        if self.grace_window_ms < GC_MIN_GRACE_WINDOW_MS {
+            return Err(CoreError::InvalidGcConfig(format!(
+                "grace_window_ms {} is below the derived safety minimum {}",
+                self.grace_window_ms, GC_MIN_GRACE_WINDOW_MS
+            )));
         }
         if self.reap_window_ms < self.grace_window_ms {
-            return Err(CoreError::Internal(
-                "gc reap_window_ms must be at least the grace window".to_owned(),
+            return Err(CoreError::InvalidGcConfig(
+                "reap_window_ms must be at least the grace window".to_owned(),
             ));
         }
         Ok(())
@@ -840,6 +846,42 @@ mod tests {
         ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
             self.0.list_prefix_stream(prefix)
         }
+    }
+
+    /// The derived floor is enforced at validation: a pass configured below
+    /// it is rejected as an invalid request before touching the store.
+    #[tokio::test]
+    async fn gc_rejects_grace_windows_below_the_derived_minimum() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+
+        let too_small = GcConfig {
+            grace_window_ms: GC_MIN_GRACE_WINDOW_MS - 1,
+            reap_window_ms: REAP_MS,
+        };
+        let error = gc_namespace(&store, &namespace_id, &too_small, &context(1_000))
+            .await
+            .expect_err("sub-minimum grace window must be rejected");
+        assert!(
+            matches!(&error, CoreError::InvalidGcConfig(message)
+                if message.contains("below the derived safety minimum")),
+            "expected invalid gc config, got {error:?}"
+        );
+        assert_eq!(
+            error.code(),
+            crate::error::ErrorCode::InvalidRequest,
+            "the rejection surfaces as invalid_request"
+        );
+
+        let inverted = GcConfig {
+            grace_window_ms: GRACE_MS,
+            reap_window_ms: GRACE_MS - 1,
+        };
+        let error = gc_namespace(&store, &namespace_id, &inverted, &context(1_000))
+            .await
+            .expect_err("reap below grace must be rejected");
+        assert!(matches!(error, CoreError::InvalidGcConfig(_)));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -61,6 +61,7 @@ mod engine;
 mod error;
 pub mod gc;
 mod invariants;
+pub mod limits;
 pub mod metadata;
 pub mod namespace;
 mod options;

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -1,0 +1,92 @@
+//! One source of truth for publication, verification, provider, and
+//! garbage-collection timing bounds.
+//!
+//! The GC grace window's safety proof (format spec, "Garbage collection",
+//! rule 1) is an inequality over these constants: every publication measures
+//! itself against a budget here and refuses to publish its root once the
+//! budget is spent, provider operations consume one deadline across retries,
+//! and the minimum grace window is derived — not tuned — from those bounds
+//! plus a margin for provider-timestamp skew. Callers may configure a larger
+//! grace window, never a smaller one.
+
+use loonfs_objectstore::{PROVIDER_ATTEMPT_TIMEOUT, PROVIDER_OP_DEADLINE};
+
+/// Provider operation deadline, in milliseconds (`loonfs-objectstore`
+/// consumes it across every retry of one logical operation).
+pub const PROVIDER_OP_DEADLINE_MS: u64 = PROVIDER_OP_DEADLINE.as_millis() as u64;
+
+/// One provider HTTP attempt's request timeout, in milliseconds. An
+/// operation's total wall time is bounded by
+/// `PROVIDER_OP_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS`, because the
+/// deadline gates starting an attempt rather than preempting one.
+pub const PROVIDER_ATTEMPT_TIMEOUT_MS: u64 = PROVIDER_ATTEMPT_TIMEOUT.as_millis() as u64;
+
+/// Self-enforced budget between starting a WAL segment PUT and initiating
+/// the head compare-and-swap. Overrunning it abandons the segment instead of
+/// publishing a stale-timed one. Local monotonic elapsed time only — never a
+/// validity input (format spec, "WAL head").
+pub const WAL_PUBLISH_BUDGET_MS: u64 = 60_000;
+
+/// Self-enforced budget between writing a checkpoint record and completing
+/// its post-write basis verification. Overrunning it counts as verification
+/// failure: the record may have raced the grace window, so it must not stand
+/// as a root.
+pub const CHECKPOINT_VERIFY_BUDGET_MS: u64 = 60_000;
+
+/// Self-enforced budget for one metadata publication — WAL flush or
+/// reorganization — measured from before the first table object is written
+/// until the root compare-and-swap is initiated. A publication that exceeds
+/// it aborts without publishing; its immutable outputs remain unreachable
+/// garbage-collection candidates.
+pub const METADATA_PUBLICATION_BUDGET_MS: u64 = 15 * 60 * 1000;
+
+/// Margin absorbing provider-timestamp skew against the GC caller's clock,
+/// plus scheduling slop around the budget checks.
+pub const GC_SAFETY_MARGIN_MS: u64 = 3 * 60 * 1000;
+
+const fn max_u64(left: u64, right: u64) -> u64 {
+    if left > right {
+        left
+    } else {
+        right
+    }
+}
+
+/// The derived minimum GC grace window: the format's rule-1 inequality as
+/// code. Any acknowledged root publication initiates its final
+/// compare-and-swap within the largest publication budget of the first
+/// immutable output's write, and that compare-and-swap lands within one
+/// provider operation bound — so an object older than this window that is
+/// still unreachable at delete time can no longer be referenced by an
+/// in-flight publication. `GcConfig::validate` rejects smaller windows.
+pub const GC_MIN_GRACE_WINDOW_MS: u64 = max_u64(
+    max_u64(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS),
+    METADATA_PUBLICATION_BUDGET_MS,
+) + PROVIDER_OP_DEADLINE_MS
+    + PROVIDER_ATTEMPT_TIMEOUT_MS
+    + GC_SAFETY_MARGIN_MS;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gc::GcConfig;
+
+    #[test]
+    fn derived_minimum_grace_window_sits_below_the_default() {
+        // 15 min publication + 2 min provider deadline + 30 s attempt
+        // timeout + 3 min margin = 20.5 minutes.
+        assert_eq!(GC_MIN_GRACE_WINDOW_MS, 1_230_000);
+        assert!(
+            GC_MIN_GRACE_WINDOW_MS < GcConfig::default().grace_window_ms,
+            "the conservative default grace window must satisfy its own floor"
+        );
+        assert!(
+            GC_MIN_GRACE_WINDOW_MS
+                > max_u64(
+                    max_u64(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS),
+                    METADATA_PUBLICATION_BUDGET_MS,
+                ) + PROVIDER_OP_DEADLINE_MS,
+            "the floor keeps a margin above budget plus provider deadline"
+        );
+    }
+}

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -27,12 +27,7 @@ use loonfs_api::NamespaceId;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore};
 use tracing::Instrument;
 
-/// Self-enforced budget between starting the WAL segment PUT and initiating
-/// the head CAS. Sized so budget + request timeout sit well inside the GC
-/// grace window; overrunning it abandons the segment instead of publishing a
-/// stale-timed one. Local monotonic elapsed time only — never a validity
-/// input (format spec, "WAL head").
-pub(crate) const PUBLISH_BUDGET_MS: u64 = 60_000;
+pub(crate) use crate::limits::WAL_PUBLISH_BUDGET_MS as PUBLISH_BUDGET_MS;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PublishBatchAgainstViewResult {

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1609,6 +1609,17 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
             .expect_err("malformed checkpoint id");
         assert_eq!(bogus_release.code, "invalid_request");
 
+        // The GC grace window's derived safety floor is enforced at the API:
+        // a sub-minimum override is rejected, not honored.
+        let unsafe_gc: Result<loonfs_api::GcResponse, ApiError> = post_admin_json_body(
+            &format!("{server_url}/v0/admin/namespaces/{namespace}/gc"),
+            "test-token",
+            serde_json::json!({ "grace_window_ms": 1 }),
+        );
+        let unsafe_gc = unsafe_gc.expect_err("sub-minimum grace window is rejected");
+        assert_eq!(unsafe_gc.code, "invalid_request");
+        assert!(unsafe_gc.message.contains("derived safety minimum"));
+
         let advanced = post_retention_advance(&server_url, namespace).expect("advance retention");
         assert_eq!(advanced.retention_floor_seq, ChangeSeq(1));
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -312,7 +312,7 @@ A representative v0 binding is shown below.
 | Flush the WAL tail | `POST /v0/admin/namespaces/{ns}/wal/flush` (folds the visible WAL tail into metadata tables and advances the metadata root; creates no checkpoint record) |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
 | Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; flush races surface as outcomes, not errors) |
-| Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; nothing sweeps without an explicit call) |
+| Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; a grace window below the derived safety floor is rejected as `invalid_request`; nothing sweeps without an explicit call) |
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile; everything else
 shown belongs to `core/v0`.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1049,6 +1049,16 @@ head watchers observe only commits. The flush is the latest-state
 maintenance operation and creates no checkpoint record; a superseded manifest
 becomes a garbage-collection candidate once nothing pins it.
 
+Every metadata publication — WAL flush and reorganization alike —
+self-enforces the metadata publication budget, measured from before its
+first table object is written until its root compare-and-swap is initiated.
+A publication that exceeds the budget aborts without publishing: its
+immutable outputs stay unreachable and are reclaimed by garbage collection
+after the grace window. This bound (with the WAL publish budget for
+commits) is what makes the GC grace window's floor derivable ("Garbage
+collection", rule 1); maintenance therefore needs no durable build-intent
+protocol.
+
 Creating a checkpoint pins one such manifest version deliberately for one
 owner. It first flushes the WAL tail as above, then writes
 `checkpoints/{id}.json` (id derived deterministically from the basis identity
@@ -1361,12 +1371,27 @@ create-vs-collect (a record written while GC concludes its basis is
 unreferenced) and publish-in-flight (an object written moments before its
 publishing CAS) — under these rules:
 
-1. **Grace window.** A configured window `T`, with
-   `T > publish_budget + request_timeout` and
-   `T > verify_budget + request_timeout` by comfortable margin. GC never
-   deletes or releases any object younger than `T`, reachable or not, and
-   treats any checkpoint record younger than `T` as a root regardless of
-   state. An object without a provider timestamp reads as young.
+1. **Grace window.** A configured window `T` with a derived floor, not a
+   free tuning parameter:
+
+   ```
+   T >= max(WAL_PUBLISH_BUDGET, CHECKPOINT_VERIFY_BUDGET,
+            METADATA_PUBLICATION_BUDGET)
+        + PROVIDER_OP_DEADLINE + PROVIDER_ATTEMPT_TIMEOUT
+        + GC_SAFETY_MARGIN
+   ```
+
+   The constants live in one place (`loonfs-core`'s `limits` module; the
+   provider bounds in `loonfs-objectstore`), every publication self-enforces
+   its budget by refusing to initiate its root compare-and-swap once the
+   budget is spent, and provider operations consume one deadline across
+   retries. A window below the floor is rejected as `invalid_request` at
+   every surface. Under the floor's inequality, any acknowledged root
+   publication lands its compare-and-swap before an object it references
+   could age past `T`, so GC never deletes or releases any object younger
+   than `T`, reachable or not, and treats any checkpoint record younger
+   than `T` as a root regardless of state. An object without a provider
+   timestamp reads as young.
 2. **Floor is necessary, not sufficient.** Being below `wal/floor.json` only
    nominates an object for deletion.
 3. **Delete-time re-verification.** Immediately before deleting, GC re-lists

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3533,7 +3533,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Objects younger than this are never deleted, reachable or not.",
+            "description": "Objects younger than this are never deleted, reachable or not. The\nwindow has a derived safety floor (publication budgets plus provider\ndeadlines); a smaller value is rejected as `invalid_request`.",
             "minimum": 0
           },
           "reap_window_ms": {
@@ -3542,7 +3542,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Abandoned bootstrap trees older than this may be reaped.",
+            "description": "Abandoned bootstrap trees older than this may be reaped. Must be at\nleast the grace window.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
GcRequest accepted any grace window down to 1ms, letting a caller reopen the publish-in-flight race the WAL publish budget exists to close, and the table-to-root-CAS window of metadata publications had no budget at all. The new loonfs-core::limits module is the single source of truth: the existing WAL and verify budgets move there, the WAL flush and reorganization gain a 15-minute publication budget measured from before their first table write and checked before the root CAS (over budget aborts without publishing, orphans reclaimed by GC), and the minimum grace window is derived as max(budgets) + provider deadline + attempt timeout + margin — 20.5 minutes, enforced by GcConfig::validate as invalid_request at every surface while the 1h default stays comfortably above. Maintenance stays bounded rather than introducing durable build intents; format.md rule 1 now states the inequality over the named constants. Stacked on conor/provider-op-deadlines; budget aborts and floor rejection are covered by deterministic-timer core tests plus an HTTP smoke assertion.