### PR TITLE
fix(core): manifest row decoders hard-reject foreign-kind rows

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -25,10 +25,7 @@ use super::validate::{
     validate_namespace_manifest,
 };
 #[cfg(test)]
-use crate::metadata::{
-    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
-    MetadataStateBuilder, RevisionRecord, SubtreeTombstoneRecord,
-};
+use crate::metadata::{MetadataState, MetadataStateBuilder};
 #[cfg(test)]
 use futures::future::try_join_all;
 #[cfg(test)]
@@ -1243,6 +1240,10 @@ pub(super) fn decoded_manifest_row_weight(row: &MetadataRow) -> usize {
     }
 }
 
+/// Projects rows into a metadata-state builder through the same decoders the
+/// lookup path uses, re-attributing a foreign-kind row to the object that
+/// carried it. Index-only families are kind-checked but not projected; their
+/// contents are validated against the canonical family separately.
 #[cfg(test)]
 pub(super) fn append_rows_to_metadata(
     metadata_state: &mut MetadataStateBuilder,
@@ -1250,126 +1251,37 @@ pub(super) fn append_rows_to_metadata(
     object_key: &str,
     rows: &[MetadataRow],
 ) -> Result<(), ManifestLoadError> {
+    use crate::metadata::row_decode;
     for row in rows {
-        match (family, row) {
-            (
-                MetadataTableFamily::Inodes,
-                MetadataRow::Inode {
-                    inode_id,
-                    inode_kind,
-                    created_seq,
-                },
-            ) => metadata_state.push_inode(InodeRecord {
-                inode_id: *inode_id,
-                inode_kind: *inode_kind,
-                created_seq: *created_seq,
-            }),
-            (
-                MetadataTableFamily::DirentryBinds,
-                MetadataRow::DirentryBind {
-                    parent_inode_id,
-                    name_key,
-                    display_name,
-                    child_inode_id,
-                    bind_seq,
-                    bind_delta_index,
-                },
-            ) => metadata_state.push_direntry_bind(DirentryBindRecord {
-                parent_inode_id: *parent_inode_id,
-                name_key: name_key.as_str().to_owned(),
-                display_name: display_name.clone(),
-                child_inode_id: *child_inode_id,
-                bind_seq: *bind_seq,
-                bind_delta_index: *bind_delta_index,
-            }),
-            (MetadataTableFamily::DirentryChildBinds, MetadataRow::DirentryBind { .. }) => {}
-            (
-                MetadataTableFamily::DirentryUnbinds,
-                MetadataRow::DirentryUnbind {
-                    parent_inode_id,
-                    name_key,
-                    child_inode_id,
-                    bind_seq,
-                    bind_delta_index,
-                    unbind_seq,
-                    unbind_delta_index,
-                },
-            ) => metadata_state.push_direntry_unbind(DirentryUnbindRecord {
-                parent_inode_id: *parent_inode_id,
-                name_key: name_key.as_str().to_owned(),
-                child_inode_id: *child_inode_id,
-                bind_seq: *bind_seq,
-                bind_delta_index: *bind_delta_index,
-                unbind_seq: *unbind_seq,
-                unbind_delta_index: *unbind_delta_index,
-            }),
-            (
-                MetadataTableFamily::Revisions,
-                MetadataRow::Revision {
-                    inode_id,
-                    revision_no,
-                    committed_seq,
-                    committed_at_ms,
-                    revision_delta_index,
-                    content_ref,
-                },
-            ) => metadata_state.push_revision(RevisionRecord {
-                inode_id: *inode_id,
-                revision_no: *revision_no,
-                committed_seq: *committed_seq,
-                committed_at_ms: *committed_at_ms,
-                revision_delta_index: *revision_delta_index,
-                content_ref: content_ref.clone(),
-            }),
-            (MetadataTableFamily::RevisionsByInodeDesc, MetadataRow::Revision { .. }) => {}
-            (
-                MetadataTableFamily::Tombstones,
-                MetadataRow::Tombstone {
-                    root_inode_id,
-                    tombstone_seq,
-                    tombstone_delta_index,
-                    action,
-                },
-            ) => metadata_state.push_subtree_tombstone(SubtreeTombstoneRecord {
-                root_inode_id: *root_inode_id,
-                tombstone_seq: *tombstone_seq,
-                tombstone_delta_index: *tombstone_delta_index,
-                action: match action {
-                    loonfs_api::wire::manifest::TombstoneRowAction::Set => {
-                        crate::metadata::SubtreeTombstoneAction::Set
-                    }
-                    loonfs_api::wire::manifest::TombstoneRowAction::Revoke {
-                        target_seq,
-                        target_delta_index,
-                    } => crate::metadata::SubtreeTombstoneAction::Revoke {
-                        target_seq: *target_seq,
-                        target_delta_index: *target_delta_index,
-                    },
-                },
-            }),
-            (
-                MetadataTableFamily::CommitReceipts,
-                MetadataRow::CommitReceipt {
-                    commit_id,
-                    semantic_commit_fingerprint,
-                    committed_seq,
-                    committed_at_ms,
-                    message,
-                },
-            ) => metadata_state.push_commit_receipt(CommitReceiptRecord {
-                commit_id: commit_id.clone(),
-                semantic_commit_fingerprint: semantic_commit_fingerprint.clone(),
-                committed_seq: *committed_seq,
-                committed_at_ms: *committed_at_ms,
-                message: message.clone(),
-            }),
-            _ => {
-                return Err(ManifestLoadError::TableRowKindMismatch {
-                    object_key: object_key.to_owned(),
-                    family,
-                    row_kind: manifest_row_kind(row).to_owned(),
-                });
+        let mismatch = |_: crate::error::CoreError| ManifestLoadError::TableRowKindMismatch {
+            object_key: object_key.to_owned(),
+            family,
+            row_kind: manifest_row_kind(row).to_owned(),
+        };
+        match family {
+            MetadataTableFamily::Inodes => metadata_state
+                .push_inode(row_decode::inode_from_manifest_row(row.clone()).map_err(mismatch)?),
+            MetadataTableFamily::DirentryBinds => metadata_state.push_direntry_bind(
+                row_decode::direntry_bind_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::DirentryChildBinds => {
+                row_decode::direntry_bind_from_manifest_row(row.clone()).map_err(mismatch)?;
             }
+            MetadataTableFamily::DirentryUnbinds => metadata_state.push_direntry_unbind(
+                row_decode::direntry_unbind_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::Revisions => metadata_state.push_revision(
+                row_decode::revision_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::RevisionsByInodeDesc => {
+                row_decode::revision_from_manifest_row(row.clone()).map_err(mismatch)?;
+            }
+            MetadataTableFamily::Tombstones => metadata_state.push_subtree_tombstone(
+                row_decode::tombstone_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::CommitReceipts => metadata_state.push_commit_receipt(
+                row_decode::commit_receipt_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
         }
     }
     Ok(())

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -27,11 +27,12 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
 ) -> Result<Option<InodeRecord>> {
     let key = lookup_keys::inode_key(inode_id);
-    Ok(tables
+    tables
         .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
-        .and_then(inode_from_manifest_row))
+        .map(inode_from_manifest_row)
+        .transpose()
 }
 
 pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
@@ -39,13 +40,13 @@ pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
     parent_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
     let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
-    Ok(tables
+    tables
         .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) struct ManifestDirentryBindCandidate {
@@ -70,7 +71,7 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
         parent_prefix.clone()
     };
     let upper_bound = string_prefix_upper_bound(&parent_prefix);
-    Ok(tables
+    tables
         .scan_range_page_with_keys(
             MetadataTableFamily::DirentryBinds,
             &lower_bound,
@@ -80,11 +81,13 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(|(row_key, row)| {
-            direntry_bind_from_manifest_row(row)
-                .map(|record| ManifestDirentryBindCandidate { row_key, record })
+        .map(|(row_key, row)| {
+            Ok(ManifestDirentryBindCandidate {
+                record: direntry_bind_from_manifest_row(row)?,
+                row_key,
+            })
         })
-        .collect())
+        .collect()
 }
 
 pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
@@ -94,7 +97,7 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<DirentryBindRecord>> {
     let filter_probe = lookup_keys::direntry_bind_probe(parent_inode_id, name_key);
     let prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryBinds,
             &prefix,
@@ -104,8 +107,8 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
@@ -114,7 +117,7 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<DirentryBindRecord>> {
     let filter_probe = lookup_keys::direntry_child_probe(child_inode_id);
     let prefix = lookup_keys::direntry_child_prefix(child_inode_id);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryChildBinds,
             &prefix,
@@ -124,8 +127,8 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
@@ -140,7 +143,7 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         direntry.bind_seq,
         direntry.bind_delta_index,
     );
-    Ok(tables
+    let unbinds: Vec<DirentryUnbindRecord> = tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryUnbinds,
             &prefix,
@@ -150,7 +153,10 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_unbind_from_manifest_row)
+        .map(direntry_unbind_from_manifest_row)
+        .collect::<Result<_>>()?;
+    Ok(unbinds
+        .into_iter()
         .filter(|unbind| unbind_matches_binding(unbind, direntry))
         .collect())
 }
@@ -185,10 +191,9 @@ pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Siz
         let last_row_key = page
             .last()
             .map(|row| row.row_key_for_family(MetadataTableFamily::DirentryUnbinds));
-        unbinds.extend(
-            page.into_iter()
-                .filter_map(direntry_unbind_from_manifest_row),
-        );
+        for row in page {
+            unbinds.push(direntry_unbind_from_manifest_row(row)?);
+        }
         if page_len < UNBIND_RANGE_SCAN_LIMIT {
             break;
         }
@@ -238,7 +243,7 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
 ) -> Result<Option<RevisionRecord>> {
     let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
     let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
-    Ok(tables
+    tables
         .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &exact_prefix,
@@ -249,8 +254,9 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(revision_from_manifest_row)
-        .next())
+        .next()
+        .map(revision_from_manifest_row)
+        .transpose()
 }
 
 pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
@@ -267,7 +273,7 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
     let lower_bound = start_after
         .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
         .unwrap_or_else(|| inode_prefix.clone());
-    Ok(tables
+    tables
         .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &lower_bound,
@@ -278,8 +284,8 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(revision_from_manifest_row)
-        .collect())
+        .map(revision_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
@@ -288,7 +294,7 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
     let filter_probe = lookup_keys::tombstone_probe(root_inode_id);
     let prefix = lookup_keys::tombstone_prefix(root_inode_id);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::Tombstones,
             &prefix,
@@ -298,8 +304,8 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(tombstone_from_manifest_row)
-        .collect())
+        .map(tombstone_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
@@ -308,7 +314,7 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
 ) -> Result<Option<CommitReceiptRecord>> {
     let filter_probe = lookup_keys::commit_receipt_probe(commit_id.as_str());
     let prefix = lookup_keys::commit_receipt_prefix(commit_id.as_str());
-    Ok(tables
+    let receipts: Vec<CommitReceiptRecord> = tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::CommitReceipts,
             &prefix,
@@ -318,7 +324,10 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(commit_receipt_from_manifest_row)
+        .map(commit_receipt_from_manifest_row)
+        .collect::<Result<_>>()?;
+    Ok(receipts
+        .into_iter()
         .max_by_key(|receipt| receipt.committed_seq))
 }
 

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -25,7 +25,7 @@ mod apply;
 mod indexes;
 pub(crate) mod manifest_index;
 mod queries;
-mod row_decode;
+pub(crate) mod row_decode;
 mod rows;
 #[cfg(test)]
 mod tests;

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -1,27 +1,43 @@
 //! Decodes durable manifest rows into the in-memory metadata record types.
+//!
+//! Every table scan is family-scoped, so a row of any other kind in the
+//! result is namespace corruption, not a case to skip: each decoder
+//! hard-rejects foreign rows instead of filtering them out.
 
+use crate::error::CoreError;
 use crate::metadata::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::MetadataRow;
 
-pub(super) fn inode_from_manifest_row(row: MetadataRow) -> Option<InodeRecord> {
+/// The scanned table can only hold `expected_kind` rows; the foreign row's
+/// self-keyed row key names its actual kind and identity.
+fn foreign_row(expected_kind: &str, row: &MetadataRow) -> CoreError {
+    CoreError::NamespaceCorrupt(format!(
+        "manifest table scan expected `{expected_kind}` rows but found foreign row `{}`",
+        row.row_key()
+    ))
+}
+
+pub(crate) fn inode_from_manifest_row(row: MetadataRow) -> Result<InodeRecord, CoreError> {
     match row {
         MetadataRow::Inode {
             inode_id,
             inode_kind,
             created_seq,
-        } => Some(InodeRecord {
+        } => Ok(InodeRecord {
             inode_id,
             inode_kind,
             created_seq,
         }),
-        _ => None,
+        other => Err(foreign_row("inode", &other)),
     }
 }
 
-pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<DirentryBindRecord> {
+pub(crate) fn direntry_bind_from_manifest_row(
+    row: MetadataRow,
+) -> Result<DirentryBindRecord, CoreError> {
     match row {
         MetadataRow::DirentryBind {
             parent_inode_id,
@@ -30,7 +46,7 @@ pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<Dirent
             child_inode_id,
             bind_seq,
             bind_delta_index,
-        } => Some(DirentryBindRecord {
+        } => Ok(DirentryBindRecord {
             parent_inode_id,
             name_key: name_key.as_str().to_owned(),
             display_name,
@@ -38,11 +54,13 @@ pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<Dirent
             bind_seq,
             bind_delta_index,
         }),
-        _ => None,
+        other => Err(foreign_row("direntry_bind", &other)),
     }
 }
 
-pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<DirentryUnbindRecord> {
+pub(crate) fn direntry_unbind_from_manifest_row(
+    row: MetadataRow,
+) -> Result<DirentryUnbindRecord, CoreError> {
     match row {
         MetadataRow::DirentryUnbind {
             parent_inode_id,
@@ -52,7 +70,7 @@ pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<Dire
             bind_delta_index,
             unbind_seq,
             unbind_delta_index,
-        } => Some(DirentryUnbindRecord {
+        } => Ok(DirentryUnbindRecord {
             parent_inode_id,
             name_key: name_key.as_str().to_owned(),
             child_inode_id,
@@ -61,11 +79,11 @@ pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<Dire
             unbind_seq,
             unbind_delta_index,
         }),
-        _ => None,
+        other => Err(foreign_row("direntry_unbind", &other)),
     }
 }
 
-pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRecord> {
+pub(crate) fn revision_from_manifest_row(row: MetadataRow) -> Result<RevisionRecord, CoreError> {
     match row {
         MetadataRow::Revision {
             inode_id,
@@ -74,7 +92,7 @@ pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRec
             committed_at_ms,
             revision_delta_index,
             content_ref,
-        } => Some(RevisionRecord {
+        } => Ok(RevisionRecord {
             inode_id,
             revision_no,
             committed_seq,
@@ -82,7 +100,7 @@ pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRec
             revision_delta_index,
             content_ref,
         }),
-        _ => None,
+        other => Err(foreign_row("revision", &other)),
     }
 }
 
@@ -103,24 +121,28 @@ fn subtree_tombstone_action(
     }
 }
 
-pub(super) fn tombstone_from_manifest_row(row: MetadataRow) -> Option<SubtreeTombstoneRecord> {
+pub(crate) fn tombstone_from_manifest_row(
+    row: MetadataRow,
+) -> Result<SubtreeTombstoneRecord, CoreError> {
     match row {
         MetadataRow::Tombstone {
             root_inode_id,
             tombstone_seq,
             tombstone_delta_index,
             action,
-        } => Some(SubtreeTombstoneRecord {
+        } => Ok(SubtreeTombstoneRecord {
             root_inode_id,
             tombstone_seq,
             tombstone_delta_index,
             action: subtree_tombstone_action(&action),
         }),
-        _ => None,
+        other => Err(foreign_row("tombstone", &other)),
     }
 }
 
-pub(super) fn commit_receipt_from_manifest_row(row: MetadataRow) -> Option<CommitReceiptRecord> {
+pub(crate) fn commit_receipt_from_manifest_row(
+    row: MetadataRow,
+) -> Result<CommitReceiptRecord, CoreError> {
     match row {
         MetadataRow::CommitReceipt {
             commit_id,
@@ -128,13 +150,52 @@ pub(super) fn commit_receipt_from_manifest_row(row: MetadataRow) -> Option<Commi
             committed_seq,
             committed_at_ms,
             message,
-        } => Some(CommitReceiptRecord {
+        } => Ok(CommitReceiptRecord {
             commit_id,
             semantic_commit_fingerprint,
             committed_seq,
             committed_at_ms,
             message,
         }),
-        _ => None,
+        other => Err(foreign_row("commit_receipt", &other)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{ChangeSeq, InodeId};
+
+    fn foreign() -> MetadataRow {
+        MetadataRow::Inode {
+            inode_id: InodeId(7),
+            inode_kind: loonfs_api::InodeKind::File,
+            created_seq: ChangeSeq(3),
+        }
+    }
+
+    #[test]
+    fn wrong_kind_rows_are_namespace_corruption() {
+        let error =
+            direntry_bind_from_manifest_row(foreign()).expect_err("foreign row must be rejected");
+        assert!(
+            matches!(&error, CoreError::NamespaceCorrupt(_)),
+            "{error:?}"
+        );
+        let message = error.to_string();
+        assert!(message.contains("`direntry_bind`"), "{message}");
+        assert!(message.contains("inode-00000000000000000007"), "{message}");
+
+        assert!(direntry_unbind_from_manifest_row(foreign()).is_err());
+        assert!(revision_from_manifest_row(foreign()).is_err());
+        assert!(tombstone_from_manifest_row(foreign()).is_err());
+        assert!(commit_receipt_from_manifest_row(foreign()).is_err());
+        let tombstone = MetadataRow::Tombstone {
+            root_inode_id: InodeId(1),
+            tombstone_seq: ChangeSeq(1),
+            tombstone_delta_index: 0,
+            action: loonfs_api::wire::manifest::TombstoneRowAction::Set,
+        };
+        assert!(inode_from_manifest_row(tombstone).is_err());
     }
 }


### PR DESCRIPTION
The six decoders in metadata/row_decode.rs turned a manifest row of the wrong kind into None, and every lookup in metadata/manifest_index.rs consumed them with filter_map. A corrupt table (a receipt row in the inode table, say) would silently thin out scan results instead of failing. That broke the hard-reject doctrine: decoders never tolerate invalid durable state.

- Decoders now return Result; a foreign-kind row is CoreError::NamespaceCorrupt, with the expected kind and the foreign row's self-keyed row key (which names its actual kind and identity) in the message.
- All ten manifest_index call sites thread the error instead of filtering. Point lookups map-then-transpose, so a wrong-kind first row is an error, not something the scan skips past.