### PR TITLE
fix(objectstore): atomic local create, recorded stream listings, storage polish

### DIFF
--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,6 +1,7 @@
 //! Azure Blob Storage provider.
 
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::object_store::Result;
 use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
@@ -34,7 +35,7 @@ pub struct AzureAbsStore {
 }
 
 impl AzureAbsStore {
-    pub fn new(config: AzureAbsStoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn new(config: AzureAbsStoreConfig) -> Result<Self> {
         if config.account_name.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "account name must not be empty".to_owned(),
@@ -102,39 +103,27 @@ fn normalize_http_endpoint_scheme(endpoint_url: &str) -> String {
 
 #[async_trait]
 impl ObjectStore for AzureAbsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.inner.head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.inner.get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.inner.get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -8,6 +8,7 @@ use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
 use crate::local_fs_store::LocalFsStore;
+use crate::object_store::Result;
 use crate::presign::{ObjectTransferIssuer, S3CompatiblePresigner, S3PresignerConfig};
 use crate::r2::{CloudflareR2Store, CloudflareR2StoreConfig};
 use crate::s3::{AwsS3Store, AwsS3StoreConfig};
@@ -61,10 +62,7 @@ enum ConfiguredObjectStoreInner {
 }
 
 impl ConfiguredObjectStore {
-    pub fn local_fs(
-        root: impl Into<PathBuf>,
-        key_prefix: Option<&str>,
-    ) -> Result<Self, ObjectStoreError> {
+    pub fn local_fs(root: impl Into<PathBuf>, key_prefix: Option<&str>) -> Result<Self> {
         Ok(Self {
             kind: ConfiguredObjectStoreKind::LocalFs,
             inner: ConfiguredObjectStoreInner::LocalFs {
@@ -75,7 +73,7 @@ impl ConfiguredObjectStore {
         })
     }
 
-    pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn aws_s3(config: AwsS3StoreConfig) -> Result<Self> {
         let transfer_issuer = Some(Arc::new(S3CompatiblePresigner::new(S3PresignerConfig {
             bucket: config.bucket.clone(),
             region: config.region.clone(),
@@ -94,7 +92,7 @@ impl ConfiguredObjectStore {
         })
     }
 
-    pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn cloudflare_r2(config: CloudflareR2StoreConfig) -> Result<Self> {
         let transfer_issuer = Some(Arc::new(S3CompatiblePresigner::new(S3PresignerConfig {
             bucket: config.bucket.clone(),
             region: "auto".to_owned(),
@@ -113,7 +111,7 @@ impl ConfiguredObjectStore {
         })
     }
 
-    pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self> {
         let store = GcpGcsStore::new(config)?;
         Ok(Self {
             kind: ConfiguredObjectStoreKind::GcpGcs,
@@ -122,7 +120,7 @@ impl ConfiguredObjectStore {
         })
     }
 
-    pub fn azure_abs(config: AzureAbsStoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn azure_abs(config: AzureAbsStoreConfig) -> Result<Self> {
         let store = AzureAbsStore::new(config)?;
         Ok(Self {
             kind: ConfiguredObjectStoreKind::AzureAbs,
@@ -142,7 +140,7 @@ impl ConfiguredObjectStore {
 
 #[async_trait]
 impl ObjectStore for ConfiguredObjectStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 store
@@ -156,7 +154,7 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 store
@@ -170,11 +168,7 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 store
@@ -188,12 +182,7 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 store
@@ -207,7 +196,7 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 store
@@ -221,10 +210,7 @@ impl ObjectStore for ConfiguredObjectStore {
         }
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         match &self.inner {
             ConfiguredObjectStoreInner::LocalFs { store, key_prefix } => {
                 let scoped_prefix = match scope_list_prefix(key_prefix.as_deref(), prefix) {

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,6 +1,7 @@
 //! Google Cloud Storage provider.
 
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::object_store::Result;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
@@ -32,7 +33,7 @@ pub struct GcpGcsStore {
 }
 
 impl GcpGcsStore {
-    pub fn new(config: GcpGcsStoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn new(config: GcpGcsStoreConfig) -> Result<Self> {
         if config.bucket.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
@@ -78,10 +79,7 @@ impl GcpGcsStore {
         }
     }
 
-    fn require_generation_compare_token(
-        key: &str,
-        expected_etag: &str,
-    ) -> Result<(), ObjectStoreError> {
+    fn require_generation_compare_token(key: &str, expected_etag: &str) -> Result<()> {
         expected_etag
             .parse::<u64>()
             .map(|_| ())
@@ -93,7 +91,7 @@ impl GcpGcsStore {
 
 #[async_trait]
 impl ObjectStore for GcpGcsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         Ok(self
             .inner
             .head(key)
@@ -101,7 +99,7 @@ impl ObjectStore for GcpGcsStore {
             .map(Self::generation_as_compare_token))
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         Ok(self
             .inner
             .get_with_metadata(key)
@@ -112,20 +110,11 @@ impl ObjectStore for GcpGcsStore {
             }))
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.inner.get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.validate_key(key)?;
         if let PutMode::CompareAndSwap { expected_etag } = &mode {
             Self::require_generation_compare_token(key, expected_etag)?;
@@ -135,14 +124,11 @@ impl ObjectStore for GcpGcsStore {
         ))
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -1,6 +1,7 @@
 //! Key construction for every durable object family.
 
 use crate::layout::ObjectLayout;
+use crate::object_store::Result;
 use crate::ObjectStoreError;
 use loonfs_api::ManifestObjectId;
 
@@ -76,7 +77,7 @@ pub fn content_store_descriptor(content_store: &str) -> String {
     ObjectLayout::new().content_store_descriptor(content_store)
 }
 
-pub fn content_blob(content_store: &str, digest: &str) -> Result<String, ObjectStoreError> {
+pub fn content_blob(content_store: &str, digest: &str) -> Result<String> {
     ObjectLayout::new().content_blob(content_store, digest)
 }
 

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -1,11 +1,9 @@
 //! Key validation and prefix scoping shared by the provider stores.
 
+use crate::object_store::Result;
 use crate::ObjectStoreError;
 
-pub(crate) fn validate_segments(
-    key: &str,
-    allow_trailing_separator: bool,
-) -> Result<Vec<&str>, ObjectStoreError> {
+pub(crate) fn validate_segments(key: &str, allow_trailing_separator: bool) -> Result<Vec<&str>> {
     if key.is_empty() {
         return Ok(Vec::new());
     }
@@ -39,9 +37,7 @@ pub(crate) fn validate_segments(
     Ok(segments)
 }
 
-pub(crate) fn normalize_key_prefix(
-    key_prefix: Option<&str>,
-) -> Result<Option<String>, ObjectStoreError> {
+pub(crate) fn normalize_key_prefix(key_prefix: Option<&str>) -> Result<Option<String>> {
     let Some(key_prefix) = key_prefix else {
         return Ok(None);
     };
@@ -53,10 +49,7 @@ pub(crate) fn normalize_key_prefix(
     Ok(Some(segments.join("/")))
 }
 
-pub(crate) fn scope_object_key(
-    key_prefix: Option<&str>,
-    key: &str,
-) -> Result<String, ObjectStoreError> {
+pub(crate) fn scope_object_key(key_prefix: Option<&str>, key: &str) -> Result<String> {
     validate_segments(key, false)?;
 
     match key_prefix {
@@ -68,10 +61,7 @@ pub(crate) fn scope_object_key(
     }
 }
 
-pub(crate) fn scope_list_prefix(
-    key_prefix: Option<&str>,
-    prefix: &str,
-) -> Result<String, ObjectStoreError> {
+pub(crate) fn scope_list_prefix(key_prefix: Option<&str>, prefix: &str) -> Result<String> {
     validate_segments(prefix, true)?;
 
     match key_prefix {
@@ -89,6 +79,37 @@ pub(crate) fn unscope_listed_key(key_prefix: Option<&str>, scoped_key: &str) -> 
     scoped_key
         .strip_prefix(&prefix)
         .map(|unscoped| unscoped.to_owned())
+}
+
+/// A parsed `http(s)://authority[/base-path]` endpoint, shared by the
+/// provider client and the presigner so the two cannot drift.
+pub(crate) struct ParsedEndpoint<'a> {
+    pub(crate) scheme: &'a str,
+    pub(crate) authority: &'a str,
+    pub(crate) path: &'a str,
+}
+
+pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>> {
+    let (scheme, rest) = value
+        .strip_prefix("https://")
+        .map(|rest| ("https", rest))
+        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
+        .ok_or_else(|| {
+            ObjectStoreError::Configuration(
+                "endpoint url must start with http:// or https://".to_owned(),
+            )
+        })?;
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    if authority.is_empty() {
+        return Err(ObjectStoreError::Configuration(
+            "endpoint url must include authority".to_owned(),
+        ));
+    }
+    Ok(ParsedEndpoint {
+        scheme,
+        authority,
+        path: path.trim_end_matches('/'),
+    })
 }
 
 #[cfg(test)]
@@ -153,35 +174,4 @@ mod tests {
             Err(ObjectStoreError::InvalidKey { .. })
         ));
     }
-}
-
-/// A parsed `http(s)://authority[/base-path]` endpoint, shared by the
-/// provider client and the presigner so the two cannot drift.
-pub(crate) struct ParsedEndpoint<'a> {
-    pub(crate) scheme: &'a str,
-    pub(crate) authority: &'a str,
-    pub(crate) path: &'a str,
-}
-
-pub(crate) fn parse_endpoint_url(value: &str) -> Result<ParsedEndpoint<'_>, ObjectStoreError> {
-    let (scheme, rest) = value
-        .strip_prefix("https://")
-        .map(|rest| ("https", rest))
-        .or_else(|| value.strip_prefix("http://").map(|rest| ("http", rest)))
-        .ok_or_else(|| {
-            ObjectStoreError::Configuration(
-                "endpoint url must start with http:// or https://".to_owned(),
-            )
-        })?;
-    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
-    if authority.is_empty() {
-        return Err(ObjectStoreError::Configuration(
-            "endpoint url must include authority".to_owned(),
-        ));
-    }
-    Ok(ParsedEndpoint {
-        scheme,
-        authority,
-        path: path.trim_end_matches('/'),
-    })
 }

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -1,6 +1,7 @@
 //! The durable key grammar: object families, their path shapes, and
 //! parsing keys back into classified families.
 
+use crate::object_store::Result;
 use crate::ObjectStoreError;
 use loonfs_api::ManifestObjectId;
 
@@ -187,11 +188,7 @@ impl ObjectLayout {
         format!("content-stores/{content_store}/descriptor.json")
     }
 
-    pub fn content_blob(
-        &self,
-        content_store: &str,
-        digest: &str,
-    ) -> Result<String, ObjectStoreError> {
+    pub fn content_blob(&self, content_store: &str, digest: &str) -> Result<String> {
         let hex = sha256_hex_from_digest(digest)?;
         Ok(format!(
             "content-stores/{content_store}/blobs/sha256/{}/{}/{}",
@@ -268,7 +265,7 @@ fn parsed(
     })
 }
 
-pub fn sha256_hex_from_digest(digest: &str) -> Result<&str, ObjectStoreError> {
+pub fn sha256_hex_from_digest(digest: &str) -> Result<&str> {
     let Some(hex) = digest.strip_prefix("sha256:") else {
         return Err(ObjectStoreError::InvalidKey {
             object_key: digest.to_owned(),

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -30,8 +30,9 @@ pub mod timing;
 mod transfer_timeouts;
 
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
+pub use object_store::ObjectStoreError as Error;
 pub use object_store::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode, Result,
     SharedObjectStore,
 };
 pub use provider_object_store::{

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -1,6 +1,12 @@
 //! [`LocalFsStore`]: the local-filesystem [`ObjectStore`] provider.
+//!
+//! This is the dev and test provider. Its correctness contract is identical
+//! to the cloud providers'; its performance shapes are deliberately relaxed
+//! (content-hash etags, whole-file reads, whole-tree listings) and are not
+//! optimization targets.
 
 use crate::keyspace::validate_segments;
+use crate::object_store::Result;
 use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -24,7 +30,7 @@ pub struct LocalFsStore {
 }
 
 impl LocalFsStore {
-    pub fn new(root: impl Into<PathBuf>) -> Result<Self, ObjectStoreError> {
+    pub fn new(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         std::fs::create_dir_all(&root).map_err(|err| {
             ObjectStoreError::Configuration(format!(
@@ -41,10 +47,7 @@ impl LocalFsStore {
     /// Extends the in-process write mutex across processes with an advisory
     /// file lock on the store root. Check-then-act writes (compare-and-swap,
     /// delete-then-prune) are only safe while both are held.
-    async fn acquire_cross_process_write_lock(
-        &self,
-        key: &str,
-    ) -> Result<std::fs::File, ObjectStoreError> {
+    async fn acquire_cross_process_write_lock(&self, key: &str) -> Result<std::fs::File> {
         let lock_path = self.root.join(STORE_LOCK_FILE_NAME);
         let lock_key = key.to_owned();
         tokio::task::spawn_blocking(move || {
@@ -66,7 +69,7 @@ impl LocalFsStore {
         &self.root
     }
 
-    fn resolve_key(&self, key: &str) -> Result<PathBuf, ObjectStoreError> {
+    fn resolve_key(&self, key: &str) -> Result<PathBuf> {
         let segments = validate_segments(key, false)?;
         // Scratch-shaped names are reserved by this store: they are hidden
         // from listings, so accepting them as keys would create objects a
@@ -84,10 +87,7 @@ impl LocalFsStore {
         Ok(path)
     }
 
-    async fn metadata_for_path(
-        key: &str,
-        path: &Path,
-    ) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn metadata_for_path(key: &str, path: &Path) -> Result<Option<ObjectMetadata>> {
         let metadata = match fs::metadata(path).await {
             Ok(metadata) => metadata,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -103,7 +103,7 @@ impl LocalFsStore {
         metadata: &std::fs::Metadata,
         content_digest: &str,
         path: &Path,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    ) -> Result<ObjectMetadata> {
         if !metadata.is_file() {
             return Err(ObjectStoreError::transport(
                 key,
@@ -124,35 +124,38 @@ impl LocalFsStore {
         })
     }
 
-    async fn create_new_object(
-        key: &str,
-        root: &Path,
-        path: &Path,
-        bytes: &[u8],
-    ) -> Result<(), ObjectStoreError> {
+    async fn create_new_object(key: &str, root: &Path, path: &Path, bytes: &[u8]) -> Result<()> {
+        // Stage to a temp file and link into place, like `replace_object`:
+        // the bytes become visible at the final key atomically, so a reader
+        // never observes a partial object and a crash never leaves a torn
+        // file wedging the key. `hard_link` fails if the key exists, which
+        // is exactly the create-if-absent precondition.
         let created_dirs = ensure_parent_dir(key, path).await?;
-        let mut file = match OpenOptions::new()
+        let temp_path = temp_path(path);
+        let mut file = OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(path)
+            .open(&temp_path)
             .await
-        {
-            Ok(file) => file,
-            Err(err) => return Err(map_create_error(key, err)),
-        };
+            .map_err(|err| io_error(key, err))?;
 
-        let result: Result<(), ObjectStoreError> = async {
+        let staged: Result<()> = async {
             file.write_all(bytes)
                 .await
                 .map_err(|err| io_error(key, err))?;
             file.sync_all().await.map_err(|err| io_error(key, err))
         }
         .await;
-
-        if result.is_err() {
-            let _ = fs::remove_file(path).await;
-            return result;
+        if staged.is_err() {
+            let _ = fs::remove_file(&temp_path).await;
+            return staged;
         }
+
+        let linked = fs::hard_link(&temp_path, path)
+            .await
+            .map_err(|err| map_create_error(key, err));
+        let _ = fs::remove_file(&temp_path).await;
+        linked?;
 
         if created_dirs {
             sync_dir_chain(key, path, root).await?;
@@ -160,16 +163,11 @@ impl LocalFsStore {
         sync_parent_dir(key, path).await
     }
 
-    async fn replace_object(
-        key: &str,
-        root: &Path,
-        path: &Path,
-        bytes: &[u8],
-    ) -> Result<(), ObjectStoreError> {
+    async fn replace_object(key: &str, root: &Path, path: &Path, bytes: &[u8]) -> Result<()> {
         let created_dirs = ensure_parent_dir(key, path).await?;
         let temp_path = temp_path(path);
 
-        let result: Result<(), ObjectStoreError> = async {
+        let result: Result<()> = async {
             let mut file = OpenOptions::new()
                 .write(true)
                 .create_new(true)
@@ -216,15 +214,12 @@ impl LocalFsStore {
 }
 
 impl LocalFsStore {
-    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         let path = self.resolve_key(key)?;
         Self::metadata_for_path(key, &path).await
     }
 
-    async fn get_with_metadata_object(
-        &self,
-        key: &str,
-    ) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata_object(&self, key: &str) -> Result<Option<ObjectBody>> {
         let path = self.resolve_key(key)?;
         let mut file = match File::open(&path).await {
             Ok(file) => file,
@@ -243,11 +238,7 @@ impl LocalFsStore {
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
-    async fn get_object(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Vec<u8>>, ObjectStoreError> {
+    async fn get_object(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Vec<u8>>> {
         let path = self.resolve_key(key)?;
         let mut file = match File::open(&path).await {
             Ok(file) => file,
@@ -279,12 +270,7 @@ impl LocalFsStore {
         }
     }
 
-    async fn put_object(
-        &self,
-        key: &str,
-        bytes: &[u8],
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put_object(&self, key: &str, bytes: &[u8], mode: PutMode) -> Result<ObjectMetadata> {
         let path = self.resolve_key(key)?;
         let _guard = self.write_lock.lock().await;
         let _cross_process_guard = self.acquire_cross_process_write_lock(key).await?;
@@ -319,7 +305,7 @@ impl LocalFsStore {
             .ok_or_else(|| ObjectStoreError::transport(key, "object disappeared after write"))
     }
 
-    async fn delete_object(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete_object(&self, key: &str) -> Result<()> {
         let path = self.resolve_key(key)?;
         let _guard = self.write_lock.lock().await;
         let _cross_process_guard = self.acquire_cross_process_write_lock(key).await?;
@@ -338,41 +324,29 @@ impl LocalFsStore {
 
 #[async_trait]
 impl ObjectStore for LocalFsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.head_object(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.get_with_metadata_object(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.get_object(key, range)
             .await
             .map(|maybe| maybe.map(Bytes::from))
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.put_object(key, &bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.delete_object(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         let root = self.root.clone();
         let prefix = prefix.to_owned();
         Box::pin(
@@ -386,10 +360,7 @@ impl ObjectStore for LocalFsStore {
     }
 }
 
-async fn list_prefix_for_root(
-    root: PathBuf,
-    prefix: String,
-) -> Result<Vec<String>, ObjectStoreError> {
+async fn list_prefix_for_root(root: PathBuf, prefix: String) -> Result<Vec<String>> {
     validate_segments(&prefix, true)?;
 
     if !fs::try_exists(&root)
@@ -407,7 +378,7 @@ async fn list_prefix_for_root(
 
 /// Creates the parent directory chain. Returns whether anything was created,
 /// so callers know the new directory entries also need to be made durable.
-async fn ensure_parent_dir(key: &str, path: &Path) -> Result<bool, ObjectStoreError> {
+async fn ensure_parent_dir(key: &str, path: &Path) -> Result<bool> {
     match path.parent() {
         Some(parent) => {
             if fs::try_exists(parent)
@@ -431,7 +402,7 @@ async fn ensure_parent_dir(key: &str, path: &Path) -> Result<bool, ObjectStoreEr
 /// Fsyncs the directory holding `path`, making a rename, create, or unlink
 /// of that entry durable. Without this, the file data can survive a crash
 /// while the directory entry pointing at it does not.
-async fn sync_parent_dir(key: &str, path: &Path) -> Result<(), ObjectStoreError> {
+async fn sync_parent_dir(key: &str, path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         if let Some(parent) = path.parent() {
@@ -449,7 +420,7 @@ async fn sync_parent_dir(key: &str, path: &Path) -> Result<(), ObjectStoreError>
 /// Fsyncs every directory from `path`'s parent up to and including the
 /// store root, so a freshly created directory chain survives a crash. The
 /// root itself pre-exists, so the chain never needs to go past it.
-async fn sync_dir_chain(key: &str, path: &Path, root: &Path) -> Result<(), ObjectStoreError> {
+async fn sync_dir_chain(key: &str, path: &Path, root: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         let mut current = path.parent();
@@ -469,7 +440,7 @@ async fn sync_dir_chain(key: &str, path: &Path, root: &Path) -> Result<(), Objec
     Ok(())
 }
 
-async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>, ObjectStoreError> {
+async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>> {
     let mut keys = Vec::new();
     let mut dirs = vec![root.clone()];
 
@@ -513,7 +484,7 @@ async fn collect_keys(prefix: &str, root: PathBuf) -> Result<Vec<String>, Object
     Ok(keys)
 }
 
-fn relative_key(prefix: &str, root: &Path, path: &Path) -> Result<String, ObjectStoreError> {
+fn relative_key(prefix: &str, root: &Path, path: &Path) -> Result<String> {
     let relative = path.strip_prefix(root).map_err(|err| {
         ObjectStoreError::transport(
             prefix,
@@ -542,11 +513,7 @@ fn relative_key(prefix: &str, root: &Path, path: &Path) -> Result<String, Object
     Ok(parts.join("/"))
 }
 
-async fn prune_empty_parent_dirs(
-    key: &str,
-    mut current: Option<&Path>,
-    root: &Path,
-) -> Result<(), ObjectStoreError> {
+async fn prune_empty_parent_dirs(key: &str, mut current: Option<&Path>, root: &Path) -> Result<()> {
     while let Some(dir) = current {
         if dir == root {
             break;

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -2,6 +2,7 @@
 //! samples classified by object family.
 
 use crate::layout::{parse_object_key, DurableObjectFamily};
+use crate::object_store::Result;
 use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -36,12 +37,12 @@ pub struct ObjectStoreMetricSample {
 #[serde(rename_all = "snake_case")]
 pub enum ObjectStoreOperation {
     Head,
-    HeadWithChecksum,
     GetWithMetadata,
     Get,
     Put,
     Delete,
     ListPrefix,
+    ListPrefixStream,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -203,37 +204,28 @@ impl<S> ObjectStore for InstrumentedObjectStore<S>
 where
     S: ObjectStore,
 {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         let start = Instant::now();
         let result = self.inner.head(key).await;
         self.record_head_like(ObjectStoreOperation::Head, key, start.elapsed(), &result);
         result
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         let start = Instant::now();
         let result = self.inner.get(key, range.clone()).await;
         self.record_get(key, range.as_ref(), start.elapsed(), &result);
         result
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         let start = Instant::now();
         let result = self.inner.get_with_metadata(key).await;
         self.record_get_with_metadata(key, start.elapsed(), &result);
         result
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         let start = Instant::now();
         let bytes_in = bytes.len() as u64;
         let result = self.inner.put(key, bytes, mode.clone()).await;
@@ -241,74 +233,32 @@ where
         result
     }
 
-    async fn put_overwrite(
-        &self,
-        key: &str,
-        bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let start = Instant::now();
-        let bytes_in = bytes.len() as u64;
-        let result = self.inner.put_overwrite(key, bytes).await;
-        self.record_put(key, bytes_in, &PutMode::Overwrite, start.elapsed(), &result);
-        result
-    }
-
-    async fn put_if_absent(
-        &self,
-        key: &str,
-        bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let start = Instant::now();
-        let bytes_in = bytes.len() as u64;
-        let result = self.inner.put_if_absent(key, bytes).await;
-        self.record_put(
-            key,
-            bytes_in,
-            &PutMode::CreateIfAbsent,
-            start.elapsed(),
-            &result,
-        );
-        result
-    }
-
-    async fn compare_and_swap(
-        &self,
-        key: &str,
-        expected_etag: &str,
-        bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let start = Instant::now();
-        let bytes_in = bytes.len() as u64;
-        let result = self.inner.compare_and_swap(key, expected_etag, bytes).await;
-        self.record_put(
-            key,
-            bytes_in,
-            &PutMode::CompareAndSwap {
-                expected_etag: expected_etag.to_owned(),
-            },
-            start.elapsed(),
-            &result,
-        );
-        result
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         let start = Instant::now();
         let result = self.inner.delete(key).await;
         self.record_unit(ObjectStoreOperation::Delete, key, start.elapsed(), &result);
         result
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
+        // Streamed listings (WAL replay, GC) must not be invisible in the
+        // metrics. The wrapper records one sample when the stream is
+        // dropped — finished or abandoned — carrying the item count and
+        // the first error's class.
+        Box::pin(RecordedListStream {
+            inner: self.inner.list_prefix_stream(prefix),
+            recorder: Arc::clone(&self.recorder),
+            store_kind: self.store_kind.clone(),
+            key_class: classify_key(prefix),
+            started: Instant::now(),
+            items: 0,
+            first_error: None,
+        })
     }
 
-    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
         let start = Instant::now();
-        let result: Result<Vec<_>, _> = self
+        let result: std::result::Result<Vec<_>, _> = self
             .inner
             .list_prefix_stream(prefix)
             .try_collect()
@@ -328,7 +278,7 @@ impl<S> InstrumentedObjectStore<S> {
         operation: ObjectStoreOperation,
         key: &str,
         elapsed: Duration,
-        result: &Result<Option<ObjectMetadata>, ObjectStoreError>,
+        result: &Result<Option<ObjectMetadata>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation,
@@ -349,7 +299,7 @@ impl<S> InstrumentedObjectStore<S> {
         key: &str,
         range: Option<&ByteRange>,
         elapsed: Duration,
-        result: &Result<Option<Bytes>, ObjectStoreError>,
+        result: &Result<Option<Bytes>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::Get,
@@ -372,7 +322,7 @@ impl<S> InstrumentedObjectStore<S> {
         &self,
         key: &str,
         elapsed: Duration,
-        result: &Result<Option<ObjectBody>, ObjectStoreError>,
+        result: &Result<Option<ObjectBody>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::GetWithMetadata,
@@ -397,7 +347,7 @@ impl<S> InstrumentedObjectStore<S> {
         bytes_in: u64,
         mode: &PutMode,
         elapsed: Duration,
-        result: &Result<ObjectMetadata, ObjectStoreError>,
+        result: &Result<ObjectMetadata>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::Put,
@@ -418,7 +368,7 @@ impl<S> InstrumentedObjectStore<S> {
         operation: ObjectStoreOperation,
         key: &str,
         elapsed: Duration,
-        result: &Result<(), ObjectStoreError>,
+        result: &Result<()>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation,
@@ -434,12 +384,7 @@ impl<S> InstrumentedObjectStore<S> {
         });
     }
 
-    fn record_list(
-        &self,
-        prefix: &str,
-        elapsed: Duration,
-        result: &Result<Vec<String>, ObjectStoreError>,
-    ) {
+    fn record_list(&self, prefix: &str, elapsed: Duration, result: &Result<Vec<String>>) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::ListPrefix,
             elapsed_micros: elapsed.as_micros(),
@@ -456,6 +401,55 @@ impl<S> InstrumentedObjectStore<S> {
 
     fn record(&self, sample: ObjectStoreMetricSample) {
         self.recorder.record(sample);
+    }
+}
+
+struct RecordedListStream {
+    inner: BoxStream<'static, Result<String>>,
+    recorder: Arc<dyn ObjectStoreMetricsRecorder>,
+    store_kind: Option<String>,
+    key_class: KeyClass,
+    started: Instant,
+    items: u64,
+    first_error: Option<ObjectStoreResultClass>,
+}
+
+impl futures::Stream for RecordedListStream {
+    type Item = Result<String>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let polled = self.inner.as_mut().poll_next(cx);
+        if let std::task::Poll::Ready(Some(item)) = &polled {
+            match item {
+                Ok(_) => self.items += 1,
+                Err(error) => {
+                    if self.first_error.is_none() {
+                        self.first_error = Some(classify_error(error));
+                    }
+                }
+            }
+        }
+        polled
+    }
+}
+
+impl Drop for RecordedListStream {
+    fn drop(&mut self) {
+        self.recorder.record(ObjectStoreMetricSample {
+            operation: ObjectStoreOperation::ListPrefixStream,
+            elapsed_micros: self.started.elapsed().as_micros(),
+            result: self.first_error.unwrap_or(ObjectStoreResultClass::Ok),
+            bytes_in: None,
+            bytes_out: None,
+            item_count: Some(self.items),
+            key_class: self.key_class,
+            range_class: None,
+            put_mode: None,
+            store_kind: self.store_kind.clone(),
+        });
     }
 }
 
@@ -484,9 +478,7 @@ fn classify_key(key: &str) -> KeyClass {
     }
 }
 
-fn classify_optional_result<T>(
-    result: &Result<Option<T>, ObjectStoreError>,
-) -> ObjectStoreResultClass {
+fn classify_optional_result<T>(result: &Result<Option<T>>) -> ObjectStoreResultClass {
     match result {
         Ok(Some(_)) => ObjectStoreResultClass::Ok,
         Ok(None) => ObjectStoreResultClass::NotFound,
@@ -494,7 +486,7 @@ fn classify_optional_result<T>(
     }
 }
 
-fn classify_result<T>(result: &Result<T, ObjectStoreError>) -> ObjectStoreResultClass {
+fn classify_result<T>(result: &Result<T>) -> ObjectStoreResultClass {
     match result {
         Ok(_) => ObjectStoreResultClass::Ok,
         Err(error) => classify_error(error),

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -77,6 +77,10 @@ pub enum ObjectStoreError {
     InvalidRange { object_key: String },
     #[error("precondition failed for `{object_key}`")]
     PreconditionFailed { object_key: String },
+    /// Producible only by fault injection (the simulator's fault store):
+    /// no real provider constructs it. Core treats it alongside
+    /// [`Self::PreconditionFailed`] so injected conflicts exercise the
+    /// same recovery paths.
     #[error("conflict for `{object_key}`")]
     Conflict { object_key: String },
     /// The provider rejected the caller's identity or authorization —
@@ -141,51 +145,34 @@ impl ObjectStoreError {
     }
 }
 
+/// Facade alias: signatures inside this crate use `Result<T>`.
+pub type Result<T> = std::result::Result<T, ObjectStoreError>;
+
 #[async_trait]
 pub trait ObjectStore: Send + Sync + Debug {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError>;
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>>;
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError>;
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>>;
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError>;
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>>;
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError>;
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata>;
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError>;
+    async fn delete(&self, key: &str) -> Result<()>;
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>>;
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>>;
 
-    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
         let mut keys: Vec<String> = self.list_prefix_stream(prefix).try_collect().await?;
         keys.sort();
         Ok(keys)
     }
 
-    async fn put_overwrite(
-        &self,
-        key: &str,
-        bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put_overwrite(&self, key: &str, bytes: Bytes) -> Result<ObjectMetadata> {
         self.put(key, bytes, PutMode::Overwrite).await
     }
 
-    async fn put_if_absent(
-        &self,
-        key: &str,
-        bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put_if_absent(&self, key: &str, bytes: Bytes) -> Result<ObjectMetadata> {
         self.put(key, bytes, PutMode::CreateIfAbsent).await
     }
 
@@ -194,7 +181,7 @@ pub trait ObjectStore: Send + Sync + Debug {
         key: &str,
         expected_etag: &str,
         bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    ) -> Result<ObjectMetadata> {
         self.put(
             key,
             bytes,
@@ -208,78 +195,54 @@ pub trait ObjectStore: Send + Sync + Debug {
 
 #[async_trait]
 impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.as_ref().head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.as_ref().get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.as_ref().get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.as_ref().put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.as_ref().delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.as_ref().list_prefix_stream(prefix)
     }
 }
 
 #[async_trait]
 impl<T: ObjectStore + ?Sized> ObjectStore for &T {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         (*self).head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         (*self).get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         (*self).get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         (*self).put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         (*self).delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         (*self).list_prefix_stream(prefix)
     }
 }

--- a/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
+++ b/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
@@ -1,5 +1,6 @@
 //! AWS Signature Version 4 primitives used to presign S3-compatible URLs.
 
+use crate::object_store::Result;
 use crate::ObjectStoreError;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -14,10 +15,7 @@ pub(crate) struct AwsSigV4Dates {
     pub(crate) amz_date: String,
 }
 
-pub(crate) fn aws_dates(
-    object_key: &str,
-    time: SystemTime,
-) -> Result<AwsSigV4Dates, ObjectStoreError> {
+pub(crate) fn aws_dates(object_key: &str, time: SystemTime) -> Result<AwsSigV4Dates> {
     let seconds = time
         .duration_since(UNIX_EPOCH)
         .map_err(|err| {

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -1,5 +1,6 @@
 //! Presigned-URL issuing for direct_put uploads.
 
+use crate::object_store::Result;
 use crate::ObjectStoreError;
 use loonfs_api::ContentRef;
 use std::collections::BTreeMap;
@@ -30,5 +31,5 @@ pub trait ObjectTransferIssuer: Send + Sync + std::fmt::Debug {
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
-    ) -> Result<PresignedUrl, ObjectStoreError>;
+    ) -> Result<PresignedUrl>;
 }

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -2,6 +2,7 @@
 
 use super::{ObjectTransferIssuer, PresignedPutRequest, PresignedUrl};
 use crate::keyspace::{parse_endpoint_url, scope_object_key};
+use crate::object_store::Result;
 use crate::presign::aws_sigv4::{
     aws_dates, canonical_query_string, hex_lower, hmac_sha256, normalize_header_value,
     percent_encode_path, percent_encode_segment,
@@ -36,7 +37,7 @@ pub struct S3CompatiblePresigner {
 }
 
 impl S3CompatiblePresigner {
-    pub fn new(config: S3PresignerConfig) -> Result<Self, ObjectStoreError> {
+    pub fn new(config: S3PresignerConfig) -> Result<Self> {
         if config.bucket.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
@@ -60,7 +61,7 @@ impl S3CompatiblePresigner {
         Ok(Self { config })
     }
 
-    fn endpoint(&self, object_key: &str) -> Result<S3Endpoint, ObjectStoreError> {
+    fn endpoint(&self, object_key: &str) -> Result<S3Endpoint> {
         let scoped_key = scope_object_key(self.config.key_prefix.as_deref(), object_key)?;
         let encoded_key = percent_encode_path(&scoped_key);
 
@@ -129,7 +130,7 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
         &self,
         request: PresignedPutRequest<'_>,
         now: SystemTime,
-    ) -> Result<PresignedUrl, ObjectStoreError> {
+    ) -> Result<PresignedUrl> {
         // Expiry comes from deployment configuration, not the transport:
         // a bad value is a config bug and must not look like network
         // weather.
@@ -217,9 +218,7 @@ impl ObjectTransferIssuer for S3CompatiblePresigner {
     }
 }
 
-fn s3_direct_put_required_headers(
-    content_ref: &ContentRef,
-) -> Result<BTreeMap<String, String>, ObjectStoreError> {
+fn s3_direct_put_required_headers(content_ref: &ContentRef) -> Result<BTreeMap<String, String>> {
     Ok(BTreeMap::from([
         (S3_CREATE_ONLY_HEADER.to_owned(), "*".to_owned()),
         (
@@ -229,7 +228,7 @@ fn s3_direct_put_required_headers(
     ]))
 }
 
-fn s3_sha256_checksum_header(content_ref: &ContentRef) -> Result<String, ObjectStoreError> {
+fn s3_sha256_checksum_header(content_ref: &ContentRef) -> Result<String> {
     if content_ref.kind != ContentRefKind::WholeFileV0 {
         return Err(invalid_direct_put_content(
             "direct_put only supports whole_file_v0 content refs",
@@ -275,7 +274,7 @@ struct S3Endpoint {
     canonical_uri: String,
 }
 
-fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64, ObjectStoreError> {
+fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64> {
     let duration = time.duration_since(std::time::UNIX_EPOCH).map_err(|err| {
         ObjectStoreError::transport(
             object_key,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -5,6 +5,7 @@
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
+use crate::object_store::Result;
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use async_trait::async_trait;
@@ -39,8 +40,11 @@ pub const PROVIDER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// every retry of that operation rather than restarting per attempt. Reads
 /// get it as the provider client's retry timeout; single-request writes and
 /// deletes get it through `TransportRetryPolicy`. The deadline gates
-/// starting another attempt, so one operation's total wall time is bounded
-/// by the deadline plus one attempt bound. The GC grace window is derived
+/// starting another attempt, and one outer attempt may itself contain the
+/// inner client's full retry budget for status-code retries — so one
+/// operation's total wall time is bounded by the deadline plus the inner
+/// retry budget plus one attempt bound (worst case roughly six minutes),
+/// still a hard bound. The GC grace window is derived
 /// above this bound (format spec, "Garbage collection", rule 1); multipart
 /// uploads deliberately carry no whole-operation clock (their parts are
 /// individually bounded), which leaves the floor inequality untouched
@@ -239,7 +243,7 @@ impl ProviderObjectStore {
         inner: Arc<dyn provider_store::ObjectStore>,
         multipart: Option<Arc<dyn MultipartStore>>,
         config: ProviderObjectStoreConfig,
-    ) -> Result<Self, ObjectStoreError> {
+    ) -> Result<Self> {
         Ok(Self {
             inner,
             multipart,
@@ -271,7 +275,7 @@ impl ProviderObjectStore {
         self
     }
 
-    fn to_path(&self, key: &str) -> Result<Path, ObjectStoreError> {
+    fn to_path(&self, key: &str) -> Result<Path> {
         let scoped = scope_object_key(self.key_prefix.as_deref(), key)?;
         Path::parse(scoped).map_err(|err| ObjectStoreError::InvalidKey {
             object_key: key.to_owned(),
@@ -279,11 +283,11 @@ impl ProviderObjectStore {
         })
     }
 
-    pub(crate) fn validate_key(&self, key: &str) -> Result<(), ObjectStoreError> {
+    pub(crate) fn validate_key(&self, key: &str) -> Result<()> {
         self.to_path(key).map(|_| ())
     }
 
-    fn list_path(&self, prefix: &str) -> Result<Option<Path>, ObjectStoreError> {
+    fn list_path(&self, prefix: &str) -> Result<Option<Path>> {
         let scoped = scope_list_prefix(self.key_prefix.as_deref(), prefix)?;
         if scoped.is_empty() {
             return Ok(None);
@@ -348,7 +352,7 @@ impl ProviderObjectStore {
         key: &str,
         path: &Path,
         bytes: Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    ) -> Result<ObjectMetadata> {
         let size_bytes = bytes.len() as u64;
         let upload = MultipartWrite {
             store: self,
@@ -439,10 +443,7 @@ struct MultipartWrite<'op> {
 }
 
 impl MultipartWrite<'_> {
-    async fn create(
-        &self,
-        payload_bytes: u64,
-    ) -> Result<provider_store::MultipartId, ObjectStoreError> {
+    async fn create(&self, payload_bytes: u64) -> Result<provider_store::MultipartId> {
         let mut retries: u32 = 0;
         loop {
             let err = match self.multipart.create_multipart(self.path).await {
@@ -470,7 +471,7 @@ impl MultipartWrite<'_> {
         &self,
         upload_id: &provider_store::MultipartId,
         bytes: &Bytes,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    ) -> Result<ObjectMetadata> {
         let part_size = self.store.multipart_geometry.part_bytes as usize;
         let part_count = bytes.len().div_ceil(part_size);
         let mut part_ids: Vec<Option<PartId>> = vec![None; part_count];
@@ -510,7 +511,7 @@ impl MultipartWrite<'_> {
         upload_id: &provider_store::MultipartId,
         part_index: usize,
         payload: Bytes,
-    ) -> Result<PartId, ObjectStoreError> {
+    ) -> Result<PartId> {
         let payload_bytes = payload.len() as u64;
         let mut retries: u32 = 0;
         loop {
@@ -549,7 +550,7 @@ impl MultipartWrite<'_> {
         upload_id: &provider_store::MultipartId,
         parts: Vec<PartId>,
         size_bytes: u64,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    ) -> Result<ObjectMetadata> {
         let mut retries: u32 = 0;
         loop {
             let err = match self
@@ -603,7 +604,7 @@ impl MultipartWrite<'_> {
 
 #[async_trait]
 impl ObjectStore for ProviderObjectStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         let path = self.to_path(key)?;
         match self.inner.head(&path).await {
             Ok(meta) => Ok(Some(Self::from_meta(meta))),
@@ -612,7 +613,7 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         let path = self.to_path(key)?;
         match self.inner.get(&path).await {
             Ok(result) => {
@@ -638,11 +639,7 @@ impl ObjectStore for ProviderObjectStore {
     /// object is `Ok(None)` however the request was shaped, an end past the
     /// object clamps, `start == size` reads empty, and `start > size` is
     /// `InvalidRange`.
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         let path = self.to_path(key)?;
         let Some(range) = range else {
             return match self.inner.get(&path).await {
@@ -710,12 +707,7 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         let path = self.to_path(key)?;
         let size_bytes = bytes.len() as u64;
 
@@ -811,7 +803,7 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         let path = self.to_path(key)?;
         let deadline =
             OperationDeadline::start(self.timer.as_ref(), self.transport_retry.op_deadline);
@@ -837,10 +829,7 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         let prefix_path = match self.list_path(prefix) {
             Ok(prefix_path) => prefix_path,
             Err(err) => return stream::once(async { Err(err) }).boxed(),

--- a/crates/loonfs-objectstore/src/r2.rs
+++ b/crates/loonfs-objectstore/src/r2.rs
@@ -2,6 +2,7 @@
 
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::object_store::Result;
 use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use async_trait::async_trait;
@@ -24,7 +25,7 @@ pub struct CloudflareR2Store {
 }
 
 impl CloudflareR2Store {
-    pub fn new(config: CloudflareR2StoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn new(config: CloudflareR2StoreConfig) -> Result<Self> {
         if config.account_id.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "account id must not be empty".to_owned(),
@@ -60,39 +61,27 @@ impl CloudflareR2Store {
 
 #[async_trait]
 impl ObjectStore for CloudflareR2Store {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.inner.head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.inner.get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.inner.get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loonfs-objectstore/src/s3.rs
+++ b/crates/loonfs-objectstore/src/s3.rs
@@ -2,6 +2,7 @@
 
 use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use crate::object_store::Result;
 use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use async_trait::async_trait;
@@ -26,7 +27,7 @@ pub struct AwsS3Store {
 }
 
 impl AwsS3Store {
-    pub fn new(config: AwsS3StoreConfig) -> Result<Self, ObjectStoreError> {
+    pub fn new(config: AwsS3StoreConfig) -> Result<Self> {
         Ok(Self {
             inner: S3CompatibleStore::new(S3CompatibleConfig {
                 provider_name: "aws-s3",
@@ -46,39 +47,27 @@ impl AwsS3Store {
 
 #[async_trait]
 impl ObjectStore for AwsS3Store {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.inner.head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.inner.get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.inner.get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.inner.list_prefix_stream(prefix)
     }
 }

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -2,6 +2,7 @@
 //! Cloudflare R2 providers.
 
 use crate::keyspace::parse_endpoint_url;
+use crate::object_store::Result;
 use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
@@ -50,7 +51,7 @@ impl fmt::Debug for S3CompatibleStore {
 }
 
 impl S3CompatibleStore {
-    pub(crate) fn new(config: S3CompatibleConfig) -> Result<Self, ObjectStoreError> {
+    pub(crate) fn new(config: S3CompatibleConfig) -> Result<Self> {
         validate_config(&config)?;
         let endpoint_url = config
             .endpoint_url
@@ -107,44 +108,32 @@ impl S3CompatibleStore {
 
 #[async_trait]
 impl ObjectStore for S3CompatibleStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         self.inner.head(key).await
     }
 
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         self.inner.get_with_metadata(key).await
     }
 
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
+    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         self.inner.get(key, range).await
     }
 
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
+    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.put(key, bytes, mode).await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+    async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
         self.inner.list_prefix_stream(prefix)
     }
 }
 
-fn validate_config(config: &S3CompatibleConfig) -> Result<(), ObjectStoreError> {
+fn validate_config(config: &S3CompatibleConfig) -> Result<()> {
     if config.bucket.trim().is_empty() {
         return Err(ObjectStoreError::Configuration(
             "bucket must not be empty".to_owned(),
@@ -172,7 +161,7 @@ fn object_store_endpoint_url(
     bucket: &str,
     endpoint_url: &str,
     force_path_style: bool,
-) -> Result<String, ObjectStoreError> {
+) -> Result<String> {
     if force_path_style {
         return Ok(endpoint_url.to_owned());
     }

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -104,7 +104,7 @@ impl StoreConfig {
     }
 
     /// Builds the configured runtime object store for this provider.
-    pub fn configured_object_store(&self) -> Result<ConfiguredObjectStore, ObjectStoreError> {
+    pub fn configured_object_store(&self) -> crate::object_store::Result<ConfiguredObjectStore> {
         match self {
             StoreConfig::LocalFs { root, key_prefix } => {
                 ConfiguredObjectStore::local_fs(root, key_prefix.as_deref())

--- a/crates/loonfs-objectstore/src/store_io_runtime.rs
+++ b/crates/loonfs-objectstore/src/store_io_runtime.rs
@@ -9,6 +9,7 @@
 //! connector onto its store's own runtime, so caller runtime topology can
 //! never affect provider IO.
 
+use crate::object_store::Result;
 use crate::transfer_timeouts::TransferTimeoutConnector;
 use crate::ObjectStoreError;
 use std::fmt;
@@ -35,7 +36,7 @@ impl StoreIoRuntime {
     ///
     /// One worker thread multiplexes every request for the store; HTTP IO is
     /// reactor-driven, so request concurrency does not need more threads.
-    pub(crate) fn new() -> Result<Self, ObjectStoreError> {
+    pub(crate) fn new() -> Result<Self> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name("loonfs-store-io")

--- a/crates/loonfs-objectstore/tests/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/objectstore_conformance.rs
@@ -447,7 +447,38 @@ async fn assert_provider_conformance<S: ObjectStore>(store: &S) {
     assert_lists_immediately_after_write_and_delete(store).await;
     assert_sorted_list_prefix(store).await;
     assert_supports_range_reads(store).await;
+    assert_multipart_overwrite_round_trips(store).await;
     assert_rejects_invalid_keys_consistently(store).await;
+}
+
+/// The one live exercise of the native multipart path: an overwrite past
+/// the threshold uploads in parts (at least two) and must read back
+/// byte-identical. R2's fixed-part-size rule and each provider's completion
+/// semantics only show up against the real service.
+async fn assert_multipart_overwrite_round_trips<S: ObjectStore>(store: &S) {
+    let key = wal_segment("ns-1", "seg_00000000000000000000000000000777");
+    let _ = store.delete(&key).await;
+
+    let payload_len = loonfs_objectstore::PROVIDER_MULTIPART_THRESHOLD_BYTES as usize
+        + loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES as usize
+        + 4096;
+    let payload: Vec<u8> = (0..payload_len).map(|index| (index % 251) as u8).collect();
+
+    let metadata = store
+        .put_overwrite(&key, Bytes::from(payload.clone()))
+        .await
+        .expect("multipart overwrite");
+    assert_eq!(metadata.size_bytes, payload_len as u64);
+
+    let read_back = store
+        .get(&key, None)
+        .await
+        .expect("read back")
+        .expect("object exists");
+    assert_eq!(read_back.len(), payload_len);
+    assert_eq!(read_back.as_ref(), payload.as_slice());
+
+    store.delete(&key).await.expect("cleanup multipart object");
 }
 
 async fn assert_get_with_metadata_returns_body_and_identity<S: ObjectStore>(store: &S) {


### PR DESCRIPTION
The local provider's create-if-absent wrote bytes incrementally at the final key while its own replace path staged through a temp file — the one nonconforming primitive in the file. A racing reader could observe a partial head object (a flake generator for the multi-thread suites, which share one store per test) and a crash left a torn file wedging the key. Create now stages to a temp file, fsyncs, and hard-links into place: atomically visible, and the link failure is exactly the create-if-absent precondition. Local stays the dev and test provider — its module doc now says so explicitly, correctness contract identical, performance shapes deliberately relaxed and not optimization targets.

Streamed listings stop being invisible: list_prefix_stream (WAL replay and GC's listing surface) records one metrics sample on drop — finished or abandoned — with the item count and first error class, while the three put-sugar overrides that duplicated the instrumented put's sample are deleted, along with the dead HeadWithChecksum operation variant that outlived its method.

The rest is the audit's consolidated polish: the Result/Error facade pair STYLE requires, with crate signatures migrated to the alias; a doc on Conflict stating only fault injection produces it; the provider deadline doc corrected to the true worst-case bound (deadline plus inner retry budget plus one attempt, roughly six minutes — it matters because the GC grace floor is derived above it); and the live conformance suite gains the first multipart exercise — a two-part overwrite that must read back byte-identical, so the next credentialed run finally covers R2's fixed-part-size rule and real completion semantics.