### PR TITLE
perf(core): resolve gram maintenance reads through the metadata table cache

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -55,6 +55,21 @@ pub(super) enum MetadataTableBlockKind {
     Manifest,
 }
 
+/// What a [`MetadataTableCache::get_or_fetch_with_admission`] miss does
+/// with the fetched block. Lookups behave identically in both modes —
+/// a cached block answers the access either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheAdmission {
+    /// A miss inserts the fetched block, displacing colder entries; the
+    /// query path's mode, where a fetched block is likely to be asked
+    /// for again.
+    Admit,
+    /// A miss serves the fetched block to the caller without inserting
+    /// it, so a bulk stream — a maintenance fold walking a whole
+    /// snapshot once — cannot evict the query-hot working set.
+    LookupOnly,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct MetadataTableCacheKey {
     /// The cached object's identity: a segment's payload checksum for block
@@ -175,16 +190,37 @@ impl MetadataTableCache {
         }
     }
 
-    /// Resolves one block access through the single-flight cell: the
-    /// winner consults the cache, fetches on a miss, and always populates;
-    /// concurrent waiters share the winner's block instead of issuing
-    /// duplicate lookups, fetches, or inserts, so hit and miss counts
-    /// measure deduplicated accesses. A failed or cancelled fetch leaves
-    /// the cell empty, so the next caller retries.
+    /// [`Self::get_or_fetch_with_admission`] in the query path's
+    /// admitting mode.
     pub(super) async fn get_or_fetch<E, F, Fut>(
         &self,
         cache_key: &MetadataTableCacheKey,
         fetch: F,
+    ) -> Result<DecodedMetadataTableBlock, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<DecodedMetadataTableBlock, E>>,
+    {
+        self.get_or_fetch_with_admission(cache_key, fetch, CacheAdmission::Admit)
+            .await
+    }
+
+    /// Resolves one block access through the single-flight cell: the
+    /// winner consults the cache, fetches on a miss, and populates when
+    /// `admission` says to; concurrent waiters — admitting or not —
+    /// share the winner's block instead of issuing duplicate lookups,
+    /// fetches, or inserts, so hit and miss counts measure deduplicated
+    /// accesses and the winner's mode decides that one fetch's
+    /// admission. In [`CacheAdmission::LookupOnly`] mode a miss fetches,
+    /// decodes, and verifies exactly as an admitting miss does, and the
+    /// caller's clone of the block is the only reference that outlives
+    /// the call. A failed or cancelled fetch leaves the cell empty, so
+    /// the next caller retries.
+    pub(super) async fn get_or_fetch_with_admission<E, F, Fut>(
+        &self,
+        cache_key: &MetadataTableCacheKey,
+        fetch: F,
+        admission: CacheAdmission,
     ) -> Result<DecodedMetadataTableBlock, E>
     where
         F: FnOnce() -> Fut,
@@ -207,7 +243,9 @@ impl MetadataTableCache {
                     return Ok(block);
                 }
                 let block = fetch().await?;
-                self.insert(cache_key.clone(), block.clone());
+                if admission == CacheAdmission::Admit {
+                    self.insert(cache_key.clone(), block.clone());
+                }
                 Ok(block)
             })
             .await
@@ -684,6 +722,39 @@ mod tests {
             recovered.is_ok(),
             "a failed fetch should leave nothing behind for the next caller"
         );
+    }
+
+    #[tokio::test]
+    async fn lookup_only_serves_hits_but_never_inserts() {
+        let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+        let fetched: Result<_, String> = cache
+            .get_or_fetch_with_admission(
+                &key("cold"),
+                || async { Ok(block(1)) },
+                super::CacheAdmission::LookupOnly,
+            )
+            .await;
+        assert!(fetched.is_ok());
+        assert_eq!(
+            cache.stats().inserts,
+            0,
+            "a lookup-only miss must not admit the fetched block"
+        );
+        assert!(
+            cache.get(&key("cold")).is_none(),
+            "the lookup-only block must not be resident afterward"
+        );
+
+        // A block someone else admitted answers a lookup-only access.
+        cache.insert(key("warm"), block(1));
+        let warm: Result<_, String> = cache
+            .get_or_fetch_with_admission(
+                &key("warm"),
+                || async { Err("a resident block must not re-fetch".to_owned()) },
+                super::CacheAdmission::LookupOnly,
+            )
+            .await;
+        assert!(warm.is_ok(), "the cached block should answer the access");
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -20,7 +20,7 @@
 //! here at index time, never on the write path; the query path applies the
 //! same rule to unindexed data so the search contract stays uniform.
 
-use super::cache::MetadataTableCache;
+use super::cache::{CacheAdmission, MetadataTableCache};
 use super::flush::{
     ensure_metadata_publication_budget, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
 };
@@ -1232,11 +1232,14 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
     // Opens are independent — one index-block read per snapshot segment —
     // so they fan out like segment writes do; the per-refill reads during
     // the merge stay serial because the heap order demands them one at a
-    // time. Sections read here insert into the shared cache under the
-    // same keys the query path uses: a base fold streams the whole
-    // snapshot through the byte-budgeted LRU once, which is accepted —
-    // entries are immutable and correctly keyed, and at current scales
-    // the index working set sits far under the cache budget.
+    // time. Sections resolve through the shared cache under the same keys
+    // the query path uses, with a split admission stance: index blocks
+    // admit (KB-scale directories, reused by every later fold step and by
+    // queries), while the data-block stream — the bulk of a snapshot's
+    // bytes, each block visited exactly once per fold walk — is
+    // lookup-only, so a base fold cannot flush the query-hot working set
+    // out of the byte-budgeted LRU. Blocks a query already admitted still
+    // serve the merge from memory.
     let mut readers = Vec::with_capacity(snapshot.len());
     for chunk in snapshot.chunks(MAX_MAINTENANCE_TABLE_IO) {
         readers.extend(
@@ -1399,6 +1402,7 @@ impl SegmentRangeReader {
             let block = load_index_segment_data_block(
                 store,
                 table_cache,
+                CacheAdmission::LookupOnly,
                 &self.object_key,
                 &self.payload_checksum,
                 &entry.block,

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -1340,13 +1340,32 @@ fn fold_snapshot_row(merged: &mut MergedRange, row: IndexRow, object_key: &str) 
 /// section resolves through the shared decoded-block cache when one is
 /// attached, so blocks a query or an earlier step already decoded are
 /// memory hits.
+///
+/// The reader holds each decoded block behind its shared [`Arc`] and
+/// serves rows borrowed in place — the [`SegmentKeyRangeBlocks`] shape
+/// metadata scans use — cloning one row per [`Self::pop`], never a
+/// block. That keeps the merge's footprint honest: data blocks resolve
+/// lookup-only, so the one block each reader holds is the merge's whole
+/// share of that segment's decoded bytes, owned here and not counted
+/// again by the cache budget.
+///
+/// [`Arc`]: std::sync::Arc
+/// [`SegmentKeyRangeBlocks`]: super::load::SegmentKeyRangeBlocks
 struct SegmentRangeReader {
     object_key: String,
     payload_checksum: String,
     entries: std::sync::Arc<Vec<loonfs_api::wire::sst_blocks::SegmentIndexEntry>>,
     next_entry: usize,
-    pending: std::collections::VecDeque<(String, IndexRow)>,
+    current: Option<CurrentDataBlock>,
     start: String,
+}
+
+/// The one decoded block a [`SegmentRangeReader`] is draining, with the
+/// offset of its next undelivered row — always in bounds while the block
+/// is held; a drained block is dropped, not kept at its end.
+struct CurrentDataBlock {
+    block: std::sync::Arc<loonfs_api::wire::sst_blocks::DecodedDataBlock<IndexRow>>,
+    next_row: usize,
 }
 
 impl SegmentRangeReader {
@@ -1372,7 +1391,7 @@ impl SegmentRangeReader {
             payload_checksum: descriptor.payload_checksum.clone(),
             next_entry: range.start,
             entries,
-            pending: std::collections::VecDeque::new(),
+            current: None,
             start: start.to_owned(),
         })
     }
@@ -1382,13 +1401,25 @@ impl SegmentRangeReader {
     }
 
     fn peek_key(&self) -> Option<&str> {
-        self.pending.front().map(|(key, _)| key.as_str())
+        self.current
+            .as_ref()
+            .map(|current| current.block.row_keys[current.next_row].as_str())
     }
 
+    /// Yields the next row, cloning exactly that row and its key out of
+    /// the shared block; the merge consumes rows by value.
     fn pop(&mut self) -> (String, IndexRow) {
-        self.pending
-            .pop_front()
-            .expect("pop is called only after peek_key returned a key")
+        let current = self
+            .current
+            .as_mut()
+            .expect("pop is called only after peek_key returned a key");
+        let key = current.block.row_keys[current.next_row].clone();
+        let row = current.block.rows[current.next_row].clone();
+        current.next_row += 1;
+        if current.next_row == current.block.row_keys.len() {
+            self.current = None;
+        }
+        (key, row)
     }
 
     async fn refill<S: ObjectStore + ?Sized>(
@@ -1396,7 +1427,7 @@ impl SegmentRangeReader {
         store: &S,
         table_cache: Option<&MetadataTableCache>,
     ) -> Result<()> {
-        while self.pending.is_empty() && self.next_entry < self.entries.len() {
+        while self.current.is_none() && self.next_entry < self.entries.len() {
             let entry = &self.entries[self.next_entry];
             self.next_entry += 1;
             let block = load_index_segment_data_block(
@@ -1408,10 +1439,14 @@ impl SegmentRangeReader {
                 &entry.block,
             )
             .await?;
-            for (key, row) in block.row_keys.iter().zip(&block.rows) {
-                if key.as_str() >= self.start.as_str() {
-                    self.pending.push_back((key.clone(), row.clone()));
-                }
+            // Only the first fetched block can hold rows below the start
+            // key; the binary search over the block's decode-validated
+            // key order is the same bound either way.
+            let next_row = block
+                .row_keys
+                .partition_point(|key| key.as_str() < self.start.as_str());
+            if next_row < block.row_keys.len() {
+                self.current = Some(CurrentDataBlock { block, next_row });
             }
         }
         Ok(())

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -20,10 +20,15 @@
 //! here at index time, never on the write path; the query path applies the
 //! same rule to unindexed data so the search contract stays uniform.
 
+use super::cache::MetadataTableCache;
 use super::flush::{
     ensure_metadata_publication_budget, next_manifest_id_after, MANIFEST_ALLOCATION_RETRY_LIMIT,
 };
-use super::load::{load_namespace_manifest_envelope_if_present, load_verified_manifest_tables};
+use super::index_read::{load_index_segment_data_block, load_index_segment_index_block};
+use super::load::{
+    load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
+    load_verified_manifest_tables_with_cache,
+};
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::runs::{CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, MAX_MAINTENANCE_TABLE_IO};
 use super::scan::string_prefix_upper_bound;
@@ -393,6 +398,11 @@ pub(crate) async fn disable_grams_index<S: ObjectStore + ?Sized>(
 /// backfill while the feature value carries a cursor, WAL-replay catch-up
 /// after. Callers invoke this repeatedly; every call re-reads durable
 /// state, so any two calls compose — including across process restarts.
+///
+/// `table_cache` is the runtime's shared decoded-block cache; the step's
+/// manifest and metadata-segment reads resolve through it when attached
+/// and fall back to direct fetches when not (the embedded unit-test
+/// shape).
 #[tracing::instrument(
     level = "info",
     name = "loon.phase",
@@ -402,6 +412,7 @@ pub(crate) async fn disable_grams_index<S: ObjectStore + ?Sized>(
 )]
 pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
     store: &S,
+    table_cache: Option<&MetadataTableCache>,
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: GramIndexBuildPolicy,
@@ -415,11 +426,16 @@ pub(crate) async fn build_grams_index_step<S: ObjectStore + ?Sized>(
         })?
         .envelope
         .state;
-    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
+    let tables = load_verified_manifest_tables_with_cache(
+        store,
+        table_cache,
+        namespace_id,
+        &root.manifest_object_id,
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+    })?;
     let previous = tables.manifest();
 
     let Some(value) = previous.payload.features.get(INDEX_GRAMS_FEATURE_KEY) else {
@@ -929,6 +945,11 @@ async fn write_index_segment<S: ObjectStore + ?Sized>(
 /// outputs stay referenced and served; postings are add-only, so readers
 /// that union them see duplicates, never gaps. Segments written while the
 /// fold runs stay out of the snapshot and survive it.
+///
+/// `table_cache` is the runtime's shared decoded-block cache; the merge's
+/// section reads resolve through it when attached — snapshot segments are
+/// immutable and share their keys with the query path's entries — and
+/// fall back to direct fetches when not (the embedded unit-test shape).
 #[tracing::instrument(
     level = "info",
     name = "loon.phase",
@@ -938,6 +959,7 @@ async fn write_index_segment<S: ObjectStore + ?Sized>(
 )]
 pub(crate) async fn fold_grams_index_step<S: ObjectStore + ?Sized>(
     store: &S,
+    table_cache: Option<&MetadataTableCache>,
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: GramIndexBuildPolicy,
@@ -951,11 +973,16 @@ pub(crate) async fn fold_grams_index_step<S: ObjectStore + ?Sized>(
         })?
         .envelope
         .state;
-    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
+    let tables = load_verified_manifest_tables_with_cache(
+        store,
+        table_cache,
+        namespace_id,
+        &root.manifest_object_id,
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+    })?;
     let previous = tables.manifest();
 
     let Some(value) = previous.payload.features.get(INDEX_GRAMS_FEATURE_KEY) else {
@@ -1078,6 +1105,7 @@ pub(crate) async fn fold_grams_index_step<S: ObjectStore + ?Sized>(
         .collect::<Result<_>>()?;
     let merged = merge_snapshot_range(
         store,
+        table_cache,
         &snapshot,
         &fold_state.cursor,
         policy.max_fold_rows_per_step,
@@ -1196,13 +1224,27 @@ struct MergedRange {
 /// segment is exhausted.
 async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
     store: &S,
+    table_cache: Option<&MetadataTableCache>,
     snapshot: &[&IndexFileRef],
     cursor: &str,
     max_rows: usize,
 ) -> Result<MergedRange> {
+    // Opens are independent — one index-block read per snapshot segment —
+    // so they fan out like segment writes do; the per-refill reads during
+    // the merge stay serial because the heap order demands them one at a
+    // time. Sections read here insert into the shared cache under the
+    // same keys the query path uses: a base fold streams the whole
+    // snapshot through the byte-budgeted LRU once, which is accepted —
+    // entries are immutable and correctly keyed, and at current scales
+    // the index working set sits far under the cache budget.
     let mut readers = Vec::with_capacity(snapshot.len());
-    for descriptor in snapshot {
-        readers.push(SegmentRangeReader::open(store, descriptor, cursor).await?);
+    for chunk in snapshot.chunks(MAX_MAINTENANCE_TABLE_IO) {
+        readers.extend(
+            try_join_all(chunk.iter().map(|descriptor| {
+                SegmentRangeReader::open(store, table_cache, descriptor, cursor)
+            }))
+            .await?,
+        );
     }
     let mut merged = MergedRange {
         postings: BTreeMap::new(),
@@ -1213,7 +1255,7 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
     let mut last_key = String::new();
     while merged.rows < max_rows as u64 {
         for reader in readers.iter_mut() {
-            reader.refill(store).await?;
+            reader.refill(store, table_cache).await?;
         }
         let mut lowest: Option<(usize, String)> = None;
         for (position, reader) in readers.iter().enumerate() {
@@ -1246,7 +1288,7 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
             loop {
                 // Peek is only meaningful after a refill, mirroring the
                 // loop head: a drained block must not end the group early.
-                reader.refill(store).await?;
+                reader.refill(store, table_cache).await?;
                 if reader.peek_key() != Some(key.as_str()) {
                     break;
                 }
@@ -1261,7 +1303,7 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
     // instead of publishing an empty trailing step.
     let mut any_left = false;
     for reader in readers.iter_mut() {
-        reader.refill(store).await?;
+        reader.refill(store, table_cache).await?;
         if reader.peek_key().is_some() {
             any_left = true;
             break;
@@ -1291,10 +1333,14 @@ fn fold_snapshot_row(merged: &mut MergedRange, row: IndexRow, object_key: &str) 
 }
 
 /// Streaming reader over one snapshot segment's rows from a start key:
-/// the segment index is fetched once, data blocks one at a time.
+/// the segment index is fetched once, data blocks one at a time. Every
+/// section resolves through the shared decoded-block cache when one is
+/// attached, so blocks a query or an earlier step already decoded are
+/// memory hits.
 struct SegmentRangeReader {
     object_key: String,
-    entries: Vec<loonfs_api::wire::sst_blocks::SegmentIndexEntry>,
+    payload_checksum: String,
+    entries: std::sync::Arc<Vec<loonfs_api::wire::sst_blocks::SegmentIndexEntry>>,
     next_entry: usize,
     pending: std::collections::VecDeque<(String, IndexRow)>,
     start: String,
@@ -1303,23 +1349,24 @@ struct SegmentRangeReader {
 impl SegmentRangeReader {
     async fn open<S: ObjectStore + ?Sized>(
         store: &S,
+        table_cache: Option<&MetadataTableCache>,
         descriptor: &IndexFileRef,
         cursor: &str,
     ) -> Result<Self> {
-        use loonfs_api::wire::sst_blocks::{decode_index_block, index_blocks_for_key_range};
-        let index_bytes =
-            fetch_index_section(store, &descriptor.object_key, &descriptor.index_block).await?;
-        let entries =
-            decode_index_block(&index_bytes, &descriptor.index_block).map_err(|error| {
-                CoreError::NamespaceCorrupt(format!(
-                    "index segment `{}` carries an unreadable index block: {error}",
-                    descriptor.object_key
-                ))
-            })?;
+        use loonfs_api::wire::sst_blocks::index_blocks_for_key_range;
+        let entries = load_index_segment_index_block(
+            store,
+            table_cache,
+            &descriptor.object_key,
+            &descriptor.payload_checksum,
+            &descriptor.index_block,
+        )
+        .await?;
         let start = if cursor.is_empty() { "gram-" } else { cursor };
         let range = index_blocks_for_key_range(&entries, start, None);
         Ok(Self {
             object_key: descriptor.object_key.clone(),
+            payload_checksum: descriptor.payload_checksum.clone(),
             next_entry: range.start,
             entries,
             pending: std::collections::VecDeque::new(),
@@ -1341,61 +1388,30 @@ impl SegmentRangeReader {
             .expect("pop is called only after peek_key returned a key")
     }
 
-    async fn refill<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        use loonfs_api::wire::sst_blocks::decode_data_block_rows;
+    async fn refill<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        table_cache: Option<&MetadataTableCache>,
+    ) -> Result<()> {
         while self.pending.is_empty() && self.next_entry < self.entries.len() {
             let entry = &self.entries[self.next_entry];
             self.next_entry += 1;
-            let block_bytes = fetch_index_section(store, &self.object_key, &entry.block).await?;
-            let block = decode_data_block_rows::<IndexRow>(&block_bytes, &entry.block).map_err(
-                |error| {
-                    CoreError::NamespaceCorrupt(format!(
-                        "index segment `{}` carries an unreadable data block: {error}",
-                        self.object_key
-                    ))
-                },
-            )?;
-            for (key, row) in block.row_keys.into_iter().zip(block.rows) {
+            let block = load_index_segment_data_block(
+                store,
+                table_cache,
+                &self.object_key,
+                &self.payload_checksum,
+                &entry.block,
+            )
+            .await?;
+            for (key, row) in block.row_keys.iter().zip(&block.rows) {
                 if key.as_str() >= self.start.as_str() {
-                    self.pending.push_back((key, row));
+                    self.pending.push_back((key.clone(), row.clone()));
                 }
             }
         }
         Ok(())
     }
-}
-
-/// Fetches one descriptor-named section by byte range, refusing handles
-/// whose bounds do not fit the address space.
-async fn fetch_index_section<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    handle: &loonfs_api::wire::sst_blocks::BlockHandle,
-) -> Result<Vec<u8>> {
-    let end_exclusive = handle
-        .offset
-        .checked_add(u64::from(handle.stored_len))
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
-                "index segment `{object_key}` descriptor names bytes past the address space"
-            ))
-        })?;
-    let bytes = store
-        .get(
-            object_key,
-            Some(loonfs_objectstore::ByteRange {
-                start_inclusive: handle.offset,
-                end_exclusive,
-            }),
-        )
-        .await
-        .map_err(|error| CoreError::store(object_key, &error))?
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
-                "manifest references missing index segment `{object_key}`"
-            ))
-        })?;
-    Ok(bytes.to_vec())
 }
 
 /// [`write_index_segments`] restamped at a fold's output level: the mid

--- a/crates/loonfs-core/src/checkpoint/index_read.rs
+++ b/crates/loonfs-core/src/checkpoint/index_read.rs
@@ -10,7 +10,8 @@
 //! unit-test shape), decoding and CRC-verifying identically either way.
 
 use super::cache::{
-    DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
+    CacheAdmission, DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache,
+    MetadataTableCacheKey,
 };
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::index_grams::IndexRow;
@@ -158,9 +159,17 @@ pub(crate) async fn load_index_segment_index_block<S: ObjectStore + ?Sized>(
 
 /// Loads one of an index segment's data blocks, rows decoded as the gram
 /// family's [`IndexRow`].
+///
+/// Data blocks are the one section kind whose caller states a
+/// [`CacheAdmission`]: they are the bulk of a segment's bytes, so a
+/// query admits them for the next query while a maintenance stream
+/// looks them up without displacing that working set. Filter and index
+/// blocks always admit — KB-scale directory sections every reader of a
+/// segment consults first.
 pub(crate) async fn load_index_segment_data_block<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
+    admission: CacheAdmission,
     object_key: &str,
     payload_checksum: &str,
     handle: &BlockHandle,
@@ -176,7 +185,11 @@ pub(crate) async fn load_index_segment_data_block<S: ObjectStore + ?Sized>(
         })
     };
     let block = match table_cache {
-        Some(cache) => cache.get_or_fetch(&cache_key, fetch).await?,
+        Some(cache) => {
+            cache
+                .get_or_fetch_with_admission(&cache_key, fetch, admission)
+                .await?
+        }
         None => fetch().await?,
     };
     match block {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -59,6 +59,7 @@ pub use self::index_build::{
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
 
+pub(crate) use self::cache::CacheAdmission;
 pub(crate) use self::create::{build_initial_namespace_manifest, create_checkpoint};
 pub(crate) use self::flush::flush_wal;
 pub(crate) use self::index_build::{

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -6031,7 +6031,7 @@ async fn drain_grams_index(
 ) -> u64 {
     let mut published = 0u64;
     loop {
-        let report = build_grams_index_step(store, namespace_id, context, policy)
+        let report = build_grams_index_step(store, None, namespace_id, context, policy)
             .await
             .expect("build step");
         match report.outcome {
@@ -6054,7 +6054,7 @@ async fn drain_grams_fold(
     loop {
         steps += 1;
         assert!(steps < 512, "the fold walk must terminate");
-        let report = fold_grams_index_step(store, namespace_id, context, policy)
+        let report = fold_grams_index_step(store, None, namespace_id, context, policy)
             .await
             .expect("fold step");
         match report.outcome {
@@ -6354,6 +6354,7 @@ async fn grams_index_disable_drops_the_feature_and_references() {
 
     let report = build_grams_index_step(
         &store,
+        None,
         &namespace_id,
         &context,
         GramIndexBuildPolicy::default(),
@@ -6518,7 +6519,7 @@ async fn grams_index_fold_merges_delta_segments_into_a_mid_run() {
     loop {
         steps += 1;
         assert!(steps < 512, "the fold walk must terminate");
-        let report = fold_grams_index_step(&store, &namespace_id, &context, fold_policy)
+        let report = fold_grams_index_step(&store, None, &namespace_id, &context, fold_policy)
             .await
             .expect("fold step");
         let completed = match report.outcome {
@@ -6584,7 +6585,7 @@ async fn grams_index_fold_merges_delta_segments_into_a_mid_run() {
         mid_segments.len() > 1,
         "one-row steps must split the outputs across segments"
     );
-    let report = fold_grams_index_step(&store, &namespace_id, &context, fold_policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, fold_policy)
         .await
         .expect("post-completion fold step");
     assert_eq!(
@@ -6806,7 +6807,7 @@ async fn grams_index_delta_fold_leaves_the_base_untouched() {
         "tiered folding must not change what the index answers"
     );
 
-    let report = fold_grams_index_step(&store, &namespace_id, &context, delta_fold_policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, delta_fold_policy)
         .await
         .expect("post-fold step");
     assert_eq!(
@@ -6885,9 +6886,10 @@ async fn grams_index_mid_runs_are_counted_by_run_ordinal_not_by_segment() {
         max_mid_runs: 2,
         ..GramIndexBuildPolicy::default()
     };
-    let report = fold_grams_index_step(&store, &namespace_id, &context, base_threshold_policy)
-        .await
-        .expect("fold step below the run threshold");
+    let report =
+        fold_grams_index_step(&store, None, &namespace_id, &context, base_threshold_policy)
+            .await
+            .expect("fold step below the run threshold");
     assert_eq!(
         report.outcome,
         GramIndexFoldOutcome::NotNeeded {
@@ -6939,7 +6941,7 @@ async fn grams_index_mid_runs_are_counted_by_run_ordinal_not_by_segment() {
         "run counting must not change what the index answers"
     );
     assert_eq!(
-        fold_grams_index_step(&store, &namespace_id, &context, base_threshold_policy)
+        fold_grams_index_step(&store, None, &namespace_id, &context, base_threshold_policy)
             .await
             .expect("post-fold step")
             .outcome,
@@ -6997,9 +6999,10 @@ async fn grams_index_backfill_folds_accumulate_distinct_mid_runs() {
     // Two backfill units, then a delta fold, twice — all mid-backfill.
     for _ in 0..2 {
         for _ in 0..2 {
-            let report = build_grams_index_step(&store, &namespace_id, &context, build_policy)
-                .await
-                .expect("backfill step");
+            let report =
+                build_grams_index_step(&store, None, &namespace_id, &context, build_policy)
+                    .await
+                    .expect("backfill step");
             assert!(
                 matches!(
                     report.outcome,
@@ -7030,7 +7033,7 @@ async fn grams_index_backfill_folds_accumulate_distinct_mid_runs() {
         max_mid_runs: 99,
         ..GramIndexBuildPolicy::default()
     };
-    let report = fold_grams_index_step(&store, &namespace_id, &context, probe_policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, probe_policy)
         .await
         .expect("probe fold step");
     assert_eq!(
@@ -7119,6 +7122,7 @@ async fn grams_index_one_build_run_split_across_segments_counts_once_in_both_tie
     // more than the mid one.
     let report = fold_grams_index_step(
         &store,
+        None,
         &namespace_id,
         &context,
         GramIndexBuildPolicy {
@@ -7161,6 +7165,7 @@ async fn grams_index_one_build_run_split_across_segments_counts_once_in_both_tie
     );
     let report = fold_grams_index_step(
         &store,
+        None,
         &namespace_id,
         &context,
         GramIndexBuildPolicy {
@@ -7256,9 +7261,15 @@ async fn grams_index_mid_threshold_folds_mids_and_base_into_a_fresh_base() {
         max_fold_rows_per_step: 1,
         ..GramIndexBuildPolicy::default()
     };
-    let first = fold_grams_index_step(&store, &namespace_id, &context, stepped_base_fold_policy)
-        .await
-        .expect("first base fold step");
+    let first = fold_grams_index_step(
+        &store,
+        None,
+        &namespace_id,
+        &context,
+        stepped_base_fold_policy,
+    )
+    .await
+    .expect("first base fold step");
     assert!(
         matches!(
             first.outcome,
@@ -7295,7 +7306,7 @@ async fn grams_index_mid_threshold_folds_mids_and_base_into_a_fresh_base() {
     )
     .await
     .expect("write echo");
-    let build = build_grams_index_step(&store, &namespace_id, &context, build_policy)
+    let build = build_grams_index_step(&store, None, &namespace_id, &context, build_policy)
         .await
         .expect("build step mid-fold");
     assert!(
@@ -7318,10 +7329,15 @@ async fn grams_index_mid_threshold_folds_mids_and_base_into_a_fresh_base() {
     loop {
         steps += 1;
         assert!(steps < 512, "the fold walk must terminate");
-        let report =
-            fold_grams_index_step(&store, &namespace_id, &context, stepped_base_fold_policy)
-                .await
-                .expect("base fold step");
+        let report = fold_grams_index_step(
+            &store,
+            None,
+            &namespace_id,
+            &context,
+            stepped_base_fold_policy,
+        )
+        .await
+        .expect("base fold step");
         let completed = match report.outcome {
             GramIndexFoldOutcome::StepPublished { completed, .. } => completed,
             other => panic!("expected a published fold step, got {other:?}"),
@@ -7372,7 +7388,7 @@ async fn grams_index_mid_threshold_folds_mids_and_base_into_a_fresh_base() {
         "the folded base answers exactly what the tiers answered"
     );
 
-    let report = fold_grams_index_step(&store, &namespace_id, &context, delta_fold_policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, delta_fold_policy)
         .await
         .expect("post-fold step");
     assert_eq!(
@@ -7463,7 +7479,7 @@ async fn grams_index_legacy_bases_count_as_mid_runs_and_fold_into_the_base() {
         max_mid_runs: 2,
         ..GramIndexBuildPolicy::default()
     };
-    let report = fold_grams_index_step(&store, &namespace_id, &context, policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, policy)
         .await
         .expect("fold step below thresholds");
     assert_eq!(
@@ -7513,7 +7529,7 @@ async fn grams_index_legacy_bases_count_as_mid_runs_and_fold_into_the_base() {
         expected_postings,
         "self-healing must not change what the index answers"
     );
-    let report = fold_grams_index_step(&store, &namespace_id, &context, policy)
+    let report = fold_grams_index_step(&store, None, &namespace_id, &context, policy)
         .await
         .expect("post-fold step");
     assert_eq!(
@@ -7575,6 +7591,7 @@ async fn fold_refuses_an_unreadable_feature_value() {
 
     let error = fold_grams_index_step(
         &store,
+        None,
         &namespace_id,
         &context,
         GramIndexBuildPolicy::default(),

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -7,7 +7,10 @@
 use super::build::{
     build_manifest_tables, build_manifest_tables_from_rows, MetadataTableSegmentation,
 };
-use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
+use super::cache::{
+    DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache,
+    MetadataTableCacheConfig, MetadataTableCacheKey,
+};
 use super::create::load_checkpoint_projection_metadata_state;
 use super::error::ManifestLoadError;
 use super::index_build::{
@@ -45,7 +48,8 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::wire::control::{HeadState, MetadataRootState};
 use loonfs_api::wire::index_grams::{
-    Gram, GramPosting, IndexGramsFeature, IndexRow, INDEX_FAMILY_GRAMS, INDEX_GRAMS_FEATURE_KEY,
+    extract_grams, Gram, GramPosting, IndexGramsFeature, IndexRow, INDEX_FAMILY_GRAMS,
+    INDEX_GRAMS_FEATURE_KEY,
 };
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, encode_namespace_manifest_json, lookup_keys, MetadataFileRef,
@@ -53,7 +57,7 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestPayload,
 };
 use loonfs_api::wire::sst_blocks::{
-    decode_data_block_rows, decode_index_block, BlockHandle, SegmentBlocksBuilder,
+    decode_data_block_rows, decode_index_block, BlockHandle, DecodedDataBlock, SegmentBlocksBuilder,
 };
 use loonfs_api::{
     ChangeSeq, CheckpointId, CommitId, EffectiveLimit, InodeId, ManifestId, ManifestObjectId,
@@ -6075,6 +6079,23 @@ fn posting(inode: u64, revision: u64) -> GramPosting {
     }
 }
 
+/// Deterministic lowercase noise whose sliding trigrams are almost all
+/// distinct, so a small file contributes hundreds of index rows; the
+/// trailing marker line gives every generated file one shared gram to
+/// probe.
+fn varied_gram_content(seed: u32, noise_bytes: usize) -> Vec<u8> {
+    let mut content = Vec::with_capacity(noise_bytes + 16);
+    let mut state = seed.wrapping_mul(2654435761).max(1);
+    while content.len() < noise_bytes {
+        // A full-period LCG keeps the letter stream aperiodic at this
+        // scale, so nearby windows rarely repeat a trigram.
+        state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+        content.push(b'a' + ((state >> 16) % 26) as u8);
+    }
+    content.extend_from_slice(b"\nshared marker\n");
+    content
+}
+
 #[tokio::test]
 async fn grams_index_backfill_covers_existing_text_and_skips_binary() {
     let temp_dir = tempdir().expect("temp dir");
@@ -6675,6 +6696,235 @@ async fn grams_index_fold_steps_consume_equal_row_keys_atomically() {
         expected,
         "every gram's group survives, not just the probe's"
     );
+}
+
+/// Review regression: fold reads used to admit every streamed data block
+/// into the shared LRU, so one fold larger than the byte budget flushed
+/// the query-hot working set. Data blocks now resolve lookup-only: a
+/// pre-warmed block survives a fold whose stream dwarfs the budget, the
+/// fold admits nothing it should not (no evictions at all), and its
+/// outputs are unchanged.
+#[tokio::test]
+async fn a_fold_bigger_than_the_cache_budget_leaves_the_hot_working_set_resident() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = NamespaceId::parse("grams-scan-resistance").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // Two files of trigram noise: thousands of distinct grams, hence
+    // thousands of merged rows, so the fold's data-block stream exceeds
+    // the budget below many times over (asserted after the fold).
+    for (path, seed) in [("/left.txt", 1u32), ("/right.txt", 2u32)] {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            path,
+            &varied_gram_content(seed, 2048),
+            &context,
+            None,
+        )
+        .await
+        .expect("write varied file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    let policy = GramIndexBuildPolicy {
+        max_files_per_step: 1,
+        max_l0_runs: 2,
+        ..GramIndexBuildPolicy::default()
+    };
+    drain_grams_index(&store, &namespace_id, &context, policy).await;
+    let shared_before = stored_gram_postings(&store, &namespace_id, Gram(*b"sha")).await;
+    assert_eq!(
+        shared_before,
+        vec![posting(2, 1), posting(3, 1)],
+        "the marker line must index both files"
+    );
+
+    // A budget the fold's stream exceeds, pre-warmed with a stand-in for
+    // the query path's hot block. The stand-in's key can collide with
+    // nothing the fold touches, so only eviction could remove it.
+    let budget = 64 * 1024usize;
+    let cache = MetadataTableCache::new(MetadataTableCacheConfig {
+        max_decoded_bytes: budget,
+    });
+    let hot_key = MetadataTableCacheKey {
+        identity: "query-hot-working-set".to_owned(),
+        block_kind: MetadataTableBlockKind::Data,
+        block_offset: 0,
+    };
+    cache.insert(
+        hot_key.clone(),
+        DecodedMetadataTableBlock::Data {
+            block: Arc::new(DecodedDataBlock {
+                row_keys: Vec::new(),
+                rows: Vec::new(),
+            }),
+            decoded_byte_len: 1024,
+        },
+    );
+
+    let mut merged_rows_total = 0u64;
+    let mut steps = 0u32;
+    loop {
+        steps += 1;
+        assert!(steps < 512, "the fold walk must terminate");
+        let report = fold_grams_index_step(&store, Some(&cache), &namespace_id, &context, policy)
+            .await
+            .expect("fold step");
+        match report.outcome {
+            GramIndexFoldOutcome::StepPublished {
+                merged_rows,
+                completed,
+                ..
+            } => {
+                merged_rows_total += merged_rows;
+                if completed {
+                    break;
+                }
+            }
+            other => panic!("expected a published fold step, got {other:?}"),
+        }
+    }
+
+    // The premise: at the cache weight heuristic's 64-byte-per-row floor
+    // alone, the merged rows outweigh the whole budget, so the old
+    // always-admit behavior was guaranteed to evict the hot block.
+    assert!(
+        merged_rows_total * 64 > budget as u64,
+        "the fold must stream more decoded bytes than the budget holds: \
+         {merged_rows_total} rows against {budget} budget bytes"
+    );
+    assert!(
+        cache.get(&hot_key).is_some(),
+        "a maintenance fold must not evict the query-hot working set"
+    );
+    assert_eq!(
+        cache.stats().evictions,
+        0,
+        "the fold's admitted sections (manifest and index blocks) must \
+         fit the budget without displacing anything"
+    );
+    assert_eq!(
+        stored_gram_postings(&store, &namespace_id, Gram(*b"sha")).await,
+        shared_before,
+        "lookup-only reads must not change what the fold writes"
+    );
+}
+
+/// The cache is an accelerator, never a correctness input: one identical
+/// build-and-fold cycle driven with the cache disabled (a zero byte
+/// budget) and one with a live cache must leave indexes that answer
+/// every gram of every written file identically.
+#[tokio::test]
+async fn grams_maintenance_answers_identically_with_and_without_a_cache() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let context = test_context();
+    let zero_cache = MetadataTableCache::new(MetadataTableCacheConfig {
+        max_decoded_bytes: 0,
+    });
+    let live_cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let contents: Vec<Vec<u8>> = (0..3u32)
+        .map(|index| varied_gram_content(index + 7, 512))
+        .collect();
+
+    let zero_ns = NamespaceId::parse("grams-parity-zero").expect("namespace id");
+    let live_ns = NamespaceId::parse("grams-parity-live").expect("namespace id");
+    for (namespace_id, cache) in [(&zero_ns, &zero_cache), (&live_ns, &live_cache)] {
+        bootstrap_namespace(&store, namespace_id, &context, false)
+            .await
+            .expect("bootstrap");
+        for (index, content) in contents.iter().enumerate() {
+            write_file_bytes(
+                &store,
+                namespace_id,
+                &format!("/file-{index}.txt"),
+                content,
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        create_checkpoint(&store, namespace_id, &context)
+            .await
+            .expect("checkpoint");
+        enable_grams_index(&store, namespace_id, &context)
+            .await
+            .expect("enable");
+        let policy = GramIndexBuildPolicy {
+            max_files_per_step: 1,
+            max_l0_runs: 2,
+            // A small row budget forces the fold across resumable steps,
+            // so cursor re-opens run through the cached path too.
+            max_fold_rows_per_step: 512,
+            ..GramIndexBuildPolicy::default()
+        };
+        loop {
+            let report =
+                build_grams_index_step(&store, Some(cache), namespace_id, &context, policy)
+                    .await
+                    .expect("build step");
+            match report.outcome {
+                GramIndexBuildOutcome::Published { .. } => {}
+                GramIndexBuildOutcome::UpToDate { .. } => break,
+                other => panic!("unexpected build outcome: {other:?}"),
+            }
+        }
+        let mut steps = 0u32;
+        loop {
+            steps += 1;
+            assert!(steps < 512, "the fold walk must terminate");
+            let report = fold_grams_index_step(&store, Some(cache), namespace_id, &context, policy)
+                .await
+                .expect("fold step");
+            match report.outcome {
+                GramIndexFoldOutcome::StepPublished { completed, .. } => {
+                    if completed {
+                        break;
+                    }
+                }
+                other => panic!("expected a published fold step, got {other:?}"),
+            }
+        }
+        assert!(steps > 1, "the row budget must split the fold into steps");
+    }
+
+    let zero_levels: Vec<u32> = live_index_files(&store, &zero_ns)
+        .await
+        .iter()
+        .map(|descriptor| descriptor.level)
+        .collect();
+    let live_levels: Vec<u32> = live_index_files(&store, &live_ns)
+        .await
+        .iter()
+        .map(|descriptor| descriptor.level)
+        .collect();
+    assert_eq!(
+        zero_levels, live_levels,
+        "both cycles must leave the same segment shape"
+    );
+    let mut grams = BTreeSet::new();
+    for content in &contents {
+        grams.extend(extract_grams(content));
+    }
+    assert!(grams.len() > 500, "the noise must spread across many grams");
+    for gram in grams {
+        assert_eq!(
+            stored_gram_postings(&store, &zero_ns, gram).await,
+            stored_gram_postings(&store, &live_ns, gram).await,
+            "gram {} must answer identically with and without a cache",
+            gram.as_hex()
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -556,12 +556,18 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// after, each unit ending in one manifest publication that advances
     /// the `index.grams` watermark. Callers invoke this repeatedly, like
     /// [`Self::reorganize_metadata`].
+    ///
+    /// `table_cache` is the runtime's shared decoded-block cache, passed
+    /// alongside the policy the way reads pass [`RuntimeReadContext`];
+    /// the step's segment reads resolve through it when attached.
     pub async fn build_grams_index_step(
         &self,
         policy: crate::checkpoint::GramIndexBuildPolicy,
+        table_cache: Option<&MetadataTableCache>,
     ) -> CoreResult<crate::checkpoint::GramIndexBuildReport> {
         crate::checkpoint::build_grams_index_step(
             &self.store,
+            table_cache,
             &self.namespace_id,
             &self.mutation_context(),
             policy,
@@ -574,12 +580,18 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// merge together with the base into a fresh base, each fold ending
     /// in manifest publications that swap the consumed references out
     /// for the outputs.
+    ///
+    /// `table_cache` is the runtime's shared decoded-block cache, passed
+    /// alongside the policy the way reads pass [`RuntimeReadContext`];
+    /// the fold's merge reads resolve through it when attached.
     pub async fn fold_grams_index_step(
         &self,
         policy: crate::checkpoint::GramIndexBuildPolicy,
+        table_cache: Option<&MetadataTableCache>,
     ) -> CoreResult<crate::checkpoint::GramIndexFoldReport> {
         crate::checkpoint::fold_grams_index_step(
             &self.store,
+            table_cache,
             &self.namespace_id,
             &self.mutation_context(),
             policy,

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -1966,6 +1966,7 @@ mod tests {
         loop {
             let report = crate::checkpoint::build_grams_index_step(
                 store,
+                None,
                 namespace_id,
                 context,
                 crate::GramIndexBuildPolicy::default(),

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -6,7 +6,7 @@
 
 use crate::checkpoint::{
     index_segment_corrupt, load_index_segment_data_block, load_index_segment_filter_block,
-    load_index_segment_index_block, string_prefix_upper_bound, MetadataTableCache,
+    load_index_segment_index_block, string_prefix_upper_bound, CacheAdmission, MetadataTableCache,
 };
 use crate::error::{CoreError, Result};
 use crate::query::grep_plan::GramQueryPlan;
@@ -212,6 +212,7 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
         let block = load_index_segment_data_block(
             store,
             table_cache,
+            CacheAdmission::Admit,
             &descriptor.object_key,
             &descriptor.payload_checksum,
             &entry.block,

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -235,8 +235,9 @@ fn router(state: AppState) -> Router {
 /// The long-lived server writer opts into background maintenance; the
 /// reader shares its caches so read endpoints observe writes immediately;
 /// the admin handle drives the explicit maintenance endpoints under its own
-/// actor identity. All three deliberately share one provider client inside
-/// this one runtime ownership domain.
+/// actor identity, sharing the writer's decoded-block cache under the
+/// configured budget. All three deliberately share one provider client
+/// inside this one runtime ownership domain.
 async fn build_handles(
     config: &ServerConfig,
     store: SharedStore,
@@ -281,6 +282,12 @@ async fn build_handles_with_metrics_jsonl_path(
     let mut admin_builder = FsAdmin::builder_with_store(store)
         .actor_id(format!("{}-admin", config.writer_id))
         .actor_version(config.writer_version.clone())
+        // The admin honors the configured cache sizing and shares the
+        // writer's decoded-block cache instance, so explicit maintenance
+        // reuses blocks reader traffic already decoded instead of
+        // populating a second, default-sized cache.
+        .runtime_cache(config.runtime_cache_config())
+        .shared_metadata_table_cache(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
     if let Some(recorder) = metrics_recorder {

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -69,7 +69,8 @@ use axum::body::Bytes;
 use futures::stream::BoxStream;
 use loonfs::ErrorCode;
 use loonfs::{
-    CreateNamespaceOptions, DeleteOptions, FsWriter, PutFileOptions, TraceMode, TraceStoreKind,
+    CreateNamespaceOptions, DeleteOptions, FsAdmin, FsWriter, MaintenanceTickOptions,
+    PutFileOptions, TraceMode, TraceStoreKind,
 };
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
@@ -640,6 +641,120 @@ async fn capability_document_advertises_the_upload_limit() {
     .expect("join blocking task");
 
     harness.server.abort();
+}
+
+/// Seeds a namespace with enough durable state that an explicit
+/// maintenance tick has metadata to load: files to flush and the gram
+/// index feature to build.
+async fn seed_namespace_for_maintenance(writer: &FsWriter, admin: &FsAdmin) -> NamespaceId {
+    let namespace = namespace_id("cache-config");
+    writer
+        .create_namespace(&namespace, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for (index, path) in ["/left.txt", "/right.txt"].iter().enumerate() {
+        write_file_bytes(
+            writer,
+            &namespace,
+            path,
+            b"a needle for maintenance\n",
+            &format!("cache-config-seed-{index:02}"),
+        )
+        .await;
+    }
+    admin
+        .enable_grams_index(&namespace)
+        .await
+        .expect("enable grams index");
+    namespace
+}
+
+/// The tick shape `/maintenance/tick` serves with a one-segment
+/// threshold override: the WAL flushes, a manifest publishes, and the
+/// gram build step loads it through the runtime cache.
+fn flush_everything_tick() -> MaintenanceTickOptions {
+    MaintenanceTickOptions {
+        max_wal_tail_segments: 1,
+        ..MaintenanceTickOptions::default()
+    }
+}
+
+/// Review regression: the admin handle behind `/maintenance/tick` was
+/// built without the configured runtime cache, so explicit maintenance
+/// ran a default 256 MiB cache no matter what the operator configured.
+/// With a zero decoded-byte budget the whole runtime cache is disabled,
+/// and maintenance driven through the admin must neither insert into
+/// nor hit any cache.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_maintenance_honors_a_zero_configured_cache_budget() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let mut config = test_config(temp_dir.path(), "server-writer");
+    config.background_maintenance = false;
+    config.runtime_cache.metadata_table_cache_max_decoded_bytes = Some(0);
+    let (writer, _reader, admin) = build_handles_with_metrics_jsonl_path(&config, store, None)
+        .await
+        .expect("build handles");
+
+    let namespace = seed_namespace_for_maintenance(&writer, &admin).await;
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace, flush_everything_tick())
+            .await
+            .expect("maintenance tick");
+    }
+
+    let stats = admin.runtime_cache_stats();
+    assert_eq!(
+        stats.metadata_table_cache_inserts, 0,
+        "a zero-budget cache must admit nothing during explicit maintenance"
+    );
+    assert_eq!(
+        stats.metadata_table_cache_hits, 0,
+        "a zero-budget cache must serve nothing during explicit maintenance"
+    );
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// The companion premise and the sharing half: with a real budget the
+/// identical flow does populate the cache, and the blocks maintenance
+/// admits land in the writer's own cache instance — one cache, one
+/// budget — rather than in a second admin-only cache.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_maintenance_populates_the_writer_visible_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let mut config = test_config(temp_dir.path(), "server-writer");
+    config.background_maintenance = false;
+    let (writer, _reader, admin) = build_handles_with_metrics_jsonl_path(&config, store, None)
+        .await
+        .expect("build handles");
+
+    let namespace = seed_namespace_for_maintenance(&writer, &admin).await;
+    // Everything after this snapshot flows through the admin handle, so
+    // any movement in the writer-visible counters is admin work landing
+    // in the shared instance.
+    let before = writer.runtime_cache_stats().metadata_table_cache_inserts;
+    for _ in 0..2 {
+        admin
+            .maintenance_tick_namespace(&namespace, flush_everything_tick())
+            .await
+            .expect("maintenance tick");
+    }
+
+    let writer_stats = writer.runtime_cache_stats();
+    assert!(
+        writer_stats.metadata_table_cache_inserts > before,
+        "explicit maintenance must populate the cache the writer observes, \
+         inserts before {before}, after {}",
+        writer_stats.metadata_table_cache_inserts
+    );
+    let admin_stats = admin.runtime_cache_stats();
+    assert_eq!(
+        admin_stats.metadata_table_cache_inserts, writer_stats.metadata_table_cache_inserts,
+        "admin and writer must observe one shared cache, not two"
+    );
+    writer.shutdown_background().await.expect("writer shutdown");
 }
 
 async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestHarness {

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -85,15 +85,25 @@ impl FsInner {
 }
 
 impl FsCore {
+    /// Opens a runtime core. `shared_metadata_table_cache` substitutes an
+    /// existing decoded-block cache for a freshly sized one, so handles
+    /// with distinct actor identities can still share warmed blocks —
+    /// sound across cores because entries are keyed by immutable
+    /// identities (payload checksums and manifest object keys); the
+    /// sharing caller owns the sizing decision, and
+    /// `config.runtime_cache.metadata_table_cache` goes unused.
     pub(crate) fn open_with_background(
         store: SharedObjectStore,
         config: FsConfig,
         background: BackgroundWork,
+        shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
     ) -> Result<Self> {
         validate_config(&config)?;
-        let metadata_table_cache = Arc::new(MetadataTableCache::new(
-            config.runtime_cache.metadata_table_cache.clone(),
-        ));
+        let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
+            Arc::new(MetadataTableCache::new(
+                config.runtime_cache.metadata_table_cache.clone(),
+            ))
+        });
         let wal_tail_projection_cache =
             Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
                 max_entries: config.runtime_cache.max_cached_namespaces,
@@ -121,6 +131,12 @@ impl FsCore {
     /// Returns this runtime's config.
     pub(crate) fn config(&self) -> &FsConfig {
         &self.inner.config
+    }
+
+    /// This runtime's shared decoded-block cache handle, for builders
+    /// that open another core sharing it.
+    pub(crate) fn metadata_table_cache(&self) -> Arc<MetadataTableCache> {
+        Arc::clone(&self.inner.metadata_table_cache)
     }
 
     fn record_trace_context(&self, span: &tracing::Span) {

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -498,8 +498,12 @@ impl FsCore {
         policy: loonfs_core::GramIndexBuildPolicy,
     ) -> Result<bool> {
         let engine = self.namespace_engine(namespace_id);
+        // The same shared decoded-block cache reads use: index segments
+        // are immutable and keyed by payload checksum, so blocks queries
+        // already decoded serve the maintenance merge from memory.
+        let table_cache = Some(self.inner.metadata_table_cache.as_ref());
         let build = engine
-            .build_grams_index_step(policy)
+            .build_grams_index_step(policy, table_cache)
             .await
             .map_err(RuntimeError::Core)?;
         let mut published = false;
@@ -543,7 +547,7 @@ impl FsCore {
             ),
         );
         let fold = engine
-            .fold_grams_index_step(policy)
+            .fold_grams_index_step(policy, table_cache)
             .await
             .map_err(RuntimeError::Core)?;
         if let loonfs_core::GramIndexFoldOutcome::StepPublished {
@@ -1736,7 +1740,7 @@ mod tests {
     async fn drain_grams_builds(engine: &loonfs_core::NamespaceEngine<crate::SharedObjectStore>) {
         for _ in 0..8 {
             let report = engine
-                .build_grams_index_step(loonfs_core::GramIndexBuildPolicy::default())
+                .build_grams_index_step(loonfs_core::GramIndexBuildPolicy::default(), None)
                 .await
                 .expect("build step");
             match report.outcome {
@@ -1754,7 +1758,7 @@ mod tests {
     ) {
         for _ in 0..64 {
             let report = engine
-                .fold_grams_index_step(policy)
+                .fold_grams_index_step(policy, None)
                 .await
                 .expect("fold step");
             match report.outcome {
@@ -1870,11 +1874,14 @@ mod tests {
             drain_grams_builds(&engine).await;
         }
         let parked = engine
-            .fold_grams_index_step(loonfs_core::GramIndexBuildPolicy {
-                max_l0_runs: 2,
-                max_fold_rows_per_step: 1,
-                ..loonfs_core::GramIndexBuildPolicy::default()
-            })
+            .fold_grams_index_step(
+                loonfs_core::GramIndexBuildPolicy {
+                    max_l0_runs: 2,
+                    max_fold_rows_per_step: 1,
+                    ..loonfs_core::GramIndexBuildPolicy::default()
+                },
+                None,
+            )
             .await
             .expect("first fold step");
         assert!(

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -200,6 +200,18 @@ impl FsAdminBuilder {
         self
     }
 
+    /// Shares `writer`'s decoded-block cache with this handle instead of
+    /// opening a separate one, so explicit maintenance reuses blocks that
+    /// writer-side reads already decoded — and warms them back. Sound
+    /// because entries are keyed by immutable identities; only for a
+    /// writer in the same runtime ownership domain. The cache keeps the
+    /// writer's byte budget: [`Self::runtime_cache`] still sizes this
+    /// handle's other caches, but its decoded-block budget goes unused.
+    pub fn shared_metadata_table_cache(mut self, writer: &super::FsWriter) -> Self {
+        self.core.shared_metadata_table_cache = Some(writer.core().metadata_table_cache());
+        self
+    }
+
     /// Sets the tracing mode label.
     pub fn trace_mode(mut self, trace_mode: TraceMode) -> Self {
         self.core.trace_mode = trace_mode;

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -33,6 +33,7 @@ use crate::{
     ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
     StoreConfig, TraceMode, TraceStoreKind,
 };
+use loonfs_core::cache::MetadataTableCache;
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
 use std::sync::Arc;
 
@@ -50,6 +51,9 @@ struct HandleBuilderCore {
     source: StoreSource,
     commit_window_ms: u64,
     runtime_cache: RuntimeCacheConfig,
+    /// An existing decoded-block cache to share instead of sizing a fresh
+    /// one from `runtime_cache`; see [`FsCore::open_with_background`].
+    shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
     trace_mode: TraceMode,
     trace_store_kind: Option<TraceStoreKind>,
     metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
@@ -69,6 +73,7 @@ impl HandleBuilderCore {
             source,
             commit_window_ms: crate::config::DEFAULT_COMMIT_WINDOW_MS,
             runtime_cache: RuntimeCacheConfig::default(),
+            shared_metadata_table_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
             metrics_recorder: None,
@@ -109,6 +114,7 @@ impl HandleBuilderCore {
                 trace_store_kind,
             },
             background,
+            self.shared_metadata_table_cache,
         )
     }
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1401,6 +1401,7 @@ mod tests {
                 trace_store_kind: TraceStoreKind::LocalFs,
             },
             BackgroundWork::new(FsBackgroundWork::ManualOnly, None),
+            None,
         )
         .expect("open runtime")
     }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -842,3 +842,143 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
 
     writer.shutdown_background().await.expect("writer shutdown");
 }
+
+/// Fold steps resolve their merge reads through the same decoded-block
+/// cache queries fill: a reader derived from the writer shares its
+/// runtime core, so a grep that decoded the delta segments must spare the
+/// next fold those segments' store reads.
+///
+/// Two identically shaped delta folds run through one runtime — eight
+/// one-file rounds each, background ticks folding on the eighth. The
+/// first fold runs cold (nothing read those segments before) and is the
+/// in-test control; before the second, a grep warms seven of its eight
+/// inputs. Only the tick that triggers a fold can write its eighth delta,
+/// so that segment is always cold and a zero-read fold is unreachable
+/// through the runtime; strictly fewer reads than the identically shaped
+/// cold fold is the deterministic form of "already-warm blocks are not
+/// re-fetched", and it stays true if segment block layout changes.
+#[tokio::test]
+async fn a_fold_reuses_the_index_blocks_a_grep_already_decoded() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-fold-cache").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-fold-writer")
+        .commit_window_ms(0)
+        .background_work(FsBackgroundWork::Enabled)
+        .build()
+        .await
+        .expect("build writer");
+    // The derived reader shares the writer's runtime core, so its greps
+    // fill the cache the writer's background fold steps read through.
+    let reader = writer.reader();
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-fold-admin")
+        .build()
+        .await
+        .expect("build admin");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+
+    // One delta segment per round: every put schedules a background drain
+    // that builds exactly the new revision, and the drain's fold step
+    // tiers the deltas into a mid run on the eighth round.
+    let put_round = |round: u32| {
+        let writer = writer.clone();
+        let namespace_id = namespace_id.clone();
+        async move {
+            writer
+                .put_file_bytes(
+                    &namespace_id,
+                    &format!("/notes/needle-{round:02}.txt"),
+                    format!("a needle numbered {round}\n").as_bytes(),
+                    PutFileOptions::default(),
+                )
+                .await
+                .expect("write file");
+            writer
+                .wait_for_background_work()
+                .await
+                .expect("background work quiesces");
+        }
+    };
+
+    for round in 1..8u32 {
+        put_round(round).await;
+    }
+    let before_cold_fold = raw_store.index_segment_get_count();
+    put_round(8).await;
+    let cold_fold_gets = raw_store.index_segment_get_count() - before_cold_fold;
+    assert!(
+        cold_fold_gets > 0,
+        "the eighth round's fold must read its snapshot segments from the store"
+    );
+
+    for round in 9..16u32 {
+        put_round(round).await;
+    }
+    // The warm-up: one grep that matches every file decodes the pending
+    // delta segments' index and posting blocks into the shared cache.
+    let warm = reader
+        .grep(&namespace_id, &grep_request("needle"))
+        .await
+        .expect("warming grep");
+    assert_eq!(warm.matches.len(), 15);
+
+    let before_warm_fold = raw_store.index_segment_get_count();
+    put_round(16).await;
+    let warm_fold_gets = raw_store.index_segment_get_count() - before_warm_fold;
+    assert!(
+        warm_fold_gets > 0,
+        "the sixteenth round's fold must still read the delta its own tick wrote"
+    );
+    assert!(
+        warm_fold_gets < cold_fold_gets,
+        "a fold whose snapshot a grep already decoded must serve those \
+         blocks from the table cache: cold fold read {cold_fold_gets} \
+         sections, query-warmed fold read {warm_fold_gets}"
+    );
+
+    // The premise of the comparison: both rounds really did fold, leaving
+    // two mid runs and no deltas.
+    let root = loonfs_core::control::load_namespace_metadata_root_control(&*store, &namespace_id)
+        .await
+        .expect("metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read namespace manifest")
+        .expect("namespace manifest exists");
+    let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
+    let grams: Vec<(u32, u64)> = manifest
+        .payload
+        .index_files
+        .iter()
+        .filter(|descriptor| descriptor.family == "grams")
+        .map(|descriptor| (descriptor.level, descriptor.run_seq.0))
+        .collect();
+    assert!(
+        grams.iter().all(|(level, _)| *level == 1),
+        "sixteen one-delta rounds must leave only mid-level segments, got {grams:?}"
+    );
+    let mid_runs: std::collections::BTreeSet<u64> =
+        grams.iter().map(|(_, run_seq)| *run_seq).collect();
+    assert_eq!(
+        mid_runs.len(),
+        2,
+        "each eight-round batch must have folded into its own mid run, got {grams:?}"
+    );
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -982,3 +982,185 @@ async fn a_fold_reuses_the_index_blocks_a_grep_already_decoded() {
 
     writer.shutdown_background().await.expect("writer shutdown");
 }
+
+/// Tracks how many GETs against gram index segment objects are in flight
+/// at once. The yield before each forwarded read lets sibling fetches
+/// issued in the same fan-out begin before this one completes, so the
+/// peak observes overlap exactly when the caller issued the GETs
+/// concurrently; serial callers can never raise it above one.
+#[derive(Debug)]
+struct InFlightIndexGetProbeStore {
+    inner: LocalFsStore,
+    in_flight: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+impl InFlightIndexGetProbeStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            in_flight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        }
+    }
+
+    fn peak_in_flight(&self) -> usize {
+        self.peak.load(Ordering::SeqCst)
+    }
+
+    async fn probed<T, F>(&self, key: &str, read: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        if !key.contains("/metadata/indexes/") {
+            return read.await;
+        }
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak.fetch_max(now, Ordering::SeqCst);
+        tokio::task::yield_now().await;
+        let result = read.await;
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        result
+    }
+}
+
+#[async_trait]
+impl ObjectStore for InFlightIndexGetProbeStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.probed(key, self.inner.get_with_metadata(key)).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.probed(key, self.inner.get(key, range)).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// A cold fold — nothing decoded its snapshot before — must fan out its
+/// per-segment cursor opens instead of paying one round trip per
+/// segment, and the fan-out must stay within the maintenance IO cap.
+///
+/// Put-and-tick rounds accumulate delta runs until the threshold folds
+/// them; single-step ticks lag the puts and may batch two puts into one
+/// run, so the rounds run until the fold's reads appear rather than to a
+/// fixed count. No query ever touches the namespace and build steps only
+/// write gram segments, so the fold's reads are the only gram-segment
+/// GETs the probe can see: the peak measures exactly the fold's opens.
+#[tokio::test]
+async fn a_cold_fold_fans_out_its_segment_opens_within_the_io_cap() {
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(InFlightIndexGetProbeStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-fold-fan-out").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-fan-out-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-fan-out-admin")
+        .build()
+        .await
+        .expect("build admin");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+
+    // Each round writes one file and runs one bounded build step plus
+    // one bounded fold step; the first gram-segment GET is, by
+    // construction, the triggered fold reading its snapshot of every
+    // accumulated delta run.
+    let mut rounds = 0u32;
+    while raw_store.peak_in_flight() == 0 {
+        rounds += 1;
+        assert!(
+            rounds <= 24,
+            "the delta threshold must fold within a bounded number of rounds"
+        );
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/notes/needle-{rounds:02}.txt"),
+                format!("a needle numbered {rounds}\n").as_bytes(),
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("write file");
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("maintenance tick");
+    }
+
+    let peak = raw_store.peak_in_flight();
+    assert!(
+        peak > 1,
+        "a cold fold's segment opens must overlap, got a serial peak of {peak}"
+    );
+    assert!(
+        peak <= 8,
+        "the fold's fan-out must respect the maintenance IO cap, got {peak}"
+    );
+
+    // The premise of the probe: the reads the peak observed were a real
+    // delta fold, which leaves a mid run behind.
+    let root = loonfs_core::control::load_namespace_metadata_root_control(&*store, &namespace_id)
+        .await
+        .expect("metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read namespace manifest")
+        .expect("namespace manifest exists");
+    let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
+    let grams: Vec<u32> = manifest
+        .payload
+        .index_files
+        .iter()
+        .filter(|descriptor| descriptor.family == "grams")
+        .map(|descriptor| descriptor.level)
+        .collect();
+    assert!(
+        grams.contains(&1),
+        "the observed fold must have left a mid run behind, got {grams:?}"
+    );
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}


### PR DESCRIPTION
The gram build and fold entry points received only the store and a MutationContext, so the fold's k-way merge read every segment block with raw serial GETs — even blocks a query had just decoded into the runtime's cache. This threads the runtime's existing MetadataTableCache reference into those entry points (alongside the policy, mirroring how read paths carry their context; MutationContext stays writer-only), resolves merge reads through the cached index-segment loaders, and fans out the per-segment cursor opens with the same chunked try_join_all the file already uses for segment writes. The no-cache path is byte-identical, so cache-less embedded tests exercise exactly the old behavior.

A new integration test drives two identically shaped folds through one runtime and asserts the one running after a warming grep issues strictly fewer index-segment GETs (probed: 16 cold vs 2 warm). Metadata reorganize/checkpoint/gc could pick up the same parameter later; deliberately left out of scope here.

Stacked on #264.