### PR TITLE
fix(objectstore): repair the polish-wave test pin and import fallout

### DIFF
--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -12,7 +12,6 @@ use crate::object_store::Result;
 use crate::presign::{ObjectTransferIssuer, S3CompatiblePresigner, S3PresignerConfig};
 use crate::r2::{CloudflareR2Store, CloudflareR2StoreConfig};
 use crate::s3::{AwsS3Store, AwsS3StoreConfig};
-use crate::ObjectStoreError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream, StreamExt};

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -2,7 +2,6 @@
 
 use crate::layout::ObjectLayout;
 use crate::object_store::Result;
-use crate::ObjectStoreError;
 use loonfs_api::ManifestObjectId;
 
 pub fn namespace_config(namespace: &str) -> String {

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -1,7 +1,6 @@
 //! Presigned-URL issuing for direct_put uploads.
 
 use crate::object_store::Result;
-use crate::ObjectStoreError;
 use loonfs_api::ContentRef;
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime};

--- a/crates/loonfs-objectstore/src/s3.rs
+++ b/crates/loonfs-objectstore/src/s3.rs
@@ -4,7 +4,6 @@ use super::s3_compatible::{S3CompatibleConfig, S3CompatibleStore};
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
 use crate::secret::SecretString;
-use crate::ObjectStoreError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -11,7 +11,7 @@ use crate::gcs::GcpGcsStoreConfig;
 use crate::r2::CloudflareR2StoreConfig;
 use crate::s3::AwsS3StoreConfig;
 use crate::secret::SecretString;
-use crate::{ConfiguredObjectStore, ConfiguredObjectStoreKind, ObjectStoreError};
+use crate::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 use http::Uri;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/metrics_instrumented_object_store.rs
@@ -44,7 +44,7 @@ async fn records_put_success() {
 }
 
 #[tokio::test]
-async fn delegates_convenience_writes_to_inner_store() {
+async fn convenience_writes_funnel_through_put_with_distinct_modes() {
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
     let store = InstrumentedObjectStore::new(DelegatingWriteStore::default(), recorder.clone());
 
@@ -62,10 +62,10 @@ async fn delegates_convenience_writes_to_inner_store() {
         .expect("compare and swap");
 
     let inner = store.into_inner();
-    assert_eq!(
-        inner.calls(),
-        vec!["put_overwrite", "put_if_absent", "compare_and_swap"]
-    );
+    // The sugar methods are trait defaults now: every write funnels through
+    // the one instrumented `put`, so the inner store sees `put` three
+    // times while the samples still carry the distinct modes below.
+    assert_eq!(inner.calls(), vec!["put", "put", "put"]);
 
     let samples = recorder.samples();
     assert_eq!(samples.len(), 3);


### PR DESCRIPTION
The previous merge landed with a broken metrics test and stale imports — the verification ran in the background and the merge did not wait for it. This repairs both, and the process error is noted so it does not repeat: merges now gate on the printed suite output.

The metrics delegation test pinned the old shape (sugar methods delegating to the inner store's own sugar methods); with those overrides deleted, every write funnels through the one instrumented put, so the test now asserts put three times with the three distinct mode samples — the intended behavior, pinned by its new name. The Result-alias migration left five unused ObjectStoreError imports and dropped two test modules' imports; both are reconciled. Full workspace suite: 40 suites, zero failures; clippy clean.