### PR TITLE
feat(api,loonfs,server,client,cli): every mutation returns the commit id it committed under

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -80,14 +80,14 @@ pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
 // in `v0`; add here only what most consumers touch.
 pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
-    CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DisableGramsIndexResponse,
     EnableGramsIndexResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest,
-    GcRequest, GcResponse, GrepMatch, GrepRequest, GrepResponse, ListFileRevisionsResponse,
-    ListPathEntriesResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
-    MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
+    FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch,
+    GrepRequest, GrepResponse, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -37,12 +37,21 @@ pub struct CommitRequest {
     pub message: Option<String>,
 }
 
-/// Response for a committed explicit request.
+/// Result of one committed mutation.
+///
+/// Every mutation resolves to this envelope — path-oriented operations and
+/// explicit commits, embedded or remote. The commit id is the caller's
+/// reconciliation handle: resubmitting the same request with the same id
+/// replays this result instead of committing twice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitResponse {
+    /// Namespace that changed.
     pub namespace_id: NamespaceId,
+    /// Idempotency key the mutation committed under: caller-supplied, or
+    /// generated on the caller's behalf when the request carried none.
     pub commit_id: CommitId,
+    /// Sequence number where the mutation became visible.
     pub committed_seq: ChangeSeq,
 }
 

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -26,11 +26,10 @@ pub use commits::{
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision,
-    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome,
-    FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MutationResult,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse,
+    ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary,
+    PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use search::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -84,16 +84,6 @@ pub struct DeleteNamespaceResponse {
     pub head_seq: ChangeSeq,
 }
 
-/// Result of a namespace-visible mutation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct MutationResult {
-    /// Namespace that changed.
-    pub namespace_id: NamespaceId,
-    /// Sequence number where the mutation became visible.
-    pub committed_seq: ChangeSeq,
-}
-
 /// Put behavior for path-oriented file writes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -171,16 +161,6 @@ pub struct FilesystemOperationRequest {
     pub content_tokens: Vec<ValidatedContentToken>,
     /// Operation to apply.
     pub operation: FilesystemOperation,
-}
-
-/// Response for one path-oriented operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct FilesystemOperationResponse {
-    /// Namespace that changed.
-    pub namespace_id: NamespaceId,
-    /// Sequence where the operation became visible.
-    pub committed_seq: ChangeSeq,
 }
 
 /// One immutable file revision.
@@ -410,24 +390,6 @@ pub struct MaintenanceTickResponse {
     /// Garbage-collection report when the tick opted into sweeping.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gc: Option<GcResponse>,
-}
-
-impl From<MutationResult> for FilesystemOperationResponse {
-    fn from(value: MutationResult) -> Self {
-        Self {
-            namespace_id: value.namespace_id,
-            committed_seq: value.committed_seq,
-        }
-    }
-}
-
-impl From<FilesystemOperationResponse> for MutationResult {
-    fn from(value: FilesystemOperationResponse) -> Self {
-        Self {
-            namespace_id: value.namespace_id,
-            committed_seq: value.committed_seq,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -35,8 +35,8 @@ pub(crate) enum Command {
     Put(FilesystemPutArgs),
     Revisions(FilesystemRevisionsArgs),
     Restore(FilesystemRestoreArgs),
-    Mkdir(FilesystemPathArgs),
-    Rm(FilesystemPathArgs),
+    Mkdir(FilesystemPathMutationArgs),
+    Rm(FilesystemPathMutationArgs),
     Mv(FilesystemTransferArgs),
     Cp(FilesystemTransferArgs),
     Changes(ChangesArgs),
@@ -255,6 +255,17 @@ pub(crate) struct FilesystemPathArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct FilesystemPathMutationArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: String,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct FilesystemRevisionsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
@@ -315,6 +326,10 @@ pub(crate) struct FilesystemPutArgs {
     pub remote_path: Option<String>,
     #[arg(long)]
     pub force: bool,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -323,6 +338,10 @@ pub(crate) struct FilesystemTransferArgs {
     pub target: TargetSelectorArgs,
     pub source_path: String,
     pub dest_path: String,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -332,6 +351,10 @@ pub(crate) struct FilesystemRestoreArgs {
     pub path: String,
     #[arg(long)]
     pub revision: u64,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -18,10 +18,10 @@ use loonfs::{
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior,
     DisableGramsIndexResponse, EffectiveLimit, EnableGramsIndexResponse, FlushWalResponse,
     GcRequest, GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceId,
+    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, PaginationPolicy, PutBehavior,
     ReleaseCheckpointResponse, RevisionNo,
 };
@@ -199,14 +199,14 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let behavior = if force {
             PutBehavior::Replace
         } else {
             PutBehavior::NoReplace
         };
-        let commit_id = generated_commit_id();
         self.writer
             .put_file_bytes(
                 &namespace_id,
@@ -214,39 +214,43 @@ impl Backend for EmbeddedBackend {
                 bytes,
                 PutFileOptions {
                     behavior,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
     }
 
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .delete_path(
                 &namespace_id,
                 &spec.absolute_path,
                 DeleteOptions {
                     behavior: DeleteDirectoryBehavior::NonRecursive,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
     }
 
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .create_directory(
                 &namespace_id,
                 &spec.absolute_path,
-                CreateDirectoryOptions {
-                    commit_id: Some(commit_id),
-                },
+                CreateDirectoryOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
@@ -256,9 +260,9 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .move_path(
                 &namespace_id,
@@ -266,7 +270,7 @@ impl Backend for EmbeddedBackend {
                 &to.absolute_path,
                 MoveOptions {
                     behavior: MoveBehavior::NoReplace,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
@@ -277,17 +281,15 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .copy_path(
                 &namespace_id,
                 &from.absolute_path,
                 &to.absolute_path,
-                CopyOptions {
-                    commit_id: Some(commit_id),
-                },
+                CopyOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
@@ -297,17 +299,15 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .restore_file_revision(
                 &namespace_id,
                 &spec.absolute_path,
                 source_revision_no,
-                RestoreRevisionOptions {
-                    commit_id: Some(commit_id),
-                },
+                RestoreRevisionOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
@@ -419,10 +419,6 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
     PaginationPolicy::default()
         .resolve_limit(limit)
         .map_err(|error| BackendError::invalid_input(error.to_string()))
-}
-
-fn generated_commit_id() -> CommitId {
-    CommitId::generate()
 }
 
 fn map_runtime_error(error: RuntimeError) -> BackendError {
@@ -636,7 +632,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn embedded_backend_generates_non_empty_commit_id_for_embedded_put() {
+    async fn embedded_backend_put_returns_the_commit_id_it_committed_under() {
         let temp_dir = tempdir().expect("create temp dir");
         let store = StoreConfig::LocalFs {
             root: temp_dir.path().display().to_string(),
@@ -651,7 +647,7 @@ mod tests {
             .await
             .expect("create namespace");
 
-        target
+        let response = target
             .backend
             .put_file_bytes(
                 &NamespacePath {
@@ -660,9 +656,11 @@ mod tests {
                 },
                 b"hello",
                 false,
+                None,
             )
             .await
             .expect("put file");
+        assert!(!response.commit_id.as_str().trim().is_empty());
 
         let changes = target
             .backend
@@ -670,7 +668,7 @@ mod tests {
             .await
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
-        assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());
+        assert_eq!(changes.changes[0].commit_id, response.commit_id);
     }
 
     #[tokio::test]

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -8,15 +8,24 @@ use super::context::{
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs, FilesystemLsArgs,
-    FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs, FilesystemRevisionsArgs,
-    FilesystemTransferArgs, RuntimeBehavior,
+    FilesystemPathArgs, FilesystemPathMutationArgs, FilesystemPutArgs, FilesystemRestoreArgs,
+    FilesystemRevisionsArgs, FilesystemTransferArgs, RuntimeBehavior,
 };
 use crate::error::CliError;
-use loonfs_api::{InodeKind, RevisionNo};
+use loonfs_api::{CommitId, InodeKind, RevisionNo};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 // --- filesystem ---
+
+fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliError> {
+    commit_id
+        .map(|value| {
+            CommitId::parse(value)
+                .map_err(|error| CliError::invalid_input(format!("invalid --commit-id: {error}")))
+        })
+        .transpose()
+}
 
 pub(crate) async fn run_filesystem_ls(
     kind: CommandKind,
@@ -387,37 +396,7 @@ pub(crate) async fn run_filesystem_put(
             CliError::io(error),
         )
     })?;
-    let result = context
-        .target
-        .backend()
-        .put_file_bytes(&spec, &bytes, args.force)
-        .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(context.profile_name),
-        mode: Some(context.mode),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
-            committed_seq: result.committed_seq.0,
-        },
-    })
-}
-
-pub(crate) async fn run_filesystem_rm(
-    kind: CommandKind,
-    args: FilesystemPathArgs,
-) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
         fail(
             kind,
             Some(context.profile_name.clone()),
@@ -428,7 +407,7 @@ pub(crate) async fn run_filesystem_rm(
     let result = context
         .target
         .backend()
-        .delete_path(&spec)
+        .put_file_bytes(&spec, &bytes, args.force, commit_id)
         .await
         .map_err(|error| {
             fail(
@@ -446,6 +425,54 @@ pub(crate) async fn run_filesystem_rm(
         data: CommandData::FileMutation {
             target: render_target(&context.namespace, &spec.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
+        },
+    })
+}
+
+pub(crate) async fn run_filesystem_rm(
+    kind: CommandKind,
+    args: FilesystemPathMutationArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .delete_path(&spec, commit_id)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }
@@ -463,37 +490,7 @@ pub(crate) async fn run_filesystem_restore(
             error,
         )
     })?;
-    let result = context
-        .target
-        .backend()
-        .restore_file_revision(&spec, RevisionNo(args.revision))
-        .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(context.profile_name),
-        mode: Some(context.mode),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
-            committed_seq: result.committed_seq.0,
-        },
-    })
-}
-
-pub(crate) async fn run_filesystem_mkdir(
-    kind: CommandKind,
-    args: FilesystemPathArgs,
-) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
         fail(
             kind,
             Some(context.profile_name.clone()),
@@ -504,7 +501,7 @@ pub(crate) async fn run_filesystem_mkdir(
     let result = context
         .target
         .backend()
-        .create_directory(&spec)
+        .restore_file_revision(&spec, RevisionNo(args.revision), commit_id)
         .await
         .map_err(|error| {
             fail(
@@ -522,6 +519,54 @@ pub(crate) async fn run_filesystem_mkdir(
         data: CommandData::FileMutation {
             target: render_target(&context.namespace, &spec.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
+        },
+    })
+}
+
+pub(crate) async fn run_filesystem_mkdir(
+    kind: CommandKind,
+    args: FilesystemPathMutationArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .create_directory(&spec, commit_id)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }
@@ -563,6 +608,14 @@ async fn run_filesystem_transfer(
         )
     })?;
 
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
     let result = if copy {
         let entry = context
             .target
@@ -588,9 +641,17 @@ async fn run_filesystem_transfer(
                 )),
             ));
         }
-        context.target.backend().copy_path(&from, &to).await
+        context
+            .target
+            .backend()
+            .copy_path(&from, &to, commit_id)
+            .await
     } else {
-        context.target.backend().move_path(&from, &to).await
+        context
+            .target
+            .backend()
+            .move_path(&from, &to, commit_id)
+            .await
     }
     .map_err(|error| {
         fail(
@@ -609,6 +670,7 @@ async fn run_filesystem_transfer(
             from: render_target(&context.namespace, &from.absolute_path),
             to: render_target(&context.namespace, &to.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -80,11 +80,13 @@ pub(crate) enum CommandData {
     FileMutation {
         target: String,
         committed_seq: u64,
+        commit_id: String,
     },
     PathMove {
         from: String,
         to: String,
         committed_seq: u64,
+        commit_id: String,
     },
     ConfigPath {
         path: String,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -367,19 +367,29 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::FileMutation {
             target,
             committed_seq,
+            commit_id,
         } => match output.kind {
-            CommandKind::FilesystemPut => format!("stored {target} @ seq {committed_seq}"),
-            CommandKind::FilesystemRm => format!("removed {target} @ seq {committed_seq}"),
-            _ => format!("{target} @ seq {committed_seq}"),
+            CommandKind::FilesystemPut => {
+                format!("stored {target} @ seq {committed_seq} (commit {commit_id})")
+            }
+            CommandKind::FilesystemRm => {
+                format!("removed {target} @ seq {committed_seq} (commit {commit_id})")
+            }
+            _ => format!("{target} @ seq {committed_seq} (commit {commit_id})"),
         },
         CommandData::PathMove {
             from,
             to,
             committed_seq,
+            commit_id,
         } => match output.kind {
-            CommandKind::FilesystemMv => format!("moved {from} -> {to} @ seq {committed_seq}"),
-            CommandKind::FilesystemCp => format!("copied {from} -> {to} @ seq {committed_seq}"),
-            _ => format!("{from} -> {to} @ seq {committed_seq}"),
+            CommandKind::FilesystemMv => {
+                format!("moved {from} -> {to} @ seq {committed_seq} (commit {commit_id})")
+            }
+            CommandKind::FilesystemCp => {
+                format!("copied {from} -> {to} @ seq {committed_seq} (commit {commit_id})")
+            }
+            _ => format!("{from} -> {to} @ seq {committed_seq} (commit {commit_id})"),
         },
         CommandData::ConfigPath { path } => path.clone(),
         CommandData::ConfigShow { config } => {

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -19,12 +19,12 @@
 use crate::{Client, ClientError, MutationOptions, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
-    v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
+    v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CommitId,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, FlushWalResponse, GcRequest,
     GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse, MaintenanceTickRequest,
-    MaintenanceTickResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
-    ReleaseCheckpointResponse, RevisionNo,
+    MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse,
+    RevisionNo,
 };
 use thiserror::Error;
 
@@ -179,35 +179,49 @@ pub trait Backend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, BackendError>;
-    /// Writes a file; `force` replaces existing content.
+    /// Writes a file; `force` replaces existing content. An explicit
+    /// `commit_id` makes the call retryable by resubmission; absent, one is
+    /// generated and returned in the response.
     async fn put_file_bytes(
         &self,
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Creates a directory.
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Deletes a file or empty directory.
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Moves a path within a namespace.
     async fn move_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Copies a file within a namespace.
     async fn copy_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Restores a file to one of its retained revisions.
     async fn restore_file_revision(
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
 
     // --- maintenance/admin plane (`admin/v0`) ---
 
@@ -266,6 +280,13 @@ impl RemoteBackend {
     /// Wraps a configured HTTP client.
     pub fn new(client: Client) -> Self {
         Self { client }
+    }
+}
+
+/// Carries a backend-level commit id into the wire client's options.
+fn mutation_options(commit_id: Option<CommitId>) -> MutationOptions {
+    MutationOptions {
+        commit_id: commit_id.map(|id| id.to_string()),
     }
 }
 
@@ -405,24 +426,34 @@ impl Backend for RemoteBackend {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
         let bytes = bytes.to_vec();
-        self.wire(move |client| {
-            client.put_file_bytes(&spec, &bytes, force, &MutationOptions::default())
-        })
-        .await
-    }
-
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
-        let spec = spec.clone();
-        self.wire(move |client| client.create_directory(&spec, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.put_file_bytes(&spec, &bytes, force, &options))
             .await
     }
 
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| client.delete_path(&spec, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.create_directory(&spec, &options))
+            .await
+    }
+
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
+        let spec = spec.clone();
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.delete_path(&spec, &options))
             .await
     }
 
@@ -430,10 +461,12 @@ impl Backend for RemoteBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.move_path(&from, &to, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.move_path(&from, &to, &options))
             .await
     }
 
@@ -441,10 +474,12 @@ impl Backend for RemoteBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.copy_path(&from, &to, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.copy_path(&from, &to, &options))
             .await
     }
 
@@ -452,12 +487,12 @@ impl Backend for RemoteBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| {
-            client.restore_file_revision(&spec, source_revision_no, &MutationOptions::default())
-        })
-        .await
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.restore_file_revision(&spec, source_revision_no, &options))
+            .await
     }
 
     async fn create_checkpoint(

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -22,10 +22,9 @@ use loonfs_api::{
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickRequest,
-    MaintenanceTickResponse, MutationResult, NamespaceId, NamespaceStatusResponse,
+    FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
+    GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId, NamespaceStatusResponse,
     NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
     RevisionNo,
 };
@@ -718,13 +717,13 @@ impl Client {
         &self,
         namespace: &str,
         request: &FilesystemOperationRequest,
-    ) -> Result<FilesystemOperationResponse, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/filesystem/operations",
             self.base_url
         );
-        self.request_json::<_, FilesystemOperationResponse>(self.agent.post(&url), Some(request))
+        self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
     fn stage_bytes_as_content_ref(
@@ -760,7 +759,7 @@ impl Client {
         bytes: &[u8],
         force: bool,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let staged = self.stage_bytes_as_content_ref(&spec.namespace, bytes)?;
         let response = self.apply_filesystem_operation(
@@ -779,7 +778,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn write_file_bytes(
@@ -787,7 +786,7 @@ impl Client {
         spec: &NamespacePath,
         bytes: &[u8],
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.put_file_bytes(spec, bytes, true, options)
     }
 
@@ -795,7 +794,7 @@ impl Client {
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -807,14 +806,14 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn delete_path(
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::NonRecursive, options)
     }
 
@@ -822,7 +821,7 @@ impl Client {
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::Recursive, options)
     }
 
@@ -831,7 +830,7 @@ impl Client {
         spec: &NamespacePath,
         behavior: DeleteDirectoryBehavior,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -844,7 +843,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn move_path(
@@ -852,7 +851,7 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot move across namespaces: {} -> {}",
@@ -872,7 +871,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn copy_path(
@@ -880,7 +879,7 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot copy across namespaces: {} -> {}",
@@ -899,7 +898,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn restore_file_revision(
@@ -907,7 +906,7 @@ impl Client {
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -920,7 +919,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn restore_file_revision_for_inode(

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -7,7 +7,7 @@ use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use loonfs_api::{
-    v0::MoveBehavior, CommitId, ContentRef, DeleteDirectoryBehavior, MutationResult, NamespaceId,
+    v0::MoveBehavior, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior, NamespaceId,
     PutBehavior, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
@@ -21,7 +21,7 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let mut results = crate::commit_engine::publish_namespace_mutations_batch(
         store,
         namespace_id,
@@ -29,13 +29,9 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
         context,
     )
     .await;
-    let response = results
+    results
         .pop()
-        .unwrap_or_else(|| Err(CoreError::Internal("empty path mutation batch".to_owned())))?;
-    Ok(MutationResult {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    })
+        .unwrap_or_else(|| Err(CoreError::Internal("empty path mutation batch".to_owned())))
 }
 
 pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -46,7 +42,7 @@ pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let content_ref =
         store_file_bytes_before_metadata_publish(store, namespace_id, absolute_path, bytes).await?;
     put_file_content_ref(
@@ -68,7 +64,7 @@ pub(crate) async fn write_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     put_file_bytes(
         store,
         namespace_id,
@@ -89,7 +85,7 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -111,7 +107,7 @@ pub(crate) async fn delete_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     delete_path_with_behavior(
         store,
         namespace_id,
@@ -130,7 +126,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
     behavior: DeleteDirectoryBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -152,7 +148,7 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -175,7 +171,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
     source_revision_no: RevisionNo,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -258,14 +258,14 @@ fn read_context<S: ObjectStore + ?Sized>(
 }
 
 /// Publishes one path intent through the commit engine — the single publish
-/// pipeline — and maps the response like the old convenience writers did.
+/// pipeline.
 async fn submit_intent_async<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<loonfs_api::MutationResult, CoreError> {
-    let response = NamespaceCommitEngine::new(namespace_id.clone())
+) -> Result<loonfs_api::CommitResponse, CoreError> {
+    NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
             vec![NamespaceMutationCandidate::Path(intent)],
@@ -274,11 +274,7 @@ async fn submit_intent_async<S: ObjectStore + ?Sized>(
         .await
         .results
         .pop()
-        .expect("one publish result")?;
-    Ok(loonfs_api::MutationResult {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    })
+        .expect("one publish result")
 }
 
 fn submit_intent<S: ObjectStore + ?Sized>(
@@ -286,7 +282,7 @@ fn submit_intent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     block_on(submit_intent_async(store, namespace_id, intent, context))
 }
 
@@ -298,7 +294,7 @@ fn put_file_bytes<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     let content = block_on(store_bytes_as_content(store, namespace_id, bytes))?;
     submit_intent(
         store,
@@ -320,7 +316,7 @@ fn write_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     put_file_bytes(
         store,
         namespace_id,
@@ -338,7 +334,7 @@ fn create_directory_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -356,7 +352,7 @@ fn delete_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -375,7 +371,7 @@ fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -395,7 +391,7 @@ fn move_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -416,7 +412,7 @@ fn copy_file_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -436,7 +432,7 @@ fn restore_file_revision<S: ObjectStore + ?Sized>(
     source_revision_no: RevisionNo,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -17,8 +17,8 @@ use loonfs_api::{
     decode_directory_cursor, decode_file_revisions_cursor,
     v0::{ChangesResponse, CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse},
     DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, InodeId, LimitError, ListFileRevisionsResponse, PageCursorError,
-    PageRequest, PaginationPolicy, RestoreFileRevisionRequest, RevisionNo,
+    InodeId, LimitError, ListFileRevisionsResponse, PageCursorError, PageRequest, PaginationPolicy,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use tracing::Instrument;
 
@@ -411,7 +411,7 @@ pub(super) async fn restore_inode_revision(
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = FilesystemOperationRequest,
         responses(
-            (status = 200, description = "Filesystem operation committed", body = FilesystemOperationResponse),
+            (status = 200, description = "Filesystem operation committed", body = ApiCommitResponse),
             (status = 400, description = "Invalid operation", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
@@ -426,7 +426,7 @@ pub(super) async fn filesystem_operation(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
     AppJson(request): AppJson<FilesystemOperationRequest>,
-) -> Result<Json<FilesystemOperationResponse>, ApiResponseError> {
+) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let FilesystemOperationRequest {
@@ -529,11 +529,7 @@ pub(super) async fn filesystem_operation(
     };
     let response = response_result
         .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
-    let result = FilesystemOperationResponse {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    };
-    Ok(Json(result))
+    Ok(Json(response))
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -16,10 +16,9 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointRequest,
     CreateCheckpointResponse, CreateNamespaceRequest, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, InodeId, ListFileRevisionsResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse,
-    ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo,
+    FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, InodeId, ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo,
 };
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
@@ -80,7 +79,6 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::MoveBehavior,
         FilesystemOperation,
         FilesystemOperationRequest,
-        FilesystemOperationResponse,
         loonfs_api::FileRevision,
         ListFileRevisionsResponse,
         RestoreFileRevisionRequest,

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -3,8 +3,8 @@
 
 use loonfs_api::{
     v0::{CompleteUploadRequest, ObjectTransferAccess, ValidatedContentToken},
-    ChangeSeq, CommitId, ContentRef, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, PutBehavior,
+    ChangeSeq, CommitId, CommitResponse, ContentRef, FilesystemOperation,
+    FilesystemOperationRequest, PutBehavior,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs_server::{
@@ -302,7 +302,7 @@ fn post_filesystem_operation(
     server_url: &str,
     namespace: &str,
     request: &FilesystemOperationRequest,
-) -> FilesystemOperationResponse {
+) -> CommitResponse {
     let response = ureq::post(&format!(
         "{server_url}/v0/namespaces/{namespace}/filesystem/operations"
     ))

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -7,11 +7,10 @@ use loonfs_api::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
         CompleteUploadRequest, ValidatedContentToken,
     },
-    AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, ContentRef,
-    CreateCheckpointResponse, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, InodeId, InodeKind, ListPathEntriesResponse, ManifestId,
-    NamespaceId, PutBehavior, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
-    LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
+    AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, CommitResponse,
+    ContentRef, CreateCheckpointResponse, FilesystemOperation, FilesystemOperationRequest, InodeId,
+    InodeKind, ListPathEntriesResponse, ManifestId, NamespaceId, PutBehavior, RevisionNo,
+    DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
 use loonfs_objectstore::keys::metadata_manifest_object;
@@ -320,10 +319,17 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         assert_eq!(directory_entry.inode_kind, InodeKind::Directory);
 
         let target = NamespacePath::parse("demo:/notes/hello.txt").expect("parse namespace path");
-        harness
+        let written = harness
             .client
-            .write_file_bytes(&target, b"hello over http\n", &MutationOptions::default())
+            .write_file_bytes(
+                &target,
+                b"hello over http\n",
+                &MutationOptions::with_commit_id("smoke-write-1"),
+            )
             .expect("write bytes");
+        // Path operations echo the commit id they committed under.
+        assert_eq!(written.commit_id.as_str(), "smoke-write-1");
+        assert_eq!(written.committed_seq, ChangeSeq(2));
 
         let entry = harness.client.stat_path(&target).expect("stat path");
         assert_eq!(entry.size_bytes, Some(16));
@@ -816,7 +822,7 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
         .set("authorization", "Bearer test-token")
         .send_json(request)
         .expect("bad token should fall back to content validation");
-        let response: FilesystemOperationResponse =
+        let response: CommitResponse =
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -19,7 +19,7 @@ use crate::{
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
     ErrorCode, FlushWalOutcome, FlushWalResponse, InodeId, ListChangesOptions,
     ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
+    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, ObjectStore, PutFileOptions,
     ReleaseCheckpointResponse, RestoreRevisionOptions, RevisionNo, RuntimeCacheStats,
     UploadContentResponse,
@@ -992,7 +992,7 @@ impl FsCore {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
@@ -1068,7 +1068,7 @@ impl FsCore {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record(
@@ -1095,7 +1095,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::CreateDir {
@@ -1115,7 +1115,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::DeletePath {
@@ -1134,7 +1134,7 @@ impl FsCore {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::MovePath {
@@ -1155,7 +1155,7 @@ impl FsCore {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::CopyFilePath {
@@ -1174,7 +1174,7 @@ impl FsCore {
         absolute_path: &str,
         source_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::RestoreRevision {
@@ -1276,18 +1276,8 @@ impl FsCore {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_through_publisher(
-            namespace_id,
-            vec![NamespaceMutationCandidate::Commit(request)],
-        )
-        .await
-        .into_iter()
-        .next()
-        .unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Internal(
-                "empty commit batch".to_owned(),
-            )))
-        })
+        self.publish_candidate(namespace_id, NamespaceMutationCandidate::Commit(request))
+            .await
     }
 
     /// Submits explicit semantic commit requests, returning one result per
@@ -1312,7 +1302,7 @@ impl FsCore {
         &self,
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
             .await
     }
@@ -1321,19 +1311,16 @@ impl FsCore {
         &self,
         namespace_id: &NamespaceId,
         candidate: NamespaceMutationCandidate,
-    ) -> Result<MutationResult> {
-        let mut results = self
-            .publish_through_publisher(namespace_id, vec![candidate])
-            .await;
-        let response = results.pop().unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Internal(
-                "empty path mutation batch".to_owned(),
-            )))
-        })?;
-        Ok(MutationResult {
-            namespace_id: response.namespace_id,
-            committed_seq: response.committed_seq,
-        })
+    ) -> Result<CommitResponse> {
+        self.publish_through_publisher(namespace_id, vec![candidate])
+            .await
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| {
+                Err(RuntimeError::Core(CoreError::Internal(
+                    "empty publication batch".to_owned(),
+                )))
+            })
     }
 
     /// Publishes direct submissions through the core's publication service

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -10,7 +10,7 @@ use crate::{
     CapabilityDocument, CommitRequest, CommitResponse, CompleteUploadRequest,
     CompleteUploadResponse, ContentRef, CopyOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    GramIndexBuildPolicy, InodeId, MoveOptions, MutationResult, NamespaceId, NamespaceSummary,
+    GramIndexBuildPolicy, InodeId, MoveOptions, NamespaceId, NamespaceSummary,
     ObjectStoreMetricsRecorder, PutFileOptions, RestoreRevisionOptions, Result, RevisionNo,
     RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind, UploadContentResponse, UploadId,
@@ -135,7 +135,7 @@ impl FsWriter {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .put_file_bytes(namespace_id, absolute_path, bytes, options)
             .await
@@ -152,7 +152,7 @@ impl FsWriter {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
             .await
@@ -164,7 +164,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .create_directory(namespace_id, absolute_path, options)
             .await
@@ -179,7 +179,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .delete_path(namespace_id, absolute_path, options)
             .await
@@ -192,7 +192,7 @@ impl FsWriter {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .move_path(namespace_id, from_path, to_path, options)
             .await
@@ -206,7 +206,7 @@ impl FsWriter {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .copy_path(namespace_id, from_path, to_path, options)
             .await
@@ -219,7 +219,7 @@ impl FsWriter {
         absolute_path: &str,
         source_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .restore_file_revision(namespace_id, absolute_path, source_revision_no, options)
             .await

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -52,14 +52,14 @@ pub use loonfs_api::{
     ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteDirectoryBehavior, DeleteNamespaceResponse,
     DirectoryPageCursor, DisableGramsIndexResponse, DisplayName, EffectiveLimit,
-    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse,
-    FlushWalOutcome, FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
-    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult, NameKey,
-    NamePolicy, NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest,
-    PaginationPolicy, PutBehavior, ReleaseCheckpointResponse, RevisionNo, UploadId,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FlushWalOutcome,
+    FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, NameKey, NamePolicy,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy,
+    PutBehavior, ReleaseCheckpointResponse, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
+    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
+    PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -127,8 +127,8 @@ struct ParkedPuts {
     store: Arc<BlockingHeadCasStore>,
     writer: Arc<FsWriter>,
     namespace_id: NamespaceId,
-    first: tokio::task::JoinHandle<loonfs::Result<loonfs::MutationResult>>,
-    second: tokio::task::JoinHandle<loonfs::Result<loonfs::MutationResult>>,
+    first: tokio::task::JoinHandle<loonfs::Result<loonfs::CommitResponse>>,
+    second: tokio::task::JoinHandle<loonfs::Result<loonfs::CommitResponse>>,
 }
 
 /// Parks one publication at the blocked head CAS with a second put queued

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -11,10 +11,10 @@ use loonfs::{
     CreateCheckpointOptions, CreateCheckpointResponse, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode, FsAdmin, FsReader,
     FsWriter, FsWriterBuilder, InodeId, InodeKind, ListChangesOptions, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
-    NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy, PutBehavior,
-    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind,
-    UploadContentResponse, UploadId,
+    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, NamespaceId,
+    NamespaceStatusResponse, PageRequest, PaginationPolicy, PutBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind, UploadContentResponse,
+    UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_head};
@@ -102,7 +102,7 @@ impl TestRuntime {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         self.writer
             .put_file_bytes(namespace_id, absolute_path, bytes, options)
             .await
@@ -114,7 +114,7 @@ impl TestRuntime {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         self.writer
             .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
             .await
@@ -297,33 +297,33 @@ trait FsTestExt {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn create_directory_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn delete_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn copy_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn begin_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
@@ -427,7 +427,7 @@ impl FsTestExt for TestRuntime {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .put_file_bytes(namespace_id, absolute_path, bytes, options),
@@ -439,7 +439,7 @@ impl FsTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .create_directory(namespace_id, absolute_path, options),
@@ -451,7 +451,7 @@ impl FsTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .delete_path(namespace_id, absolute_path, options),
@@ -464,7 +464,7 @@ impl FsTestExt for TestRuntime {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .move_path(namespace_id, from_path, to_path, options),
@@ -477,7 +477,7 @@ impl FsTestExt for TestRuntime {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .copy_path(namespace_id, from_path, to_path, options),
@@ -1754,6 +1754,67 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
         .read_file_bytes_blocking(&namespace_id, "/docs/report.txt")
         .expect("read retried file");
     assert_eq!(read.bytes, b"overlap survives");
+}
+
+#[test]
+fn path_mutations_return_the_commit_id_they_committed_under() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let object_store = store(temp_dir.path());
+    block_on(async {
+        let fs = open_runtime_async(object_store, "commit-id-echo-test").await;
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+
+        let commit_id = CommitId::parse("retry-key-1").expect("valid commit id");
+        let first = fs
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions {
+                    commit_id: Some(commit_id.clone()),
+                    ..PutFileOptions::default()
+                },
+            )
+            .await
+            .expect("first put");
+        assert_eq!(first.namespace_id, namespace_id);
+        assert_eq!(first.commit_id, commit_id);
+
+        // Resubmitting the identical mutation with the same commit id
+        // replays the original commit instead of committing again.
+        let replay = fs
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions {
+                    commit_id: Some(commit_id.clone()),
+                    ..PutFileOptions::default()
+                },
+            )
+            .await
+            .expect("identical resubmission replays the original commit");
+        assert_eq!(replay.commit_id, first.commit_id);
+        assert_eq!(replay.committed_seq, first.committed_seq);
+
+        // Without a caller-supplied id, the generated one is still returned,
+        // so every caller holds a reconciliation handle.
+        let generated = fs
+            .writer
+            .create_directory(
+                &namespace_id,
+                "/docs/sub",
+                CreateDirectoryOptions::default(),
+            )
+            .await
+            .expect("mkdir");
+        assert!(!generated.commit_id.as_str().is_empty());
+        assert_ne!(generated.commit_id, first.commit_id);
+        assert!(generated.committed_seq > first.committed_seq);
+    });
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -265,8 +265,7 @@ orphaned, and the request is not committed.
 
 If the head update's outcome was never observed — a transport failure after
 the update was sent — the server reports `commit_outcome_unknown`: the commit
-may already be visible. A retry must reuse the same `commit_id`, which replays
-the committed response instead of double-committing.
+may already be visible. Section 5.2 defines how the caller resolves it.
 
 The server may publish multiple committed logical commits in one WAL segment
 and one head update, but it must preserve per-commit idempotency, ordering,
@@ -282,6 +281,36 @@ Callers may bound a response with `limit`; a truncated page returns
 the requested cursor is older than the retention floor, the caller must
 re-bootstrap instead of expecting older incremental history to remain
 available.
+
+### 5.2 Mutation responses and safe retry
+
+Every committed mutation — an explicit commit or a path-oriented operation —
+returns the same response envelope: the `namespace_id` that changed, the
+`commit_id` the mutation committed under, and the `committed_seq` where it
+became visible. When the caller did not supply a commit id, the surface that
+accepted the request generates one and returns it, so every caller holds the
+identity it needs to reconcile an uncertain outcome.
+
+The retry rule has three cases:
+
+- Resubmitting the semantically identical mutation with the same `commit_id`
+  is safe: if the original committed, the response replays the original
+  `committed_seq` without committing again; if it never committed, the
+  resubmission completes it.
+- Reusing a `commit_id` for a different mutation fails with
+  `commit_id_reuse_conflict`.
+- Retrying with a new `commit_id` is a new logical mutation.
+
+Identical resubmission is the reconciliation mechanism. There is no separate
+commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
+a process restart, resubmit the same request with the same `commit_id` and
+read the definitive answer from the response.
+
+Committed mutations record a durable receipt binding the `commit_id` to its
+`committed_seq`; replay reads that receipt. Receipts are currently retained
+for the life of the namespace. When receipt retention becomes bounded, this
+contract will state the replay window explicitly, and resubmission after the
+window must fail loudly rather than silently committing again.
 
 The standard lower-level mutation set is defined in `format.md` ("Standard
 mutation operations"). The path-oriented filesystem surface may compile
@@ -601,13 +630,15 @@ Representative request:
 ```
 
 A successful response is returned only after the underlying change is actually
-committed: the WAL segment is durable and the head has advanced.
+committed: the WAL segment is durable and the head has advanced. Path
+operations return the same envelope as explicit commits (section 5.2).
 
 Representative response:
 
 ```json
 {
   "namespace_id": "demo",
+  "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
   "committed_seq": 419
 }
 ```

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1337,7 +1337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FilesystemOperationResponse"
+                  "$ref": "#/components/schemas/CommitResponse"
                 }
               }
             }
@@ -3234,7 +3234,7 @@
       },
       "CommitResponse": {
         "type": "object",
-        "description": "Response for a committed explicit request.",
+        "description": "Result of one committed mutation.\n\nEvery mutation resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.",
         "required": [
           "namespace_id",
           "commit_id",
@@ -3242,13 +3242,16 @@
         ],
         "properties": {
           "commit_id": {
-            "$ref": "#/components/schemas/CommitId"
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Idempotency key the mutation committed under: caller-supplied, or\ngenerated on the caller's behalf when the request carried none."
           },
           "committed_seq": {
-            "$ref": "#/components/schemas/ChangeSeq"
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence number where the mutation became visible."
           },
           "namespace_id": {
-            "$ref": "#/components/schemas/NamespaceId"
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that changed."
           }
         }
       },
@@ -3717,24 +3720,6 @@
           "operation": {
             "$ref": "#/components/schemas/FilesystemOperation",
             "description": "Operation to apply."
-          }
-        }
-      },
-      "FilesystemOperationResponse": {
-        "type": "object",
-        "description": "Response for one path-oriented operation.",
-        "required": [
-          "namespace_id",
-          "committed_seq"
-        ],
-        "properties": {
-          "committed_seq": {
-            "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Sequence where the operation became visible."
-          },
-          "namespace_id": {
-            "$ref": "#/components/schemas/NamespaceId",
-            "description": "Namespace that changed."
           }
         }
       },


### PR DESCRIPTION
Every path mutation already produced a full commit response internally — the publisher and engine return `CommitResponse { namespace_id, commit_id, committed_seq }` — but the convenience surfaces dropped the commit id at the boundary: `MutationResult` and `FilesystemOperationResponse` carried only the namespace and sequence. A caller who let the id auto-generate held nothing to reconcile with after a timeout or an unknown outcome, even though durable receipts make resubmitting the same id replay the original commit.

This deletes both trimmed envelopes and returns `CommitResponse` from every mutation on every surface: the embedded writer methods, the `/filesystem/operations` route, the client SDK path methods, and the CLI. The CLI also accepts `--commit-id` on put/rm/mkdir/mv/cp/restore and prints the id each mutation committed under; its redundant local id minting is deleted (the runtime already generates one when the option is absent). The API spec gains a "Mutation responses and safe retry" section stating the retry rule — identical resubmission replays, different semantics under the same id is `commit_id_reuse_conflict`, a new id is a new mutation — and naming identical resubmission as the reconciliation mechanism, with the receipt-retention caveat spelled out.

New coverage: an embedded runtime test proves a supplied commit id is echoed back and that identical resubmission through the path door replays the original committed seq; the HTTP smoke test asserts the echo over the wire.