### PR TITLE
chore(api,core,objectstore): delete the provider-checksum read path

### DIFF
--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -96,9 +96,7 @@ pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     content_ref: &ContentRef,
 ) -> Result<ValidatedDurableContent, DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
-    if let Some(validated) = validate_content_metadata(store, &object_key, content_ref).await? {
-        return Ok(validated);
-    }
+    validate_content_size(store, &object_key, content_ref).await?;
 
     let bytes = load_required_object(store, &object_key).await?;
     validate_loaded_content_bytes(object_key, content_ref, &bytes)
@@ -171,12 +169,16 @@ fn validate_loaded_content_bytes(
     })
 }
 
-async fn validate_content_metadata<S: ObjectStore + ?Sized>(
+/// Cheap prevalidation before the authoritative read-and-hash: existence
+/// and size come from one HEAD, so a wrong-sized object fails fast without
+/// downloading it. Digest verification always reads the bytes — provider
+/// checksums are not part of the read contract anywhere in the fleet.
+async fn validate_content_size<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     content_ref: &ContentRef,
-) -> Result<Option<ValidatedDurableContent>, DurableContentValidationError> {
-    let metadata = match store.head_with_checksum(object_key).await {
+) -> Result<(), DurableContentValidationError> {
+    let metadata = match store.head(object_key).await {
         Ok(Some(metadata)) => metadata,
         Ok(None) => {
             return Err(DurableContentValidationError::MissingContentObject {
@@ -198,31 +200,7 @@ async fn validate_content_metadata<S: ObjectStore + ?Sized>(
             actual: metadata.size_bytes,
         });
     }
-
-    let Some(actual_digest) = metadata.checksum_sha256 else {
-        return Ok(None);
-    };
-
-    if actual_digest != content_ref.digest {
-        return Err(DurableContentValidationError::ContentDigestMismatch {
-            object_key: object_key.to_owned(),
-            expected: content_ref.digest.clone(),
-            actual: actual_digest,
-        });
-    }
-
-    Ok(Some(ValidatedDurableContent {
-        content_ref: content_ref.clone(),
-        object_key: object_key.to_owned(),
-        file_size_bytes: metadata.size_bytes,
-        file_digest_sha256: actual_digest,
-        checked_invariants: vec![
-            InvariantId::WholeFileContentRefKindIsSupported,
-            InvariantId::WholeFileContentObjectKeyMatchesDigest,
-            InvariantId::WholeFileContentSizeMatchesRef,
-            InvariantId::WholeFileContentDigestMatchesRef,
-        ],
-    }))
+    Ok(())
 }
 
 #[tracing::instrument(
@@ -327,18 +305,17 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
     expected_bytes: &[u8],
 ) -> Result<bool, ImmutableObjectWriteError> {
     let expected_size = expected_bytes.len() as u64;
-    let expected_digest = sha256_digest(expected_bytes);
-    if let Some(metadata) = store.head_with_checksum(object_key).await.map_err(|err| {
-        ImmutableObjectWriteError::Store {
-            object_key: object_key.to_owned(),
-            message: err.message(),
-        }
-    })? {
+    if let Some(metadata) =
+        store
+            .head(object_key)
+            .await
+            .map_err(|err| ImmutableObjectWriteError::Store {
+                object_key: object_key.to_owned(),
+                message: err.message(),
+            })?
+    {
         if metadata.size_bytes != expected_size {
             return Ok(false);
-        }
-        if let Some(digest) = metadata.checksum_sha256.as_deref() {
-            return Ok(digest == expected_digest);
         }
     }
 
@@ -407,9 +384,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_whole_file_content_ref_falls_back_to_get_when_checksum_metadata_is_absent() {
+    async fn validate_whole_file_content_ref_reads_and_hashes_the_bytes() {
         let (_temp_dir, inner, content_store_id) = test_store();
-        let store = NoChecksumStore::new(inner);
+        let store = GetCountingStore::new(inner);
         let bytes = b"whole file bytes";
         let content_ref = ContentRef::whole_file_v0(bytes);
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
@@ -751,12 +728,12 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct NoChecksumStore {
+    struct GetCountingStore {
         inner: LocalFsStore,
         content_blob_gets: AtomicUsize,
     }
 
-    impl NoChecksumStore {
+    impl GetCountingStore {
         fn new(inner: LocalFsStore) -> Self {
             Self {
                 inner,
@@ -774,13 +751,9 @@ mod tests {
     }
 
     #[async_trait]
-    impl ObjectStore for NoChecksumStore {
+    impl ObjectStore for GetCountingStore {
         async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            let mut metadata = self.inner.head(key).await?;
-            if let Some(metadata) = &mut metadata {
-                metadata.checksum_sha256 = None;
-            }
-            Ok(metadata)
+            self.inner.head(key).await
         }
 
         async fn get(
@@ -801,11 +774,7 @@ mod tests {
             if key.starts_with("content-stores/") && key.contains("/blobs/") {
                 self.content_blob_gets.fetch_add(1, Ordering::Relaxed);
             }
-            let mut body = self.inner.get_with_metadata(key).await?;
-            if let Some(body) = &mut body {
-                body.metadata.checksum_sha256 = None;
-            }
-            Ok(body)
+            self.inner.get_with_metadata(key).await
         }
 
         async fn put(

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1567,7 +1567,7 @@ async fn complete_upload_rejects_direct_put_session_without_bound_target() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn path_put_file_uses_checksum_metadata_for_content_validation() {
+async fn path_put_file_validates_content_by_reading_it_once() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1594,11 +1594,13 @@ async fn path_put_file_uses_checksum_metadata_for_content_validation() {
     );
 
     assert!(responses[0].is_ok());
-    assert_eq!(store.content_blob_get_count(), 0);
+    // Durable validation is read-and-hash: one content GET, no provider
+    // checksum shortcut anywhere in the fleet.
+    assert_eq!(store.content_blob_get_count(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn path_batch_validates_repeated_content_ref_without_blob_gets() {
+async fn path_batch_validates_a_repeated_content_ref_once() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1631,7 +1633,9 @@ async fn path_batch_validates_repeated_content_ref_without_blob_gets() {
     );
 
     assert!(responses.iter().all(Result::is_ok));
-    assert_eq!(store.content_blob_get_count(), 0);
+    // Two puts share one content ref: the batch tracker validates it once
+    // (one read-and-hash), and the second candidate reuses the verdict.
+    assert_eq!(store.content_blob_get_count(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1680,8 +1684,8 @@ async fn valid_content_admission_skips_durable_content_validation() {
     );
 
     assert!(responses[0].is_ok());
+    // A live admission is the fast path: no content read at all.
     assert_eq!(store.content_blob_get_count(), 0);
-    assert_eq!(store.content_blob_checksum_head_count(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1732,8 +1736,9 @@ async fn expired_content_admission_falls_back_to_durable_validation() {
     );
 
     assert!(responses[0].is_ok());
-    assert_eq!(store.content_blob_get_count(), 0);
-    assert_eq!(store.content_blob_checksum_head_count(), 1);
+    // An expired admission falls back to durable validation, which reads
+    // the bytes.
+    assert_eq!(store.content_blob_get_count(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5290,7 +5295,6 @@ impl ObjectStore for ReplayReadGuardStore {
 struct ContentBlobGetCountingStore {
     inner: LocalFsStore,
     content_blob_gets: AtomicUsize,
-    content_blob_checksum_heads: AtomicUsize,
 }
 
 impl ContentBlobGetCountingStore {
@@ -5298,7 +5302,6 @@ impl ContentBlobGetCountingStore {
         Self {
             inner: LocalFsStore::new(root.as_ref()).expect("store"),
             content_blob_gets: AtomicUsize::new(0),
-            content_blob_checksum_heads: AtomicUsize::new(0),
         }
     }
 
@@ -5306,13 +5309,8 @@ impl ContentBlobGetCountingStore {
         self.content_blob_gets.load(Ordering::SeqCst)
     }
 
-    fn content_blob_checksum_head_count(&self) -> usize {
-        self.content_blob_checksum_heads.load(Ordering::SeqCst)
-    }
-
     fn reset_content_blob_counters(&self) {
         self.content_blob_gets.store(0, Ordering::SeqCst);
-        self.content_blob_checksum_heads.store(0, Ordering::SeqCst);
     }
 
     fn reset_content_blob_get_count(&self) {
@@ -5330,17 +5328,6 @@ impl ContentBlobGetCountingStore {
 impl ObjectStore for ContentBlobGetCountingStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         self.inner.head(key).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_checksum_heads
-                .fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.head_with_checksum(key).await
     }
 
     async fn get(
@@ -5411,13 +5398,6 @@ impl MetadataSstGetCountingStore {
 impl ObjectStore for MetadataSstGetCountingStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         self.inner.head(key).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head_with_checksum(key).await
     }
 
     async fn get(
@@ -5594,13 +5574,6 @@ impl StaleHeadGetStore {
 impl ObjectStore for StaleHeadGetStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         self.inner.head(key).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head_with_checksum(key).await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -83,7 +83,6 @@ impl AzureAbsStore {
             Some(provider),
             ProviderObjectStoreConfig {
                 key_prefix: config.key_prefix,
-                sha256_checksum_metadata: false,
             },
         )?;
         Ok(Self {

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -156,23 +156,6 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
-                store
-                    .head_with_checksum(&scope_object_key(key_prefix.as_deref(), key)?)
-                    .await
-            }
-            ConfiguredObjectStoreInner::AwsS3(store) => store.head_with_checksum(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.head_with_checksum(key).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.head_with_checksum(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.head_with_checksum(key).await,
-        }
-    }
-
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -62,7 +62,6 @@ impl GcpGcsStore {
             Some(provider),
             ProviderObjectStoreConfig {
                 key_prefix: config.key_prefix,
-                sha256_checksum_metadata: false,
             },
         )?;
 

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -87,7 +87,6 @@ impl LocalFsStore {
     async fn metadata_for_path(
         key: &str,
         path: &Path,
-        include_checksum: bool,
     ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         let metadata = match fs::metadata(path).await {
             Ok(metadata) => metadata,
@@ -96,16 +95,13 @@ impl LocalFsStore {
         };
         let content_digest =
             sha256_digest(&fs::read(path).await.map_err(|err| io_error(key, err))?);
-        let checksum_sha256 = include_checksum.then_some(content_digest.clone());
-        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, checksum_sha256, path)
-            .map(Some)
+        Self::metadata_from_fs_metadata(key, &metadata, &content_digest, path).map(Some)
     }
 
     fn metadata_from_fs_metadata(
         key: &str,
         metadata: &std::fs::Metadata,
         content_digest: &str,
-        checksum_sha256: Option<String>,
         path: &Path,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         if !metadata.is_file() {
@@ -124,7 +120,6 @@ impl LocalFsStore {
             etag: Some(format!("local-fs-v1:{content_digest}")),
             version: None,
             size_bytes: metadata.len(),
-            checksum_sha256,
             last_modified_ms,
         })
     }
@@ -221,13 +216,9 @@ impl LocalFsStore {
 }
 
 impl LocalFsStore {
-    async fn head_object(
-        &self,
-        key: &str,
-        include_checksum: bool,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         let path = self.resolve_key(key)?;
-        Self::metadata_for_path(key, &path, include_checksum).await
+        Self::metadata_for_path(key, &path).await
     }
 
     async fn get_with_metadata_object(
@@ -248,13 +239,7 @@ impl LocalFsStore {
             .map_err(|err| io_error(key, err))?;
 
         let content_digest = sha256_digest(&bytes);
-        let metadata = Self::metadata_from_fs_metadata(
-            key,
-            &fs_metadata,
-            &content_digest,
-            Some(content_digest.clone()),
-            &path,
-        )?;
+        let metadata = Self::metadata_from_fs_metadata(key, &fs_metadata, &content_digest, &path)?;
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
@@ -319,7 +304,7 @@ impl LocalFsStore {
                 Self::create_new_object(key, &self.root, &path, bytes).await?;
             }
             PutMode::CompareAndSwap { expected_etag } => {
-                let current = Self::metadata_for_path(key, &path, false)
+                let current = Self::metadata_for_path(key, &path)
                     .await?
                     .ok_or_else(precondition_failed)?;
                 if current.etag.as_deref() != Some(expected_etag.as_str()) {
@@ -329,7 +314,7 @@ impl LocalFsStore {
             }
         }
 
-        Self::metadata_for_path(key, &path, true)
+        Self::metadata_for_path(key, &path)
             .await?
             .ok_or_else(|| ObjectStoreError::transport(key, "object disappeared after write"))
     }
@@ -354,14 +339,7 @@ impl LocalFsStore {
 #[async_trait]
 impl ObjectStore for LocalFsStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.head_object(key, false).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.head_object(key, true).await
+        self.head_object(key).await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -209,21 +209,6 @@ where
         result
     }
 
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        let start = Instant::now();
-        let result = self.inner.head_with_checksum(key).await;
-        self.record_head_like(
-            ObjectStoreOperation::HeadWithChecksum,
-            key,
-            start.elapsed(),
-            &result,
-        );
-        result
-    }
-
     async fn get(
         &self,
         key: &str,

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -22,11 +22,6 @@ pub struct ObjectMetadata {
     /// Provider version identifier when available.
     pub version: Option<String>,
     pub size_bytes: u64,
-    /// Provider-verified full-object SHA-256 when available, normalized as `sha256:<64hex>`.
-    ///
-    /// This is part of the object-store contract only when present. Callers must fall back to
-    /// reading and hashing object bytes if this field is absent.
-    pub checksum_sha256: Option<String>,
     /// Provider last-modified time in unix milliseconds, when available.
     ///
     /// Advisory: garbage collection uses it for grace/reap age checks and
@@ -141,13 +136,6 @@ impl ObjectStoreError {
 pub trait ObjectStore: Send + Sync + Debug {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError>;
 
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.head(key).await
-    }
-
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError>;
 
     async fn get(
@@ -215,13 +203,6 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
         self.as_ref().head(key).await
     }
 
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.as_ref().head_with_checksum(key).await
-    }
-
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
         self.as_ref().get_with_metadata(key).await
     }
@@ -259,13 +240,6 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
 impl<T: ObjectStore + ?Sized> ObjectStore for &T {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         (*self).head(key).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        (*self).head_with_checksum(key).await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -10,7 +10,6 @@ use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream, FuturesUnordered, StreamExt};
-use loonfs_api::sha256_digest;
 use object_store as provider_store;
 use provider_store::multipart::{MultipartStore, PartId};
 use provider_store::path::Path;
@@ -25,7 +24,6 @@ use std::time::Duration;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderObjectStoreConfig {
     pub key_prefix: Option<String>,
-    pub sha256_checksum_metadata: bool,
 }
 
 /// Bound for one control-plane HTTP attempt's request phase, and the
@@ -223,7 +221,6 @@ pub struct ProviderObjectStore {
     multipart: Option<Arc<dyn MultipartStore>>,
     multipart_geometry: MultipartGeometry,
     key_prefix: Option<String>,
-    sha256_checksum_metadata: bool,
     transport_retry: TransportRetryPolicy,
     timer: Arc<dyn MonotonicTimer>,
 }
@@ -232,7 +229,6 @@ impl fmt::Debug for ProviderObjectStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProviderObjectStore")
             .field("key_prefix", &self.key_prefix)
-            .field("sha256_checksum_metadata", &self.sha256_checksum_metadata)
             .field("multipart_upload", &self.multipart.is_some())
             .finish_non_exhaustive()
     }
@@ -249,7 +245,6 @@ impl ProviderObjectStore {
             multipart,
             multipart_geometry: MultipartGeometry::DEFAULT,
             key_prefix: normalize_key_prefix(config.key_prefix.as_deref())?,
-            sha256_checksum_metadata: config.sha256_checksum_metadata,
             transport_retry: TransportRetryPolicy::DEFAULT,
             timer: Arc::new(StdMonotonicTimer::default()),
         })
@@ -301,26 +296,20 @@ impl ProviderObjectStore {
             })
     }
 
-    fn from_meta(meta: ObjectMeta, checksum_sha256: Option<String>) -> ObjectMetadata {
+    fn from_meta(meta: ObjectMeta) -> ObjectMetadata {
         ObjectMetadata {
             etag: meta.e_tag,
             version: meta.version,
             size_bytes: meta.size,
-            checksum_sha256,
             last_modified_ms: u64::try_from(meta.last_modified.timestamp_millis()).ok(),
         }
     }
 
-    fn from_put_result(
-        result: PutResult,
-        size_bytes: u64,
-        checksum_sha256: Option<String>,
-    ) -> ObjectMetadata {
+    fn from_put_result(result: PutResult, size_bytes: u64) -> ObjectMetadata {
         ObjectMetadata {
             etag: result.e_tag,
             version: result.version,
             size_bytes,
-            checksum_sha256,
             last_modified_ms: None,
         }
     }
@@ -359,7 +348,6 @@ impl ProviderObjectStore {
         key: &str,
         path: &Path,
         bytes: Bytes,
-        checksum_sha256: Option<String>,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         let size_bytes = bytes.len() as u64;
         let upload = MultipartWrite {
@@ -372,10 +360,7 @@ impl ProviderObjectStore {
         let upload_id = upload.create(size_bytes).await?;
         let result = upload.upload_parts_and_complete(&upload_id, &bytes).await;
         match result {
-            Ok(mut metadata) => {
-                metadata.checksum_sha256 = checksum_sha256;
-                Ok(metadata)
-            }
+            Ok(metadata) => Ok(metadata),
             Err(err) => {
                 // Best effort, and harmless when the failure raced a landed
                 // completion: the upload id no longer exists then, and the
@@ -572,11 +557,7 @@ impl MultipartWrite<'_> {
                 .complete_multipart(self.path, upload_id, parts.clone())
                 .await
             {
-                Ok(result) => {
-                    return Ok(ProviderObjectStore::from_put_result(
-                        result, size_bytes, None,
-                    ))
-                }
+                Ok(result) => return Ok(ProviderObjectStore::from_put_result(result, size_bytes)),
                 Err(err) => err,
             };
             if !provider_transport_retryable(&err) {
@@ -625,24 +606,17 @@ impl ObjectStore for ProviderObjectStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         let path = self.to_path(key)?;
         match self.inner.head(&path).await {
-            Ok(meta) => Ok(Some(Self::from_meta(meta, None))),
+            Ok(meta) => Ok(Some(Self::from_meta(meta))),
             Err(err) if provider_not_found(&err) => Ok(None),
             Err(err) => Err(map_provider_error(key, err)),
         }
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.head(key).await
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
         let path = self.to_path(key)?;
         match self.inner.get(&path).await {
             Ok(result) => {
-                let metadata = Self::from_meta(result.meta.clone(), None);
+                let metadata = Self::from_meta(result.meta.clone());
                 let bytes = result
                     .bytes()
                     .await
@@ -743,7 +717,6 @@ impl ObjectStore for ProviderObjectStore {
         mode: PutMode,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         let path = self.to_path(key)?;
-        let checksum_sha256 = self.sha256_checksum_metadata.then(|| sha256_digest(&bytes));
         let size_bytes = bytes.len() as u64;
 
         if matches!(mode, PutMode::CompareAndSwap { .. }) {
@@ -761,7 +734,7 @@ impl ObjectStore for ProviderObjectStore {
                 .put_opts(&path, PutPayload::from(bytes), options)
                 .await
             {
-                Ok(result) => Ok(Self::from_put_result(result, size_bytes, checksum_sha256)),
+                Ok(result) => Ok(Self::from_put_result(result, size_bytes)),
                 Err(err) if provider_not_found(&err) => Err(ObjectStoreError::PreconditionFailed {
                     object_key: key.to_owned(),
                 }),
@@ -775,7 +748,7 @@ impl ObjectStore for ProviderObjectStore {
         {
             if let Some(multipart) = self.multipart.clone() {
                 return self
-                    .put_large_multipart(multipart.as_ref(), key, &path, bytes, checksum_sha256)
+                    .put_large_multipart(multipart.as_ref(), key, &path, bytes)
                     .await;
             }
         }
@@ -795,9 +768,7 @@ impl ObjectStore for ProviderObjectStore {
                 .put_opts(&path, PutPayload::from(bytes.clone()), options)
                 .await
             {
-                Ok(result) => {
-                    return Ok(Self::from_put_result(result, size_bytes, checksum_sha256))
-                }
+                Ok(result) => return Ok(Self::from_put_result(result, size_bytes)),
                 Err(err) => err,
             };
 
@@ -806,9 +777,7 @@ impl ObjectStore for ProviderObjectStore {
                     Some(body) if body.bytes.as_slice() == bytes.as_ref() => {
                         // Our earlier attempt landed: report it as the
                         // successful write it was, not a conflict.
-                        let mut metadata = body.metadata;
-                        metadata.checksum_sha256 = checksum_sha256;
-                        return Ok(metadata);
+                        return Ok(body.metadata);
                     }
                     Some(_) => {
                         return Err(ObjectStoreError::PreconditionFailed {
@@ -995,7 +964,6 @@ mod tests {
             Some(inner),
             ProviderObjectStoreConfig {
                 key_prefix: Some("tenant-a".to_owned()),
-                sha256_checksum_metadata: true,
             },
         )
         .expect("provider store")
@@ -1012,7 +980,6 @@ mod tests {
             .expect("put");
         assert_eq!(metadata.size_bytes, 4);
         assert!(metadata.etag.is_some());
-        assert_eq!(metadata.checksum_sha256, Some(sha256_digest(b"head")));
 
         let head = store.head(key).await.expect("head").expect("head exists");
         assert_eq!(head.size_bytes, 4);
@@ -1489,7 +1456,6 @@ mod tests {
             Some(flaky),
             ProviderObjectStoreConfig {
                 key_prefix: Some("tenant-a".to_owned()),
-                sha256_checksum_metadata: true,
             },
         )
         .expect("provider store")
@@ -1590,10 +1556,6 @@ mod tests {
 
         assert_eq!(flaky.puts.load(Ordering::SeqCst), 2);
         assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            metadata.checksum_sha256,
-            Some(sha256_digest(b"upload session"))
-        );
         let head = store.head(key).await.expect("head").expect("object exists");
         assert_eq!(metadata.etag, head.etag);
     }
@@ -1912,7 +1874,6 @@ mod tests {
         assert_eq!(part_attempts(&flaky, 1), 1);
         assert_eq!(part_attempts(&flaky, 2), 1);
         assert_eq!(metadata.size_bytes, 1300);
-        assert_eq!(metadata.checksum_sha256, Some(sha256_digest(&payload)));
         assert_eq!(
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))
@@ -1954,13 +1915,12 @@ mod tests {
         let store = multipart_test_store(Arc::clone(&flaky));
         let payload = multipart_payload(1300);
 
-        let metadata = store
+        store
             .put_if_absent(MULTIPART_KEY, Bytes::from(payload.clone()))
             .await
             .expect("create absent large object");
         assert_eq!(flaky.multipart_creates.load(Ordering::SeqCst), 0);
         assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
-        assert_eq!(metadata.checksum_sha256, Some(sha256_digest(&payload)));
 
         let error = store
             .put_if_absent(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
@@ -2064,7 +2024,6 @@ mod tests {
         assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 0);
         assert_eq!(metadata.size_bytes, 1300);
-        assert_eq!(metadata.checksum_sha256, Some(sha256_digest(&payload)));
         assert_eq!(
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))

--- a/crates/loonfs-objectstore/src/r2.rs
+++ b/crates/loonfs-objectstore/src/r2.rs
@@ -46,7 +46,13 @@ impl CloudflareR2Store {
                 // hosting would use the endpoint verbatim and address keys
                 // as buckets.
                 force_path_style: true,
-                sha256_checksum_metadata: false,
+                // Left off pending a live verification: R2 historically
+                // rejected aws-chunked checksummed uploads, yet its
+                // presigner requires `x-amz-checksum-sha256` on direct
+                // puts — so R2 provably accepts the checksum and this is
+                // likely stale caution. Verify single-part and multipart
+                // against live R2 before enabling.
+                sha256_upload_checksum: false,
             })?,
         })
     }

--- a/crates/loonfs-objectstore/src/s3.rs
+++ b/crates/loonfs-objectstore/src/s3.rs
@@ -38,7 +38,7 @@ impl AwsS3Store {
                 session_token: config.session_token,
                 key_prefix: config.key_prefix,
                 force_path_style: config.force_path_style,
-                sha256_checksum_metadata: true,
+                sha256_upload_checksum: true,
             })?,
         })
     }

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -25,7 +25,10 @@ pub(crate) struct S3CompatibleConfig {
     pub session_token: Option<SecretString>,
     pub key_prefix: Option<String>,
     pub force_path_style: bool,
-    pub sha256_checksum_metadata: bool,
+    /// Attach a client-computed SHA-256 to every upload so the provider
+    /// verifies the bytes on PUT (`x-amz-checksum-sha256`). Upload transport
+    /// integrity only; nothing reads checksums back.
+    pub sha256_upload_checksum: bool,
 }
 
 #[derive(Clone)]
@@ -76,7 +79,7 @@ impl S3CompatibleStore {
         if let Some(session_token) = &config.session_token {
             builder = builder.with_token(session_token.expose());
         }
-        if config.sha256_checksum_metadata {
+        if config.sha256_upload_checksum {
             builder = builder.with_checksum_algorithm(Checksum::SHA256);
         }
 
@@ -90,7 +93,6 @@ impl S3CompatibleStore {
             Some(provider),
             ProviderObjectStoreConfig {
                 key_prefix: config.key_prefix,
-                sha256_checksum_metadata: config.sha256_checksum_metadata,
             },
         )?;
 
@@ -233,7 +235,7 @@ mod tests {
             session_token: None,
             key_prefix: Some("tenant-a".to_owned()),
             force_path_style: true,
-            sha256_checksum_metadata: true,
+            sha256_upload_checksum: true,
         }
     }
 

--- a/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use loonfs_api::ManifestObjectId;
-use loonfs_objectstore::keys::{
-    metadata_manifest_object, metadata_table, namespace_config, wal_head, wal_segment,
-};
+use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table, wal_head, wal_segment};
 use loonfs_objectstore::layout::ObjectLayout;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::metrics::{
@@ -109,36 +107,6 @@ async fn records_get_success_bytes_out() {
     assert_eq!(sample.bytes_out, Some(3));
     assert_eq!(sample.key_class, KeyClass::Content);
     assert_eq!(sample.range_class, Some(RangeClass::Bounded));
-}
-
-#[tokio::test]
-async fn records_head_and_head_with_checksum_as_distinct_operations() {
-    let temp_dir = tempdir().expect("tempdir");
-    let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
-    let store = instrumented_object_store(temp_dir.path(), recorder.clone());
-    let object_key = namespace_config("ns-1");
-
-    store
-        .put_overwrite(&object_key, bytes(b"descriptor"))
-        .await
-        .expect("put object");
-    store.head(&object_key).await.expect("head");
-    store
-        .head_with_checksum(&object_key)
-        .await
-        .expect("head with checksum");
-    store
-        .get_with_metadata(&object_key)
-        .await
-        .expect("get with metadata");
-
-    let samples = recorder.samples();
-    assert_eq!(samples[1].operation, ObjectStoreOperation::Head);
-    assert_eq!(samples[2].operation, ObjectStoreOperation::HeadWithChecksum);
-    assert_eq!(samples[3].operation, ObjectStoreOperation::GetWithMetadata);
-    assert_eq!(samples[1].key_class, KeyClass::Metadata);
-    assert_eq!(samples[2].key_class, KeyClass::Metadata);
-    assert_eq!(samples[3].key_class, KeyClass::Metadata);
 }
 
 #[tokio::test]
@@ -359,7 +327,6 @@ impl DelegatingWriteStore {
             etag: Some(format!("{call}-etag")),
             version: None,
             size_bytes: 0,
-            checksum_sha256: None,
             last_modified_ms: None,
         }
     }

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -222,16 +222,6 @@ where
         result
     }
 
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        let op = self.next_object_op(ObjectOpKind::HeadWithChecksum, key);
-        let result = self.inner.head_with_checksum(key).await;
-        self.push_trace(op, "head_with_checksum", None, result_class(&result));
-        result
-    }
-
     async fn get(
         &self,
         key: &str,

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2159,7 +2159,6 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.latest_metadata_view_reads, 2);
     assert_eq!(raw_store.content_blob_get_count(), 0);
-    assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2254,7 +2253,6 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     // validation issues no probe for content the put itself is writing.
     assert_eq!(raw_store.content_blob_put_count(), 1);
     assert_eq!(raw_store.content_blob_get_count(), 0);
-    assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 
     // A replace put rides the same overlapped path: new blob, no probe.
     raw_store.reset_content_blob_counters();
@@ -2271,7 +2269,6 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
 
     assert_eq!(raw_store.content_blob_put_count(), 1);
     assert_eq!(raw_store.content_blob_get_count(), 0);
-    assert_eq!(raw_store.content_blob_checksum_head_count(), 0);
 }
 
 #[test]
@@ -3488,7 +3485,6 @@ impl ObjectStore for HeadCasFailureStore {
 struct ContentBlobGetCountingStore {
     inner: LocalFsStore,
     content_blob_gets: AtomicUsize,
-    content_blob_checksum_heads: AtomicUsize,
     content_blob_puts: AtomicUsize,
 }
 
@@ -3497,23 +3493,17 @@ impl ContentBlobGetCountingStore {
         Self {
             inner: LocalFsStore::new(root).expect("create local-fs store"),
             content_blob_gets: AtomicUsize::new(0),
-            content_blob_checksum_heads: AtomicUsize::new(0),
             content_blob_puts: AtomicUsize::new(0),
         }
     }
 
     fn reset_content_blob_counters(&self) {
         self.content_blob_gets.store(0, Ordering::SeqCst);
-        self.content_blob_checksum_heads.store(0, Ordering::SeqCst);
         self.content_blob_puts.store(0, Ordering::SeqCst);
     }
 
     fn content_blob_get_count(&self) -> usize {
         self.content_blob_gets.load(Ordering::SeqCst)
-    }
-
-    fn content_blob_checksum_head_count(&self) -> usize {
-        self.content_blob_checksum_heads.load(Ordering::SeqCst)
     }
 
     fn content_blob_put_count(&self) -> usize {
@@ -3525,17 +3515,6 @@ impl ContentBlobGetCountingStore {
 impl ObjectStore for ContentBlobGetCountingStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
         self.inner.head(key).await
-    }
-
-    async fn head_with_checksum(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_checksum_heads
-                .fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.head_with_checksum(key).await
     }
 
     async fn get(

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -209,10 +209,12 @@ The content model has five rules.
 3. Immutable content objects are written with create-if-absent semantics.
 4. A metadata commit may reference a `content_ref` only after the referenced
    object is already durable.
-5. When provider-verified full-object SHA-256 metadata is available, the
-   object-store layer may expose it as `sha256:<64hex>`. If SHA-256 metadata
-   is absent, readers and writers must fall back to reading and hashing bytes
-   before treating a `content_ref` as verified.
+5. Content verification is read-and-hash: a `content_ref` is verified only
+   by reading the object bytes and computing the digest. Provider checksum
+   metadata is not part of the read contract — checksum semantics diverge
+   across providers, so it is used (where a provider supports it) purely as
+   upload transport integrity, never consulted on reads. A HEAD may
+   prevalidate existence and size so a wrong-sized object fails fast.
 
 In v0, file content is stored as one whole-file object whose
 `content_ref.kind` is `whole_file_v0`. The digest remains serialized as
@@ -735,10 +737,11 @@ The server validates each commit request against the reconstructed state:
 1. Resolve any operation-local references needed to identify referenced
    content.
 2. Verify that all referenced content objects are already durable in object
-   storage, and that `content_ref.kind`, digest, and size match. When
-   provider-verified SHA-256 metadata is present, this validation may use
-   metadata instead of downloading the whole object; otherwise it must read
-   and hash the object bytes.
+   storage, and that `content_ref.kind`, digest, and size match. Existence
+   and size prevalidate from a HEAD; the digest is verified by reading and
+   hashing the object bytes (or skipped entirely under a valid content
+   admission token, which proves this server already validated the staged
+   bytes).
 3. Evaluate preconditions in order (see section 3.6 for the precondition
    catalogue).
 4. Resolve inode references and allocate new inode ids monotonically from the


### PR DESCRIPTION
head_with_checksum was a contract method no cloud provider implemented: the trait default and the provider wrapper both just called head and returned no checksum, so core's cheap-validation branch was dead code fleet-wide — every deployment already validated content by reading and hashing the bytes — while S3 paid per-PUT cost storing checksums nothing read back, and only the test-only local provider ever exercised the fast path (by reading the whole file anyway). GCS and ABS can never supply full-object SHA-256, so implementing the method for real would have bought a permanent per-provider asymmetry.

The read path now says what it does: the trait method, the ObjectMetadata.checksum_sha256 field, and every piece of read-side plumbing are gone. Content validation prevalidates existence and size from one HEAD (a wrong-sized object fails fast without a download) and verifies the digest by reading the bytes — the SlateDB shape, where integrity lives in your own checksums on read, which LoonFS's envelope checksums and content addressing already provide. Content admission tokens remain the real fast path (zero reads) and their tests still pin it.

Two bonuses fell out. The sha256_checksum_metadata flag turned out to gate both the metadata population and the S3 client's upload checksum; it is renamed sha256_upload_checksum and now does only the latter, which is the part worth keeping (provider-verified PUT integrity). And the uncommented R2/S3 checksum divergence the audit flagged now sits on a flag whose name says exactly what it controls, with a comment explaining why R2 stays off pending a live verification.

format.md's content rules now state the read-and-hash contract instead of promising an optional metadata shortcut. Net −270 lines.