### PR TITLE
docs(loonfs): drop leftover lease wording from runtime comments

### DIFF
--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -1,10 +1,9 @@
-//! Runtime configuration: writer identity, lease duration, and cache
+//! Runtime configuration: writer identity, publication pacing, and cache
 //! sizing, with the defaults the rest of the crate advertises.
 
 use crate::trace::{TraceMode, TraceStoreKind};
 use crate::{GramIndexBuildPolicy, MetadataTableCacheConfig, Result, RuntimeError};
 
-/// Default lease duration for write operations, in milliseconds.
 /// Default visible WAL-tail length, in segments, at which a maintenance tick
 /// publishes a checkpoint.
 pub const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -766,7 +766,7 @@ impl NamespacePublisher {
                 true
             }
             Err(error) => {
-                // The namespace was not deleted (stale precondition, lease
+                // The namespace was not deleted (stale precondition, fencing
                 // conflict, ...). Report it and let queued work publish.
                 for waiter in pending.waiters {
                     let _ = waiter.send(Err(error.clone()));


### PR DESCRIPTION
The runtime config module doc and a stray constant doc line still described a "lease duration for write operations", and a publisher comment listed "lease conflict" as a delete-failure cause. LoonFS has no lease concept anywhere — writer ownership is epoch fencing with no expiry (writer_epoch.rs states this explicitly), and FsConfig has no lease field. Comment-only change aligning the words with the design.