### PR TITLE
fix(core): checkpoint re-create renews the durable expiry

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -4,8 +4,8 @@
 use super::build::{build_manifest_tables, debug_assert_manifest_table_segments_do_not_overlap};
 use super::flush::{try_flush_wal, TryFlushWal};
 use super::record::{
-    deterministic_checkpoint_id, set_checkpoint_record_state, verify_checkpoint_basis,
-    write_checkpoint_record, CheckpointRecordWrite,
+    deterministic_checkpoint_id, renew_checkpoint_record, set_checkpoint_record_state,
+    verify_checkpoint_basis, write_checkpoint_record, CheckpointRecordWrite,
 };
 #[cfg(test)]
 use super::row::manifest_rows_for_family;
@@ -100,20 +100,21 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
         let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
             <= CHECKPOINT_VERIFY_BUDGET_MS;
         if verified && within_budget {
-            if let CheckpointRecordWrite::Existing(existing) = written {
-                // Deterministic ids make re-creation idempotent; a released
+            if let CheckpointRecordWrite::Existing = written {
+                // Deterministic ids make re-creation a renewal: the durable
+                // expiry becomes exactly what this create requested (last
+                // write wins, shrink and clear included), and a released
                 // record for the same verified basis and owner is revived
-                // rather than duplicated.
-                if existing.state == CheckpointRecordLifecycle::Released {
-                    set_checkpoint_record_state(
-                        store,
-                        namespace_id,
-                        &checkpoint_id,
-                        CheckpointRecordLifecycle::Active,
-                        &context.writer_version,
-                    )
-                    .await?;
-                }
+                // rather than duplicated — so the response below always
+                // echoes the durable state.
+                renew_checkpoint_record(
+                    store,
+                    namespace_id,
+                    &checkpoint_id,
+                    expires_at_ms,
+                    &context.writer_version,
+                )
+                .await?;
             }
             return Ok(CreateCheckpointResponse {
                 namespace_id: namespace_id.clone(),

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -70,7 +70,9 @@ pub(crate) fn deterministic_checkpoint_id(
 
 pub(crate) enum CheckpointRecordWrite {
     Created,
-    Existing(Box<CheckpointRecordState>),
+    /// The record already exists. The caller renews it — the renew path
+    /// re-reads and validates the record, so no state rides along here.
+    Existing,
 }
 
 pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
@@ -93,15 +95,7 @@ pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
         Ok(_) => Ok(CheckpointRecordWrite::Created),
         Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
-            let existing =
-                read_checkpoint_record(store, &record.namespace_id, &record.checkpoint_id)
-                    .await?
-                    .ok_or_else(|| {
-                        CoreError::Internal(format!(
-                            "checkpoint record `{object_key}` conflicted but cannot be read back"
-                        ))
-                    })?;
-            Ok(CheckpointRecordWrite::Existing(Box::new(existing.state)))
+            Ok(CheckpointRecordWrite::Existing)
         }
         Err(error) => Err(CoreError::store(&object_key, &error)),
     }
@@ -149,6 +143,50 @@ pub(crate) async fn set_checkpoint_record_state<S: ObjectStore + ?Sized>(
     target: CheckpointRecordLifecycle,
     writer_version: &str,
 ) -> Result<(), CoreError> {
+    cas_checkpoint_record(store, namespace_id, checkpoint_id, writer_version, |next| {
+        if next.state == target {
+            return false;
+        }
+        next.state = target;
+        true
+    })
+    .await
+}
+
+/// Renews a record: `active` with exactly the requested expiry, last write
+/// wins. Re-creating an existing checkpoint routes here, so the durable
+/// expiry always matches what the latest create acknowledged — extended,
+/// shortened, or cleared — and a released record is revived. `created_at_ms`
+/// keeps the original creation instant. Returns `Ok` without writing when
+/// the record already matches.
+pub(crate) async fn renew_checkpoint_record<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    expires_at_ms: Option<u64>,
+    writer_version: &str,
+) -> Result<(), CoreError> {
+    cas_checkpoint_record(store, namespace_id, checkpoint_id, writer_version, |next| {
+        if next.state == CheckpointRecordLifecycle::Active && next.expires_at_ms == expires_at_ms {
+            return false;
+        }
+        next.state = CheckpointRecordLifecycle::Active;
+        next.expires_at_ms = expires_at_ms;
+        true
+    })
+    .await
+}
+
+/// The compare-and-swap loop behind the record mutators: `apply` edits the
+/// loaded state and returns `false` when the record already matches, in
+/// which case nothing is written.
+async fn cas_checkpoint_record<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    writer_version: &str,
+    apply: impl Fn(&mut CheckpointRecordState) -> bool,
+) -> Result<(), CoreError> {
     const STATE_CAS_ATTEMPTS: usize = 4;
     let object_key = checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str());
     for _attempt in 0..STATE_CAS_ATTEMPTS {
@@ -157,11 +195,10 @@ pub(crate) async fn set_checkpoint_record_state<S: ObjectStore + ?Sized>(
                 "checkpoint record `{object_key}` disappeared during a state change"
             )));
         };
-        if loaded.state.state == target {
+        let mut next = loaded.state;
+        if !apply(&mut next) {
             return Ok(());
         }
-        let mut next = loaded.state;
-        next.state = target;
         let envelope = CheckpointRecordEnvelope::from_state(
             ControlObjectKind::CheckpointRecord,
             writer_version,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -764,10 +764,21 @@ async fn create_checkpoint_revives_a_dead_record_for_a_verified_basis() {
     .await
     .expect("mark dead");
 
-    let revived = create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("recreate checkpoint");
+    // Revival goes through renewal: the re-create's expiry (here a real
+    // one, where the original had none) is what the revived record carries.
+    let revived = super::create::create_checkpoint(
+        &store,
+        &namespace_id,
+        loonfs_api::wire::control::CheckpointOwner::User {
+            name: "test-pin".to_owned(),
+        },
+        Some(90_000),
+        &context,
+    )
+    .await
+    .expect("recreate checkpoint");
     assert_eq!(revived.checkpoint_id, first.checkpoint_id);
+    assert_eq!(revived.expires_at_ms, Some(90_000));
     let record = read_checkpoint_record(&store, &namespace_id, &first.checkpoint_id)
         .await
         .expect("read checkpoint record")
@@ -777,6 +788,68 @@ async fn create_checkpoint_revives_a_dead_record_for_a_verified_basis() {
         record.state,
         loonfs_api::wire::control::CheckpointRecordLifecycle::Active
     );
+    assert_eq!(record.expires_at_ms, Some(90_000));
+}
+
+#[tokio::test]
+async fn re_creating_a_checkpoint_renews_its_expiry_last_write_wins() {
+    // Same basis + owner on an idle namespace hashes to the same record;
+    // each re-create sets the durable expiry to exactly what it asked —
+    // extend, shrink, and clear — while created_at_ms keeps the original
+    // creation instant and the response echoes the durable state.
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let owner = || loonfs_api::wire::control::CheckpointOwner::User {
+        name: "test-pin".to_owned(),
+    };
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/file.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write");
+
+    let first =
+        super::create::create_checkpoint(&store, &namespace_id, owner(), Some(10_000), &context)
+            .await
+            .expect("create checkpoint");
+    assert_eq!(first.expires_at_ms, Some(10_000));
+
+    let mut renew_context = test_context();
+    renew_context.now_ms = 2_000;
+    for renewed_expiry in [Some(99_000), Some(5_000), None] {
+        let renewed = super::create::create_checkpoint(
+            &store,
+            &namespace_id,
+            owner(),
+            renewed_expiry,
+            &renew_context,
+        )
+        .await
+        .expect("renew checkpoint");
+        assert_eq!(renewed.checkpoint_id, first.checkpoint_id);
+        assert_eq!(renewed.expires_at_ms, renewed_expiry);
+        let record = read_checkpoint_record(&store, &namespace_id, &first.checkpoint_id)
+            .await
+            .expect("read checkpoint record")
+            .expect("record exists")
+            .state;
+        assert_eq!(record.expires_at_ms, renewed_expiry);
+        assert_eq!(record.created_at_ms, 1_000, "creation instant is history");
+        assert_eq!(
+            record.state,
+            loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -568,6 +568,7 @@ impl From<crate::control_update::ControlUpdateError> for CoreError {
 fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> ErrorCode {
     match error {
         WriterEpochAcquireError::LoadHead(error) => classify_control_object_load_error(error),
+        WriterEpochAcquireError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
         WriterEpochAcquireError::EmptyWriterId
         | WriterEpochAcquireError::EmptyWriterSessionId
         | WriterEpochAcquireError::MissingHeadEtag { .. }

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -4,7 +4,7 @@
 use crate::context::MutationContext;
 use crate::control_update::{update_head, ControlUpdateError, HeadUpdate};
 use crate::namespace::control::ControlObjectLoadError;
-use loonfs_api::wire::control::{AcquiredWriter, HeadState, WriterBlock};
+use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState, WriterBlock};
 use loonfs_api::{NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,8 @@ const MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS: usize = 8;
 pub enum WriterEpochAcquireError {
     #[error(transparent)]
     LoadHead(ControlObjectLoadError),
+    #[error("namespace `{namespace_id}` is deleted")]
+    NamespaceDeleted { namespace_id: NamespaceId },
     #[error("empty writer id")]
     EmptyWriterId,
     #[error("empty writer session id")]
@@ -37,13 +39,18 @@ pub enum WriterEpochAcquireError {
 /// the non-authoritative `writer` block, which fences every other session at
 /// its next publish. There is no lease and no expiry: nothing arbitrates
 /// between two live writers except the epoch itself, so acquisition never
-/// refuses a caller and contention resolves as deterministic
+/// refuses a live caller and contention resolves as deterministic
 /// last-writer-wins. A session that has been fenced must not call this again
 /// on its own; reacquisition is an explicit caller decision.
 ///
-/// The only non-bumping path is idempotent retry: when the head's writer
-/// block already names this exact session, its current epoch is returned
-/// without a CAS.
+/// The one refusal is terminal state: a deleted namespace's head is an
+/// immutable tombstone, so acquisition fails with `NamespaceDeleted` before
+/// any CAS — no attempt may rewrite the tombstone, inflate its epoch, or
+/// name a "current writer" for a dead namespace.
+///
+/// The only non-bumping success path is idempotent retry: when the head's
+/// writer block already names this exact session, its current epoch is
+/// returned without a CAS.
 pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -63,6 +70,14 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS,
         |loaded_head| {
             let head = &loaded_head.envelope.state;
+            // Terminal-state guard before the idempotent-retry path: even
+            // the session named in the tombstone's writer block must not get
+            // an epoch back for a deleted namespace.
+            if head.state == NamespaceState::Deleted {
+                return Err(WriterEpochAcquireError::NamespaceDeleted {
+                    namespace_id: head.namespace_id.clone(),
+                });
+            }
             if let Some(writer) = head.writer.as_ref() {
                 if writer.writer_id == params.writer_id
                     && writer.writer_session_id == params.writer_session_id
@@ -284,6 +299,78 @@ mod tests {
             head.writer.expect("writer block").writer_session_id,
             "session-b"
         );
+    }
+
+    #[tokio::test]
+    async fn acquire_on_deleted_namespace_is_rejected_and_leaves_the_tombstone_unchanged() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        // The tombstone names the deleting session in its writer block: even
+        // that exact session must be refused, so the guard precedes the
+        // idempotent-retry path.
+        let mut tombstone = head_with_session(&namespace_id, "writer", "session-a", WriterEpoch(7));
+        tombstone.state = NamespaceState::Deleted;
+        write_head(&store, &namespace_id, tombstone).await;
+        let etag_before = head_etag(&store, &namespace_id).await;
+
+        for session in ["session-a", "session-b"] {
+            let error =
+                acquire_writer_epoch(&store, &namespace_id, &context("writer", session, 1_000))
+                    .await
+                    .expect_err("acquire on a deleted namespace must be refused");
+            assert!(matches!(
+                &error,
+                WriterEpochAcquireError::NamespaceDeleted { namespace_id: deleted_id }
+                    if *deleted_id == namespace_id
+            ));
+            assert_eq!(
+                crate::error::CoreError::from(error).code(),
+                ErrorCode::NamespaceDeleted
+            );
+        }
+
+        // The tombstone is byte-identical after every attempt: no epoch
+        // inflation, no new writer block, no churn on a terminal object.
+        assert_eq!(head_etag(&store, &namespace_id).await, etag_before);
+        let head = read_head_object(&store, &namespace_id)
+            .await
+            .expect("read head")
+            .envelope
+            .state;
+        assert_eq!(head.state, NamespaceState::Deleted);
+        assert_eq!(head.writer_epoch, WriterEpoch(7));
+    }
+
+    #[tokio::test]
+    async fn deleting_an_already_deleted_namespace_still_answers_namespace_deleted() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer = context("writer-a", "session-a", 1_000);
+        bootstrap_namespace(&store, &namespace_id, &writer, false)
+            .await
+            .expect("bootstrap");
+        delete_namespace(
+            &store,
+            &namespace_id,
+            DeleteNamespaceOptions::default(),
+            &writer,
+        )
+        .await
+        .expect("first delete");
+
+        // The refusal now surfaces at epoch acquire instead of inside the
+        // delete loop; the public code is unchanged.
+        let error = delete_namespace(
+            &store,
+            &namespace_id,
+            DeleteNamespaceOptions::default(),
+            &context("writer-a", "session-b", 2_000),
+        )
+        .await
+        .expect_err("second delete must be refused");
+        assert_eq!(error.code(), ErrorCode::NamespaceDeleted);
     }
 
     #[tokio::test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -645,9 +645,13 @@ this closes the create-vs-collect race: within the grace window any record is
 protected unconditionally by age.
 
 Record ids derive deterministically from the basis identity plus the owner
-identity: repeating creation for the same pinned manifest and owner returns
+identity: repeating creation for the same pinned manifest and owner renews
 the existing record (reviving a released one after re-verification) without
-listing, while distinct owners of one basis hold distinct records with
+listing. Renewal is last-write-wins on the expiry: the record's
+`expires_at_ms` becomes exactly what the latest create requested — extended,
+shortened, or cleared — while `created_at_ms` keeps the original creation
+instant, and the response always reports the durable state. Distinct owners
+of one basis hold distinct records with
 independent lifecycles. Explicit release flips a user-owned record
 `active -> released` by compare-and-swap and is idempotent; the record itself
 is reaped by a later garbage-collection pass, and its basis becomes


### PR DESCRIPTION
Deterministic checkpoint ids make re-creation the natural renew operation, but the Existing arm only flipped a Released record back to Active — the caller's expires_at_ms was silently discarded while the response echoed it as applied. Re-creating a pin to extend its TTL on an idle namespace acknowledged the new expiry and durably kept the old one, including an already-past expiry on a revived record, so a pin the user was just told exists could be released on the next GC pass.

Re-create now renews: a CAS rewrites the record to active with exactly the requested expiry — extended, shortened, or cleared, last write wins — while created_at_ms keeps the original creation instant, so the response always reports durable state. This matches SlateDB's checkpoint refresh semantics, spelled through the deterministic id. The Released-only flip and the renew share one CAS loop via a small private helper.

The revival test now exercises a real expiry (the previously uncovered case), and a new test pins extend, shrink, and clear against both the response and the durable record. Spec: the deterministic-id paragraph in format.md now defines renewal.