### PR TITLE
fix(objectstore): auth failures classify as permission denied, not transport

### DIFF
--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -598,6 +598,12 @@ fn map_create_error(key: &str, err: std::io::Error) -> ObjectStoreError {
 }
 
 fn io_error(key: &str, err: std::io::Error) -> ObjectStoreError {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        return ObjectStoreError::PermissionDenied {
+            object_key: key.to_owned(),
+            message: err.to_string(),
+        };
+    }
     ObjectStoreError::transport(key, err.to_string())
 }
 

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -54,6 +54,7 @@ pub enum ObjectStoreResultClass {
     InvalidRange,
     PreconditionFailed,
     Conflict,
+    PermissionDenied,
     Unsupported,
     Transport,
     OtherError,
@@ -508,6 +509,7 @@ fn classify_error(error: &ObjectStoreError) -> ObjectStoreResultClass {
         ObjectStoreError::InvalidRange { .. } => ObjectStoreResultClass::InvalidRange,
         ObjectStoreError::PreconditionFailed { .. } => ObjectStoreResultClass::PreconditionFailed,
         ObjectStoreError::Conflict { .. } => ObjectStoreResultClass::Conflict,
+        ObjectStoreError::PermissionDenied { .. } => ObjectStoreResultClass::PermissionDenied,
         ObjectStoreError::Unsupported(_) => ObjectStoreResultClass::Unsupported,
         // Configuration failures happen at store construction, before any
         // metered operation; classify defensively as transport.

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -79,6 +79,11 @@ pub enum ObjectStoreError {
     PreconditionFailed { object_key: String },
     #[error("conflict for `{object_key}`")]
     Conflict { object_key: String },
+    /// The provider rejected the caller's identity or authorization —
+    /// wrong, expired, or insufficient credentials. Configuration-shaped
+    /// and never transient: retrying cannot help, an operator can.
+    #[error("permission denied for `{object_key}`: {message}")]
+    PermissionDenied { object_key: String, message: String },
     /// Not object-scoped: the store lacks a required capability.
     #[error("unsupported capability: {0}")]
     Unsupported(&'static str),
@@ -108,6 +113,7 @@ impl ObjectStoreError {
             | Self::InvalidRange { object_key }
             | Self::PreconditionFailed { object_key }
             | Self::Conflict { object_key }
+            | Self::PermissionDenied { object_key, .. }
             | Self::Transport { object_key, .. } => Some(object_key),
             Self::InvalidContentRef(_) | Self::Unsupported(_) | Self::Configuration(_) => None,
         }
@@ -123,6 +129,9 @@ impl ObjectStoreError {
             Self::InvalidRange { .. } => "invalid byte range".to_owned(),
             Self::PreconditionFailed { .. } => "precondition failed".to_owned(),
             Self::Conflict { .. } => "conflict".to_owned(),
+            Self::PermissionDenied { message, .. } => {
+                format!("permission denied: {message}")
+            }
             Self::Unsupported(capability) => format!("unsupported capability: {capability}"),
             Self::Configuration(message) => {
                 format!("invalid object store configuration: {message}")

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -124,16 +124,17 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
         request: PresignedPutRequest<'_>,
         now: SystemTime,
     ) -> Result<PresignedUrl, ObjectStoreError> {
+        // Expiry comes from deployment configuration, not the transport:
+        // a bad value is a config bug and must not look like network
+        // weather.
         if request.expires_in.is_zero() {
-            return Err(ObjectStoreError::transport(
-                request.object_key,
-                "presigned URL expiry must be greater than zero",
+            return Err(ObjectStoreError::Configuration(
+                "presigned URL expiry must be greater than zero".to_owned(),
             ));
         }
         if request.expires_in.as_secs() > 604_800 {
-            return Err(ObjectStoreError::transport(
-                request.object_key,
-                "presigned URL expiry must not exceed seven days",
+            return Err(ObjectStoreError::Configuration(
+                "presigned URL expiry must not exceed seven days".to_owned(),
             ));
         }
 

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -945,7 +945,10 @@ fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectSto
         }
         provider_store::Error::PermissionDenied { source, .. }
         | provider_store::Error::Unauthenticated { source, .. } => {
-            ObjectStoreError::transport(object_key, source.to_string())
+            ObjectStoreError::PermissionDenied {
+                object_key: object_key.to_owned(),
+                message: source.to_string(),
+            }
         }
         other => ObjectStoreError::transport(object_key, other.to_string()),
     }
@@ -1750,7 +1753,7 @@ mod tests {
             .await
             .expect_err("auth rejection surfaces immediately");
 
-        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        assert!(matches!(error, ObjectStoreError::PermissionDenied { .. }));
         assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
     }
 
@@ -2000,7 +2003,9 @@ mod tests {
             .await
             .expect_err("auth rejection surfaces immediately");
 
-        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        // Auth failures carry their own classification — never mistaken
+        // for network weather, and never retried.
+        assert!(matches!(error, ObjectStoreError::PermissionDenied { .. }));
         assert_eq!(part_attempts(&flaky, 0), 1);
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -541,6 +541,9 @@ fn result_class<T>(result: &Result<T, ObjectStoreError>) -> SimEventResult {
         Err(ObjectStoreError::PreconditionFailed { .. }) => SimEventResult::Error {
             class: "precondition_failed".to_owned(),
         },
+        Err(ObjectStoreError::PermissionDenied { .. }) => SimEventResult::Error {
+            class: "permission_denied".to_owned(),
+        },
         Err(ObjectStoreError::Conflict { .. }) => SimEventResult::Error {
             class: "conflict".to_owned(),
         },


### PR DESCRIPTION
Misconfigured credentials are the most common day-one deployment failure, and the store folded them into the transient-sounding transport bucket: provider PermissionDenied and Unauthenticated both surfaced as transport errors, indistinguishable from network weather in every log line and metric, and any future retry-transport policy above this layer would have spun on them.

ObjectStoreError gains PermissionDenied with the object key and provider message. The provider wrapper maps auth rejections to it, the local provider's io PermissionDenied arm comes along for cross-provider consistency, the JSONL metrics learn a permission_denied result class, and the sim's fault-store event classes gain the same. The retry gate already refused to retry these; the two tests that pinned that behavior now also pin the classification.

Presign expiry validation stops calling transport() too — those bounds come from deployment configuration, not the wire, so they classify as Configuration.

Upstream the wire code remains server_error for now (there is no permission_denied registry code yet — that is a workstream 5 decision); what changes is that operators grep one unambiguous classification instead of reading tea leaves in transport messages.