### PR TITLE
chore(objectstore,sim): one key surface, one endpoint parser, validated presign scoping

### DIFF
--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -5,23 +5,19 @@ use crate::ObjectStoreError;
 use loonfs_api::ManifestObjectId;
 
 pub fn namespace_config(namespace: &str) -> String {
-    ObjectLayout::new()
-        .namespace_config(namespace)
-        .into_string()
+    ObjectLayout::new().namespace_config(namespace)
 }
 
 pub fn wal_head(namespace: &str) -> String {
-    ObjectLayout::new().wal_head(namespace).into_string()
+    ObjectLayout::new().wal_head(namespace)
 }
 
 pub fn wal_floor(namespace: &str) -> String {
-    ObjectLayout::new().wal_floor(namespace).into_string()
+    ObjectLayout::new().wal_floor(namespace)
 }
 
 pub fn wal_segment(namespace: &str, segment_id: &str) -> String {
-    ObjectLayout::new()
-        .wal_segment(namespace, segment_id)
-        .into_string()
+    ObjectLayout::new().wal_segment(namespace, segment_id)
 }
 
 pub fn wal_segment_prefix(namespace: &str) -> String {
@@ -33,7 +29,7 @@ pub fn wal_segment_id_from_key(key: &str) -> Option<&str> {
 }
 
 pub fn metadata_root(namespace: &str) -> String {
-    ObjectLayout::new().metadata_root(namespace).into_string()
+    ObjectLayout::new().metadata_root(namespace)
 }
 
 pub fn metadata_manifest_prefix(namespace: &str) -> String {
@@ -45,21 +41,15 @@ pub fn metadata_table_prefix(namespace: &str) -> String {
 }
 
 pub fn metadata_manifest_object(namespace: &str, manifest_object_id: &ManifestObjectId) -> String {
-    ObjectLayout::new()
-        .metadata_manifest_object(namespace, manifest_object_id)
-        .into_string()
+    ObjectLayout::new().metadata_manifest_object(namespace, manifest_object_id)
 }
 
 pub fn metadata_table(namespace: &str, table_id: &str) -> String {
-    ObjectLayout::new()
-        .metadata_table(namespace, table_id)
-        .into_string()
+    ObjectLayout::new().metadata_table(namespace, table_id)
 }
 
 pub fn index_segment(namespace: &str, segment_id: &str) -> String {
-    ObjectLayout::new()
-        .index_segment(namespace, segment_id)
-        .into_string()
+    ObjectLayout::new().index_segment(namespace, segment_id)
 }
 
 pub fn index_segment_prefix(namespace: &str) -> String {
@@ -67,9 +57,7 @@ pub fn index_segment_prefix(namespace: &str) -> String {
 }
 
 pub fn checkpoint_record(namespace: &str, checkpoint_id: &str) -> String {
-    ObjectLayout::new()
-        .checkpoint_record(namespace, checkpoint_id)
-        .into_string()
+    ObjectLayout::new().checkpoint_record(namespace, checkpoint_id)
 }
 
 pub fn checkpoint_prefix(namespace: &str) -> String {
@@ -81,21 +69,15 @@ pub fn upload_session_prefix(namespace: &str) -> String {
 }
 
 pub fn upload_session(namespace: &str, upload_id: &str) -> String {
-    ObjectLayout::new()
-        .upload_session(namespace, upload_id)
-        .into_string()
+    ObjectLayout::new().upload_session(namespace, upload_id)
 }
 
 pub fn content_store_descriptor(content_store: &str) -> String {
-    ObjectLayout::new()
-        .content_store_descriptor(content_store)
-        .into_string()
+    ObjectLayout::new().content_store_descriptor(content_store)
 }
 
 pub fn content_blob(content_store: &str, digest: &str) -> Result<String, ObjectStoreError> {
-    ObjectLayout::new()
-        .content_blob(content_store, digest)
-        .map(|key| key.into_string())
+    ObjectLayout::new().content_blob(content_store, digest)
 }
 
 #[cfg(test)]

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -154,3 +154,34 @@ mod tests {
         ));
     }
 }
+
+/// A parsed `http(s)://authority[/base-path]` endpoint, shared by the
+/// provider client and the presigner so the two cannot drift.
+pub(crate) struct ParsedEndpoint<'a> {
+    pub(crate) scheme: &'a str,
+    pub(crate) authority: &'a str,
+    pub(crate) path: &'a str,
+}
+
+pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>, ObjectStoreError> {
+    let (scheme, rest) = value
+        .strip_prefix("https://")
+        .map(|rest| ("https", rest))
+        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
+        .ok_or_else(|| {
+            ObjectStoreError::Configuration(
+                "endpoint url must start with http:// or https://".to_owned(),
+            )
+        })?;
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    if authority.is_empty() {
+        return Err(ObjectStoreError::Configuration(
+            "endpoint url must include authority".to_owned(),
+        ));
+    }
+    Ok(ParsedEndpoint {
+        scheme,
+        authority,
+        path: path.trim_end_matches('/'),
+    })
+}

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -46,48 +46,6 @@ pub struct ParsedObjectKey<'a> {
     owner_namespace_id: Option<&'a str>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ObjectKey(String);
-
-macro_rules! typed_key {
-    ($name:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-        pub struct $name(ObjectKey);
-
-        impl $name {
-            pub fn as_str(&self) -> &str {
-                self.0.as_str()
-            }
-
-            pub fn into_string(self) -> String {
-                self.0.into_string()
-            }
-        }
-
-        impl From<$name> for String {
-            fn from(key: $name) -> Self {
-                key.into_string()
-            }
-        }
-    };
-}
-
-typed_key!(NamespaceConfigKey);
-typed_key!(WalHeadKey);
-typed_key!(WalFloorKey);
-typed_key!(WalIndexKey);
-typed_key!(WalIndexRunKey);
-typed_key!(WalSegmentKey);
-typed_key!(MetadataRootKey);
-typed_key!(MetadataManifestKey);
-typed_key!(MetadataTableKey);
-typed_key!(IndexSegmentKey);
-typed_key!(CheckpointRecordKey);
-typed_key!(PinKey);
-typed_key!(UploadSessionKey);
-typed_key!(ContentStoreDescriptorKey);
-typed_key!(ContentBlobKey);
-
 impl<'a> ParsedObjectKey<'a> {
     pub fn family(&self) -> DurableObjectFamily {
         self.family
@@ -95,20 +53,6 @@ impl<'a> ParsedObjectKey<'a> {
 
     pub fn owner_namespace_id(&self) -> Option<&'a str> {
         self.owner_namespace_id
-    }
-}
-
-impl ObjectKey {
-    fn new(key: impl Into<String>) -> Self {
-        Self(key.into())
-    }
-
-    fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    fn into_string(self) -> String {
-        self.0
     }
 }
 
@@ -123,47 +67,35 @@ impl ObjectLayout {
 
     /// Stable namespace identity and immutable configuration; written last
     /// during bootstrap as the namespace completion marker.
-    pub fn namespace_config(&self, namespace: &str) -> NamespaceConfigKey {
-        NamespaceConfigKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/namespace.json"
-        )))
+    pub fn namespace_config(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/namespace.json")
     }
 
     /// Hot head of the semantic commit stream: the only object whose CAS
     /// gates user-write throughput.
-    pub fn wal_head(&self, namespace: &str) -> WalHeadKey {
-        WalHeadKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/wal/head.json"
-        )))
+    pub fn wal_head(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/wal/head.json")
     }
 
     /// Cold lower bound of retained WAL/change history.
-    pub fn wal_floor(&self, namespace: &str) -> WalFloorKey {
-        WalFloorKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/wal/floor.json"
-        )))
+    pub fn wal_floor(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/wal/floor.json")
     }
 
     /// Optional mutable pointer to the newest WAL index run (accelerator,
     /// never authority). Reserved: parseable and buildable ahead of the
     /// accelerator subsystem landing.
-    pub fn wal_index(&self, namespace: &str) -> WalIndexKey {
-        WalIndexKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/wal/index.json"
-        )))
+    pub fn wal_index(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/wal/index.json")
     }
 
     /// Optional immutable run of visible-chain segment pointers. Reserved.
-    pub fn wal_index_run(&self, namespace: &str, index_id: &str) -> WalIndexRunKey {
-        WalIndexRunKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/wal/indexes/{index_id}.json"
-        )))
+    pub fn wal_index_run(&self, namespace: &str, index_id: &str) -> String {
+        format!("namespaces/{namespace}/wal/indexes/{index_id}.json")
     }
 
-    pub fn wal_segment(&self, namespace: &str, segment_id: &str) -> WalSegmentKey {
-        WalSegmentKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/wal/segments/{segment_id}.wal.zst"
-        )))
+    pub fn wal_segment(&self, namespace: &str, segment_id: &str) -> String {
+        format!("namespaces/{namespace}/wal/segments/{segment_id}.wal.zst")
     }
 
     /// Listing prefix that contains every WAL segment of `namespace` and
@@ -186,31 +118,27 @@ impl ObjectLayout {
     }
 
     /// Cold pointer to the best known materialized metadata root.
-    pub fn metadata_root(&self, namespace: &str) -> MetadataRootKey {
-        MetadataRootKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/metadata/root.json"
-        )))
+    pub fn metadata_root(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/metadata/root.json")
     }
 
     pub fn metadata_manifest_object(
         &self,
         namespace: &str,
         manifest_object_id: &ManifestObjectId,
-    ) -> MetadataManifestKey {
-        MetadataManifestKey(ObjectKey::new(format!(
+    ) -> String {
+        format!(
             "namespaces/{namespace}/metadata/manifests/{}.manifest.json",
             manifest_object_id.as_str()
-        )))
+        )
     }
 
     pub fn metadata_manifest_prefix(&self, namespace: &str) -> String {
         format!("namespaces/{namespace}/metadata/manifests/")
     }
 
-    pub fn metadata_table(&self, namespace: &str, table_id: &str) -> MetadataTableKey {
-        MetadataTableKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/metadata/tables/{table_id}.sst.zst"
-        )))
+    pub fn metadata_table(&self, namespace: &str, table_id: &str) -> String {
+        format!("namespaces/{namespace}/metadata/tables/{table_id}.sst.zst")
     }
 
     pub fn metadata_table_prefix(&self, namespace: &str) -> String {
@@ -220,10 +148,8 @@ impl ObjectLayout {
     /// Derived-index segment (format spec, "Derived work"): same block
     /// grammar as a metadata table, feature-owned row payload, referenced
     /// from the manifest's `index_files` list.
-    pub fn index_segment(&self, namespace: &str, segment_id: &str) -> IndexSegmentKey {
-        IndexSegmentKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/metadata/indexes/{segment_id}.idx.zst"
-        )))
+    pub fn index_segment(&self, namespace: &str, segment_id: &str) -> String {
+        format!("namespaces/{namespace}/metadata/indexes/{segment_id}.idx.zst")
     }
 
     pub fn index_segment_prefix(&self, namespace: &str) -> String {
@@ -231,10 +157,8 @@ impl ObjectLayout {
     }
 
     /// Durable stable-view pin to a metadata manifest.
-    pub fn checkpoint_record(&self, namespace: &str, checkpoint_id: &str) -> CheckpointRecordKey {
-        CheckpointRecordKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/checkpoints/{checkpoint_id}.json"
-        )))
+    pub fn checkpoint_record(&self, namespace: &str, checkpoint_id: &str) -> String {
+        format!("namespaces/{namespace}/checkpoints/{checkpoint_id}.json")
     }
 
     pub fn checkpoint_prefix(&self, namespace: &str) -> String {
@@ -243,44 +167,38 @@ impl ObjectLayout {
 
     /// Explicit reachability pin, stored under the **source** namespace —
     /// the namespace whose objects it protects.
-    pub fn pin(&self, source_namespace: &str, pin_id: &str) -> PinKey {
-        PinKey(ObjectKey::new(format!(
-            "namespaces/{source_namespace}/pins/{pin_id}.json"
-        )))
+    pub fn pin(&self, source_namespace: &str, pin_id: &str) -> String {
+        format!("namespaces/{source_namespace}/pins/{pin_id}.json")
     }
 
     pub fn pin_prefix(&self, source_namespace: &str) -> String {
         format!("namespaces/{source_namespace}/pins/")
     }
 
-    pub fn upload_session(&self, namespace: &str, upload_id: &str) -> UploadSessionKey {
-        UploadSessionKey(ObjectKey::new(format!(
-            "namespaces/{namespace}/uploads/{upload_id}.json"
-        )))
+    pub fn upload_session(&self, namespace: &str, upload_id: &str) -> String {
+        format!("namespaces/{namespace}/uploads/{upload_id}.json")
     }
 
     pub fn upload_session_prefix(&self, namespace: &str) -> String {
         format!("namespaces/{namespace}/uploads/")
     }
 
-    pub fn content_store_descriptor(&self, content_store: &str) -> ContentStoreDescriptorKey {
-        ContentStoreDescriptorKey(ObjectKey::new(format!(
-            "content-stores/{content_store}/descriptor.json"
-        )))
+    pub fn content_store_descriptor(&self, content_store: &str) -> String {
+        format!("content-stores/{content_store}/descriptor.json")
     }
 
     pub fn content_blob(
         &self,
         content_store: &str,
         digest: &str,
-    ) -> Result<ContentBlobKey, ObjectStoreError> {
+    ) -> Result<String, ObjectStoreError> {
         let hex = sha256_hex_from_digest(digest)?;
-        Ok(ContentBlobKey(ObjectKey::new(format!(
+        Ok(format!(
             "content-stores/{content_store}/blobs/sha256/{}/{}/{}",
             &hex[0..2],
             &hex[2..4],
             hex
-        ))))
+        ))
     }
 }
 
@@ -490,71 +408,50 @@ mod tests {
         let layout = ObjectLayout::new();
         let cases = [
             (
-                layout.namespace_config("ns-1").into_string(),
+                layout.namespace_config("ns-1"),
                 DurableObjectFamily::NamespaceConfig,
             ),
+            (layout.wal_head("ns-1"), DurableObjectFamily::WalHead),
+            (layout.wal_floor("ns-1"), DurableObjectFamily::WalFloor),
+            (layout.wal_index("ns-1"), DurableObjectFamily::WalIndex),
             (
-                layout.wal_head("ns-1").into_string(),
-                DurableObjectFamily::WalHead,
-            ),
-            (
-                layout.wal_floor("ns-1").into_string(),
-                DurableObjectFamily::WalFloor,
-            ),
-            (
-                layout.wal_index("ns-1").into_string(),
-                DurableObjectFamily::WalIndex,
-            ),
-            (
-                layout
-                    .wal_index_run("ns-1", "idx_00000000000000000000000000000001")
-                    .into_string(),
+                layout.wal_index_run("ns-1", "idx_00000000000000000000000000000001"),
                 DurableObjectFamily::WalIndexRun,
             ),
             (
-                layout
-                    .wal_segment("ns-1", "seg_00000000000000000000000000000001")
-                    .into_string(),
+                layout.wal_segment("ns-1", "seg_00000000000000000000000000000001"),
                 DurableObjectFamily::WalSegment,
             ),
             (
-                layout.metadata_root("ns-1").into_string(),
+                layout.metadata_root("ns-1"),
                 DurableObjectFamily::MetadataRoot,
             ),
             (
-                layout
-                    .metadata_manifest_object(
-                        "ns-1",
-                        &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
-                            .expect("valid manifest object id"),
-                    )
-                    .into_string(),
+                layout.metadata_manifest_object(
+                    "ns-1",
+                    &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
+                        .expect("valid manifest object id"),
+                ),
                 DurableObjectFamily::MetadataManifest,
             ),
             (
-                layout.metadata_table("ns-1", "tbl_abc").into_string(),
+                layout.metadata_table("ns-1", "tbl_abc"),
                 DurableObjectFamily::MetadataTable,
             ),
             (
-                layout.index_segment("ns-1", "idx_abc").into_string(),
+                layout.index_segment("ns-1", "idx_abc"),
                 DurableObjectFamily::IndexSegment,
             ),
             (
-                layout
-                    .checkpoint_record("ns-1", "chk_00000000000000000000000000000001")
-                    .into_string(),
+                layout.checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),
                 DurableObjectFamily::CheckpointRecord,
             ),
             (
-                layout
-                    .pin("ns-1", "pin_00000000000000000000000000000001")
-                    .into_string(),
+                layout.pin("ns-1", "pin_00000000000000000000000000000001"),
                 DurableObjectFamily::Pin,
             ),
             (
-                layout
-                    .upload_session("ns-1", "upl_00000000000000000000000000000001")
-                    .into_string(),
+                layout.upload_session("ns-1", "upl_00000000000000000000000000000001"),
                 DurableObjectFamily::UploadSession,
             ),
         ];
@@ -609,13 +506,10 @@ mod tests {
                 "cs_00000000000000000000000000000001",
                 "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
             )
-            .expect("content key")
-            .into_string();
+            .expect("content key");
         let cases = [
             (
-                layout
-                    .content_store_descriptor("cs_00000000000000000000000000000001")
-                    .into_string(),
+                layout.content_store_descriptor("cs_00000000000000000000000000000001"),
                 DurableObjectFamily::ContentStoreDescriptor,
             ),
             (content_key, DurableObjectFamily::ContentBlob),

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -29,11 +29,6 @@ mod store_io_runtime;
 pub mod timing;
 mod transfer_timeouts;
 
-/// Simulator-contract hook: the frozen `loonfs-sim` crate imports the local
-/// provider as `loonfs_objectstore::fs`. In-repo code spells out
-/// [`local_fs_store`]; do not add new users of this alias.
-pub use local_fs_store as fs;
-
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 pub use object_store::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -1,6 +1,7 @@
 //! Presigner for S3-compatible providers (AWS S3, Cloudflare R2).
 
 use super::{ObjectTransferIssuer, PresignedPutRequest, PresignedUrl};
+use crate::keyspace::{parse_endpoint_url, scope_object_key};
 use crate::presign::aws_sigv4::{
     aws_dates, canonical_query_string, hex_lower, hmac_sha256, normalize_header_value,
     percent_encode_path, percent_encode_segment,
@@ -66,13 +67,18 @@ impl S3CompatiblePresigner {
         match self.config.endpoint_url.as_deref() {
             Some(endpoint_url) => {
                 let parsed = parse_endpoint_url(endpoint_url)?;
+                let base_path = if parsed.path.is_empty() {
+                    String::new()
+                } else {
+                    format!("/{}", parsed.path)
+                };
                 if self.config.force_path_style {
                     Ok(S3Endpoint {
-                        scheme: parsed.scheme,
-                        host: parsed.authority,
+                        scheme: parsed.scheme.to_owned(),
+                        host: parsed.authority.to_owned(),
                         canonical_uri: format!(
                             "{}/{}/{}",
-                            parsed.base_path,
+                            base_path,
                             percent_encode_segment(&self.config.bucket),
                             encoded_key
                         ),
@@ -80,14 +86,14 @@ impl S3CompatiblePresigner {
                 } else {
                     let bucket_prefix = format!("{}.", self.config.bucket);
                     let host = if parsed.authority.starts_with(&bucket_prefix) {
-                        parsed.authority
+                        parsed.authority.to_owned()
                     } else {
                         format!("{}.{}", self.config.bucket, parsed.authority)
                     };
                     Ok(S3Endpoint {
-                        scheme: parsed.scheme,
+                        scheme: parsed.scheme.to_owned(),
                         host,
-                        canonical_uri: format!("{}/{}", parsed.base_path, encoded_key),
+                        canonical_uri: format!("{}/{}", base_path, encoded_key),
                     })
                 }
             }
@@ -267,57 +273,6 @@ struct S3Endpoint {
     scheme: String,
     host: String,
     canonical_uri: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedEndpoint {
-    scheme: String,
-    authority: String,
-    base_path: String,
-}
-
-fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint, ObjectStoreError> {
-    let (scheme, rest) = value
-        .strip_prefix("https://")
-        .map(|rest| ("https", rest))
-        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
-        .ok_or_else(|| {
-            ObjectStoreError::Configuration(
-                "endpoint url must start with http:// or https://".to_owned(),
-            )
-        })?;
-    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
-    if authority.is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "endpoint url must include authority".to_owned(),
-        ));
-    }
-    let path = path.trim_end_matches('/');
-    Ok(ParsedEndpoint {
-        scheme: scheme.to_owned(),
-        authority: authority.to_owned(),
-        base_path: if path.is_empty() {
-            String::new()
-        } else {
-            format!("/{path}")
-        },
-    })
-}
-
-fn scope_object_key(prefix: Option<&str>, key: &str) -> Result<String, ObjectStoreError> {
-    let key = key.trim_start_matches('/');
-    if key.is_empty() {
-        return Err(ObjectStoreError::InvalidKey {
-            object_key: key.to_owned(),
-            message: "object key must not be empty".to_owned(),
-        });
-    }
-    Ok(match prefix {
-        Some(prefix) if !prefix.trim_matches('/').is_empty() => {
-            format!("{}/{}", prefix.trim_matches('/'), key)
-        }
-        _ => key.to_owned(),
-    })
 }
 
 fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64, ObjectStoreError> {

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -1,6 +1,7 @@
 //! The shared S3-compatible store implementation behind the AWS S3 and
 //! Cloudflare R2 providers.
 
+use crate::keyspace::parse_endpoint_url;
 use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
@@ -188,36 +189,6 @@ fn object_store_endpoint_url(
     )
     .trim_end_matches('/')
     .to_owned())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ParsedEndpoint<'a> {
-    scheme: &'a str,
-    authority: &'a str,
-    path: &'a str,
-}
-
-fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>, ObjectStoreError> {
-    let (scheme, rest) = value
-        .strip_prefix("https://")
-        .map(|rest| ("https", rest))
-        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
-        .ok_or_else(|| {
-            ObjectStoreError::Configuration(
-                "endpoint url must start with http:// or https://".to_owned(),
-            )
-        })?;
-    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
-    if authority.is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "endpoint url must include authority".to_owned(),
-        ));
-    }
-    Ok(ParsedEndpoint {
-        scheme,
-        authority,
-        path: path.trim_end_matches('/'),
-    })
 }
 
 #[cfg(test)]

--- a/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
@@ -224,31 +224,25 @@ async fn classifies_gc_namespace_layout_family() {
 
     store
         .put_overwrite(
-            &layout
-                .metadata_manifest_object(
-                    "ns-1",
-                    &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
-                        .expect("valid manifest object id"),
-                )
-                .into_string(),
+            &layout.metadata_manifest_object(
+                "ns-1",
+                &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
+                    .expect("valid manifest object id"),
+            ),
             bytes(b"manifest"),
         )
         .await
         .expect("put namespace manifest");
     store
         .put_overwrite(
-            &layout
-                .metadata_table("ns-1", "tbl_00000000000000000000000000000001")
-                .into_string(),
+            &layout.metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
             bytes(b"metadata"),
         )
         .await
         .expect("put metadata sst");
     store
         .put_overwrite(
-            &layout
-                .pin("ns-1", "pin_00000000000000000000000000000001")
-                .into_string(),
+            &layout.pin("ns-1", "pin_00000000000000000000000000000001"),
             bytes(b"boundary"),
         )
         .await

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -566,7 +566,7 @@ mod tests {
     use super::*;
     use crate::fault::ScheduledFault;
     use crate::rng::SimSeed;
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
 
     fn temp_store() -> (tempfile::TempDir, LocalFsStore) {
         let temp_dir = tempfile::tempdir().expect("temp dir");

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -77,7 +77,7 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use loonfs_objectstore::fs::LocalFsStore;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
 
     #[tokio::test]
     async fn namespace_object_summary_counts_known_key_families() {


### PR DESCRIPTION
Three ways to build the same key, two copies of the endpoint parser, and a presign path that skipped the traversal validation the provider path enforces.

The fifteen typed_key! newtypes are gone: nothing held them — core imports the string-returning keys facade exclusively, and the simulator calls as_str() on layout returns, which String provides — so ObjectLayout methods now return String directly and the private ObjectKey wrapper dies with the macro. The keys facade drops its into_string() ceremony.

The presigner's private scope_object_key was a bare trim-and-join with none of keyspace's empty and dot-segment rejection, so a traversal-shaped key reaching presign would have been signed while the provider path rejected it. Presign now scopes through keyspace's validated helper, and the duplicated endpoint parser folds into one shared copy in keyspace, used by both the provider client and the presigner so the two cannot drift.

The local_fs_store-as-fs alias is deleted outright and the simulator's two imports updated: per the standing decision, loonfs-sim is updatable and the external driver follows it — no compat aliases kept for its sake. STYLE.md's crate table now states that contract instead of 'frozen'. Net −180 lines.