### PR TITLE
fix(core): grep pages share a session, bound examinations, and bless cursor drift

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -25,10 +25,7 @@ use super::validate::{
     validate_namespace_manifest,
 };
 #[cfg(test)]
-use crate::metadata::{
-    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
-    MetadataStateBuilder, RevisionRecord, SubtreeTombstoneRecord,
-};
+use crate::metadata::{MetadataState, MetadataStateBuilder};
 #[cfg(test)]
 use futures::future::try_join_all;
 #[cfg(test)]
@@ -1243,6 +1240,10 @@ pub(super) fn decoded_manifest_row_weight(row: &MetadataRow) -> usize {
     }
 }
 
+/// Projects rows into a metadata-state builder through the same decoders the
+/// lookup path uses, re-attributing a foreign-kind row to the object that
+/// carried it. Index-only families are kind-checked but not projected; their
+/// contents are validated against the canonical family separately.
 #[cfg(test)]
 pub(super) fn append_rows_to_metadata(
     metadata_state: &mut MetadataStateBuilder,
@@ -1250,126 +1251,37 @@ pub(super) fn append_rows_to_metadata(
     object_key: &str,
     rows: &[MetadataRow],
 ) -> Result<(), ManifestLoadError> {
+    use crate::metadata::row_decode;
     for row in rows {
-        match (family, row) {
-            (
-                MetadataTableFamily::Inodes,
-                MetadataRow::Inode {
-                    inode_id,
-                    inode_kind,
-                    created_seq,
-                },
-            ) => metadata_state.push_inode(InodeRecord {
-                inode_id: *inode_id,
-                inode_kind: *inode_kind,
-                created_seq: *created_seq,
-            }),
-            (
-                MetadataTableFamily::DirentryBinds,
-                MetadataRow::DirentryBind {
-                    parent_inode_id,
-                    name_key,
-                    display_name,
-                    child_inode_id,
-                    bind_seq,
-                    bind_delta_index,
-                },
-            ) => metadata_state.push_direntry_bind(DirentryBindRecord {
-                parent_inode_id: *parent_inode_id,
-                name_key: name_key.as_str().to_owned(),
-                display_name: display_name.clone(),
-                child_inode_id: *child_inode_id,
-                bind_seq: *bind_seq,
-                bind_delta_index: *bind_delta_index,
-            }),
-            (MetadataTableFamily::DirentryChildBinds, MetadataRow::DirentryBind { .. }) => {}
-            (
-                MetadataTableFamily::DirentryUnbinds,
-                MetadataRow::DirentryUnbind {
-                    parent_inode_id,
-                    name_key,
-                    child_inode_id,
-                    bind_seq,
-                    bind_delta_index,
-                    unbind_seq,
-                    unbind_delta_index,
-                },
-            ) => metadata_state.push_direntry_unbind(DirentryUnbindRecord {
-                parent_inode_id: *parent_inode_id,
-                name_key: name_key.as_str().to_owned(),
-                child_inode_id: *child_inode_id,
-                bind_seq: *bind_seq,
-                bind_delta_index: *bind_delta_index,
-                unbind_seq: *unbind_seq,
-                unbind_delta_index: *unbind_delta_index,
-            }),
-            (
-                MetadataTableFamily::Revisions,
-                MetadataRow::Revision {
-                    inode_id,
-                    revision_no,
-                    committed_seq,
-                    committed_at_ms,
-                    revision_delta_index,
-                    content_ref,
-                },
-            ) => metadata_state.push_revision(RevisionRecord {
-                inode_id: *inode_id,
-                revision_no: *revision_no,
-                committed_seq: *committed_seq,
-                committed_at_ms: *committed_at_ms,
-                revision_delta_index: *revision_delta_index,
-                content_ref: content_ref.clone(),
-            }),
-            (MetadataTableFamily::RevisionsByInodeDesc, MetadataRow::Revision { .. }) => {}
-            (
-                MetadataTableFamily::Tombstones,
-                MetadataRow::Tombstone {
-                    root_inode_id,
-                    tombstone_seq,
-                    tombstone_delta_index,
-                    action,
-                },
-            ) => metadata_state.push_subtree_tombstone(SubtreeTombstoneRecord {
-                root_inode_id: *root_inode_id,
-                tombstone_seq: *tombstone_seq,
-                tombstone_delta_index: *tombstone_delta_index,
-                action: match action {
-                    loonfs_api::wire::manifest::TombstoneRowAction::Set => {
-                        crate::metadata::SubtreeTombstoneAction::Set
-                    }
-                    loonfs_api::wire::manifest::TombstoneRowAction::Revoke {
-                        target_seq,
-                        target_delta_index,
-                    } => crate::metadata::SubtreeTombstoneAction::Revoke {
-                        target_seq: *target_seq,
-                        target_delta_index: *target_delta_index,
-                    },
-                },
-            }),
-            (
-                MetadataTableFamily::CommitReceipts,
-                MetadataRow::CommitReceipt {
-                    commit_id,
-                    semantic_commit_fingerprint,
-                    committed_seq,
-                    committed_at_ms,
-                    message,
-                },
-            ) => metadata_state.push_commit_receipt(CommitReceiptRecord {
-                commit_id: commit_id.clone(),
-                semantic_commit_fingerprint: semantic_commit_fingerprint.clone(),
-                committed_seq: *committed_seq,
-                committed_at_ms: *committed_at_ms,
-                message: message.clone(),
-            }),
-            _ => {
-                return Err(ManifestLoadError::TableRowKindMismatch {
-                    object_key: object_key.to_owned(),
-                    family,
-                    row_kind: manifest_row_kind(row).to_owned(),
-                });
+        let mismatch = |_: crate::error::CoreError| ManifestLoadError::TableRowKindMismatch {
+            object_key: object_key.to_owned(),
+            family,
+            row_kind: manifest_row_kind(row).to_owned(),
+        };
+        match family {
+            MetadataTableFamily::Inodes => metadata_state
+                .push_inode(row_decode::inode_from_manifest_row(row.clone()).map_err(mismatch)?),
+            MetadataTableFamily::DirentryBinds => metadata_state.push_direntry_bind(
+                row_decode::direntry_bind_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::DirentryChildBinds => {
+                row_decode::direntry_bind_from_manifest_row(row.clone()).map_err(mismatch)?;
             }
+            MetadataTableFamily::DirentryUnbinds => metadata_state.push_direntry_unbind(
+                row_decode::direntry_unbind_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::Revisions => metadata_state.push_revision(
+                row_decode::revision_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::RevisionsByInodeDesc => {
+                row_decode::revision_from_manifest_row(row.clone()).map_err(mismatch)?;
+            }
+            MetadataTableFamily::Tombstones => metadata_state.push_subtree_tombstone(
+                row_decode::tombstone_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
+            MetadataTableFamily::CommitReceipts => metadata_state.push_commit_receipt(
+                row_decode::commit_receipt_from_manifest_row(row.clone()).map_err(mismatch)?,
+            ),
         }
     }
     Ok(())

--- a/crates/loonfs-core/src/commit/metadata_overlay.rs
+++ b/crates/loonfs-core/src/commit/metadata_overlay.rs
@@ -71,9 +71,11 @@ mod tests {
     fn assert_overlay_matches_replay(committed_seq: ChangeSeq, ops: &[ValidatedOp]) {
         let overlay = overlay_rows(committed_seq, ops);
         let mut replayed = MetadataState::default();
-        replayed
-            .apply_committed_wal_deltas_mut(committed_seq, 4_200, &materialized_wal_deltas(ops))
-            .expect("replaying materialized deltas is infallible");
+        replayed.apply_committed_wal_deltas_mut(
+            committed_seq,
+            4_200,
+            &materialized_wal_deltas(ops),
+        );
 
         assert!(
             replayed.row_count() > 0,
@@ -421,16 +423,16 @@ mod tests {
         let second_overlay = overlay_rows(second_seq, &second_ops);
 
         let mut replayed = MetadataState::default();
-        replayed
-            .apply_committed_wal_deltas_mut(first_seq, 4_200, &materialized_wal_deltas(&first_ops))
-            .expect("replaying first commit deltas is infallible");
-        replayed
-            .apply_committed_wal_deltas_mut(
-                second_seq,
-                4_200,
-                &materialized_wal_deltas(&second_ops),
-            )
-            .expect("replaying second commit deltas is infallible");
+        replayed.apply_committed_wal_deltas_mut(
+            first_seq,
+            4_200,
+            &materialized_wal_deltas(&first_ops),
+        );
+        replayed.apply_committed_wal_deltas_mut(
+            second_seq,
+            4_200,
+            &materialized_wal_deltas(&second_ops),
+        );
 
         assert_eq!(
             concat(first_overlay.inodes(), second_overlay.inodes()),

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -703,7 +703,7 @@ async fn validate_directory_empty_precondition<V: CommitValidationView>(
         );
     }
 
-    if !metadata_state.visible_children(inode_id).await?.is_empty() {
+    if metadata_state.has_visible_children(inode_id).await? {
         return Err(CommitValidationError::DirectoryEmptyPreconditionNotEmpty { inode_id }.into());
     }
 

--- a/crates/loonfs-core/src/commit/validate/view.rs
+++ b/crates/loonfs-core/src/commit/validate/view.rs
@@ -47,10 +47,10 @@ pub(super) trait CommitValidationView {
         name_key: &str,
     ) -> Result<Option<DirentryBindRecord>, Self::Error>;
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error>;
+    /// Whether the directory has at least one visible child — the
+    /// directory-empty checks need only existence, so implementations answer
+    /// with a bounded probe instead of materializing the child list.
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error>;
 
     async fn latest_revision_record(
         &self,
@@ -168,12 +168,9 @@ impl CommitValidationView for InMemoryValidationView<'_> {
             .map_err(commit_validation_from_core)
     }
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error> {
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error> {
         self.view()
-            .visible_children(parent_inode_id)
+            .has_visible_children(parent_inode_id)
             .await
             .map_err(commit_validation_from_core)
     }
@@ -299,11 +296,8 @@ impl<S: ObjectStore + ?Sized> CommitValidationView for PublishValidationView<'_,
         self.view().visible_child(parent_inode_id, name_key).await
     }
 
-    async fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, Self::Error> {
-        self.view().visible_children(parent_inode_id).await
+    async fn has_visible_children(&self, parent_inode_id: InodeId) -> Result<bool, Self::Error> {
+        self.view().has_visible_children(parent_inode_id).await
     }
 
     async fn latest_revision_record(

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -381,14 +381,7 @@ impl NamespaceCommitEngine {
             return wal_tail_segments;
         };
         for record in &published.published_records {
-            if projection
-                .tail_state
-                .apply_committed_wal_record_mut(record)
-                .is_err()
-            {
-                self.invalidate();
-                return wal_tail_segments;
-            }
+            projection.tail_state.apply_committed_wal_record_mut(record);
         }
         projection.head_seq = resulting_head.seq;
         projection.head_etag = resulting_head_etag;

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -8,7 +8,7 @@ use crate::error::Result as CoreResult;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::{bootstrap, delete, fork, BootstrapNamespaceError};
 use crate::options::{BootstrapOptions, DeleteNamespaceOptions};
-use crate::path::query::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
+use crate::path::read::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
 use loonfs_api::generated_id;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -528,7 +528,6 @@ fn classify_wal_chain_load_error(error: &WalChainLoadError) -> ErrorCode {
 
 fn classify_visible_path_error(error: &VisiblePathError) -> ErrorCode {
     match error {
-        VisiblePathError::InvalidAbsolutePath { .. } => ErrorCode::InvalidRequest,
         VisiblePathError::RootMissing => ErrorCode::NamespaceCorrupt,
         VisiblePathError::PathNotFound { .. } => ErrorCode::PathNotFound,
         VisiblePathError::PathComponentNotDirectory { .. } => ErrorCode::PathConflict,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -7,7 +7,7 @@
 
 use crate::checkpoint::ManifestLoadError;
 use crate::commit::{CommitConversionError, CommitHeadPublishError, CommitValidationError};
-use crate::metadata::{MetadataApplyError, VisiblePathError};
+use crate::metadata::VisiblePathError;
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::namespace::control::ControlObjectLoadError;
 use crate::namespace::writer_epoch::WriterEpochAcquireError;
@@ -53,8 +53,6 @@ pub enum CoreError {
     CommitValidation(#[from] CommitValidationError),
     #[error("wal build failed: {0}")]
     WalBuild(#[from] WalBuildError),
-    #[error("metadata apply failed: {0}")]
-    MetadataApply(#[from] MetadataApplyError),
     #[error("head publish failed: {0}")]
     HeadPublish(#[from] CommitHeadPublishError),
     #[error("failed to write wal object `{object_key}`: {message}")]
@@ -303,7 +301,6 @@ impl CoreError {
             CoreError::WriterEpoch(error) => classify_writer_epoch_acquire_error(error),
             CoreError::CommitValidation(error) => classify_commit_validation_error(error),
             CoreError::WalBuild(_)
-            | CoreError::MetadataApply(_)
             | CoreError::WalWrite { .. }
             | CoreError::Store { .. }
             | CoreError::Internal(_) => ErrorCode::ServerError,

--- a/crates/loonfs-core/src/metadata/apply.rs
+++ b/crates/loonfs-core/src/metadata/apply.rs
@@ -9,7 +9,6 @@ use crate::invariants::InvariantId;
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalDelta};
 use loonfs_api::{ChangeSeq, CommitId};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppliedMetadataState {
@@ -17,27 +16,21 @@ pub struct AppliedMetadataState {
     pub checked_invariants: Vec<InvariantId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
-pub enum MetadataApplyError {}
-
 impl MetadataState {
     pub fn apply_committed_wal_deltas(
         &self,
         committed_seq: ChangeSeq,
         committed_at_ms: u64,
         deltas: &[WalDelta],
-    ) -> Result<AppliedMetadataState, MetadataApplyError> {
+    ) -> AppliedMetadataState {
         let mut metadata_state = self.clone();
-        let checked_invariants = metadata_state.apply_committed_wal_deltas_mut(
-            committed_seq,
-            committed_at_ms,
-            deltas,
-        )?;
+        let checked_invariants =
+            metadata_state.apply_committed_wal_deltas_mut(committed_seq, committed_at_ms, deltas);
 
-        Ok(AppliedMetadataState {
+        AppliedMetadataState {
             metadata_state,
             checked_invariants,
-        })
+        }
     }
 
     pub fn apply_committed_wal_deltas_mut(
@@ -45,7 +38,7 @@ impl MetadataState {
         committed_seq: ChangeSeq,
         committed_at_ms: u64,
         deltas: &[WalDelta],
-    ) -> Result<Vec<InvariantId>, MetadataApplyError> {
+    ) -> Vec<InvariantId> {
         let mut checked_invariants = Vec::new();
 
         for delta in deltas {
@@ -54,7 +47,7 @@ impl MetadataState {
             push_unique_invariant(&mut checked_invariants, checked_invariant);
         }
 
-        Ok(checked_invariants)
+        checked_invariants
     }
 
     /// Appends the metadata row encoded by one committed WAL delta and
@@ -171,7 +164,7 @@ impl MetadataState {
     pub fn apply_committed_wal_record_mut(
         &mut self,
         record: &WalCommitPayload,
-    ) -> Result<Vec<InvariantId>, MetadataApplyError> {
+    ) -> Vec<InvariantId> {
         self.apply_committed_wal_record_parts_mut(
             record.seq,
             record.committed_at_ms,
@@ -190,7 +183,7 @@ impl MetadataState {
         semantic_commit_fingerprint: &str,
         message: Option<&str>,
         deltas: &[WalCommitDelta],
-    ) -> Result<Vec<InvariantId>, MetadataApplyError> {
+    ) -> Vec<InvariantId> {
         let mut checked_invariants = Vec::new();
         for delta in deltas {
             let checked_invariant =
@@ -208,7 +201,7 @@ impl MetadataState {
             &mut checked_invariants,
             InvariantId::WalReplayRecordsCommitReceipt,
         );
-        Ok(checked_invariants)
+        checked_invariants
     }
 }
 

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -6,9 +6,8 @@ use super::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneAction, SubtreeTombstoneRecord,
 };
-use loonfs_api::{ChangeSeq, CommitId, InodeId, RevisionNo};
+use loonfs_api::{ChangeSeq, CommitId, InodeId};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::ops::Bound;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct MetadataIndexes {
@@ -22,8 +21,6 @@ pub(super) struct MetadataIndexes {
     active_parent_by_child: HashMap<InodeId, DirentryBindRecord>,
     unbound_binding_keys: HashSet<BindingKey>,
     tombstone_by_root: HashMap<InodeId, SubtreeTombstoneRecord>,
-    latest_revision_by_inode: HashMap<InodeId, RevisionRecord>,
-    revision_by_inode_no: HashMap<(InodeId, RevisionNo), RevisionRecord>,
     commit_receipt_by_id: HashMap<CommitId, CommitReceiptRecord>,
 }
 
@@ -37,8 +34,6 @@ impl Default for MetadataIndexes {
             active_parent_by_child: HashMap::new(),
             unbound_binding_keys: HashSet::new(),
             tombstone_by_root: HashMap::new(),
-            latest_revision_by_inode: HashMap::new(),
-            revision_by_inode_no: HashMap::new(),
             commit_receipt_by_id: HashMap::new(),
         }
     }
@@ -137,27 +132,6 @@ impl MetadataIndexes {
             .cloned()
     }
 
-    pub(super) fn active_children(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
-        self.active_children_after_name_key(parent_inode_id, None)
-            .cloned()
-            .collect()
-    }
-
-    pub(super) fn active_children_after_name_key<'a>(
-        &'a self,
-        parent_inode_id: InodeId,
-        start_after_name_key: Option<&str>,
-    ) -> impl Iterator<Item = &'a DirentryBindRecord> + 'a {
-        let lower_bound = match start_after_name_key {
-            Some(name_key) => Bound::Excluded((parent_inode_id, name_key.to_owned())),
-            None => Bound::Excluded((parent_inode_id, String::new())),
-        };
-        self.active_child_by_parent_name
-            .range((lower_bound, Bound::Unbounded))
-            .take_while(move |((candidate_parent, _), _)| *candidate_parent == parent_inode_id)
-            .map(|(_, record)| record)
-    }
-
     pub(super) fn active_parent_for_child(
         &self,
         child_inode_id: InodeId,
@@ -174,20 +148,6 @@ impl MetadataIndexes {
         self.tombstone_by_root
             .get(&root_inode_id)
             .filter(|tombstone| matches!(tombstone.action, SubtreeTombstoneAction::Set))
-            .cloned()
-    }
-
-    pub(super) fn latest_revision(&self, inode_id: InodeId) -> Option<RevisionRecord> {
-        self.latest_revision_by_inode.get(&inode_id).cloned()
-    }
-
-    pub(super) fn revision(
-        &self,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-    ) -> Option<RevisionRecord> {
-        self.revision_by_inode_no
-            .get(&(inode_id, revision_no))
             .cloned()
     }
 
@@ -261,18 +221,11 @@ impl MetadataIndexes {
         }
     }
 
+    /// Revisions contribute only the seq watermark: no read consults an
+    /// in-memory revision index — revision lookups scan the rows, which stay
+    /// tail-sized in memory (the manifest tables answer the bulk).
     pub(super) fn record_revision(&mut self, record: &RevisionRecord) {
         self.indexed_seq = self.indexed_seq.max(record.committed_seq);
-        replace_if_newer_revision(
-            &mut self.latest_revision_by_inode,
-            record.inode_id,
-            record.clone(),
-        );
-        replace_if_newer_revision(
-            &mut self.revision_by_inode_no,
-            (record.inode_id, record.revision_no),
-            record.clone(),
-        );
     }
 
     pub(super) fn record_tombstone(&mut self, record: &SubtreeTombstoneRecord) {
@@ -345,22 +298,6 @@ fn replace_if_newer_bind<K>(
     }
 }
 
-fn replace_if_newer_revision<K>(
-    map: &mut HashMap<K, RevisionRecord>,
-    key: K,
-    record: RevisionRecord,
-) where
-    K: Eq + std::hash::Hash,
-{
-    let should_replace = map
-        .get(&key)
-        .map(|existing| revision_order_key(&record) > revision_order_key(existing))
-        .unwrap_or(true);
-    if should_replace {
-        map.insert(key, record);
-    }
-}
-
 fn replace_if_newer_receipt(
     map: &mut HashMap<CommitId, CommitReceiptRecord>,
     key: CommitId,
@@ -418,14 +355,6 @@ fn remove_active_child_if_same(
 
 fn bind_order_key(record: &DirentryBindRecord) -> (ChangeSeq, u32) {
     (record.bind_seq, record.bind_delta_index)
-}
-
-fn revision_order_key(record: &RevisionRecord) -> (RevisionNo, ChangeSeq, u32) {
-    (
-        record.revision_no,
-        record.committed_seq,
-        record.revision_delta_index,
-    )
 }
 
 fn tombstone_order_key(record: &SubtreeTombstoneRecord) -> (ChangeSeq, u32) {

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -27,11 +27,12 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
 ) -> Result<Option<InodeRecord>> {
     let key = lookup_keys::inode_key(inode_id);
-    Ok(tables
+    tables
         .get_for_lookup(MetadataTableFamily::Inodes, &key, &key)
         .await
         .map_err(manifest_error_to_core)?
-        .and_then(inode_from_manifest_row))
+        .map(inode_from_manifest_row)
+        .transpose()
 }
 
 pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
@@ -39,13 +40,13 @@ pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
     parent_inode_id: InodeId,
 ) -> Result<Vec<DirentryBindRecord>> {
     let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
-    Ok(tables
+    tables
         .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) struct ManifestDirentryBindCandidate {
@@ -70,7 +71,7 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
         parent_prefix.clone()
     };
     let upper_bound = string_prefix_upper_bound(&parent_prefix);
-    Ok(tables
+    tables
         .scan_range_page_with_keys(
             MetadataTableFamily::DirentryBinds,
             &lower_bound,
@@ -80,11 +81,13 @@ pub(super) async fn direntry_binds_for_parent_name_key_page<S: ObjectStore + ?Si
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(|(row_key, row)| {
-            direntry_bind_from_manifest_row(row)
-                .map(|record| ManifestDirentryBindCandidate { row_key, record })
+        .map(|(row_key, row)| {
+            Ok(ManifestDirentryBindCandidate {
+                record: direntry_bind_from_manifest_row(row)?,
+                row_key,
+            })
         })
-        .collect())
+        .collect()
 }
 
 pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
@@ -94,7 +97,7 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<DirentryBindRecord>> {
     let filter_probe = lookup_keys::direntry_bind_probe(parent_inode_id, name_key);
     let prefix = lookup_keys::direntry_bind_prefix(parent_inode_id, name_key);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryBinds,
             &prefix,
@@ -104,8 +107,8 @@ pub(super) async fn direntry_binds_for_parent_name<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
@@ -114,7 +117,7 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<DirentryBindRecord>> {
     let filter_probe = lookup_keys::direntry_child_probe(child_inode_id);
     let prefix = lookup_keys::direntry_child_prefix(child_inode_id);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryChildBinds,
             &prefix,
@@ -124,8 +127,8 @@ pub(super) async fn direntry_binds_for_child<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_bind_from_manifest_row)
-        .collect())
+        .map(direntry_bind_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
@@ -140,7 +143,7 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         direntry.bind_seq,
         direntry.bind_delta_index,
     );
-    Ok(tables
+    let unbinds: Vec<DirentryUnbindRecord> = tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::DirentryUnbinds,
             &prefix,
@@ -150,7 +153,10 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(direntry_unbind_from_manifest_row)
+        .map(direntry_unbind_from_manifest_row)
+        .collect::<Result<_>>()?;
+    Ok(unbinds
+        .into_iter()
         .filter(|unbind| unbind_matches_binding(unbind, direntry))
         .collect())
 }
@@ -185,10 +191,9 @@ pub(super) async fn direntry_unbinds_for_parent_name_range<S: ObjectStore + ?Siz
         let last_row_key = page
             .last()
             .map(|row| row.row_key_for_family(MetadataTableFamily::DirentryUnbinds));
-        unbinds.extend(
-            page.into_iter()
-                .filter_map(direntry_unbind_from_manifest_row),
-        );
+        for row in page {
+            unbinds.push(direntry_unbind_from_manifest_row(row)?);
+        }
         if page_len < UNBIND_RANGE_SCAN_LIMIT {
             break;
         }
@@ -238,7 +243,7 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
 ) -> Result<Option<RevisionRecord>> {
     let exact_prefix = revision_by_inode_desc_exact_revision_prefix(inode_id, revision_no);
     let filter_probe = revision_by_inode_desc_filter_probe(inode_id);
-    Ok(tables
+    tables
         .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &exact_prefix,
@@ -249,8 +254,9 @@ pub(super) async fn revision_for_inode_no<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(revision_from_manifest_row)
-        .next())
+        .next()
+        .map(revision_from_manifest_row)
+        .transpose()
 }
 
 pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
@@ -267,7 +273,7 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
     let lower_bound = start_after
         .map(|position| resume_after_row_key(&revision_by_inode_desc_row_key(inode_id, position)))
         .unwrap_or_else(|| inode_prefix.clone());
-    Ok(tables
+    tables
         .scan_range_page_for_lookup(
             MetadataTableFamily::RevisionsByInodeDesc,
             &lower_bound,
@@ -278,8 +284,8 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(revision_from_manifest_row)
-        .collect())
+        .map(revision_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
@@ -288,7 +294,7 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
 ) -> Result<Vec<SubtreeTombstoneRecord>> {
     let filter_probe = lookup_keys::tombstone_probe(root_inode_id);
     let prefix = lookup_keys::tombstone_prefix(root_inode_id);
-    Ok(tables
+    tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::Tombstones,
             &prefix,
@@ -298,8 +304,8 @@ pub(super) async fn tombstones_for_root<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(tombstone_from_manifest_row)
-        .collect())
+        .map(tombstone_from_manifest_row)
+        .collect()
 }
 
 pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
@@ -308,7 +314,7 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
 ) -> Result<Option<CommitReceiptRecord>> {
     let filter_probe = lookup_keys::commit_receipt_probe(commit_id.as_str());
     let prefix = lookup_keys::commit_receipt_prefix(commit_id.as_str());
-    Ok(tables
+    let receipts: Vec<CommitReceiptRecord> = tables
         .scan_prefix_for_lookup(
             MetadataTableFamily::CommitReceipts,
             &prefix,
@@ -318,7 +324,10 @@ pub(super) async fn commit_receipt<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .filter_map(commit_receipt_from_manifest_row)
+        .map(commit_receipt_from_manifest_row)
+        .collect::<Result<_>>()?;
+    Ok(receipts
+        .into_iter()
         .max_by_key(|receipt| receipt.committed_seq))
 }
 

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -35,20 +35,6 @@ pub(super) async fn inode_at_seq<S: ObjectStore + ?Sized>(
         .transpose()
 }
 
-pub(super) async fn direntry_binds_for_parent<S: ObjectStore + ?Sized>(
-    tables: &VerifiedMetadataTables<'_, S>,
-    parent_inode_id: InodeId,
-) -> Result<Vec<DirentryBindRecord>> {
-    let prefix = lookup_keys::direntry_parent_prefix(parent_inode_id);
-    tables
-        .scan_prefix(MetadataTableFamily::DirentryBinds, &prefix)
-        .await
-        .map_err(manifest_error_to_core)?
-        .into_iter()
-        .map(direntry_bind_from_manifest_row)
-        .collect()
-}
-
 pub(super) struct ManifestDirentryBindCandidate {
     pub(super) row_key: String,
     pub(super) record: DirentryBindRecord,

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -32,7 +32,7 @@ mod tests;
 mod view;
 mod visibility;
 
-pub use self::apply::{AppliedMetadataState, MetadataApplyError};
+pub use self::apply::AppliedMetadataState;
 pub use self::queries::{ResolvedVisiblePath, VisiblePathError};
 pub use self::rows::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -25,7 +25,7 @@ mod apply;
 mod indexes;
 pub(crate) mod manifest_index;
 mod queries;
-mod row_decode;
+pub(crate) mod row_decode;
 mod rows;
 #[cfg(test)]
 mod tests;

--- a/crates/loonfs-core/src/metadata/queries.rs
+++ b/crates/loonfs-core/src/metadata/queries.rs
@@ -8,10 +8,8 @@
 //! (historical scan or at-head index) answers the primitive lookups.
 
 use super::visibility::{self, resolve_in_memory_read, unbind_matches_binding};
-use super::{
-    DirentryBindRecord, InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneRecord,
-};
-use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NamePolicy, RevisionNo};
+use super::{DirentryBindRecord, InodeRecord, MetadataState, SubtreeTombstoneRecord};
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NamePolicy};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use thiserror::Error;
@@ -27,8 +25,6 @@ pub struct ResolvedVisiblePath {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum VisiblePathError {
-    #[error("invalid absolute path `{absolute_path}`")]
-    InvalidAbsolutePath { absolute_path: String },
     #[error("canonical root inode is missing")]
     RootMissing,
     #[error("visible path not found: `{absolute_path}`")]
@@ -59,76 +55,6 @@ impl MetadataState {
         self.inodes
             .iter()
             .find(|inode| inode.inode_id == inode_id && inode.created_seq <= base_seq)
-            .cloned()
-    }
-
-    pub fn latest_revision_head_at_seq(
-        &self,
-        inode_id: InodeId,
-        base_seq: ChangeSeq,
-    ) -> Option<RevisionRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.latest_revision_at_head(inode_id);
-        }
-        self.latest_revision_head_at_seq_scan(inode_id, base_seq)
-    }
-
-    pub fn latest_revision_at_head(&self, inode_id: InodeId) -> Option<RevisionRecord> {
-        self.indexes.latest_revision(inode_id)
-    }
-
-    fn latest_revision_head_at_seq_scan(
-        &self,
-        inode_id: InodeId,
-        base_seq: ChangeSeq,
-    ) -> Option<RevisionRecord> {
-        self.revisions
-            .iter()
-            .filter(|revision| revision.inode_id == inode_id && revision.committed_seq <= base_seq)
-            .max_by_key(|revision| {
-                (
-                    revision.revision_no,
-                    revision.committed_seq,
-                    revision.revision_delta_index,
-                )
-            })
-            .cloned()
-    }
-
-    pub fn revision_at_seq(
-        &self,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-        base_seq: ChangeSeq,
-    ) -> Option<RevisionRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.revision_at_head(inode_id, revision_no);
-        }
-        self.revision_at_seq_scan(inode_id, revision_no, base_seq)
-    }
-
-    pub fn revision_at_head(
-        &self,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-    ) -> Option<RevisionRecord> {
-        self.indexes.revision(inode_id, revision_no)
-    }
-
-    fn revision_at_seq_scan(
-        &self,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-        base_seq: ChangeSeq,
-    ) -> Option<RevisionRecord> {
-        self.revisions
-            .iter()
-            .filter(|revision| {
-                revision.inode_id == inode_id
-                    && revision.revision_no == revision_no
-                    && revision.committed_seq <= base_seq
-            })
-            .max_by_key(|revision| (revision.committed_seq, revision.revision_delta_index))
             .cloned()
     }
 
@@ -257,15 +183,6 @@ impl MetadataState {
         ))
     }
 
-    pub fn current_revision_head(
-        &self,
-        inode_id: InodeId,
-        base_seq: ChangeSeq,
-    ) -> Option<RevisionRecord> {
-        self.visible_inode(inode_id, base_seq)?;
-        self.latest_revision_head_at_seq(inode_id, base_seq)
-    }
-
     pub fn visible_child(
         &self,
         parent_inode_id: InodeId,
@@ -292,133 +209,6 @@ impl MetadataState {
             parent_inode_id,
             name_key,
         ))
-    }
-
-    pub fn visible_children(
-        &self,
-        parent_inode_id: InodeId,
-        base_seq: ChangeSeq,
-    ) -> Vec<DirentryBindRecord> {
-        if base_seq >= self.indexed_seq() {
-            return self.visible_children_at_head(parent_inode_id);
-        }
-
-        let Some(parent) = self.visible_inode(parent_inode_id, base_seq) else {
-            return Vec::new();
-        };
-        if parent.inode_kind != InodeKind::Directory {
-            return Vec::new();
-        }
-
-        let mut reads = self.reads_at_seq(base_seq);
-        let mut children = self
-            .direntry_binds
-            .iter()
-            .filter(|direntry| {
-                direntry.parent_inode_id == parent_inode_id && direntry.bind_seq <= base_seq
-            })
-            .filter(|direntry| {
-                read_now(visibility::is_visible_child_direntry(&mut reads, direntry))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        children.sort_by(|left, right| {
-            left.display_name
-                .cmp(&right.display_name)
-                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
-        });
-        children
-    }
-
-    pub fn visible_children_page_by_name_key(
-        &self,
-        parent_inode_id: InodeId,
-        base_seq: ChangeSeq,
-        start_after_name_key: Option<&str>,
-        limit: usize,
-    ) -> Vec<DirentryBindRecord> {
-        if limit == 0 {
-            return Vec::new();
-        }
-        if base_seq >= self.indexed_seq() {
-            return self.visible_children_page_by_name_key_at_head(
-                parent_inode_id,
-                start_after_name_key,
-                limit,
-            );
-        }
-
-        let mut children = self.visible_children(parent_inode_id, base_seq);
-        children.sort_by(|left, right| left.name_key.cmp(&right.name_key));
-        children
-            .into_iter()
-            .filter(|child| {
-                start_after_name_key
-                    .map(|last_name_key| child.name_key.as_str() > last_name_key)
-                    .unwrap_or(true)
-            })
-            .take(limit)
-            .collect()
-    }
-
-    pub fn visible_children_page_by_name_key_at_head(
-        &self,
-        parent_inode_id: InodeId,
-        start_after_name_key: Option<&str>,
-        limit: usize,
-    ) -> Vec<DirentryBindRecord> {
-        if limit == 0 {
-            return Vec::new();
-        }
-        let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
-            return Vec::new();
-        };
-        if parent.inode_kind != InodeKind::Directory {
-            return Vec::new();
-        }
-
-        let mut children = Vec::with_capacity(limit);
-        for direntry in self
-            .indexes
-            .active_children_after_name_key(parent_inode_id, start_after_name_key)
-        {
-            if self
-                .visible_inode_at_head(direntry.child_inode_id)
-                .is_none()
-            {
-                continue;
-            }
-            children.push(direntry.clone());
-            if children.len() == limit {
-                break;
-            }
-        }
-        children
-    }
-
-    pub fn visible_children_at_head(&self, parent_inode_id: InodeId) -> Vec<DirentryBindRecord> {
-        let Some(parent) = self.visible_inode_at_head(parent_inode_id) else {
-            return Vec::new();
-        };
-        if parent.inode_kind != InodeKind::Directory {
-            return Vec::new();
-        }
-
-        let mut children = self
-            .indexes
-            .active_children(parent_inode_id)
-            .into_iter()
-            .filter(|direntry| {
-                self.visible_inode_at_head(direntry.child_inode_id)
-                    .is_some()
-            })
-            .collect::<Vec<_>>();
-        children.sort_by(|left, right| {
-            left.display_name
-                .cmp(&right.display_name)
-                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
-        });
-        children
     }
 
     pub fn resolve_visible_path(

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -1,27 +1,43 @@
 //! Decodes durable manifest rows into the in-memory metadata record types.
+//!
+//! Every table scan is family-scoped, so a row of any other kind in the
+//! result is namespace corruption, not a case to skip: each decoder
+//! hard-rejects foreign rows instead of filtering them out.
 
+use crate::error::CoreError;
 use crate::metadata::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::MetadataRow;
 
-pub(super) fn inode_from_manifest_row(row: MetadataRow) -> Option<InodeRecord> {
+/// The scanned table can only hold `expected_kind` rows; the foreign row's
+/// self-keyed row key names its actual kind and identity.
+fn foreign_row(expected_kind: &str, row: &MetadataRow) -> CoreError {
+    CoreError::NamespaceCorrupt(format!(
+        "manifest table scan expected `{expected_kind}` rows but found foreign row `{}`",
+        row.row_key()
+    ))
+}
+
+pub(crate) fn inode_from_manifest_row(row: MetadataRow) -> Result<InodeRecord, CoreError> {
     match row {
         MetadataRow::Inode {
             inode_id,
             inode_kind,
             created_seq,
-        } => Some(InodeRecord {
+        } => Ok(InodeRecord {
             inode_id,
             inode_kind,
             created_seq,
         }),
-        _ => None,
+        other => Err(foreign_row("inode", &other)),
     }
 }
 
-pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<DirentryBindRecord> {
+pub(crate) fn direntry_bind_from_manifest_row(
+    row: MetadataRow,
+) -> Result<DirentryBindRecord, CoreError> {
     match row {
         MetadataRow::DirentryBind {
             parent_inode_id,
@@ -30,7 +46,7 @@ pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<Dirent
             child_inode_id,
             bind_seq,
             bind_delta_index,
-        } => Some(DirentryBindRecord {
+        } => Ok(DirentryBindRecord {
             parent_inode_id,
             name_key: name_key.as_str().to_owned(),
             display_name,
@@ -38,11 +54,13 @@ pub(super) fn direntry_bind_from_manifest_row(row: MetadataRow) -> Option<Dirent
             bind_seq,
             bind_delta_index,
         }),
-        _ => None,
+        other => Err(foreign_row("direntry_bind", &other)),
     }
 }
 
-pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<DirentryUnbindRecord> {
+pub(crate) fn direntry_unbind_from_manifest_row(
+    row: MetadataRow,
+) -> Result<DirentryUnbindRecord, CoreError> {
     match row {
         MetadataRow::DirentryUnbind {
             parent_inode_id,
@@ -52,7 +70,7 @@ pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<Dire
             bind_delta_index,
             unbind_seq,
             unbind_delta_index,
-        } => Some(DirentryUnbindRecord {
+        } => Ok(DirentryUnbindRecord {
             parent_inode_id,
             name_key: name_key.as_str().to_owned(),
             child_inode_id,
@@ -61,11 +79,11 @@ pub(super) fn direntry_unbind_from_manifest_row(row: MetadataRow) -> Option<Dire
             unbind_seq,
             unbind_delta_index,
         }),
-        _ => None,
+        other => Err(foreign_row("direntry_unbind", &other)),
     }
 }
 
-pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRecord> {
+pub(crate) fn revision_from_manifest_row(row: MetadataRow) -> Result<RevisionRecord, CoreError> {
     match row {
         MetadataRow::Revision {
             inode_id,
@@ -74,7 +92,7 @@ pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRec
             committed_at_ms,
             revision_delta_index,
             content_ref,
-        } => Some(RevisionRecord {
+        } => Ok(RevisionRecord {
             inode_id,
             revision_no,
             committed_seq,
@@ -82,7 +100,7 @@ pub(super) fn revision_from_manifest_row(row: MetadataRow) -> Option<RevisionRec
             revision_delta_index,
             content_ref,
         }),
-        _ => None,
+        other => Err(foreign_row("revision", &other)),
     }
 }
 
@@ -103,24 +121,28 @@ fn subtree_tombstone_action(
     }
 }
 
-pub(super) fn tombstone_from_manifest_row(row: MetadataRow) -> Option<SubtreeTombstoneRecord> {
+pub(crate) fn tombstone_from_manifest_row(
+    row: MetadataRow,
+) -> Result<SubtreeTombstoneRecord, CoreError> {
     match row {
         MetadataRow::Tombstone {
             root_inode_id,
             tombstone_seq,
             tombstone_delta_index,
             action,
-        } => Some(SubtreeTombstoneRecord {
+        } => Ok(SubtreeTombstoneRecord {
             root_inode_id,
             tombstone_seq,
             tombstone_delta_index,
             action: subtree_tombstone_action(&action),
         }),
-        _ => None,
+        other => Err(foreign_row("tombstone", &other)),
     }
 }
 
-pub(super) fn commit_receipt_from_manifest_row(row: MetadataRow) -> Option<CommitReceiptRecord> {
+pub(crate) fn commit_receipt_from_manifest_row(
+    row: MetadataRow,
+) -> Result<CommitReceiptRecord, CoreError> {
     match row {
         MetadataRow::CommitReceipt {
             commit_id,
@@ -128,13 +150,52 @@ pub(super) fn commit_receipt_from_manifest_row(row: MetadataRow) -> Option<Commi
             committed_seq,
             committed_at_ms,
             message,
-        } => Some(CommitReceiptRecord {
+        } => Ok(CommitReceiptRecord {
             commit_id,
             semantic_commit_fingerprint,
             committed_seq,
             committed_at_ms,
             message,
         }),
-        _ => None,
+        other => Err(foreign_row("commit_receipt", &other)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{ChangeSeq, InodeId};
+
+    fn foreign() -> MetadataRow {
+        MetadataRow::Inode {
+            inode_id: InodeId(7),
+            inode_kind: loonfs_api::InodeKind::File,
+            created_seq: ChangeSeq(3),
+        }
+    }
+
+    #[test]
+    fn wrong_kind_rows_are_namespace_corruption() {
+        let error =
+            direntry_bind_from_manifest_row(foreign()).expect_err("foreign row must be rejected");
+        assert!(
+            matches!(&error, CoreError::NamespaceCorrupt(_)),
+            "{error:?}"
+        );
+        let message = error.to_string();
+        assert!(message.contains("`direntry_bind`"), "{message}");
+        assert!(message.contains("inode-00000000000000000007"), "{message}");
+
+        assert!(direntry_unbind_from_manifest_row(foreign()).is_err());
+        assert!(revision_from_manifest_row(foreign()).is_err());
+        assert!(tombstone_from_manifest_row(foreign()).is_err());
+        assert!(commit_receipt_from_manifest_row(foreign()).is_err());
+        let tombstone = MetadataRow::Tombstone {
+            root_inode_id: InodeId(1),
+            tombstone_seq: ChangeSeq(1),
+            tombstone_delta_index: 0,
+            action: loonfs_api::wire::manifest::TombstoneRowAction::Set,
+        };
+        assert!(inode_from_manifest_row(tombstone).is_err());
     }
 }

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -9,19 +9,17 @@ use loonfs_api::{
 
 #[test]
 fn bind_direntry_replay_uses_persisted_name_key() {
-    let applied = MetadataState::default()
-        .apply_committed_wal_deltas(
-            ChangeSeq(1),
-            4_200,
-            &[WalDelta::BindDirentry {
-                delta_index: 7,
-                parent_inode_id: InodeId(1),
-                name_key: "persisted-key".to_owned(),
-                display_name: "Report.TXT".to_owned(),
-                child_inode_id: InodeId(2),
-            }],
-        )
-        .expect("apply bind delta");
+    let applied = MetadataState::default().apply_committed_wal_deltas(
+        ChangeSeq(1),
+        4_200,
+        &[WalDelta::BindDirentry {
+            delta_index: 7,
+            parent_inode_id: InodeId(1),
+            name_key: "persisted-key".to_owned(),
+            display_name: "Report.TXT".to_owned(),
+            child_inode_id: InodeId(2),
+        }],
+    );
 
     assert_eq!(applied.metadata_state.direntry_binds().len(), 1);
     let bind = &applied.metadata_state.direntry_binds()[0];
@@ -141,7 +139,6 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
                 bind_delta_index: 0,
             }],
         )
-        .expect("unbind")
         .metadata_state;
     assert!(metadata_state
         .visible_child_at_head(InodeId(1), "docs")
@@ -162,7 +159,6 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
                 child_inode_id: InodeId(2),
             }],
         )
-        .expect("rebind")
         .metadata_state;
     assert!(metadata_state
         .visible_child_at_head(InodeId(1), "docs")
@@ -184,7 +180,6 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
                 root_inode_id: InodeId(2),
             }],
         )
-        .expect("tombstone")
         .metadata_state;
     assert!(metadata_state
         .visible_child_at_head(InodeId(1), "renamed")
@@ -531,100 +526,92 @@ fn revisions_advance_watermark_and_receipt_index_round_trips() {
 /// `deleted` with only a dead binding.
 fn churned_binding_state() -> MetadataState {
     let mut state = MetadataState::default();
-    state
-        .apply_committed_wal_deltas_mut(
-            ChangeSeq(0),
-            4_200,
-            &[WalDelta::CreateInode {
+    state.apply_committed_wal_deltas_mut(
+        ChangeSeq(0),
+        4_200,
+        &[WalDelta::CreateInode {
+            delta_index: 0,
+            inode_id: InodeId(1),
+            inode_kind: InodeKind::Directory,
+        }],
+    );
+    state.apply_committed_wal_deltas_mut(
+        ChangeSeq(1),
+        4_200,
+        &[
+            WalDelta::CreateInode {
                 delta_index: 0,
-                inode_id: InodeId(1),
+                inode_id: InodeId(2),
                 inode_kind: InodeKind::Directory,
-            }],
-        )
-        .expect("seed root");
-    state
-        .apply_committed_wal_deltas_mut(
-            ChangeSeq(1),
-            4_200,
-            &[
-                WalDelta::CreateInode {
-                    delta_index: 0,
-                    inode_id: InodeId(2),
-                    inode_kind: InodeKind::Directory,
-                },
-                WalDelta::BindDirentry {
-                    delta_index: 1,
-                    parent_inode_id: InodeId(1),
-                    name_key: "contested".to_owned(),
-                    display_name: "contested".to_owned(),
-                    child_inode_id: InodeId(2),
-                },
-                WalDelta::CreateInode {
-                    delta_index: 2,
-                    inode_id: InodeId(4),
-                    inode_kind: InodeKind::Directory,
-                },
-                WalDelta::BindDirentry {
-                    delta_index: 3,
-                    parent_inode_id: InodeId(1),
-                    name_key: "deleted".to_owned(),
-                    display_name: "deleted".to_owned(),
-                    child_inode_id: InodeId(4),
-                },
-            ],
-        )
-        .expect("bind children 2 and 4");
-    state
-        .apply_committed_wal_deltas_mut(
-            ChangeSeq(2),
-            4_200,
-            &[
-                WalDelta::UnbindDirentry {
-                    delta_index: 0,
-                    parent_inode_id: InodeId(1),
-                    name_key: "contested".to_owned(),
-                    child_inode_id: InodeId(2),
-                    bind_seq: ChangeSeq(1),
-                    bind_delta_index: 1,
-                },
-                WalDelta::BindDirentry {
-                    delta_index: 1,
-                    parent_inode_id: InodeId(1),
-                    name_key: "renamed-away".to_owned(),
-                    display_name: "renamed-away".to_owned(),
-                    child_inode_id: InodeId(2),
-                },
-                WalDelta::UnbindDirentry {
-                    delta_index: 2,
-                    parent_inode_id: InodeId(1),
-                    name_key: "deleted".to_owned(),
-                    child_inode_id: InodeId(4),
-                    bind_seq: ChangeSeq(1),
-                    bind_delta_index: 3,
-                },
-            ],
-        )
-        .expect("rename child 2, unbind child 4");
-    state
-        .apply_committed_wal_deltas_mut(
-            ChangeSeq(3),
-            4_200,
-            &[
-                WalDelta::CreateInode {
-                    delta_index: 0,
-                    inode_id: InodeId(3),
-                    inode_kind: InodeKind::Directory,
-                },
-                WalDelta::BindDirentry {
-                    delta_index: 1,
-                    parent_inode_id: InodeId(1),
-                    name_key: "contested".to_owned(),
-                    display_name: "contested".to_owned(),
-                    child_inode_id: InodeId(3),
-                },
-            ],
-        )
-        .expect("bind child 3");
+            },
+            WalDelta::BindDirentry {
+                delta_index: 1,
+                parent_inode_id: InodeId(1),
+                name_key: "contested".to_owned(),
+                display_name: "contested".to_owned(),
+                child_inode_id: InodeId(2),
+            },
+            WalDelta::CreateInode {
+                delta_index: 2,
+                inode_id: InodeId(4),
+                inode_kind: InodeKind::Directory,
+            },
+            WalDelta::BindDirentry {
+                delta_index: 3,
+                parent_inode_id: InodeId(1),
+                name_key: "deleted".to_owned(),
+                display_name: "deleted".to_owned(),
+                child_inode_id: InodeId(4),
+            },
+        ],
+    );
+    state.apply_committed_wal_deltas_mut(
+        ChangeSeq(2),
+        4_200,
+        &[
+            WalDelta::UnbindDirentry {
+                delta_index: 0,
+                parent_inode_id: InodeId(1),
+                name_key: "contested".to_owned(),
+                child_inode_id: InodeId(2),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: 1,
+            },
+            WalDelta::BindDirentry {
+                delta_index: 1,
+                parent_inode_id: InodeId(1),
+                name_key: "renamed-away".to_owned(),
+                display_name: "renamed-away".to_owned(),
+                child_inode_id: InodeId(2),
+            },
+            WalDelta::UnbindDirentry {
+                delta_index: 2,
+                parent_inode_id: InodeId(1),
+                name_key: "deleted".to_owned(),
+                child_inode_id: InodeId(4),
+                bind_seq: ChangeSeq(1),
+                bind_delta_index: 3,
+            },
+        ],
+    );
+    state.apply_committed_wal_deltas_mut(
+        ChangeSeq(3),
+        4_200,
+        &[
+            WalDelta::CreateInode {
+                delta_index: 0,
+                inode_id: InodeId(3),
+                inode_kind: InodeKind::Directory,
+            },
+            WalDelta::BindDirentry {
+                delta_index: 1,
+                parent_inode_id: InodeId(1),
+                name_key: "contested".to_owned(),
+                display_name: "contested".to_owned(),
+                child_inode_id: InodeId(3),
+            },
+        ],
+    );
     state
 }
 

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -440,8 +440,11 @@ fn find_commit_receipt_returns_latest_matching_receipt() {
     assert_eq!(receipt.semantic_commit_fingerprint, "new");
 }
 
+/// Revision rows keep no in-memory index — reads scan the tail-sized rows —
+/// but they must still advance the indexed-seq watermark that gates at-head
+/// query routing, and the receipt index must survive a serde round trip.
 #[test]
-fn revision_and_receipt_indexes_rebuild_and_update_incrementally() {
+fn revisions_advance_watermark_and_receipt_index_round_trips() {
     let commit_id = CommitId::parse("indexed-commit").expect("valid commit id");
     let content_ref = ContentRef {
         kind: loonfs_api::ContentRefKind::WholeFileV0,
@@ -489,19 +492,14 @@ fn revision_and_receipt_indexes_rebuild_and_update_incrementally() {
 
     assert_eq!(metadata_state.row_count(), 4);
     assert!(metadata_state.decoded_bytes() >= metadata_state.row_count());
+    assert_eq!(metadata_state.indexed_seq(), ChangeSeq(3));
     assert_eq!(
         metadata_state
-            .latest_revision_at_head(InodeId(7))
-            .expect("latest revision")
-            .revision_no,
-        RevisionNo(2)
-    );
-    assert_eq!(
-        metadata_state
-            .revision_at_head(InodeId(7), RevisionNo(1))
-            .expect("first revision")
+            .revisions()
+            .last()
+            .expect("revision rows")
             .content_ref,
-        content_ref
+        replacement_ref
     );
     assert_eq!(
         metadata_state
@@ -514,13 +512,7 @@ fn revision_and_receipt_indexes_rebuild_and_update_incrementally() {
     let decoded: MetadataState =
         serde_json::from_value(serde_json::to_value(&metadata_state).expect("encode"))
             .expect("decode");
-    assert_eq!(
-        decoded
-            .latest_revision_at_head(InodeId(7))
-            .expect("latest revision after decode")
-            .content_ref,
-        replacement_ref
-    );
+    assert_eq!(decoded.indexed_seq(), ChangeSeq(3));
     assert_eq!(
         decoded
             .find_commit_receipt(&commit_id)

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -724,3 +724,71 @@ fn queries_above_indexed_seq_match_at_head_results() {
         state.visible_inode_at_head(InodeId(3)),
     );
 }
+
+/// The directory-empty checks probe existence through the bounded
+/// [`MetadataView::has_visible_children`]; a directory whose every child
+/// binding was unbound must read as empty again.
+#[test]
+fn has_visible_children_sees_through_unbinds() {
+    let dir = InodeId(1);
+    let state = MetadataState::from_rows(
+        vec![
+            InodeRecord {
+                inode_id: dir,
+                inode_kind: InodeKind::Directory,
+                created_seq: ChangeSeq(1),
+            },
+            InodeRecord {
+                inode_id: InodeId(2),
+                inode_kind: InodeKind::File,
+                created_seq: ChangeSeq(2),
+            },
+        ],
+        vec![DirentryBindRecord {
+            parent_inode_id: dir,
+            name_key: "doc.txt".to_owned(),
+            display_name: "doc.txt".to_owned(),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(2),
+            bind_delta_index: 0,
+        }],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let view =
+        InMemoryMetadataView::in_memory(&state, None, ChangeSeq(2), NamePolicy::NfcCasefoldV0);
+    assert!(
+        visibility::resolve_in_memory_read(view.has_visible_children(dir))
+            .expect("probe bound child")
+    );
+    // The file inode is not a directory: probing it reports no children.
+    assert!(
+        !visibility::resolve_in_memory_read(view.has_visible_children(InodeId(2)))
+            .expect("probe non-directory")
+    );
+
+    let emptied = MetadataState::from_rows(
+        state.inodes().to_vec(),
+        state.direntry_binds().to_vec(),
+        vec![DirentryUnbindRecord {
+            parent_inode_id: dir,
+            name_key: "doc.txt".to_owned(),
+            child_inode_id: InodeId(2),
+            bind_seq: ChangeSeq(2),
+            bind_delta_index: 0,
+            unbind_seq: ChangeSeq(3),
+            unbind_delta_index: 0,
+        }],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let view =
+        InMemoryMetadataView::in_memory(&emptied, None, ChangeSeq(3), NamePolicy::NfcCasefoldV0);
+    assert!(
+        !visibility::resolve_in_memory_read(view.has_visible_children(dir))
+            .expect("probe emptied directory")
+    );
+}

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -237,31 +237,18 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         MetadataViewReads { view: *self }
     }
 
-    pub(crate) async fn visible_children(
+    /// Whether the directory currently has at least one visible child,
+    /// answered by a limit-1 page through a fresh session so the cost stays
+    /// bounded no matter how wide the directory is.
+    pub(crate) async fn has_visible_children(
         &self,
         parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let Some(parent) = self.visible_inode(parent_inode_id).await? else {
-            return Ok(Vec::new());
-        };
-        if parent.inode_kind != InodeKind::Directory {
-            return Ok(Vec::new());
-        }
-
-        let candidates = self.direntry_binds_for_parent(parent_inode_id).await?;
-        let mut reads = self.reads();
-        let mut children = Vec::new();
-        for direntry in candidates {
-            if visibility::is_visible_child_direntry(&mut reads, &direntry).await? {
-                children.push(direntry);
-            }
-        }
-        children.sort_by(|left, right| {
-            left.display_name
-                .cmp(&right.display_name)
-                .then(left.child_inode_id.0.cmp(&right.child_inode_id.0))
-        });
-        Ok(children)
+    ) -> Result<bool, CoreError> {
+        let mut session = self.session();
+        Ok(!session
+            .visible_children_page_by_name_key(parent_inode_id, None, 1)
+            .await?
+            .is_empty())
     }
 
     pub(crate) async fn resolve_visible_path(
@@ -501,49 +488,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             tombstones,
             self.visible_seq(),
         ))
-    }
-
-    async fn direntry_binds_for_parent(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<Vec<DirentryBindRecord>, CoreError> {
-        let durable = if let Some(cached) = self
-            .sources
-            .durable_cache
-            .and_then(|cache| cache.get(|inner| &mut inner.binds_for_parent, &parent_inode_id))
-        {
-            cached
-        } else {
-            let mut durable = if let Some(tables) = self.manifest_tables() {
-                manifest_index::direntry_binds_for_parent(tables, parent_inode_id).await?
-            } else {
-                Vec::new()
-            };
-            durable.extend(self.durable_row_states().flat_map(|state| {
-                state
-                    .direntry_binds()
-                    .iter()
-                    .filter(move |direntry| direntry.parent_inode_id == parent_inode_id)
-                    .cloned()
-            }));
-            if let Some(cache) = self.sources.durable_cache {
-                cache.insert(
-                    |inner| &mut inner.binds_for_parent,
-                    parent_inode_id,
-                    durable.clone(),
-                );
-            }
-            durable
-        };
-        let mut bindings = durable;
-        bindings.extend(self.overlay_state().into_iter().flat_map(|state| {
-            state
-                .direntry_binds()
-                .iter()
-                .filter(move |direntry| direntry.parent_inode_id == parent_inode_id)
-                .cloned()
-        }));
-        Ok(bindings)
     }
 
     async fn direntry_binds_for_parent_name(
@@ -1685,7 +1629,6 @@ pub(crate) struct DurableVisibilityCache {
 struct DurableVisibilityCacheInner {
     inodes: HashMap<InodeId, Option<InodeRecord>>,
     binds_for_parent_name: HashMap<ParentNameCacheKey, Vec<DirentryBindRecord>>,
-    binds_for_parent: HashMap<InodeId, Vec<DirentryBindRecord>>,
     binds_for_child: HashMap<InodeId, Vec<DirentryBindRecord>>,
     unbinds_for_binding: HashMap<BindingCacheKey, Vec<DirentryUnbindRecord>>,
     tombstones_for_root: HashMap<InodeId, Vec<SubtreeTombstoneRecord>>,

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -15,7 +15,7 @@
 //!   path — never to re-derive the rules.
 //! - The free functions ([`active_child_binding`],
 //!   [`current_parent_binding_for_child`], [`covering_subtree_tombstone`],
-//!   [`visible_inode`], [`visible_child`], [`is_visible_child_direntry`],
+//!   [`visible_inode`], [`visible_child`],
 //!   [`would_create_directory_cycle`], [`resolve_visible_path`]) are the
 //!   canonical rule bodies that both the provided trait methods and every
 //!   caching/gating override delegate to.
@@ -350,25 +350,6 @@ pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
 /// and its child inode is visible. Enumerating candidate rows is storage
 /// specific; deciding them is not. Callers must already have checked that
 /// the parent is a visible directory.
-pub(crate) async fn is_visible_child_direntry<R: MetadataVisibilityReads>(
-    reads: &mut R,
-    direntry: &DirentryBindRecord,
-) -> Result<bool, R::Error> {
-    let Some(active) = reads
-        .active_child_binding(direntry.parent_inode_id, &direntry.name_key)
-        .await?
-    else {
-        return Ok(false);
-    };
-    if !active.same_binding(direntry) {
-        return Ok(false);
-    }
-    Ok(reads
-        .visible_inode(direntry.child_inode_id)
-        .await?
-        .is_some())
-}
-
 /// Resolves `absolute_path` component by component through visible
 /// directories and visible child bindings, starting at the canonical root
 /// inode.

--- a/crates/loonfs-core/src/path/mod.rs
+++ b/crates/loonfs-core/src/path/mod.rs
@@ -1,7 +1,6 @@
 //! Path parsing, reading, and mutation planning over namespace metadata.
 
 pub(crate) mod helpers;
-pub(crate) mod query;
 pub(crate) mod read;
 pub(crate) mod write;
 

--- a/crates/loonfs-core/src/path/query.rs
+++ b/crates/loonfs-core/src/path/query.rs
@@ -1,4 +1,0 @@
-//! Re-exports the read-side view loading entry points under their
-//! query-path names.
-
-pub(crate) use super::read::{load_metadata_view, LoadedMetadataView, ReadLoadContext};

--- a/crates/loonfs-core/src/path/read/grep.rs
+++ b/crates/loonfs-core/src/path/read/grep.rs
@@ -38,6 +38,13 @@ pub(super) const GREP_LINE_CAP_BYTES: usize = 512;
 /// resume cursor, so a page's cost is bounded by its own budget rather
 /// than by how many false-positive candidates the plan admits.
 pub(super) const MAX_GREP_VERIFIED_FILES_PER_PAGE: usize = 256;
+/// Candidates one page will examine — visibility, latest revision, path
+/// derivation, scope — before returning with a resume cursor: the metadata
+/// twin of [`MAX_GREP_VERIFIED_FILES_PER_PAGE`], for pages where a scope
+/// filter rejects nearly every candidate. Rejected candidates move the
+/// cursor with them (see `fold_rejected_frontier`), so the next page
+/// continues past them instead of re-examining the same run.
+pub(super) const MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE: usize = 4096;
 /// Concurrent gram posting probes one grep query issues at a time: the
 /// (gram, segment) probes of an OR-set fan out in chunks of this size,
 /// each probe a handful of small ranged GETs (filter, index, and posting
@@ -136,6 +143,12 @@ pub(super) async fn indexed_candidates<S: ObjectStore + ?Sized>(
                 probes.push((gram_lookup, descriptor));
             }
         }
+        // This union is the query's peak memory: worst case one
+        // (inode, revision) pair per indexed revision when a gram is
+        // common to every file — 16 bytes a pair, on the order of 16 MiB
+        // per million indexed revisions. A streamed merge-intersection
+        // would trade that ceiling for probe-ordering complexity; not
+        // taken until a profile shows these unions dominating.
         let mut set_postings = BTreeSet::new();
         for chunk in probes.chunks(MAX_GREP_READ_IO) {
             let batches = try_join_all(chunk.iter().map(|(gram_lookup, descriptor)| {
@@ -386,9 +399,10 @@ pub(super) fn line_matches(content: &[u8], pattern: &regex::bytes::Regex) -> Vec
 /// bindings to the root, then verifies the derived path forward under the
 /// full visibility rules — tombstones, unbinds, kinds — by resolving it
 /// back to the same inode. `None` means the inode is not visible at the
-/// view's sequence.
+/// view's sequence. Runs over the page's session so candidates under the
+/// same directories share the ancestor lookups.
 pub(super) async fn derive_visible_path<S: ObjectStore + ?Sized>(
-    view: &crate::metadata::MetadataView<'_, '_, S>,
+    session: &mut crate::metadata::MetadataViewSession<'_, '_, S>,
     inode_id: InodeId,
 ) -> Result<Option<VisiblePathChain>> {
     const MAX_PATH_DEPTH: usize = 4096;
@@ -403,7 +417,7 @@ pub(super) async fn derive_visible_path<S: ObjectStore + ?Sized>(
         if segments.len() >= MAX_PATH_DEPTH {
             return Ok(None);
         }
-        let Some(binding) = view.current_parent_binding_for_child(current).await? else {
+        let Some(binding) = session.current_parent_binding_for_child(current).await? else {
             return Ok(None);
         };
         segments.push(binding.display_name.clone());
@@ -418,13 +432,32 @@ pub(super) async fn derive_visible_path<S: ObjectStore + ?Sized>(
         // path result; the file is unreachable by path and skipped.
         Err(_) => return Ok(None),
     };
-    match view.resolve_visible_path(&parsed).await {
+    match session.resolve_visible_path(&parsed, false).await {
         Ok(resolved) if resolved.inode_id == inode_id => {
             Ok(Some(VisiblePathChain { path, ancestors }))
         }
         Ok(_) => Ok(None),
         Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => Ok(None),
         Err(error) => Err(error),
+    }
+}
+
+/// Folds the page's highest examined-and-rejected candidate into the resume
+/// cursor on a budget exit. Sound only when every examined candidate is
+/// resolved — rejected, or scanned by a fully-walked batch — which the
+/// budget exits guarantee. Never sound on a mid-file page fill: there,
+/// later batch members were examined but their fetched contents discarded,
+/// and the cursor must stay at the last emitted match.
+pub(super) fn fold_rejected_frontier(
+    resume_cursor: &mut Option<(InodeId, u64)>,
+    rejected_frontier: Option<InodeId>,
+) {
+    let Some(frontier) = rejected_frontier else {
+        return;
+    };
+    let folded = (frontier, u64::MAX);
+    if resume_cursor.is_none_or(|cursor| cursor < folded) {
+        *resume_cursor = Some(folded);
     }
 }
 
@@ -655,5 +688,28 @@ mod tests {
             peak <= MAX_GREP_READ_IO,
             "the probe's fan-out must respect the grep read cap, got {peak}"
         );
+    }
+
+    /// Budget exits fold the highest rejection into the cursor so a run of
+    /// rejections longer than a page budget still advances the page.
+    #[test]
+    fn rejected_frontier_folds_forward_only() {
+        let mut cursor = None;
+        fold_rejected_frontier(&mut cursor, None);
+        assert_eq!(cursor, None);
+
+        fold_rejected_frontier(&mut cursor, Some(InodeId(9)));
+        assert_eq!(cursor, Some((InodeId(9), u64::MAX)));
+
+        // A frontier below the cursor never moves it backward.
+        cursor = Some((InodeId(12), 40));
+        fold_rejected_frontier(&mut cursor, Some(InodeId(9)));
+        assert_eq!(cursor, Some((InodeId(12), 40)));
+
+        // A frontier past the cursor finishes that inode and moves past it.
+        fold_rejected_frontier(&mut cursor, Some(InodeId(12)));
+        assert_eq!(cursor, Some((InodeId(12), u64::MAX)));
+        fold_rejected_frontier(&mut cursor, Some(InodeId(30)));
+        assert_eq!(cursor, Some((InodeId(30), u64::MAX)));
     }
 }

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -4,12 +4,15 @@ use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::ResolvedVisiblePath;
 use loonfs_api::{ChangeSeq, DirectoryPageCursor, InodeKind};
 
-pub(super) fn page_head_seq(
+/// A directory cursor is only honored at the head it was minted at: a cursor
+/// from the future is unanswerable, and a cursor from an older head would
+/// need a historical listing this view does not serve.
+pub(super) fn validate_cursor_head(
     current_head_seq: ChangeSeq,
     cursor: Option<&DirectoryPageCursor>,
-) -> Result<ChangeSeq> {
+) -> Result<()> {
     let Some(cursor) = cursor else {
-        return Ok(current_head_seq);
+        return Ok(());
     };
     if cursor.head_seq > current_head_seq {
         return Err(MetadataViewError::SnapshotUnavailable {
@@ -18,7 +21,14 @@ pub(super) fn page_head_seq(
         }
         .into());
     }
-    Ok(cursor.head_seq)
+    if cursor.head_seq < current_head_seq {
+        return Err(MetadataViewError::UnsupportedHistoricalRead {
+            requested_seq: cursor.head_seq,
+            head_seq: current_head_seq,
+        }
+        .into());
+    }
+    Ok(())
 }
 
 pub(super) fn validate_directory_cursor(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -6,7 +6,7 @@ use super::grep::{
     DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_CONTENT_IO, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
     MAX_GREP_TAIL_FILES, MAX_GREP_VERIFIED_FILES_PER_PAGE,
 };
-use super::listing::{invalid_cursor, page_head_seq, validate_directory_cursor};
+use super::listing::{invalid_cursor, validate_cursor_head, validate_directory_cursor};
 use crate::checkpoint::{
     head_from_manifest, load_verified_manifest_tables_with_cache, MetadataTableCache,
     VerifiedMetadataTables, WalTailProjectionCache, WalTailProjectionCacheKey,
@@ -885,14 +885,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         absolute_path: &str,
         request: PageRequest<DirectoryPageCursor>,
     ) -> Result<Page<AuthoritativePathEntry, DirectoryPageCursor>, CoreError> {
-        let page_head_seq = page_head_seq(self.head.seq, request.cursor.as_ref())?;
-        if page_head_seq != self.head.seq {
-            return Err(MetadataViewError::UnsupportedHistoricalRead {
-                requested_seq: page_head_seq,
-                head_seq: self.head.seq,
-            }
-            .into());
-        }
+        validate_cursor_head(self.head.seq, request.cursor.as_ref())?;
 
         let absolute_path = parse_absolute_path_for_core(absolute_path)?;
         let mut session = self.metadata_view().session();
@@ -951,7 +944,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 .last()
                 .expect("non-zero page limit with more children must return an item");
             Some(DirectoryPageCursor {
-                head_seq: page_head_seq,
+                head_seq: self.head.seq,
                 dir_inode_id: resolved.inode_id,
                 last_name_key: NameKey::parse(&last.binding.name_key).map_err(|error| {
                     CoreError::NamespaceCorrupt(format!("invalid stored name_key: {error}"))

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -2,8 +2,9 @@
 //! that answers every read — stat, list, revisions, content, grep.
 
 use super::grep::{
-    derive_visible_path, indexed_candidates, line_matches, tail_revisions, GrepCandidates,
-    DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_CONTENT_IO, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
+    derive_visible_path, fold_rejected_frontier, indexed_candidates, line_matches, tail_revisions,
+    GrepCandidates, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_CONTENT_IO,
+    MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
     MAX_GREP_TAIL_FILES, MAX_GREP_VERIFIED_FILES_PER_PAGE,
 };
 use super::listing::{invalid_cursor, validate_cursor_head, validate_directory_cursor};
@@ -398,7 +399,11 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .build()
             .map_err(|error| CoreError::InvalidQuery(error.to_string()))?;
 
-        let view = self.metadata_view();
+        // One view session serves the whole page: candidates in the same
+        // directory tree share ancestor bindings, tombstone checks, and
+        // path verifications, so the per-candidate metadata walks below hit
+        // the session caches instead of re-fetching per candidate.
+        let mut session = self.metadata_view().session();
         // The scope filter tests durable identity: resolve the prefix to
         // its inode once, then require it among each candidate's ancestors,
         // so name-policy folding and path normalization apply exactly as
@@ -407,7 +412,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let scope_root = match &request.path_prefix {
             Some(prefix) => {
                 let parsed = parse_absolute_path_for_core(prefix)?;
-                match view.resolve_visible_path(&parsed).await {
+                match session.resolve_visible_path(&parsed, false).await {
                     Ok(resolved) => Some(resolved.inode_id),
                     Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => {
                         return Ok(GrepResponse {
@@ -473,11 +478,18 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
 
         let mut matches: Vec<GrepMatch> = Vec::new();
         let mut verified_files = 0usize;
+        let mut examined_candidates = 0usize;
         let mut has_more = false;
         // Where the next page resumes when this one stops early: the last
         // candidate this page finished scanning (offset MAX), or the last
         // emitted match when the page filled mid-file.
         let mut resume_cursor: Option<(InodeId, u64)> = None;
+        // Highest candidate this page examined and rejected (invisible,
+        // superseded, or out of scope). A rejection is final for the page,
+        // so budget exits fold this into the cursor — without it, a run of
+        // rejections longer than a page budget would resume at the same
+        // cursor and re-reject the same candidates forever.
+        let mut rejected_frontier: Option<InodeId> = None;
         let ordered_candidates = candidates.inodes().collect::<Vec<_>>();
         let mut next_candidate = 0usize;
         'page: loop {
@@ -492,17 +504,36 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             let mut budget_exhausted = false;
             while next_candidate < ordered_candidates.len() {
                 let inode_id = ordered_candidates[next_candidate];
-                next_candidate += 1;
                 if let Some((last_inode, last_offset)) = resume {
                     if inode_id < last_inode || (inode_id == last_inode && last_offset == u64::MAX)
                     {
+                        next_candidate += 1;
                         continue;
                     }
                 }
-                let Some(revision) = view.latest_revision_head(inode_id).await? else {
+                // The examination budget bounds a page's metadata work the
+                // way the verified budget bounds its content work: a scope
+                // filter that rejects nearly every candidate would
+                // otherwise walk metadata for the entire candidate set in
+                // one page. The candidate at the boundary is left for the
+                // next page.
+                if examined_candidates == MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE {
+                    budget_exhausted = true;
+                    break;
+                }
+                next_candidate += 1;
+                examined_candidates += 1;
+                if session.visible_inode(inode_id).await?.is_none() {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                }
+                let Some(revision) = session.latest_revision_head_of_visible(inode_id).await?
+                else {
+                    rejected_frontier = Some(inode_id);
                     continue;
                 };
                 if !candidates.admits(inode_id, revision.revision_no) {
+                    rejected_frontier = Some(inode_id);
                     continue;
                 }
                 // With the tail skipped (`allow_stale`), serve the index's
@@ -512,13 +543,16 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 // — a mix of two snapshots rather than a stale-but-
                 // consistent one.
                 if !tail_scanned && revision.committed_seq > feature.built_through_seq {
+                    rejected_frontier = Some(inode_id);
                     continue;
                 }
-                let Some(chain) = derive_visible_path(&view, inode_id).await? else {
+                let Some(chain) = derive_visible_path(&mut session, inode_id).await? else {
+                    rejected_frontier = Some(inode_id);
                     continue;
                 };
                 if let Some(scope_root) = scope_root {
                     if !chain.ancestors.contains(&scope_root) {
+                        rejected_frontier = Some(inode_id);
                         continue;
                     }
                 }
@@ -550,6 +584,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             if batch.is_empty() {
                 if budget_exhausted {
                     has_more = true;
+                    fold_rejected_frontier(&mut resume_cursor, rejected_frontier);
                 }
                 break 'page;
             }
@@ -623,6 +658,10 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             }
             if budget_exhausted {
                 has_more = true;
+                // The whole final batch was scanned, so every examined
+                // candidate is resolved; rejections past the last scanned
+                // file move the cursor with them.
+                fold_rejected_frontier(&mut resume_cursor, rejected_frontier);
                 break 'page;
             }
         }

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -601,11 +601,11 @@ async fn plan_publish_delete_path<S: ObjectStore + ?Sized>(
             root_inode_id: resolved.inode_id,
         },
         InodeKind::Directory => {
-            let children = view
+            if view
                 .metadata_state
-                .visible_children(resolved.inode_id)
-                .await?;
-            if !children.is_empty() {
+                .has_visible_children(resolved.inode_id)
+                .await?
+            {
                 return Err(CoreError::DirectoryNotEmpty(
                     absolute_path.as_str().to_owned(),
                 ));

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -5,7 +5,7 @@ use super::intent::PathMutationIntent;
 use super::planner::{plan_path_mutation_against_publish_view, PlannedPathMutation};
 use crate::commit::CommitPlan;
 use crate::error::CoreError;
-use crate::metadata::{DurableVisibilityCache, MetadataApplyError, MetadataState, MetadataView};
+use crate::metadata::{DurableVisibilityCache, MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
 #[cfg(test)]
@@ -63,15 +63,10 @@ impl PublishPlanningSession {
 
     /// Folds an accepted commit into the session so later candidates in the
     /// same batch plan and validate against it.
-    pub(crate) fn apply_accepted_commit(
-        &mut self,
-        preview: &WalCommitPayload,
-        plan: &CommitPlan,
-    ) -> Result<(), MetadataApplyError> {
-        self.accepted_rows.apply_committed_wal_record_mut(preview)?;
+    pub(crate) fn apply_accepted_commit(&mut self, preview: &WalCommitPayload, plan: &CommitPlan) {
+        self.accepted_rows.apply_committed_wal_record_mut(preview);
         self.head.seq = plan.assigned_seq;
         self.head.next_inode_id = plan.resulting_next_inode_id;
-        Ok(())
     }
 }
 

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -216,15 +216,12 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                     }
                 }
             };
-            let applied = {
+            {
                 let _span = tracing::info_span!("loon.phase", phase = "apply_committed_wal_record")
                     .entered();
-                session.apply_accepted_commit(&preview, &plan)
-            };
-            match applied {
-                Ok(()) => accepted.push((index, materialized)),
-                Err(error) => outcomes[index] = Some(Err(error.into())),
+                session.apply_accepted_commit(&preview, &plan);
             }
+            accepted.push((index, materialized));
         }
     }
     .instrument(prepare_span.clone())

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -2,7 +2,6 @@
 //! replay paths.
 
 use crate::invariants::InvariantId;
-use crate::metadata::MetadataApplyError;
 use loonfs_api::wire::control::{HeadState, WalSegmentPointer};
 use loonfs_api::wire::wal::{WalCommitDelta, WalCommitPayload, WalSegmentEnvelope};
 use loonfs_api::{ChangeSeq, CommitId, NamespaceId, WalSegmentId, WriterEpoch};
@@ -228,8 +227,6 @@ pub enum WalReplayError {
     EmptySegment,
     #[error("WAL segment summary does not match its records")]
     SegmentSummaryMismatch,
-    #[error(transparent)]
-    MetadataApply(#[from] MetadataApplyError),
     #[error("sequence counter overflow")]
     SeqOverflow,
 }

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -50,16 +50,14 @@ where
         current_head.head_commit_id = record.commit_id.clone();
         current_head.next_inode_id =
             replay_next_inode_id_from_commit_deltas(current_head.next_inode_id, &record.deltas);
-        let apply_invariants = current_metadata_state
-            .apply_committed_wal_record_parts_mut(
-                record.seq,
-                record.committed_at_ms,
-                record.commit_id,
-                record.semantic_commit_fingerprint,
-                record.message,
-                &record.deltas,
-            )
-            .map_err(WalReplayError::MetadataApply)?;
+        let apply_invariants = current_metadata_state.apply_committed_wal_record_parts_mut(
+            record.seq,
+            record.committed_at_ms,
+            record.commit_id,
+            record.semantic_commit_fingerprint,
+            record.message,
+            &record.deltas,
+        );
         push_invariant(
             &mut checked_invariants,
             InvariantId::WalReplayAppliesMetadataRows,

--- a/crates/loonfs-core/tests/differential.rs
+++ b/crates/loonfs-core/tests/differential.rs
@@ -137,13 +137,10 @@ fn metadata_apply_matches_model_for_basic_commit_sequence() {
 
     let core_state = core_state
         .apply_committed_wal_deltas(ChangeSeq(1), 4_200, &create_directory)
-        .expect("core applies create-dir delta")
         .metadata_state
         .apply_committed_wal_deltas(ChangeSeq(2), 4_200, &create_file)
-        .expect("core applies create-file deltas")
         .metadata_state
         .apply_committed_wal_deltas(ChangeSeq(3), 4_200, &replace_file)
-        .expect("core applies replace-file delta")
         .metadata_state;
 
     let model_state = model_state
@@ -238,7 +235,6 @@ fn core_bootstrap_state() -> CoreMetadataState {
                 inode_kind: InodeKind::Directory,
             }],
         )
-        .expect("bootstrap core root")
         .metadata_state
 }
 
@@ -254,7 +250,6 @@ fn assert_states_match(sequences: &[Vec<WalDelta>]) {
         let seq = ChangeSeq(u64::try_from(index + 1).expect("seq"));
         core_state = core_state
             .apply_committed_wal_deltas(seq, 4_200, deltas)
-            .expect("core apply")
             .metadata_state;
         model_state = model_state
             .apply_committed_wal_deltas(seq, deltas)

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -1193,10 +1193,8 @@ async fn restore_revision_overflow_is_rejected() {
                 inode_kind: InodeKind::Directory,
             }],
         )
-        .expect("bootstrap root")
         .metadata_state
         .apply_committed_wal_deltas(ChangeSeq(1), 4_200, &deltas)
-        .expect("create max revision")
         .metadata_state;
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
@@ -5145,7 +5143,6 @@ fn metadata_state_after(sequences: &[Vec<WalDelta>]) -> MetadataState {
                 inode_kind: InodeKind::Directory,
             }],
         )
-        .expect("bootstrap root")
         .metadata_state;
 
     for (index, deltas) in sequences.iter().enumerate() {
@@ -5155,7 +5152,6 @@ fn metadata_state_after(sequences: &[Vec<WalDelta>]) -> MetadataState {
                 4_200,
                 deltas,
             )
-            .expect("apply deltas")
             .metadata_state;
     }
 

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -51,6 +51,10 @@ pub(crate) struct BackgroundWork {
 struct BackgroundState {
     closed: bool,
     inflight: BTreeSet<NamespaceId>,
+    /// Full maintenance requested while an index-only tick already owns the
+    /// namespace's singleflight slot. The owner consumes this before it
+    /// releases the slot, so crossing the WAL threshold is never lost.
+    pending_full_ticks: BTreeSet<NamespaceId>,
     tasks: Vec<JoinHandle<()>>,
 }
 
@@ -69,6 +73,7 @@ impl BackgroundWork {
             state: Mutex::new(BackgroundState {
                 closed: false,
                 inflight: BTreeSet::new(),
+                pending_full_ticks: BTreeSet::new(),
                 tasks: Vec::new(),
             }),
         }
@@ -78,10 +83,12 @@ impl BackgroundWork {
         self.state.lock().expect("background state lock poisoned")
     }
 
-    /// Claims the namespace's singleflight slot. Returns false when the
-    /// policy, a shutdown, the global concurrency cap, or an already
-    /// in-flight tick for the namespace forbids scheduling another.
-    pub(crate) fn try_claim(&self, namespace_id: &NamespaceId) -> bool {
+    /// Claims the namespace's singleflight slot. A full tick rejected by an
+    /// existing tick is deferred to that owner; cheaper index-only work can
+    /// be subsumed by the owner's own index drain.
+    ///
+    /// Returns true only when the caller must spawn a new task.
+    pub(crate) fn try_claim(&self, namespace_id: &NamespaceId, full_tick: bool) -> bool {
         if self.policy != FsBackgroundWork::Enabled {
             return false;
         }
@@ -89,7 +96,13 @@ impl BackgroundWork {
         if state.closed {
             return false;
         }
-        if state.inflight.len() >= self.max_concurrent && !state.inflight.contains(namespace_id) {
+        if state.inflight.contains(namespace_id) {
+            if full_tick {
+                state.pending_full_ticks.insert(namespace_id.clone());
+            }
+            return false;
+        }
+        if state.inflight.len() >= self.max_concurrent {
             tracing::debug!(
                 namespace_id = %namespace_id,
                 max_concurrent = self.max_concurrent,
@@ -101,9 +114,25 @@ impl BackgroundWork {
         state.inflight.insert(namespace_id.clone())
     }
 
+    /// Completes one tick while holding the namespace claim. Returns true
+    /// when a full tick arrived behind it and must run before release.
+    /// Testing and releasing happen under one lock so a threshold crossing
+    /// cannot land between those decisions and be stranded without an owner.
+    pub(crate) fn finish_tick(&self, namespace_id: &NamespaceId) -> bool {
+        let mut state = self.lock_state();
+        if state.pending_full_ticks.remove(namespace_id) {
+            true
+        } else {
+            state.inflight.remove(namespace_id);
+            false
+        }
+    }
+
     /// Releases a namespace's singleflight slot.
     pub(crate) fn release(&self, namespace_id: &NamespaceId) {
-        self.lock_state().inflight.remove(namespace_id);
+        let mut state = self.lock_state();
+        state.inflight.remove(namespace_id);
+        state.pending_full_ticks.remove(namespace_id);
     }
 
     /// Rejects any further background scheduling.
@@ -194,7 +223,7 @@ mod tests {
         let namespace_id = namespace_id();
 
         // The racy interleaving a shutdown must win: the claim lands first...
-        assert!(background.try_claim(&namespace_id));
+        assert!(background.try_claim(&namespace_id, false));
         // ...then a close (shut_down + drain) completes while the registry
         // is still empty...
         background.shut_down();
@@ -257,28 +286,53 @@ mod tests {
     async fn claims_are_singleflight_and_refused_after_shut_down() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
         let namespace_id = namespace_id();
-        assert!(background.try_claim(&namespace_id));
+        assert!(background.try_claim(&namespace_id, false));
         assert!(
-            !background.try_claim(&namespace_id),
+            !background.try_claim(&namespace_id, false),
             "one in-flight tick per namespace"
         );
         background.release(&namespace_id);
         assert!(
-            background.try_claim(&namespace_id),
+            background.try_claim(&namespace_id, false),
             "a released slot is claimable again"
         );
         background.release(&namespace_id);
         background.shut_down();
         assert!(
-            !background.try_claim(&namespace_id),
+            !background.try_claim(&namespace_id, false),
             "no new claims after shutdown"
         );
     }
 
     #[tokio::test]
+    async fn a_full_tick_is_deferred_behind_an_index_only_tick() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let namespace_id = namespace_id();
+
+        assert!(background.try_claim(&namespace_id, false));
+        assert!(
+            !background.try_claim(&namespace_id, true),
+            "the existing owner keeps the singleflight slot"
+        );
+        assert!(
+            background.finish_tick(&namespace_id),
+            "the owner is promoted to the deferred full tick"
+        );
+        assert!(
+            !background.try_claim(&namespace_id, false),
+            "the promoted owner keeps the slot"
+        );
+        assert!(
+            !background.finish_tick(&namespace_id),
+            "the slot is released after the deferred tick"
+        );
+        assert!(background.try_claim(&namespace_id, false));
+    }
+
+    #[tokio::test]
     async fn manual_only_policy_never_claims() {
         let background = BackgroundWork::new(FsBackgroundWork::ManualOnly, None, 8);
-        assert!(!background.try_claim(&namespace_id()));
+        assert!(!background.try_claim(&namespace_id(), false));
     }
 
     #[tokio::test]
@@ -288,16 +342,16 @@ mod tests {
         let second = NamespaceId::parse("second").expect("valid namespace id");
         let third = NamespaceId::parse("third").expect("valid namespace id");
 
-        assert!(background.try_claim(&first));
-        assert!(background.try_claim(&second));
+        assert!(background.try_claim(&first, false));
+        assert!(background.try_claim(&second, false));
         assert!(
-            !background.try_claim(&third),
+            !background.try_claim(&third, false),
             "a third namespace must wait for a slot"
         );
 
         background.release(&first);
         assert!(
-            background.try_claim(&third),
+            background.try_claim(&third, false),
             "a released slot admits the waiting namespace"
         );
     }
@@ -306,7 +360,7 @@ mod tests {
     async fn a_zero_cap_is_normalized_to_one_slot() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 0);
         assert!(
-            background.try_claim(&namespace_id()),
+            background.try_claim(&namespace_id(), false),
             "the policy, not the cap, is the off switch"
         );
     }

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -1525,54 +1525,49 @@ impl FsCore {
         if !run_full_tick && !index_may_lag {
             return;
         }
-        if !self.inner.background.try_claim(namespace_id) {
+        if !self.inner.background.try_claim(namespace_id, run_full_tick) {
             return;
         }
-        let claim = BackgroundTickClaim {
+        let mut claim = BackgroundTickClaim {
             fs: self.clone(),
             namespace_id: namespace_id.clone(),
+            releases_on_drop: true,
         };
         self.inner.background.spawn(async move {
-            let tick = if run_full_tick {
-                claim
+            let mut run_full_tick = run_full_tick;
+            loop {
+                if let Err(error) = claim
                     .fs
-                    .maintenance_tick_namespace(&claim.namespace_id, options)
+                    .run_auto_maintenance(&claim.namespace_id, options, run_full_tick)
                     .await
-                    .map(|_| ())
-            } else {
-                Ok(())
-            };
-            let drained = match tick {
-                Ok(()) => {
-                    let folds = if run_full_tick {
-                        claim
-                            .fs
-                            .drain_reorganization_backlog(&claim.namespace_id)
-                            .await
-                    } else {
-                        Ok(())
-                    };
-                    match folds {
-                        Ok(()) => {
-                            claim
-                                .fs
-                                .drain_grams_index_backlog(&claim.namespace_id)
-                                .await
-                        }
-                        Err(error) => Err(error),
-                    }
+                {
+                    tracing::info!(
+                        phase = "auto_maintenance_tick",
+                        result = "error",
+                        error = %error,
+                        "post-publish maintenance tick failed"
+                    );
                 }
-                Err(error) => Err(error),
-            };
-            if let Err(error) = drained {
-                tracing::info!(
-                    phase = "auto_maintenance_tick",
-                    result = "error",
-                    error = %error,
-                    "post-publish maintenance tick failed"
-                );
+                if !claim.finish_tick() {
+                    break;
+                }
+                run_full_tick = true;
             }
         });
+    }
+
+    async fn run_auto_maintenance(
+        &self,
+        namespace_id: &NamespaceId,
+        options: MaintenanceTickOptions,
+        run_full_tick: bool,
+    ) -> Result<()> {
+        if run_full_tick {
+            self.maintenance_tick_namespace(namespace_id, options)
+                .await?;
+            self.drain_reorganization_backlog(namespace_id).await?;
+        }
+        self.drain_grams_index_backlog(namespace_id).await
     }
 
     /// Waits until every scheduled background maintenance tick has finished.
@@ -1741,11 +1736,25 @@ impl FsCore {
 struct BackgroundTickClaim {
     fs: FsCore,
     namespace_id: NamespaceId,
+    releases_on_drop: bool,
+}
+
+impl BackgroundTickClaim {
+    fn finish_tick(&mut self) -> bool {
+        // Disarm before releasing the slot so a new owner cannot claim it
+        // and then be accidentally released by this guard's later drop.
+        self.releases_on_drop = false;
+        let run_deferred_full_tick = self.fs.inner.background.finish_tick(&self.namespace_id);
+        self.releases_on_drop = run_deferred_full_tick;
+        run_deferred_full_tick
+    }
 }
 
 impl Drop for BackgroundTickClaim {
     fn drop(&mut self) {
-        self.fs.inner.background.release(&self.namespace_id);
+        if self.releases_on_drop {
+            self.fs.inner.background.release(&self.namespace_id);
+        }
     }
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1005,7 +1005,22 @@ than its limit and still carry a cursor. Each page is evaluated against
 the namespace head at page time and reports it in `head_seq`; the cursor
 resumes strictly after the last candidate the issuing page finished
 scanning and is bound to that request — replaying it with different
-criteria is rejected as `invalid_request`. A pattern with no required
+criteria is rejected as `invalid_request`.
+
+Grep cursors deliberately tolerate head drift, unlike directory listing
+cursors (section 5), which are bound to the head that minted them and must
+re-bootstrap after any commit. A grep cursor minted at an older head is
+accepted, and the resumed page evaluates at the then-current head and
+reports it: each page is internally consistent at its own head, but a
+multi-page search spans whatever heads its pages ran at, and candidates
+the cursor has passed are not revisited even if later commits changed
+them. A search is a bounded sampling read over content, not an
+enumeration contract; a client that needs one consistent cut across pages
+re-issues the search when `head_seq` changes between pages. A cursor from
+a head newer than the serving view's is still rejected
+(`snapshot_unavailable`) — drift tolerance runs forward, never backward.
+
+A pattern with no required
 literal bytes is rejected with `query_unindexable` unless `allow_scan`
 opts into a capped exhaustive scan. A tail past the scan budget is
 rejected with `index_lagging` unless `allow_stale` accepts indexed-only


### PR DESCRIPTION
Three grep-page disciplines, plus the spec paragraph that makes the cursor's drift behavior a documented contract instead of an accident.

- One view session per page. The candidate walk ran its metadata lookups (visibility, latest revision, ancestor-chain path derivation, forward path verification) on the bare view, refetching shared ancestors for every candidate. The page now opens a single session and routes the scope-prefix resolution, the visibility gate, the revision lookup, and derive_visible_path through its caches — candidates under the same directories share those lookups. Semantics are unchanged: the session methods delegate to the same visibility rules.
- Examination budget. Only verified (content-read) candidates were budgeted; a scope filter rejecting nearly everything let one page walk metadata for the entire candidate set. A page now examines at most 4096 candidates (MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE) before returning a cursor, the metadata twin of the 256-file verification budget.
- Rejections advance the cursor on budget exits. This is what makes the examination budget sound: the page's highest examined-and-rejected candidate folds into the resume cursor (fold_rejected_frontier, unit-tested), so a run of rejections longer than a page budget resumes past them instead of re-examining the same run forever. The fold is applied only on budget exits, where every examined candidate is fully resolved — never on a mid-file page fill, where later batch members' fetched contents are discarded and the cursor must stay at the last emitted match.
- api.md now states the grep cursor drift contract (approved decision): a cursor from an older head is accepted and the resumed page evaluates at the current head — each page internally consistent, a multi-page search spanning the heads its pages ran at — deliberately unlike directory listing cursors, which stay head-bound and re-bootstrap. Forward-only: cursors from a newer head still answer snapshot_unavailable.
- The gram AND-set union gets its deferred-decision bound comment: peak memory is one (inode, revision) pair per indexed revision worst case (roughly 16 MiB per million revisions); a streamed merge-intersection is named as the replacement if profiles ever show these unions dominating.