### PR TITLE
feat(loonfs,server): gram index upkeep in maintenance ticks and admin toggles

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -81,13 +81,13 @@ pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
 pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
     CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch, GrepRequest, GrepResponse,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOutcome,
-    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, DisableGramsIndexResponse,
+    EnableGramsIndexResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
+    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest,
+    GcRequest, GcResponse, GrepMatch, GrepRequest, GrepResponse, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceStatusResponse,
+    NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -33,7 +33,9 @@ pub use operations::{
     RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
-pub use search::{GrepMatch, GrepRequest, GrepResponse};
+pub use search::{
+    DisableGramsIndexResponse, EnableGramsIndexResponse, GrepMatch, GrepRequest, GrepResponse,
+};
 pub use uploads::{
     BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
     DirectPutUpload, ObjectTransferAccess, UploadContentResponse, UploadMode,

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -101,3 +101,26 @@ pub struct GrepResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
+
+/// Result of enabling the gram index on a namespace (admin plane).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct EnableGramsIndexResponse {
+    /// Namespace the feature entry was published for.
+    pub namespace_id: NamespaceId,
+    /// Backfill covers commits at or below this sequence; later commits
+    /// arrive through WAL replay once backfill completes.
+    pub built_through_seq: ChangeSeq,
+    /// True when the namespace already carried the feature entry.
+    pub already_enabled: bool,
+}
+
+/// Result of disabling the gram index on a namespace (admin plane).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DisableGramsIndexResponse {
+    /// Namespace the feature entry was removed from.
+    pub namespace_id: NamespaceId,
+    /// False when the namespace had no feature entry to remove.
+    pub was_enabled: bool,
+}

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -353,6 +353,8 @@ pub(crate) enum AdminCommand {
     RetentionAdvance(AdminNamespaceArgs),
     Tick(AdminTickArgs),
     Gc(AdminGcArgs),
+    IndexEnable(AdminNamespaceArgs),
+    IndexDisable(AdminNamespaceArgs),
 }
 
 #[derive(Debug, Args)]
@@ -469,6 +471,8 @@ pub(crate) enum CommandKind {
     AdminRetentionAdvance,
     AdminTick,
     AdminGc,
+    AdminIndexEnable,
+    AdminIndexDisable,
     ConfigPath,
     ConfigShow,
     Version,
@@ -508,6 +512,8 @@ impl CommandKind {
             CommandKind::AdminRetentionAdvance => "admin_retention_advance",
             CommandKind::AdminTick => "admin_tick",
             CommandKind::AdminGc => "admin_gc",
+            CommandKind::AdminIndexEnable => "admin_index_enable",
+            CommandKind::AdminIndexDisable => "admin_index_disable",
             CommandKind::ConfigPath => "config_path",
             CommandKind::ConfigShow => "config_show",
             CommandKind::Version => "version",
@@ -558,6 +564,8 @@ impl Cli {
                 AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
                 AdminCommand::Tick(_) => CommandKind::AdminTick,
                 AdminCommand::Gc(_) => CommandKind::AdminGc,
+                AdminCommand::IndexEnable(_) => CommandKind::AdminIndexEnable,
+                AdminCommand::IndexDisable(_) => CommandKind::AdminIndexDisable,
             },
             Command::Config { command } => match command {
                 ConfigCommand::Path => CommandKind::ConfigPath,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -18,8 +18,9 @@ use loonfs::{
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior, EffectiveLimit,
-    FlushWalResponse, GcRequest, GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse,
+    CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior,
+    DisableGramsIndexResponse, EffectiveLimit, EnableGramsIndexResponse, FlushWalResponse,
+    GcRequest, GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse,
     MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, PaginationPolicy, PutBehavior,
     ReleaseCheckpointResponse, RevisionNo,
@@ -131,6 +132,28 @@ impl Backend for EmbeddedBackend {
         let parsed = parse_namespace_id(namespace_id)?;
         self.reader
             .grep(&parsed, request)
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
+    async fn enable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<EnableGramsIndexResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        self.admin
+            .enable_grams_index(&parsed)
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
+    async fn disable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<DisableGramsIndexResponse, BackendError> {
+        let parsed = parse_namespace_id(namespace_id)?;
+        self.admin
+            .disable_grams_index(&parsed)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -19,6 +19,8 @@ pub(crate) async fn run_admin_command(
         AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
         AdminCommand::Tick(args) => run_admin_tick(kind, args).await,
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
+        AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
+        AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, args).await,
     }
 }
 
@@ -221,5 +223,57 @@ pub(crate) async fn run_admin_changes(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::Changes(response),
+    })
+}
+
+async fn run_admin_index_enable(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let response = context
+        .target
+        .backend()
+        .enable_grams_index(&context.namespace)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::GramsIndexEnabled(response),
+    })
+}
+
+async fn run_admin_index_disable(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let response = context
+        .target
+        .backend()
+        .disable_grams_index(&context.namespace)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::GramsIndexDisabled(response),
     })
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -5,8 +5,9 @@ use crate::profiles::ProfileSummary;
 use loonfs_api::v0::ChangesResponse;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, CreateCheckpointResponse,
-    DeleteNamespaceResponse, FileRevision, FlushWalResponse, GcResponse, GrepMatch,
-    MaintenanceTickResponse, NamespaceSummary, ReleaseCheckpointResponse,
+    DeleteNamespaceResponse, DisableGramsIndexResponse, EnableGramsIndexResponse, FileRevision,
+    FlushWalResponse, GcResponse, GrepMatch, MaintenanceTickResponse, NamespaceSummary,
+    ReleaseCheckpointResponse,
 };
 use serde::Serialize;
 
@@ -52,6 +53,8 @@ pub(crate) enum CommandData {
     RetentionAdvanced(AdvanceRetentionResponse),
     MaintenanceTicked(MaintenanceTickResponse),
     GarbageCollected(GcResponse),
+    GramsIndexEnabled(EnableGramsIndexResponse),
+    GramsIndexDisabled(DisableGramsIndexResponse),
     Changes(ChangesResponse),
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -272,6 +272,26 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n"),
+        CommandData::GramsIndexEnabled(response) => {
+            if response.already_enabled {
+                format!(
+                    "gram index already enabled on {} (built through seq {})",
+                    response.namespace_id, response.built_through_seq.0
+                )
+            } else {
+                format!(
+                    "gram index enabled on {}; backfill covers seq <= {} on upcoming ticks",
+                    response.namespace_id, response.built_through_seq.0
+                )
+            }
+        }
+        CommandData::GramsIndexDisabled(response) => {
+            if response.was_enabled {
+                format!("gram index disabled on {}", response.namespace_id)
+            } else {
+                format!("gram index was not enabled on {}", response.namespace_id)
+            }
+        }
         CommandData::GrepMatches {
             pattern,
             matches,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -970,6 +970,8 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
                 &["admin", "retention-advance"],
                 &["admin", "tick"],
                 &["admin", "gc"],
+                &["admin", "index-enable"],
+                &["admin", "index-disable"],
             ],
         ),
     ];

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -20,10 +20,11 @@ use crate::{Client, ClientError, MutationOptions, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
     v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse, ErrorCode,
-    FlushWalResponse, GcRequest, GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
+    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
+    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, FlushWalResponse, GcRequest,
+    GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse, MaintenanceTickRequest,
+    MaintenanceTickResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
+    ReleaseCheckpointResponse, RevisionNo,
 };
 use thiserror::Error;
 
@@ -155,6 +156,16 @@ pub trait Backend {
         namespace_id: &str,
         request: &GrepRequest,
     ) -> Result<GrepResponse, BackendError>;
+    /// Enables the gram index on a namespace (admin plane).
+    async fn enable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<EnableGramsIndexResponse, BackendError>;
+    /// Disables the gram index on a namespace (admin plane).
+    async fn disable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<DisableGramsIndexResponse, BackendError>;
     /// Reads a retained file revision's content.
     async fn read_file_revision_bytes(
         &self,
@@ -346,6 +357,24 @@ impl Backend for RemoteBackend {
         let namespace_id = namespace_id.to_owned();
         let request = request.clone();
         self.wire(move |client| client.grep(&namespace_id, &request))
+            .await
+    }
+
+    async fn enable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<EnableGramsIndexResponse, BackendError> {
+        let namespace_id = namespace_id.to_owned();
+        self.wire(move |client| client.enable_grams_index(&namespace_id))
+            .await
+    }
+
+    async fn disable_grams_index(
+        &self,
+        namespace_id: &str,
+    ) -> Result<DisableGramsIndexResponse, BackendError> {
+        let namespace_id = namespace_id.to_owned();
+        self.wire(move |client| client.disable_grams_index(&namespace_id))
             .await
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -20,8 +20,9 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
-    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorCode, ErrorKind,
-    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse, FlushWalResponse,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse,
+    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorKind, FilesystemOperation,
+    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalResponse,
     ForkNamespaceRequest, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
     ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickRequest,
     MaintenanceTickResponse, MutationResult, NamespaceId, NamespaceStatusResponse,
@@ -683,6 +684,34 @@ impl Client {
         let namespace = namespace_url_segment(namespace)?;
         let url = format!("{}/v0/namespaces/{namespace}/query/grep", self.base_url);
         self.request_json(self.agent.post(&url), Some(request))
+    }
+
+    /// Publishes the `index.grams` feature entry (admin plane); backfill
+    /// runs through maintenance ticks. Idempotent.
+    pub fn enable_grams_index(
+        &self,
+        namespace: &str,
+    ) -> Result<EnableGramsIndexResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/index/grams/enable",
+            self.base_url
+        );
+        self.request_json::<(), EnableGramsIndexResponse>(self.agent.post(&url), None)
+    }
+
+    /// Removes the `index.grams` feature entry (admin plane); garbage
+    /// collection reclaims the segments. Idempotent.
+    pub fn disable_grams_index(
+        &self,
+        namespace: &str,
+    ) -> Result<DisableGramsIndexResponse, ClientError> {
+        let namespace = namespace_url_segment(namespace)?;
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace}/index/grams/disable",
+            self.base_url
+        );
+        self.request_json::<(), DisableGramsIndexResponse>(self.agent.post(&url), None)
     }
 
     fn apply_filesystem_operation(

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -7,7 +7,9 @@ use axum::http::HeaderMap;
 use axum::Json;
 #[cfg(feature = "openapi")]
 use loonfs_api::v0::ApiError;
-use loonfs_api::v0::{GrepRequest, GrepResponse};
+use loonfs_api::v0::{
+    DisableGramsIndexResponse, EnableGramsIndexResponse, GrepRequest, GrepResponse,
+};
 
 #[cfg_attr(
     feature = "openapi",
@@ -41,6 +43,70 @@ pub(super) async fn grep(
     let response = state
         .reader
         .grep(&namespace_id, &request)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/index/grams/enable",
+        tag = "admin",
+        summary = "Enable the gram index",
+        description = "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next maintenance tick and the index stays current from then on. Idempotent.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Feature entry published or already present", body = EnableGramsIndexResponse),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn enable_grams_index(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+) -> Result<Json<EnableGramsIndexResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let response = state
+        .admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/namespaces/{namespace}/index/grams/disable",
+        tag = "admin",
+        summary = "Disable the gram index",
+        description = "Removes the namespace's index.grams feature entry and its segment references; garbage collection reclaims the segments. Idempotent.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Feature entry removed or already absent", body = DisableGramsIndexResponse),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn disable_grams_index(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+) -> Result<Json<DisableGramsIndexResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let response = state
+        .admin
+        .disable_grams_index(&namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -37,7 +37,7 @@ use self::handlers_namespace::{
     advance_retention, create_checkpoint, create_namespace, delete_namespace, flush_wal,
     fork_namespace, gc_namespace, maintenance_tick, namespace_status, release_checkpoint,
 };
-use self::handlers_query::grep;
+use self::handlers_query::{disable_grams_index, enable_grams_index, grep};
 use self::handlers_uploads::{begin_upload, complete_upload, upload_content};
 use crate::config::{ServerConfig, ServerConfigError};
 use axum::async_trait;
@@ -170,6 +170,14 @@ fn router(state: AppState) -> Router {
             get(get_content),
         )
         .route("/v0/namespaces/:namespace/query/grep", post(grep))
+        .route(
+            "/v0/admin/namespaces/:namespace/index/grams/enable",
+            post(enable_grams_index),
+        )
+        .route(
+            "/v0/admin/namespaces/:namespace/index/grams/disable",
+            post(disable_grams_index),
+        )
         .route(
             "/v0/namespaces/:namespace/filesystem/revisions",
             get(list_path_revisions),

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -63,7 +63,9 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_namespace::advance_retention,
         crate::http::handlers_namespace::maintenance_tick,
         crate::http::handlers_namespace::gc_namespace,
-        crate::http::handlers_query::grep
+        crate::http::handlers_query::grep,
+        crate::http::handlers_query::enable_grams_index,
+        crate::http::handlers_query::disable_grams_index
     ),
     components(schemas(
         loonfs_api::CapabilityDocument,
@@ -126,7 +128,9 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         ChangesResponse,
         loonfs_api::v0::GrepRequest,
         loonfs_api::v0::GrepMatch,
-        loonfs_api::v0::GrepResponse
+        loonfs_api::v0::GrepResponse,
+        loonfs_api::v0::EnableGramsIndexResponse,
+        loonfs_api::v0::DisableGramsIndexResponse
     )),
     tags(
         (name = "health", description = "Server health"),

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -63,6 +63,12 @@ pub(crate) struct FsInner {
     pub(crate) cache_stats: RuntimeCacheStatsInner,
     pub(crate) background: BackgroundWork,
     pub(crate) commit_windows: CommitWindows,
+    /// Per-namespace gram-index enablement, learned in-process: `None`
+    /// until any tick, enable, or disable observes the namespace. Publishes
+    /// consult it so index catch-up is scheduled by index lag, not only by
+    /// the WAL-segment threshold — one publish can add more tail files
+    /// than a grep will scan without ever crossing that threshold.
+    pub(crate) grams_enabled_hints: Mutex<BTreeMap<NamespaceId, bool>>,
 }
 
 /// Lock accessors for the runtime caches.
@@ -107,6 +113,7 @@ impl FsCore {
                 cache_stats: RuntimeCacheStatsInner::default(),
                 background,
                 commit_windows: CommitWindows::default(),
+                grams_enabled_hints: Mutex::new(BTreeMap::new()),
             }),
         })
     }
@@ -399,6 +406,7 @@ impl FsCore {
             .enable_grams_index()
             .await
             .map_err(RuntimeError::Core)?;
+        self.record_grams_hint(namespace_id, true);
         self.invalidate_namespace_cache(namespace_id);
         match outcome {
             loonfs_core::GramIndexEnableOutcome::Enabled { built_through_seq } => {
@@ -434,6 +442,7 @@ impl FsCore {
             .disable_grams_index()
             .await
             .map_err(RuntimeError::Core)?;
+        self.record_grams_hint(namespace_id, false);
         self.invalidate_namespace_cache(namespace_id);
         match outcome {
             loonfs_core::GramIndexDisableOutcome::Disabled => Ok(DisableGramsIndexResponse {
@@ -450,6 +459,23 @@ impl FsCore {
                 )))
             }
         }
+    }
+
+    fn record_grams_hint(&self, namespace_id: &NamespaceId, enabled: bool) {
+        self.inner
+            .grams_enabled_hints
+            .lock()
+            .expect("grams hint lock poisoned")
+            .insert(namespace_id.clone(), enabled);
+    }
+
+    fn grams_hint(&self, namespace_id: &NamespaceId) -> Option<bool> {
+        self.inner
+            .grams_enabled_hints
+            .lock()
+            .expect("grams hint lock poisoned")
+            .get(namespace_id)
+            .copied()
     }
 
     /// One bounded gram index build step, then one bounded fold step. A
@@ -490,20 +516,35 @@ impl FsCore {
             loonfs_core::GramIndexBuildOutcome::NotEnabled
             | loonfs_core::GramIndexBuildOutcome::UpToDate { .. } => {}
         }
+        // `UnsupportedFeatureVersion` also records false: this writer cannot
+        // advance that index, so scheduling it a tick per publish is waste.
+        self.record_grams_hint(
+            namespace_id,
+            !matches!(
+                build.outcome,
+                loonfs_core::GramIndexBuildOutcome::NotEnabled
+                    | loonfs_core::GramIndexBuildOutcome::UnsupportedFeatureVersion { .. }
+            ),
+        );
         let fold = engine
             .fold_grams_index_step(loonfs_core::GramIndexBuildPolicy::default())
             .await
             .map_err(RuntimeError::Core)?;
-        if let loonfs_core::GramIndexFoldOutcome::UnitPublished {
-            merged_segments,
+        if let loonfs_core::GramIndexFoldOutcome::StepPublished {
+            merged_rows,
             segments_written,
+            completed,
         } = &fold.outcome
         {
+            // An unfinished fold keeps a cursor in the feature value; the
+            // drain loop keeps stepping it.
+            published |= !completed;
             self.invalidate_namespace_cache(namespace_id);
             tracing::info!(
-                merged_segments,
+                merged_rows,
                 segments_written,
-                "gram index fold unit published"
+                completed,
+                "gram index fold step published"
             );
         }
         Ok(published)
@@ -1361,7 +1402,17 @@ impl FsCore {
     /// this, as it tracks no tail projection to observe.
     fn maybe_auto_tick_after_publish(&self, namespace_id: &NamespaceId, wal_tail_segments: u64) {
         let options = MaintenanceTickOptions::default();
-        if wal_tail_segments < options.max_wal_tail_segments {
+        let run_full_tick = wal_tail_segments >= options.max_wal_tail_segments;
+        // Below the WAL threshold, index catch-up alone is still scheduled
+        // when the gram index is (or may be) enabled: index lag is measured
+        // in files, not segments, and one publish can put more files in the
+        // tail than a grep will scan. `None` means this process has not
+        // observed the namespace yet; the drain it schedules learns the
+        // answer, so the discovery cost is one cheap step per namespace per
+        // process. Flush cadence is unchanged — only the full tick moves
+        // WAL segments into tables.
+        let index_may_lag = self.grams_hint(namespace_id) != Some(false);
+        if !run_full_tick && !index_may_lag {
             return;
         }
         if !self.inner.background.try_claim(namespace_id) {
@@ -1372,16 +1423,25 @@ impl FsCore {
             namespace_id: namespace_id.clone(),
         };
         self.inner.background.spawn(async move {
-            let tick = claim
-                .fs
-                .maintenance_tick_namespace(&claim.namespace_id, options)
-                .await;
+            let tick = if run_full_tick {
+                claim
+                    .fs
+                    .maintenance_tick_namespace(&claim.namespace_id, options)
+                    .await
+                    .map(|_| ())
+            } else {
+                Ok(())
+            };
             let drained = match tick {
-                Ok(_) => {
-                    let folds = claim
-                        .fs
-                        .drain_reorganization_backlog(&claim.namespace_id)
-                        .await;
+                Ok(()) => {
+                    let folds = if run_full_tick {
+                        claim
+                            .fs
+                            .drain_reorganization_backlog(&claim.namespace_id)
+                            .await
+                    } else {
+                        Ok(())
+                    };
                     match folds {
                         Ok(()) => {
                             claim

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -28,11 +28,12 @@ use crate::{
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
     encode_directory_cursor, encode_file_revisions_cursor, generated_id, AbsolutePath,
-    CapabilityDocument, DirectoryPageCursor, EffectiveLimit, FileRevision, FileRevisionsPageCursor,
-    GrepRequest, GrepResponse, Page, PageRequest, PaginationPolicy, UploadId,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
-    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    CapabilityDocument, DirectoryPageCursor, DisableGramsIndexResponse, EffectiveLimit,
+    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, GrepRequest, GrepResponse,
+    Page, PageRequest, PaginationPolicy, UploadId, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, PROFILE_ADMIN_V0,
+    PROFILE_CORE_V0, PROFILE_QUERY_V0, PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
     load_namespace_head_summary, MetadataTableCache, WalTailProjectionCache,
@@ -272,6 +273,7 @@ impl FsCore {
         let observed_head_seq = status_before.head_seq;
         if status_before.wal_tail_segments < options.max_wal_tail_segments {
             self.run_tick_reorganization(namespace_id).await?;
+            self.run_tick_grams_index(namespace_id).await?;
             let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
             return Ok(MaintenanceTickResult {
                 namespace_id: namespace_id.clone(),
@@ -285,6 +287,7 @@ impl FsCore {
             Ok(flush) => flush,
             Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
                 self.run_tick_reorganization(namespace_id).await?;
+                self.run_tick_grams_index(namespace_id).await?;
                 let gc = self.run_tick_gc(namespace_id, options.gc.as_ref()).await?;
                 return Ok(MaintenanceTickResult {
                     namespace_id: namespace_id.clone(),
@@ -296,6 +299,7 @@ impl FsCore {
             Err(error) => return Err(error),
         };
         self.run_tick_reorganization(namespace_id).await?;
+        self.run_tick_grams_index(namespace_id).await?;
 
         let outcome = match flush.outcome {
             FlushWalOutcome::Published => MaintenanceTickOutcome::WalFlushed {
@@ -382,6 +386,140 @@ impl FsCore {
             return Ok(None);
         };
         Ok(Some(self.gc_namespace(namespace_id, config).await?))
+    }
+
+    /// Publishes the `index.grams` feature entry, scheduling gram index
+    /// backfill; maintenance ticks build it from then on.
+    pub(crate) async fn enable_grams_index(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<EnableGramsIndexResponse> {
+        let outcome = self
+            .namespace_engine(namespace_id)
+            .enable_grams_index()
+            .await
+            .map_err(RuntimeError::Core)?;
+        self.invalidate_namespace_cache(namespace_id);
+        match outcome {
+            loonfs_core::GramIndexEnableOutcome::Enabled { built_through_seq } => {
+                Ok(EnableGramsIndexResponse {
+                    namespace_id: namespace_id.clone(),
+                    built_through_seq,
+                    already_enabled: false,
+                })
+            }
+            loonfs_core::GramIndexEnableOutcome::AlreadyEnabled { built_through_seq } => {
+                Ok(EnableGramsIndexResponse {
+                    namespace_id: namespace_id.clone(),
+                    built_through_seq,
+                    already_enabled: true,
+                })
+            }
+            loonfs_core::GramIndexEnableOutcome::Superseded => {
+                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
+                    "enabling the gram index lost a manifest publication race; retry".to_owned(),
+                )))
+            }
+        }
+    }
+
+    /// Removes the `index.grams` feature entry and its segment references;
+    /// the segments become garbage-collection candidates.
+    pub(crate) async fn disable_grams_index(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<DisableGramsIndexResponse> {
+        let outcome = self
+            .namespace_engine(namespace_id)
+            .disable_grams_index()
+            .await
+            .map_err(RuntimeError::Core)?;
+        self.invalidate_namespace_cache(namespace_id);
+        match outcome {
+            loonfs_core::GramIndexDisableOutcome::Disabled => Ok(DisableGramsIndexResponse {
+                namespace_id: namespace_id.clone(),
+                was_enabled: true,
+            }),
+            loonfs_core::GramIndexDisableOutcome::NotEnabled => Ok(DisableGramsIndexResponse {
+                namespace_id: namespace_id.clone(),
+                was_enabled: false,
+            }),
+            loonfs_core::GramIndexDisableOutcome::Superseded => {
+                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
+                    "disabling the gram index lost a manifest publication race; retry".to_owned(),
+                )))
+            }
+        }
+    }
+
+    /// One bounded gram index build step, then one bounded fold step. A
+    /// namespace without the feature entry reports and costs nothing.
+    async fn run_tick_grams_index(&self, namespace_id: &NamespaceId) -> Result<bool> {
+        let engine = self.namespace_engine(namespace_id);
+        let build = engine
+            .build_grams_index_step(loonfs_core::GramIndexBuildPolicy::default())
+            .await
+            .map_err(RuntimeError::Core)?;
+        let mut published = false;
+        match &build.outcome {
+            loonfs_core::GramIndexBuildOutcome::Published {
+                built_through_seq,
+                indexed_revisions,
+                materialized,
+                ..
+            } => {
+                published = true;
+                self.invalidate_namespace_cache(namespace_id);
+                tracing::info!(
+                    built_through_seq = built_through_seq.0,
+                    indexed_revisions,
+                    materialized,
+                    "gram index build step published"
+                );
+            }
+            loonfs_core::GramIndexBuildOutcome::UnsupportedFeatureVersion { found } => {
+                tracing::warn!(
+                    found,
+                    "gram index feature version is not supported; skipping"
+                );
+            }
+            loonfs_core::GramIndexBuildOutcome::Superseded => {
+                published = true;
+                tracing::info!("gram index build step superseded; will retry");
+            }
+            loonfs_core::GramIndexBuildOutcome::NotEnabled
+            | loonfs_core::GramIndexBuildOutcome::UpToDate { .. } => {}
+        }
+        let fold = engine
+            .fold_grams_index_step(loonfs_core::GramIndexBuildPolicy::default())
+            .await
+            .map_err(RuntimeError::Core)?;
+        if let loonfs_core::GramIndexFoldOutcome::UnitPublished {
+            merged_segments,
+            segments_written,
+        } = &fold.outcome
+        {
+            self.invalidate_namespace_cache(namespace_id);
+            tracing::info!(
+                merged_segments,
+                segments_written,
+                "gram index fold unit published"
+            );
+        }
+        Ok(published)
+    }
+
+    /// Builds gram index steps until the watermark reaches the head. Only
+    /// writer-scheduled background ticks drain like this, mirroring
+    /// [`Self::drain_reorganization_backlog`].
+    async fn drain_grams_index_backlog(&self, namespace_id: &NamespaceId) -> Result<()> {
+        const MAX_STEPS_PER_DRAIN: usize = 16;
+        for _ in 0..MAX_STEPS_PER_DRAIN {
+            if !self.run_tick_grams_index(namespace_id).await? {
+                break;
+            }
+        }
+        Ok(())
     }
 
     /// Runs the v1 mark-and-sweep garbage collector for one namespace.
@@ -558,6 +696,25 @@ impl FsCore {
         request: &GrepRequest,
     ) -> Result<GrepResponse> {
         let (engine, read_context) = self.pinned_read(namespace_id).await?;
+        // The manifest features map gates this read, and the metadata root
+        // can move without the head moving (index enablement, folds), so a
+        // head-revalidated anchor is not enough: confirm the root still
+        // names the pinned manifest and reload the anchor when it moved.
+        let root =
+            loonfs_core::control::load_namespace_metadata_root_control(self.store(), namespace_id)
+                .await
+                .map_err(|error| {
+                    RuntimeError::Core(CoreError::MetadataProjection(
+                        loonfs_core::MetadataProjectionLoadError::LoadHead(error),
+                    ))
+                })?;
+        let (engine, read_context) =
+            if root.state.manifest_object_id != read_context.manifest_object_id {
+                self.invalidate_namespace_read_cache(namespace_id);
+                self.pinned_read(namespace_id).await?
+            } else {
+                (engine, read_context)
+            };
         let response = engine
             .grep_with_runtime_context(request, &read_context)
             .await?;
@@ -1221,10 +1378,19 @@ impl FsCore {
                 .await;
             let drained = match tick {
                 Ok(_) => {
-                    claim
+                    let folds = claim
                         .fs
                         .drain_reorganization_backlog(&claim.namespace_id)
-                        .await
+                        .await;
+                    match folds {
+                        Ok(()) => {
+                            claim
+                                .fs
+                                .drain_grams_index_backlog(&claim.namespace_id)
+                                .await
+                        }
+                        Err(error) => Err(error),
+                    }
                 }
                 Err(error) => Err(error),
             };

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -6,10 +6,10 @@ use crate::config::default_writer_version;
 use crate::fs::FsCore;
 use crate::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
-    FlushWalResponse, GcConfig, GcReport, MaintenanceTickOptions, MaintenanceTickResult,
-    NamespaceId, NamespaceStatusResponse, ObjectStoreMetricsRecorder, ReleaseCheckpointResponse,
-    Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
-    TraceMode, TraceStoreKind,
+    DisableGramsIndexResponse, EnableGramsIndexResponse, FlushWalResponse, GcConfig, GcReport,
+    MaintenanceTickOptions, MaintenanceTickResult, NamespaceId, NamespaceStatusResponse,
+    ObjectStoreMetricsRecorder, ReleaseCheckpointResponse, Result, RuntimeCacheConfig,
+    RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -72,6 +72,25 @@ impl FsAdmin {
         self.core
             .maintenance_tick_namespace(namespace_id, options)
             .await
+    }
+
+    /// Publishes the `index.grams` feature entry for a namespace: gram
+    /// index backfill starts on the next maintenance tick, and ticks keep
+    /// the index current from then on. Idempotent.
+    pub async fn enable_grams_index(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<EnableGramsIndexResponse> {
+        self.core.enable_grams_index(namespace_id).await
+    }
+
+    /// Removes the `index.grams` feature entry and its segment references;
+    /// garbage collection reclaims the segments. Idempotent.
+    pub async fn disable_grams_index(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<DisableGramsIndexResponse> {
+        self.core.disable_grams_index(namespace_id).await
     }
 
     /// Creates or reuses a named checkpoint pinning the current namespace

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -51,14 +51,15 @@ pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
     ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteDirectoryBehavior, DeleteNamespaceResponse,
-    DirectoryPageCursor, DisplayName, EffectiveLimit, FileRevision, FileRevisionsPageCursor,
-    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, GrepMatch, GrepRequest,
-    GrepResponse, InodeId, InodeKind, ListFileRevisionsResponse, ListPathEntriesResponse,
-    ManifestId, MutationResult, NameKey, NamePolicy, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, Page, PageRequest, PaginationPolicy, PutBehavior, ReleaseCheckpointResponse,
-    RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
-    FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
-    PROFILE_CORE_V0, PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    DirectoryPageCursor, DisableGramsIndexResponse, DisplayName, EffectiveLimit,
+    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse,
+    FlushWalOutcome, FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult, NameKey,
+    NamePolicy, NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest,
+    PaginationPolicy, PutBehavior, ReleaseCheckpointResponse, RevisionNo, UploadId,
+    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROFILE_QUERY_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -5,7 +5,7 @@
 //! build through maintenance ticks, query through `FsReader`, disable.
 
 use loonfs::{
-    CreateNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter, GrepRequest,
+    CreateNamespaceOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepRequest,
     MaintenanceTickOptions, NamespaceId, PutFileOptions,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -147,6 +147,79 @@ async fn maintenance_ticks_build_the_gram_index_once_enabled() {
         panic!("expected a core error, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NotSupported);
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Index catch-up is scheduled by index lag, not by the WAL-segment
+/// threshold: one small publish must still get the index built in the
+/// background, with no explicit ticks and a tail far below the threshold.
+#[tokio::test]
+async fn a_publish_below_the_wal_threshold_still_schedules_index_catch_up() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: loonfs::SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grams-auto-tick").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-auto-writer")
+        .commit_window_ms(0)
+        .background_work(FsBackgroundWork::Enabled)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-auto-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+
+    // The writer runtime has not observed this namespace's feature yet, so
+    // this publish exercises the discovery path of the scheduling hint.
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/delta.txt",
+            b"a needle in delta\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write delta");
+    writer
+        .wait_for_background_work()
+        .await
+        .expect("background work quiesces");
+
+    let status = admin.namespace_status(&namespace_id).await.expect("status");
+    assert!(
+        status.wal_tail_segments < MaintenanceTickOptions::default().max_wal_tail_segments,
+        "the tail must stay below the flush threshold for this test to \
+         exercise index-only scheduling: {status:?}"
+    );
+
+    // A stale grep serves from the index alone, so a match here proves the
+    // background drain advanced the watermark past the publish.
+    let mut stale = grep_request("needle");
+    stale.allow_stale = true;
+    let response = reader
+        .grep(&namespace_id, &stale)
+        .await
+        .expect("stale grep after background catch-up");
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/delta.txt");
 
     writer.shutdown_background().await.expect("writer shutdown");
 }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -1,0 +1,152 @@
+#![allow(clippy::panic)]
+// Lifecycle assertions use panic for precise failure diagnostics.
+
+//! Handle-level lifecycle of the gram index: enable through `FsAdmin`,
+//! build through maintenance ticks, query through `FsReader`, disable.
+
+use loonfs::{
+    CreateNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter, GrepRequest,
+    MaintenanceTickOptions, NamespaceId, PutFileOptions,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn grep_request(pattern: &str) -> GrepRequest {
+    GrepRequest {
+        pattern: pattern.to_owned(),
+        case_insensitive: false,
+        path_prefix: None,
+        cursor: None,
+        limit: None,
+        allow_stale: false,
+        allow_scan: false,
+    }
+}
+
+#[tokio::test]
+async fn maintenance_ticks_build_the_gram_index_once_enabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: loonfs::SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grams-runtime").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/alpha.txt",
+            b"a needle in alpha\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write alpha");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/bravo.txt",
+            b"nothing here\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write bravo");
+
+    // Before enablement, grep names the missing data half.
+    let error = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect_err("grep without the feature must be refused");
+    let loonfs::Error::Core(core) = &error else {
+        panic!("expected a core error, got {error:?}");
+    };
+    assert_eq!(core.code(), ErrorCode::NotSupported);
+
+    let enabled = admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    assert!(!enabled.already_enabled);
+    let again = admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("re-enable");
+    assert!(again.already_enabled);
+
+    // Explicit maintenance ticks run the backfill and keep the watermark
+    // current; two ticks comfortably cover backfill plus catch-up here.
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("maintenance tick");
+    }
+
+    let response = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("grep after ticks");
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/alpha.txt");
+
+    // New commits are visible immediately through the exhaustive tail, and
+    // a later tick absorbs them into the index.
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/charlie.txt",
+            b"another needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write charlie");
+    let response = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("grep with tail");
+    assert_eq!(response.matches.len(), 2);
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("tick after write");
+    let response = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("grep after catch-up tick");
+    assert_eq!(response.matches.len(), 2);
+    assert!(response.built_through_seq.0 > 0);
+
+    let disabled = admin
+        .disable_grams_index(&namespace_id)
+        .await
+        .expect("disable");
+    assert!(disabled.was_enabled);
+    let error = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect_err("grep after disable must be refused");
+    let loonfs::Error::Core(core) = &error else {
+        panic!("expected a core error, got {error:?}");
+    };
+    assert_eq!(core.code(), ErrorCode::NotSupported);
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -322,6 +322,8 @@ A representative v0 binding is shown below.
 | Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; flush races surface as outcomes, not errors) |
 | Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; a grace window below the derived safety floor is rejected as `invalid_request`; nothing sweeps without an explicit call) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires the namespace's `index.grams` feature entry) |
+| Enable the gram index | `POST /v0/admin/namespaces/{ns}/index/grams/enable` (publishes the `index.grams` feature entry; backfill and upkeep run through maintenance ticks; idempotent) |
+| Disable the gram index | `POST /v0/admin/namespaces/{ns}/index/grams/disable` (removes the feature entry and segment references; garbage collection reclaims the segments; idempotent) |
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -275,6 +275,132 @@
         }
       }
     },
+    "/v0/admin/namespaces/{namespace}/index/grams/disable": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Disable the gram index",
+        "description": "Removes the namespace's index.grams feature entry and its segment references; garbage collection reclaims the segments. Idempotent.",
+        "operationId": "disable_grams_index",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature entry removed or already absent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisableGramsIndexResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Lost a manifest publication race; retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/admin/namespaces/{namespace}/index/grams/enable": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Enable the gram index",
+        "description": "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next maintenance tick and the index stays current from then on. Idempotent.",
+        "operationId": "enable_grams_index",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature entry published or already present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnableGramsIndexResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Lost a manifest publication race; retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/admin/namespaces/{namespace}/maintenance/tick": {
       "post": {
         "tags": [
@@ -3347,6 +3473,47 @@
           },
           "content_ref": {
             "$ref": "#/components/schemas/ContentRef"
+          }
+        }
+      },
+      "DisableGramsIndexResponse": {
+        "type": "object",
+        "description": "Result of disabling the gram index on a namespace (admin plane).",
+        "required": [
+          "namespace_id",
+          "was_enabled"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the feature entry was removed from."
+          },
+          "was_enabled": {
+            "type": "boolean",
+            "description": "False when the namespace had no feature entry to remove."
+          }
+        }
+      },
+      "EnableGramsIndexResponse": {
+        "type": "object",
+        "description": "Result of enabling the gram index on a namespace (admin plane).",
+        "required": [
+          "namespace_id",
+          "built_through_seq",
+          "already_enabled"
+        ],
+        "properties": {
+          "already_enabled": {
+            "type": "boolean",
+            "description": "True when the namespace already carried the feature entry."
+          },
+          "built_through_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Backfill covers commits at or below this sequence; later commits\narrive through WAL replay once backfill completes."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the feature entry was published for."
           }
         }
       },


### PR DESCRIPTION
Final wave of the content search index: the operational half.

Once a namespace carries the index.grams feature entry, maintenance keeps the index current without further attention: every tick runs one budgeted build step and one fold step alongside reorganization, and writer-scheduled background ticks drain the build backlog after draining folds. A namespace without the entry costs one manifest field check and nothing else.

Enablement gets a proper surface: FsAdmin::enable_grams_index / disable_grams_index, POST /v0/admin/namespaces/{ns}/index/grams/enable and /disable, remote client methods, and loon admin index-enable / index-disable (with api.md rows and the OpenAPI document regenerated).

The handle-level lifecycle test caught a real staleness bug: a standalone reader's pinned anchor revalidates by head, but enabling the index moves the metadata root without moving the head, so the reader kept serving the pre-enable manifest — and the features map lives in the manifest. Grep's runtime path now confirms the root still names the pinned manifest (one small GET, negligible against a search) and reloads the anchor when it moved. Worth noting for review: any future read that depends on manifest features rather than filesystem rows will need the same discipline.

Deferred from the original wave plan: richer index status introspection (segment counts, lag) and the lab benchmark run — the lab rig lives outside this repo, and index size and query latency there should inform any default-on conversation.