### PR TITLE
fix(objectstore): key parser recognizes the metadata/indexes/ family

### DIFF
--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -322,7 +322,7 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
         ["namespaces", namespace, "metadata", "tables", table] if table.ends_with(".sst.zst") => {
             parsed(DurableObjectFamily::MetadataTable, Some(namespace))
         }
-        ["namespaces", namespace, "metadata", "index", segment]
+        ["namespaces", namespace, "metadata", "indexes", segment]
             if segment.ends_with(".idx.zst") =>
         {
             parsed(DurableObjectFamily::IndexSegment, Some(namespace))
@@ -534,6 +534,10 @@ mod tests {
             (
                 layout.metadata_table("ns-1", "tbl_abc").into_string(),
                 DurableObjectFamily::MetadataTable,
+            ),
+            (
+                layout.index_segment("ns-1", "idx_abc").into_string(),
+                DurableObjectFamily::IndexSegment,
             ),
             (
                 layout


### PR DESCRIPTION
The prefix rename in #259 updated the builder to metadata/indexes/ but missed the parser, which still matched singular metadata/index — so every real index-segment key parsed as None, metrics classified gram-index IO as unknown, and the simulator's namespace summary counted the segments as foreign objects. The round-trip test that exists to prevent exactly this drift omitted the IndexSegment family from its case list, which is how it slipped through.

Parser arm fixed and the family added to the round-trip cases so builder, parser, and spec cannot drift apart again.