### PR TITLE
fix(core): directory-empty checks probe one page, not the whole directory

### DIFF
--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -703,7 +703,7 @@ async fn validate_directory_empty_precondition<V: CommitValidationView>(
         );
     }
 
-    if !metadata_state.visible_children(inode_id).await?.is_empty() {
+    if metadata_state.has_visible_children(inode_id).await? {
         return Err(CommitValidationError::DirectoryEmptyPreconditionNotEmpty { inode_id }.into());
     }
 

--- a/crates/loonfs-core/src/commit/validate/view.rs
+++ b/crates/loonfs-core/src/commit/validate/view.rs
@@ -47,10 +47,10 @@ pub(super) trait CommitValidationView {
         name_key: &str,
     ) -> Result<Option<DirentryBindRecord>, Self::Error>;
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error>;
+    /// Whether the directory has at least one visible child — the
+    /// directory-empty checks need only existence, so implementations answer
+    /// with a bounded probe instead of materializing the child list.
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error>;
 
     async fn latest_revision_record(
         &self,
@@ -168,12 +168,9 @@ impl CommitValidationView for InMemoryValidationView<'_> {
             .map_err(commit_validation_from_core)
     }
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error> {
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error> {
         self.view()
-            .visible_children(parent_inode_id)
+            .has_visible_children(parent_inode_id)
             .await
             .map_err(commit_validation_from_core)
     }
@@ -299,11 +296,8 @@ impl<S: ObjectStore + ?Sized> CommitValidationView for PublishValidationView<'_,
         self.view().visible_child(parent_inode_id, name_key).await
     }
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error> {
-        self.view().visible_children(parent_inode_id).await
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error> {
+        self.view().has_visible_children(parent_inode_id).await
     }
 
     async fn latest_revision_record(

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -35,20 +35,6 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
         .transpose()
 }
 
-pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
-    tables: &VerifiedMetadataTables<'_, S>,
-    parent_inode_id: InodeId,
-) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
-    tables
-        .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
-        .await
-        .map_err(manifest_error_to_core)?
-        .into_iter()
-        .map(direntry_bind_from_manifest_row)
-        .collect()
-}
-
 pub(super) struct ManifestDirentryBindCandidate {
     pub(super) row_key: String,
     pub(super) record: DirentryBindRecord,

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -724,3 +724,71 @@ fn queries_above_indexed_seq_match_at_head_results() {
         state.visible_inode_at_head(InodeId(3)),
     );
 }
+
+/// The directory-empty checks probe existence through the bounded
+/// [`MetadataView::has_visible_children`]; a directory whose every child
+/// binding was unbound must read as empty again.
+#[test]
+fn has_visible_children_sees_through_unbinds() {
+    let dir = InodeId(1);
+    let state = MetadataState::from_rows(
+        vec![
+            InodeRecord {
+                inode_id: dir,
+                inode_kind: InodeKind::Directory,
+                created_seq: ChangeSeq(1),
+            },
+            InodeRecord {
+                inode_id: InodeId(2),
+                inode_kind: InodeKind::File,
+                created_seq: ChangeSeq(2),
+            },
+        ],
+        vec![DirentryBindRecord {
+            parent_inode_id: dir,
+            name_key: "doc.txt".to_owned(),
+            display_name: "doc.txt".to_owned(),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(2),
+            bind_delta_index: 0,
+        }],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let view =
+        InMemoryMetadataView::in_memory(&state, None, ChangeSeq(2), NamePolicy::NfcCasefoldV0);
+    assert!(
+        visibility::resolve_in_memory_read(view.has_visible_children(dir))
+            .expect("probe bound child")
+    );
+    // The file inode is not a directory: probing it reports no children.
+    assert!(
+        !visibility::resolve_in_memory_read(view.has_visible_children(InodeId(2)))
+            .expect("probe non-directory")
+    );
+
+    let emptied = MetadataState::from_rows(
+        state.inodes().to_vec(),
+        state.direntry_binds().to_vec(),
+        vec![DirentryUnbindRecord {
+            parent_inode_id: dir,
+            name_key: "doc.txt".to_owned(),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(2),
+            bind_delta_index: 0,
+            unbind_seq: ChangeSeq(3),
+            unbind_delta_index: 0,
+        }],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let view =
+        InMemoryMetadataView::in_memory(&emptied, None, ChangeSeq(3), NamePolicy::NfcCasefoldV0);
+    assert!(
+        !visibility::resolve_in_memory_read(view.has_visible_children(dir))
+            .expect("probe emptied directory")
+    );
+}

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -237,31 +237,18 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         MetadataViewReads { view: *self }
     }
 
-    pub(crate) async fn visible_children(
+    /// Whether the directory currently has at least one visible child,
+    /// answered by a limit-1 page through a fresh session so the cost stays
+    /// bounded no matter how wide the directory is.
+    pub(crate) async fn has_visible_children(
         &self,
         parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let Some(parent) = self.visible_inode(parent_inode_id).await? else {
-            return Ok(Vec::new());
-        };
-        if parent.inode_kind != InodeKind::Directory {
-            return Ok(Vec::new());
-        }
-
-        let candidates = self.direntry_binds_for_parent(parent_inode_id).await?;
-        let mut reads = self.reads();
-        let mut children = Vec::new();
-        for direntry in candidates {
-            if visibility::is_visible_child_direntry(&mut reads, &direntry).await? {
-                children.push(direntry);
-            }
-        }
-        children.sort_by(|left, right| {
-            left.display_name
-                .cmp(&right.display_name)
-                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
-        });
-        Ok(children)
+    ) -> Result<bool, CoreError> {
+        let mut session = self.session();
+        Ok(!session
+            .visible_children_page_by_name_key(parent_inode_id, None, 1)
+            .await?
+            .is_empty())
     }
 
     pub(crate) async fn resolve_visible_path(
@@ -501,49 +488,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             tombstones,
             self.visible_seq(),
         ))
-    }
-
-    async fn direntry_binds_for_parent(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_parent, &parent_inode_id))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(tables) = self.manifest_tables() {
-                manifest_index::direntry_binds_for_parent(tables, parent_inode_id).await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| direntry.parent_inode_id == parent_inode_id)
-                    .cloned()
-            }));
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.binds_for_parent,
-                    parent_inode_id,
-                    durable.clone(),
-                );
-            }
-            durable
-        };
-        let mut bindings = durable;
-        bindings.extend(self.overlay_state().into_iter().flat_map(|state| {
-            state
-                .direntry_binds()
-                .iter()
-                .filter(move |direntry| direntry.parent_inode_id == parent_inode_id)
-                .cloned()
-        }));
-        Ok(bindings)
     }
 
     async fn direntry_binds_for_parent_name(
@@ -1685,7 +1629,6 @@ pub(crate) struct DurableVisibilityCache {
 struct DurableVisibilityCacheInner {
     inodes: HashMap<InodeId, Option<InodeRecord>>,
     binds_for_parent_name: HashMap<ParentNameCacheKey, Vec<DirentryBindRecord>>,
-    binds_for_parent: HashMap<InodeId, Vec<DirentryBindRecord>>,
     binds_for_child: HashMap<InodeId, Vec<DirentryBindRecord>>,
     unbinds_for_binding: HashMap<BindingCacheKey, Vec<DirentryUnbindRecord>>,
     tombstones_for_root: HashMap<InodeId, Vec<SubtreeTombstoneRecord>>,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -601,11 +601,11 @@ async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
             root_inode_id: resolved.inode_id,
         },
         InodeKind::Directory => {
-            let children = view
+            if view
                 .metadata_state
-                .visible_children(resolved.inode_id)
-                .await?;
-            if !children.is_empty() {
+                .has_visible_children(resolved.inode_id)
+                .await?
+            {
                 return Err(CoreError::DirectoryNotEmpty(
                     absolute_path.as_str().to_owned(),
                 ));


### PR DESCRIPTION
Both directory-empty checks — the non-recursive delete planner and the DirectoryEmpty commit precondition — answered "is it empty?" by materializing every visible child of the directory: full bind-prefix scan, per-child visibility filtering, then is_empty(). Deleting (or failing to delete) a directory with 100k children paid for all 100k.

- MetadataView gains has_visible_children: a limit-1 page through a fresh view session (the same pager the list endpoint runs), so the probe's cost is one page no matter how wide the directory is.
- The CommitValidationView trait's visible_children method is replaced by has_visible_children; both implementations (in-memory preview and publish) delegate to the shared probe. The planner's direct call is switched the same way.
- That change strands the whole unbounded chain, deleted here: MetadataView::visible_children, MetadataView::direntry_binds_for_parent, the manifest_index full-prefix bind scan behind it, and the binds_for_parent map in DurableVisibilityCache that existed only to memoize it. No caller materializes a full unpaged child list anymore.
- New test pins the semantics the checks depend on: a bound child reads as non-empty, a non-directory probes as childless, and a directory whose only child was unbound reads as empty again.