### PR TITLE
perf(core,loonfs,server): grep fan-out tuning, probe budgeting, and build-policy configuration

### DIFF
--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -27,6 +27,18 @@ writer_version = "loonfs-server/0.1.0"
 # Decoded-byte budget for the metadata table cache; unlimited by default.
 #metadata_table_cache_max_decoded_bytes = 268435456
 
+# Optional gram index build budgets; omitted fields keep the runtime
+# defaults. Each maintenance tick runs one build step and one fold step
+# under these budgets — bulk backfills raise the per-step budgets so a
+# tick indexes more files per manifest publish.
+#[gram_index_build]
+#max_files_per_step = 256
+#max_content_bytes_per_step = 67108864
+#max_rows_per_segment = 65536
+#max_l0_runs = 8
+#max_mid_runs = 8
+#max_fold_rows_per_step = 131072
+
 [store]
 kind = "local-fs"
 root = "./.loonfs-store"

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -98,7 +98,7 @@ pub(super) const INDEX_GRAMS_BASE_LEVEL: u32 = 2;
 /// Writer-side budgets for one build step. Work stops at a commit boundary
 /// once a budget is exceeded; the next step resumes from the published
 /// watermark or cursor.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GramIndexBuildPolicy {
     /// Revisions examined per step.
     pub max_files_per_step: usize,
@@ -131,8 +131,11 @@ pub struct GramIndexBuildPolicy {
 impl GramIndexBuildPolicy {
     /// Zero-valued budgets would report progress without doing work (a
     /// zero file budget consumes no commit yet returns up to date); every
-    /// step normalizes to at least one unit of each budget.
-    fn normalized(self) -> Self {
+    /// step normalizes to at least one unit of each budget. Build and fold
+    /// steps normalize their argument themselves; runtimes converting
+    /// external configuration into a policy should still normalize at that
+    /// boundary so the stored policy reads as the one that will run.
+    pub fn normalized(self) -> Self {
         Self {
             max_files_per_step: self.max_files_per_step.max(1),
             max_content_bytes_per_step: self.max_content_bytes_per_step.max(1),

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -8272,3 +8272,207 @@ async fn grep_scope_stale_cut_and_single_line_files() {
         assert!(response.matches.is_empty());
     }
 }
+
+/// Counts store GETs against gram index segment objects, so tests can
+/// assert how many posting-probe reads a query cost.
+#[derive(Debug)]
+struct IndexSegmentGetCountingStore {
+    inner: LocalFsStore,
+    index_segment_gets: Mutex<usize>,
+}
+
+impl IndexSegmentGetCountingStore {
+    fn new(inner: LocalFsStore) -> Self {
+        Self {
+            inner,
+            index_segment_gets: Mutex::new(0),
+        }
+    }
+
+    fn index_segment_gets(&self) -> usize {
+        *self
+            .index_segment_gets
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn record_if_index_segment(&self, key: &str) {
+        if key.contains("/metadata/indexes/") {
+            *self
+                .index_segment_gets
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for IndexSegmentGetCountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record_if_index_segment(key);
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record_if_index_segment(key);
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// Probing stops once the running intersection fits the page's
+/// verification budget (256 verified files): a rare 18-byte literal plans
+/// sixteen single-gram AND sets, but its first set already narrows the
+/// candidates far below the budget, so the other fifteen sets' posting
+/// probes are never issued. Results stay byte-identical to exhaustive
+/// verification — the stop only widens the candidate set, and the real
+/// pattern still runs over every candidate, including the decoy that
+/// shares the first probed gram.
+#[tokio::test]
+async fn grep_stops_probing_once_the_intersection_fits_the_page_budget() {
+    let temp_dir = tempdir().expect("temp dir");
+    let store =
+        IndexSegmentGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grep-probe-budget").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // Three true matches carrying the full literal, and one decoy that
+    // carries only the first probed gram (`-bu`, the smallest gram of the
+    // literal, probed first because the plan's sets are sorted): the decoy
+    // rides the widened candidate set into verification and is rejected
+    // there, exactly where a full probe's later sets would have pruned it.
+    let pattern_literal = "loon-gram-budget-x";
+    let matching = [
+        ("/alpha.txt", "alpha keeps loon-gram-budget-x notes\n"),
+        ("/bravo.txt", "bravo tracks loon-gram-budget-x drift\n"),
+        ("/charlie.txt", "charlie files loon-gram-budget-x wins\n"),
+    ];
+    for (path, content) in matching {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            path,
+            content.as_bytes(),
+            &context,
+            None,
+        )
+        .await
+        .expect("write matching file");
+    }
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/decoy.txt",
+        b"carbon-buffer ledger\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write decoy");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint");
+    enable_grams_index(&store, &namespace_id, &context)
+        .await
+        .expect("enable");
+    drain_grams_index(
+        &store.inner,
+        &namespace_id,
+        &context,
+        GramIndexBuildPolicy::default(),
+    )
+    .await;
+
+    // The premises that make the GET arithmetic below meaningful: the
+    // pattern plans sixteen single-gram AND sets, and one segment holds
+    // every posting, so a full probe would touch all sixteen (gram,
+    // segment) pairs — at least one segment GET each with no decoded-block
+    // cache attached.
+    let crate::query::grep_plan::GramPlanOutcome::Indexable(plan) =
+        crate::query::grep_plan::plan_pattern(pattern_literal, false).expect("plan")
+    else {
+        panic!("an 18-byte literal must be indexable");
+    };
+    assert_eq!(plan.required.len(), 16, "sixteen single-gram AND sets");
+    assert!(
+        plan.required.iter().all(|set| set.len() == 1),
+        "a literal plans singleton sets"
+    );
+    let grams_segments = live_index_files(&store.inner, &namespace_id)
+        .await
+        .into_iter()
+        .filter(|descriptor| descriptor.family == INDEX_FAMILY_GRAMS)
+        .count();
+    assert_eq!(grams_segments, 1, "one delta run holds every posting");
+
+    let gets_before = store.index_segment_gets();
+    let view = crate::path::read::load_metadata_view(
+        &store,
+        &namespace_id,
+        crate::path::read::ReadLoadContext::latest(),
+    )
+    .await
+    .expect("load view");
+    let response = view
+        .grep(&store, &grep_request(pattern_literal))
+        .await
+        .expect("grep");
+    let probe_gets = store.index_segment_gets() - gets_before;
+
+    // (a) Results are byte-identical to exhaustive verification of the
+    // known corpus: every literal-carrying file's line, nothing from the
+    // decoy the stopped plan admitted as a candidate.
+    assert!(response.tail_scanned);
+    assert!(response.next_cursor.is_none());
+    let found: Vec<(&str, &str)> = response
+        .matches
+        .iter()
+        .map(|found| (found.absolute_path.as_str(), found.line.as_str()))
+        .collect();
+    let expected: Vec<(&str, &str)> = matching
+        .iter()
+        .map(|(path, content)| (*path, content.trim_end_matches('\n')))
+        .collect();
+    assert_eq!(found, expected);
+
+    // (b) Fewer index-segment GETs than a full sixteen-gram probe would
+    // need: sixteen surviving probes cost at least one GET each uncached,
+    // so strictly under sixteen proves sets were skipped (the stopped run
+    // reads one index block and one posting block).
+    assert!(probe_gets > 0, "the probe must read the cold index segment");
+    assert!(
+        probe_gets < 16,
+        "stopping after the first AND set must probe fewer than the plan's \
+         sixteen sets, got {probe_gets} GETs"
+    );
+}

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -195,8 +195,10 @@ impl GramLookup {
 /// One gram's postings from one segment: bloom filter first (the inline
 /// copy when the descriptor carries one — no fetch at all — otherwise the
 /// cached filter block), then only the data blocks the segment index
-/// names for the gram's key range. Every fetched section resolves through
-/// the shared decoded-block cache when one is attached.
+/// names for the gram's key range, loaded concurrently in chunks of
+/// [`MAX_GREP_READ_IO`] (the cap applies per probe). Every fetched
+/// section resolves through the shared decoded-block cache when one is
+/// attached.
 async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -243,29 +245,37 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     .await?;
     let range =
         index_blocks_for_key_range(&entries, &gram_lookup.prefix, gram_lookup.upper.as_deref());
-    for entry in &entries[range] {
-        let block = load_index_segment_data_block(
-            store,
-            table_cache,
-            CacheAdmission::Admit,
-            &descriptor.object_key,
-            &descriptor.payload_checksum,
-            &entry.block,
-        )
+    // The range's blocks are independent ranged GETs, so they fan out
+    // instead of paying one round trip each; `try_join_all` returns them
+    // in entry order and rows fold in that order, so assembly stays
+    // deterministic even though the posting union is order-independent.
+    for chunk in entries[range].chunks(MAX_GREP_READ_IO) {
+        let blocks = try_join_all(chunk.iter().map(|entry| {
+            load_index_segment_data_block(
+                store,
+                table_cache,
+                CacheAdmission::Admit,
+                &descriptor.object_key,
+                &descriptor.payload_checksum,
+                &entry.block,
+            )
+        }))
         .await?;
-        for row in &block.rows {
-            let IndexRow::GramPostings { gram: row_gram, .. } = row;
-            if *row_gram != gram_lookup.gram {
-                continue;
+        for block in blocks {
+            for row in &block.rows {
+                let IndexRow::GramPostings { gram: row_gram, .. } = row;
+                if *row_gram != gram_lookup.gram {
+                    continue;
+                }
+                let batch = row.postings().map_err(|error| {
+                    index_segment_corrupt(&descriptor.object_key, "posting batch", &error)
+                })?;
+                postings.extend(
+                    batch
+                        .into_iter()
+                        .map(|posting| (posting.inode_id, posting.revision_no)),
+                );
             }
-            let batch = row.postings().map_err(|error| {
-                index_segment_corrupt(&descriptor.object_key, "posting batch", &error)
-            })?;
-            postings.extend(
-                batch
-                    .into_iter()
-                    .map(|posting| (posting.inode_id, posting.revision_no)),
-            );
         }
     }
     Ok(postings)
@@ -426,6 +436,16 @@ pub(super) struct VisiblePathChain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::stream::BoxStream;
+    use loonfs_api::wire::index_grams::GramPosting;
+    use loonfs_api::wire::manifest::hex_encode_bytes;
+    use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
+    use loonfs_api::{sha256_digest, IndexSegmentId};
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn pattern(text: &str) -> regex::bytes::Regex {
         regex::bytes::Regex::new(text).expect("pattern")
@@ -459,5 +479,179 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].line_number, 2);
         assert_eq!(matches[0].line, "two needle");
+    }
+
+    /// Tracks how many GETs are in flight against the store at once. The
+    /// yield before each forwarded read lets sibling fetches issued in
+    /// the same fan-out begin before this one completes, so the peak
+    /// observes overlap exactly when the caller issued the GETs
+    /// concurrently; serial callers can never raise it above one.
+    #[derive(Debug)]
+    struct InFlightGetProbeStore {
+        inner: LocalFsStore,
+        in_flight: AtomicUsize,
+        peak: AtomicUsize,
+    }
+
+    impl InFlightGetProbeStore {
+        fn new(root: &std::path::Path) -> Self {
+            Self {
+                inner: LocalFsStore::new(root).expect("create local-fs store"),
+                in_flight: AtomicUsize::new(0),
+                peak: AtomicUsize::new(0),
+            }
+        }
+
+        fn peak_in_flight(&self) -> usize {
+            self.peak.load(Ordering::SeqCst)
+        }
+
+        async fn probed<T, F>(&self, read: F) -> T
+        where
+            F: std::future::Future<Output = T>,
+        {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(now, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            let result = read.await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            result
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for InFlightGetProbeStore {
+        async fn head(
+            &self,
+            key: &str,
+        ) -> std::result::Result<Option<ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> std::result::Result<Option<ObjectBody>, ObjectStoreError> {
+            self.probed(self.inner.get_with_metadata(key)).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<ByteRange>,
+        ) -> std::result::Result<Option<Bytes>, ObjectStoreError> {
+            self.probed(self.inner.get(key, range)).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: Bytes,
+            mode: PutMode,
+        ) -> std::result::Result<ObjectMetadata, ObjectStoreError> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> std::result::Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            prefix: &str,
+        ) -> BoxStream<'static, std::result::Result<String, ObjectStoreError>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    /// One probe whose key range spans many data blocks must load those
+    /// blocks concurrently, within [`MAX_GREP_READ_IO`], and still
+    /// assemble the postings the serial walk produced.
+    ///
+    /// The segment is built directly with a one-byte block target so each
+    /// posting row closes its own data block: production blocks target 64
+    /// KiB, so a single gram's range only spans several blocks after tens
+    /// of thousands of postings — far past what a test corpus can write —
+    /// and the build policy's `max_rows_per_segment` splits segments,
+    /// never blocks. Block layout is a read-side contract the descriptor
+    /// fully describes, so a reader must serve any valid layout.
+    #[tokio::test]
+    async fn a_probes_data_block_loads_overlap_within_the_read_cap() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let store = InFlightGetProbeStore::new(temp_dir.path());
+        let namespace_id = NamespaceId::parse("probe-fan-out").expect("namespace id");
+        let gram = Gram(*b"nee");
+
+        // Sixty-four single-posting rows for one gram: with the one-byte
+        // block target every row lands in its own data block, so the
+        // gram's key range names sixty-four blocks — four full fan-out
+        // chunks at the current cap.
+        let expected: BTreeSet<(InodeId, RevisionNo)> =
+            (1..=64u64).map(|i| (InodeId(i), RevisionNo(1))).collect();
+        let mut builder = SegmentBlocksBuilder::new(1);
+        for (inode_id, revision_no) in &expected {
+            let row = IndexRow::gram_postings(
+                gram,
+                &[GramPosting {
+                    inode_id: *inode_id,
+                    revision_no: *revision_no,
+                }],
+            )
+            .expect("build posting row");
+            builder
+                .push(&row.row_key(), &row.filter_key(), &row)
+                .expect("push row");
+        }
+        let built = builder.finish().expect("finish segment");
+
+        let object_key = "namespaces/probe-fan-out/metadata/indexes/seg-probe.idx.zst";
+        store
+            .put(
+                object_key,
+                Bytes::from(built.bytes.clone()),
+                PutMode::CreateIfAbsent,
+            )
+            .await
+            .expect("write segment object");
+        let filter_start = built.filter.offset as usize;
+        let filter_inline = hex_encode_bytes(
+            &built.bytes[filter_start..filter_start + built.filter.stored_len as usize],
+        );
+        let descriptor = IndexFileRef {
+            owner_namespace_id: namespace_id,
+            segment_id: IndexSegmentId::generate(),
+            object_key: object_key.to_owned(),
+            family: INDEX_FAMILY_GRAMS.to_owned(),
+            run_seq: ChangeSeq(1),
+            run_ordinal: 0,
+            level: 0,
+            segment_index: 0,
+            row_count: built.row_count,
+            min_key: built.min_key.clone(),
+            max_key: built.max_key.clone(),
+            index_block: built.index,
+            filter_block: built.filter,
+            // Inline so the probe starts at the index block: the one GET
+            // issued before the data fan-out, which therefore can never
+            // raise the peak above one by itself.
+            filter_inline: Some(filter_inline),
+            payload_checksum: sha256_digest(&built.bytes),
+        };
+
+        let postings = segment_postings_for_gram(&store, None, &descriptor, &GramLookup::new(gram))
+            .await
+            .expect("probe postings");
+
+        assert_eq!(postings, expected, "every block's posting must arrive");
+        let peak = store.peak_in_flight();
+        assert!(
+            peak > 1,
+            "a multi-block probe's data-block loads must overlap, got a \
+             serial peak of {peak}"
+        );
+        assert!(
+            peak <= MAX_GREP_READ_IO,
+            "the probe's fan-out must respect the grep read cap, got {peak}"
+        );
     }
 }

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -36,13 +36,25 @@ pub(super) const GREP_LINE_CAP_BYTES: usize = 512;
 /// resume cursor, so a page's cost is bounded by its own budget rather
 /// than by how many false-positive candidates the plan admits.
 pub(super) const MAX_GREP_VERIFIED_FILES_PER_PAGE: usize = 256;
-/// Concurrent store reads one grep query issues at a time: gram posting
-/// probes fan out across (gram, segment) pairs and candidate content
-/// reads fan out across verified files, both in chunks of this size — the
-/// "small fixed fan-out" the design doc names for candidate reads
-/// (docs/design/content-search-index.md), the read-side sibling of the
-/// maintenance path's `MAX_MAINTENANCE_TABLE_IO` (`checkpoint/runs.rs`).
-pub(super) const MAX_GREP_READ_IO: usize = 8;
+/// Concurrent gram posting probes one grep query issues at a time: the
+/// (gram, segment) probes of an OR-set fan out in chunks of this size,
+/// each probe a handful of small ranged GETs (filter, index, and posting
+/// blocks). Deliberately below [`MAX_GREP_CONTENT_IO`]: probes multiply
+/// into many small requests per chunk, where a content read is one whole
+/// object. The read-side sibling of the maintenance path's
+/// `MAX_MAINTENANCE_TABLE_IO` (`checkpoint/runs.rs`), which stays at its
+/// own value.
+pub(super) const MAX_GREP_READ_IO: usize = 16;
+/// Concurrent candidate content reads one grep query issues at a time.
+/// Content verification is a whole-object GET of a small file (index
+/// eligibility caps candidates at `INDEX_GRAMS_MAX_FILE_BYTES`), so it
+/// tolerates a wider fan-out than the posting probes: 32 matches the
+/// content-object concurrency the ecosystem already runs against these
+/// stores (bulk content uploads fan out 32 wide). Each batch is
+/// additionally bounded by the remaining
+/// [`MAX_GREP_VERIFIED_FILES_PER_PAGE`] budget, so a page issues at most
+/// that many content reads however wide the batches are.
+pub(super) const MAX_GREP_CONTENT_IO: usize = 32;
 
 /// The revisions a query must examine, keyed by durable inode identity.
 #[derive(Debug, Default)]

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -93,6 +93,19 @@ impl GrepCandidates {
 /// [`MAX_GREP_READ_IO`]; the sets union order-independently, so the
 /// result is identical to a serial evaluation, and an AND set whose
 /// running intersection empties still short-circuits the sets after it.
+///
+/// Probing also stops once the running intersection fits the page's
+/// verification budget ([`MAX_GREP_VERIFIED_FILES_PER_PAGE`]): further AND
+/// sets could only shrink a candidate set the page can already afford to
+/// verify whole. The invariant that makes this sound: dropping AND
+/// constraints only WIDENS the candidate set, and verification runs the
+/// real pattern over every candidate, so grep results are byte-identical
+/// — the only effect is fewer cold posting reads (a rare literal's 16
+/// single-gram sets typically stop after the first few). The stop rule is
+/// deliberately this simple; a refinement that also stops when an AND set
+/// fails to shrink the intersection materially (common terms whose grams
+/// match nearly everything) is left out until evidence demands a
+/// heuristic.
 pub(super) async fn indexed_candidates<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -136,6 +149,16 @@ pub(super) async fn indexed_candidates<S: ObjectStore + ?Sized>(
             Some(current) => current.intersection(&set_postings).copied().collect(),
         });
         if intersection.as_ref().is_some_and(BTreeSet::is_empty) {
+            break;
+        }
+        // The budget stop: the intersection holds (inode, revision) pairs,
+        // an upper bound on the files a page could ever verify from it, so
+        // once it fits the per-page verification budget the remaining AND
+        // sets are constraints the page cannot use.
+        if intersection
+            .as_ref()
+            .is_some_and(|candidates| candidates.len() <= MAX_GREP_VERIFIED_FILES_PER_PAGE)
+        {
             break;
         }
     }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -3,7 +3,7 @@
 
 use super::grep::{
     derive_visible_path, indexed_candidates, line_matches, tail_revisions, GrepCandidates,
-    DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_READ_IO, MAX_GREP_SCAN_FILES,
+    DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_CONTENT_IO, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
     MAX_GREP_TAIL_FILES, MAX_GREP_VERIFIED_FILES_PER_PAGE,
 };
 use super::listing::{invalid_cursor, page_head_seq, validate_directory_cursor};
@@ -539,7 +539,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                     path: chain.path,
                     oversized,
                 });
-                if batch.len() == MAX_GREP_READ_IO {
+                if batch.len() == MAX_GREP_CONTENT_IO {
                     break;
                 }
             }

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1,7 +1,7 @@
 //! Server configuration: strict TOML decoding of the listen address,
 //! store, and runtime cache overrides.
 
-use loonfs::RuntimeCacheConfig;
+use loonfs::{GramIndexBuildPolicy, RuntimeCacheConfig};
 use loonfs_objectstore::{ConfiguredObjectStore, SecretString, StoreConfigError};
 use serde::Deserialize;
 use std::env;
@@ -39,6 +39,14 @@ pub struct ServerConfig {
     pub writer_version: String,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
+    /// Budgets for the gram index build and fold steps run by this
+    /// server's maintenance (background catch-up after writes and explicit
+    /// ticks). Omitted fields keep the runtime defaults; bulk backfills
+    /// typically raise the per-step budgets so each tick indexes more
+    /// files per manifest publish. Zero values are normalized up to one
+    /// unit by the runtime.
+    #[serde(default)]
+    pub gram_index_build: GramIndexBuildPolicyOverrides,
     /// Whether the server writer schedules maintenance (checkpoints and
     /// reorganization folds) after writes that cross the WAL-tail
     /// threshold. On by default; set `false` on write-serving nodes when a
@@ -76,6 +84,19 @@ pub struct RuntimeCacheConfigOverrides {
     pub max_cached_wal_tail_projection_rows: Option<usize>,
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
+}
+
+/// Optional `[gram_index_build]` overrides, field-for-field the budgets of
+/// [`GramIndexBuildPolicy`]; omitted fields keep that policy's defaults.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GramIndexBuildPolicyOverrides {
+    pub max_files_per_step: Option<usize>,
+    pub max_content_bytes_per_step: Option<u64>,
+    pub max_rows_per_segment: Option<usize>,
+    pub max_l0_runs: Option<usize>,
+    pub max_mid_runs: Option<usize>,
+    pub max_fold_rows_per_step: Option<usize>,
 }
 
 #[derive(Debug, Error)]
@@ -133,6 +154,31 @@ impl ServerConfig {
             config.metadata_table_cache.max_decoded_bytes = value;
         }
         config
+    }
+
+    pub fn gram_index_build_policy(&self) -> GramIndexBuildPolicy {
+        let mut policy = GramIndexBuildPolicy::default();
+        if let Some(value) = self.gram_index_build.max_files_per_step {
+            policy.max_files_per_step = value;
+        }
+        if let Some(value) = self.gram_index_build.max_content_bytes_per_step {
+            policy.max_content_bytes_per_step = value;
+        }
+        if let Some(value) = self.gram_index_build.max_rows_per_segment {
+            policy.max_rows_per_segment = value;
+        }
+        if let Some(value) = self.gram_index_build.max_l0_runs {
+            policy.max_l0_runs = value;
+        }
+        if let Some(value) = self.gram_index_build.max_mid_runs {
+            policy.max_mid_runs = value;
+        }
+        if let Some(value) = self.gram_index_build.max_fold_rows_per_step {
+            policy.max_fold_rows_per_step = value;
+        }
+        // Every budget runs normalized (at least one unit), so the policy
+        // handed to the runtime is the one maintenance will execute.
+        policy.normalized()
     }
 
     pub fn object_store(&self) -> Result<ConfiguredObjectStore, ServerConfigError> {
@@ -742,11 +788,27 @@ kind = "local-fs"
 root = "/tmp/loonfs-server"
 "#,
         );
+        let gram_index_build_level = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[gram_index_build]
+max_files_per_stepp = 3
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
 
         for (path, typo) in [
             (top_level, "lease_duration"),
             (store_level, "key_prefiks"),
             (runtime_cache_level, "max_cached_namespacs"),
+            (gram_index_build_level, "max_files_per_stepp"),
         ] {
             let error = load_server_config(&path).expect_err("typo'd key must be rejected");
             match error {
@@ -868,6 +930,96 @@ root = "/tmp/loonfs-server"
             .expect("load config")
             .runtime_cache_config();
         assert_eq!(config, loonfs::RuntimeCacheConfig::disabled());
+    }
+
+    #[test]
+    fn load_uses_default_gram_index_build_policy_when_omitted() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let config = load_server_config(&path).expect("load config");
+        assert_eq!(
+            config.gram_index_build_policy(),
+            loonfs::GramIndexBuildPolicy::default()
+        );
+    }
+
+    #[test]
+    fn load_applies_gram_index_build_overrides() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[gram_index_build]
+max_files_per_step = 4096
+max_content_bytes_per_step = 536870912
+max_rows_per_segment = 131072
+max_l0_runs = 4
+max_mid_runs = 6
+max_fold_rows_per_step = 262144
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let policy = load_server_config(&path)
+            .expect("load config")
+            .gram_index_build_policy();
+        assert_eq!(policy.max_files_per_step, 4096);
+        assert_eq!(policy.max_content_bytes_per_step, 536_870_912);
+        assert_eq!(policy.max_rows_per_segment, 131_072);
+        assert_eq!(policy.max_l0_runs, 4);
+        assert_eq!(policy.max_mid_runs, 6);
+        assert_eq!(policy.max_fold_rows_per_step, 262_144);
+    }
+
+    #[test]
+    fn gram_index_build_overrides_normalize_zero_budgets() {
+        // Zero budgets would let a step report progress without doing
+        // work; the conversion hands the runtime the normalized policy it
+        // will actually run.
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[gram_index_build]
+max_files_per_step = 0
+max_l0_runs = 0
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let policy = load_server_config(&path)
+            .expect("load config")
+            .gram_index_build_policy();
+        assert_eq!(policy.max_files_per_step, 1);
+        assert_eq!(policy.max_l0_runs, 1);
+        assert_eq!(
+            policy.max_mid_runs,
+            loonfs::GramIndexBuildPolicy::default().max_mid_runs,
+            "untouched budgets keep their defaults"
+        );
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -271,6 +271,7 @@ async fn build_handles_with_metrics_jsonl_path(
             FsBackgroundWork::ManualOnly
         })
         .runtime_cache(config.runtime_cache_config())
+        .gram_index_build(config.gram_index_build_policy())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
     if let Some(recorder) = metrics_recorder.clone() {
@@ -287,6 +288,7 @@ async fn build_handles_with_metrics_jsonl_path(
         // reuses blocks reader traffic already decoded instead of
         // populating a second, default-sized cache.
         .runtime_cache(config.runtime_cache_config())
+        .gram_index_build(config.gram_index_build_policy())
         .shared_metadata_table_cache(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -797,6 +797,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        gram_index_build: crate::config::GramIndexBuildPolicyOverrides::default(),
         background_maintenance: true,
         max_upload_bytes: 256 * 1024 * 1024,
         allow_unauthenticated_remote: false,

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -10,7 +10,8 @@ mod http;
 mod trace;
 
 pub use config::{
-    load_server_config, RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig,
+    load_server_config, GramIndexBuildPolicyOverrides, RuntimeCacheConfigOverrides, ServerConfig,
+    ServerConfigError, StoreConfig,
 };
 pub use http::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle};
 #[cfg(feature = "openapi")]

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -7,7 +7,9 @@ use loonfs_api::{
     FilesystemOperationResponse, PutBehavior,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loonfs_server::{app, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
+use loonfs_server::{
+    app, GramIndexBuildPolicyOverrides, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -26,6 +28,7 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-aws-s3".to_owned(),
         writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        gram_index_build: GramIndexBuildPolicyOverrides::default(),
         background_maintenance: true,
         max_upload_bytes: 256 * 1024 * 1024,
         allow_unauthenticated_remote: false,
@@ -55,6 +58,7 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-r2".to_owned(),
         writer_version: "direct-put-r2/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        gram_index_build: GramIndexBuildPolicyOverrides::default(),
         background_maintenance: true,
         max_upload_bytes: 256 * 1024 * 1024,
         allow_unauthenticated_remote: false,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1957,6 +1957,7 @@ fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        gram_index_build: loonfs_server::GramIndexBuildPolicyOverrides::default(),
         background_maintenance: true,
         max_upload_bytes: 256 * 1024 * 1024,
         allow_unauthenticated_remote: false,

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -2,7 +2,7 @@
 //! sizing, with the defaults the rest of the crate advertises.
 
 use crate::trace::{TraceMode, TraceStoreKind};
-use crate::{MetadataTableCacheConfig, Result, RuntimeError};
+use crate::{GramIndexBuildPolicy, MetadataTableCacheConfig, Result, RuntimeError};
 
 /// Default lease duration for write operations, in milliseconds.
 /// Default visible WAL-tail length, in segments, at which a maintenance tick
@@ -33,6 +33,10 @@ pub(crate) struct FsConfig {
     pub commit_window_ms: u64,
     /// Cache configuration.
     pub runtime_cache: RuntimeCacheConfig,
+    /// Budgets for the gram index build and fold steps this runtime's
+    /// maintenance ticks run. Stored normalized (every budget at least one
+    /// unit), so the config reads as the policy that will run.
+    pub gram_index_build: GramIndexBuildPolicy,
     /// Tracing mode label.
     pub trace_mode: TraceMode,
     /// Object-store kind label used by tracing.

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -99,6 +99,13 @@ impl FsCore {
         shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
     ) -> Result<Self> {
         validate_config(&config)?;
+        // Store the policy normalized so the config always reads as the
+        // budgets maintenance will actually run (the core normalizes again
+        // at each step; this keeps the two views identical).
+        let config = FsConfig {
+            gram_index_build: config.gram_index_build.normalized(),
+            ..config
+        };
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
             Arc::new(MetadataTableCache::new(
                 config.runtime_cache.metadata_table_cache.clone(),
@@ -494,20 +501,18 @@ impl FsCore {
             .copied()
     }
 
-    /// One bounded gram index build step, then one bounded fold step. A
-    /// namespace without the feature entry reports and costs nothing.
+    /// One bounded gram index build step, then one bounded fold step,
+    /// under the configured [`crate::GramIndexBuildPolicy`]. A namespace
+    /// without the feature entry reports and costs nothing.
     async fn run_tick_grams_index(&self, namespace_id: &NamespaceId) -> Result<bool> {
-        self.run_tick_grams_index_with_policy(
-            namespace_id,
-            loonfs_core::GramIndexBuildPolicy::default(),
-        )
-        .await
+        self.run_tick_grams_index_with_policy(namespace_id, self.inner.config.gram_index_build)
+            .await
     }
 
     /// [`Self::run_tick_grams_index`] with explicit budgets. Production
-    /// paths run the defaults; tests inject small budgets to shape states
-    /// — like a multi-step fold — the defaults never produce at test
-    /// scale.
+    /// paths run the handle's configured policy; tests inject small
+    /// budgets to shape states — like a multi-step fold — that neither
+    /// the defaults nor any sane configuration produce at test scale.
     async fn run_tick_grams_index_with_policy(
         &self,
         namespace_id: &NamespaceId,
@@ -591,15 +596,13 @@ impl FsCore {
         Ok(published)
     }
 
-    /// Builds gram index steps until the watermark reaches the head. Only
-    /// writer-scheduled background ticks drain like this, mirroring
+    /// Builds gram index steps until the watermark reaches the head,
+    /// each step under the configured [`crate::GramIndexBuildPolicy`].
+    /// Only writer-scheduled background ticks drain like this, mirroring
     /// [`Self::drain_reorganization_backlog`].
     async fn drain_grams_index_backlog(&self, namespace_id: &NamespaceId) -> Result<()> {
-        self.drain_grams_index_backlog_with_policy(
-            namespace_id,
-            loonfs_core::GramIndexBuildPolicy::default(),
-        )
-        .await
+        self.drain_grams_index_backlog_with_policy(namespace_id, self.inner.config.gram_index_build)
+            .await
     }
 
     /// [`Self::drain_grams_index_backlog`] with explicit budgets, for the

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -7,9 +7,10 @@ use crate::fs::FsCore;
 use crate::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, FlushWalResponse, GcConfig, GcReport,
-    MaintenanceTickOptions, MaintenanceTickResult, NamespaceId, NamespaceStatusResponse,
-    ObjectStoreMetricsRecorder, ReleaseCheckpointResponse, Result, RuntimeCacheConfig,
-    RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    GramIndexBuildPolicy, MaintenanceTickOptions, MaintenanceTickResult, NamespaceId,
+    NamespaceStatusResponse, ObjectStoreMetricsRecorder, ReleaseCheckpointResponse, Result,
+    RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
+    TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -197,6 +198,16 @@ impl FsAdminBuilder {
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;
+        self
+    }
+
+    /// Sets the gram index build budgets this handle's explicit
+    /// maintenance ticks run instead of [`GramIndexBuildPolicy::default`].
+    /// Bulk backfills raise the per-step budgets so a tick indexes more
+    /// files per manifest publish. Values are normalized to at least one
+    /// unit per budget.
+    pub fn gram_index_build(mut self, policy: GramIndexBuildPolicy) -> Self {
+        self.core.gram_index_build = policy;
         self
     }
 

--- a/crates/loonfs/src/handle/mod.rs
+++ b/crates/loonfs/src/handle/mod.rs
@@ -30,8 +30,8 @@ use crate::background::BackgroundWork;
 use crate::config::FsConfig;
 use crate::fs::FsCore;
 use crate::{
-    ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore,
-    StoreConfig, TraceMode, TraceStoreKind,
+    GramIndexBuildPolicy, ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError,
+    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use loonfs_core::cache::MetadataTableCache;
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
@@ -51,6 +51,7 @@ struct HandleBuilderCore {
     source: StoreSource,
     commit_window_ms: u64,
     runtime_cache: RuntimeCacheConfig,
+    gram_index_build: GramIndexBuildPolicy,
     /// An existing decoded-block cache to share instead of sizing a fresh
     /// one from `runtime_cache`; see [`FsCore::open_with_background`].
     shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
@@ -73,6 +74,7 @@ impl HandleBuilderCore {
             source,
             commit_window_ms: crate::config::DEFAULT_COMMIT_WINDOW_MS,
             runtime_cache: RuntimeCacheConfig::default(),
+            gram_index_build: GramIndexBuildPolicy::default(),
             shared_metadata_table_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
@@ -110,6 +112,7 @@ impl HandleBuilderCore {
                 writer_version,
                 commit_window_ms: self.commit_window_ms,
                 runtime_cache: self.runtime_cache,
+                gram_index_build: self.gram_index_build,
                 trace_mode: self.trace_mode,
                 trace_store_kind,
             },

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -10,7 +10,7 @@ use crate::{
     CapabilityDocument, CommitRequest, CommitResponse, CompleteUploadRequest,
     CompleteUploadResponse, ContentRef, CopyOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    InodeId, MoveOptions, MutationResult, NamespaceId, NamespaceSummary,
+    GramIndexBuildPolicy, InodeId, MoveOptions, MutationResult, NamespaceId, NamespaceSummary,
     ObjectStoreMetricsRecorder, PutFileOptions, RestoreRevisionOptions, Result, RevisionNo,
     RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind, UploadContentResponse, UploadId,
@@ -404,6 +404,16 @@ impl FsWriterBuilder {
     /// Sets runtime cache behavior.
     pub fn runtime_cache(mut self, runtime_cache: RuntimeCacheConfig) -> Self {
         self.core.runtime_cache = runtime_cache;
+        self
+    }
+
+    /// Sets the gram index build budgets this writer's maintenance runs —
+    /// the background catch-up ticks scheduled after writes — instead of
+    /// [`GramIndexBuildPolicy::default`]. Bulk backfills raise the
+    /// per-step budgets so a tick indexes more files per manifest publish.
+    /// Values are normalized to at least one unit per budget.
+    pub fn gram_index_build(mut self, policy: GramIndexBuildPolicy) -> Self {
+        self.core.gram_index_build = policy;
         self
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -65,6 +65,7 @@ pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapNamespaceError, DeleteNamespaceOptions,
     DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind, GcConfig, GcReport,
+    GramIndexBuildPolicy,
 };
 
 /// Integration seam: the vocabulary for handing classified mutation work to

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1397,6 +1397,7 @@ mod tests {
                 // windows would only add latency to these tests.
                 commit_window_ms: 0,
                 runtime_cache: RuntimeCacheConfig::default(),
+                gram_index_build: crate::GramIndexBuildPolicy::default(),
                 trace_mode: TraceMode::Remote,
                 trace_store_kind: TraceStoreKind::LocalFs,
             },

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -8,11 +8,13 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs::{
-    CreateNamespaceOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepRequest,
-    MaintenanceTickOptions, NamespaceId, PutFileOptions,
+    ChangeSeq, CreateNamespaceOptions, ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter,
+    GramIndexBuildPolicy, GrepRequest, MaintenanceTickOptions, NamespaceId, PutFileOptions,
 };
 use loonfs_api::decode_grep_cursor;
-use loonfs_api::wire::index_grams::INDEX_GRAMS_MAX_FILE_BYTES;
+use loonfs_api::wire::index_grams::{
+    IndexGramsFeature, INDEX_GRAMS_FEATURE_KEY, INDEX_GRAMS_MAX_FILE_BYTES,
+};
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -47,6 +49,32 @@ async fn content_blob_keys(store: &loonfs::SharedObjectStore) -> BTreeSet<String
         .into_iter()
         .filter(|key| key.contains("/blobs/sha256/"))
         .collect()
+}
+
+/// The `index.grams` watermark from the namespace's current manifest.
+async fn grams_built_through_seq(
+    store: &loonfs::SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> ChangeSeq {
+    let root = loonfs_core::control::load_namespace_metadata_root_control(&**store, namespace_id)
+        .await
+        .expect("metadata root");
+    let manifest_key =
+        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_bytes = store
+        .get(&manifest_key, None)
+        .await
+        .expect("read namespace manifest")
+        .expect("namespace manifest exists");
+    let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
+    let value = manifest
+        .payload
+        .features
+        .get(INDEX_GRAMS_FEATURE_KEY)
+        .expect("index.grams feature present");
+    IndexGramsFeature::from_value(value)
+        .expect("decode feature value")
+        .built_through_seq
 }
 
 #[tokio::test]
@@ -245,6 +273,89 @@ async fn a_publish_below_the_wal_threshold_still_schedules_index_catch_up() {
         .expect("stale grep after background catch-up");
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.matches[0].absolute_path, "/delta.txt");
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// A build policy set through the handle builder reaches the maintenance
+/// tick path: with `max_files_per_step: 3`, one tick's build step consumes
+/// exactly three of the five pending file commits — the watermark lands on
+/// the third put's committed seq — and the next tick consumes the rest.
+/// Under the default 256-file budget the first tick would have caught up
+/// to the head outright, so the intermediate watermark is exactly the
+/// configured budget observed in effect.
+#[tokio::test]
+async fn a_configured_build_policy_bounds_each_ticks_build_step() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: loonfs::SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grams-config-policy").expect("namespace id");
+
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-config-writer")
+        .commit_window_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-config-admin")
+        .gram_index_build(GramIndexBuildPolicy {
+            max_files_per_step: 3,
+            ..GramIndexBuildPolicy::default()
+        })
+        .build()
+        .await
+        .expect("build admin");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    // Materialize the (empty) backfill so the ticks below run pure WAL
+    // catch-up, where the file budget maps one-to-one onto the puts.
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("materializing tick");
+
+    let mut put_seqs = Vec::new();
+    for index in 0..5u32 {
+        let result = writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/notes/needle-{index}.txt"),
+                format!("a needle numbered {index}\n").as_bytes(),
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("write file");
+        put_seqs.push(result.committed_seq);
+    }
+
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("first bounded tick");
+    let after_first = grams_built_through_seq(&store, &namespace_id).await;
+    assert_eq!(
+        after_first, put_seqs[2],
+        "a three-file budget must stop the build step exactly after the \
+         third put's commit"
+    );
+
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("second bounded tick");
+    let after_second = grams_built_through_seq(&store, &namespace_id).await;
+    assert_eq!(
+        after_second, put_seqs[4],
+        "the next tick must consume the remaining two commits"
+    );
 
     writer.shutdown_background().await.expect("writer shutdown");
 }


### PR DESCRIPTION
Follow-on tuning to the grep read-path stack, four independent pieces:

Content-verification reads now fan out 32 wide (whole-object GETs of small files, matching the ecosystem's content-object concurrency) while posting-block probes widen to 16 — the two workloads deserve different constants. Gram probing stops once the running intersection already fits the page's verification budget: dropping AND constraints only widens a candidate set the verifier re-checks anyway, so results are byte-identical while a rare literal's cold probe cost drops sharply (16x fewer index-segment GETs in the pinned test). A probe's data blocks within one segment now load concurrently instead of one at a time. And GramIndexBuildPolicy is exposed through loonfs builder config and the server's TOML ([gram_index_build]), so bulk backfills can raise per-tick budgets without recompiling; defaults unchanged.

Stacked on #265.