### PR TITLE
docs: clarify single-writer multi-reader model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![LoonFS Logo](assets/loonfs-wordmark-black.svg)
 
-LoonFS is a durable filesystem built on object storage. It can be used to store, manage, index, and retrieve files and folders for a variety of use cases. Object storage is the only durable dependency from which LoonFS derives virtually unlimited storage and a high throughput ceiling. It is designed for use cases with many writers and readers, and can be used across sessions, agents, and teams as an embedded engine or through a remote server connection.
+LoonFS is a durable filesystem built on object storage. It can be used to store, manage, index, and retrieve files and folders for a variety of use cases. Object storage is the only durable dependency from which LoonFS derives virtually unlimited storage and a high throughput ceiling. It uses a single-writer, multi-reader model and can be used across sessions and clients as an embedded engine or through a remote server connection.
 
 ## Download
 


### PR DESCRIPTION
Clarifies that LoonFS uses a single-writer, multi-reader model.