### PR TITLE
fix(loonfs): commit-window cancellation reports honest outcomes

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -17,7 +17,7 @@ use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCom
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};
 use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NamespaceMutationCandidate {
@@ -86,17 +86,39 @@ pub struct ResultingReadState {
     pub tail_rows: Arc<MetadataState>,
 }
 
-#[derive(Debug, Clone)]
-pub struct NamespaceCommitEngine {
-    namespace_id: NamespaceId,
-    publish_tail_projection: Option<PublishTailProjection>,
+/// Writer-session state for one namespace: the epoch this session acquired
+/// and its terminal fencing record.
+///
+/// This is authoritative session state, not a cache of durable state —
+/// nothing in the store can rebuild "this session was fenced". Runtimes keep
+/// one shared instance per namespace in a registry that outlives every
+/// rebuildable cache (invalidation, LRU eviction, cache-disabled
+/// configurations) and hand it to each engine they build for the namespace.
+/// An engine built without one gets private state, which keeps the
+/// documented one-shot semantics: each one-shot commit is its own
+/// acquisition decision.
+#[derive(Debug, Default)]
+pub struct WriterSessionState {
     /// Epoch acquired lazily on this session's first publish and reused for
     /// its lifetime; no per-publish acquisition CAS.
     acquired_writer: Option<AcquiredWriter>,
     /// Terminal fencing record. Once another session supersedes our epoch,
     /// every later publish fails with `writer_fenced` without touching the
-    /// store; the session never reacquires on its own.
+    /// store; the session never reacquires on its own. Reacquisition is an
+    /// explicit caller decision, left to a future takeover API.
     fenced: Option<String>,
+}
+
+/// Shared handle to one namespace's [`WriterSessionState`].
+pub type SharedWriterSessionState = Arc<Mutex<WriterSessionState>>;
+
+#[derive(Debug, Clone)]
+pub struct NamespaceCommitEngine {
+    namespace_id: NamespaceId,
+    publish_tail_projection: Option<PublishTailProjection>,
+    /// This session's epoch and fencing for the namespace; see
+    /// [`WriterSessionState`].
+    session: SharedWriterSessionState,
     /// Local monotonic source for the self-enforced publish budget.
     timer: Arc<dyn MonotonicTimer>,
     /// Shared decoded-block cache for publish-view table reads. Blocks are
@@ -113,12 +135,27 @@ impl NamespaceCommitEngine {
         Self {
             namespace_id,
             publish_tail_projection: None,
-            acquired_writer: None,
-            fenced: None,
+            session: SharedWriterSessionState::default(),
             timer: Arc::new(StdMonotonicTimer::default()),
             table_cache: None,
             catalog_entry: None,
         }
+    }
+
+    /// Attaches the runtime's session state for this namespace, so the
+    /// acquired epoch and fencing outlive this engine instance.
+    pub fn with_writer_session(mut self, session: SharedWriterSessionState) -> Self {
+        self.session = session;
+        self
+    }
+
+    fn lock_session(&self) -> std::sync::MutexGuard<'_, WriterSessionState> {
+        // Poisoning is propagated as a panic: every critical section is a
+        // plain field read or write, so a poisoned lock means another
+        // thread panicked mid-update.
+        self.session
+            .lock()
+            .expect("writer session state lock poisoned")
     }
 
     #[cfg(test)]
@@ -138,9 +175,10 @@ impl NamespaceCommitEngine {
     }
 
     pub fn invalidate(&mut self) {
-        // Drops only the tail projection. The acquired epoch is a number
-        // whose validity is re-checked against the head on every publish
-        // view load, and a fenced session stays fenced.
+        // Drops only the tail projection. The acquired epoch and fencing
+        // are session state, not cached state: the epoch's validity is
+        // re-checked against the head on every publish view load, and a
+        // fenced session stays fenced.
         self.publish_tail_projection = None;
     }
 
@@ -175,18 +213,40 @@ impl NamespaceCommitEngine {
         }
 
         let candidate_count = candidates.len();
-        if let Some(message) = &self.fenced {
-            return NamespaceCommitEnginePublishResult {
-                results: repeated_error(candidate_count, CoreError::WriterFenced(message.clone())),
-                wal_tail_segments: 0,
-                resulting_read_state: None,
-            };
-        }
-        let acquired_writer = match &self.acquired_writer {
-            Some(value) => value.clone(),
+        let already_acquired = {
+            let session = self.lock_session();
+            if let Some(message) = &session.fenced {
+                let message = message.clone();
+                drop(session);
+                return NamespaceCommitEnginePublishResult {
+                    results: repeated_error(candidate_count, CoreError::WriterFenced(message)),
+                    wal_tail_segments: 0,
+                    resulting_read_state: None,
+                };
+            }
+            session.acquired_writer.clone()
+        };
+        let acquired_writer = match already_acquired {
+            Some(value) => value,
             None => match acquire_writer_epoch(store, &self.namespace_id, context).await {
                 Ok(value) => {
-                    self.acquired_writer = Some(value.clone());
+                    let mut session = self.lock_session();
+                    if let Some(message) = session.fenced.clone() {
+                        // Another engine sharing this session observed
+                        // fencing while we were acquiring; the session
+                        // stays fenced.
+                        drop(session);
+                        return NamespaceCommitEnginePublishResult {
+                            results: repeated_error(
+                                candidate_count,
+                                CoreError::WriterFenced(message),
+                            ),
+                            wal_tail_segments: 0,
+                            resulting_read_state: None,
+                        };
+                    }
+                    session.acquired_writer = Some(value.clone());
+                    drop(session);
                     value
                 }
                 Err(error) => {
@@ -234,8 +294,9 @@ impl NamespaceCommitEngine {
             Err(error) => {
                 self.invalidate();
                 if let CoreError::WriterFenced(message) = &error {
-                    self.fenced = Some(message.clone());
-                    self.acquired_writer = None;
+                    let mut session = self.lock_session();
+                    session.fenced = Some(message.clone());
+                    session.acquired_writer = None;
                 }
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
@@ -452,6 +513,73 @@ mod tests {
             .envelope
             .state;
         assert_eq!(head.writer_epoch, epoch_after_takeover);
+        assert_eq!(head.writer.expect("writer block").writer_id, "writer-b");
+    }
+
+    #[tokio::test]
+    async fn shared_session_keeps_fencing_across_engine_rebuilds() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer_a = context("writer-a", "session-a");
+        bootstrap_namespace(&store, &namespace_id, &writer_a, false)
+            .await
+            .expect("bootstrap");
+
+        let session = SharedWriterSessionState::default();
+        let mut engine_a1 = NamespaceCommitEngine::new(namespace_id.clone())
+            .with_writer_session(Arc::clone(&session));
+        engine_a1
+            .publish_batch(&store, vec![create_dir("from-a-first", "alpha")], &writer_a)
+            .await
+            .results
+            .remove(0)
+            .expect("writer a first commit");
+
+        let writer_b = context("writer-b", "session-b");
+        let mut engine_b = NamespaceCommitEngine::new(namespace_id.clone());
+        engine_b
+            .publish_batch(&store, vec![create_dir("from-b-first", "beta")], &writer_b)
+            .await
+            .results
+            .remove(0)
+            .expect("writer b takeover commit");
+
+        let fenced = engine_a1
+            .publish_batch(
+                &store,
+                vec![create_dir("from-a-second", "gamma")],
+                &writer_a,
+            )
+            .await;
+        let error = fenced.results[0].as_ref().expect_err("fenced publish");
+        assert_eq!(error.code(), ErrorCode::WriterFenced);
+        let epoch_after_fencing = read_head_object(&store, &namespace_id)
+            .await
+            .expect("read head")
+            .envelope
+            .state
+            .writer_epoch;
+
+        // A rebuilt engine — cache eviction, cache-disabled mode — shares
+        // the session state, so the session stays terminally fenced and
+        // never touches the head.
+        drop(engine_a1);
+        let mut engine_a2 =
+            NamespaceCommitEngine::new(namespace_id.clone()).with_writer_session(session);
+        let still_fenced = engine_a2
+            .publish_batch(&store, vec![create_dir("from-a-third", "delta")], &writer_a)
+            .await;
+        let error = still_fenced.results[0]
+            .as_ref()
+            .expect_err("rebuilt engine stays fenced");
+        assert_eq!(error.code(), ErrorCode::WriterFenced);
+        let head = read_head_object(&store, &namespace_id)
+            .await
+            .expect("read head")
+            .envelope
+            .state;
+        assert_eq!(head.writer_epoch, epoch_after_fencing);
         assert_eq!(head.writer.expect("writer block").writer_id, "writer-b");
     }
 

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -101,7 +101,7 @@ pub mod publish {
     pub use crate::commit::{CommitHeadPublishError, SemanticMutationIdentity};
     pub use crate::commit_engine::{
         NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
-        ResultingReadState,
+        ResultingReadState, SharedWriterSessionState, WriterSessionState,
     };
     pub use crate::path::write::PathMutationIntent;
     pub use crate::protocol::PublishTailOptions;

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -17,7 +17,7 @@ use loonfs_core::control::{
     ControlObjectLoadError, LoadedHeadControl, LoadedMetadataRootControl,
     VerifiedNamespaceCatalogEntry,
 };
-use loonfs_core::publish::NamespaceCommitEngine;
+use loonfs_core::publish::{NamespaceCommitEngine, SharedWriterSessionState};
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext};
 use loonfs_objectstore::keys::{namespace_config, wal_head};
 use std::collections::{HashMap, VecDeque};
@@ -38,10 +38,10 @@ struct NamespaceControlCacheEntry {
     /// The namespace's spec-immutable catalog pair (config plus content-store
     /// binding): loaded once, never revalidated.
     catalog: Option<VerifiedNamespaceCatalogEntry>,
-    /// This process's commit engine for the namespace: writer-session state
-    /// (acquired epoch, fencing, tail projection). Survives invalidation —
-    /// only its tail projection is dropped; removal happens on namespace
-    /// deletion or LRU eviction.
+    /// This process's commit engine for the namespace: publication
+    /// serialization plus rebuildable state (tail projection, catalog).
+    /// The session's acquired epoch and fencing live in the writer-session
+    /// registry, which this entry's invalidation or eviction never touches.
     engine: Option<Arc<AsyncMutex<NamespaceCommitEngine>>>,
 }
 
@@ -192,10 +192,11 @@ impl RuntimeControlCache {
     fn invalidate_namespace(&mut self, namespace_id: &NamespaceId) {
         // The head anchor goes stale on every mutation; the catalog pair is
         // immutable for the namespace's lifetime (a deleted namespace id
-        // never rebinds), and the engine keeps its session state ("a fenced
-        // session stays fenced") — only its tail projection goes stale. A
-        // held engine lock means a publish is in flight; that publish
-        // revalidates against the live head itself.
+        // never rebinds), and the engine drops only its tail projection —
+        // the session's epoch and fencing live in the writer-session
+        // registry, which invalidation never touches. A held engine lock
+        // means a publish is in flight; that publish revalidates against
+        // the live head itself.
         if let Some(entry) = self.namespaces.get_mut(namespace_id) {
             entry.head = None;
             if let Some(engine) = &entry.engine {
@@ -220,20 +221,25 @@ impl RuntimeControlCache {
         namespace_id: &NamespaceId,
         max_cached_namespaces: usize,
         table_cache: Arc<MetadataTableCache>,
+        session: SharedWriterSessionState,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         if max_cached_namespaces == 0 {
             // Diagnostic mode: nothing is cached, every publish gets a
-            // throwaway engine.
+            // throwaway engine — carrying the session state, which is not
+            // a cache and never gets disabled.
             return Arc::new(AsyncMutex::new(
-                NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache),
+                NamespaceCommitEngine::new(namespace_id.clone())
+                    .with_table_cache(table_cache)
+                    .with_writer_session(session),
             ));
         }
         let entry = self.namespace_entry(namespace_id, max_cached_namespaces);
         if let Some(engine) = &entry.engine {
             return Arc::clone(engine);
         }
-        let mut engine =
-            NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(table_cache);
+        let mut engine = NamespaceCommitEngine::new(namespace_id.clone())
+            .with_table_cache(table_cache)
+            .with_writer_session(session);
         if let Some(catalog) = &entry.catalog {
             engine = engine.with_catalog_entry(catalog.clone());
         }
@@ -407,10 +413,12 @@ impl FsCore {
         namespace_id: &NamespaceId,
     ) -> Arc<AsyncMutex<NamespaceCommitEngine>> {
         let cache_config = &self.inner.config.runtime_cache;
+        let session = self.inner.writer_sessions.state(namespace_id);
         self.inner.control_cache().engine(
             namespace_id,
             cache_config.max_cached_namespaces,
             Arc::clone(&self.inner.metadata_table_cache),
+            session,
         )
     }
 

--- a/crates/loonfs/src/commit_window.rs
+++ b/crates/loonfs/src/commit_window.rs
@@ -15,8 +15,13 @@
 //! Submissions buffer metadata only — content a submission references is
 //! already durable before it enters the window — so members share the
 //! flush's publication fate (a failed WAL write or head CAS rejects the
-//! batch) but never each other's uploads. An opener cancelled before
-//! flushing closes the window and fails the members that joined it.
+//! batch) but never each other's uploads. Opener cancellation has two
+//! distinct outcomes for the members: cancelled while the window is still
+//! buffering, the window closes and rejects them explicitly (nothing was
+//! published; a retry is safe); cancelled after draining the window, the
+//! flush disappears mid-publish and each member surfaces
+//! `commit_outcome_unknown` — the batch may have durably committed, so this
+//! must never be reported as a definite failure.
 
 use crate::publish::NamespaceMutationCandidate;
 use crate::{CommitResponse, CoreError, NamespaceId, Result, RuntimeError};
@@ -99,9 +104,10 @@ impl CommitWindows {
 }
 
 /// Closes the opener's window exactly once: normally by draining it for the
-/// flush, or on drop when the opener was cancelled first — dropping the
-/// buffered entries then cancels the joiners' receivers, so an abandoned
-/// window fails its members instead of wedging the namespace.
+/// flush, or on drop when the opener was cancelled first. The drop path
+/// rejects the buffered members explicitly — nothing was published, so an
+/// abandoned window is a definite, retryable failure, distinguishable from
+/// a flush that disappeared mid-publish.
 pub(crate) struct OpenerGuard<'a> {
     windows: &'a CommitWindows,
     namespace_id: NamespaceId,
@@ -122,10 +128,35 @@ impl OpenerGuard<'_> {
 
 impl Drop for OpenerGuard<'_> {
     fn drop(&mut self) {
-        if self.armed {
-            self.windows.lock_open().remove(&self.namespace_id);
+        if !self.armed {
+            return;
+        }
+        let entries = self
+            .windows
+            .lock_open()
+            .remove(&self.namespace_id)
+            .unwrap_or_default();
+        // The opener was cancelled while the window was still buffering:
+        // nothing was drained, so nothing was published. Reject each member
+        // with a definite failure instead of dropping its result channel,
+        // which is reserved for a flush that disappeared in flight.
+        for entry in entries {
+            let results = window_closed_results(entry.candidates.len());
+            let _ = entry.result_sender.send(results);
         }
     }
+}
+
+fn window_closed_results(count: usize) -> WindowResults {
+    (0..count)
+        .map(|_| {
+            Err(RuntimeError::Core(CoreError::Internal(
+                "commit window closed before its flush was attempted; nothing was published and \
+                 the submission can be retried"
+                    .to_owned(),
+            )))
+        })
+        .collect()
 }
 
 /// Pads a distributed result slice when the publish returned fewer results

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -40,6 +40,7 @@ use loonfs_core::cache::{
     load_namespace_head_summary, MetadataTableCache, WalTailProjectionCache,
     WalTailProjectionCacheConfig,
 };
+use loonfs_core::commit::CommitHeadPublishError;
 use loonfs_core::{MutationContext, NamespaceEngine};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -1355,13 +1356,20 @@ impl FsCore {
         };
         match result_receiver.await {
             Ok(results) => results,
-            // The opener was cancelled before distributing results; the
-            // window closed behind it, so the submission failed rather than
-            // committed and the caller may retry.
+            // A dropped result channel means the opener's future was
+            // cancelled after it drained the window: the flush was in
+            // flight and its durable outcome was never observed. (An opener
+            // cancelled before draining rejects members explicitly instead.)
+            // The mutation may have committed, so this must surface as an
+            // unknown outcome, never as a definite failure; retrying with
+            // the same commit id replays the durable receipt if it landed.
             Err(_) => (0..candidate_count)
                 .map(|_| {
-                    Err(RuntimeError::Core(CoreError::Internal(
-                        "commit window abandoned before its flush completed".to_owned(),
+                    Err(RuntimeError::Core(CoreError::HeadPublish(
+                        CommitHeadPublishError::OutcomeUnknown(
+                            "commit window opener was cancelled while its flush was in flight"
+                                .to_owned(),
+                        ),
                     )))
                 })
                 .collect(),

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -11,6 +11,7 @@ use crate::config::{validate_config, FsConfig};
 use crate::content_tokens::ContentAdmission;
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use crate::time::current_time_ms;
+use crate::writer_session::WriterSessionRegistry;
 use crate::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry,
     BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse, ChangeSeq,
@@ -63,6 +64,9 @@ pub(crate) struct FsInner {
     pub(crate) cache_stats: RuntimeCacheStatsInner,
     pub(crate) background: BackgroundWork,
     pub(crate) commit_windows: CommitWindows,
+    /// Session-owned writer state (acquired epochs, fencing), deliberately
+    /// outside every rebuildable cache; see [`crate::writer_session`].
+    pub(crate) writer_sessions: WriterSessionRegistry,
     /// Per-namespace gram-index enablement, learned in-process: `None`
     /// until any tick, enable, or disable observes the namespace. Publishes
     /// consult it so index catch-up is scheduled by index lag, not only by
@@ -130,6 +134,7 @@ impl FsCore {
                 cache_stats: RuntimeCacheStatsInner::default(),
                 background,
                 commit_windows: CommitWindows::default(),
+                writer_sessions: WriterSessionRegistry::default(),
                 grams_enabled_hints: Mutex::new(BTreeMap::new()),
             }),
         })
@@ -212,6 +217,12 @@ impl FsCore {
                 .await
                 .map_err(RuntimeError::from)
         };
+        if result.is_ok() {
+            // Only a namespace that is actually gone releases its session
+            // state: a failed delete (a fenced deleter, say) must not erase
+            // the fencing record and hand the session a fresh epoch.
+            self.inner.writer_sessions.remove(namespace_id);
+        }
         self.invalidate_namespace_cache_for_delete(namespace_id);
         result
     }
@@ -1432,10 +1443,16 @@ impl FsCore {
             return results;
         }
 
-        let engine = self.namespace_engine_with_store(namespace_id, store);
+        // Cache-disabled diagnostic mode: a throwaway engine per publish,
+        // but the session's epoch and fencing still come from the registry —
+        // no cache configuration disables session state.
+        let mut engine = loonfs_core::publish::NamespaceCommitEngine::new(namespace_id.clone())
+            .with_writer_session(self.inner.writer_sessions.state(namespace_id));
+        let context = self.mutation_context();
         // Boxed for the same type-recursion reason as the cached-engine path.
-        let results: Vec<_> = Box::pin(engine.publish_namespace_mutations_batch(candidates))
+        let results: Vec<_> = Box::pin(engine.publish_batch(&store, candidates, &context))
             .await
+            .results
             .into_iter()
             .map(|result| result.map_err(RuntimeError::Core))
             .collect();

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -38,6 +38,7 @@ mod options;
 pub mod publisher;
 mod time;
 mod trace;
+mod writer_session;
 
 use thiserror::Error;
 

--- a/crates/loonfs/src/writer_session.rs
+++ b/crates/loonfs/src/writer_session.rs
@@ -1,0 +1,45 @@
+//! Session-owned writer state, kept apart from every rebuildable cache.
+//!
+//! A writer session's acquired epoch and terminal fencing record are facts
+//! about this process, not cached views of durable state: nothing in the
+//! store can rebuild "this session was fenced". When they lived inside the
+//! LRU control cache, eviction erased them (and cache-disabled runs never
+//! kept them at all), so a fenced writer could silently bump the epoch back
+//! and fence the legitimate writer instead. This registry holds one entry
+//! per namespace the session has published to; entries are a few dozen
+//! bytes, and they are removed only when the namespace itself is deleted,
+//! because a deleted namespace id never rebinds.
+
+use crate::NamespaceId;
+use loonfs_core::publish::SharedWriterSessionState;
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+/// One runtime core's writer-session states, keyed by namespace.
+#[derive(Debug, Default)]
+pub(crate) struct WriterSessionRegistry {
+    namespaces: Mutex<HashMap<NamespaceId, SharedWriterSessionState>>,
+}
+
+impl WriterSessionRegistry {
+    /// The session state for one namespace, created on first use. Every
+    /// engine built for the namespace shares the returned handle, so a
+    /// fenced session stays fenced across engine rebuilds.
+    pub(crate) fn state(&self, namespace_id: &NamespaceId) -> SharedWriterSessionState {
+        self.lock().entry(namespace_id.clone()).or_default().clone()
+    }
+
+    /// Namespace-terminal removal: the namespace is gone and its id never
+    /// rebinds, so the session state goes with it.
+    pub(crate) fn remove(&self, namespace_id: &NamespaceId) {
+        self.lock().remove(namespace_id);
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<NamespaceId, SharedWriterSessionState>> {
+        // Poisoning is propagated as a panic, matching the runtime's cache
+        // locks: every critical section is a plain map operation.
+        self.namespaces
+            .lock()
+            .expect("writer session registry lock poisoned")
+    }
+}

--- a/crates/loonfs/tests/commit_window.rs
+++ b/crates/loonfs/tests/commit_window.rs
@@ -1,0 +1,342 @@
+//! Commit-window cancellation semantics: a cancelled opener must reject
+//! members explicitly while the window is still buffering, must surface an
+//! unknown outcome once the flush is in flight (the batch may have durably
+//! committed), and a cancelled joiner must not cancel admitted work.
+
+#![allow(clippy::panic, clippy::disallowed_methods)]
+// Cancellation tests drive real window timers to real await points, so they
+// poll with short sleeps and panic on missed signals for readable failures.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs::{
+    CreateNamespaceOptions, ErrorCode, FsWriter, NamespaceId, PutFileOptions, RuntimeError,
+    SharedObjectStore,
+};
+use loonfs_objectstore::keys::wal_head;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::time::{sleep, timeout, Duration};
+
+/// Object store for driving a window flush to a precise point: it can apply
+/// a head compare-and-swap durably and then never return — the shape of a
+/// request that landed while the future awaiting it gets cancelled — and it
+/// counts writes so tests can prove what did or did not reach the store.
+#[derive(Debug)]
+struct WindowTestStore {
+    inner: LocalFsStore,
+    head_key: String,
+    hang_head_cas: AtomicBool,
+    head_cas_hang_reached: AtomicBool,
+    head_cas_writes: AtomicUsize,
+    other_puts: AtomicUsize,
+}
+
+impl WindowTestStore {
+    fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            head_key: wal_head(namespace_id.as_str()),
+            hang_head_cas: AtomicBool::new(false),
+            head_cas_hang_reached: AtomicBool::new(false),
+            head_cas_writes: AtomicUsize::new(0),
+            other_puts: AtomicUsize::new(0),
+        }
+    }
+
+    fn reset_counters(&self) {
+        self.head_cas_writes.store(0, Ordering::SeqCst);
+        self.other_puts.store(0, Ordering::SeqCst);
+    }
+
+    fn head_cas_writes(&self) -> usize {
+        self.head_cas_writes.load(Ordering::SeqCst)
+    }
+
+    fn other_puts(&self) -> usize {
+        self.other_puts.load(Ordering::SeqCst)
+    }
+
+    fn head_cas_hang_reached(&self) -> bool {
+        self.head_cas_hang_reached.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for WindowTestStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let is_head_cas = key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. });
+        if is_head_cas {
+            self.head_cas_writes.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.other_puts.fetch_add(1, Ordering::SeqCst);
+        }
+        let result = self.inner.put(key, bytes, mode).await;
+        if is_head_cas && self.hang_head_cas.load(Ordering::SeqCst) && result.is_ok() {
+            // The CAS landed durably; the response never arrives.
+            self.head_cas_hang_reached.store(true, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+        }
+        result
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+async fn writer_with_window(store: &SharedObjectStore, window_ms: u64) -> FsWriter {
+    FsWriter::builder_with_store(store.clone())
+        .writer_id("window-writer")
+        .commit_window_ms(window_ms)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+/// Polls a condition every few milliseconds; panics after ten seconds so a
+/// missed signal fails the test instead of hanging it.
+async fn wait_until(what: &str, condition: impl Fn() -> bool) {
+    for _ in 0..2_000 {
+        if condition() {
+            return;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    panic!("timed out waiting for {what}");
+}
+
+fn core_code(error: &RuntimeError) -> Option<ErrorCode> {
+    match error {
+        RuntimeError::Core(core) => Some(core.code()),
+        _ => None,
+    }
+}
+
+/// Opener cancelled while the head compare-and-swap is in flight: the CAS
+/// landed durably, so the joiner must be told the outcome is unknown — a
+/// definite failure here would deny a commit that is visible to every
+/// reader.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancelled_opener_mid_flush_reports_unknown_outcome_and_the_commit_lands() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("midflush").expect("valid namespace id");
+    let test_store = Arc::new(WindowTestStore::new(temp_dir.path(), &namespace_id));
+    let store: SharedObjectStore = test_store.clone();
+    let writer = Arc::new(writer_with_window(&store, 500).await);
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    test_store.reset_counters();
+    test_store.hang_head_cas.store(true, Ordering::SeqCst);
+
+    let opener_writer = Arc::clone(&writer);
+    let opener_namespace = namespace_id.clone();
+    let opener = tokio::spawn(async move {
+        opener_writer
+            .put_file_bytes(&opener_namespace, "/a.txt", b"a", PutFileOptions::default())
+            .await
+    });
+    // The opener's content upload is durable before it enters the window;
+    // give it a beat to take the opener role, then join the same window.
+    wait_until("opener content upload", || test_store.other_puts() >= 1).await;
+    sleep(Duration::from_millis(50)).await;
+    let joiner_writer = Arc::clone(&writer);
+    let joiner_namespace = namespace_id.clone();
+    let joiner = tokio::spawn(async move {
+        joiner_writer
+            .put_file_bytes(&joiner_namespace, "/b.txt", b"b", PutFileOptions::default())
+            .await
+    });
+
+    wait_until("head CAS applied and hanging", || {
+        test_store.head_cas_hang_reached()
+    })
+    .await;
+    opener.abort();
+    let _ = opener.await;
+    test_store.hang_head_cas.store(false, Ordering::SeqCst);
+
+    let joiner_result = timeout(Duration::from_secs(15), joiner)
+        .await
+        .expect("joiner must settle once the opener is cancelled")
+        .expect("joiner task");
+    let error = joiner_result.expect_err("the joiner's outcome was never distributed");
+    assert_eq!(
+        core_code(&error),
+        Some(ErrorCode::CommitOutcomeUnknown),
+        "a flush cancelled in flight must surface an unknown outcome, got: {error:?}"
+    );
+
+    // Ground truth: the batch committed durably and is visible.
+    let reader = writer.reader();
+    reader
+        .read_file_bytes(&namespace_id, "/a.txt")
+        .await
+        .expect("opener's mutation committed");
+    reader
+        .read_file_bytes(&namespace_id, "/b.txt")
+        .await
+        .expect("joiner's mutation committed");
+}
+
+/// Opener cancelled while the window is still buffering: nothing was
+/// published, so members get a definite, retryable rejection and the store
+/// shows no publication attempt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancelled_opener_before_flush_rejects_members_and_retry_succeeds() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("preflush").expect("valid namespace id");
+    let test_store = Arc::new(WindowTestStore::new(temp_dir.path(), &namespace_id));
+    let store: SharedObjectStore = test_store.clone();
+    let writer = Arc::new(writer_with_window(&store, 1_500).await);
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    test_store.reset_counters();
+    let opener_writer = Arc::clone(&writer);
+    let opener_namespace = namespace_id.clone();
+    let opener = tokio::spawn(async move {
+        opener_writer
+            .put_file_bytes(&opener_namespace, "/a.txt", b"a", PutFileOptions::default())
+            .await
+    });
+    wait_until("opener content upload", || test_store.other_puts() >= 1).await;
+    sleep(Duration::from_millis(50)).await;
+    let joiner_writer = Arc::clone(&writer);
+    let joiner_namespace = namespace_id.clone();
+    let joiner = tokio::spawn(async move {
+        joiner_writer
+            .put_file_bytes(&joiner_namespace, "/b.txt", b"b", PutFileOptions::default())
+            .await
+    });
+    wait_until("joiner content upload", || test_store.other_puts() >= 2).await;
+    sleep(Duration::from_millis(50)).await;
+
+    // The opener is parked in the window delay; cancelling it closes the
+    // window before any flush.
+    opener.abort();
+    let _ = opener.await;
+
+    let joiner_result = timeout(Duration::from_secs(15), joiner)
+        .await
+        .expect("joiner must settle once the window closes")
+        .expect("joiner task");
+    let error = joiner_result.expect_err("the window closed before publishing");
+    assert!(
+        format!("{error}").contains("closed before its flush was attempted"),
+        "expected the explicit pre-flush rejection, got: {error:?}"
+    );
+    assert_eq!(
+        test_store.head_cas_writes(),
+        0,
+        "no publication may have been attempted"
+    );
+    let reader = writer.reader();
+    reader
+        .read_file_bytes(&namespace_id, "/b.txt")
+        .await
+        .expect_err("nothing was published");
+
+    // A definite rejection is safe to retry, and the retry lands.
+    writer
+        .put_file_bytes(&namespace_id, "/b.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("retry after a definite rejection");
+    reader
+        .read_file_bytes(&namespace_id, "/b.txt")
+        .await
+        .expect("retried mutation is visible");
+}
+
+/// A cancelled joiner abandons only its result: the submission it buffered
+/// was admitted to the window and still publishes with the batch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancelled_joiner_does_not_cancel_admitted_work() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("joiner").expect("valid namespace id");
+    let test_store = Arc::new(WindowTestStore::new(temp_dir.path(), &namespace_id));
+    let store: SharedObjectStore = test_store.clone();
+    let writer = Arc::new(writer_with_window(&store, 500).await);
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    test_store.reset_counters();
+    let opener_writer = Arc::clone(&writer);
+    let opener_namespace = namespace_id.clone();
+    let opener = tokio::spawn(async move {
+        opener_writer
+            .put_file_bytes(&opener_namespace, "/a.txt", b"a", PutFileOptions::default())
+            .await
+    });
+    wait_until("opener content upload", || test_store.other_puts() >= 1).await;
+    sleep(Duration::from_millis(50)).await;
+    let joiner_writer = Arc::clone(&writer);
+    let joiner_namespace = namespace_id.clone();
+    let joiner = tokio::spawn(async move {
+        joiner_writer
+            .put_file_bytes(&joiner_namespace, "/b.txt", b"b", PutFileOptions::default())
+            .await
+    });
+    wait_until("joiner content upload", || test_store.other_puts() >= 2).await;
+    sleep(Duration::from_millis(50)).await;
+
+    joiner.abort();
+    let _ = joiner.await;
+
+    timeout(Duration::from_secs(15), opener)
+        .await
+        .expect("opener must settle")
+        .expect("opener task")
+        .expect("opener's mutation commits");
+    let reader = writer.reader();
+    reader
+        .read_file_bytes(&namespace_id, "/a.txt")
+        .await
+        .expect("opener's mutation is visible");
+    reader
+        .read_file_bytes(&namespace_id, "/b.txt")
+        .await
+        .expect("the cancelled joiner's admitted mutation still published");
+}

--- a/crates/loonfs/tests/invalidation.rs
+++ b/crates/loonfs/tests/invalidation.rs
@@ -1,18 +1,21 @@
 //! Post-publish cache behavior: a landed publish seeds the read caches
-//! instead of dropping them, and cache invalidation never erases writer
-//! fencing.
+//! instead of dropping them, and no cache lifecycle event — invalidation,
+//! LRU eviction, or running with caches disabled — erases writer fencing.
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs::{
-    CreateNamespaceOptions, FsWriter, NamespaceId, PutFileOptions, RuntimeError, SharedObjectStore,
+    CreateNamespaceOptions, FsWriter, NamespaceId, PutFileOptions, RuntimeCacheConfig,
+    RuntimeError, SharedObjectStore,
 };
+use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
@@ -84,12 +87,97 @@ impl ObjectStore for GetRecordingStore {
 }
 
 async fn writer(store: &SharedObjectStore, writer_id: &str) -> FsWriter {
+    writer_with_cache(store, writer_id, RuntimeCacheConfig::default()).await
+}
+
+async fn writer_with_cache(
+    store: &SharedObjectStore,
+    writer_id: &str,
+    runtime_cache: RuntimeCacheConfig,
+) -> FsWriter {
     FsWriter::builder_with_store(store.clone())
         .writer_id(writer_id)
         .commit_window_ms(0)
+        .runtime_cache(runtime_cache)
         .build()
         .await
         .expect("build writer")
+}
+
+fn expect_writer_fenced<T: std::fmt::Debug>(result: loonfs::Result<T>, when: &str) {
+    let error = result.expect_err(when);
+    assert!(
+        matches!(
+            &error,
+            RuntimeError::Core(core) if core.code() == loonfs::ErrorCode::WriterFenced
+        ),
+        "{when}: unexpected error: {error:?}"
+    );
+}
+
+/// Counts head compare-and-swap writes for one namespace's head key, so a
+/// test can prove a fenced session stops touching durable state.
+#[derive(Debug)]
+struct HeadCasCountingStore {
+    inner: LocalFsStore,
+    head_key: String,
+    head_cas_writes: AtomicUsize,
+}
+
+impl HeadCasCountingStore {
+    fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            head_key: wal_head(namespace_id.as_str()),
+            head_cas_writes: AtomicUsize::new(0),
+        }
+    }
+
+    fn head_cas_writes(&self) -> usize {
+        self.head_cas_writes.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for HeadCasCountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
+            self.head_cas_writes.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 /// A fenced writer session must stay fenced: before this fix, the runtime
@@ -144,6 +232,129 @@ async fn fenced_writer_stays_fenced_instead_of_reacquiring() {
             RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::WriterFenced
         ),
         "unexpected error: {still_fenced:?}"
+    );
+    writer_b
+        .put_file_bytes(&namespace_id, "/b2.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("live writer is not fenced back");
+}
+
+/// Fencing must also survive LRU eviction of the namespace's cache entry:
+/// the writer-session registry, not the evictable commit engine, owns it.
+/// Before this fix, capacity pressure from touching other namespaces
+/// evicted the fenced engine, and the fresh engine's first publish silently
+/// re-acquired the epoch — the fenced writer resumed publishing and fenced
+/// the legitimate writer back.
+#[tokio::test]
+async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let ns_fence = NamespaceId::parse("fence").expect("valid namespace id");
+    let ns_other = NamespaceId::parse("other").expect("valid namespace id");
+    let counting = Arc::new(HeadCasCountingStore::new(temp_dir.path(), &ns_fence));
+    let store: SharedObjectStore = counting.clone();
+
+    let single_entry_cache = RuntimeCacheConfig {
+        max_cached_namespaces: 1,
+        ..RuntimeCacheConfig::default()
+    };
+    let writer_a = writer_with_cache(&store, "writer-a", single_entry_cache).await;
+    writer_a
+        .create_namespace(&ns_fence, CreateNamespaceOptions::default())
+        .await
+        .expect("create fence namespace");
+    writer_a
+        .create_namespace(&ns_other, CreateNamespaceOptions::default())
+        .await
+        .expect("create other namespace");
+    writer_a
+        .put_file_bytes(&ns_fence, "/a1.txt", b"a", PutFileOptions::default())
+        .await
+        .expect("writer a first put");
+
+    let writer_b = writer(&store, "writer-b").await;
+    writer_b
+        .put_file_bytes(&ns_fence, "/b1.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("writer b takes over the epoch");
+
+    expect_writer_fenced(
+        writer_a
+            .put_file_bytes(&ns_fence, "/a2.txt", b"a", PutFileOptions::default())
+            .await,
+        "superseded writer surfaces fencing",
+    );
+
+    // Publishing to the other namespace evicts the fenced namespace's cache
+    // entry (capacity one), commit engine included.
+    writer_a
+        .put_file_bytes(&ns_other, "/spill.txt", b"s", PutFileOptions::default())
+        .await
+        .expect("writer a publishes to the other namespace");
+
+    let head_cas_after_fencing = counting.head_cas_writes();
+    expect_writer_fenced(
+        writer_a
+            .put_file_bytes(&ns_fence, "/a3.txt", b"a", PutFileOptions::default())
+            .await,
+        "fenced session stays fenced after eviction",
+    );
+    assert_eq!(
+        counting.head_cas_writes(),
+        head_cas_after_fencing,
+        "a fenced session must not touch the fenced namespace's head"
+    );
+    writer_b
+        .put_file_bytes(&ns_fence, "/b2.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("live writer is not fenced back");
+}
+
+/// With runtime caches disabled every publish gets a throwaway engine, but
+/// the session's epoch and fencing come from the registry, which no cache
+/// configuration disables. Before this fix, cache-disabled runs never kept
+/// fencing at all: a superseded writer re-acquired the epoch on every
+/// publish and the two writers fenced each other back and forth.
+#[tokio::test]
+async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("nocache").expect("valid namespace id");
+    let counting = Arc::new(HeadCasCountingStore::new(temp_dir.path(), &namespace_id));
+    let store: SharedObjectStore = counting.clone();
+
+    let writer_a = writer_with_cache(&store, "writer-a", RuntimeCacheConfig::disabled()).await;
+    writer_a
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer_a
+        .put_file_bytes(&namespace_id, "/a1.txt", b"a", PutFileOptions::default())
+        .await
+        .expect("writer a first put");
+
+    let writer_b = writer(&store, "writer-b").await;
+    writer_b
+        .put_file_bytes(&namespace_id, "/b1.txt", b"b", PutFileOptions::default())
+        .await
+        .expect("writer b takes over the epoch");
+
+    expect_writer_fenced(
+        writer_a
+            .put_file_bytes(&namespace_id, "/a2.txt", b"a", PutFileOptions::default())
+            .await,
+        "superseded writer surfaces fencing",
+    );
+
+    let head_cas_after_fencing = counting.head_cas_writes();
+    expect_writer_fenced(
+        writer_a
+            .put_file_bytes(&namespace_id, "/a3.txt", b"a", PutFileOptions::default())
+            .await,
+        "fenced session stays fenced across throwaway engines",
+    );
+    assert_eq!(
+        counting.head_cas_writes(),
+        head_cas_after_fencing,
+        "a fenced session must not touch the namespace's head"
     );
     writer_b
         .put_file_bytes(&namespace_id, "/b2.txt", b"b", PutFileOptions::default())


### PR DESCRIPTION
When a commit-window opener's future was cancelled mid-flush, the joiners that had batched into its window got a plain internal error claiming the submission "failed rather than committed" — while the head compare-and-swap may already have landed. Reproduced on main: a joiner was told internal error while its mutation was durably committed and visible to readers.

The two cancellation cases are now distinguished, mirroring what the batching publisher already does. Cancelled while the window is still buffering: the opener guard's drop rejects each member explicitly — nothing was published, a definite and retryable failure. Cancelled after the window was drained: a dropped result channel now surfaces commit_outcome_unknown (an existing code), never a definite failure; retrying with the same commit id replays the durable receipt if the flush landed.

The tests drive a flush to a precise point with a store that applies the head compare-and-swap durably and then never returns, then cancel the opener at each await point; a third test pins the existing guarantee that a cancelled joiner does not cancel admitted work.

Scope note: admitted work is still lost when the opener is cancelled mid-flush — this fixes what waiters are told, not who owns the flush. Ownership moves out of caller futures in the planned publication-path consolidation onto the publisher.

Stacked on #267.