### PR TITLE
perf(core): cache gram index blocks and fan out grep and index-build reads

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -3,6 +3,7 @@
 
 use super::runs::MetadataRunManifest;
 use crate::metadata::MetadataState;
+use loonfs_api::wire::index_grams::IndexRow;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
@@ -67,7 +68,10 @@ pub(super) struct MetadataTableCacheKey {
 /// One decoded, verified object the cache holds: a CRC-checked segment
 /// section (index, filter, or data) or a validated namespace manifest.
 /// Everything shares the cache and its byte budget; the key's `block_kind`
-/// and `block_offset` make collisions between kinds impossible.
+/// and `block_offset` make collisions between kinds impossible. Data
+/// blocks come in two payloads — metadata rows and gram-index rows — that
+/// can never collide either, because a key's identity is its segment's
+/// payload checksum and one segment object belongs to exactly one family.
 #[derive(Debug, Clone)]
 pub(super) enum DecodedMetadataTableBlock {
     Index {
@@ -80,6 +84,12 @@ pub(super) enum DecodedMetadataTableBlock {
     },
     Data {
         block: Arc<DecodedDataBlock>,
+        decoded_byte_len: usize,
+    },
+    /// A gram-index segment's data block: the same block grammar as
+    /// metadata data blocks with the index family's row payload.
+    IndexData {
+        block: Arc<DecodedDataBlock<IndexRow>>,
         decoded_byte_len: usize,
     },
     Manifest {
@@ -102,6 +112,9 @@ impl DecodedMetadataTableBlock {
                 decoded_byte_len, ..
             }
             | Self::Data {
+                decoded_byte_len, ..
+            }
+            | Self::IndexData {
                 decoded_byte_len, ..
             }
             | Self::Manifest {
@@ -635,6 +648,7 @@ mod tests {
             DecodedMetadataTableBlock::Data { block: rows, .. } => Arc::clone(rows),
             DecodedMetadataTableBlock::Index { .. }
             | DecodedMetadataTableBlock::Filter { .. }
+            | DecodedMetadataTableBlock::IndexData { .. }
             | DecodedMetadataTableBlock::Manifest { .. } => {
                 unreachable!("fixture builds a data block")
             }
@@ -647,6 +661,7 @@ mod tests {
             } => Arc::ptr_eq(hit_rows, &rows),
             DecodedMetadataTableBlock::Index { .. }
             | DecodedMetadataTableBlock::Filter { .. }
+            | DecodedMetadataTableBlock::IndexData { .. }
             | DecodedMetadataTableBlock::Manifest { .. } => false,
         };
         assert!(

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -539,7 +539,13 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
         built_through_seq: feature.built_through_seq,
         backfill_cursor: Some(cursor),
     };
-    let mut content_bytes_read = 0u64;
+    // Select first, fetch after: the byte budget is charged from each
+    // reference's declared size, which the verified content read proves
+    // equal to the fetched length, so the walk stops at exactly the row
+    // the fetch-then-count serial loop stopped at.
+    let mut pending = Vec::new();
+    let mut planned_content_bytes = 0u64;
+    let mut budget_reached = false;
     for (row_key, row) in page {
         let MetadataRow::Revision {
             inode_id,
@@ -556,30 +562,29 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
         // Revisions past the enable-time watermark belong to WAL replay;
         // the cursor still advances over them so the walk terminates.
         if committed_seq <= feature.built_through_seq {
-            let indexed = index_revision_content(
-                store,
-                content_store_id,
-                inode_id,
-                revision_no,
-                &content_ref,
-                &mut unit.postings,
-                &mut content_bytes_read,
-            )
-            .await?;
-            if indexed {
-                unit.indexed_revisions += 1;
-            } else {
+            // The size cap is checked from the reference before any
+            // fetch; oversized files cost nothing to skip.
+            if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
                 unit.skipped_revisions += 1;
+            } else {
+                planned_content_bytes += content_ref.size_bytes;
+                pending.push(PendingRevisionContent {
+                    inode_id,
+                    revision_no,
+                    content_ref,
+                });
             }
         }
         unit.backfill_cursor = Some(row_key);
-        if content_bytes_read >= policy.max_content_bytes_per_step {
-            return Ok(unit);
+        if planned_content_bytes >= policy.max_content_bytes_per_step {
+            budget_reached = true;
+            break;
         }
     }
-    if walk_complete {
+    if walk_complete && !budget_reached {
         unit.backfill_cursor = None;
     }
+    fetch_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
     Ok(unit)
 }
 
@@ -642,7 +647,12 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
         built_through_seq: feature.built_through_seq,
         backfill_cursor: None,
     };
-    let mut content_bytes_read = 0u64;
+    // Select first, fetch after: the byte budget is charged from each
+    // reference's declared size, which the verified content read proves
+    // equal to the fetched length, so the unit consumes exactly the
+    // commits the fetch-then-count serial loop consumed.
+    let mut pending = Vec::new();
+    let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
     'commits: for segment in wal_chain.segments() {
         for record in segment.records() {
@@ -652,7 +662,7 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
             // A commit is consumed whole or not at all: the watermark is a
             // commit boundary, so budgets are checked between commits.
             if examined_files >= policy.max_files_per_step
-                || content_bytes_read >= policy.max_content_bytes_per_step
+                || planned_content_bytes >= policy.max_content_bytes_per_step
             {
                 break 'commits;
             }
@@ -665,20 +675,17 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
                 } = &delta.delta
                 {
                     examined_files += 1;
-                    let indexed = index_revision_content(
-                        store,
-                        content_store_id,
-                        *inode_id,
-                        *revision_no,
-                        content_ref,
-                        &mut unit.postings,
-                        &mut content_bytes_read,
-                    )
-                    .await?;
-                    if indexed {
-                        unit.indexed_revisions += 1;
-                    } else {
+                    // The size cap is checked from the reference before
+                    // any fetch; oversized files cost nothing to skip.
+                    if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
                         unit.skipped_revisions += 1;
+                    } else {
+                        planned_content_bytes += content_ref.size_bytes;
+                        pending.push(PendingRevisionContent {
+                            inode_id: *inode_id,
+                            revision_no: *revision_no,
+                            content_ref: content_ref.clone(),
+                        });
                     }
                 }
             }
@@ -689,39 +696,52 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
     if unit.built_through_seq == feature.built_through_seq {
         return Ok(None);
     }
+    fetch_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
     Ok(Some(unit))
 }
 
-/// Reads one revision's content and folds its grams into the unit's
-/// postings. Returns whether the revision was indexed (false: ineligible).
-#[allow(clippy::too_many_arguments)]
-async fn index_revision_content<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: &ContentStoreId,
+/// One revision a build unit selected for indexing, before its content
+/// fetch: everything eligibility already decided, so the fetch stage runs
+/// without re-deriving it.
+struct PendingRevisionContent {
     inode_id: InodeId,
     revision_no: RevisionNo,
-    content_ref: &ContentRef,
-    postings: &mut BTreeMap<Gram, Vec<GramPosting>>,
-    content_bytes_read: &mut u64,
-) -> Result<bool> {
-    // The size cap is checked from the reference before any fetch; the
-    // sniff needs bytes, so oversized files cost nothing to skip.
-    if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
-        return Ok(false);
+    content_ref: ContentRef,
+}
+
+/// Fetches the selected revisions' contents in chunks of
+/// [`MAX_MAINTENANCE_TABLE_IO`] and folds each eligible file's grams into
+/// the unit, strictly in selection order. Selection already excluded
+/// oversized revisions, so every entry here costs one content read; the
+/// text sniff still runs on the fetched bytes and drops non-text files
+/// after the read, exactly as the serial path did.
+async fn fetch_and_fold_revision_contents<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    pending: &[PendingRevisionContent],
+    unit: &mut CollectedIndexUnit,
+) -> Result<()> {
+    for chunk in pending.chunks(MAX_MAINTENANCE_TABLE_IO) {
+        let contents = try_join_all(chunk.iter().map(|revision| {
+            read_durable_content_bytes(store, content_store_id, &revision.content_ref)
+        }))
+        .await?;
+        for (revision, content) in chunk.iter().zip(contents) {
+            if !is_indexable_text_content(&content.bytes) {
+                unit.skipped_revisions += 1;
+                continue;
+            }
+            let posting = GramPosting {
+                inode_id: revision.inode_id,
+                revision_no: revision.revision_no,
+            };
+            for gram in extract_grams(&content.bytes) {
+                unit.postings.entry(gram).or_default().push(posting);
+            }
+            unit.indexed_revisions += 1;
+        }
     }
-    let content = read_durable_content_bytes(store, content_store_id, content_ref).await?;
-    *content_bytes_read += content.bytes.len() as u64;
-    if !is_indexable_text_content(&content.bytes) {
-        return Ok(false);
-    }
-    let posting = GramPosting {
-        inode_id,
-        revision_no,
-    };
-    for gram in extract_grams(&content.bytes) {
-        postings.entry(gram).or_default().push(posting);
-    }
-    Ok(true)
+    Ok(())
 }
 
 /// Batches collected postings into rows, in ascending row-key order.

--- a/crates/loonfs-core/src/checkpoint/index_read.rs
+++ b/crates/loonfs-core/src/checkpoint/index_read.rs
@@ -1,0 +1,209 @@
+//! Cached reads of gram-index segment sections.
+//!
+//! Index segments share the metadata segments' block grammar and their
+//! immutability contract: a decoded section is identified by the segment's
+//! payload checksum plus the block kind and offset, so it can never go
+//! stale. These loaders resolve a section through the shared
+//! [`MetadataTableCache`] — the same cache and byte budget metadata blocks
+//! use, with distinct checksums keeping the two families apart — and fall
+//! back to a direct ranged fetch when no cache is attached (the embedded
+//! unit-test shape), decoding and CRC-verifying identically either way.
+
+use super::cache::{
+    DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
+};
+use crate::error::{CoreError, Result};
+use loonfs_api::wire::index_grams::IndexRow;
+use loonfs_api::wire::sst_blocks::{
+    decode_data_block_rows, decode_filter_block, decode_index_block, BlockHandle, DecodedDataBlock,
+    SegmentFilter, SegmentIndexEntry,
+};
+use loonfs_objectstore::{ByteRange, ObjectStore};
+use std::sync::Arc;
+
+/// The error every index-segment reader reports for a section that fetched
+/// but would not decode.
+pub(crate) fn index_segment_corrupt(
+    object_key: &str,
+    what: &str,
+    error: &dyn std::fmt::Display,
+) -> CoreError {
+    CoreError::NamespaceCorrupt(format!(
+        "index segment `{object_key}` carries an unreadable {what}: {error}"
+    ))
+}
+
+fn index_section_cache_key(
+    payload_checksum: &str,
+    block_kind: MetadataTableBlockKind,
+    handle: &BlockHandle,
+) -> MetadataTableCacheKey {
+    MetadataTableCacheKey {
+        // The same identity convention metadata segments use — the payload
+        // checksum verbatim — so both families share one cache without
+        // colliding: distinct objects have distinct checksums.
+        identity: payload_checksum.to_owned(),
+        block_kind,
+        block_offset: handle.offset,
+    }
+}
+
+/// Fetches exactly the byte range a handle names, refusing handles whose
+/// bounds do not fit the address space.
+async fn fetch_index_section_bytes<S: ObjectStore + ?Sized>(
+    store: &S,
+    object_key: &str,
+    handle: &BlockHandle,
+) -> Result<Vec<u8>> {
+    let end_exclusive = handle
+        .offset
+        .checked_add(u64::from(handle.stored_len))
+        .ok_or_else(|| {
+            CoreError::NamespaceCorrupt(format!(
+                "index segment `{object_key}` descriptor names bytes past the address space"
+            ))
+        })?;
+    let bytes = store
+        .get(
+            object_key,
+            Some(ByteRange {
+                start_inclusive: handle.offset,
+                end_exclusive,
+            }),
+        )
+        .await
+        .map_err(|error| CoreError::store(object_key, &error))?
+        .ok_or_else(|| {
+            CoreError::NamespaceCorrupt(format!(
+                "manifest references missing index segment `{object_key}`"
+            ))
+        })?;
+    Ok(bytes.to_vec())
+}
+
+/// Loads an index segment's bloom filter block, decoded once at fetch time
+/// and shared through the cache afterward. Callers with an inline filter
+/// copy in the descriptor decode it locally and never reach here.
+pub(crate) async fn load_index_segment_filter_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<SegmentFilter>> {
+    let cache_key =
+        index_section_cache_key(payload_checksum, MetadataTableBlockKind::Filter, handle);
+    let fetch = || async {
+        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let filter = decode_filter_block(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?;
+        Ok::<_, CoreError>(DecodedMetadataTableBlock::Filter {
+            decoded_byte_len: handle.decoded_len as usize,
+            filter: Arc::new(filter),
+        })
+    };
+    let block = match table_cache {
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
+        None => fetch().await?,
+    };
+    match block {
+        DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
+        DecodedMetadataTableBlock::Index { .. }
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::IndexData { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(index_segment_corrupt(
+            object_key,
+            "filter block",
+            &"cache returned a non-filter block for a filter key",
+        )),
+    }
+}
+
+/// Loads an index segment's index block: the block directory a probe
+/// narrows before touching any data block.
+pub(crate) async fn load_index_segment_index_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<Vec<SegmentIndexEntry>>> {
+    let cache_key =
+        index_section_cache_key(payload_checksum, MetadataTableBlockKind::Index, handle);
+    let fetch = || async {
+        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let entries = decode_index_block(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?;
+        Ok::<_, CoreError>(DecodedMetadataTableBlock::Index {
+            decoded_byte_len: handle.decoded_len as usize,
+            entries: Arc::new(entries),
+        })
+    };
+    let block = match table_cache {
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
+        None => fetch().await?,
+    };
+    match block {
+        DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
+        DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::IndexData { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(index_segment_corrupt(
+            object_key,
+            "index block",
+            &"cache returned a non-index block for an index key",
+        )),
+    }
+}
+
+/// Loads one of an index segment's data blocks, rows decoded as the gram
+/// family's [`IndexRow`].
+pub(crate) async fn load_index_segment_data_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<DecodedDataBlock<IndexRow>>> {
+    let cache_key = index_section_cache_key(payload_checksum, MetadataTableBlockKind::Data, handle);
+    let fetch = || async {
+        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let block = decode_data_block_rows::<IndexRow>(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?;
+        Ok::<_, CoreError>(DecodedMetadataTableBlock::IndexData {
+            decoded_byte_len: decoded_index_block_weight(&block),
+            block: Arc::new(block),
+        })
+    };
+    let block = match table_cache {
+        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
+        None => fetch().await?,
+    };
+    match block {
+        DecodedMetadataTableBlock::IndexData { block, .. } => Ok(block),
+        DecodedMetadataTableBlock::Index { .. }
+        | DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::Manifest { .. } => Err(index_segment_corrupt(
+            object_key,
+            "data block",
+            &"cache returned a non-data block for a data key",
+        )),
+    }
+}
+
+/// In-memory weight of a decoded gram data block for the cache's byte
+/// budget: row keys plus each row's packed posting bytes, with the same
+/// per-row and per-block overheads the metadata weight heuristic charges.
+fn decoded_index_block_weight(block: &DecodedDataBlock<IndexRow>) -> usize {
+    let row_weight = block
+        .row_keys
+        .iter()
+        .zip(&block.rows)
+        .map(|(key, row)| {
+            let IndexRow::GramPostings { postings, .. } = row;
+            64 + key.len() + postings.len()
+        })
+        .sum::<usize>();
+    row_weight.saturating_add(128)
+}

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -208,7 +208,8 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         } => (manifest, scan_runs),
         DecodedMetadataTableBlock::Index { .. }
         | DecodedMetadataTableBlock::Filter { .. }
-        | DecodedMetadataTableBlock::Data { .. } => {
+        | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::IndexData { .. } => {
             return Err(segment_codec_error(
                 &manifest_key,
                 "cache returned a non-manifest entry for a manifest key",
@@ -940,6 +941,7 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
         DecodedMetadataTableBlock::Index { entries, .. } => Ok(entries),
         DecodedMetadataTableBlock::Filter { .. }
         | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::IndexData { .. }
         | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
             &descriptor.object_key,
             "cache returned a non-index block for an index key",
@@ -1001,6 +1003,7 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         DecodedMetadataTableBlock::Filter { filter, .. } => Ok(filter),
         DecodedMetadataTableBlock::Index { .. }
         | DecodedMetadataTableBlock::Data { .. }
+        | DecodedMetadataTableBlock::IndexData { .. }
         | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
             &descriptor.object_key,
             "cache returned a non-filter block",
@@ -1045,6 +1048,7 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         DecodedMetadataTableBlock::Data { block, .. } => Ok(block),
         DecodedMetadataTableBlock::Index { .. }
         | DecodedMetadataTableBlock::Filter { .. }
+        | DecodedMetadataTableBlock::IndexData { .. }
         | DecodedMetadataTableBlock::Manifest { .. } => Err(segment_codec_error(
             &descriptor.object_key,
             "cache returned a non-data block for a data key",

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -12,7 +12,9 @@
 //!   the resulting manifest under one durable record.
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
 //! - [`index_build`] builds the gram index in budgeted maintenance steps,
-//!   publishing manifests that advance the `index.grams` watermark.
+//!   publishing manifests that advance the `index.grams` watermark, and
+//!   [`index_read`] serves its segments' sections through the shared
+//!   decoded-block cache.
 //! - [`publish`] writes manifest objects and advances `metadata/root.json`
 //!   by compare-and-swap.
 //! - [`load`] and [`validate`] provide envelope-only loading and
@@ -29,6 +31,7 @@ mod create;
 mod error;
 mod flush;
 mod index_build;
+mod index_read;
 mod load;
 mod publish;
 pub(crate) mod record;
@@ -61,6 +64,10 @@ pub(crate) use self::flush::flush_wal;
 pub(crate) use self::index_build::{
     build_grams_index_step, disable_grams_index, enable_grams_index, fold_grams_index_step,
     is_indexable_text_content,
+};
+pub(crate) use self::index_read::{
+    index_segment_corrupt, load_index_segment_data_block, load_index_segment_filter_block,
+    load_index_segment_index_block,
 };
 pub(crate) use self::load::{
     head_from_manifest, load_namespace_manifest_envelope, load_verified_manifest_tables,

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -50,6 +50,13 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         self.manifest.as_ref()
     }
 
+    /// The shared decoded-block cache this view was loaded with, if any,
+    /// for readers of manifest-referenced segments outside the metadata
+    /// families (the gram index).
+    pub(crate) fn table_cache(&self) -> Option<&MetadataTableCache> {
+        self.table_cache
+    }
+
     pub(crate) async fn get_for_lookup(
         &self,
         family: MetadataTableFamily,

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -4,20 +4,21 @@
 //! (`materialized_view.rs`); this module holds the pieces that need no
 //! access to the view's internals.
 
-use crate::checkpoint::string_prefix_upper_bound;
+use crate::checkpoint::{
+    index_segment_corrupt, load_index_segment_data_block, load_index_segment_filter_block,
+    load_index_segment_index_block, string_prefix_upper_bound, MetadataTableCache,
+};
 use crate::error::{CoreError, Result};
 use crate::query::grep_plan::GramQueryPlan;
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use futures::future::try_join_all;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::index_grams::{lookup, Gram, IndexRow, INDEX_FAMILY_GRAMS};
 use loonfs_api::wire::manifest::{hex_decode_bytes, IndexFileRef};
-use loonfs_api::wire::sst_blocks::{
-    decode_data_block_rows, decode_filter_block, decode_index_block, index_blocks_for_key_range,
-    BlockHandle,
-};
+use loonfs_api::wire::sst_blocks::{decode_filter_block, index_blocks_for_key_range};
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{ChangeSeq, ContentRef, InodeId, NamespaceId, RevisionNo};
-use loonfs_objectstore::{ByteRange, ObjectStore};
+use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Matches returned per page when the request names no limit.
@@ -35,6 +36,13 @@ pub(super) const GREP_LINE_CAP_BYTES: usize = 512;
 /// resume cursor, so a page's cost is bounded by its own budget rather
 /// than by how many false-positive candidates the plan admits.
 pub(super) const MAX_GREP_VERIFIED_FILES_PER_PAGE: usize = 256;
+/// Concurrent store reads one grep query issues at a time: gram posting
+/// probes fan out across (gram, segment) pairs and candidate content
+/// reads fan out across verified files, both in chunks of this size — the
+/// "small fixed fan-out" the design doc names for candidate reads
+/// (docs/design/content-search-index.md), the read-side sibling of the
+/// maintenance path's `MAX_MAINTENANCE_TABLE_IO` (`checkpoint/runs.rs`).
+pub(super) const MAX_GREP_READ_IO: usize = 8;
 
 /// The revisions a query must examine, keyed by durable inode identity.
 #[derive(Debug, Default)]
@@ -68,16 +76,48 @@ impl GrepCandidates {
 
 /// Evaluates the plan against every gram index segment: for each AND set,
 /// the union of its grams' postings; the candidates are the intersection.
+/// The probes of one AND set — one per surviving (gram, segment) pair —
+/// are independent, so they run concurrently in chunks of
+/// [`MAX_GREP_READ_IO`]; the sets union order-independently, so the
+/// result is identical to a serial evaluation, and an AND set whose
+/// running intersection empties still short-circuits the sets after it.
 pub(super) async fn indexed_candidates<S: ObjectStore + ?Sized>(
     store: &S,
+    table_cache: Option<&MetadataTableCache>,
     segments: &[IndexFileRef],
     plan: &GramQueryPlan,
 ) -> Result<BTreeMap<InodeId, BTreeSet<RevisionNo>>> {
     let mut intersection: Option<BTreeSet<(InodeId, RevisionNo)>> = None;
     for or_set in &plan.required {
+        // Lookup keys derive once per gram; the key-range prune is free
+        // (already in the descriptor), so only surviving probes fan out.
+        let lookups: Vec<GramLookup> = or_set.iter().map(|gram| GramLookup::new(*gram)).collect();
+        let mut probes: Vec<(&GramLookup, &IndexFileRef)> = Vec::new();
+        for gram_lookup in &lookups {
+            for descriptor in segments {
+                if descriptor.family != INDEX_FAMILY_GRAMS {
+                    continue;
+                }
+                if descriptor.max_key.as_str() < gram_lookup.probe.as_str()
+                    || gram_lookup
+                        .upper
+                        .as_deref()
+                        .is_some_and(|upper| descriptor.min_key.as_str() >= upper)
+                {
+                    continue;
+                }
+                probes.push((gram_lookup, descriptor));
+            }
+        }
         let mut set_postings = BTreeSet::new();
-        for gram in or_set {
-            set_postings.extend(postings_for_gram(store, segments, *gram).await?);
+        for chunk in probes.chunks(MAX_GREP_READ_IO) {
+            let batches = try_join_all(chunk.iter().map(|(gram_lookup, descriptor)| {
+                segment_postings_for_gram(store, table_cache, descriptor, gram_lookup)
+            }))
+            .await?;
+            for batch in batches {
+                set_postings.extend(batch);
+            }
         }
         intersection = Some(match intersection {
             None => set_postings,
@@ -94,97 +134,105 @@ pub(super) async fn indexed_candidates<S: ObjectStore + ?Sized>(
     Ok(candidates)
 }
 
-/// The union of one gram's postings across every segment, pruned per
-/// segment by key range and bloom filter, reading only the blocks the
-/// segment index names.
-async fn postings_for_gram<S: ObjectStore + ?Sized>(
-    store: &S,
-    segments: &[IndexFileRef],
+/// One gram's derived lookup keys: the exact filter probe, the row-key
+/// prefix its postings share, and that prefix's exclusive upper bound.
+struct GramLookup {
     gram: Gram,
+    probe: String,
+    prefix: String,
+    upper: Option<String>,
+}
+
+impl GramLookup {
+    fn new(gram: Gram) -> Self {
+        let probe = lookup::gram_probe(gram);
+        let prefix = lookup::gram_prefix(gram);
+        let upper = string_prefix_upper_bound(&prefix);
+        Self {
+            gram,
+            probe,
+            prefix,
+            upper,
+        }
+    }
+}
+
+/// One gram's postings from one segment: bloom filter first (the inline
+/// copy when the descriptor carries one — no fetch at all — otherwise the
+/// cached filter block), then only the data blocks the segment index
+/// names for the gram's key range. Every fetched section resolves through
+/// the shared decoded-block cache when one is attached.
+async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    descriptor: &IndexFileRef,
+    gram_lookup: &GramLookup,
 ) -> Result<BTreeSet<(InodeId, RevisionNo)>> {
-    let probe = lookup::gram_probe(gram);
-    let prefix = lookup::gram_prefix(gram);
-    let upper = string_prefix_upper_bound(&prefix);
     let mut postings = BTreeSet::new();
-    for descriptor in segments {
-        if descriptor.family != INDEX_FAMILY_GRAMS {
-            continue;
-        }
-        // Key-range pruning first (free, already in the descriptor).
-        if descriptor.max_key.as_str() < probe.as_str()
-            || upper
-                .as_deref()
-                .is_some_and(|upper| descriptor.min_key.as_str() >= upper)
-        {
-            continue;
-        }
-        let filter_bytes = match &descriptor.filter_inline {
-            Some(inline) => hex_decode_bytes(inline).map_err(|error| {
+    let admitted = match &descriptor.filter_inline {
+        Some(inline) => {
+            let filter_bytes = hex_decode_bytes(inline).map_err(|error| {
                 CoreError::NamespaceCorrupt(format!(
                     "index segment `{}` carries undecodable inline filter hex: {error}",
                     descriptor.object_key
                 ))
-            })?,
-            None => fetch_section(store, &descriptor.object_key, &descriptor.filter_block).await?,
-        };
-        let filter = decode_filter_block(&filter_bytes, &descriptor.filter_block)
-            .map_err(|error| segment_corrupt(&descriptor.object_key, "filter block", &error))?;
-        if !filter.may_contain(&probe) {
-            continue;
-        }
-        let index_bytes =
-            fetch_section(store, &descriptor.object_key, &descriptor.index_block).await?;
-        let entries = decode_index_block(&index_bytes, &descriptor.index_block)
-            .map_err(|error| segment_corrupt(&descriptor.object_key, "index block", &error))?;
-        let range = index_blocks_for_key_range(&entries, &prefix, upper.as_deref());
-        for entry in &entries[range] {
-            let block_bytes = fetch_section(store, &descriptor.object_key, &entry.block).await?;
-            let block = decode_data_block_rows::<IndexRow>(&block_bytes, &entry.block)
-                .map_err(|error| segment_corrupt(&descriptor.object_key, "data block", &error))?;
-            for row in &block.rows {
-                let IndexRow::GramPostings { gram: row_gram, .. } = row;
-                if *row_gram != gram {
-                    continue;
-                }
-                let batch = row.postings().map_err(|error| {
-                    segment_corrupt(&descriptor.object_key, "posting batch", &error)
+            })?;
+            let filter =
+                decode_filter_block(&filter_bytes, &descriptor.filter_block).map_err(|error| {
+                    index_segment_corrupt(&descriptor.object_key, "filter block", &error)
                 })?;
-                postings.extend(
-                    batch
-                        .into_iter()
-                        .map(|posting| (posting.inode_id, posting.revision_no)),
-                );
+            filter.may_contain(&gram_lookup.probe)
+        }
+        None => {
+            let filter = load_index_segment_filter_block(
+                store,
+                table_cache,
+                &descriptor.object_key,
+                &descriptor.payload_checksum,
+                &descriptor.filter_block,
+            )
+            .await?;
+            filter.may_contain(&gram_lookup.probe)
+        }
+    };
+    if !admitted {
+        return Ok(postings);
+    }
+    let entries = load_index_segment_index_block(
+        store,
+        table_cache,
+        &descriptor.object_key,
+        &descriptor.payload_checksum,
+        &descriptor.index_block,
+    )
+    .await?;
+    let range =
+        index_blocks_for_key_range(&entries, &gram_lookup.prefix, gram_lookup.upper.as_deref());
+    for entry in &entries[range] {
+        let block = load_index_segment_data_block(
+            store,
+            table_cache,
+            &descriptor.object_key,
+            &descriptor.payload_checksum,
+            &entry.block,
+        )
+        .await?;
+        for row in &block.rows {
+            let IndexRow::GramPostings { gram: row_gram, .. } = row;
+            if *row_gram != gram_lookup.gram {
+                continue;
             }
+            let batch = row.postings().map_err(|error| {
+                index_segment_corrupt(&descriptor.object_key, "posting batch", &error)
+            })?;
+            postings.extend(
+                batch
+                    .into_iter()
+                    .map(|posting| (posting.inode_id, posting.revision_no)),
+            );
         }
     }
     Ok(postings)
-}
-
-fn segment_corrupt(object_key: &str, what: &str, error: &dyn std::fmt::Display) -> CoreError {
-    CoreError::NamespaceCorrupt(format!(
-        "index segment `{object_key}` carries an unreadable {what}: {error}"
-    ))
-}
-
-async fn fetch_section<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    handle: &BlockHandle,
-) -> Result<Vec<u8>> {
-    let range = ByteRange {
-        start_inclusive: handle.offset,
-        end_exclusive: handle.offset + u64::from(handle.stored_len),
-    };
-    let bytes = store
-        .get(object_key, Some(range))
-        .await
-        .map_err(|error| CoreError::store(object_key, &error))?
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
-                "manifest references missing index segment `{object_key}`"
-            ))
-        })?;
-    Ok(bytes.to_vec())
 }
 
 /// The file revisions committed after the index watermark, newest revision

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -25,7 +25,9 @@ use crate::storage::content::read_durable_content_bytes;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use futures::future::join_all;
 use loonfs_api::wire::control::{HeadState, NamespaceState};
-use loonfs_api::wire::index_grams::{IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY};
+use loonfs_api::wire::index_grams::{
+    IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY, INDEX_GRAMS_MAX_FILE_BYTES,
+};
 use loonfs_api::wire::manifest::MetadataTableFamily;
 use loonfs_api::ManifestObjectId;
 use loonfs_api::{
@@ -521,10 +523,21 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                     break;
                 }
                 verified_files += 1;
+                // Content past the index eligibility cap can never be
+                // indexable text, so tail and scan candidates skip their
+                // doomed reads on the declared size alone — the same
+                // pre-fetch check the index builder applies
+                // (`checkpoint/index_build.rs`); index-supplied candidates
+                // are under the cap by construction. The candidate still
+                // rides the batch in inode order, so the budget and the
+                // resume cursor advance exactly as if its bytes had been
+                // fetched and refused.
+                let oversized = revision.content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES;
                 batch.push(GrepContentCandidate {
                     inode_id,
                     revision,
                     path: chain.path,
+                    oversized,
                 });
                 if batch.len() == MAX_GREP_READ_IO {
                     break;
@@ -542,12 +555,19 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             // candidate — the position the serial loop surfaced it. A
             // failure the walk never reaches (the page filled first) is
             // discarded with the rest of the speculative batch; the next
-            // page re-issues that read and reports it then.
-            let contents = join_all(batch.iter().map(|candidate| {
-                read_durable_content_bytes(
-                    store,
-                    &self.content_store_id,
-                    &candidate.revision.content_ref,
+            // page re-issues that read and reports it then. An oversized
+            // candidate carries no read at all (`None`).
+            let contents = join_all(batch.iter().map(|candidate| async move {
+                if candidate.oversized {
+                    return None;
+                }
+                Some(
+                    read_durable_content_bytes(
+                        store,
+                        &self.content_store_id,
+                        &candidate.revision.content_ref,
+                    )
+                    .await,
                 )
             }))
             .await;
@@ -557,6 +577,13 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             // exactly as the serial walk advanced them.
             for (candidate, content) in batch.iter().zip(contents) {
                 let inode_id = candidate.inode_id;
+                let Some(content) = content else {
+                    // Skipped as oversized: scanned-and-refused without the
+                    // fetch, so the cursor moves past it like any other
+                    // ineligible file.
+                    resume_cursor = Some((inode_id, u64::MAX));
+                    continue;
+                };
                 let content = content?;
                 if !crate::checkpoint::is_indexable_text_content(&content.bytes) {
                     resume_cursor = Some((inode_id, u64::MAX));
@@ -1087,6 +1114,10 @@ struct GrepContentCandidate {
     inode_id: InodeId,
     revision: RevisionRecord,
     path: String,
+    /// The declared content size exceeds the index eligibility cap, so no
+    /// read is scheduled: the file could never pass the post-read text
+    /// check, and the walk skips it as fully scanned.
+    oversized: bool,
 }
 
 fn validate_file_revisions_cursor(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -23,7 +23,7 @@ use crate::namespace::control::read_head_and_metadata_root;
 use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::read_durable_content_bytes;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
-use futures::future::try_join_all;
+use futures::future::join_all;
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::wire::index_grams::{IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY};
 use loonfs_api::wire::manifest::MetadataTableFamily;
@@ -536,20 +536,28 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 }
                 break 'page;
             }
-            let contents = try_join_all(batch.iter().map(|candidate| {
+            // The reads fan out, but their errors do not short-circuit:
+            // each result rides with its candidate into the ordered walk
+            // below, which surfaces a failure only when it reaches that
+            // candidate — the position the serial loop surfaced it. A
+            // failure the walk never reaches (the page filled first) is
+            // discarded with the rest of the speculative batch; the next
+            // page re-issues that read and reports it then.
+            let contents = join_all(batch.iter().map(|candidate| {
                 read_durable_content_bytes(
                     store,
                     &self.content_store_id,
                     &candidate.revision.content_ref,
                 )
             }))
-            .await?;
+            .await;
             // Emission stays strictly in candidate (inode) order: the batch
             // was selected in order and its results are consumed in order,
-            // so matches, limits, and the resume cursor advance exactly as
-            // the serial walk advanced them.
+            // so matches, limits, errors, and the resume cursor advance
+            // exactly as the serial walk advanced them.
             for (candidate, content) in batch.iter().zip(contents) {
                 let inode_id = candidate.inode_id;
+                let content = content?;
                 if !crate::checkpoint::is_indexable_text_content(&content.bytes) {
                     resume_cursor = Some((inode_id, u64::MAX));
                     continue;

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -3,8 +3,8 @@
 
 use super::grep::{
     derive_visible_path, indexed_candidates, line_matches, tail_revisions, GrepCandidates,
-    DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,
-    MAX_GREP_VERIFIED_FILES_PER_PAGE,
+    DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_READ_IO, MAX_GREP_SCAN_FILES,
+    MAX_GREP_TAIL_FILES, MAX_GREP_VERIFIED_FILES_PER_PAGE,
 };
 use super::listing::{invalid_cursor, page_head_seq, validate_directory_cursor};
 use crate::checkpoint::{
@@ -23,6 +23,7 @@ use crate::namespace::control::read_head_and_metadata_root;
 use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core};
 use crate::storage::content::read_durable_content_bytes;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
+use futures::future::try_join_all;
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::wire::index_grams::{IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY};
 use loonfs_api::wire::manifest::MetadataTableFamily;
@@ -425,8 +426,13 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .map_err(CoreError::InvalidQuery)?
         {
             GramPlanOutcome::Indexable(plan) => {
-                candidates.indexed =
-                    indexed_candidates(store, &manifest.payload.index_files, &plan).await?;
+                candidates.indexed = indexed_candidates(
+                    store,
+                    self.tables.table_cache(),
+                    &manifest.payload.index_files,
+                    &plan,
+                )
+                .await?;
             }
             GramPlanOutcome::Unindexable => {
                 if !request.allow_scan {
@@ -466,69 +472,120 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         // candidate this page finished scanning (offset MAX), or the last
         // emitted match when the page filled mid-file.
         let mut resume_cursor: Option<(InodeId, u64)> = None;
-        'inodes: for inode_id in candidates.inodes().collect::<Vec<_>>() {
-            if let Some((last_inode, last_offset)) = resume {
-                if inode_id < last_inode || (inode_id == last_inode && last_offset == u64::MAX) {
-                    continue;
-                }
-            }
-            let Some(revision) = view.latest_revision_head(inode_id).await? else {
-                continue;
-            };
-            if !candidates.admits(inode_id, revision.revision_no) {
-                continue;
-            }
-            // With the tail skipped (`allow_stale`), serve the index's cut
-            // and nothing newer: a candidate whose newest revision is past
-            // the watermark would otherwise be verified at an unindexed
-            // revision while tail-only files stay invisible — a mix of two
-            // snapshots rather than a stale-but-consistent one.
-            if !tail_scanned && revision.committed_seq > feature.built_through_seq {
-                continue;
-            }
-            let Some(chain) = derive_visible_path(&view, inode_id).await? else {
-                continue;
-            };
-            if let Some(scope_root) = scope_root {
-                if !chain.ancestors.contains(&scope_root) {
-                    continue;
-                }
-            }
-            if verified_files == MAX_GREP_VERIFIED_FILES_PER_PAGE {
-                has_more = true;
-                break 'inodes;
-            }
-            verified_files += 1;
-            let content =
-                read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
-                    .await?;
-            if !crate::checkpoint::is_indexable_text_content(&content.bytes) {
-                resume_cursor = Some((inode_id, u64::MAX));
-                continue;
-            }
-            for found in line_matches(&content.bytes, &pattern) {
+        let ordered_candidates = candidates.inodes().collect::<Vec<_>>();
+        let mut next_candidate = 0usize;
+        'page: loop {
+            // Select the next fan-out batch: walk candidates in inode
+            // order through the cheap checks (metadata lookups served by
+            // the loaded view) until enough survivors need content, the
+            // verified-file budget fills, or the candidates run out. The
+            // content read is the only per-candidate store fetch, so it is
+            // the only stage that fans out — the design doc's "small fixed
+            // fan-out" for candidate reads.
+            let mut batch: Vec<GrepContentCandidate> = Vec::new();
+            let mut budget_exhausted = false;
+            while next_candidate < ordered_candidates.len() {
+                let inode_id = ordered_candidates[next_candidate];
+                next_candidate += 1;
                 if let Some((last_inode, last_offset)) = resume {
-                    if inode_id == last_inode && found.byte_offset <= last_offset {
+                    if inode_id < last_inode || (inode_id == last_inode && last_offset == u64::MAX)
+                    {
                         continue;
                     }
                 }
-                if matches.len() == limit {
-                    has_more = true;
-                    break 'inodes;
+                let Some(revision) = view.latest_revision_head(inode_id).await? else {
+                    continue;
+                };
+                if !candidates.admits(inode_id, revision.revision_no) {
+                    continue;
                 }
-                resume_cursor = Some((inode_id, found.byte_offset));
-                matches.push(GrepMatch {
-                    absolute_path: chain.path.clone(),
+                // With the tail skipped (`allow_stale`), serve the index's
+                // cut and nothing newer: a candidate whose newest revision
+                // is past the watermark would otherwise be verified at an
+                // unindexed revision while tail-only files stay invisible
+                // — a mix of two snapshots rather than a stale-but-
+                // consistent one.
+                if !tail_scanned && revision.committed_seq > feature.built_through_seq {
+                    continue;
+                }
+                let Some(chain) = derive_visible_path(&view, inode_id).await? else {
+                    continue;
+                };
+                if let Some(scope_root) = scope_root {
+                    if !chain.ancestors.contains(&scope_root) {
+                        continue;
+                    }
+                }
+                if verified_files == MAX_GREP_VERIFIED_FILES_PER_PAGE {
+                    budget_exhausted = true;
+                    break;
+                }
+                verified_files += 1;
+                batch.push(GrepContentCandidate {
                     inode_id,
-                    revision_no: revision.revision_no,
-                    line_number: found.line_number,
-                    byte_offset: found.byte_offset,
-                    line: found.line,
-                    line_truncated: found.line_truncated,
+                    revision,
+                    path: chain.path,
                 });
+                if batch.len() == MAX_GREP_READ_IO {
+                    break;
+                }
             }
-            // The file was fully scanned; a later stop resumes past it.
-            resume_cursor = Some((inode_id, u64::MAX));
+            if batch.is_empty() {
+                if budget_exhausted {
+                    has_more = true;
+                }
+                break 'page;
+            }
+            let contents = try_join_all(batch.iter().map(|candidate| {
+                read_durable_content_bytes(
+                    store,
+                    &self.content_store_id,
+                    &candidate.revision.content_ref,
+                )
+            }))
+            .await?;
+            // Emission stays strictly in candidate (inode) order: the batch
+            // was selected in order and its results are consumed in order,
+            // so matches, limits, and the resume cursor advance exactly as
+            // the serial walk advanced them.
+            for (candidate, content) in batch.iter().zip(contents) {
+                let inode_id = candidate.inode_id;
+                if !crate::checkpoint::is_indexable_text_content(&content.bytes) {
+                    resume_cursor = Some((inode_id, u64::MAX));
+                    continue;
+                }
+                for found in line_matches(&content.bytes, &pattern) {
+                    if let Some((last_inode, last_offset)) = resume {
+                        if inode_id == last_inode && found.byte_offset <= last_offset {
+                            continue;
+                        }
+                    }
+                    if matches.len() == limit {
+                        // The page filled mid-batch: contents already
+                        // fetched for the batch's later candidates are
+                        // discarded, and the cursor resumes from the last
+                        // processed candidate, never a discarded one.
+                        has_more = true;
+                        break 'page;
+                    }
+                    resume_cursor = Some((inode_id, found.byte_offset));
+                    matches.push(GrepMatch {
+                        absolute_path: candidate.path.clone(),
+                        inode_id,
+                        revision_no: candidate.revision.revision_no,
+                        line_number: found.line_number,
+                        byte_offset: found.byte_offset,
+                        line: found.line,
+                        line_truncated: found.line_truncated,
+                    });
+                }
+                // The file was fully scanned; a later stop resumes past it.
+                resume_cursor = Some((inode_id, u64::MAX));
+            }
+            if budget_exhausted {
+                has_more = true;
+                break 'page;
+            }
         }
 
         let next_cursor = if has_more {
@@ -1013,6 +1070,15 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             self.wal_tail_rows.as_ref(),
         )
     }
+}
+
+/// One grep candidate that survived the cheap visibility checks and awaits
+/// its content read, carrying everything match emission needs so the
+/// fetched batch is processed without further metadata lookups.
+struct GrepContentCandidate {
+    inode_id: InodeId,
+    revision: RevisionRecord,
+    path: String,
 }
 
 fn validate_file_revisions_cursor(

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -4,11 +4,19 @@
 //! Handle-level lifecycle of the gram index: enable through `FsAdmin`,
 //! build through maintenance ticks, query through `FsReader`, disable.
 
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
 use loonfs::{
     CreateNamespaceOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepRequest,
     MaintenanceTickOptions, NamespaceId, PutFileOptions,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -220,6 +228,161 @@ async fn a_publish_below_the_wal_threshold_still_schedules_index_catch_up() {
         .expect("stale grep after background catch-up");
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.matches[0].absolute_path, "/delta.txt");
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Counts store GETs against gram index segment objects, so tests can
+/// assert how many posting-block reads a query cost.
+#[derive(Debug)]
+struct IndexSegmentGetCountingStore {
+    inner: LocalFsStore,
+    index_segment_gets: AtomicUsize,
+}
+
+impl IndexSegmentGetCountingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            index_segment_gets: AtomicUsize::new(0),
+        }
+    }
+
+    fn index_segment_get_count(&self) -> usize {
+        self.index_segment_gets.load(Ordering::SeqCst)
+    }
+
+    fn record_if_index_segment(&self, key: &str) {
+        if key.contains("/metadata/indexes/") {
+            self.index_segment_gets.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for IndexSegmentGetCountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record_if_index_segment(key);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record_if_index_segment(key);
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// Index segment blocks are immutable and keyed by payload checksum, so a
+/// reader's decoded-block cache must serve a repeated query's posting
+/// probes without re-fetching the segments it already decoded.
+#[tokio::test]
+async fn repeated_grep_serves_posting_blocks_from_the_table_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-cache").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-cache-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-cache-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/alpha.txt",
+            b"a needle in alpha\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write alpha");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/bravo.txt",
+            b"nothing here\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write bravo");
+
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("maintenance tick");
+    }
+
+    let before_first = raw_store.index_segment_get_count();
+    let first = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("first grep");
+    assert_eq!(first.matches.len(), 1);
+    let after_first = raw_store.index_segment_get_count();
+    assert!(
+        after_first > before_first,
+        "the first grep must read posting blocks from the store"
+    );
+
+    let second = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("second grep");
+    assert_eq!(second.matches, first.matches);
+    let after_second = raw_store.index_segment_get_count();
+    assert_eq!(
+        after_second, after_first,
+        "an identical grep through the same reader must serve every \
+         posting block from the decoded-block cache"
+    );
 
     writer.shutdown_background().await.expect("writer shutdown");
 }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -15,6 +15,7 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -30,6 +31,18 @@ fn grep_request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+/// Content blob object keys currently in the store, for pinpointing the
+/// object behind one file's bytes by diffing around its write.
+async fn content_blob_keys(store: &loonfs::SharedObjectStore) -> BTreeSet<String> {
+    store
+        .list_prefix("content-stores/")
+        .await
+        .expect("list content blobs")
+        .into_iter()
+        .filter(|key| key.contains("/blobs/sha256/"))
+        .collect()
 }
 
 #[tokio::test]
@@ -383,6 +396,133 @@ async fn repeated_grep_serves_posting_blocks_from_the_table_cache() {
         "an identical grep through the same reader must serve every \
          posting block from the decoded-block cache"
     );
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Concurrent candidate content reads keep the serial loop's error
+/// positions: a failed read surfaces only when the in-order walk reaches
+/// that candidate, so a page that fills first still returns its full
+/// matches and a cursor, and the error waits for the next page.
+#[tokio::test]
+async fn a_failed_candidate_read_surfaces_in_traversal_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: loonfs::SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grams-read-fault").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-fault-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-fault-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    // Two matches in alpha, so a one-match page fills before the walk
+    // reaches bravo.
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/alpha.txt",
+            b"needle one\nneedle two\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write alpha");
+    let blobs_before_bravo = content_blob_keys(&store).await;
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/bravo.txt",
+            b"needle three\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write bravo");
+    let new_blobs: Vec<String> = content_blob_keys(&store)
+        .await
+        .difference(&blobs_before_bravo)
+        .cloned()
+        .collect();
+    let [bravo_content_key] = new_blobs.as_slice() else {
+        panic!("bravo must add exactly one content blob, got {new_blobs:?}");
+    };
+
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("maintenance tick");
+    }
+    let healthy = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("grep before the fault");
+    assert_eq!(healthy.matches.len(), 3);
+
+    // Break bravo's content read out from under the query.
+    store
+        .delete(bravo_content_key)
+        .await
+        .expect("delete bravo's content object");
+
+    // An unlimited page walks past alpha into bravo, so the failed read
+    // fails that page, exactly as the serial scan did.
+    let error = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect_err("a reached candidate's failed read must fail its page");
+    let loonfs::Error::Core(core) = &error else {
+        panic!("expected a core error, got {error:?}");
+    };
+    assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
+
+    // With a one-match limit, alpha's second match fills the page before
+    // the walk reaches bravo: the speculative failed read is discarded and
+    // the full page comes back with a cursor.
+    let mut first_page = grep_request("needle");
+    first_page.limit = Some(1);
+    let response = reader
+        .grep(&namespace_id, &first_page)
+        .await
+        .expect("a page that fills before the failed candidate must succeed");
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/alpha.txt");
+    assert_eq!(response.matches[0].line, "needle one");
+    let cursor = response
+        .next_cursor
+        .expect("a truncated page must carry a cursor");
+
+    // The next page's walk reaches bravo and surfaces the read error at
+    // the position the serial scan would have.
+    let mut second_page = grep_request("needle");
+    second_page.limit = Some(1);
+    second_page.cursor = Some(cursor);
+    let error = reader
+        .grep(&namespace_id, &second_page)
+        .await
+        .expect_err("the deferred read error must surface on the next page");
+    let loonfs::Error::Core(core) = &error else {
+        panic!("expected a core error, got {error:?}");
+    };
+    assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
 
     writer.shutdown_background().await.expect("writer shutdown");
 }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -11,6 +11,8 @@ use loonfs::{
     CreateNamespaceOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepRequest,
     MaintenanceTickOptions, NamespaceId, PutFileOptions,
 };
+use loonfs_api::decode_grep_cursor;
+use loonfs_api::wire::index_grams::INDEX_GRAMS_MAX_FILE_BYTES;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -18,7 +20,7 @@ use loonfs_objectstore::{
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
 fn grep_request(pattern: &str) -> GrepRequest {
@@ -523,6 +525,220 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         panic!("expected a core error, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Records the key of every store GET against a content blob object, so
+/// tests can assert exactly which file contents a query fetched.
+#[derive(Debug)]
+struct ContentBlobGetRecordingStore {
+    inner: LocalFsStore,
+    content_blob_gets: Mutex<Vec<String>>,
+}
+
+impl ContentBlobGetRecordingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            content_blob_gets: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn content_blob_get_keys(&self) -> Vec<String> {
+        self.content_blob_gets
+            .lock()
+            .expect("content GET log lock")
+            .clone()
+    }
+
+    fn record_if_content_blob(&self, key: &str) {
+        if key.contains("/blobs/sha256/") {
+            self.content_blob_gets
+                .lock()
+                .expect("content GET log lock")
+                .push(key.to_owned());
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ContentBlobGetRecordingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record_if_content_blob(key);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record_if_content_blob(key);
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// An unindexed-tail candidate larger than the index eligibility cap can
+/// never pass verification, so grep must skip it on its declared size
+/// alone: no content GET for it, unchanged page budgets, and a cursor
+/// that resumes past it.
+#[tokio::test]
+async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(ContentBlobGetRecordingStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-oversized-tail").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-oversized-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-oversized-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/alpha.txt",
+            b"a needle in alpha\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write alpha");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("maintenance tick");
+    }
+
+    // Oversized and full of matches: were it ever fetched and scanned, it
+    // would flood the results instead of being skipped.
+    let oversized_bytes = b"needle\n".repeat(INDEX_GRAMS_MAX_FILE_BYTES as usize / 7 + 1);
+    assert!(oversized_bytes.len() as u64 > INDEX_GRAMS_MAX_FILE_BYTES);
+    let blobs_before_bravo = content_blob_keys(&store).await;
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/bravo.big",
+            &oversized_bytes,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write bravo");
+    let new_blobs: Vec<String> = content_blob_keys(&store)
+        .await
+        .difference(&blobs_before_bravo)
+        .cloned()
+        .collect();
+    let [oversized_content_key] = new_blobs.as_slice() else {
+        panic!("the oversized write must add exactly one content blob, got {new_blobs:?}");
+    };
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/charlie.txt",
+            b"a needle in charlie\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write charlie");
+    // No tick after these writes: bravo and charlie stay in the unindexed
+    // tail, where no gram filter screens candidates before verification.
+
+    let gets_before_greps = raw_store.content_blob_get_keys().len();
+
+    let mut first_page = grep_request("needle");
+    first_page.limit = Some(1);
+    let page_one = reader
+        .grep(&namespace_id, &first_page)
+        .await
+        .expect("first page");
+    assert_eq!(page_one.matches.len(), 1);
+    assert_eq!(page_one.matches[0].absolute_path, "/alpha.txt");
+    let cursor_token = page_one
+        .next_cursor
+        .clone()
+        .expect("a truncated page must carry a cursor");
+
+    // The cursor already stands past the oversized file: fully scanned,
+    // never to be re-verified by a later page.
+    let cursor = decode_grep_cursor(&cursor_token).expect("decode grep cursor");
+    assert!(
+        cursor.last_inode_id > page_one.matches[0].inode_id,
+        "the cursor must have advanced past the oversized candidate"
+    );
+    assert_eq!(cursor.last_byte_offset, u64::MAX);
+
+    let mut second_page = grep_request("needle");
+    second_page.limit = Some(1);
+    second_page.cursor = Some(cursor_token);
+    let page_two = reader
+        .grep(&namespace_id, &second_page)
+        .await
+        .expect("second page");
+    assert_eq!(page_two.matches.len(), 1);
+    assert_eq!(page_two.matches[0].absolute_path, "/charlie.txt");
+    assert!(page_two.next_cursor.is_none());
+    assert!(
+        cursor.last_inode_id < page_two.matches[0].inode_id,
+        "the first page's cursor must sit between alpha and charlie"
+    );
+
+    let content_gets = raw_store.content_blob_get_keys();
+    let fetched_during_greps = &content_gets[gets_before_greps..];
+    assert!(
+        !fetched_during_greps.is_empty(),
+        "the greps must fetch the small candidates' contents"
+    );
+    assert!(
+        fetched_during_greps
+            .iter()
+            .all(|key| key != oversized_content_key),
+        "no content GET may touch the oversized object: {fetched_during_greps:?}"
+    );
 
     writer.shutdown_background().await.expect("writer shutdown");
 }


### PR DESCRIPTION
Grep against S3 spent essentially all of its latency on serial, uncached round trips: posting-block reads bypassed the decoded-block cache that already serves the metadata families (a zero-match query cost 4.8s over 44 GETs just to prove absence), every await in the query and build paths ran one at a time, and each result page re-fetched the same posting blocks because candidate evaluation restarts per page. Index segment sections are immutable and already carry the payload checksum the cache keys on, so this routes them through the existing MetadataTableCache and applies the existing chunked try_join_all fan-out to the three serial loops: posting probes, candidate content verification, and build content reads.

Measured on the lab s3-grep-10k-quick profile (10k files of 32 KiB on S3): negative query 3.8s -> 0.16s, rare 36.7s -> 5.2s, common-term pagination 37.2s -> 1.85s per page, index build halved. Cold boot, warm ops, and compaction are byte-identical. Match ordering, page budgets, counters, and resume cursors are preserved exactly; a new integration test pins that repeating a grep issues zero additional index-segment GETs.