### PR TITLE
docs: align agent docs with the single-writer model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ loon namespace create {namespace_id}
 loon use {namespace_id}
 ```
 
+## Running a server
+
+Embedded mode gives one process at a time direct object-store access. To share a deployment across machines and let many clients write concurrently, run the reference server and point remote profiles at it:
+
+```bash
+cargo build -p loonfs-server
+./target/debug/loonfs-server --config configs/loonfs-server.local-fs.example.toml
+```
+
+Commented example configs for every supported store live in [configs/](configs) (`local-fs`, `aws-s3`, `gcp-gcs`, `cloudflare-r2`, `azure-abs`). The required fields are `bind`, `writer_id`, `writer_version`, and a `[store]` block; everything else defaults. Connect a client:
+
+```bash
+export LOONFS_AUTH_TOKEN={auth_token}
+loon init default --no-input --mode remote --server-url http://127.0.0.1:9400
+```
+
 ## Documentation
 
 Visit loonfs.com/docs to learn more.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -626,7 +626,7 @@ The response body is the authoritative file bytes. Metadata may be exposed in
 headers, but the body itself is raw content rather than JSON.
 
 Revision listing endpoints return newest revisions first and use the same
-`limit` / `cursor` pattern as directory and namespace listing. Path-based
+`limit` / `cursor` pattern as directory listing. Path-based
 revision listing resolves the current path to its current inode, while inode
 revision listing is stable across later renames. Responses include
 `next_cursor` only when another page is available.

--- a/examples/SKILL.md
+++ b/examples/SKILL.md
@@ -37,7 +37,7 @@ Check the CLI is installed with `loon version`. If `loon current --json` reports
 
 2. **Durable / shared setup**. Ask the user for S3/R2 credentials (provider, bucket, region, access key, secret) or a hosted Loon server URL + auth token. Put secrets in the environment, not on the command line (argv lands in shell history): the CLI reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and `LOONFS_AUTH_TOKEN` automatically. Then run `loon profile create <name> --mode embedded --store-kind aws-s3 --bucket ... --region ...` (or `--store-kind cloudflare-r2 ...`, or `--mode remote --server-url ...`). Do not invent credentials.
 
-After init, create a namespace with `loon namespace create <namespace_id>`, or use the one the user names. Namespaces are addressed by id — there is no listing command.
+After init, create a namespace with `loon namespace create <namespace_id>`, or use the one the user names.
 
 ## Two canonical patterns
 

--- a/examples/SKILL.md
+++ b/examples/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: loon
-description: Use the `loon` CLI (LoonFS) for durable, multiplayer, versioned agent workspaces. Use when the user asks to read, write, list, move, copy, fork, restore, or hand off files stored in Loon; mentions Loon namespaces, shared agent state, durable handoffs, persisted project docs, artifacts that future agents should read, rolling back an agent's changes, branching a workspace for an experiment, or files that are not in the local filesystem but sound like a shared or persistent workspace.
+description: Use the `loon` CLI (LoonFS) for durable, shared, versioned agent workspaces. Use when the user asks to read, write, list, move, copy, fork, restore, or hand off files stored in Loon; mentions Loon namespaces, shared agent state, durable handoffs, persisted project docs, artifacts that future agents should read, rolling back an agent's changes, branching a workspace for an experiment, or files that are not in the local filesystem but sound like a shared or persistent workspace.
 ---
 
 # loon
 
-Use `loon` to give an agent task a durable, versioned, multiplayer workspace. Treat Loon state as shared team and agent state: writes, deletes, restores, and moves are immediately visible to other users and agents with access to the same namespace.
+Use `loon` to give an agent task a durable, versioned, shared workspace. Treat Loon state as shared team and agent state: writes, deletes, restores, and moves are immediately visible to other users and agents with access to the same namespace.
 
 Binary: `loon` on `PATH`. Run `loon help` or `loon <subcommand> --help` if the exact CLI shape is unclear.
 
@@ -37,7 +37,7 @@ Check the CLI is installed with `loon version`. If `loon current --json` reports
 
 2. **Durable / shared setup**. Ask the user for S3/R2 credentials (provider, bucket, region, access key, secret) or a hosted Loon server URL + auth token. Put secrets in the environment, not on the command line (argv lands in shell history): the CLI reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and `LOONFS_AUTH_TOKEN` automatically. Then run `loon profile create <name> --mode embedded --store-kind aws-s3 --bucket ... --region ...` (or `--store-kind cloudflare-r2 ...`, or `--mode remote --server-url ...`). Do not invent credentials.
 
-After init, list or create a namespace: `loon namespace list`, `loon namespace create <namespace_id>`.
+After init, create a namespace with `loon namespace create <namespace_id>`, or use the one the user names. Namespaces are addressed by id — there is no listing command.
 
 ## Two canonical patterns
 
@@ -66,7 +66,7 @@ loon get /plans/gtm-q3.md ./gtm-q3.md --namespace <ns>
 loon put ./gtm-q3.md /plans/gtm-q3-marketing-led.md --namespace <ns>
 ```
 
-At session end, surface both paths so the user can compare. To promote the alternate to canonical, `loon mv` it over the original after the user confirms — revision history is preserved. For "I wrote v2 into the original and want to undo," use Pattern B (restore), not a fork.
+At session end, surface both paths so the user can compare. To promote the alternate to canonical after the user confirms, copy it over the original: `loon cp /plans/gtm-q3-marketing-led.md /plans/gtm-q3.md --force`. The copy lands as a new revision of the original file, so the original's full history stays restorable; optionally `loon rm` the alternate afterwards. Do not `mv` over the original — a move replaces the file's identity and makes the original's revision history unreachable. For "I wrote v2 into the original and want to undo," use Pattern B (restore), not a fork.
 
 #### A.2 — Fork the namespace (heavyweight)
 
@@ -80,7 +80,7 @@ loon namespace fork <source_namespace> <source_namespace>-<task_or_agent_id>
 
 After forking, **operate exclusively in the child namespace** — pass `--namespace <child>` on every data command. When the work is done: promote the child (leave it canonical), merge selected files back into the source by `cat` + `put`, or abandon the fork (no cleanup needed; abandoned forks cost nothing in content storage).
 
-For agent fleets where work cannot be cleanly partitioned by path (several agents trying alternate framings of the same artifact): one child namespace per agent. If the fleet's work *can* be partitioned by path (one agent per section of a brief, each writing to its own file), keep them in the same namespace and skip the fork — Loon's multiplayer-by-default model handles non-overlapping concurrent writes.
+For agent fleets: one child namespace per agent. LoonFS is single-writer per namespace — reads are concurrent from anywhere, but only one writer owns a namespace at a time. Writing through a shared Loon server (`--mode remote`) is safe for any number of parallel agents because the server is the writer and serializes their commits; in embedded mode each CLI process is the writer, so parallel embedded writes to one namespace fail with `writer_fenced`. Forks avoid the contention in every mode.
 
 ### Pattern B — Restore on failure
 
@@ -97,7 +97,7 @@ For multi-file rollbacks: repeat per path. If the scope is large (more than ~5 f
 
 ## Namespace discipline
 
-Pick the namespace from the task subject, not from the current working directory — the user may be in one repo while asking about a different workspace. If the namespace is ambiguous, run `loon namespace list --json` to surface options or ask the user. Do not fall back to the active default.
+Pick the namespace from the task subject, not from the current working directory — the user may be in one repo while asking about a different workspace. If the namespace is ambiguous, ask the user — namespaces are addressed by id and there is no listing command. Do not fall back to the active default.
 
 Always pass `--namespace <ns>` explicitly on every data command. The active default (`loon current`) is shared local profile state that another terminal or agent can change. Do not run `loon use <ns>` from this skill unless the user explicitly asks to change the default.
 
@@ -118,12 +118,14 @@ loon get       <remote> <local> --namespace <ns> [--revision <n>]
 # write
 loon put       <local>  <remote> --namespace <ns> [--force]
 loon mkdir     <dir>    --namespace <ns>
-loon mv        <src>    <dst>    --namespace <ns>
-loon cp        <src>    <dst>    --namespace <ns>
+loon mv        <src>    <dst>    --namespace <ns> [--force]
+loon cp        <src>    <dst>    --namespace <ns> [--force]
 loon rm        <path>   --namespace <ns>
 ```
 
-**Before any destructive operation** (`put` over an existing path, `mv`, `cp`, `rm`, `restore`): run `loon stat` first, show the user the current size and revision, and ask before proceeding. `--force` on `put` requires explicit user confirmation. Revisions survive `rm`, so accidental deletes can be recovered via Pattern B.
+**Safe retries.** Every write accepts `--commit-id <id>`. When a write fails in an uncertain way (timeout, `server_busy`, killed process), retry it with the same commit id and identical arguments: a retry of a commit that already landed returns the original result instead of writing twice, and a reused id with different content fails with `commit_id_reuse_conflict`. Generate one id per logical write (for example `c-$(uuidgen)`) and hold it across attempts.
+
+**Before any destructive operation** (`put` over an existing path, `mv`, `cp`, `rm`, `restore`): run `loon stat` first, show the user the current size and revision, and ask before proceeding. `--force` requires explicit user confirmation. Treat `rm` — and `mv --force` over an existing file — as permanent: the deleted or replaced file's revision history stops being reachable from its path, and there is no undelete.
 
 For generated artifacts, prefer clear paths:
 

--- a/examples/agents/agents-md/AGENTS.md
+++ b/examples/agents/agents-md/AGENTS.md
@@ -36,7 +36,7 @@ If `loon current --json` reports no configured profile:
   ```
 - **Shared / cross-machine setup**: ask the user for S3 / R2 credentials or a hosted Loon server URL + auth token; do not invent them. Put secrets in the environment, not on the command line (argv lands in shell history): the CLI reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and `LOONFS_AUTH_TOKEN` automatically. Then run `loon profile create <name> --mode embedded --store-kind aws-s3 --bucket ... --region ...` (or `--store-kind cloudflare-r2 ...`, or `--mode remote --server-url ...`).
 
-Create a namespace with `loon namespace create <id>`, or use the one the user names. Namespaces are addressed by id — there is no listing command; if the target namespace is ambiguous, ask the user.
+Create a namespace with `loon namespace create <id>`, or use the one the user names.
 
 ## Pattern A — Branch your work
 

--- a/examples/agents/agents-md/AGENTS.md
+++ b/examples/agents/agents-md/AGENTS.md
@@ -1,4 +1,4 @@
-# Loon — durable, multiplayer, versioned agent workspaces
+# Loon — durable, shared, versioned agent workspaces
 
 > Drop-in `AGENTS.md` snippet for any tool that follows the [agents.md](https://agents.md) convention (Codex, Aider, OpenHands, GitHub Copilot, Gemini CLI, Devin, Windsurf, Zed, Factory, Jules, VS Code, and others). Append this block to an existing `AGENTS.md`, or use this file as-is.
 
@@ -9,7 +9,7 @@
 - **Namespaces** — isolated, versioned workspaces backed by object storage.
 - **O(1) forks** — branch a namespace when multiple files or agents would otherwise collide; no byte copy.
 - **Per-file revision history + restore** — roll back any path to any prior revision.
-- **Multiplayer-by-default** — multiple agents and humans can read and write the same namespace concurrently.
+- **Shared by default** — every agent and human with access to a namespace sees the same committed files, and any number of clients can read concurrently. Writes go through a single writer per namespace (see the fleet note under Pattern A).
 
 Binary: `loon` on `PATH`. Run `loon help` or `loon <subcommand> --help` for exact shapes.
 
@@ -36,7 +36,7 @@ If `loon current --json` reports no configured profile:
   ```
 - **Shared / cross-machine setup**: ask the user for S3 / R2 credentials or a hosted Loon server URL + auth token; do not invent them. Put secrets in the environment, not on the command line (argv lands in shell history): the CLI reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and `LOONFS_AUTH_TOKEN` automatically. Then run `loon profile create <name> --mode embedded --store-kind aws-s3 --bucket ... --region ...` (or `--store-kind cloudflare-r2 ...`, or `--mode remote --server-url ...`).
 
-Create or pick a namespace: `loon namespace list`, `loon namespace create <id>`.
+Create a namespace with `loon namespace create <id>`, or use the one the user names. Namespaces are addressed by id — there is no listing command; if the target namespace is ambiguous, ask the user.
 
 ## Pattern A — Branch your work
 
@@ -48,7 +48,7 @@ Before a risky, exploratory, or parallel edit, give the work an isolated branch.
 
 **A.1 — Sibling filename (lightweight).** One agent iterating on one artifact. Keep the original at its current path; write the alternate to a clearly-named sibling. No fork, no `--namespace` change.
 
-Examples: `/plans/gtm-q3.md` stays; alternate at `/plans/gtm-q3-marketing-led.md`. Or `/proposals/acme-rev3.md` alongside `/proposals/acme-rev2.md`. At session end, surface both paths so the user can compare and pick. To promote the alternate to canonical, `loon mv` it over the original after confirming — revision history is preserved. For "undo a write to the original," use Pattern B (restore), not a fork.
+Examples: `/plans/gtm-q3.md` stays; alternate at `/plans/gtm-q3-marketing-led.md`. Or `/proposals/acme-rev3.md` alongside `/proposals/acme-rev2.md`. At session end, surface both paths so the user can compare and pick. To promote the alternate to canonical after the user confirms, copy it over the original: `loon cp <alternate> <canonical> --force`. The copy lands as a new revision of the original file, so the original's full history stays restorable; optionally `loon rm` the alternate afterwards. Do not `mv` over the original — a move replaces the file's identity and makes the original's revision history unreachable. For "undo a write to the original," use Pattern B (restore), not a fork.
 
 **A.2 — Fork the namespace (heavyweight).** Multi-file artifacts that cross-reference each other (plan + appendices, design doc + diagrams), or multi-agent fleets that would collide on overlapping paths.
 
@@ -58,7 +58,7 @@ loon namespace fork <source_namespace> <source_namespace>-<task_or_agent_id>
 
 `fork` is O(1) and does not copy bytes. Operate exclusively in the child namespace by passing `--namespace <child>` on every command. Good child namespace names: `gtm-q3-marketing-led`, `rfc-billing-event-sourced`, `acme-proposal-rev3`, `brief-2026-06-04-agent-a`.
 
-For agent fleets where work can be partitioned cleanly by path (one agent per section of a brief, each writing its own file), keep them in the same namespace and skip the fork — Loon handles non-overlapping concurrent writes natively.
+A note on fleets: LoonFS is single-writer per namespace. Reads are concurrent from anywhere, but only one writer owns a namespace at a time. Writing through a shared Loon server (`--mode remote`) is safe for any number of parallel agents — the server is the writer and serializes their commits. In embedded mode each CLI process is the writer, so parallel embedded writes to one namespace fail with `writer_fenced`; give each embedded agent its own fork instead.
 
 ## Pattern B — Restore on failure
 
@@ -85,7 +85,7 @@ loon cp /docs/a.md /archive/a.md --namespace <ns>
 loon rm /docs/old.md --namespace <ns>
 ```
 
-Use `--json` for parseable commands (`ls`, `stat`, `revisions`, `profile list`, `namespace list`, `current`). Do not combine `--json` with streaming output (`cat`, `get -`).
+Use `--json` for parseable commands (`ls`, `stat`, `revisions`, `profile list`, `current`). Do not combine `--json` with streaming output (`cat`, `get -`).
 
 ## Writes — inspect first
 
@@ -93,7 +93,12 @@ Before `put` over an existing path, or before `rm`, `mv`, `cp`, `restore`:
 
 1. `loon stat <path> --namespace <ns> --json` to see size and revision.
 2. Show the user; ask before overwriting / deleting / moving.
-3. Only pass `--force` to `put` after explicit user confirmation.
+3. Only pass `--force` after explicit user confirmation.
+4. Treat `rm` — and `mv --force` over an existing file — as permanent: the deleted or replaced file's revision history stops being reachable from its path. There is no undelete.
+
+## Safe retries
+
+Every write accepts `--commit-id <id>`. When a write fails in an uncertain way (timeout, `server_busy`, killed process), retry it with the same commit id and identical arguments: a retry of a commit that already landed returns the original result instead of writing twice, and a reused id with different content fails with `commit_id_reuse_conflict`. Generate one id per logical write (for example `c-$(uuidgen)`) and hold it across attempts.
 
 After writing, report both the path and the namespace — for example, `Wrote /plans/gtm-q3.md in namespace gtm-2026`.
 
@@ -101,6 +106,6 @@ After writing, report both the path and the namespace — for example, `Wrote /p
 
 - Never upload secrets, credentials, `.env` files, tokens, or private keys.
 - Ask before uploading customer data unless the namespace is already approved for that data.
-- Report failed Loon commands explicitly (command intent, namespace, path, error summary); do not silently retry.
+- Report failed Loon commands explicitly (command intent, namespace, path, error summary); if you retry, reuse the same `--commit-id` (see Safe retries).
 - For risky changes (>5 writes, bulk edits, deletes), branch first (sibling filename or fork, per the Pattern A decision rule) rather than editing in place.
 - Do not use Loon for source-code edits. Use the local filesystem and git for code; use Loon for docs, plans, briefs, RFCs, proposals, postmortems.


### PR DESCRIPTION
A black-box usage test ran the examples docs against the CLI and found four promises the product does not keep: "multiplayer-by-default" concurrent writes in one namespace (embedded writers fence each other by design), recovery of deleted files via the restore pattern (path-based revisions/restore return path_not_found after rm), promotion by mv over the canonical path "preserving history" (a move replaces the destination inode, cutting its history off from the path), and a loon namespace list command that no longer exists (listing is intentionally unsupported per the API spec).

This updates AGENTS.md and SKILL.md to tell the truth: reads are concurrent everywhere; writes are single-writer per namespace (the server serializes concurrent clients in remote mode; embedded fleets fork per agent); promotion is cp --force over the canonical path, which appends a revision and keeps the original's history restorable; rm and mv --force are permanent until an undelete exists. Both docs also gain a short safe-retries section teaching the existing --commit-id idempotency idiom, since the test showed retries being hand-rolled without it.

Also adds a "Running a server" README section pointing at the commented example configs in configs/ (the test author started the server by chasing missing-field errors one at a time, never finding the examples), and drops a stale "namespace listing" phrase from the pagination spec.