### PR TITLE
refactor(core,loonfs,server): mutation intents carry validated absolute paths

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -80,14 +80,14 @@ pub use path::{AbsolutePath, DisplayName, PathComponent, PathError};
 // in `v0`; add here only what most consumers touch.
 pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
-    CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DisableGramsIndexResponse,
     EnableGramsIndexResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest,
-    GcRequest, GcResponse, GrepMatch, GrepRequest, GrepResponse, ListFileRevisionsResponse,
-    ListPathEntriesResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
-    MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
+    FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch,
+    GrepRequest, GrepResponse, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -82,12 +82,12 @@ pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
     CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
     DeleteDirectoryBehavior, DeleteNamespaceResponse, DisableGramsIndexResponse,
-    EnableGramsIndexResponse, FileRevision, FilesystemOperation, FilesystemOperationRequest,
-    FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch,
-    GrepRequest, GrepResponse, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    EnableGramsIndexResponse, ErrorDetails, FileRevision, FilesystemOperation,
+    FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, GrepMatch, GrepRequest, GrepResponse, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, MoveBehavior, NamespaceStatusResponse, NamespaceSummary, PutBehavior,
+    ReleaseCheckpointResponse, RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -37,12 +37,21 @@ pub struct CommitRequest {
     pub message: Option<String>,
 }
 
-/// Response for a committed explicit request.
+/// Result of one committed mutation.
+///
+/// Every mutation resolves to this envelope — path-oriented operations and
+/// explicit commits, embedded or remote. The commit id is the caller's
+/// reconciliation handle: resubmitting the same request with the same id
+/// replays this result instead of committing twice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitResponse {
+    /// Namespace that changed.
     pub namespace_id: NamespaceId,
+    /// Idempotency key the mutation committed under: caller-supplied, or
+    /// generated on the caller's behalf when the request carried none.
     pub commit_id: CommitId,
+    /// Sequence number where the mutation became visible.
     pub committed_seq: ChangeSeq,
 }
 

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -26,11 +26,10 @@ pub use commits::{
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision,
-    FilesystemOperation, FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome,
-    FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse, MutationResult,
-    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse,
+    ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome,
+    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary,
+    PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use search::{

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -25,11 +25,12 @@ pub use commits::{
 };
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointRequest, CreateCheckpointResponse,
-    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, FileRevision,
-    FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse, MaintenanceTickOutcome,
-    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary,
-    PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, ErrorDetails,
+    FileRevision, FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome,
+    FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse,
+    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use search::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -84,16 +84,6 @@ pub struct DeleteNamespaceResponse {
     pub head_seq: ChangeSeq,
 }
 
-/// Result of a namespace-visible mutation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct MutationResult {
-    /// Namespace that changed.
-    pub namespace_id: NamespaceId,
-    /// Sequence number where the mutation became visible.
-    pub committed_seq: ChangeSeq,
-}
-
 /// Put behavior for path-oriented file writes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -171,16 +161,6 @@ pub struct FilesystemOperationRequest {
     pub content_tokens: Vec<ValidatedContentToken>,
     /// Operation to apply.
     pub operation: FilesystemOperation,
-}
-
-/// Response for one path-oriented operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct FilesystemOperationResponse {
-    /// Namespace that changed.
-    pub namespace_id: NamespaceId,
-    /// Sequence where the operation became visible.
-    pub committed_seq: ChangeSeq,
 }
 
 /// One immutable file revision.
@@ -410,24 +390,6 @@ pub struct MaintenanceTickResponse {
     /// Garbage-collection report when the tick opted into sweeping.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gc: Option<GcResponse>,
-}
-
-impl From<MutationResult> for FilesystemOperationResponse {
-    fn from(value: MutationResult) -> Self {
-        Self {
-            namespace_id: value.namespace_id,
-            committed_seq: value.committed_seq,
-        }
-    }
-}
-
-impl From<FilesystemOperationResponse> for MutationResult {
-    fn from(value: FilesystemOperationResponse) -> Self {
-        Self {
-            namespace_id: value.namespace_id,
-            committed_seq: value.committed_seq,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -7,6 +7,7 @@
 use super::{MoveBehavior, ValidatedContentToken};
 use crate::{
     ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId, RevisionNo,
+    WriterEpoch,
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,56 @@ pub struct ApiError {
     pub feature: Option<String>,
     /// Human-readable error message.
     pub message: String,
+    /// Correlation id the server assigned to the failed request; the same
+    /// value is sent as the `x-request-id` response header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    /// Structured context for the code, present when the failure carries
+    /// machine-usable identity (API spec, "Standard error contract"). Boxed
+    /// so the rare detailed error does not widen every error-carrying result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Box<ErrorDetails>>,
+}
+
+/// Structured, machine-readable context accompanying an [`ApiError`].
+///
+/// Every field is optional: a code populates the fields that apply to it
+/// (API spec, "Standard error contract"), and clients must tolerate absent
+/// fields exactly as they tolerate unknown codes. Retry decisions still key
+/// off the code; these fields carry the identity a caller needs to act —
+/// which commit to resubmit, which epoch displaced it, which revision the
+/// precondition saw.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ErrorDetails {
+    /// Idempotency key of the mutation the error concerns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_id: Option<CommitId>,
+    /// Epoch the failing writer session held when it was displaced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fenced_epoch: Option<WriterEpoch>,
+    /// Epoch that currently owns the namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_writer_epoch: Option<WriterEpoch>,
+    /// Writer id recorded by the current epoch's acquirer, when the head
+    /// recorded one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_writer: Option<String>,
+    /// Inode the failed precondition or operation targeted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inode_id: Option<InodeId>,
+    /// Revision the request expected to be current.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_revision: Option<RevisionNo>,
+    /// Revision that is actually current; absent when the inode has none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_revision: Option<RevisionNo>,
+    /// Change-feed cursor the request asked to resume after.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_seq: Option<ChangeSeq>,
+    /// Oldest sequence still promised for incremental replay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_floor_seq: Option<ChangeSeq>,
 }
 
 /// Request to create a namespace.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -35,8 +35,8 @@ pub(crate) enum Command {
     Put(FilesystemPutArgs),
     Revisions(FilesystemRevisionsArgs),
     Restore(FilesystemRestoreArgs),
-    Mkdir(FilesystemPathArgs),
-    Rm(FilesystemPathArgs),
+    Mkdir(FilesystemPathMutationArgs),
+    Rm(FilesystemPathMutationArgs),
     Mv(FilesystemTransferArgs),
     Cp(FilesystemTransferArgs),
     Changes(ChangesArgs),
@@ -255,6 +255,17 @@ pub(crate) struct FilesystemPathArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct FilesystemPathMutationArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    pub path: String,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct FilesystemRevisionsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
@@ -315,6 +326,10 @@ pub(crate) struct FilesystemPutArgs {
     pub remote_path: Option<String>,
     #[arg(long)]
     pub force: bool,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -323,6 +338,10 @@ pub(crate) struct FilesystemTransferArgs {
     pub target: TargetSelectorArgs,
     pub source_path: String,
     pub dest_path: String,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -332,6 +351,10 @@ pub(crate) struct FilesystemRestoreArgs {
     pub path: String,
     #[arg(long)]
     pub revision: u64,
+    /// Idempotency key for the commit; resubmit with the same id to retry
+    /// safely. Generated when absent and returned in the output.
+    #[arg(long)]
+    pub commit_id: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -18,10 +18,10 @@ use loonfs::{
 };
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, DeleteDirectoryBehavior,
     DisableGramsIndexResponse, EffectiveLimit, EnableGramsIndexResponse, FlushWalResponse,
     GcRequest, GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, MutationResult, NamespaceId,
+    MaintenanceTickRequest, MaintenanceTickResponse, MoveBehavior, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, PaginationPolicy, PutBehavior,
     ReleaseCheckpointResponse, RevisionNo,
 };
@@ -199,14 +199,14 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
         let behavior = if force {
             PutBehavior::Replace
         } else {
             PutBehavior::NoReplace
         };
-        let commit_id = generated_commit_id();
         self.writer
             .put_file_bytes(
                 &namespace_id,
@@ -214,39 +214,43 @@ impl Backend for EmbeddedBackend {
                 bytes,
                 PutFileOptions {
                     behavior,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
     }
 
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .delete_path(
                 &namespace_id,
                 &spec.absolute_path,
                 DeleteOptions {
                     behavior: DeleteDirectoryBehavior::NonRecursive,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
     }
 
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .create_directory(
                 &namespace_id,
                 &spec.absolute_path,
-                CreateDirectoryOptions {
-                    commit_id: Some(commit_id),
-                },
+                CreateDirectoryOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
@@ -256,9 +260,9 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .move_path(
                 &namespace_id,
@@ -266,7 +270,7 @@ impl Backend for EmbeddedBackend {
                 &to.absolute_path,
                 MoveOptions {
                     behavior: MoveBehavior::NoReplace,
-                    commit_id: Some(commit_id),
+                    commit_id,
                 },
             )
             .await
@@ -277,17 +281,15 @@ impl Backend for EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&from.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .copy_path(
                 &namespace_id,
                 &from.absolute_path,
                 &to.absolute_path,
-                CopyOptions {
-                    commit_id: Some(commit_id),
-                },
+                CopyOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&from.namespace, error))
@@ -297,17 +299,15 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let namespace_id = parse_namespace_id(&spec.namespace)?;
-        let commit_id = generated_commit_id();
         self.writer
             .restore_file_revision(
                 &namespace_id,
                 &spec.absolute_path,
                 source_revision_no,
-                RestoreRevisionOptions {
-                    commit_id: Some(commit_id),
-                },
+                RestoreRevisionOptions { commit_id },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
@@ -419,10 +419,6 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
     PaginationPolicy::default()
         .resolve_limit(limit)
         .map_err(|error| BackendError::invalid_input(error.to_string()))
-}
-
-fn generated_commit_id() -> CommitId {
-    CommitId::generate()
 }
 
 fn map_runtime_error(error: RuntimeError) -> BackendError {
@@ -636,7 +632,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn embedded_backend_generates_non_empty_commit_id_for_embedded_put() {
+    async fn embedded_backend_put_returns_the_commit_id_it_committed_under() {
         let temp_dir = tempdir().expect("create temp dir");
         let store = StoreConfig::LocalFs {
             root: temp_dir.path().display().to_string(),
@@ -651,7 +647,7 @@ mod tests {
             .await
             .expect("create namespace");
 
-        target
+        let response = target
             .backend
             .put_file_bytes(
                 &NamespacePath {
@@ -660,9 +656,11 @@ mod tests {
                 },
                 b"hello",
                 false,
+                None,
             )
             .await
             .expect("put file");
+        assert!(!response.commit_id.as_str().trim().is_empty());
 
         let changes = target
             .backend
@@ -670,7 +668,7 @@ mod tests {
             .await
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
-        assert!(!changes.changes[0].commit_id.as_str().trim().is_empty());
+        assert_eq!(changes.changes[0].commit_id, response.commit_id);
     }
 
     #[tokio::test]

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -8,15 +8,24 @@ use super::context::{
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs, FilesystemLsArgs,
-    FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs, FilesystemRevisionsArgs,
-    FilesystemTransferArgs, RuntimeBehavior,
+    FilesystemPathArgs, FilesystemPathMutationArgs, FilesystemPutArgs, FilesystemRestoreArgs,
+    FilesystemRevisionsArgs, FilesystemTransferArgs, RuntimeBehavior,
 };
 use crate::error::CliError;
-use loonfs_api::{InodeKind, RevisionNo};
+use loonfs_api::{CommitId, InodeKind, RevisionNo};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 // --- filesystem ---
+
+fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliError> {
+    commit_id
+        .map(|value| {
+            CommitId::parse(value)
+                .map_err(|error| CliError::invalid_input(format!("invalid --commit-id: {error}")))
+        })
+        .transpose()
+}
 
 pub(crate) async fn run_filesystem_ls(
     kind: CommandKind,
@@ -387,37 +396,7 @@ pub(crate) async fn run_filesystem_put(
             CliError::io(error),
         )
     })?;
-    let result = context
-        .target
-        .backend()
-        .put_file_bytes(&spec, &bytes, args.force)
-        .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(context.profile_name),
-        mode: Some(context.mode),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
-            committed_seq: result.committed_seq.0,
-        },
-    })
-}
-
-pub(crate) async fn run_filesystem_rm(
-    kind: CommandKind,
-    args: FilesystemPathArgs,
-) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
         fail(
             kind,
             Some(context.profile_name.clone()),
@@ -428,7 +407,7 @@ pub(crate) async fn run_filesystem_rm(
     let result = context
         .target
         .backend()
-        .delete_path(&spec)
+        .put_file_bytes(&spec, &bytes, args.force, commit_id)
         .await
         .map_err(|error| {
             fail(
@@ -446,6 +425,54 @@ pub(crate) async fn run_filesystem_rm(
         data: CommandData::FileMutation {
             target: render_target(&context.namespace, &spec.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
+        },
+    })
+}
+
+pub(crate) async fn run_filesystem_rm(
+    kind: CommandKind,
+    args: FilesystemPathMutationArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .delete_path(&spec, commit_id)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }
@@ -463,37 +490,7 @@ pub(crate) async fn run_filesystem_restore(
             error,
         )
     })?;
-    let result = context
-        .target
-        .backend()
-        .restore_file_revision(&spec, RevisionNo(args.revision))
-        .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(context.profile_name),
-        mode: Some(context.mode),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
-            committed_seq: result.committed_seq.0,
-        },
-    })
-}
-
-pub(crate) async fn run_filesystem_mkdir(
-    kind: CommandKind,
-    args: FilesystemPathArgs,
-) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
         fail(
             kind,
             Some(context.profile_name.clone()),
@@ -504,7 +501,7 @@ pub(crate) async fn run_filesystem_mkdir(
     let result = context
         .target
         .backend()
-        .create_directory(&spec)
+        .restore_file_revision(&spec, RevisionNo(args.revision), commit_id)
         .await
         .map_err(|error| {
             fail(
@@ -522,6 +519,54 @@ pub(crate) async fn run_filesystem_mkdir(
         data: CommandData::FileMutation {
             target: render_target(&context.namespace, &spec.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
+        },
+    })
+}
+
+pub(crate) async fn run_filesystem_mkdir(
+    kind: CommandKind,
+    args: FilesystemPathMutationArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
+    let result = context
+        .target
+        .backend()
+        .create_directory(&spec, commit_id)
+        .await
+        .map_err(|error| {
+            fail(
+                kind,
+                Some(context.profile_name.clone()),
+                Some(context.mode.clone()),
+                error,
+            )
+        })?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, &spec.absolute_path),
+            committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }
@@ -563,6 +608,14 @@ async fn run_filesystem_transfer(
         )
     })?;
 
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
+        fail(
+            kind,
+            Some(context.profile_name.clone()),
+            Some(context.mode.clone()),
+            error,
+        )
+    })?;
     let result = if copy {
         let entry = context
             .target
@@ -588,9 +641,17 @@ async fn run_filesystem_transfer(
                 )),
             ));
         }
-        context.target.backend().copy_path(&from, &to).await
+        context
+            .target
+            .backend()
+            .copy_path(&from, &to, commit_id)
+            .await
     } else {
-        context.target.backend().move_path(&from, &to).await
+        context
+            .target
+            .backend()
+            .move_path(&from, &to, commit_id)
+            .await
     }
     .map_err(|error| {
         fail(
@@ -609,6 +670,7 @@ async fn run_filesystem_transfer(
             from: render_target(&context.namespace, &from.absolute_path),
             to: render_target(&context.namespace, &to.absolute_path),
             committed_seq: result.committed_seq.0,
+            commit_id: result.commit_id.to_string(),
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -80,11 +80,13 @@ pub(crate) enum CommandData {
     FileMutation {
         target: String,
         committed_seq: u64,
+        commit_id: String,
     },
     PathMove {
         from: String,
         to: String,
         committed_seq: u64,
+        commit_id: String,
     },
     ConfigPath {
         path: String,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -367,19 +367,29 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::FileMutation {
             target,
             committed_seq,
+            commit_id,
         } => match output.kind {
-            CommandKind::FilesystemPut => format!("stored {target} @ seq {committed_seq}"),
-            CommandKind::FilesystemRm => format!("removed {target} @ seq {committed_seq}"),
-            _ => format!("{target} @ seq {committed_seq}"),
+            CommandKind::FilesystemPut => {
+                format!("stored {target} @ seq {committed_seq} (commit {commit_id})")
+            }
+            CommandKind::FilesystemRm => {
+                format!("removed {target} @ seq {committed_seq} (commit {commit_id})")
+            }
+            _ => format!("{target} @ seq {committed_seq} (commit {commit_id})"),
         },
         CommandData::PathMove {
             from,
             to,
             committed_seq,
+            commit_id,
         } => match output.kind {
-            CommandKind::FilesystemMv => format!("moved {from} -> {to} @ seq {committed_seq}"),
-            CommandKind::FilesystemCp => format!("copied {from} -> {to} @ seq {committed_seq}"),
-            _ => format!("{from} -> {to} @ seq {committed_seq}"),
+            CommandKind::FilesystemMv => {
+                format!("moved {from} -> {to} @ seq {committed_seq} (commit {commit_id})")
+            }
+            CommandKind::FilesystemCp => {
+                format!("copied {from} -> {to} @ seq {committed_seq} (commit {commit_id})")
+            }
+            _ => format!("{from} -> {to} @ seq {committed_seq} (commit {commit_id})"),
         },
         CommandData::ConfigPath { path } => path.clone(),
         CommandData::ConfigShow { config } => {

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -19,12 +19,12 @@
 use crate::{Client, ClientError, MutationOptions, NamespacePath};
 use async_trait::async_trait;
 use loonfs_api::{
-    v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
+    v0::ChangesResponse, AdvanceRetentionResponse, AuthoritativePathEntry, ChangeSeq, CommitId,
+    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, FlushWalResponse, GcRequest,
     GcResponse, GrepRequest, GrepResponse, ListFileRevisionsResponse, MaintenanceTickRequest,
-    MaintenanceTickResponse, MutationResult, NamespaceStatusResponse, NamespaceSummary,
-    ReleaseCheckpointResponse, RevisionNo,
+    MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse,
+    RevisionNo,
 };
 use thiserror::Error;
 
@@ -179,35 +179,49 @@ pub trait Backend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, BackendError>;
-    /// Writes a file; `force` replaces existing content.
+    /// Writes a file; `force` replaces existing content. An explicit
+    /// `commit_id` makes the call retryable by resubmission; absent, one is
+    /// generated and returned in the response.
     async fn put_file_bytes(
         &self,
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Creates a directory.
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Deletes a file or empty directory.
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError>;
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Moves a path within a namespace.
     async fn move_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Copies a file within a namespace.
     async fn copy_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
     /// Restores a file to one of its retained revisions.
     async fn restore_file_revision(
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError>;
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError>;
 
     // --- maintenance/admin plane (`admin/v0`) ---
 
@@ -266,6 +280,13 @@ impl RemoteBackend {
     /// Wraps a configured HTTP client.
     pub fn new(client: Client) -> Self {
         Self { client }
+    }
+}
+
+/// Carries a backend-level commit id into the wire client's options.
+fn mutation_options(commit_id: Option<CommitId>) -> MutationOptions {
+    MutationOptions {
+        commit_id: commit_id.map(|id| id.to_string()),
     }
 }
 
@@ -405,24 +426,34 @@ impl Backend for RemoteBackend {
         spec: &NamespacePath,
         bytes: &[u8],
         force: bool,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
         let bytes = bytes.to_vec();
-        self.wire(move |client| {
-            client.put_file_bytes(&spec, &bytes, force, &MutationOptions::default())
-        })
-        .await
-    }
-
-    async fn create_directory(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
-        let spec = spec.clone();
-        self.wire(move |client| client.create_directory(&spec, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.put_file_bytes(&spec, &bytes, force, &options))
             .await
     }
 
-    async fn delete_path(&self, spec: &NamespacePath) -> Result<MutationResult, BackendError> {
+    async fn create_directory(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| client.delete_path(&spec, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.create_directory(&spec, &options))
+            .await
+    }
+
+    async fn delete_path(
+        &self,
+        spec: &NamespacePath,
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
+        let spec = spec.clone();
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.delete_path(&spec, &options))
             .await
     }
 
@@ -430,10 +461,12 @@ impl Backend for RemoteBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.move_path(&from, &to, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.move_path(&from, &to, &options))
             .await
     }
 
@@ -441,10 +474,12 @@ impl Backend for RemoteBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        self.wire(move |client| client.copy_path(&from, &to, &MutationOptions::default()))
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.copy_path(&from, &to, &options))
             .await
     }
 
@@ -452,12 +487,12 @@ impl Backend for RemoteBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-    ) -> Result<MutationResult, BackendError> {
+        commit_id: Option<CommitId>,
+    ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        self.wire(move |client| {
-            client.restore_file_revision(&spec, source_revision_no, &MutationOptions::default())
-        })
-        .await
+        let options = mutation_options(commit_id);
+        self.wire(move |client| client.restore_file_revision(&spec, source_revision_no, &options))
+            .await
     }
 
     async fn create_checkpoint(

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -574,6 +574,8 @@ mod tests {
             code: "namespace_not_found".to_owned(),
             feature: None,
             message: "namespace `demo` does not exist".to_owned(),
+            request_id: None,
+            details: None,
         });
 
         assert_eq!(error.code, "namespace_not_found");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -22,10 +22,9 @@ use loonfs_api::{
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickRequest,
-    MaintenanceTickResponse, MutationResult, NamespaceId, NamespaceStatusResponse,
+    FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
+    GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
+    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId, NamespaceStatusResponse,
     NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
     RevisionNo,
 };
@@ -718,13 +717,13 @@ impl Client {
         &self,
         namespace: &str,
         request: &FilesystemOperationRequest,
-    ) -> Result<FilesystemOperationResponse, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let namespace = namespace_url_segment(namespace)?;
         let url = format!(
             "{}/v0/namespaces/{namespace}/filesystem/operations",
             self.base_url
         );
-        self.request_json::<_, FilesystemOperationResponse>(self.agent.post(&url), Some(request))
+        self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
     fn stage_bytes_as_content_ref(
@@ -760,7 +759,7 @@ impl Client {
         bytes: &[u8],
         force: bool,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let staged = self.stage_bytes_as_content_ref(&spec.namespace, bytes)?;
         let response = self.apply_filesystem_operation(
@@ -779,7 +778,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn write_file_bytes(
@@ -787,7 +786,7 @@ impl Client {
         spec: &NamespacePath,
         bytes: &[u8],
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.put_file_bytes(spec, bytes, true, options)
     }
 
@@ -795,7 +794,7 @@ impl Client {
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -807,14 +806,14 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn delete_path(
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::NonRecursive, options)
     }
 
@@ -822,7 +821,7 @@ impl Client {
         &self,
         spec: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         self.delete_path_with_behavior(spec, DeleteDirectoryBehavior::Recursive, options)
     }
 
@@ -831,7 +830,7 @@ impl Client {
         spec: &NamespacePath,
         behavior: DeleteDirectoryBehavior,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -844,7 +843,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn move_path(
@@ -852,7 +851,7 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot move across namespaces: {} -> {}",
@@ -872,7 +871,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn copy_path(
@@ -880,7 +879,7 @@ impl Client {
         from: &NamespacePath,
         to: &NamespacePath,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         if from.namespace != to.namespace {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot copy across namespaces: {} -> {}",
@@ -899,7 +898,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn restore_file_revision(
@@ -907,7 +906,7 @@ impl Client {
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
         options: &MutationOptions,
-    ) -> Result<MutationResult, ClientError> {
+    ) -> Result<ApiCommitResponse, ClientError> {
         let commit_id = options.resolve_commit_id()?;
         let response = self.apply_filesystem_operation(
             &spec.namespace,
@@ -920,7 +919,7 @@ impl Client {
                 },
             },
         )?;
-        Ok(response.into())
+        Ok(response)
     }
 
     pub fn restore_file_revision_for_inode(

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -21,12 +21,12 @@ use loonfs_api::{
     AdvanceRetentionResponse, ApiError, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse,
-    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorKind, FilesystemOperation,
-    FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
-    GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, PutBehavior, ReleaseCheckpointResponse, RestoreFileRevisionRequest,
-    RevisionNo,
+    DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, ErrorDetails, ErrorKind,
+    FilesystemOperation, FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest,
+    GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse,
+    ListPathEntriesResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
+    NamespaceStatusResponse, NamespaceSummary, PutBehavior, ReleaseCheckpointResponse,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use serde::Deserialize;
 use std::fs;
@@ -109,6 +109,11 @@ pub enum ClientError {
         /// Capability feature key accompanying `not_supported` errors.
         feature: Option<String>,
         message: String,
+        /// Correlation id the server assigned to the failed request.
+        request_id: Option<String>,
+        /// Structured context for the code, when the server sent any. Boxed
+        /// so the rare detailed error does not widen every client result.
+        details: Option<Box<ErrorDetails>>,
     },
     #[error("i/o error: {0}")]
     Io(String),
@@ -990,6 +995,8 @@ impl Client {
                         code: body.code,
                         feature: body.feature,
                         message: body.message,
+                        request_id: body.request_id,
+                        details: body.details,
                     },
                     Err(err) => ClientError::Http(err.to_string()),
                 }
@@ -1120,6 +1127,8 @@ mod tests {
             code: code.to_owned(),
             feature: None,
             message: "test".to_owned(),
+            request_id: None,
+            details: None,
         }
     }
 

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -6,7 +6,9 @@ use crate::checkpoint::MetadataTableCache;
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
 use crate::content::ContentAdmission;
 use crate::context::MutationContext;
-use crate::error::{CoreError, MetadataProjectionLoadError, MetadataViewError, Result};
+use crate::error::{
+    CoreError, MetadataProjectionLoadError, MetadataViewError, Result, WriterFence,
+};
 use crate::metadata::MetadataState;
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::writer_epoch::acquire_writer_epoch;
@@ -106,7 +108,7 @@ pub struct WriterSessionState {
     /// every later publish fails with `writer_fenced` without touching the
     /// store; the session never reacquires on its own. Reacquisition is an
     /// explicit caller decision, left to a future takeover API.
-    fenced: Option<String>,
+    fenced: Option<WriterFence>,
 }
 
 /// Shared handle to one namespace's [`WriterSessionState`].
@@ -215,11 +217,11 @@ impl NamespaceCommitEngine {
         let candidate_count = candidates.len();
         let already_acquired = {
             let session = self.lock_session();
-            if let Some(message) = &session.fenced {
-                let message = message.clone();
+            if let Some(fence) = &session.fenced {
+                let fence = fence.clone();
                 drop(session);
                 return NamespaceCommitEnginePublishResult {
-                    results: repeated_error(candidate_count, CoreError::WriterFenced(message)),
+                    results: repeated_error(candidate_count, CoreError::WriterFenced(fence)),
                     wal_tail_segments: 0,
                     resulting_read_state: None,
                 };
@@ -231,7 +233,7 @@ impl NamespaceCommitEngine {
             None => match acquire_writer_epoch(store, &self.namespace_id, context).await {
                 Ok(value) => {
                     let mut session = self.lock_session();
-                    if let Some(message) = session.fenced.clone() {
+                    if let Some(fence) = session.fenced.clone() {
                         // Another engine sharing this session observed
                         // fencing while we were acquiring; the session
                         // stays fenced.
@@ -239,7 +241,7 @@ impl NamespaceCommitEngine {
                         return NamespaceCommitEnginePublishResult {
                             results: repeated_error(
                                 candidate_count,
-                                CoreError::WriterFenced(message),
+                                CoreError::WriterFenced(fence),
                             ),
                             wal_tail_segments: 0,
                             resulting_read_state: None,
@@ -293,9 +295,9 @@ impl NamespaceCommitEngine {
             Ok(value) => value,
             Err(error) => {
                 self.invalidate();
-                if let CoreError::WriterFenced(message) = &error {
+                if let CoreError::WriterFenced(fence) = &error {
                     let mut session = self.lock_session();
-                    session.fenced = Some(message.clone());
+                    session.fenced = Some(fence.clone());
                     session.acquired_writer = None;
                 }
                 return NamespaceCommitEnginePublishResult {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -15,8 +15,8 @@ use crate::storage::content::{DurableContentValidationError, ImmutableObjectWrit
 use crate::wal::{WalBuildError, WalChainLoadError, WalReplayError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::{
-    ChangeSeq, CommitIdValidationError, GeneratedIdValidationError, InodeId, InodeKind,
-    NamespaceId, NamespaceIdValidationError, UploadId,
+    ChangeSeq, CommitId, CommitIdValidationError, ErrorDetails, GeneratedIdValidationError,
+    InodeId, InodeKind, NamespaceId, NamespaceIdValidationError, UploadId, WriterEpoch,
 };
 use loonfs_objectstore::ObjectStoreError;
 use thiserror::Error;
@@ -146,7 +146,7 @@ pub enum CoreError {
     /// This writer session's epoch was superseded. Terminal for the session:
     /// callers surface it without reacquiring.
     #[error("writer session fenced: {0}")]
-    WriterFenced(String),
+    WriterFenced(WriterFence),
     #[error("object store error for `{object_key}`: {message}")]
     Store { object_key: String, message: String },
     /// Non-store internal failure (codec, overflow, invariant breach). Same
@@ -344,6 +344,86 @@ impl CoreError {
 
     pub fn message(&self) -> String {
         self.to_string()
+    }
+
+    /// Structured wire details for this error, when the variant carries
+    /// machine-usable identity (API spec, "Standard error contract"). The
+    /// server serializes this beside [`CoreError::code`]; embedded callers
+    /// can match the typed variants directly instead.
+    pub fn details(&self) -> Option<ErrorDetails> {
+        match self {
+            CoreError::WriterFenced(fence) => Some(ErrorDetails {
+                fenced_epoch: Some(fence.fenced_epoch),
+                active_writer_epoch: Some(fence.active_epoch),
+                active_writer: fence.active_writer.clone(),
+                ..ErrorDetails::default()
+            }),
+            CoreError::CommitIdReuseConflict(commit_id) => Some(ErrorDetails {
+                commit_id: CommitId::parse(commit_id).ok(),
+                ..ErrorDetails::default()
+            }),
+            CoreError::RebootstrapRequired {
+                after_seq,
+                retention_floor_seq,
+            } => Some(ErrorDetails {
+                after_seq: Some(*after_seq),
+                retention_floor_seq: Some(*retention_floor_seq),
+                ..ErrorDetails::default()
+            }),
+            CoreError::CommitValidation(error) => commit_validation_details(error),
+            _ => None,
+        }
+    }
+}
+
+/// The fencing event a writer session observed: the epoch the session held,
+/// the epoch that displaced it, and the winner's writer id when the head
+/// recorded one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriterFence {
+    /// Epoch the fenced session held.
+    pub fenced_epoch: WriterEpoch,
+    /// Epoch that owns the namespace now.
+    pub active_epoch: WriterEpoch,
+    /// Writer id recorded by the winning acquirer, when known.
+    pub active_writer: Option<String>,
+}
+
+impl std::fmt::Display for WriterFence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "epoch {} was fenced by epoch {} (writer `{}`)",
+            self.fenced_epoch,
+            self.active_epoch,
+            self.active_writer.as_deref().unwrap_or("unknown")
+        )
+    }
+}
+
+fn commit_validation_details(error: &CommitValidationError) -> Option<ErrorDetails> {
+    match error {
+        CommitValidationError::ReplaceFileBaseRevisionMismatch {
+            inode_id,
+            expected,
+            actual,
+        }
+        | CommitValidationError::RestoreRevisionBaseRevisionMismatch {
+            inode_id,
+            expected,
+            actual,
+        } => Some(ErrorDetails {
+            inode_id: Some(*inode_id),
+            expected_revision: Some(*expected),
+            actual_revision: *actual,
+            ..ErrorDetails::default()
+        }),
+        CommitValidationError::StaleWriterEpoch { active, requested } => Some(ErrorDetails {
+            fenced_epoch: Some(*requested),
+            active_writer_epoch: Some(*active),
+            ..ErrorDetails::default()
+        }),
+        _ => None,
     }
 }
 
@@ -551,8 +631,12 @@ fn classify_head_publish_error(error: &CommitHeadPublishError) -> ErrorCode {
 
 #[cfg(test)]
 mod tests {
-    use super::{CoreError, ErrorCode, ErrorKind, MetadataViewError};
-    use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
+    use super::{
+        CommitValidationError, CoreError, ErrorCode, ErrorKind, MetadataViewError, WriterFence,
+    };
+    use loonfs_api::{
+        ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, RevisionNo, WriterEpoch,
+    };
 
     #[test]
     fn public_error_kind_groups_detailed_codes() {
@@ -630,5 +714,42 @@ mod tests {
             let error = CoreError::from(metadata_error);
             assert_eq!(error.code(), code);
         }
+    }
+
+    #[test]
+    fn identity_bearing_errors_expose_structured_wire_details() {
+        let fenced = CoreError::WriterFenced(WriterFence {
+            fenced_epoch: WriterEpoch(3),
+            active_epoch: WriterEpoch(4),
+            active_writer: Some("writer-b".to_owned()),
+        });
+        let details = fenced.details().expect("fence details");
+        assert_eq!(details.fenced_epoch, Some(WriterEpoch(3)));
+        assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
+        assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
+        assert!(fenced
+            .to_string()
+            .contains("epoch 3 was fenced by epoch 4 (writer `writer-b`)"));
+
+        let reuse = CoreError::CommitIdReuseConflict("retry-key-1".to_owned());
+        let details = reuse.details().expect("reuse details");
+        assert_eq!(
+            details.commit_id,
+            Some(CommitId::parse("retry-key-1").expect("valid commit id"))
+        );
+
+        let stale =
+            CoreError::CommitValidation(CommitValidationError::ReplaceFileBaseRevisionMismatch {
+                inode_id: InodeId(7),
+                expected: RevisionNo(2),
+                actual: Some(RevisionNo(5)),
+            });
+        let details = stale.details().expect("stale-revision details");
+        assert_eq!(details.inode_id, Some(InodeId(7)));
+        assert_eq!(details.expected_revision, Some(RevisionNo(2)));
+        assert_eq!(details.actual_revision, Some(RevisionNo(5)));
+
+        // Errors without machine-usable identity stay detail-free.
+        assert!(CoreError::Internal("boom".to_owned()).details().is_none());
     }
 }

--- a/crates/loonfs-core/src/gc.rs
+++ b/crates/loonfs-core/src/gc.rs
@@ -742,7 +742,7 @@ mod tests {
     use crate::storage::content::store_bytes_as_content;
     use bytes::Bytes;
     use futures::stream::BoxStream;
-    use loonfs_api::{CommitId, PutBehavior};
+    use loonfs_api::{AbsolutePath, CommitId, PutBehavior};
     use loonfs_objectstore::fs::LocalFsStore;
     use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
     use tempfile::tempdir;
@@ -806,7 +806,7 @@ mod tests {
                 vec![NamespaceMutationCandidate::Path(
                     PathMutationIntent::PutFile {
                         commit_id: CommitId::parse(commit_id).expect("commit id"),
-                        absolute_path: path.to_owned(),
+                        absolute_path: AbsolutePath::parse(path).expect("path"),
                         content_ref,
                         behavior: PutBehavior::NoReplace,
                     },

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -16,7 +16,7 @@
 //! this crate with caching and batching.
 //!
 //! ```no_run
-//! use loonfs_api::{CommitId, NamespaceId};
+//! use loonfs_api::{AbsolutePath, CommitId, NamespaceId};
 //! use loonfs_core::publish::{
 //!     NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent,
 //! };
@@ -45,7 +45,7 @@
 //!     &publish_store,
 //!     vec![NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
 //!         commit_id: CommitId::generate(),
-//!         absolute_path: "/plans".to_owned(),
+//!         absolute_path: AbsolutePath::parse("/plans").expect("path"),
 //!     })],
 //!     &context,
 //! );

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -119,6 +119,7 @@ pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
+    WriterFence,
 };
 pub use gc::{gc_namespace, GcConfig, GcReport};
 pub use namespace::BootstrapNamespaceError;

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -63,15 +63,11 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
         // The epoch is the fence: any takeover bumps it, so a mismatch means
         // another writer owns the namespace and this delete must not land.
         if head.writer_epoch != acquired_writer.writer_epoch {
-            let winner = head
-                .writer
-                .as_ref()
-                .map(|writer| writer.writer_id.as_str())
-                .unwrap_or("unknown");
-            return Err(CoreError::WriterFenced(format!(
-                "delete with epoch {} was fenced by epoch {} (writer `{winner}`)",
-                acquired_writer.writer_epoch.0, head.writer_epoch.0
-            )));
+            return Err(CoreError::WriterFenced(crate::error::WriterFence {
+                fenced_epoch: acquired_writer.writer_epoch,
+                active_epoch: head.writer_epoch,
+                active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+            }));
         }
 
         if let Some(expected) = options.expected_head_seq {

--- a/crates/loonfs-core/src/path/helpers.rs
+++ b/crates/loonfs-core/src/path/helpers.rs
@@ -6,11 +6,9 @@ use loonfs_api::{AbsolutePath, PathError};
 /// Checks the mutation-path invariant without keeping the parsed path: the
 /// path must parse as an absolute path and must not be the root.
 ///
-/// This is the one named home for the invariant. Core mutation planning
-/// enforces it through [`parse_mutation_path`], and callers that stage
-/// content before planning (for example the runtime facade's `put` pre-flight)
-/// call this directly so the same rule rejects the request before any bytes
-/// are written.
+/// Callers that only stage content before planning call this directly;
+/// surfaces that go on to build an intent use [`parse_mutation_path`] and
+/// keep the parsed path.
 pub fn validate_path_for_mutation(absolute_path: &str) -> Result<()> {
     parse_mutation_path(absolute_path).map(|_| ())
 }
@@ -19,12 +17,26 @@ pub(crate) fn parse_absolute_path_for_core(absolute_path: &str) -> Result<Absolu
     AbsolutePath::parse(absolute_path).map_err(map_path_error_to_core)
 }
 
-pub(crate) fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
+/// Parses a raw string into the validated, normalized path a
+/// [`PathMutationIntent`](crate::path::write::PathMutationIntent) carries:
+/// absolute, normalized, and not the root.
+///
+/// This is the one named home for the invariant. Every surface that accepts
+/// a raw mutation path parses through it exactly once; planning re-asserts
+/// only the root guard ([`ensure_mutation_path`]) and never re-parses.
+pub fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
     let path = parse_absolute_path_for_core(absolute_path)?;
+    ensure_mutation_path(&path)?;
+    Ok(path)
+}
+
+/// The root-mutation guard on an already-parsed path. Intents can be built
+/// from parsed paths directly, so planning re-asserts this invariant.
+pub(crate) fn ensure_mutation_path(path: &AbsolutePath) -> Result<()> {
     if path.is_root() {
         return Err(CoreError::RootMutationForbidden);
     }
-    Ok(path)
+    Ok(())
 }
 
 pub(crate) fn map_path_error_to_core(error: PathError) -> CoreError {

--- a/crates/loonfs-core/src/path/mod.rs
+++ b/crates/loonfs-core/src/path/mod.rs
@@ -5,4 +5,4 @@ pub(crate) mod query;
 pub(crate) mod read;
 pub(crate) mod write;
 
-pub use helpers::validate_path_for_mutation;
+pub use helpers::{parse_mutation_path, validate_path_for_mutation};

--- a/crates/loonfs-core/src/path/write/intent.rs
+++ b/crates/loonfs-core/src/path/write/intent.rs
@@ -1,50 +1,55 @@
 //! [`PathMutationIntent`]: a user-facing path mutation before planning.
 
 use loonfs_api::{
-    v0::MoveBehavior, CommitId, ContentRef, DeleteDirectoryBehavior, PutBehavior, RevisionNo,
+    v0::MoveBehavior, AbsolutePath, CommitId, ContentRef, DeleteDirectoryBehavior, PutBehavior,
+    RevisionNo,
 };
 
 /// User-facing path mutation before it is planned against namespace state.
 ///
 /// Server and embedded publishers accept these intents, then resolve paths and
-/// preconditions immediately before publishing.
+/// preconditions immediately before publishing. Paths are parsed once at the
+/// surface that accepts the raw string ([`parse_mutation_path`]); an intent
+/// always carries validated, normalized paths.
+///
+/// [`parse_mutation_path`]: crate::path::parse_mutation_path
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathMutationIntent {
     /// Create one directory.
     CreateDir {
         commit_id: CommitId,
-        absolute_path: String,
+        absolute_path: AbsolutePath,
     },
     /// Put one file at a path.
     PutFile {
         commit_id: CommitId,
-        absolute_path: String,
+        absolute_path: AbsolutePath,
         content_ref: ContentRef,
         behavior: PutBehavior,
     },
     /// Delete one path.
     DeletePath {
         commit_id: CommitId,
-        absolute_path: String,
+        absolute_path: AbsolutePath,
         behavior: DeleteDirectoryBehavior,
     },
     /// Move one path to another path.
     MovePath {
         commit_id: CommitId,
-        from_path: String,
-        to_path: String,
+        from_path: AbsolutePath,
+        to_path: AbsolutePath,
         behavior: MoveBehavior,
     },
     /// Copy one file path to another path.
     CopyFilePath {
         commit_id: CommitId,
-        from_path: String,
-        to_path: String,
+        from_path: AbsolutePath,
+        to_path: AbsolutePath,
     },
     /// Restore a file revision at a path.
     RestoreRevision {
         commit_id: CommitId,
-        absolute_path: String,
+        absolute_path: AbsolutePath,
         source_revision_no: RevisionNo,
     },
 }

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -6,6 +6,7 @@ use super::intent::PathMutationIntent;
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::CoreError;
+use crate::path::helpers::parse_mutation_path;
 use loonfs_api::{
     v0::MoveBehavior, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior, NamespaceId,
     PutBehavior, RevisionNo,
@@ -92,7 +93,7 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::PutFile {
             commit_id,
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: parse_mutation_path(absolute_path)?,
             content_ref,
             behavior,
         },
@@ -133,7 +134,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id,
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: parse_mutation_path(absolute_path)?,
             behavior,
         },
         context,
@@ -155,8 +156,8 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::MovePath {
             commit_id,
-            from_path: from_path.to_owned(),
-            to_path: to_path.to_owned(),
+            from_path: parse_mutation_path(from_path)?,
+            to_path: parse_mutation_path(to_path)?,
             behavior: MoveBehavior::NoReplace,
         },
         context,
@@ -178,7 +179,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::RestoreRevision {
             commit_id,
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: parse_mutation_path(absolute_path)?,
             source_revision_no,
         },
         context,

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -7,7 +7,7 @@ use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use loonfs_api::{
-    v0::MoveBehavior, CommitId, ContentRef, DeleteDirectoryBehavior, MutationResult, NamespaceId,
+    v0::MoveBehavior, CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior, NamespaceId,
     PutBehavior, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
@@ -21,7 +21,7 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let mut results = crate::commit_engine::publish_namespace_mutations_batch(
         store,
         namespace_id,
@@ -29,13 +29,9 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
         context,
     )
     .await;
-    let response = results
+    results
         .pop()
-        .unwrap_or_else(|| Err(CoreError::Internal("empty path mutation batch".to_owned())))?;
-    Ok(MutationResult {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    })
+        .unwrap_or_else(|| Err(CoreError::Internal("empty path mutation batch".to_owned())))
 }
 
 pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
@@ -46,7 +42,7 @@ pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let content_ref =
         store_file_bytes_before_metadata_publish(store, namespace_id, absolute_path, bytes).await?;
     put_file_content_ref(
@@ -68,7 +64,7 @@ pub(crate) async fn write_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     put_file_bytes(
         store,
         namespace_id,
@@ -89,7 +85,7 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -111,7 +107,7 @@ pub(crate) async fn delete_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     delete_path_with_behavior(
         store,
         namespace_id,
@@ -130,7 +126,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
     behavior: DeleteDirectoryBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -152,7 +148,7 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,
@@ -175,7 +171,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
     source_revision_no: RevisionNo,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
-) -> Result<MutationResult, CoreError> {
+) -> Result<CommitResponse, CoreError> {
     let commit_id = normalized_commit_id(commit_id);
     submit_path_intent(
         store,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -7,7 +7,7 @@ use crate::error::CoreError;
 #[cfg(test)]
 use crate::metadata::MetadataState;
 use crate::metadata::{MetadataView, ResolvedVisiblePath, VisiblePathError};
-use crate::path::helpers::{final_component, parse_absolute_path_for_core, parse_mutation_path};
+use crate::path::helpers::{ensure_mutation_path, final_component};
 use loonfs_api::wire::control::HeadState;
 #[cfg(test)]
 use loonfs_api::ChangeSeq;
@@ -95,7 +95,7 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
     let identity = match intent {
         PathMutationIntent::CreateDir { absolute_path, .. } => PathFingerprintInput::CreateDir {
             namespace_id: namespace_id.clone(),
-            absolute_path: normalized_path_for_fingerprint(absolute_path)?,
+            absolute_path: absolute_path.as_str().to_owned(),
         },
         PathMutationIntent::PutFile {
             absolute_path,
@@ -104,7 +104,7 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             ..
         } => PathFingerprintInput::PutFile {
             namespace_id: namespace_id.clone(),
-            absolute_path: normalized_path_for_fingerprint(absolute_path)?,
+            absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
             content_ref: content_ref.clone(),
         },
@@ -114,7 +114,7 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             ..
         } => PathFingerprintInput::DeletePath {
             namespace_id: namespace_id.clone(),
-            absolute_path: normalized_path_for_fingerprint(absolute_path)?,
+            absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
         },
         PathMutationIntent::MovePath {
@@ -124,16 +124,16 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             ..
         } => PathFingerprintInput::MovePath {
             namespace_id: namespace_id.clone(),
-            from_path: normalized_path_for_fingerprint(from_path)?,
-            to_path: normalized_path_for_fingerprint(to_path)?,
+            from_path: from_path.as_str().to_owned(),
+            to_path: to_path.as_str().to_owned(),
             behavior: *behavior,
         },
         PathMutationIntent::CopyFilePath {
             from_path, to_path, ..
         } => PathFingerprintInput::CopyFilePath {
             namespace_id: namespace_id.clone(),
-            from_path: normalized_path_for_fingerprint(from_path)?,
-            to_path: normalized_path_for_fingerprint(to_path)?,
+            from_path: from_path.as_str().to_owned(),
+            to_path: to_path.as_str().to_owned(),
         },
         PathMutationIntent::RestoreRevision {
             absolute_path,
@@ -141,17 +141,11 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             ..
         } => PathFingerprintInput::RestoreRevision {
             namespace_id: namespace_id.clone(),
-            absolute_path: normalized_path_for_fingerprint(absolute_path)?,
+            absolute_path: absolute_path.as_str().to_owned(),
             source_revision_no: *source_revision_no,
         },
     };
     path_intent_fingerprint(&identity)
-}
-
-fn normalized_path_for_fingerprint(absolute_path: &str) -> Result<String, CoreError> {
-    Ok(parse_absolute_path_for_core(absolute_path)?
-        .as_str()
-        .to_owned())
 }
 
 fn is_missing_visible_path(error: &CoreError) -> bool {
@@ -318,15 +312,15 @@ async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
-    absolute_path: &str,
+    absolute_path: &AbsolutePath,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let absolute_path = parse_mutation_path(absolute_path)?;
-    publish_reject_tombstoned_path_ancestor(view, &absolute_path).await?;
+    ensure_mutation_path(absolute_path)?;
+    publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
     match view
         .metadata_state
-        .resolve_visible_path(&absolute_path)
+        .resolve_visible_path(absolute_path)
         .await
     {
         Ok(_) => {
@@ -337,8 +331,8 @@ async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
         Err(error) if is_missing_visible_path(&error) => {}
         Err(error) => return Err(error),
     }
-    let parent_inode_id = publish_resolve_parent_directory(view, &absolute_path).await?;
-    let display_name = final_component(&absolute_path)?;
+    let parent_inode_id = publish_resolve_parent_directory(view, absolute_path).await?;
+    let display_name = final_component(absolute_path)?;
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
         ops: vec![ApiCommitOp::CreateDirectory {
@@ -356,25 +350,25 @@ async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
-    absolute_path: &str,
+    absolute_path: &AbsolutePath,
     content_ref: ContentRef,
     behavior: PutBehavior,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let absolute_path = parse_mutation_path(absolute_path)?;
-    publish_reject_tombstoned_path_ancestor(view, &absolute_path).await?;
+    ensure_mutation_path(absolute_path)?;
+    publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
     let target = view
         .metadata_state
-        .resolve_visible_path(&absolute_path)
+        .resolve_visible_path(absolute_path)
         .await;
 
     let mut ops = Vec::new();
     let mut next_inode_id = view.head.next_inode_id;
     let final_parent_inode =
-        publish_ensure_parent_directories(&absolute_path, view, &mut ops, &mut next_inode_id)
+        publish_ensure_parent_directories(absolute_path, view, &mut ops, &mut next_inode_id)
             .await?;
-    let final_name = final_component(&absolute_path)?;
+    let final_name = final_component(absolute_path)?;
     let mut preconditions = Vec::new();
 
     match target {
@@ -443,15 +437,15 @@ async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
-    absolute_path: &str,
+    absolute_path: &AbsolutePath,
     behavior: DeleteDirectoryBehavior,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let absolute_path = parse_mutation_path(absolute_path)?;
+    ensure_mutation_path(absolute_path)?;
     let resolved = view
         .metadata_state
-        .resolve_visible_path(&absolute_path)
+        .resolve_visible_path(absolute_path)
         .await?;
     let recursive = behavior == DeleteDirectoryBehavior::Recursive;
     let op = match resolved.inode_kind {
@@ -491,20 +485,20 @@ async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_move_path<S: ObjectStore + ?Sized>(
-    from_path: &str,
-    to_path: &str,
+    from_path: &AbsolutePath,
+    to_path: &AbsolutePath,
     behavior: MoveBehavior,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let from_path = parse_mutation_path(from_path)?;
-    let to_path = parse_mutation_path(to_path)?;
-    publish_reject_tombstoned_path_ancestor(view, &from_path).await?;
-    publish_reject_tombstoned_path_ancestor(view, &to_path).await?;
-    let source = view.metadata_state.resolve_visible_path(&from_path).await?;
-    let target_parent = publish_resolve_parent_directory(view, &to_path).await?;
-    let target_name = final_component(&to_path)?;
-    match view.metadata_state.resolve_visible_path(&to_path).await {
+    ensure_mutation_path(from_path)?;
+    ensure_mutation_path(to_path)?;
+    publish_reject_tombstoned_path_ancestor(view, from_path).await?;
+    publish_reject_tombstoned_path_ancestor(view, to_path).await?;
+    let source = view.metadata_state.resolve_visible_path(from_path).await?;
+    let target_parent = publish_resolve_parent_directory(view, to_path).await?;
+    let target_name = final_component(to_path)?;
+    match view.metadata_state.resolve_visible_path(to_path).await {
         Ok(_) => return Err(CoreError::DestinationExists(to_path.as_str().to_owned())),
         Err(error) if is_missing_visible_path(&error) => {}
         Err(error) => return Err(error),
@@ -532,17 +526,17 @@ async fn plan_publish_move_path<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
-    from_path: &str,
-    to_path: &str,
+    from_path: &AbsolutePath,
+    to_path: &AbsolutePath,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let from_path = parse_mutation_path(from_path)?;
-    let to_path = parse_mutation_path(to_path)?;
-    publish_reject_tombstoned_path_ancestor(view, &from_path).await?;
-    publish_reject_tombstoned_path_ancestor(view, &to_path).await?;
+    ensure_mutation_path(from_path)?;
+    ensure_mutation_path(to_path)?;
+    publish_reject_tombstoned_path_ancestor(view, from_path).await?;
+    publish_reject_tombstoned_path_ancestor(view, to_path).await?;
 
-    let source = view.metadata_state.resolve_visible_path(&from_path).await?;
+    let source = view.metadata_state.resolve_visible_path(from_path).await?;
     if source.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
             path: from_path.as_str().to_owned(),
@@ -550,7 +544,7 @@ async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
         });
     }
 
-    match view.metadata_state.resolve_visible_path(&to_path).await {
+    match view.metadata_state.resolve_visible_path(to_path).await {
         Ok(_) => return Err(CoreError::DestinationExists(to_path.as_str().to_owned())),
         Err(error) if is_missing_visible_path(&error) => {}
         Err(error) => return Err(error),
@@ -562,8 +556,8 @@ async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
         .await?
         .ok_or_else(|| CoreError::PathNotFound(from_path.as_str().to_owned()))?;
 
-    let target_parent = publish_resolve_parent_directory(view, &to_path).await?;
-    let target_name = final_component(&to_path)?;
+    let target_parent = publish_resolve_parent_directory(view, to_path).await?;
+    let target_name = final_component(to_path)?;
     Ok(ApiCommitRequest {
         commit_id: commit_id.to_owned(),
         ops: vec![ApiCommitOp::CreateFile {
@@ -590,16 +584,16 @@ async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
 }
 
 async fn plan_publish_restore_revision<S: ObjectStore + ?Sized>(
-    absolute_path: &str,
+    absolute_path: &AbsolutePath,
     source_revision_no: RevisionNo,
     commit_id: &CommitId,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<ApiCommitRequest, CoreError> {
-    let absolute_path = parse_mutation_path(absolute_path)?;
-    publish_reject_tombstoned_path_ancestor(view, &absolute_path).await?;
+    ensure_mutation_path(absolute_path)?;
+    publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
     let target = view
         .metadata_state
-        .resolve_visible_path(&absolute_path)
+        .resolve_visible_path(absolute_path)
         .await?;
     if target.inode_kind != InodeKind::File {
         return Err(CoreError::ExpectedFile {
@@ -769,7 +763,7 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let intent = PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("c_00000000000000000000000000000042").expect("commit id"),
-            absolute_path: "/docs".to_owned(),
+            absolute_path: AbsolutePath::parse("/docs").expect("path"),
         };
 
         let fingerprint =
@@ -837,7 +831,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-a").expect("valid commit id"),
-                absolute_path: "/docs//a/".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs//a/").expect("path"),
             },
         )
         .expect("left fingerprint");
@@ -845,7 +839,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-b").expect("valid commit id"),
-                absolute_path: "/docs/a".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a").expect("path"),
             },
         )
         .expect("right fingerprint");
@@ -860,7 +854,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
-                absolute_path: "/docs".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs").expect("path"),
             },
         )
         .expect("baseline fingerprint");
@@ -868,7 +862,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-drafts").expect("valid commit id"),
-                absolute_path: "/drafts".to_owned(),
+                absolute_path: AbsolutePath::parse("/drafts").expect("path"),
             },
         )
         .expect("changed fingerprint");
@@ -883,7 +877,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
-                absolute_path: "/docs".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs").expect("path"),
             },
         )
         .expect("path fingerprint");
@@ -912,7 +906,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
-                absolute_path: "/docs".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs").expect("path"),
             },
         )
         .await;
@@ -948,7 +942,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-nested").expect("valid commit id"),
-                absolute_path: "/docs/nested/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/nested/a.txt").expect("path"),
                 content_ref: staged.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             },
@@ -998,8 +992,8 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-file").expect("valid commit id"),
-                from_path: "/docs/a.txt".to_owned(),
-                to_path: "/docs/b.txt".to_owned(),
+                from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 behavior: MoveBehavior::NoReplace,
             },
         )
@@ -1098,8 +1092,8 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CopyFilePath {
                 commit_id: CommitId::parse("copy-file").expect("valid commit id"),
-                from_path: "/docs/a.txt".to_owned(),
-                to_path: "/docs/copy.txt".to_owned(),
+                from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                to_path: AbsolutePath::parse("/docs/copy.txt").expect("path"),
             },
         )
         .await;
@@ -1204,7 +1198,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-under-dead").expect("valid commit id"),
-                absolute_path: "/dead/new.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/dead/new.txt").expect("path"),
                 content_ref: staged.content_ref,
                 behavior: PutBehavior::NoReplace,
             },

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -8,6 +8,8 @@ use crate::error::CoreError;
 use crate::metadata::{DurableVisibilityCache, MetadataApplyError, MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
+#[cfg(test)]
+use loonfs_api::AbsolutePath;
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::ObjectStore;
 
@@ -118,7 +120,7 @@ mod tests {
     ) -> NamespaceMutationCandidate {
         NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
             commit_id: CommitId::parse(commit_id).expect("valid commit id"),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             content_ref,
             behavior: PutBehavior::NoReplace,
         })
@@ -163,7 +165,7 @@ mod tests {
 
         let first_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("plan-a").expect("valid commit id"),
-            absolute_path: "/docs/a.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             content_ref: staged.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         };
@@ -175,7 +177,7 @@ mod tests {
 
         let second_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("plan-b").expect("valid commit id"),
-            absolute_path: "/docs/b.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             content_ref: staged.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         };
@@ -276,7 +278,7 @@ mod tests {
                 ),
                 NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                     commit_id: CommitId::parse("delete-doomed").expect("valid commit id"),
-                    absolute_path: "/docs/doomed.txt".to_owned(),
+                    absolute_path: AbsolutePath::parse("/docs/doomed.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                 }),
             ],

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -214,15 +214,11 @@ fn ensure_publish_head_matches_acquired_writer(
     acquired_writer: &AcquiredWriter,
 ) -> Result<()> {
     if head.writer_epoch != acquired_writer.writer_epoch {
-        let winner = head
-            .writer
-            .as_ref()
-            .map(|writer| writer.writer_id.as_str())
-            .unwrap_or("unknown");
-        return Err(CoreError::WriterFenced(format!(
-            "writer epoch {} was fenced by epoch {} (writer `{winner}`)",
-            acquired_writer.writer_epoch.0, head.writer_epoch.0
-        )));
+        return Err(CoreError::WriterFenced(crate::error::WriterFence {
+            fenced_epoch: acquired_writer.writer_epoch,
+            active_epoch: head.writer_epoch,
+            active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+        }));
     }
     Ok(())
 }

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::v0::BeginUploadRequest;
+use loonfs_api::AbsolutePath;
 use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
@@ -43,7 +44,7 @@ async fn put_file<S: ObjectStore + ?Sized>(
             vec![NamespaceMutationCandidate::Path(
                 PathMutationIntent::PutFile {
                     commit_id: loonfs_api::CommitId::generate(),
-                    absolute_path: absolute_path.to_owned(),
+                    absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                     content_ref: content.content_ref,
                     behavior: loonfs_api::PutBehavior::NoReplace,
                 },

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -258,14 +258,14 @@ fn read_context<S: ObjectStore + ?Sized>(
 }
 
 /// Publishes one path intent through the commit engine — the single publish
-/// pipeline — and maps the response like the old convenience writers did.
+/// pipeline.
 async fn submit_intent_async<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<loonfs_api::MutationResult, CoreError> {
-    let response = NamespaceCommitEngine::new(namespace_id.clone())
+) -> Result<loonfs_api::CommitResponse, CoreError> {
+    NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
             vec![NamespaceMutationCandidate::Path(intent)],
@@ -274,11 +274,7 @@ async fn submit_intent_async<S: ObjectStore + ?Sized>(
         .await
         .results
         .pop()
-        .expect("one publish result")?;
-    Ok(loonfs_api::MutationResult {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    })
+        .expect("one publish result")
 }
 
 fn submit_intent<S: ObjectStore + ?Sized>(
@@ -286,7 +282,7 @@ fn submit_intent<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     block_on(submit_intent_async(store, namespace_id, intent, context))
 }
 
@@ -298,7 +294,7 @@ fn put_file_bytes<S: ObjectStore + ?Sized>(
     behavior: PutBehavior,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     let content = block_on(store_bytes_as_content(store, namespace_id, bytes))?;
     submit_intent(
         store,
@@ -320,7 +316,7 @@ fn write_file_bytes<S: ObjectStore + ?Sized>(
     bytes: &[u8],
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     put_file_bytes(
         store,
         namespace_id,
@@ -338,7 +334,7 @@ fn create_directory_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -356,7 +352,7 @@ fn delete_path<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -375,7 +371,7 @@ fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     absolute_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -395,7 +391,7 @@ fn move_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -416,7 +412,7 @@ fn copy_file_path<S: ObjectStore + ?Sized>(
     to_path: &str,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,
@@ -436,7 +432,7 @@ fn restore_file_revision<S: ObjectStore + ?Sized>(
     source_revision_no: RevisionNo,
     context: &MutationContext,
     commit_id: Option<&str>,
-) -> Result<loonfs_api::MutationResult, CoreError> {
+) -> Result<loonfs_api::CommitResponse, CoreError> {
     submit_intent(
         store,
         namespace_id,

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -23,7 +23,7 @@ use loonfs_api::{
         NamespaceManifestEnvelope,
     },
     wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
-    AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
+    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
     DeleteDirectoryBehavior, DirectoryPageCursor, EffectiveLimit, InodeId, InodeKind, ManifestId,
     NameKey, NamespaceId, Page, PageRequest, PutBehavior, RevisionNo, UploadId, WriterEpoch,
 };
@@ -301,7 +301,7 @@ fn put_file_bytes<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::PutFile {
             commit_id: test_commit_id(commit_id),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             content_ref: content.content_ref,
             behavior,
         },
@@ -340,7 +340,7 @@ fn create_directory_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::CreateDir {
             commit_id: test_commit_id(commit_id),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
         },
         context,
     )
@@ -358,7 +358,7 @@ fn delete_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: test_commit_id(commit_id),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::Recursive,
         },
         context,
@@ -377,7 +377,7 @@ fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: test_commit_id(commit_id),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
         },
         context,
@@ -397,8 +397,8 @@ fn move_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::MovePath {
             commit_id: test_commit_id(commit_id),
-            from_path: from_path.to_owned(),
-            to_path: to_path.to_owned(),
+            from_path: AbsolutePath::parse(from_path).expect("path"),
+            to_path: AbsolutePath::parse(to_path).expect("path"),
             behavior: MoveBehavior::NoReplace,
         },
         context,
@@ -418,8 +418,8 @@ fn copy_file_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::CopyFilePath {
             commit_id: test_commit_id(commit_id),
-            from_path: from_path.to_owned(),
-            to_path: to_path.to_owned(),
+            from_path: AbsolutePath::parse(from_path).expect("path"),
+            to_path: AbsolutePath::parse(to_path).expect("path"),
         },
         context,
     )
@@ -438,7 +438,7 @@ fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::RestoreRevision {
             commit_id: test_commit_id(commit_id),
-            absolute_path: absolute_path.to_owned(),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             source_revision_no,
         },
         context,
@@ -1559,7 +1559,7 @@ async fn path_put_file_uses_checksum_metadata_for_content_validation() {
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-cold-content").expect("valid commit id"),
-                absolute_path: "/docs/hello.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/hello.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             },
@@ -1590,13 +1590,13 @@ async fn path_batch_validates_repeated_content_ref_without_blob_gets() {
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-a").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-b").expect("valid commit id"),
-                absolute_path: "/docs/b.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             }),
@@ -1644,7 +1644,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
         vec![NamespaceMutationCandidate::PathWithContentAdmission {
             intent: PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-admitted-content").expect("valid commit id"),
-                absolute_path: "/docs/admitted.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/admitted.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             },
@@ -1696,7 +1696,7 @@ async fn expired_content_admission_falls_back_to_durable_validation() {
         vec![NamespaceMutationCandidate::PathWithContentAdmission {
             intent: PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-expired-admission").expect("valid commit id"),
-                absolute_path: "/docs/expired.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/expired.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             },
@@ -1964,12 +1964,12 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
         namespace_engine(&store, &namespace_id, &context).publish_namespace_mutations_batch(vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
-                absolute_path: "/docs/cycled.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
-                absolute_path: "/docs/cycled.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                 content_ref: staged.content_ref,
                 behavior: PutBehavior::NoReplace,
             }),
@@ -2692,7 +2692,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("before-delete").expect("valid commit id"),
-            absolute_path: "/keep.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/keep.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         },
@@ -2726,7 +2726,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("after-delete").expect("valid commit id"),
-            absolute_path: "/late.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/late.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         },
@@ -2769,7 +2769,7 @@ async fn fork_clone_survives_source_delete() {
         &source,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("seed-clone").expect("valid commit id"),
-            absolute_path: "/shared.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/shared.txt").expect("path"),
             content_ref: content.content_ref,
             behavior: PutBehavior::NoReplace,
         },
@@ -2804,7 +2804,7 @@ async fn ack_lost_head_cas_reports_unknown_outcome_and_replays_idempotently() {
         .expect("stage content");
     let intent = || PathMutationIntent::PutFile {
         commit_id: CommitId::parse("ack-lost-put").expect("valid commit id"),
-        absolute_path: "/ack.txt".to_owned(),
+        absolute_path: AbsolutePath::parse("/ack.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: PutBehavior::NoReplace,
     };
@@ -2840,7 +2840,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("stage content");
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("retry-after-orphan").expect("valid commit id"),
-        absolute_path: "/retry.txt".to_owned(),
+        absolute_path: AbsolutePath::parse("/retry.txt").expect("path"),
         content_ref: content.content_ref,
         behavior: PutBehavior::NoReplace,
     };
@@ -2929,13 +2929,13 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             // Rejected against the durable materialization: nothing was accepted yet.
             NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
-                absolute_path: "/missing.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
             }),
             // Accepted into the batch.
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("accept-a").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             }),
@@ -2943,14 +2943,14 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             // in-batch create.
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             }),
             // Alias of the materialization-decided rejection.
             NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
-                absolute_path: "/missing.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
             }),
         ]
@@ -3017,18 +3017,18 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
-                absolute_path: "/missing.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("accept-a").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             }),
@@ -3386,7 +3386,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("put-path").expect("valid commit id"),
-            absolute_path: "/docs/a.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         },
@@ -3401,8 +3401,8 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-path").expect("valid commit id"),
-            from_path: "/docs/a.txt".to_owned(),
-            to_path: "/docs/b.txt".to_owned(),
+            from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+            to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: loonfs_api::v0::MoveBehavior::NoReplace,
         },
         &context,
@@ -3416,8 +3416,8 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::CopyFilePath {
             commit_id: CommitId::parse("copy-path").expect("valid commit id"),
-            from_path: "/docs/b.txt".to_owned(),
-            to_path: "/docs/c.txt".to_owned(),
+            from_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
+            to_path: AbsolutePath::parse("/docs/c.txt").expect("path"),
         },
         &context,
     )
@@ -3430,7 +3430,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: CommitId::parse("delete-path").expect("valid commit id"),
-            absolute_path: "/docs/b.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
         },
         &context,
@@ -3457,7 +3457,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
 
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
-        absolute_path: "/same//path.txt".to_owned(),
+        absolute_path: AbsolutePath::parse("/same//path.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: PutBehavior::NoReplace,
     };
@@ -3469,7 +3469,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
-            absolute_path: "/same/path.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: PutBehavior::NoReplace,
         },
@@ -3484,7 +3484,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         &namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
-            absolute_path: "/same/path.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
         },
         &context,
@@ -3520,14 +3520,14 @@ async fn path_intents_in_one_batch_see_tentative_state() {
         vec![
             NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
-                absolute_path: "/docs/a.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             }),
             NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-batched-path").expect("valid commit id"),
-                from_path: "/docs/a.txt".to_owned(),
-                to_path: "/docs/b.txt".to_owned(),
+                from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 behavior: loonfs_api::v0::MoveBehavior::NoReplace,
             }),
         ],
@@ -4514,7 +4514,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
                 commit_id: commit_id.clone(),
-                absolute_path: "/docs/idempotent.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: PutBehavior::NoReplace,
             },
@@ -4536,7 +4536,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
         vec![NamespaceMutationCandidate::Path(
             PathMutationIntent::PutFile {
                 commit_id,
-                absolute_path: "/docs/idempotent.txt".to_owned(),
+                absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: PutBehavior::NoReplace,
             },

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::{BootstrapNamespaceError, CoreError, ErrorCode, ErrorKind, RuntimeError};
-use loonfs_api::{ApiError, NamespaceId, NamespaceIdValidationError};
+use loonfs_api::{ApiError, CommitId, ErrorDetails, NamespaceId, NamespaceIdValidationError};
 
 pub(super) struct ApiResponseError {
     status: StatusCode,
@@ -20,6 +20,8 @@ impl ApiResponseError {
                 code: code.as_str().to_owned(),
                 feature: None,
                 message: message.to_owned(),
+                request_id: None,
+                details: None,
             },
         }
     }
@@ -31,8 +33,23 @@ impl ApiResponseError {
                 code: ErrorCode::NotSupported.as_str().to_owned(),
                 feature: Some(feature.to_owned()),
                 message: message.to_owned(),
+                request_id: None,
+                details: None,
             },
         }
+    }
+
+    /// Stamps the mutation's idempotency key into the error details, so a
+    /// failed or uncertain outcome carries the caller's reconciliation
+    /// handle (API spec, "Mutation responses and safe retry"). Details the
+    /// error already carries win over the stamp.
+    pub(super) fn with_commit_id(mut self, commit_id: &CommitId) -> Self {
+        self.body
+            .details
+            .get_or_insert_with(Box::<ErrorDetails>::default)
+            .commit_id
+            .get_or_insert_with(|| commit_id.clone());
+        self
     }
 
     pub(super) fn invalid_namespace_id(error: NamespaceIdValidationError) -> Self {
@@ -66,6 +83,7 @@ impl ApiResponseError {
     fn core(error: CoreError) -> Self {
         let status = status_for_core_error_code(error.code());
         let mut response = Self::new(status, error.code(), &error.to_string());
+        response.body.details = error.details().map(Box::new);
         // `not_supported` responses name the capability the caller lacks
         // (API spec, "Standard error contract"); for a data-dependent
         // capability that is the namespace feature key, not an endpoint.
@@ -132,7 +150,11 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
 }
 
 impl IntoResponse for ApiResponseError {
-    fn into_response(self) -> Response {
+    fn into_response(mut self) -> Response {
+        // The correlation id is scoped by the request-id middleware; a body
+        // rendered outside a request scope (tests constructing errors
+        // directly) simply omits it.
+        self.body.request_id = super::REQUEST_ID.try_with(|id| id.clone()).ok();
         (self.status, Json(self.body)).into_response()
     }
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -392,11 +392,14 @@ pub(super) async fn restore_inode_revision(
         }],
         message: None,
     };
+    let commit_id = commit.commit_id.clone();
     let response = state
         .publisher
         .submit_commit(namespace_id.clone(), commit)
         .await
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
+        })?;
     Ok(Json(response))
 }
 
@@ -434,6 +437,9 @@ pub(super) async fn filesystem_operation(
         content_tokens,
         operation,
     } = request;
+    // Failed and uncertain outcomes echo the idempotency key the caller can
+    // resubmit under (API spec, "Mutation responses and safe retry").
+    let commit_id_for_errors = commit_id.clone();
     let put_payload_class = match &operation {
         FilesystemOperation::PutFile { content_ref, .. } => Some(payload_class(
             usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
@@ -527,8 +533,10 @@ pub(super) async fn filesystem_operation(
             .submit_path_intent(namespace_id.clone(), intent)
             .await
     };
-    let response = response_result
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+    let response = response_result.map_err(|error| {
+        ApiResponseError::core_for_namespace(&namespace_id, error)
+            .with_commit_id(&commit_id_for_errors)
+    })?;
     Ok(Json(response))
 }
 
@@ -561,11 +569,14 @@ pub(super) async fn commit_operations(
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let commit_id = request.commit_id.clone();
     let response = state
         .publisher
         .submit_commit(namespace_id.clone(), request)
         .await
-        .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
+        })?;
     Ok(Json(response))
 }
 

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -17,8 +17,8 @@ use loonfs_api::{
     decode_directory_cursor, decode_file_revisions_cursor,
     v0::{ChangesResponse, CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse},
     DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, InodeId, LimitError, ListFileRevisionsResponse, PageCursorError,
-    PageRequest, PaginationPolicy, RestoreFileRevisionRequest, RevisionNo,
+    InodeId, LimitError, ListFileRevisionsResponse, PageCursorError, PageRequest, PaginationPolicy,
+    RestoreFileRevisionRequest, RevisionNo,
 };
 use tracing::Instrument;
 
@@ -411,7 +411,7 @@ pub(super) async fn restore_inode_revision(
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = FilesystemOperationRequest,
         responses(
-            (status = 200, description = "Filesystem operation committed", body = FilesystemOperationResponse),
+            (status = 200, description = "Filesystem operation committed", body = ApiCommitResponse),
             (status = 400, description = "Invalid operation", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
@@ -426,7 +426,7 @@ pub(super) async fn filesystem_operation(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
     AppJson(request): AppJson<FilesystemOperationRequest>,
-) -> Result<Json<FilesystemOperationResponse>, ApiResponseError> {
+) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let FilesystemOperationRequest {
@@ -529,11 +529,7 @@ pub(super) async fn filesystem_operation(
     };
     let response = response_result
         .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
-    let result = FilesystemOperationResponse {
-        namespace_id: response.namespace_id,
-        committed_seq: response.committed_seq,
-    };
-    Ok(Json(result))
+    Ok(Json(response))
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -9,7 +9,7 @@ use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use loonfs::publish::PathMutationIntent;
+use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{payload_class, ErrorCode, ListChangesOptions, TraceStoreKind};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -456,10 +456,18 @@ pub(super) async fn filesystem_operation(
         ),
         _ => Vec::new(),
     };
+    // Wire paths are raw strings; the intent carries validated paths, so
+    // this is the convert-once point for the whole remote mutation path.
+    let parse_path = |path: &str| {
+        parse_mutation_path(path).map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error)
+                .with_commit_id(&commit_id_for_errors)
+        })
+    };
     let intent = match operation {
         FilesystemOperation::CreateDirectory { path } => PathMutationIntent::CreateDir {
             commit_id,
-            absolute_path: path,
+            absolute_path: parse_path(&path)?,
         },
         FilesystemOperation::PutFile {
             path,
@@ -467,13 +475,13 @@ pub(super) async fn filesystem_operation(
             behavior,
         } => PathMutationIntent::PutFile {
             commit_id,
-            absolute_path: path,
+            absolute_path: parse_path(&path)?,
             content_ref,
             behavior,
         },
         FilesystemOperation::DeletePath { path, behavior } => PathMutationIntent::DeletePath {
             commit_id,
-            absolute_path: path,
+            absolute_path: parse_path(&path)?,
             behavior,
         },
         FilesystemOperation::MovePath {
@@ -482,21 +490,21 @@ pub(super) async fn filesystem_operation(
             behavior,
         } => PathMutationIntent::MovePath {
             commit_id,
-            from_path,
-            to_path,
+            from_path: parse_path(&from_path)?,
+            to_path: parse_path(&to_path)?,
             behavior,
         },
         FilesystemOperation::CopyPath { from_path, to_path } => PathMutationIntent::CopyFilePath {
             commit_id,
-            from_path,
-            to_path,
+            from_path: parse_path(&from_path)?,
+            to_path: parse_path(&to_path)?,
         },
         FilesystemOperation::RestoreRevision {
             path,
             source_revision_no,
         } => PathMutationIntent::RestoreRevision {
             commit_id,
-            absolute_path: path,
+            absolute_path: parse_path(&path)?,
             source_revision_no,
         },
     };

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -43,9 +43,11 @@ use crate::config::{ServerConfig, ServerConfigError};
 use axum::async_trait;
 use axum::body::Bytes;
 use axum::extract::rejection::PathRejection;
-use axum::extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath};
+use axum::extract::{DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath, Request};
 use axum::http::request::Parts;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use loonfs::publisher::PublisherRegistry;
@@ -62,6 +64,31 @@ use thiserror::Error;
 
 type SharedStore = SharedObjectStore;
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
+
+/// Response header carrying the request's correlation id.
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+tokio::task_local! {
+    /// Correlation id of the request being served. Scoped around every
+    /// handler by [`with_request_id`]; [`error::ApiResponseError`] reads it
+    /// when rendering an error body.
+    pub(super) static REQUEST_ID: String;
+}
+
+/// Assigns each request a correlation id: every response carries it as the
+/// `x-request-id` header, and error bodies repeat it as
+/// `ApiError.request_id` so a caller's log line and the server's trace can
+/// be joined without header plumbing.
+async fn with_request_id(request: Request, next: Next) -> Response {
+    let request_id = loonfs_api::generated_id("req");
+    let mut response = REQUEST_ID
+        .scope(request_id.clone(), next.run(request))
+        .await;
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    response
+}
 
 /// Purpose-specific handles over one shared store client: read endpoints go
 /// through `reader`, mutations through `writer` (and its publisher),
@@ -227,6 +254,7 @@ fn router(state: AppState) -> Router {
             post(maintenance_tick),
         )
         .route("/v0/admin/namespaces/:namespace/gc", post(gc_namespace))
+        .layer(middleware::from_fn(with_request_id))
         .with_state(state)
 }
 

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -16,10 +16,9 @@ use loonfs_api::{
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointRequest,
     CreateCheckpointResponse, CreateNamespaceRequest, FilesystemOperation,
-    FilesystemOperationRequest, FilesystemOperationResponse, FlushWalOutcome, FlushWalResponse,
-    ForkNamespaceRequest, GcRequest, GcResponse, InodeId, ListFileRevisionsResponse,
-    MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse,
-    ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo,
+    FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest,
+    GcResponse, InodeId, ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
+    MaintenanceTickResponse, ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo,
 };
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
@@ -80,7 +79,6 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::MoveBehavior,
         FilesystemOperation,
         FilesystemOperationRequest,
-        FilesystemOperationResponse,
         loonfs_api::FileRevision,
         ListFileRevisionsResponse,
         RestoreFileRevisionRequest,

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -69,6 +69,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     components(schemas(
         loonfs_api::CapabilityDocument,
         ApiError,
+        loonfs_api::ErrorDetails,
+        loonfs_api::WriterEpoch,
         CreateNamespaceRequest,
         ForkNamespaceRequest,
         loonfs_api::NamespaceSummary,

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -3,8 +3,8 @@
 
 use loonfs_api::{
     v0::{CompleteUploadRequest, ObjectTransferAccess, ValidatedContentToken},
-    ChangeSeq, CommitId, ContentRef, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, PutBehavior,
+    ChangeSeq, CommitId, CommitResponse, ContentRef, FilesystemOperation,
+    FilesystemOperationRequest, PutBehavior,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs_server::{
@@ -302,7 +302,7 @@ fn post_filesystem_operation(
     server_url: &str,
     namespace: &str,
     request: &FilesystemOperationRequest,
-) -> FilesystemOperationResponse {
+) -> CommitResponse {
     let response = ureq::post(&format!(
         "{server_url}/v0/namespaces/{namespace}/filesystem/operations"
     ))

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -822,6 +822,12 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
         .set("authorization", "Bearer test-token")
         .send_json(request)
         .expect("bad token should fall back to content validation");
+        // Every response carries the correlation id header, success included.
+        let request_id = response
+            .header("x-request-id")
+            .expect("x-request-id header")
+            .to_owned();
+        assert!(request_id.starts_with("req_"), "got `{request_id}`");
         let response: CommitResponse =
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
@@ -1206,8 +1212,20 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
             .client
             .commit_operations(namespace, &conflicting_request)
         {
-            Err(ClientError::Api { code, .. }) => {
-                assert_eq!(code, "commit_id_reuse_conflict")
+            Err(ClientError::Api {
+                code,
+                request_id,
+                details,
+                ..
+            }) => {
+                assert_eq!(code, "commit_id_reuse_conflict");
+                // The error carries the caller's reconciliation identity as
+                // structured fields, not prose (API spec, "Standard error
+                // contract").
+                let details = details.expect("structured details");
+                assert_eq!(details.commit_id, Some(first_request.commit_id.clone()));
+                let request_id = request_id.expect("request id");
+                assert!(request_id.starts_with("req_"), "got `{request_id}`");
             }
             other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
         }
@@ -1990,6 +2008,8 @@ fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Resu
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         }),
         Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
             response.into_reader(),
@@ -1998,11 +2018,15 @@ fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Resu
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         })),
         Err(ureq::Error::Transport(error)) => Err(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            request_id: None,
+            details: None,
         }),
     }
 }
@@ -2083,6 +2107,8 @@ fn decode_admin_response<T: serde::de::DeserializeOwned>(
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         }),
         Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
             response.into_reader(),
@@ -2091,11 +2117,15 @@ fn decode_admin_response<T: serde::de::DeserializeOwned>(
             code: "invalid_json".to_owned(),
             feature: None,
             message: err.to_string(),
+            request_id: None,
+            details: None,
         })),
         Err(ureq::Error::Transport(error)) => Err(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            request_id: None,
+            details: None,
         }),
     }
 }

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -7,11 +7,10 @@ use loonfs_api::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
         CompleteUploadRequest, ValidatedContentToken,
     },
-    AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, ContentRef,
-    CreateCheckpointResponse, FilesystemOperation, FilesystemOperationRequest,
-    FilesystemOperationResponse, InodeId, InodeKind, ListPathEntriesResponse, ManifestId,
-    NamespaceId, PutBehavior, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
-    LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
+    AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, CommitResponse,
+    ContentRef, CreateCheckpointResponse, FilesystemOperation, FilesystemOperationRequest, InodeId,
+    InodeKind, ListPathEntriesResponse, ManifestId, NamespaceId, PutBehavior, RevisionNo,
+    DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
 use loonfs_objectstore::keys::metadata_manifest_object;
@@ -320,10 +319,17 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         assert_eq!(directory_entry.inode_kind, InodeKind::Directory);
 
         let target = NamespacePath::parse("demo:/notes/hello.txt").expect("parse namespace path");
-        harness
+        let written = harness
             .client
-            .write_file_bytes(&target, b"hello over http\n", &MutationOptions::default())
+            .write_file_bytes(
+                &target,
+                b"hello over http\n",
+                &MutationOptions::with_commit_id("smoke-write-1"),
+            )
             .expect("write bytes");
+        // Path operations echo the commit id they committed under.
+        assert_eq!(written.commit_id.as_str(), "smoke-write-1");
+        assert_eq!(written.committed_seq, ChangeSeq(2));
 
         let entry = harness.client.stat_path(&target).expect("stat path");
         assert_eq!(entry.size_bytes, Some(16));
@@ -816,7 +822,7 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
         .set("authorization", "Bearer test-token")
         .send_json(request)
         .expect("bad token should fall back to content validation");
-        let response: FilesystemOperationResponse =
+        let response: CommitResponse =
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
 

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -19,7 +19,7 @@ use crate::{
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
     ErrorCode, FlushWalOutcome, FlushWalResponse, InodeId, ListChangesOptions,
     ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, MutationResult, NamespaceId,
+    MaintenanceTickOutcome, MaintenanceTickResult, MoveOptions, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, ObjectStore, PutFileOptions,
     ReleaseCheckpointResponse, RestoreRevisionOptions, RevisionNo, RuntimeCacheStats,
     UploadContentResponse,
@@ -992,7 +992,7 @@ impl FsCore {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
@@ -1068,7 +1068,7 @@ impl FsCore {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record(
@@ -1095,7 +1095,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::CreateDir {
@@ -1115,7 +1115,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::DeletePath {
@@ -1134,7 +1134,7 @@ impl FsCore {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::MovePath {
@@ -1155,7 +1155,7 @@ impl FsCore {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::CopyFilePath {
@@ -1174,7 +1174,7 @@ impl FsCore {
         absolute_path: &str,
         source_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_path_intent(
             namespace_id,
             PathMutationIntent::RestoreRevision {
@@ -1276,18 +1276,8 @@ impl FsCore {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_through_publisher(
-            namespace_id,
-            vec![NamespaceMutationCandidate::Commit(request)],
-        )
-        .await
-        .into_iter()
-        .next()
-        .unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Internal(
-                "empty commit batch".to_owned(),
-            )))
-        })
+        self.publish_candidate(namespace_id, NamespaceMutationCandidate::Commit(request))
+            .await
     }
 
     /// Submits explicit semantic commit requests, returning one result per
@@ -1312,7 +1302,7 @@ impl FsCore {
         &self,
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.publish_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
             .await
     }
@@ -1321,19 +1311,16 @@ impl FsCore {
         &self,
         namespace_id: &NamespaceId,
         candidate: NamespaceMutationCandidate,
-    ) -> Result<MutationResult> {
-        let mut results = self
-            .publish_through_publisher(namespace_id, vec![candidate])
-            .await;
-        let response = results.pop().unwrap_or_else(|| {
-            Err(RuntimeError::Core(CoreError::Internal(
-                "empty path mutation batch".to_owned(),
-            )))
-        })?;
-        Ok(MutationResult {
-            namespace_id: response.namespace_id,
-            committed_seq: response.committed_seq,
-        })
+    ) -> Result<CommitResponse> {
+        self.publish_through_publisher(namespace_id, vec![candidate])
+            .await
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| {
+                Err(RuntimeError::Core(CoreError::Internal(
+                    "empty publication batch".to_owned(),
+                )))
+            })
     }
 
     /// Publishes direct submissions through the core's publication service

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -996,10 +996,10 @@ impl FsCore {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
-        // Pre-flight the mutation-path invariant before staging content so an
-        // invalid or root path cannot orphan an already-written content blob;
-        // core re-checks the same invariant when the intent is planned.
-        loonfs_core::path::validate_path_for_mutation(absolute_path)?;
+        // Parse the mutation path before staging content so an invalid or
+        // root path cannot orphan an already-written content blob; the
+        // intent carries the parsed path from here on.
+        let absolute_path = loonfs_core::path::parse_mutation_path(absolute_path)?;
         // The bytes become durable content before the publish is submitted,
         // so the publication queue never waits on a content upload and an
         // upload failure surfaces here with nothing published. A publish
@@ -1035,7 +1035,7 @@ impl FsCore {
             NamespaceMutationCandidate::PathWithContentAdmission {
                 intent: PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                    absolute_path: absolute_path.to_owned(),
+                    absolute_path,
                     content_ref: stored.content_ref,
                     behavior: options.behavior,
                 },
@@ -1081,7 +1081,7 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::PutFile {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: absolute_path.to_owned(),
+                absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 content_ref,
                 behavior: options.behavior,
             },
@@ -1100,7 +1100,7 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::CreateDir {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: absolute_path.to_owned(),
+                absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
             },
         )
         .await
@@ -1120,7 +1120,7 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::DeletePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: absolute_path.to_owned(),
+                absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 behavior: options.behavior,
             },
         )
@@ -1139,8 +1139,8 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::MovePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                from_path: from_path.to_owned(),
-                to_path: to_path.to_owned(),
+                from_path: loonfs_core::path::parse_mutation_path(from_path)?,
+                to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                 behavior: options.behavior,
             },
         )
@@ -1160,8 +1160,8 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::CopyFilePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                from_path: from_path.to_owned(),
-                to_path: to_path.to_owned(),
+                from_path: loonfs_core::path::parse_mutation_path(from_path)?,
+                to_path: loonfs_core::path::parse_mutation_path(to_path)?,
             },
         )
         .await
@@ -1179,7 +1179,7 @@ impl FsCore {
             namespace_id,
             PathMutationIntent::RestoreRevision {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: absolute_path.to_owned(),
+                absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 source_revision_no,
             },
         )

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -10,7 +10,7 @@ use crate::{
     CapabilityDocument, CommitRequest, CommitResponse, CompleteUploadRequest,
     CompleteUploadResponse, ContentRef, CopyOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    GramIndexBuildPolicy, InodeId, MoveOptions, MutationResult, NamespaceId, NamespaceSummary,
+    GramIndexBuildPolicy, InodeId, MoveOptions, NamespaceId, NamespaceSummary,
     ObjectStoreMetricsRecorder, PutFileOptions, RestoreRevisionOptions, Result, RevisionNo,
     RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind, UploadContentResponse, UploadId,
@@ -135,7 +135,7 @@ impl FsWriter {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .put_file_bytes(namespace_id, absolute_path, bytes, options)
             .await
@@ -152,7 +152,7 @@ impl FsWriter {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
             .await
@@ -164,7 +164,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .create_directory(namespace_id, absolute_path, options)
             .await
@@ -179,7 +179,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .delete_path(namespace_id, absolute_path, options)
             .await
@@ -192,7 +192,7 @@ impl FsWriter {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .move_path(namespace_id, from_path, to_path, options)
             .await
@@ -206,7 +206,7 @@ impl FsWriter {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .copy_path(namespace_id, from_path, to_path, options)
             .await
@@ -219,7 +219,7 @@ impl FsWriter {
         absolute_path: &str,
         source_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
-    ) -> Result<MutationResult> {
+    ) -> Result<CommitResponse> {
         self.core
             .restore_file_revision(namespace_id, absolute_path, source_revision_no, options)
             .await

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -52,14 +52,14 @@ pub use loonfs_api::{
     ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteDirectoryBehavior, DeleteNamespaceResponse,
     DirectoryPageCursor, DisableGramsIndexResponse, DisplayName, EffectiveLimit,
-    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FilesystemOperationResponse,
-    FlushWalOutcome, FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
-    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, MutationResult, NameKey,
-    NamePolicy, NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest,
-    PaginationPolicy, PutBehavior, ReleaseCheckpointResponse, RevisionNo, UploadId,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FlushWalOutcome,
+    FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, NameKey, NamePolicy,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy,
+    PutBehavior, ReleaseCheckpointResponse, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
+    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
+    PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -75,6 +75,7 @@ pub use loonfs_core::{
 /// [`publish::NamespaceMutationCandidate`]s directly. Most embedded users
 /// never need this module.
 pub mod publish {
+    pub use loonfs_core::path::parse_mutation_path;
     pub use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
 }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -65,7 +65,7 @@ pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{
     BeginDirectPutUploadTargetResponse, BootstrapNamespaceError, DeleteNamespaceOptions,
     DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind, GcConfig, GcReport,
-    GramIndexBuildPolicy,
+    GramIndexBuildPolicy, WriterFence,
 };
 
 /// Integration seam: the vocabulary for handing classified mutation work to

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1055,7 +1055,7 @@ mod tests {
     use futures::stream::BoxStream;
     use loonfs_api::v0::{CommitOp, CommitRequest};
     use loonfs_api::wire::wal::decode_wal_segment_envelope_zstd;
-    use loonfs_api::{ChangeSeq, InodeId, PutBehavior};
+    use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, PutBehavior};
     use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::{
@@ -1532,7 +1532,7 @@ mod tests {
         ));
         let path = NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("path-trace").expect("valid commit id"),
-            absolute_path: "/private/path".to_owned(),
+            absolute_path: AbsolutePath::parse("/private/path").expect("path"),
         });
 
         assert_eq!(operation_class(&commit), "explicit_commit");
@@ -2075,7 +2075,7 @@ mod tests {
         };
         let path_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("path-put").expect("valid commit id"),
-            absolute_path: "/file.txt".to_owned(),
+            absolute_path: AbsolutePath::parse("/file.txt").expect("path"),
             content_ref: staged.content_ref,
             behavior: PutBehavior::NoReplace,
         };

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -15,6 +15,7 @@ use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_api::AbsolutePath;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -146,7 +147,10 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
                 loonfs::publish::PathMutationIntent::PutFile {
                     commit_id: loonfs::CommitId::generate(),
-                    absolute_path: format!("/tree/dir-000000/file-{index:09}.txt"),
+                    absolute_path: AbsolutePath::parse(format!(
+                        "/tree/dir-000000/file-{index:09}.txt"
+                    ))
+                    .expect("path"),
                     content_ref,
                     behavior: loonfs::PutBehavior::NoReplace,
                 },

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -127,8 +127,8 @@ struct ParkedPuts {
     store: Arc<BlockingHeadCasStore>,
     writer: Arc<FsWriter>,
     namespace_id: NamespaceId,
-    first: tokio::task::JoinHandle<loonfs::Result<loonfs::MutationResult>>,
-    second: tokio::task::JoinHandle<loonfs::Result<loonfs::MutationResult>>,
+    first: tokio::task::JoinHandle<loonfs::Result<loonfs::CommitResponse>>,
+    second: tokio::task::JoinHandle<loonfs::Result<loonfs::CommitResponse>>,
 }
 
 /// Parks one publication at the blocked head CAS with a second put queued

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -14,6 +14,7 @@ use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
     PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
 };
+use loonfs_api::AbsolutePath;
 
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::metadata_manifest_object;
@@ -224,7 +225,8 @@ async fn warm_phase_request_accounting() {
             candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
                 loonfs::publish::PathMutationIntent::PutFile {
                     commit_id: loonfs::CommitId::generate(),
-                    absolute_path: format!("/hot/file-{index:05}.txt"),
+                    absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
+                        .expect("path"),
                     content_ref,
                     behavior: loonfs::PutBehavior::NoReplace,
                 },

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -11,10 +11,10 @@ use loonfs::{
     CreateCheckpointOptions, CreateCheckpointResponse, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode, FsAdmin, FsReader,
     FsWriter, FsWriterBuilder, InodeId, InodeKind, ListChangesOptions, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, MutationResult,
-    NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy, PutBehavior,
-    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind,
-    UploadContentResponse, UploadId,
+    MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions, NamespaceId,
+    NamespaceStatusResponse, PageRequest, PaginationPolicy, PutBehavior, PutFileOptions,
+    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind, UploadContentResponse,
+    UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_head};
@@ -102,7 +102,7 @@ impl TestRuntime {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         self.writer
             .put_file_bytes(namespace_id, absolute_path, bytes, options)
             .await
@@ -114,7 +114,7 @@ impl TestRuntime {
         absolute_path: &str,
         content_ref: ContentRef,
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         self.writer
             .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
             .await
@@ -297,33 +297,33 @@ trait FsTestExt {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn create_directory_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn delete_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn move_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn copy_path_blocking(
         &self,
         namespace_id: &NamespaceId,
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> loonfs::Result<MutationResult>;
+    ) -> loonfs::Result<CommitResponse>;
     fn begin_upload_blocking(
         &self,
         namespace_id: &NamespaceId,
@@ -427,7 +427,7 @@ impl FsTestExt for TestRuntime {
         absolute_path: &str,
         bytes: &[u8],
         options: PutFileOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .put_file_bytes(namespace_id, absolute_path, bytes, options),
@@ -439,7 +439,7 @@ impl FsTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .create_directory(namespace_id, absolute_path, options),
@@ -451,7 +451,7 @@ impl FsTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .delete_path(namespace_id, absolute_path, options),
@@ -464,7 +464,7 @@ impl FsTestExt for TestRuntime {
         from_path: &str,
         to_path: &str,
         options: MoveOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .move_path(namespace_id, from_path, to_path, options),
@@ -477,7 +477,7 @@ impl FsTestExt for TestRuntime {
         from_path: &str,
         to_path: &str,
         options: CopyOptions,
-    ) -> loonfs::Result<MutationResult> {
+    ) -> loonfs::Result<CommitResponse> {
         block_on(
             self.writer
                 .copy_path(namespace_id, from_path, to_path, options),
@@ -1754,6 +1754,67 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
         .read_file_bytes_blocking(&namespace_id, "/docs/report.txt")
         .expect("read retried file");
     assert_eq!(read.bytes, b"overlap survives");
+}
+
+#[test]
+fn path_mutations_return_the_commit_id_they_committed_under() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let object_store = store(temp_dir.path());
+    block_on(async {
+        let fs = open_runtime_async(object_store, "commit-id-echo-test").await;
+        fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+
+        let commit_id = CommitId::parse("retry-key-1").expect("valid commit id");
+        let first = fs
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions {
+                    commit_id: Some(commit_id.clone()),
+                    ..PutFileOptions::default()
+                },
+            )
+            .await
+            .expect("first put");
+        assert_eq!(first.namespace_id, namespace_id);
+        assert_eq!(first.commit_id, commit_id);
+
+        // Resubmitting the identical mutation with the same commit id
+        // replays the original commit instead of committing again.
+        let replay = fs
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/a.txt",
+                b"alpha",
+                PutFileOptions {
+                    commit_id: Some(commit_id.clone()),
+                    ..PutFileOptions::default()
+                },
+            )
+            .await
+            .expect("identical resubmission replays the original commit");
+        assert_eq!(replay.commit_id, first.commit_id);
+        assert_eq!(replay.committed_seq, first.committed_seq);
+
+        // Without a caller-supplied id, the generated one is still returned,
+        // so every caller holds a reconciliation handle.
+        let generated = fs
+            .writer
+            .create_directory(
+                &namespace_id,
+                "/docs/sub",
+                CreateDirectoryOptions::default(),
+            )
+            .await
+            .expect("mkdir");
+        assert!(!generated.commit_id.as_str().is_empty());
+        assert_ne!(generated.commit_id, first.commit_id);
+        assert!(generated.committed_seq > first.committed_seq);
+    });
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -265,8 +265,7 @@ orphaned, and the request is not committed.
 
 If the head update's outcome was never observed — a transport failure after
 the update was sent — the server reports `commit_outcome_unknown`: the commit
-may already be visible. A retry must reuse the same `commit_id`, which replays
-the committed response instead of double-committing.
+may already be visible. Section 5.2 defines how the caller resolves it.
 
 The server may publish multiple committed logical commits in one WAL segment
 and one head update, but it must preserve per-commit idempotency, ordering,
@@ -282,6 +281,36 @@ Callers may bound a response with `limit`; a truncated page returns
 the requested cursor is older than the retention floor, the caller must
 re-bootstrap instead of expecting older incremental history to remain
 available.
+
+### 5.2 Mutation responses and safe retry
+
+Every committed mutation — an explicit commit or a path-oriented operation —
+returns the same response envelope: the `namespace_id` that changed, the
+`commit_id` the mutation committed under, and the `committed_seq` where it
+became visible. When the caller did not supply a commit id, the surface that
+accepted the request generates one and returns it, so every caller holds the
+identity it needs to reconcile an uncertain outcome.
+
+The retry rule has three cases:
+
+- Resubmitting the semantically identical mutation with the same `commit_id`
+  is safe: if the original committed, the response replays the original
+  `committed_seq` without committing again; if it never committed, the
+  resubmission completes it.
+- Reusing a `commit_id` for a different mutation fails with
+  `commit_id_reuse_conflict`.
+- Retrying with a new `commit_id` is a new logical mutation.
+
+Identical resubmission is the reconciliation mechanism. There is no separate
+commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
+a process restart, resubmit the same request with the same `commit_id` and
+read the definitive answer from the response.
+
+Committed mutations record a durable receipt binding the `commit_id` to its
+`committed_seq`; replay reads that receipt. Receipts are currently retained
+for the life of the namespace. When receipt retention becomes bounded, this
+contract will state the replay window explicitly, and resubmission after the
+window must fail loudly rather than silently committing again.
 
 The standard lower-level mutation set is defined in `format.md` ("Standard
 mutation operations"). The path-oriented filesystem surface may compile
@@ -601,13 +630,15 @@ Representative request:
 ```
 
 A successful response is returned only after the underlying change is actually
-committed: the WAL segment is durable and the head has advanced.
+committed: the WAL segment is durable and the head has advanced. Path
+operations return the same envelope as explicit commits (section 5.2).
 
 Representative response:
 
 ```json
 {
   "namespace_id": "demo",
+  "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
   "committed_seq": 419
 }
 ```

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -152,9 +152,14 @@ Every error response is a JSON body:
 
 ```json
 {
-  "code": "not_supported",
-  "feature": "core.namespaces.delete",
-  "message": "this deployment does not support namespace deletion"
+  "code": "writer_fenced",
+  "message": "writer session fenced: epoch 3 was fenced by epoch 4 (writer `server-b`)",
+  "request_id": "req_9c2f4a1b7d8e4f21a0b3c4d5e6f70819",
+  "details": {
+    "fenced_epoch": 3,
+    "active_writer_epoch": 4,
+    "active_writer": "server-b"
+  }
 }
 ```
 
@@ -163,6 +168,23 @@ change between releases; `feature` is present only on `not_supported` errors
 and names the capability-document key the client should reconcile against.
 Clients must branch on `code`, must tolerate codes they do not recognize, and
 must not parse `message`.
+
+`request_id` is the correlation id the server assigned to the request; every
+response — success or error — also carries it as the `x-request-id` header,
+so a caller's log line and the server's trace can be joined.
+
+`details` is present when the failure carries machine-usable identity, so a
+caller never has to parse `message` to act. Every field is optional and
+clients must tolerate absent fields exactly as they tolerate unknown codes.
+The codes that populate it:
+
+| Code | Detail fields |
+| --- | --- |
+| `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, `active_writer` (when the head recorded the winner's writer id) |
+| `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
+| `commit_id_reuse_conflict` | `commit_id` |
+| `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
+| any failed mutation | `commit_id` — the idempotency key the request committed under, echoed so failed and uncertain outcomes carry the caller's reconciliation handle (section 5.2) |
 
 One code exists specifically so capability handling is uniform from day one:
 
@@ -311,6 +333,21 @@ Committed mutations record a durable receipt binding the `commit_id` to its
 for the life of the namespace. When receipt retention becomes bounded, this
 contract will state the replay window explicitly, and resubmission after the
 window must fail loudly rather than silently committing again.
+
+### 5.3 Writer topology and fencing
+
+Each namespace has one active writer session. Many concurrent clients may
+submit mutations through that session — the reference server is exactly this
+shape: one service-level writer session coordinating every client request —
+and independent readers scale separately.
+
+Replacing the active writer is not an approval flow. Opening a writer and
+publishing acquires the next writer epoch, and epoch fencing — not liveness,
+not a lease — is what keeps the displaced session from corrupting anything:
+its next publish fails with `writer_fenced`, terminally for that session.
+The error's `details` name the epoch and writer that displaced it, so an
+operator can tell a planned failover from two writers misconfigured against
+one namespace.
 
 The standard lower-level mutation set is defined in `format.md` ("Standard
 mutation operations"). The path-oriented filesystem surface may compile

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1337,7 +1337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FilesystemOperationResponse"
+                  "$ref": "#/components/schemas/CommitResponse"
                 }
               }
             }
@@ -3234,7 +3234,7 @@
       },
       "CommitResponse": {
         "type": "object",
-        "description": "Response for a committed explicit request.",
+        "description": "Result of one committed mutation.\n\nEvery mutation resolves to this envelope — path-oriented operations and\nexplicit commits, embedded or remote. The commit id is the caller's\nreconciliation handle: resubmitting the same request with the same id\nreplays this result instead of committing twice.",
         "required": [
           "namespace_id",
           "commit_id",
@@ -3242,13 +3242,16 @@
         ],
         "properties": {
           "commit_id": {
-            "$ref": "#/components/schemas/CommitId"
+            "$ref": "#/components/schemas/CommitId",
+            "description": "Idempotency key the mutation committed under: caller-supplied, or\ngenerated on the caller's behalf when the request carried none."
           },
           "committed_seq": {
-            "$ref": "#/components/schemas/ChangeSeq"
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Sequence number where the mutation became visible."
           },
           "namespace_id": {
-            "$ref": "#/components/schemas/NamespaceId"
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that changed."
           }
         }
       },
@@ -3717,24 +3720,6 @@
           "operation": {
             "$ref": "#/components/schemas/FilesystemOperation",
             "description": "Operation to apply."
-          }
-        }
-      },
-      "FilesystemOperationResponse": {
-        "type": "object",
-        "description": "Response for one path-oriented operation.",
-        "required": [
-          "namespace_id",
-          "committed_seq"
-        ],
-        "properties": {
-          "committed_seq": {
-            "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Sequence where the operation became visible."
-          },
-          "namespace_id": {
-            "$ref": "#/components/schemas/NamespaceId",
-            "description": "Namespace that changed."
           }
         }
       },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2435,6 +2435,17 @@
             "type": "string",
             "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
           },
+          "details": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ErrorDetails",
+                "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+              }
+            ]
+          },
           "feature": {
             "type": [
               "string",
@@ -2445,6 +2456,13 @@
           "message": {
             "type": "string",
             "description": "Human-readable error message."
+          },
+          "request_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
           }
         }
       },
@@ -3520,6 +3538,107 @@
           }
         }
       },
+      "ErrorDetails": {
+        "type": "object",
+        "description": "Structured, machine-readable context accompanying an [`ApiError`].\n\nEvery field is optional: a code populates the fields that apply to it\n(API spec, \"Standard error contract\"), and clients must tolerate absent\nfields exactly as they tolerate unknown codes. Retry decisions still key\noff the code; these fields carry the identity a caller needs to act —\nwhich commit to resubmit, which epoch displaced it, which revision the\nprecondition saw.",
+        "properties": {
+          "active_writer": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Writer id recorded by the current epoch's acquirer, when the head\nrecorded one."
+          },
+          "active_writer_epoch": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WriterEpoch",
+                "description": "Epoch that currently owns the namespace."
+              }
+            ]
+          },
+          "actual_revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RevisionNo",
+                "description": "Revision that is actually current; absent when the inode has none."
+              }
+            ]
+          },
+          "after_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Change-feed cursor the request asked to resume after."
+              }
+            ]
+          },
+          "commit_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CommitId",
+                "description": "Idempotency key of the mutation the error concerns."
+              }
+            ]
+          },
+          "expected_revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RevisionNo",
+                "description": "Revision the request expected to be current."
+              }
+            ]
+          },
+          "fenced_epoch": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WriterEpoch",
+                "description": "Epoch the failing writer session held when it was displaced."
+              }
+            ]
+          },
+          "inode_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InodeId",
+                "description": "Inode the failed precondition or operation targeted."
+              }
+            ]
+          },
+          "retention_floor_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Oldest sequence still promised for incremental replay."
+              }
+            ]
+          }
+        }
+      },
       "FileRevision": {
         "type": "object",
         "description": "One immutable file revision.",
@@ -4473,6 +4592,12 @@
             "description": "Opaque, server-signed token. Clients must not parse it."
           }
         }
+      },
+      "WriterEpoch": {
+        "type": "integer",
+        "format": "int64",
+        "description": "Monotonically increasing writer epoch for namespace write fencing.",
+        "minimum": 0
       }
     }
   },


### PR DESCRIPTION
`PathMutationIntent` carried raw `String` paths, so every plan function re-parsed and re-validated deep inside the planner, and the validated `AbsolutePath` type sat unused at the mutation boundary. Paths are now parsed exactly once, at whichever surface accepts the raw string: the embedded entry methods (for put, before content staging, preserving the no-orphaned-blob ordering), the HTTP handler when it converts the wire operation into an intent, and the test-support wrappers. `parse_mutation_path` is the one named home for the parse-plus-not-root invariant; planning keeps only the root re-check for intents built directly from parsed paths, and never re-parses.

Fingerprints are unchanged: they previously hashed the parse-normalized path string, and the intent now carries exactly that normalized form.