### PR TITLE
feat(core): gram index build steps with backfill and wal catch-up

### DIFF
--- a/crates/loonfs-api/src/index_grams.rs
+++ b/crates/loonfs-api/src/index_grams.rs
@@ -52,6 +52,12 @@ pub const INDEX_FAMILY_GRAMS: &str = "grams";
 /// Bytes per gram. Fixed for version 1; a variable-width tokenizer would
 /// be a new feature version.
 pub const GRAM_LEN: usize = 3;
+/// Largest content the version-1 eligibility rule admits, in bytes. Like
+/// the tokenizer, this is a format constant, not a tunable: queries decide
+/// the exhaustive-scan and verification cut with the same rule the builder
+/// used, and a divergence would silently drop matches once the watermark
+/// passes a file one side considers eligible and the other does not.
+pub const INDEX_GRAMS_MAX_FILE_BYTES: u64 = 8 * 1024 * 1024;
 
 /// One tokenizer gram: three content bytes, ASCII-case-folded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -40,7 +40,7 @@ use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use futures::future::try_join_all;
 use loonfs_api::wire::index_grams::{
     extract_grams, Gram, GramPosting, IndexGramsFeature, IndexRow, INDEX_FAMILY_GRAMS,
-    INDEX_GRAMS_FEATURE_KEY, INDEX_GRAMS_FORMAT_VERSION,
+    INDEX_GRAMS_FEATURE_KEY, INDEX_GRAMS_FORMAT_VERSION, INDEX_GRAMS_MAX_FILE_BYTES,
 };
 use loonfs_api::wire::manifest::{
     hex_encode_bytes, IndexFileRef, MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope,
@@ -75,10 +75,21 @@ pub struct GramIndexBuildPolicy {
     pub max_files_per_step: usize,
     /// Content bytes read per step.
     pub max_content_bytes_per_step: u64,
-    /// Revisions larger than this are never indexed.
-    pub max_file_bytes: u64,
     /// Rows per written index segment.
     pub max_rows_per_segment: usize,
+}
+
+impl GramIndexBuildPolicy {
+    /// Zero-valued budgets would report progress without doing work (a
+    /// zero file budget consumes no commit yet returns up to date); every
+    /// step normalizes to at least one unit of each budget.
+    fn normalized(self) -> Self {
+        Self {
+            max_files_per_step: self.max_files_per_step.max(1),
+            max_content_bytes_per_step: self.max_content_bytes_per_step.max(1),
+            max_rows_per_segment: self.max_rows_per_segment.max(1),
+        }
+    }
 }
 
 impl Default for GramIndexBuildPolicy {
@@ -86,7 +97,6 @@ impl Default for GramIndexBuildPolicy {
         Self {
             max_files_per_step: 256,
             max_content_bytes_per_step: 64 * 1024 * 1024,
-            max_file_bytes: 8 * 1024 * 1024,
             max_rows_per_segment: 65_536,
         }
     }
@@ -146,8 +156,8 @@ pub enum GramIndexDisableOutcome {
 /// leading sample; a sample that ends inside a multi-byte character still
 /// counts as valid). The query path applies the same rule to unindexed
 /// data, so eligibility is uniform whether or not a revision was indexed.
-pub(crate) fn is_indexable_text_content(content: &[u8], max_file_bytes: u64) -> bool {
-    if content.len() as u64 > max_file_bytes {
+pub(crate) fn is_indexable_text_content(content: &[u8]) -> bool {
+    if content.len() as u64 > INDEX_GRAMS_MAX_FILE_BYTES {
         return false;
     }
     let sample = &content[..content.len().min(ELIGIBILITY_SAMPLE_BYTES)];
@@ -200,6 +210,12 @@ pub(crate) async fn enable_grams_index<S: ObjectStore + ?Sized>(
         built_through_seq,
         backfill_cursor: Some(String::new()),
     };
+    let predecessor_object_id = previous.payload.manifest_object_id.clone();
+    // Manifest publishers must gate the root swap behind the publication
+    // budget (format spec, "Garbage collection", rule 1); an enable is a
+    // publisher like any other.
+    let timer = StdMonotonicTimer::default();
+    let publication_started_ms = timer.monotonic_now_ms();
     let manifest = write_index_successor_manifest(
         store,
         namespace_id,
@@ -209,10 +225,12 @@ pub(crate) async fn enable_grams_index<S: ObjectStore + ?Sized>(
         &context.writer_version,
     )
     .await?;
+    ensure_metadata_publication_budget(&timer, publication_started_ms, namespace_id)?;
     match publish_metadata_root(
         store,
         namespace_id,
         &manifest,
+        &predecessor_object_id,
         context.now_ms,
         &context.writer_version,
     )
@@ -260,6 +278,9 @@ pub(crate) async fn disable_grams_index<S: ObjectStore + ?Sized>(
     payload
         .index_files
         .retain(|descriptor| descriptor.family != INDEX_FAMILY_GRAMS);
+    let predecessor_object_id = previous.payload.manifest_object_id.clone();
+    let timer = StdMonotonicTimer::default();
+    let publication_started_ms = timer.monotonic_now_ms();
     let manifest = write_successor_manifest_from_payload(
         store,
         namespace_id,
@@ -268,10 +289,12 @@ pub(crate) async fn disable_grams_index<S: ObjectStore + ?Sized>(
         &context.writer_version,
     )
     .await?;
+    ensure_metadata_publication_budget(&timer, publication_started_ms, namespace_id)?;
     match publish_metadata_root(
         store,
         namespace_id,
         &manifest,
+        &predecessor_object_id,
         context.now_ms,
         &context.writer_version,
     )
@@ -301,8 +324,8 @@ pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     policy: GramIndexBuildPolicy,
 ) -> Result<GramIndexBuildReport> {
+    let policy = policy.normalized();
     let timer = StdMonotonicTimer::default();
-    let publication_started_ms = timer.monotonic_now_ms();
     let root = read_metadata_root_object(store, namespace_id)
         .await
         .map_err(|error| {
@@ -362,6 +385,11 @@ pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
     };
 
     let rows = gram_postings_rows(unit.postings)?;
+    // The publication budget starts at the first object write: it exists
+    // to bound how long written-but-unpublished objects can age toward the
+    // GC grace window, and content reads write nothing. One oversized
+    // commit may take arbitrarily long to read yet still publish.
+    let publication_started_ms = timer.monotonic_now_ms();
     let new_segments = write_index_segments(
         store,
         namespace_id,
@@ -380,6 +408,7 @@ pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
         backfill_cursor: unit.backfill_cursor.clone(),
     };
     let materialized = next_feature.is_materialized();
+    let predecessor_object_id = previous.payload.manifest_object_id.clone();
     let manifest = write_index_successor_manifest(
         store,
         namespace_id,
@@ -394,6 +423,7 @@ pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
         store,
         namespace_id,
         &manifest,
+        &predecessor_object_id,
         context.now_ms,
         &context.writer_version,
     )
@@ -490,7 +520,6 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
                 inode_id,
                 revision_no,
                 &content_ref,
-                policy,
                 &mut unit.postings,
                 &mut content_bytes_read,
             )
@@ -600,7 +629,6 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
                         *inode_id,
                         *revision_no,
                         content_ref,
-                        policy,
                         &mut unit.postings,
                         &mut content_bytes_read,
                     )
@@ -631,18 +659,17 @@ async fn index_revision_content<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     revision_no: RevisionNo,
     content_ref: &ContentRef,
-    policy: GramIndexBuildPolicy,
     postings: &mut BTreeMap<Gram, Vec<GramPosting>>,
     content_bytes_read: &mut u64,
 ) -> Result<bool> {
     // The size cap is checked from the reference before any fetch; the
     // sniff needs bytes, so oversized files cost nothing to skip.
-    if content_ref.size_bytes > policy.max_file_bytes {
+    if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
         return Ok(false);
     }
     let content = read_durable_content_bytes(store, content_store_id, content_ref).await?;
     *content_bytes_read += content.bytes.len() as u64;
-    if !is_indexable_text_content(&content.bytes, policy.max_file_bytes) {
+    if !is_indexable_text_content(&content.bytes) {
         return Ok(false);
     }
     let posting = GramPosting {
@@ -840,14 +867,17 @@ mod tests {
 
     #[test]
     fn eligibility_accepts_text_and_rejects_binary_and_oversize() {
-        assert!(is_indexable_text_content(b"plain text\n", 1024));
-        assert!(is_indexable_text_content(&[], 1024));
-        assert!(is_indexable_text_content("Grüße".as_bytes(), 1024));
-        assert!(!is_indexable_text_content(b"bin\0ary", 1024));
-        assert!(!is_indexable_text_content(&[0xff, 0xfe, 0x00, 0x01], 1024));
-        assert!(!is_indexable_text_content(b"too big", 3));
+        assert!(is_indexable_text_content(b"plain text\n"));
+        assert!(is_indexable_text_content(&[]));
+        assert!(is_indexable_text_content("Grüße".as_bytes()));
+        assert!(!is_indexable_text_content(b"bin\0ary"));
+        assert!(!is_indexable_text_content(&[0xff, 0xfe, 0x00, 0x01]));
+        // The cap is a format constant of feature version 1; one byte over
+        // it is ineligible.
+        let oversized = vec![b'a'; INDEX_GRAMS_MAX_FILE_BYTES as usize + 1];
+        assert!(!is_indexable_text_content(&oversized));
         // Invalid UTF-8 that is not a truncated tail is rejected.
-        assert!(!is_indexable_text_content(&[b'a', 0xc3, b'a'], 1024));
+        assert!(!is_indexable_text_content(&[b'a', 0xc3, b'a']));
     }
 
     #[test]
@@ -857,10 +887,7 @@ mod tests {
         let mut content = vec![b'a'; super::ELIGIBILITY_SAMPLE_BYTES - 1];
         content.extend_from_slice("é".as_bytes());
         content.extend_from_slice(b" more text");
-        assert!(is_indexable_text_content(
-            &content,
-            2 * super::ELIGIBILITY_SAMPLE_BYTES as u64
-        ));
+        assert!(is_indexable_text_content(&content));
     }
 
     #[test]

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -1,0 +1,902 @@
+//! Gram index building: budgeted maintenance steps that read eligible file
+//! content, extract grams, write index segments, and publish manifests
+//! advancing the `index.grams` watermark (format spec, sections 4.2.2 and 5).
+//!
+//! Like reorganization, every step reads the live manifest, does a bounded
+//! amount of work, and ends in one manifest publication through the normal
+//! root compare-and-swap — the manifest is the only progress record. Two
+//! modes share that discipline:
+//!
+//! - **Backfill** (the feature value carries `backfill_cursor`): walk the
+//!   revisions family in row-key order from the cursor, indexing revisions
+//!   committed at or below the enable-time watermark. The cursor is the
+//!   resume point; queries stay refused until the walk completes.
+//! - **Steady state**: replay the WAL after `built_through_seq` — the
+//!   change feed is the designed index-building extension point — and index
+//!   the file revisions that appeared, advancing the watermark to the last
+//!   fully consumed commit.
+//!
+//! Content is read server-side through the verified durable-content path.
+//! Eligibility (text sniffing, the size cap) is writer-side policy decided
+//! here at index time, never on the write path; the query path applies the
+//! same rule to unindexed data so the search contract stays uniform.
+
+use super::flush::{
+    ensure_metadata_publication_budget, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
+};
+use super::load::{load_namespace_manifest_envelope_if_present, load_verified_manifest_tables};
+use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
+use super::runs::{CHECKPOINT_L0_RUN_LEVEL, MAX_MAINTENANCE_TABLE_IO};
+use super::scan::string_prefix_upper_bound;
+use crate::context::MutationContext;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::namespace::catalog::load_namespace_catalog_entry;
+use crate::namespace::control::{
+    load_namespace_head_control, read_metadata_root_object, read_wal_floor_seq_or_zero,
+};
+use crate::storage::content::{read_durable_content_bytes, write_immutable_object};
+use crate::timing::{MonotonicTimer, StdMonotonicTimer};
+use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use futures::future::try_join_all;
+use loonfs_api::wire::index_grams::{
+    extract_grams, Gram, GramPosting, IndexGramsFeature, IndexRow, INDEX_FAMILY_GRAMS,
+    INDEX_GRAMS_FEATURE_KEY, INDEX_GRAMS_FORMAT_VERSION,
+};
+use loonfs_api::wire::manifest::{
+    hex_encode_bytes, IndexFileRef, MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope,
+    NamespaceManifestPayload,
+};
+use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
+use loonfs_api::wire::wal::WalDelta;
+use loonfs_api::{
+    sha256_digest, ChangeSeq, ContentRef, ContentStoreId, IndexSegmentId, InodeId,
+    ManifestObjectId, NamespaceId, RevisionNo,
+};
+use loonfs_objectstore::keys::{index_segment, metadata_manifest_object};
+use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeMap;
+
+/// Postings per gram-postings row. A writer-side default: readers take
+/// whatever batches rows carry.
+const GRAM_POSTING_BATCH_TARGET: usize = 256;
+/// Bytes of leading content the eligibility sniff inspects.
+const ELIGIBILITY_SAMPLE_BYTES: usize = 8 * 1024;
+/// Largest filter block inlined into an index descriptor, matching the
+/// metadata-segment rule so gram probes on small delta segments skip the
+/// object fetch.
+const INLINE_INDEX_FILTER_MAX_BYTES: u32 = 1024;
+
+/// Writer-side budgets for one build step. Work stops at a commit boundary
+/// once a budget is exceeded; the next step resumes from the published
+/// watermark or cursor.
+#[derive(Debug, Clone, Copy)]
+pub struct GramIndexBuildPolicy {
+    /// Revisions examined per step.
+    pub max_files_per_step: usize,
+    /// Content bytes read per step.
+    pub max_content_bytes_per_step: u64,
+    /// Revisions larger than this are never indexed.
+    pub max_file_bytes: u64,
+    /// Rows per written index segment.
+    pub max_rows_per_segment: usize,
+}
+
+impl Default for GramIndexBuildPolicy {
+    fn default() -> Self {
+        Self {
+            max_files_per_step: 256,
+            max_content_bytes_per_step: 64 * 1024 * 1024,
+            max_file_bytes: 8 * 1024 * 1024,
+            max_rows_per_segment: 65_536,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GramIndexBuildReport {
+    pub namespace_id: NamespaceId,
+    pub outcome: GramIndexBuildOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GramIndexBuildOutcome {
+    /// The namespace has no `index.grams` feature entry.
+    NotEnabled,
+    /// The feature value names a version this build does not implement;
+    /// the step refuses to touch it and reads are unaffected.
+    UnsupportedFeatureVersion { found: u32 },
+    /// The index already covers the current head.
+    UpToDate { built_through_seq: ChangeSeq },
+    /// One bounded unit of work landed in a published manifest.
+    Published {
+        built_through_seq: ChangeSeq,
+        indexed_revisions: u64,
+        skipped_revisions: u64,
+        segments_written: u64,
+        /// False while a backfill cursor remains in the feature value.
+        materialized: bool,
+    },
+    /// Someone published a newer root first; rerun against it.
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GramIndexEnableOutcome {
+    /// The feature entry was published; backfill starts on the next step.
+    Enabled {
+        built_through_seq: ChangeSeq,
+    },
+    AlreadyEnabled {
+        built_through_seq: ChangeSeq,
+    },
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GramIndexDisableOutcome {
+    /// The feature entry and every index segment reference were dropped;
+    /// the segments become garbage-collection candidates.
+    Disabled,
+    NotEnabled,
+    Superseded,
+}
+
+/// True when content participates in the gram index: within the size cap
+/// and text by the grep-family sniff (no NUL byte and valid UTF-8 in the
+/// leading sample; a sample that ends inside a multi-byte character still
+/// counts as valid). The query path applies the same rule to unindexed
+/// data, so eligibility is uniform whether or not a revision was indexed.
+pub(crate) fn is_indexable_text_content(content: &[u8], max_file_bytes: u64) -> bool {
+    if content.len() as u64 > max_file_bytes {
+        return false;
+    }
+    let sample = &content[..content.len().min(ELIGIBILITY_SAMPLE_BYTES)];
+    if sample.contains(&0) {
+        return false;
+    }
+    match std::str::from_utf8(sample) {
+        Ok(_) => true,
+        // `error_len() == None` means the sample ends mid-character, which
+        // says nothing about the content; anything else is real non-text.
+        Err(error) => error.error_len().is_none() && error.valid_up_to() > 0,
+    }
+}
+
+/// Publishes the `index.grams` feature entry, scheduling backfill over the
+/// namespace's existing revisions. Idempotent: enabling an enabled
+/// namespace reports its current watermark.
+pub(crate) async fn enable_grams_index<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<GramIndexEnableOutcome> {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let previous = tables.manifest();
+
+    if let Some(value) = previous.payload.features.get(INDEX_GRAMS_FEATURE_KEY) {
+        let feature = decode_feature(namespace_id, value)?;
+        return Ok(GramIndexEnableOutcome::AlreadyEnabled {
+            built_through_seq: feature.built_through_seq,
+        });
+    }
+
+    // Backfill covers revisions committed at or below this manifest's head;
+    // everything after it arrives through WAL replay once backfill ends,
+    // which is why the watermark starts here rather than at zero.
+    let built_through_seq = previous.payload.head_seq;
+    let feature = IndexGramsFeature {
+        version: INDEX_GRAMS_FORMAT_VERSION,
+        built_through_seq,
+        backfill_cursor: Some(String::new()),
+    };
+    let manifest = write_index_successor_manifest(
+        store,
+        namespace_id,
+        previous,
+        previous.payload.index_files.clone(),
+        feature,
+        &context.writer_version,
+    )
+    .await?;
+    match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        context.now_ms,
+        &context.writer_version,
+    )
+    .await?
+    {
+        ManifestPublicationOutcome::Published(_) => {
+            Ok(GramIndexEnableOutcome::Enabled { built_through_seq })
+        }
+        ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
+            Ok(GramIndexEnableOutcome::Superseded)
+        }
+    }
+}
+
+/// Removes the feature entry and every index segment reference. The
+/// segments become unreachable and garbage collection reclaims them.
+pub(crate) async fn disable_grams_index<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<GramIndexDisableOutcome> {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let previous = tables.manifest();
+    if !previous
+        .payload
+        .features
+        .contains_key(INDEX_GRAMS_FEATURE_KEY)
+    {
+        return Ok(GramIndexDisableOutcome::NotEnabled);
+    }
+
+    let mut payload = previous.payload.clone();
+    payload.features.remove(INDEX_GRAMS_FEATURE_KEY);
+    payload
+        .index_files
+        .retain(|descriptor| descriptor.family != INDEX_FAMILY_GRAMS);
+    let manifest = write_successor_manifest_from_payload(
+        store,
+        namespace_id,
+        previous,
+        payload,
+        &context.writer_version,
+    )
+    .await?;
+    match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        context.now_ms,
+        &context.writer_version,
+    )
+    .await?
+    {
+        ManifestPublicationOutcome::Published(_) => Ok(GramIndexDisableOutcome::Disabled),
+        ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
+            Ok(GramIndexDisableOutcome::Superseded)
+        }
+    }
+}
+
+/// Runs at most one gram index build unit against the live manifest:
+/// backfill while the feature value carries a cursor, WAL-replay catch-up
+/// after. Callers invoke this repeatedly; every call re-reads durable
+/// state, so any two calls compose — including across process restarts.
+#[tracing::instrument(
+    level = "info",
+    name = "loon.phase",
+    err,
+    skip_all,
+    fields(phase = "build_grams_index", key_class = "manifest")
+)]
+pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: GramIndexBuildPolicy,
+) -> Result<GramIndexBuildReport> {
+    let timer = StdMonotonicTimer::default();
+    let publication_started_ms = timer.monotonic_now_ms();
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let previous = tables.manifest();
+
+    let Some(value) = previous.payload.features.get(INDEX_GRAMS_FEATURE_KEY) else {
+        return Ok(GramIndexBuildReport {
+            namespace_id: namespace_id.clone(),
+            outcome: GramIndexBuildOutcome::NotEnabled,
+        });
+    };
+    let feature = match IndexGramsFeature::from_value(value) {
+        Ok(feature) => feature,
+        Err(loonfs_api::wire::index_grams::IndexGramsCodecError::UnsupportedFeatureVersion {
+            found,
+            ..
+        }) => {
+            return Ok(GramIndexBuildReport {
+                namespace_id: namespace_id.clone(),
+                outcome: GramIndexBuildOutcome::UnsupportedFeatureVersion { found },
+            });
+        }
+        Err(error) => {
+            return Err(CoreError::NamespaceCorrupt(format!(
+                "namespace `{}` carries an unreadable index.grams feature value: {error}",
+                namespace_id.as_str()
+            )));
+        }
+    };
+
+    let catalog = load_namespace_catalog_entry(store, namespace_id).await?;
+    let content_store_id = catalog.content_store_id().clone();
+
+    let unit = if let Some(cursor) = feature.backfill_cursor.clone() {
+        collect_backfill_unit(&tables, &feature, cursor, store, &content_store_id, policy).await?
+    } else {
+        match collect_wal_unit(store, namespace_id, &feature, &content_store_id, policy).await? {
+            Some(unit) => unit,
+            None => {
+                return Ok(GramIndexBuildReport {
+                    namespace_id: namespace_id.clone(),
+                    outcome: GramIndexBuildOutcome::UpToDate {
+                        built_through_seq: feature.built_through_seq,
+                    },
+                });
+            }
+        }
+    };
+
+    let rows = gram_postings_rows(unit.postings)?;
+    let new_segments = write_index_segments(
+        store,
+        namespace_id,
+        unit.run_seq,
+        rows,
+        policy.max_rows_per_segment,
+    )
+    .await?;
+    let segments_written = new_segments.len() as u64;
+
+    let mut index_files = previous.payload.index_files.clone();
+    index_files.extend(new_segments);
+    let next_feature = IndexGramsFeature {
+        version: INDEX_GRAMS_FORMAT_VERSION,
+        built_through_seq: unit.built_through_seq,
+        backfill_cursor: unit.backfill_cursor.clone(),
+    };
+    let materialized = next_feature.is_materialized();
+    let manifest = write_index_successor_manifest(
+        store,
+        namespace_id,
+        previous,
+        index_files,
+        next_feature,
+        &context.writer_version,
+    )
+    .await?;
+    ensure_metadata_publication_budget(&timer, publication_started_ms, namespace_id)?;
+    match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        context.now_ms,
+        &context.writer_version,
+    )
+    .await?
+    {
+        ManifestPublicationOutcome::Published(_) => Ok(GramIndexBuildReport {
+            namespace_id: namespace_id.clone(),
+            outcome: GramIndexBuildOutcome::Published {
+                built_through_seq: unit.built_through_seq,
+                indexed_revisions: unit.indexed_revisions,
+                skipped_revisions: unit.skipped_revisions,
+                segments_written,
+                materialized,
+            },
+        }),
+        ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
+            Ok(GramIndexBuildReport {
+                namespace_id: namespace_id.clone(),
+                outcome: GramIndexBuildOutcome::Superseded,
+            })
+        }
+    }
+}
+
+/// One bounded unit of collected work, before segments are written.
+struct CollectedIndexUnit {
+    postings: BTreeMap<Gram, Vec<GramPosting>>,
+    indexed_revisions: u64,
+    skipped_revisions: u64,
+    /// The run sequence stamped on the segments this unit writes.
+    run_seq: ChangeSeq,
+    built_through_seq: ChangeSeq,
+    backfill_cursor: Option<String>,
+}
+
+async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
+    tables: &super::scan::VerifiedMetadataTables<'_, S>,
+    feature: &IndexGramsFeature,
+    cursor: String,
+    store: &S,
+    content_store_id: &ContentStoreId,
+    policy: GramIndexBuildPolicy,
+) -> Result<CollectedIndexUnit> {
+    // Resume strictly after the cursor row key; the empty cursor starts at
+    // the family prefix. The walk reads the manifest, never old WAL, so
+    // enablement works regardless of what retention has discarded.
+    let lower_bound = if cursor.is_empty() {
+        "revision-".to_owned()
+    } else {
+        format!("{cursor}\0")
+    };
+    let upper_bound = string_prefix_upper_bound("revision-");
+    let page = tables
+        .scan_range_page_with_keys(
+            MetadataTableFamily::Revisions,
+            &lower_bound,
+            upper_bound.as_deref(),
+            policy.max_files_per_step.max(1),
+        )
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?;
+    let walk_complete = page.len() < policy.max_files_per_step.max(1);
+
+    let mut unit = CollectedIndexUnit {
+        postings: BTreeMap::new(),
+        indexed_revisions: 0,
+        skipped_revisions: 0,
+        run_seq: feature.built_through_seq,
+        built_through_seq: feature.built_through_seq,
+        backfill_cursor: Some(cursor),
+    };
+    let mut content_bytes_read = 0u64;
+    for (row_key, row) in page {
+        let MetadataRow::Revision {
+            inode_id,
+            revision_no,
+            committed_seq,
+            content_ref,
+            ..
+        } = row
+        else {
+            return Err(CoreError::NamespaceCorrupt(format!(
+                "revisions family returned a non-revision row at `{row_key}`"
+            )));
+        };
+        // Revisions past the enable-time watermark belong to WAL replay;
+        // the cursor still advances over them so the walk terminates.
+        if committed_seq <= feature.built_through_seq {
+            let indexed = index_revision_content(
+                store,
+                content_store_id,
+                inode_id,
+                revision_no,
+                &content_ref,
+                policy,
+                &mut unit.postings,
+                &mut content_bytes_read,
+            )
+            .await?;
+            if indexed {
+                unit.indexed_revisions += 1;
+            } else {
+                unit.skipped_revisions += 1;
+            }
+        }
+        unit.backfill_cursor = Some(row_key);
+        if content_bytes_read >= policy.max_content_bytes_per_step {
+            return Ok(unit);
+        }
+    }
+    if walk_complete {
+        unit.backfill_cursor = None;
+    }
+    Ok(unit)
+}
+
+/// Collects the next WAL-replay unit, or `None` when the index already
+/// covers the head.
+async fn collect_wal_unit<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    feature: &IndexGramsFeature,
+    content_store_id: &ContentStoreId,
+    policy: GramIndexBuildPolicy,
+) -> Result<Option<CollectedIndexUnit>> {
+    let head = load_namespace_head_control(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?
+        .state;
+    if feature.built_through_seq >= head.seq {
+        return Ok(None);
+    }
+    let floor_seq = read_wal_floor_seq_or_zero(store, namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    if feature.built_through_seq < floor_seq {
+        // Retention advancement is clamped to the watermark while the
+        // feature is enabled, so this indicates operator surgery; the index
+        // must be rebuilt (disable, then enable) rather than silently skip
+        // history.
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "index.grams watermark {} is below the retention floor {}; \
+             disable and re-enable the index to rebuild it",
+            feature.built_through_seq.0, floor_seq.0
+        )));
+    }
+
+    let wal_chain = load_validated_wal_chain(
+        store,
+        WalChainLoadRequest {
+            namespace_id,
+            chain_base_seq: floor_seq,
+            head_seq: head.seq,
+            visible_tip: head.visible_wal_tip.clone(),
+            stop_after_seq: Some(feature.built_through_seq),
+            recent_segments: &head.recent_segments,
+        },
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+    })?;
+
+    let mut unit = CollectedIndexUnit {
+        postings: BTreeMap::new(),
+        indexed_revisions: 0,
+        skipped_revisions: 0,
+        run_seq: feature.built_through_seq,
+        built_through_seq: feature.built_through_seq,
+        backfill_cursor: None,
+    };
+    let mut content_bytes_read = 0u64;
+    let mut examined_files = 0usize;
+    'commits: for segment in wal_chain.segments() {
+        for record in segment.records() {
+            if record.seq <= feature.built_through_seq {
+                continue;
+            }
+            // A commit is consumed whole or not at all: the watermark is a
+            // commit boundary, so budgets are checked between commits.
+            if examined_files >= policy.max_files_per_step
+                || content_bytes_read >= policy.max_content_bytes_per_step
+            {
+                break 'commits;
+            }
+            for delta in &record.deltas {
+                if let WalDelta::AppendFileRevision {
+                    inode_id,
+                    revision_no,
+                    content_ref,
+                    ..
+                } = &delta.delta
+                {
+                    examined_files += 1;
+                    let indexed = index_revision_content(
+                        store,
+                        content_store_id,
+                        *inode_id,
+                        *revision_no,
+                        content_ref,
+                        policy,
+                        &mut unit.postings,
+                        &mut content_bytes_read,
+                    )
+                    .await?;
+                    if indexed {
+                        unit.indexed_revisions += 1;
+                    } else {
+                        unit.skipped_revisions += 1;
+                    }
+                }
+            }
+            unit.built_through_seq = record.seq;
+            unit.run_seq = record.seq;
+        }
+    }
+    if unit.built_through_seq == feature.built_through_seq {
+        return Ok(None);
+    }
+    Ok(Some(unit))
+}
+
+/// Reads one revision's content and folds its grams into the unit's
+/// postings. Returns whether the revision was indexed (false: ineligible).
+#[allow(clippy::too_many_arguments)]
+async fn index_revision_content<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    inode_id: InodeId,
+    revision_no: RevisionNo,
+    content_ref: &ContentRef,
+    policy: GramIndexBuildPolicy,
+    postings: &mut BTreeMap<Gram, Vec<GramPosting>>,
+    content_bytes_read: &mut u64,
+) -> Result<bool> {
+    // The size cap is checked from the reference before any fetch; the
+    // sniff needs bytes, so oversized files cost nothing to skip.
+    if content_ref.size_bytes > policy.max_file_bytes {
+        return Ok(false);
+    }
+    let content = read_durable_content_bytes(store, content_store_id, content_ref).await?;
+    *content_bytes_read += content.bytes.len() as u64;
+    if !is_indexable_text_content(&content.bytes, policy.max_file_bytes) {
+        return Ok(false);
+    }
+    let posting = GramPosting {
+        inode_id,
+        revision_no,
+    };
+    for gram in extract_grams(&content.bytes) {
+        postings.entry(gram).or_default().push(posting);
+    }
+    Ok(true)
+}
+
+/// Batches collected postings into rows, in ascending row-key order.
+fn gram_postings_rows(postings: BTreeMap<Gram, Vec<GramPosting>>) -> Result<Vec<IndexRow>> {
+    let mut rows = Vec::new();
+    for (gram, mut gram_postings) in postings {
+        // Discovery order is commit order, not inode order; batches must be
+        // strictly ascending by durable identity.
+        gram_postings.sort_unstable();
+        gram_postings.dedup();
+        for batch in gram_postings.chunks(GRAM_POSTING_BATCH_TARGET) {
+            rows.push(IndexRow::gram_postings(gram, batch).map_err(|error| {
+                CoreError::Internal(format!("failed to build gram postings row: {error}"))
+            })?);
+        }
+    }
+    Ok(rows)
+}
+
+/// Writes the unit's index segments and returns their descriptors.
+async fn write_index_segments<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    run_seq: ChangeSeq,
+    rows: Vec<IndexRow>,
+    max_rows_per_segment: usize,
+) -> Result<Vec<IndexFileRef>> {
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut requests = Vec::new();
+    for (segment_index, segment_rows) in rows.chunks(max_rows_per_segment.max(1)).enumerate() {
+        let segment_index = u32::try_from(segment_index)
+            .map_err(|_| CoreError::Internal("index segment index overflow".to_owned()))?;
+        requests.push((segment_index, segment_rows.to_vec()));
+    }
+    let mut descriptors = Vec::with_capacity(requests.len());
+    let mut pending = requests.into_iter();
+    loop {
+        let chunk = pending
+            .by_ref()
+            .take(MAX_MAINTENANCE_TABLE_IO)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        descriptors.extend(
+            try_join_all(chunk.into_iter().map(|(segment_index, segment_rows)| {
+                write_index_segment(store, namespace_id, run_seq, segment_index, segment_rows)
+            }))
+            .await?,
+        );
+    }
+    Ok(descriptors)
+}
+
+async fn write_index_segment<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    run_seq: ChangeSeq,
+    segment_index: u32,
+    rows: Vec<IndexRow>,
+) -> Result<IndexFileRef> {
+    let segment_id = IndexSegmentId::generate();
+    let object_key = index_segment(namespace_id.as_str(), segment_id.as_str());
+    let mut builder = SegmentBlocksBuilder::default();
+    for row in &rows {
+        builder
+            .push(&row.row_key(), &row.filter_key(), row)
+            .map_err(|err| {
+                CoreError::Internal(format!(
+                    "failed to build index segment `{object_key}`: {err}"
+                ))
+            })?;
+    }
+    let built = builder.finish().map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build index segment `{object_key}`: {err}"
+        ))
+    })?;
+    write_immutable_object(store, &object_key, &built.bytes).await?;
+    let filter_inline = (built.filter.stored_len <= INLINE_INDEX_FILTER_MAX_BYTES).then(|| {
+        let start = built.filter.offset as usize;
+        hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])
+    });
+    Ok(IndexFileRef {
+        owner_namespace_id: namespace_id.clone(),
+        segment_id,
+        object_key,
+        family: INDEX_FAMILY_GRAMS.to_owned(),
+        run_seq,
+        level: CHECKPOINT_L0_RUN_LEVEL,
+        segment_index,
+        row_count: built.row_count,
+        min_key: built.min_key,
+        max_key: built.max_key,
+        index_block: built.index,
+        filter_block: built.filter,
+        filter_inline,
+        payload_checksum: sha256_digest(&built.bytes),
+    })
+}
+
+fn decode_feature(
+    namespace_id: &NamespaceId,
+    value: &serde_json::Value,
+) -> Result<IndexGramsFeature> {
+    IndexGramsFeature::from_value(value).map_err(|error| {
+        CoreError::NamespaceCorrupt(format!(
+            "namespace `{}` carries an unreadable index.grams feature value: {error}",
+            namespace_id.as_str()
+        ))
+    })
+}
+
+async fn write_index_successor_manifest<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    previous: &NamespaceManifestEnvelope,
+    index_files: Vec<IndexFileRef>,
+    feature: IndexGramsFeature,
+    writer_version: &str,
+) -> Result<NamespaceManifestEnvelope> {
+    let mut payload = previous.payload.clone();
+    payload.index_files = index_files;
+    payload
+        .features
+        .insert(INDEX_GRAMS_FEATURE_KEY.to_owned(), feature.to_value());
+    write_successor_manifest_from_payload(store, namespace_id, previous, payload, writer_version)
+        .await
+}
+
+/// Writes a successor manifest whose payload differs from `previous` only
+/// in the caller's edits: same head, same metadata files, next manifest id.
+/// The same allocation pattern as reorganization and flush — collisions
+/// re-generate the object id, identical checksums are idempotent successes.
+async fn write_successor_manifest_from_payload<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    previous: &NamespaceManifestEnvelope,
+    mut payload: NamespaceManifestPayload,
+    writer_version: &str,
+) -> Result<NamespaceManifestEnvelope> {
+    let manifest_id = next_manifest_id_after(previous.payload.manifest_id)?;
+    payload.manifest_id = manifest_id;
+    for _allocation_attempt in 0..MANIFEST_ALLOCATION_RETRY_LIMIT {
+        let manifest_object_id = ManifestObjectId::generate(manifest_id);
+        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        match load_namespace_manifest_envelope_if_present(
+            store,
+            namespace_id,
+            &manifest_object_id,
+            &manifest_key,
+        )
+        .await
+        {
+            Ok(Some(_existing)) => continue,
+            Ok(None) => {}
+            Err(error) => {
+                return Err(CoreError::MetadataProjection(
+                    MetadataProjectionLoadError::ManifestLoad(error),
+                ))
+            }
+        }
+        let mut candidate = payload.clone();
+        candidate.manifest_object_id = manifest_object_id;
+        let manifest = NamespaceManifestEnvelope::from_payload(writer_version, candidate)
+            .map_err(|err| CoreError::Internal(format!("failed to build index manifest: {err}")))?;
+        match write_namespace_manifest(store, &manifest).await {
+            Ok(()) => return Ok(manifest),
+            Err(MetadataProjectionLoadError::ManifestLoad(
+                super::error::ManifestLoadError::ManifestConflict { .. },
+            )) => continue,
+            Err(error) => return Err(CoreError::MetadataProjection(error)),
+        }
+    }
+    Err(CoreError::Internal(
+        "index manifest allocation retry exhausted".to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eligibility_accepts_text_and_rejects_binary_and_oversize() {
+        assert!(is_indexable_text_content(b"plain text\n", 1024));
+        assert!(is_indexable_text_content(&[], 1024));
+        assert!(is_indexable_text_content("Grüße".as_bytes(), 1024));
+        assert!(!is_indexable_text_content(b"bin\0ary", 1024));
+        assert!(!is_indexable_text_content(&[0xff, 0xfe, 0x00, 0x01], 1024));
+        assert!(!is_indexable_text_content(b"too big", 3));
+        // Invalid UTF-8 that is not a truncated tail is rejected.
+        assert!(!is_indexable_text_content(&[b'a', 0xc3, b'a'], 1024));
+    }
+
+    #[test]
+    fn eligibility_tolerates_a_sample_split_mid_character() {
+        // A multi-byte character straddling the sample boundary must not
+        // disqualify the file: build the sample so it ends mid-character.
+        let mut content = vec![b'a'; super::ELIGIBILITY_SAMPLE_BYTES - 1];
+        content.extend_from_slice("é".as_bytes());
+        content.extend_from_slice(b" more text");
+        assert!(is_indexable_text_content(
+            &content,
+            2 * super::ELIGIBILITY_SAMPLE_BYTES as u64
+        ));
+    }
+
+    #[test]
+    fn gram_rows_sort_dedup_and_batch_postings() {
+        let mut postings = BTreeMap::new();
+        postings.insert(
+            Gram(*b"abc"),
+            vec![
+                GramPosting {
+                    inode_id: InodeId(9),
+                    revision_no: RevisionNo(1),
+                },
+                GramPosting {
+                    inode_id: InodeId(2),
+                    revision_no: RevisionNo(1),
+                },
+                GramPosting {
+                    inode_id: InodeId(2),
+                    revision_no: RevisionNo(1),
+                },
+            ],
+        );
+        let rows = gram_postings_rows(postings).expect("rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].postings().expect("postings"),
+            vec![
+                GramPosting {
+                    inode_id: InodeId(2),
+                    revision_no: RevisionNo(1),
+                },
+                GramPosting {
+                    inode_id: InodeId(9),
+                    revision_no: RevisionNo(1),
+                },
+            ]
+        );
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -11,6 +11,8 @@
 //! - [`create`] orchestrates checkpoint creation: flush, then pin
 //!   the resulting manifest under one durable record.
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
+//! - [`index_build`] builds the gram index in budgeted maintenance steps,
+//!   publishing manifests that advance the `index.grams` watermark.
 //! - [`publish`] writes manifest objects and advances `current_manifest_id`
 //!   on the head by compare-and-swap.
 //! - [`load`] and [`validate`] provide envelope-only loading and
@@ -26,6 +28,7 @@ mod cache;
 mod create;
 mod error;
 mod flush;
+mod index_build;
 mod load;
 mod publish;
 pub(crate) mod record;
@@ -46,11 +49,18 @@ pub use self::cache::{
     DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
+pub use self::index_build::{
+    GramIndexBuildOutcome, GramIndexBuildPolicy, GramIndexBuildReport, GramIndexDisableOutcome,
+    GramIndexEnableOutcome,
+};
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::{build_initial_namespace_manifest, create_checkpoint};
 pub(crate) use self::flush::flush_wal;
+pub(crate) use self::index_build::{
+    build_grams_index_step, disable_grams_index, enable_grams_index,
+};
 pub(crate) use self::load::{
     head_from_manifest, load_namespace_manifest_envelope, load_verified_manifest_tables,
     load_verified_manifest_tables_with_cache,

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_object, ControlObjectKind, WalFloorBasis, WalFloorEnvelope, WalFloorState,
 };
+use loonfs_api::wire::index_grams::{IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY};
 use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 
@@ -46,7 +47,25 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             manifest_tables.manifest().payload_checksum,
         )));
     }
-    let target_floor = manifest_tables.manifest().payload.head_seq;
+    let mut target_floor = manifest_tables.manifest().payload.head_seq;
+    // The gram index replays the WAL from its watermark, so while the
+    // feature is enabled the floor may not advance past `built_through_seq`
+    // (format spec, "Namespace features map"). Clamping — rather than
+    // refusing — lets retention advance as far as the index has caught up.
+    if let Some(value) = manifest_tables
+        .manifest()
+        .payload
+        .features
+        .get(INDEX_GRAMS_FEATURE_KEY)
+    {
+        let feature = IndexGramsFeature::from_value(value).map_err(|error| {
+            CoreError::NamespaceCorrupt(format!(
+                "namespace `{}` carries an unreadable index.grams feature value: {error}",
+                namespace_id.as_str()
+            ))
+        })?;
+        target_floor = target_floor.min(feature.built_through_seq);
+    }
     let current_floor = read_wal_floor_object(store, namespace_id)
         .await
         .map_err(|error| {
@@ -68,24 +87,33 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     // must never remove an object reachable from the current manifest or a
     // retained checkpoint or pin (format spec, "Garbage collection").
     // Corruption discovered later is caught by read-path checksums.
-    for metadata_files in manifest_tables
+    let segment_keys = manifest_tables
         .manifest()
         .payload
         .metadata_files
-        .chunks(MAX_RETENTION_PROBE_IO)
-    {
-        let probes = metadata_files.iter().map(|metadata_file| async move {
+        .iter()
+        .map(|metadata_file| metadata_file.object_key.as_str())
+        .chain(
+            manifest_tables
+                .manifest()
+                .payload
+                .index_files
+                .iter()
+                .map(|index_file| index_file.object_key.as_str()),
+        )
+        .collect::<Vec<_>>();
+    for segment_keys in segment_keys.chunks(MAX_RETENTION_PROBE_IO) {
+        let probes = segment_keys.iter().copied().map(|object_key| async move {
             let present = store
-                .head(&metadata_file.object_key)
+                .head(object_key)
                 .await
-                .map_err(|error| CoreError::store(&metadata_file.object_key, &error))?
+                .map_err(|error| CoreError::store(object_key, &error))?
                 .is_some();
             if present {
                 Ok(())
             } else {
                 Err(CoreError::CheckpointUnavailable(format!(
-                    "retention floor cannot advance: missing metadata segment `{}`",
-                    metadata_file.object_key
+                    "retention floor cannot advance: missing metadata segment `{object_key}`"
                 )))
             }
         });

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -5930,3 +5930,403 @@ async fn stale_basis_publication_cannot_clobber_a_sibling_root() {
         sibling.payload.manifest_object_id
     );
 }
+// ---------------------------------------------------------------------------
+// Gram index build
+// ---------------------------------------------------------------------------
+
+async fn grams_feature(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> Option<IndexGramsFeature> {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .expect("load manifest tables");
+    tables
+        .manifest()
+        .payload
+        .features
+        .get(INDEX_GRAMS_FEATURE_KEY)
+        .map(|value| IndexGramsFeature::from_value(value).expect("decode feature value"))
+}
+
+async fn live_index_files(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> Vec<loonfs_api::wire::manifest::IndexFileRef> {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .expect("load manifest tables");
+    tables.manifest().payload.index_files.clone()
+}
+
+/// Brute reader over every referenced index segment: the union of postings
+/// stored for `gram`, in ascending order.
+async fn stored_gram_postings(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    gram: Gram,
+) -> Vec<GramPosting> {
+    fn section<'a>(bytes: &'a [u8], handle: &BlockHandle) -> &'a [u8] {
+        &bytes[handle.offset as usize..handle.offset as usize + handle.stored_len as usize]
+    }
+    let mut postings = Vec::new();
+    for descriptor in live_index_files(store, namespace_id).await {
+        let bytes = store
+            .get(&descriptor.object_key, None)
+            .await
+            .expect("read index segment")
+            .expect("index segment exists");
+        let index = decode_index_block(
+            section(&bytes, &descriptor.index_block),
+            &descriptor.index_block,
+        )
+        .expect("decode index block");
+        for entry in &index {
+            let block =
+                decode_data_block_rows::<IndexRow>(section(&bytes, &entry.block), &entry.block)
+                    .expect("decode index data block");
+            for row in &block.rows {
+                let IndexRow::GramPostings { gram: row_gram, .. } = row;
+                if *row_gram == gram {
+                    postings.extend(row.postings().expect("decode postings"));
+                }
+            }
+        }
+    }
+    postings.sort_unstable();
+    postings
+}
+
+/// Runs build steps until the index reports up to date, returning how many
+/// steps published work.
+async fn drain_grams_index(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: GramIndexBuildPolicy,
+) -> u64 {
+    let mut published = 0u64;
+    loop {
+        let report = build_grams_index_step(store, namespace_id, context, policy)
+            .await
+            .expect("build step");
+        match report.outcome {
+            GramIndexBuildOutcome::Published { .. } => published += 1,
+            GramIndexBuildOutcome::UpToDate { .. } => return published,
+            other => panic!("unexpected build outcome: {other:?}"),
+        }
+    }
+}
+
+fn posting(inode: u64, revision: u64) -> GramPosting {
+    GramPosting {
+        inode_id: InodeId(inode),
+        revision_no: RevisionNo(revision),
+    }
+}
+
+#[tokio::test]
+async fn grams_index_backfill_covers_existing_text_and_skips_binary() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = NamespaceId::parse("grams-backfill").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // Inode allocation is sequential from the root: alpha 2, bravo 3, bin 4.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/alpha.txt",
+        b"alpha alpha\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write alpha");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/bravo.txt",
+        b"bravo file\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write bravo");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/blob.bin",
+        b"zz\0binary",
+        &context,
+        None,
+    )
+    .await
+    .expect("write binary");
+    let checkpoint_seq = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint")
+        .checkpoint_seq;
+
+    let enabled = enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    assert_eq!(
+        enabled,
+        GramIndexEnableOutcome::Enabled {
+            built_through_seq: checkpoint_seq
+        }
+    );
+    let feature = grams_feature(&store, &namespace_id).await.expect("feature");
+    assert!(!feature.is_materialized(), "backfill starts unmaterialized");
+
+    // A two-file page budget forces the backfill across several steps.
+    let policy = GramIndexBuildPolicy {
+        max_files_per_step: 2,
+        ..GramIndexBuildPolicy::default()
+    };
+    let published = drain_grams_index(&store, &namespace_id, &context, policy).await;
+    assert!(
+        published >= 2,
+        "expected a multi-step backfill, got {published}"
+    );
+
+    let feature = grams_feature(&store, &namespace_id).await.expect("feature");
+    assert!(feature.is_materialized());
+    assert_eq!(feature.built_through_seq, checkpoint_seq);
+
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"alp")).await,
+        vec![posting(2, 1)]
+    );
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"rav")).await,
+        vec![posting(3, 1)]
+    );
+    // The binary file contributed nothing.
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"nar")).await,
+        Vec::new()
+    );
+
+    assert_eq!(
+        drain_grams_index(&store, &namespace_id, &context, policy).await,
+        0,
+        "an up-to-date index publishes nothing"
+    );
+}
+
+#[tokio::test]
+async fn grams_index_steady_state_follows_the_wal_and_survives_flush() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = NamespaceId::parse("grams-steady").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/alpha.txt",
+        b"alpha one\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write alpha");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    let policy = GramIndexBuildPolicy::default();
+    drain_grams_index(&store, &namespace_id, &context, policy).await;
+
+    // New commits after materialization arrive through WAL replay, without
+    // any checkpoint in between.
+    let charlie = write_file_bytes(
+        &store,
+        &namespace_id,
+        "/charlie.txt",
+        b"charlie code\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write charlie");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/alpha.txt",
+        b"alpha two\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("overwrite alpha");
+
+    let published = drain_grams_index(&store, &namespace_id, &context, policy).await;
+    assert!(published >= 1);
+    let feature = grams_feature(&store, &namespace_id).await.expect("feature");
+    assert!(feature.built_through_seq > charlie.committed_seq);
+
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"har")).await,
+        vec![posting(3, 1)]
+    );
+    // Both revisions of alpha are retained history; both stay indexed.
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"alp")).await,
+        vec![posting(2, 1), posting(2, 2)]
+    );
+
+    // A checkpoint flush publishes a successor manifest; the feature entry
+    // and the index segment references must carry forward verbatim.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/delta.txt",
+        b"delta\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write delta");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint after index");
+    let feature = grams_feature(&store, &namespace_id)
+        .await
+        .expect("feature survives flush");
+    assert!(feature.is_materialized());
+    assert!(
+        !live_index_files(&store, &namespace_id).await.is_empty(),
+        "index segments survive flush"
+    );
+}
+
+#[tokio::test]
+async fn retention_floor_clamps_to_the_grams_watermark() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = NamespaceId::parse("grams-retention").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(&store, &namespace_id, "/one.txt", b"one\n", &context, None)
+        .await
+        .expect("write one");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    let policy = GramIndexBuildPolicy::default();
+    drain_grams_index(&store, &namespace_id, &context, policy).await;
+    let watermark = grams_feature(&store, &namespace_id)
+        .await
+        .expect("feature")
+        .built_through_seq;
+
+    // Move the manifest head past the watermark without building the index.
+    write_file_bytes(&store, &namespace_id, "/two.txt", b"two\n", &context, None)
+        .await
+        .expect("write two");
+    let head_seq = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint")
+        .checkpoint_seq;
+    assert!(head_seq > watermark);
+
+    let clamped = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention");
+    assert_eq!(
+        clamped.retention_floor_seq, watermark,
+        "the floor must not pass the index watermark"
+    );
+
+    // Catch the index up; the floor may then advance to the head.
+    drain_grams_index(&store, &namespace_id, &context, policy).await;
+    let advanced = advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention after catch-up");
+    assert_eq!(advanced.retention_floor_seq, head_seq);
+}
+
+#[tokio::test]
+async fn grams_index_disable_drops_the_feature_and_references() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = NamespaceId::parse("grams-disable").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/one.txt",
+        b"searchable\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write one");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    drain_grams_index(
+        &store,
+        &namespace_id,
+        &context,
+        GramIndexBuildPolicy::default(),
+    )
+    .await;
+    assert!(!live_index_files(&store, &namespace_id).await.is_empty());
+
+    let disabled = disable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("disable");
+    assert_eq!(disabled, GramIndexDisableOutcome::Disabled);
+    assert!(grams_feature(&store, &namespace_id).await.is_none());
+    assert!(live_index_files(&store, &namespace_id).await.is_empty());
+
+    let report = build_grams_index_step(
+        &store,
+        &namespace_id,
+        &context,
+        GramIndexBuildPolicy::default(),
+    )
+    .await
+    .expect("build step after disable");
+    assert_eq!(report.outcome, GramIndexBuildOutcome::NotEnabled);
+
+    let enabled_again = enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("re-enable");
+    assert!(matches!(
+        enabled_again,
+        GramIndexEnableOutcome::Enabled { .. }
+    ));
+}

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -10,6 +10,10 @@ use super::build::{
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::create::load_checkpoint_projection_metadata_state;
 use super::error::ManifestLoadError;
+use super::index_build::{
+    build_grams_index_step, disable_grams_index, enable_grams_index, GramIndexBuildOutcome,
+    GramIndexBuildPolicy, GramIndexDisableOutcome, GramIndexEnableOutcome,
+};
 use super::load::{
     head_from_manifest, load_manifest_materialization_for_inspection,
     load_manifest_metadata_state_for_inspection_from_manifest, load_verified_manifest_tables,
@@ -39,12 +43,17 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::wire::control::{HeadState, MetadataRootState};
+use loonfs_api::wire::index_grams::{
+    Gram, GramPosting, IndexGramsFeature, IndexRow, INDEX_GRAMS_FEATURE_KEY,
+};
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, encode_namespace_manifest_json, lookup_keys, MetadataFileRef,
     MetadataRow, MetadataTableFamily as ApiMetadataTableFamily, NamespaceManifestEnvelope,
     NamespaceManifestPayload,
 };
-use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
+use loonfs_api::wire::sst_blocks::{
+    decode_data_block_rows, decode_index_block, BlockHandle, SegmentBlocksBuilder,
+};
 use loonfs_api::{
     ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId, ManifestObjectId,
     NameKey, NamespaceId, PutBehavior, RevisionNo,
@@ -6329,4 +6338,72 @@ async fn grams_index_disable_drops_the_feature_and_references() {
         enabled_again,
         GramIndexEnableOutcome::Enabled { .. }
     ));
+}
+
+#[tokio::test]
+async fn forking_a_lagging_index_restarts_backfill_instead_of_inheriting_a_gap() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let source = NamespaceId::parse("grams-fork-source").expect("namespace id");
+    let target = NamespaceId::parse("grams-fork-target").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &source, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(&store, &source, "/one.txt", b"needle one\n", &context, None)
+        .await
+        .expect("write one");
+    create_checkpoint(&store, &source, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &source, &context)
+        .await
+        .expect("enable");
+    drain_grams_index(&store, &source, &context, GramIndexBuildPolicy::default()).await;
+    let watermark = grams_feature(&store, &source)
+        .await
+        .expect("source feature")
+        .built_through_seq;
+
+    // Move the fork point past the watermark without building the index:
+    // the fork target will never hold the WAL that covers this gap.
+    write_file_bytes(
+        &store,
+        &source,
+        "/gap.txt",
+        b"needle in the gap\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write gap");
+    crate::namespace::fork::fork_namespace(&store, &source, &target, &context)
+        .await
+        .expect("fork");
+
+    let feature = grams_feature(&store, &target)
+        .await
+        .expect("target feature");
+    assert!(
+        feature.built_through_seq > watermark,
+        "fork point is past the watermark"
+    );
+    assert!(
+        !feature.is_materialized(),
+        "a lagging inherited index must restart backfill"
+    );
+
+    // Backfill over the copied metadata tables rebuilds the gap.
+    drain_grams_index(&store, &target, &context, GramIndexBuildPolicy::default()).await;
+    let feature = grams_feature(&store, &target)
+        .await
+        .expect("target feature after drain");
+    assert!(feature.is_materialized());
+    let gap_postings = stored_gram_postings(&store, &target, Gram(*b"gap")).await;
+    assert!(
+        !gap_postings.is_empty(),
+        "the fork gap must be indexed on the target"
+    );
+    let old_postings = stored_gram_postings(&store, &target, Gram(*b"one")).await;
+    assert!(!old_postings.is_empty());
 }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -509,6 +509,51 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
+    /// Publishes the `index.grams` feature entry, scheduling gram index
+    /// backfill over the namespace's existing revisions (format spec,
+    /// sections 4.2.2 and 5). Idempotent for an already-enabled namespace.
+    pub async fn enable_grams_index(
+        &self,
+    ) -> CoreResult<crate::checkpoint::GramIndexEnableOutcome> {
+        crate::checkpoint::enable_grams_index(
+            &self.store,
+            &self.namespace_id,
+            &self.mutation_context(),
+        )
+        .await
+    }
+
+    /// Removes the `index.grams` feature entry and every index segment
+    /// reference; the segments become garbage-collection candidates.
+    pub async fn disable_grams_index(
+        &self,
+    ) -> CoreResult<crate::checkpoint::GramIndexDisableOutcome> {
+        crate::checkpoint::disable_grams_index(
+            &self.store,
+            &self.namespace_id,
+            &self.mutation_context(),
+        )
+        .await
+    }
+
+    /// Runs at most one gram index build unit: backfill while initial
+    /// materialization is walking existing revisions, WAL-replay catch-up
+    /// after, each unit ending in one manifest publication that advances
+    /// the `index.grams` watermark. Callers invoke this repeatedly, like
+    /// [`Self::reorganize_metadata`].
+    pub async fn build_grams_index_step(
+        &self,
+        policy: crate::checkpoint::GramIndexBuildPolicy,
+    ) -> CoreResult<crate::checkpoint::GramIndexBuildReport> {
+        crate::checkpoint::build_grams_index_step(
+            &self.store,
+            &self.namespace_id,
+            &self.mutation_context(),
+            policy,
+        )
+        .await
+    }
+
     /// Runs at most one metadata reorganization unit: folds one family
     /// group's L0 delta rows into new base segments and publishes a manifest
     /// swapping that group's references. Checkpoints only append L0 runs, so

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -106,7 +106,10 @@ pub mod publish {
     pub use crate::protocol::PublishTailOptions;
 }
 
-pub use checkpoint::{MetadataReorganizeOutcome, MetadataReorganizeReport};
+pub use checkpoint::{
+    GramIndexBuildOutcome, GramIndexBuildPolicy, GramIndexBuildReport, GramIndexDisableOutcome,
+    GramIndexEnableOutcome, MetadataReorganizeOutcome, MetadataReorganizeReport,
+};
 pub use context::MutationContext;
 #[doc(hidden)]
 pub use engine::RuntimeReadContext;

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -18,6 +18,9 @@ use loonfs_api::wire::control::{
     NamespaceConfigState, NamespaceState, WalFloorBasis, WalFloorEnvelope, WalFloorState,
     WriterBlock,
 };
+use loonfs_api::wire::index_grams::{
+    IndexGramsCodecError, IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY,
+};
 use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope, NamespaceManifestFork, NamespaceManifestPayload,
 };
@@ -139,7 +142,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
             source_namespace_id,
             source_manifest,
             &source_record,
-        ),
+        )?,
     )
     .map_err(|err| CoreError::Internal(format!("failed to build fork control envelope: {err}")))?;
     // Freshen the record before the first target write: the compare-and-swap
@@ -241,9 +244,41 @@ fn fork_target_manifest_payload(
     source_namespace_id: &NamespaceId,
     source_manifest: &NamespaceManifestEnvelope,
     source_record: &CheckpointRecordState,
-) -> NamespaceManifestPayload {
+) -> Result<NamespaceManifestPayload> {
     let fork_seq = source_record.manifest_head_seq;
-    NamespaceManifestPayload {
+    // The target adopts the source's gram index, with one repair: the
+    // target does not inherit the source WAL, so a source index that
+    // trails the fork point could never replay the gap. Keeping the
+    // segments but restarting the backfill cursor rebuilds the gap from
+    // the copied metadata tables; duplicate postings from the re-walk are
+    // harmless because readers union batches and folds re-batch them.
+    let mut features = source_manifest.payload.features.clone();
+    if let Some(value) = features.get(INDEX_GRAMS_FEATURE_KEY) {
+        match IndexGramsFeature::from_value(value) {
+            Ok(feature) if feature.built_through_seq < fork_seq || !feature.is_materialized() => {
+                features.insert(
+                    INDEX_GRAMS_FEATURE_KEY.to_owned(),
+                    IndexGramsFeature {
+                        version: feature.version,
+                        built_through_seq: fork_seq,
+                        backfill_cursor: Some(String::new()),
+                    }
+                    .to_value(),
+                );
+            }
+            Ok(_) => {}
+            // A feature version this build does not implement is preserved
+            // verbatim; its own specification owns fork semantics.
+            Err(IndexGramsCodecError::UnsupportedFeatureVersion { .. }) => {}
+            Err(error) => {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "fork source `{}` carries an unreadable index.grams feature value: {error}",
+                    source_namespace_id.as_str()
+                )));
+            }
+        }
+    }
+    Ok(NamespaceManifestPayload {
         namespace_id: new_namespace_id.clone(),
         manifest_id: target_manifest_id,
         manifest_object_id: target_manifest_object_id,
@@ -263,10 +298,10 @@ fn fork_target_manifest_payload(
             source_manifest_object_id: source_record.manifest_object_id.clone(),
             source_head_seq: source_record.manifest_head_seq,
         }),
-        features: source_manifest.payload.features.clone(),
+        features,
         metadata_files: source_manifest.payload.metadata_files.clone(),
         index_files: source_manifest.payload.index_files.clone(),
-    }
+    })
 }
 
 async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
@@ -410,7 +445,8 @@ mod tests {
             &NamespaceId::parse("source").expect("source namespace"),
             &source,
             &source_checkpoint,
-        );
+        )
+        .expect("fork payload");
 
         assert_eq!(target.features, source.payload.features);
         assert_eq!(target.metadata_files, source.payload.metadata_files);


### PR DESCRIPTION
Second wave of the content search index (docs/design/content-search-index.md): the build half. The engine gains enable, disable, and a budgeted build step, all following the reorganization discipline — read the live manifest, do bounded work, publish one manifest through the root compare-and-swap, let the manifest be the resume point.

Enabling publishes the index.grams feature entry with a backfill cursor; backfill walks the revisions family in row-key order (reading the manifest, not old WAL, so it works regardless of retention history) and indexes revisions at or below the enable-time watermark. Once materialized, steps replay the WAL after built_through_seq and consume whole commits up to the file and byte budgets. Eligibility is decided at index time: a size cap plus the grep-family sniff (no NUL, valid UTF-8 sample). Retention advancement now clamps to the watermark while the feature is enabled, and probes index segments alongside metadata segments, so the WAL the next build step needs is always retained.

Tests cover multi-step backfill with a two-file page budget, binary skipping, steady-state WAL follow including multiple revisions of an overwritten file, feature and segment carry-forward across a checkpoint flush, the retention clamp, and disable dropping the feature and references.