### PR TITLE
feat(api,core,server,client): structured error details and request correlation ids

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -82,12 +82,12 @@ pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
     CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DisableGramsIndexResponse,
-    EnableGramsIndexResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
-    FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch,
-    GrepRequest, GrepResponse, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    EnableGramsIndexResponse, ErrorDetails, FileRevision, FilesystemOperation,
+    FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, GrepMatch, GrepRequest, GrepResponse, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, MoveBehavior, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
+    ReleaseCheckpointResponse, RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -25,11 +25,12 @@ pub use commits::{
 };
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointRequest, CreateCheckpointResponse,
-    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision,
-    FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome,
-    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary,
-    PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorDetails,
+    FileRevision, FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome,
+    FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse,
+    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use search::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -7,6 +7,7 @@
 use super::{MoveBehavior, ValidatedContentToken};
 use crate::{
     ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId, RevisionNo,
+    WriterEpoch,
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,56 @@ pub struct ApiError {
     pub feature: Option<String>,
     /// Human-readable error message.
     pub message: String,
+    /// Correlation id the server assigned to the failed request; the same
+    /// value is sent as the `x-request-id` response header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    /// Structured context for the code, present when the failure carries
+    /// machine-usable identity (API spec, "Standard error contract"). Boxed
+    /// so the rare detailed error does not widen every error-carrying result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Box<ErrorDetails>>,
+}
+
+/// Structured, machine-readable context accompanying an [`ApiError`].
+///
+/// Every field is optional: a code populates the fields that apply to it
+/// (API spec, "Standard error contract"), and clients must tolerate absent
+/// fields exactly as they tolerate unknown codes. Retry decisions still key
+/// off the code; these fields carry the identity a caller needs to act —
+/// which commit to resubmit, which epoch displaced it, which revision the
+/// precondition saw.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ErrorDetails {
+    /// Idempotency key of the mutation the error concerns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_id: Option<CommitId>,
+    /// Epoch the failing writer session held when it was displaced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fenced_epoch: Option<WriterEpoch>,
+    /// Epoch that currently owns the namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_writer_epoch: Option<WriterEpoch>,
+    /// Writer id recorded by the current epoch's acquirer, when the head
+    /// recorded one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_writer: Option<String>,
+    /// Inode the failed precondition or operation targeted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inode_id: Option<InodeId>,
+    /// Revision the request expected to be current.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_revision: Option<RevisionNo>,
+    /// Revision that is actually current; absent when the inode has none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_revision: Option<RevisionNo>,
+    /// Change-feed cursor the request asked to resume after.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_seq: Option<ChangeSeq>,
+    /// Oldest sequence still promised for incremental replay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_floor_seq: Option<ChangeSeq>,
 }
 
 /// Request to create a namespace.

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -574,6 +574,8 @@ mod tests {
             code: "namespace_not_found".to_owned(),
             feature: None,
             message: "namespace `demo` does not exist".to_owned(),
+            request_id: None,
+            details: None,
         });
 
         assert_eq!(error.code, "namespace_not_found");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -21,12 +21,12 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse,
-    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
-    GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
-    RevisionNo,
+    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorDetails, ErrorKind,
+    FilesystemOperation, FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest,
+    GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -109,6 +109,11 @@ pub enum ClientError {
         /// Capability feature key accompanying `not_supported` errors.
         feature: Option<String>,
         message: String,
+        /// Correlation id the server assigned to the failed request.
+        request_id: Option<String>,
+        /// Structured context for the code, when the server sent any. Boxed
+        /// so the rare detailed error does not widen every client result.
+        details: Option<Box<ErrorDetails>>,
     },
     #[error("i/o error: {0}")]
     Io(String),
@@ -990,6 +995,8 @@ impl Client {
                         code: body.code,
                         feature: body.feature,
                         message: body.message,
+                        request_id: body.request_id,
+                        details: body.details,
                     },
                     Err(err) => ClientError::Http(err.to_string()),
                 }
@@ -1120,6 +1127,8 @@ mod tests {
             code: code.to_owned(),
             feature: None,
             message: "test".to_owned(),
+            request_id: None,
+            details: None,
         }
     }
 

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -6,7 +6,9 @@ use crate::checkpoint::MetadataTableCache;
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
-use crate::error::{CoreError, MetadataProjectionLoadError, MetadataViewError, Result};
+use crate::error::{
+    CoreError, MetadataProjectionLoadError, MetadataViewError, Result, WriterFence,
+};
 use crate::metadata::MetadataState;
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
@@ -106,7 +108,7 @@ pub struct WriterSessionState {
     /// every later publish fails with `writer_fenced` without touching the
     /// store; the session never reacquires on its own. Reacquisition is an
     /// explicit caller decision, left to a future takeover API.
-    fenced: Option<String>,
+    fenced: Option<WriterFence>,
 }
 
 /// Shared handle to one namespace's [`WriterSessionState`].
@@ -215,11 +217,11 @@ impl NamespaceCommitEngine {
         let candidate_count = candidates.len();
         let already_acquired = {
             let session = self.lock_session();
-            if let Some(message) = &session.fenced {
-                let message = message.clone();
+            if let Some(fence) = &session.fenced {
+                let fence = fence.clone();
                 drop(session);
                 return NamespaceCommitEnginePublishResult {
-                    results: repeated_error(candidate_count, CoreError::WriterFenced(message)),
+                    results: repeated_error(candidate_count, CoreError::WriterFenced(fence)),
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
@@ -231,7 +233,7 @@ impl NamespaceCommitEngine {
             None => match acquire_writer_epoch(store, &self.namespace_id, context).await {
                 Ok(value) => {
                     let mut session = self.lock_session();
-                    if let Some(message) = session.fenced.clone() {
+                    if let Some(fence) = session.fenced.clone() {
                         // Another engine sharing this session observed
                         // fencing while we were acquiring; the session
                         // stays fenced.
@@ -239,7 +241,7 @@ impl NamespaceCommitEngine {
                         return NamespaceCommitEnginePublishResult {
                             results: repeated_error(
                                 candidate_count,
-                                CoreError::WriterFenced(message),
+                                CoreError::WriterFenced(fence),
                             ),
                             wal_tail_segments: 0,
                             resulting_read_state: None,
@@ -293,9 +295,9 @@ impl NamespaceCommitEngine {
             Ok(value) => value,
             Err(error) => {
                 self.invalidate();
-                if let CoreError::WriterFenced(message) = &error {
+                if let CoreError::WriterFenced(fence) = &error {
                     let mut session = self.lock_session();
-                    session.fenced = Some(message.clone());
+                    session.fenced = Some(fence.clone());
                     session.acquired_writer = None;
                 }
                 return NamespaceCommitEnginePublishResult {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -15,8 +15,8 @@ use crate::storage::content::{DurableContentValidationError, ImmutableObjectWrit
 use crate::wal::{WalBuildError, WalChainLoadError, WalReplayError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{
-    ChangeSeq, CommitIdValidationError, GeneratedIdValidationError, InodeId, InodeKind,
-    NamespaceId, NamespaceIdValidationError, UploadId,
+    ChangeSeq, CommitId, CommitIdValidationError, ErrorDetails, GeneratedIdValidationError,
+    InodeId, InodeKind, NamespaceId, NamespaceIdValidationError, UploadId, WriterEpoch,
 };
 use loonfs_objectstore::ObjectStoreError;
 use thiserror::Error;
@@ -146,7 +146,7 @@ pub enum CoreError {
     /// This writer session's epoch was superseded. Terminal for the session:
     /// callers surface it without reacquiring.
     #[error("writer session fenced: {0}")]
-    WriterFenced(String),
+    WriterFenced(WriterFence),
     #[error("object store error for `{object_key}`: {message}")]
     Store { object_key: String, message: String },
     /// Non-store internal failure (codec, overflow, invariant breach). Same
@@ -344,6 +344,86 @@ impl CoreError {
 
     pub fn message(&self) -> String {
         self.to_string()
+    }
+
+    /// Structured wire details for this error, when the variant carries
+    /// machine-usable identity (API spec, "Standard error contract"). The
+    /// server serializes this beside [`CoreError::code`]; embedded callers
+    /// can match the typed variants directly instead.
+    pub fn details(&self) -> Option<ErrorDetails> {
+        match self {
+            CoreError::WriterFenced(fence) => Some(ErrorDetails {
+                fenced_epoch: Some(fence.fenced_epoch),
+                active_writer_epoch: Some(fence.active_epoch),
+                active_writer: fence.active_writer.clone(),
+                ..ErrorDetails::default()
+            }),
+            CoreError::CommitIdReuseConflict(commit_id) => Some(ErrorDetails {
+                commit_id: CommitId::parse(commit_id).ok(),
+                ..ErrorDetails::default()
+            }),
+            CoreError::RebootstrapRequired {
+                after_seq,
+                retention_floor_seq,
+            } => Some(ErrorDetails {
+                after_seq: Some(*after_seq),
+                retention_floor_seq: Some(*retention_floor_seq),
+                ..ErrorDetails::default()
+            }),
+            CoreError::CommitValidation(error) => commit_validation_details(error),
+            _ => None,
+        }
+    }
+}
+
+/// The fencing event a writer session observed: the epoch the session held,
+/// the epoch that displaced it, and the winner's writer id when the head
+/// recorded one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriterFence {
+    /// Epoch the fenced session held.
+    pub fenced_epoch: WriterEpoch,
+    /// Epoch that owns the namespace now.
+    pub active_epoch: WriterEpoch,
+    /// Writer id recorded by the winning acquirer, when known.
+    pub active_writer: Option<String>,
+}
+
+impl std::fmt::Display for WriterFence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "epoch {} was fenced by epoch {} (writer `{}`)",
+            self.fenced_epoch,
+            self.active_epoch,
+            self.active_writer.as_deref().unwrap_or("unknown")
+        )
+    }
+}
+
+fn commit_validation_details(error: &CommitValidationError) -> Option<ErrorDetails> {
+    match error {
+        CommitValidationError::ReplaceFileBaseRevisionMismatch {
+            inode_id,
+            expected,
+            actual,
+        }
+        | CommitValidationError::RestoreRevisionBaseRevisionMismatch {
+            inode_id,
+            expected,
+            actual,
+        } => Some(ErrorDetails {
+            inode_id: Some(*inode_id),
+            expected_revision: Some(*expected),
+            actual_revision: *actual,
+            ..ErrorDetails::default()
+        }),
+        CommitValidationError::StaleWriterEpoch { active, requested } => Some(ErrorDetails {
+            fenced_epoch: Some(*requested),
+            active_writer_epoch: Some(*active),
+            ..ErrorDetails::default()
+        }),
+        _ => None,
     }
 }
 
@@ -551,8 +631,12 @@ fn classify_head_publish_error(error: &CommitHeadPublishError) -> ErrorCode {
 
 #[cfg(test)]
 mod tests {
-    use super::{CoreError, ErrorCode, ErrorKind, MetadataViewError};
-    use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
+    use super::{
+        CommitValidationError, CoreError, ErrorCode, ErrorKind, MetadataViewError, WriterFence,
+    };
+    use loonfs_api::{
+        ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, RevisionNo, WriterEpoch,
+    };
 
     #[test]
     fn public_error_kind_groups_detailed_codes() {
@@ -630,5 +714,42 @@ mod tests {
             let error = CoreError::from(metadata_error);
             assert_eq!(error.code(), code);
         }
+    }
+
+    #[test]
+    fn identity_bearing_errors_expose_structured_wire_details() {
+        let fenced = CoreError::WriterFenced(WriterFence {
+            fenced_epoch: WriterEpoch(3),
+            active_epoch: WriterEpoch(4),
+            active_writer: Some("writer-b".to_owned()),
+        });
+        let details = fenced.details().expect("fence details");
+        assert_eq!(details.fenced_epoch, Some(WriterEpoch(3)));
+        assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
+        assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
+        assert!(fenced
+            .to_string()
+            .contains("epoch 3 was fenced by epoch 4 (writer `writer-b`)"));
+
+        let reuse = CoreError::CommitIdReuseConflict("retry-key-1".to_owned());
+        let details = reuse.details().expect("reuse details");
+        assert_eq!(
+            details.commit_id,
+            Some(CommitId::parse("retry-key-1").expect("valid commit id"))
+        );
+
+        let stale =
+            CoreError::CommitValidation(CommitValidationError::ReplaceFileBaseRevisionMismatch {
+                inode_id: InodeId(7),
+                expected: RevisionNo(2),
+                actual: Some(RevisionNo(5)),
+            });
+        let details = stale.details().expect("stale-revision details");
+        assert_eq!(details.inode_id, Some(InodeId(7)));
+        assert_eq!(details.expected_revision, Some(RevisionNo(2)));
+        assert_eq!(details.actual_revision, Some(RevisionNo(5)));
+
+        // Errors without machine-usable identity stay detail-free.
+        assert!(CoreError::Internal("boom".to_owned()).details().is_none());
     }
 }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -119,6 +119,7 @@ pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
+    WriterFence,
 };
 pub use gc::{gc_namespace, GcConfig, GcReport};
 pub use namespace::BootstrapNamespaceError;

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -63,15 +63,11 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
         // The epoch is the fence: any takeover bumps it, so a mismatch means
         // another writer owns the namespace and this delete must not land.
         if head.writer_epoch != acquired_writer.writer_epoch {
-            let winner = head
-                .writer
-                .as_ref()
-                .map(|writer| writer.writer_id.as_str())
-                .unwrap_or("unknown");
-            return Err(CoreError::WriterFenced(format!(
-                "delete with epoch {} was fenced by epoch {} (writer `{winner}`)",
-                acquired_writer.writer_epoch.0, head.writer_epoch.0
-            )));
+            return Err(CoreError::WriterFenced(crate::error::WriterFence {
+                fenced_epoch: acquired_writer.writer_epoch,
+                active_epoch: head.writer_epoch,
+                active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+            }));
         }
 
         if let Some(expected) = options.expected_head_seq {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -214,15 +214,11 @@ fn ensure_publish_head_matches_acquired_writer(
     acquired_writer: &AcquiredWriter,
 ) -> Result<()> {
     if head.writer_epoch != acquired_writer.writer_epoch {
-        let winner = head
-            .writer
-            .as_ref()
-            .map(|writer| writer.writer_id.as_str())
-            .unwrap_or("unknown");
-        return Err(CoreError::WriterFenced(format!(
-            "writer epoch {} was fenced by epoch {} (writer `{winner}`)",
-            acquired_writer.writer_epoch.0, head.writer_epoch.0
-        )));
+        return Err(CoreError::WriterFenced(crate::error::WriterFence {
+            fenced_epoch: acquired_writer.writer_epoch,
+            active_epoch: head.writer_epoch,
+            active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+        }));
     }
     Ok(())
 }

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::{BootstrapNamespaceError, CoreError, ErrorCode, ErrorKind, RuntimeError};
-use loonfs_api::{ApiError, NamespaceId, NamespaceIdValidationError};
+use loonfs_api::{ApiError, CommitId, ErrorDetails, NamespaceId, NamespaceIdValidationError};
 
 pub(super) struct ApiResponseError {
     status: StatusCode,
@@ -20,6 +20,8 @@ impl ApiResponseError {
                 code: code.as_str().to_owned(),
                 feature: None,
                 message: message.to_owned(),
+                request_id: None,
+                details: None,
             },
         }
     }
@@ -31,8 +33,23 @@ impl ApiResponseError {
                 code: ErrorCode::NotSupported.as_str().to_owned(),
                 feature: Some(feature.to_owned()),
                 message: message.to_owned(),
+                request_id: None,
+                details: None,
             },
         }
+    }
+
+    /// Stamps the mutation's idempotency key into the error details, so a
+    /// failed or uncertain outcome carries the caller's reconciliation
+    /// handle (API spec, "Mutation responses and safe retry"). Details the
+    /// error already carries win over the stamp.
+    pub(super) fn with_commit_id(mut self, commit_id: &CommitId) -> Self {
+        self.body
+            .details
+            .get_or_insert_with(Box::<ErrorDetails>::default)
+            .commit_id
+            .get_or_insert_with(|| commit_id.clone());
+        self
     }
 
     pub(super) fn invalid_namespace_id(error: NamespaceIdValidationError) -> Self {
@@ -66,6 +83,7 @@ impl ApiResponseError {
     fn core(error: CoreError) -> Self {
         let status = status_for_core_error_code(error.code());
         let mut response = Self::new(status, error.code(), &error.to_string());
+        response.body.details = error.details().map(Box::new);
         // `not_supported` responses name the capability the caller lacks
         // (API spec, "Standard error contract"); for a data-dependent
         // capability that is the namespace feature key, not an endpoint.
@@ -132,7 +150,11 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
 }
 
 impl IntoResponse for ApiResponseError {
-    fn into_response(self) -> Response {
+    fn into_response(mut self) -> Response {
+        // The correlation id is scoped by the request-id middleware; a body
+        // rendered outside a request scope (tests constructing errors
+        // directly) simply omits it.
+        self.body.request_id = super::REQUEST_ID.try_with(|id| id.clone()).ok();
         (self.status, Json(self.body)).into_response()
     }
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -392,11 +392,14 @@ pub(super) async fn restore_inode_revision(
         }],
         message: None,
     };
+    let commit_id = commit.commit_id.clone();
     let response = state
         .publisher
         .submit_commit(namespace_id.clone(), commit)
         .await
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
+        })?;
     Ok(Json(response))
 }
 
@@ -434,6 +437,9 @@ pub(super) async fn filesystem_operation(
         content_tokens,
         operation,
     } = request;
+    // Failed and uncertain outcomes echo the idempotency key the caller can
+    // resubmit under (API spec, "Mutation responses and safe retry").
+    let commit_id_for_errors = commit_id.clone();
     let put_payload_class = match &operation {
         FilesystemOperation::PutFile { content_ref, .. } => Some(payload_class(
             usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
@@ -527,8 +533,10 @@ pub(super) async fn filesystem_operation(
             .submit_path_intent(namespace_id.clone(), intent)
             .await
     };
-    let response = response_result
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+    let response = response_result.map_err(|error| {
+        ApiResponseError::core_for_namespace(&namespace_id, error)
+            .with_commit_id(&commit_id_for_errors)
+    })?;
     Ok(Json(response))
 }
 
@@ -561,11 +569,14 @@ pub(super) async fn commit_operations(
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let commit_id = request.commit_id.clone();
     let response = state
         .publisher
         .submit_commit(namespace_id.clone(), request)
         .await
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
+        })?;
     Ok(Json(response))
 }
 

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -43,9 +43,11 @@ use crate::config::{ServerConfig, ServerConfigError};
 use axum::async_trait;
 use axum::body::Bytes;
 use axum::extract::rejection::PathRejection;
-use axum::extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath};
+use axum::extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath, Request};
 use axum::http::request::Parts;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use loonfs::publisher::PublisherRegistry;
@@ -62,6 +64,31 @@ use thiserror::Error;
 
 type SharedStore = SharedObjectStore;
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
+
+/// Response header carrying the request's correlation id.
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+tokio::task_local! {
+    /// Correlation id of the request being served. Scoped around every
+    /// handler by [`with_request_id`]; [`error::ApiResponseError`] reads it
+    /// when rendering an error body.
+    pub(super) static REQUEST_ID: String;
+}
+
+/// Assigns each request a correlation id: every response carries it as the
+/// `x-request-id` header, and error bodies repeat it as
+/// `ApiError.request_id` so a caller's log line and the server's trace can
+/// be joined without header plumbing.
+async fn with_request_id(request: Request, next: Next) -> Response {
+    let request_id = loonfs_api::generated_id("req");
+    let mut response = REQUEST_ID
+        .scope(request_id.clone(), next.run(request))
+        .await;
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    response
+}
 
 /// Purpose-specific handles over one shared store client: read endpoints go
 /// through `reader`, mutations through `writer` (and its publisher),
@@ -227,6 +254,7 @@ fn router(state: AppState) -> Router {
             post(maintenance_tick),
         )
         .route("/v0/admin/namespaces/:namespace/gc", post(gc_namespace))
+        .layer(middleware::from_fn(with_request_id))
         .with_state(state)
 }
 

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -69,6 +69,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     components(schemas(
         loonfs_api::CapabilityDocument,
         ApiError,
+        loonfs_api::ErrorDetails,
+        loonfs_api::WriterEpoch,
         CreateNamespaceRequest,
         ForkNamespaceRequest,
         loonfs_api::NamespaceSummary,

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -822,6 +822,12 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
         .set("authorization", "Bearer test-token")
         .send_json(request)
         .expect("bad token should fall back to content validation");
+        // Every response carries the correlation id header, success included.
+        let request_id = response
+            .header("x-request-id")
+            .expect("x-request-id header")
+            .to_owned();
+        assert!(request_id.starts_with("req_"), "got `{request_id}`");
         let response: CommitResponse =
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
@@ -1206,8 +1212,20 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
             .client
             .commit_operations(namespace, &conflicting_request)
         {
-            Err(ClientError::Api { code, .. }) => {
-                assert_eq!(code, "commit_id_reuse_conflict")
+            Err(ClientError::Api {
+                code,
+                request_id,
+                details,
+                ..
+            }) => {
+                assert_eq!(code, "commit_id_reuse_conflict");
+                // The error carries the caller's reconciliation identity as
+                // structured fields, not prose (API spec, "Standard error
+                // contract").
+                let details = details.expect("structured details");
+                assert_eq!(details.commit_id, Some(first_request.commit_id.clone()));
+                let request_id = request_id.expect("request id");
+                assert!(request_id.starts_with("req_"), "got `{request_id}`");
             }
             other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
         }
@@ -1990,6 +2008,8 @@ fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Resu
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         }),
         Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
             response.into_reader(),
@@ -1998,11 +2018,15 @@ fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Resu
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         })),
         Err(ureq::Error::Transport(error)) => Err(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            request_id: None,
+            details: None,
         }),
     }
 }
@@ -2083,6 +2107,8 @@ fn decode_admin_response<T: serde::de::DeserializeOwned>(
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         }),
         Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
             response.into_reader(),
@@ -2091,11 +2117,15 @@ fn decode_admin_response<T: serde::de::DeserializeOwned>(
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         })),
         Err(ureq::Error::Transport(error)) => Err(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            request_id: None,
+            details: None,
         }),
     }
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -65,7 +65,7 @@ pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapNamespaceError, DeleteNamespaceOptions,
     DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind, GcConfig, GcReport,
-    GramIndexBuildPolicy,
+    GramIndexBuildPolicy, WriterFence,
 };
 
 /// Integration seam: the vocabulary for handing classified mutation work to

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -152,9 +152,14 @@ Every error response is a JSON body:
 
 ```json
 {
-  "code": "not_supported",
-  "feature": "core.namespaces.delete",
-  "message": "this deployment does not support namespace deletion"
+  "code": "writer_fenced",
+  "message": "writer session fenced: epoch 3 was fenced by epoch 4 (writer `server-b`)",
+  "request_id": "req_9c2f4a1b7d8e4f21a0b3c4d5e6f70819",
+  "details": {
+    "fenced_epoch": 3,
+    "active_writer_epoch": 4,
+    "active_writer": "server-b"
+  }
 }
 ```
 
@@ -163,6 +168,23 @@ change between releases; `feature` is present only on `not_supported` errors
 and names the capability-document key the client should reconcile against.
 Clients must branch on `code`, must tolerate codes they do not recognize, and
 must not parse `message`.
+
+`request_id` is the correlation id the server assigned to the request; every
+response — success or error — also carries it as the `x-request-id` header,
+so a caller's log line and the server's trace can be joined.
+
+`details` is present when the failure carries machine-usable identity, so a
+caller never has to parse `message` to act. Every field is optional and
+clients must tolerate absent fields exactly as they tolerate unknown codes.
+The codes that populate it:
+
+| Code | Detail fields |
+| --- | --- |
+| `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, `active_writer` (when the head recorded the winner's writer id) |
+| `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
+| `commit_id_reuse_conflict` | `commit_id` |
+| `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
+| any failed mutation | `commit_id` — the idempotency key the request committed under, echoed so failed and uncertain outcomes carry the caller's reconciliation handle (section 5.2) |
 
 One code exists specifically so capability handling is uniform from day one:
 
@@ -311,6 +333,21 @@ Committed mutations record a durable receipt binding the `commit_id` to its
 for the life of the namespace. When receipt retention becomes bounded, this
 contract will state the replay window explicitly, and resubmission after the
 window must fail loudly rather than silently committing again.
+
+### 5.3 Writer topology and fencing
+
+Each namespace has one active writer session. Many concurrent clients may
+submit mutations through that session — the reference server is exactly this
+shape: one service-level writer session coordinating every client request —
+and independent readers scale separately.
+
+Replacing the active writer is not an approval flow. Opening a writer and
+publishing acquires the next writer epoch, and epoch fencing — not liveness,
+not a lease — is what keeps the displaced session from corrupting anything:
+its next publish fails with `writer_fenced`, terminally for that session.
+The error's `details` name the epoch and writer that displaced it, so an
+operator can tell a planned failover from two writers misconfigured against
+one namespace.
 
 The standard lower-level mutation set is defined in `format.md` ("Standard
 mutation operations"). The path-oriented filesystem surface may compile

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2435,6 +2435,17 @@
             "type": "string",
             "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
           },
+          "details": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ErrorDetails",
+                "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+              }
+            ]
+          },
           "feature": {
             "type": [
               "string",
@@ -2445,6 +2456,13 @@
           "message": {
             "type": "string",
             "description": "Human-readable error message."
+          },
+          "request_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
       },
@@ -3520,6 +3538,107 @@
           }
         }
       },
+      "ErrorDetails": {
+        "type": "object",
+        "description": "Structured, machine-readable context accompanying an [`ApiError`].\n\nEvery field is optional: a code populates the fields that apply to it\n(API spec, \"Standard error contract\"), and clients must tolerate absent\nfields exactly as they tolerate unknown codes. Retry decisions still key\noff the code; these fields carry the identity a caller needs to act —\nwhich commit to resubmit, which epoch displaced it, which revision the\nprecondition saw.",
+        "properties": {
+          "active_writer": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Writer id recorded by the current epoch's acquirer, when the head\nrecorded one."
+          },
+          "active_writer_epoch": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WriterEpoch",
+                "description": "Epoch that currently owns the namespace."
+              }
+            ]
+          },
+          "actual_revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RevisionNo",
+                "description": "Revision that is actually current; absent when the inode has none."
+              }
+            ]
+          },
+          "after_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Change-feed cursor the request asked to resume after."
+              }
+            ]
+          },
+          "commit_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CommitId",
+                "description": "Idempotency key of the mutation the error concerns."
+              }
+            ]
+          },
+          "expected_revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RevisionNo",
+                "description": "Revision the request expected to be current."
+              }
+            ]
+          },
+          "fenced_epoch": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WriterEpoch",
+                "description": "Epoch the failing writer session held when it was displaced."
+              }
+            ]
+          },
+          "inode_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InodeId",
+                "description": "Inode the failed precondition or operation targeted."
+              }
+            ]
+          },
+          "retention_floor_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Oldest sequence still promised for incremental replay."
+              }
+            ]
+          }
+        }
+      },
       "FileRevision": {
         "type": "object",
         "description": "One immutable file revision.",
@@ -4473,6 +4592,12 @@
             "description": "Opaque, server-signed token. Clients must not parse it."
           }
         }
+      },
+      "WriterEpoch": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Monotonically increasing writer epoch for namespace write fencing.",
+        "minimum": 0
       }
     }
   },


### PR DESCRIPTION
The wire error body was `{code, feature, message}`, and the spec forbids parsing `message` — so the typed detail core already carries (which epoch fenced you, which revision a precondition saw, which commit id conflicted) was unreachable for HTTP callers. This PR makes errors actionable without prose-parsing, stacked on the unified-envelope PR.

`ApiError` gains two optional fields. `details` is a flat, all-optional struct populated per code: `writer_fenced` carries the fenced and active epochs plus the winning writer id (`CoreError::WriterFenced` is now a structured `WriterFence` instead of a preformatted string, and the session fencing latch stores it typed); `stale_revision` carries inode and expected/actual revisions; `commit_id_reuse_conflict` carries the id; `rebootstrap_required` carries the cursor and retention floor. Mutation handlers additionally stamp the request's own commit id into any failure, so uncertain outcomes like `commit_outcome_unknown` always hand the caller its reconciliation handle. `request_id` is assigned per request by middleware, echoed in error bodies, and sent as `x-request-id` on every response.

Deliberately not included: a `retryable` boolean (the code registry plus the code-to-kind mapping is already the retry contract), stale-head sequence fields (that error site only observes etags today; inventing numbers would be worse than omitting them), and detail versioning (pre-release stance: unknown-field tolerance, no compat machinery).

The spec's error-contract section documents the new fields and which codes set them, and section 5.3 states the writer topology plainly: one active writer session per namespace, many clients submitting through it, replacement by epoch fencing rather than an approval flow.