### PR TITLE
refactor(api,core): name keys are typed NameKey from wire to record

### DIFF
--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -5,8 +5,8 @@ use crate::control::WalSegmentPointer;
 use crate::digest::sha256_digest;
 use crate::envelope::EnvelopeProbe;
 use crate::{
-    ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo, WalSegmentId,
-    WriterEpoch,
+    ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo,
+    WalSegmentId, WriterEpoch,
 };
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
@@ -43,14 +43,14 @@ pub enum WalDelta {
     BindDirentry {
         delta_index: u32,
         parent_inode_id: InodeId,
-        name_key: String,
+        name_key: NameKey,
         display_name: String,
         child_inode_id: InodeId,
     },
     UnbindDirentry {
         delta_index: u32,
         parent_inode_id: InodeId,
-        name_key: String,
+        name_key: NameKey,
         child_inode_id: InodeId,
         bind_seq: ChangeSeq,
         bind_delta_index: u32,

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -159,7 +159,7 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             delta: WalDelta::BindDirentry {
                 delta_index: 1,
                 parent_inode_id: InodeId(1),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 display_name: "Docs".to_owned(),
                 child_inode_id: InodeId(7),
             },
@@ -169,7 +169,7 @@ fn sample_wal_envelope() -> WalSegmentEnvelope {
             delta: WalDelta::UnbindDirentry {
                 delta_index: 2,
                 parent_inode_id: InodeId(1),
-                name_key: "old.txt".to_owned(),
+                name_key: NameKey::parse("old.txt").expect("valid name key"),
                 child_inode_id: InodeId(5),
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 0,
@@ -581,6 +581,33 @@ fn with_cbor_document_entry(
 }
 
 #[test]
+fn wal_delta_decode_rejects_invalid_name_key() {
+    // The WAL delta's `name_key` field is a typed `NameKey`, so the wire
+    // decode boundary is where malformed keys are rejected — nothing
+    // downstream re-validates. Encode a valid bind delta, corrupt the key
+    // in the CBOR map, and require the decode to fail.
+    let valid = WalDelta::BindDirentry {
+        delta_index: 0,
+        parent_inode_id: InodeId(1),
+        name_key: name_key("docs"),
+        display_name: "Docs".to_owned(),
+        child_inode_id: InodeId(2),
+    };
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(&valid, &mut encoded).expect("encode delta");
+    let corrupted = with_cbor_document_entry(&encoded, "name_key", |value| {
+        *value = ciborium::Value::from("bad/key");
+    });
+
+    ciborium::de::from_reader::<WalDelta, _>(corrupted.as_slice())
+        .expect_err("invalid name key must fail wire decode");
+
+    let round_tripped: WalDelta =
+        ciborium::de::from_reader(encoded.as_slice()).expect("valid delta round-trips");
+    assert_eq!(round_tripped, valid);
+}
+
+#[test]
 fn wal_decode_rejects_future_format_version_cleanly() {
     let document = unzstd(&encode_wal_segment_envelope_zstd(&sample_wal_envelope()).expect("wal"));
     let bumped = with_cbor_document_entry(&document, "format_version", |value| {
@@ -778,7 +805,7 @@ fn wal_delta_wire_tags_match_spec_names() {
             serde_json::to_value(WalDelta::BindDirentry {
                 delta_index: 0,
                 parent_inode_id: InodeId(1),
-                name_key: "a".to_owned(),
+                name_key: NameKey::parse("a").expect("valid name key"),
                 display_name: "a".to_owned(),
                 child_inode_id: InodeId(2),
             }),
@@ -788,7 +815,7 @@ fn wal_delta_wire_tags_match_spec_names() {
             serde_json::to_value(WalDelta::UnbindDirentry {
                 delta_index: 0,
                 parent_inode_id: InodeId(1),
-                name_key: "a".to_owned(),
+                name_key: NameKey::parse("a").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 0,

--- a/crates/loonfs-core/src/checkpoint/row.rs
+++ b/crates/loonfs-core/src/checkpoint/row.rs
@@ -1,7 +1,7 @@
 //! Converts in-memory metadata state into manifest rows, per family and in
 //! row-key order.
 
-use crate::metadata::{record_name_key, MetadataState};
+use crate::metadata::MetadataState;
 use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
 use loonfs_api::ChangeSeq;
 
@@ -52,7 +52,7 @@ pub(super) fn manifest_rows_for_family(
                 .iter()
                 .map(|direntry| MetadataRow::DirentryBind {
                     parent_inode_id: direntry.parent_inode_id,
-                    name_key: record_name_key(&direntry.name_key),
+                    name_key: direntry.name_key.clone(),
                     display_name: direntry.display_name.clone(),
                     child_inode_id: direntry.child_inode_id,
                     bind_seq: direntry.bind_seq,
@@ -65,7 +65,7 @@ pub(super) fn manifest_rows_for_family(
             .iter()
             .map(|unbind| MetadataRow::DirentryUnbind {
                 parent_inode_id: unbind.parent_inode_id,
-                name_key: record_name_key(&unbind.name_key),
+                name_key: unbind.name_key.clone(),
                 child_inode_id: unbind.child_inode_id,
                 bind_seq: unbind.bind_seq,
                 bind_delta_index: unbind.bind_delta_index,

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -4228,11 +4228,13 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         .metadata_state
         .direntry_binds()
         .iter()
-        .find(|binding| binding.name_key == "x.txt")
+        .find(|binding| binding.name_key.as_str() == "x.txt")
         .expect("binding for x.txt")
         .clone();
-    let prefix = lookup_keys::direntry_bind_prefix(binding.parent_inode_id, &binding.name_key);
-    let probe = lookup_keys::direntry_bind_probe(binding.parent_inode_id, &binding.name_key);
+    let prefix =
+        lookup_keys::direntry_bind_prefix(binding.parent_inode_id, binding.name_key.as_str());
+    let probe =
+        lookup_keys::direntry_bind_probe(binding.parent_inode_id, binding.name_key.as_str());
 
     store.reset_metadata_sst_gets();
     let rows = tables

--- a/crates/loonfs-core/src/commit/durable_adapter.rs
+++ b/crates/loonfs-core/src/commit/durable_adapter.rs
@@ -38,7 +38,7 @@ mod tests {
     use crate::commit::{
         materialize_commit, CommitOp, CommitPlan, CommitRequest, PreparedCommit, ValidatedOp,
     };
-    use loonfs_api::{ChangeSeq, CommitId, InodeId, NamespaceId, WriterEpoch};
+    use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WriterEpoch};
 
     #[test]
     fn durable_adapter_builds_expected_wal_payload() {
@@ -65,7 +65,7 @@ mod tests {
                 op_index: 0,
                 parent_inode_id: InodeId(1),
                 display_name: "docs".to_owned(),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 create_inode_delta_index: 0,
                 bind_delta_index: 1,

--- a/crates/loonfs-core/src/commit/metadata_overlay.rs
+++ b/crates/loonfs-core/src/commit/metadata_overlay.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::commit::ResolvedBinding;
     use loonfs_api::wire::wal::WalDelta;
-    use loonfs_api::{ContentRef, ContentRefKind, InodeId, RevisionNo};
+    use loonfs_api::{ContentRef, ContentRefKind, InodeId, NameKey, RevisionNo};
 
     /// The commit overlay derives its rows from the WAL encoding
     /// (`materialize_validated_op` + `apply_committed_wal_delta_mut`), the
@@ -146,7 +146,7 @@ mod tests {
     ) -> ResolvedBinding {
         ResolvedBinding {
             parent_inode_id: InodeId(parent),
-            name_key: name_key.to_owned(),
+            name_key: NameKey::parse(name_key).expect("valid name key"),
             display_name: display_name.to_owned(),
             child_inode_id: InodeId(child),
             bind_seq: ChangeSeq(bind_seq),
@@ -162,7 +162,7 @@ mod tests {
                 op_index: 0,
                 parent_inode_id: InodeId(1),
                 display_name: "Docs".to_owned(),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 create_inode_delta_index: 0,
                 bind_delta_index: 1,
@@ -178,7 +178,7 @@ mod tests {
                 op_index: 0,
                 parent_inode_id: InodeId(1),
                 display_name: "Note.TXT".to_owned(),
-                name_key: "note.txt".to_owned(),
+                name_key: NameKey::parse("note.txt").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 content_ref: content_ref(1),
                 create_inode_delta_index: 0,
@@ -241,7 +241,7 @@ mod tests {
                 source_binding: binding(2, "old.txt", "Old.TXT", 4, 11, 2),
                 new_parent_inode_id: InodeId(3),
                 new_display_name: "New.TXT".to_owned(),
-                new_name_key: "new.txt".to_owned(),
+                new_name_key: NameKey::parse("new.txt").expect("valid name key"),
                 unbind_delta_index: 0,
                 bind_delta_index: 1,
             }],
@@ -261,7 +261,7 @@ mod tests {
                     op_index: 0,
                     parent_inode_id: InodeId(1),
                     display_name: "Draft.md".to_owned(),
-                    name_key: "draft.md".to_owned(),
+                    name_key: NameKey::parse("draft.md").expect("valid name key"),
                     child_inode_id: InodeId(2),
                     content_ref: content_ref(4),
                     create_inode_delta_index: 0,
@@ -274,7 +274,7 @@ mod tests {
                     source_binding: binding(1, "draft.md", "Draft.md", 2, committed_seq.0, 1),
                     new_parent_inode_id: InodeId(1),
                     new_display_name: "Final.md".to_owned(),
-                    new_name_key: "final.md".to_owned(),
+                    new_name_key: NameKey::parse("final.md").expect("valid name key"),
                     unbind_delta_index: 3,
                     bind_delta_index: 4,
                 },
@@ -311,7 +311,7 @@ mod tests {
                     op_index: 0,
                     parent_inode_id: InodeId(1),
                     display_name: "Docs".to_owned(),
-                    name_key: "docs".to_owned(),
+                    name_key: NameKey::parse("docs").expect("valid name key"),
                     child_inode_id: InodeId(2),
                     create_inode_delta_index: 0,
                     bind_delta_index: 1,
@@ -320,7 +320,7 @@ mod tests {
                     op_index: 1,
                     parent_inode_id: InodeId(2),
                     display_name: "Note.txt".to_owned(),
-                    name_key: "note.txt".to_owned(),
+                    name_key: NameKey::parse("note.txt").expect("valid name key"),
                     child_inode_id: InodeId(3),
                     content_ref: content_ref(5),
                     create_inode_delta_index: 2,
@@ -340,7 +340,7 @@ mod tests {
                     source_binding: binding(2, "note.txt", "Note.txt", 3, committed_seq.0, 3),
                     new_parent_inode_id: InodeId(2),
                     new_display_name: "Renamed.txt".to_owned(),
-                    new_name_key: "renamed.txt".to_owned(),
+                    new_name_key: NameKey::parse("renamed.txt").expect("valid name key"),
                     unbind_delta_index: 6,
                     bind_delta_index: 7,
                 },
@@ -382,7 +382,7 @@ mod tests {
                 op_index: 0,
                 parent_inode_id: InodeId(1),
                 display_name: "a".to_owned(),
-                name_key: "a".to_owned(),
+                name_key: NameKey::parse("a").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 create_inode_delta_index: 0,
                 bind_delta_index: 1,
@@ -391,7 +391,7 @@ mod tests {
                 op_index: 1,
                 parent_inode_id: InodeId(2),
                 display_name: "f".to_owned(),
-                name_key: "f".to_owned(),
+                name_key: NameKey::parse("f").expect("valid name key"),
                 child_inode_id: InodeId(3),
                 content_ref: content_ref(7),
                 create_inode_delta_index: 2,
@@ -413,7 +413,7 @@ mod tests {
                 source_binding: binding(2, "f", "f", 3, first_seq.0, 3),
                 new_parent_inode_id: InodeId(1),
                 new_display_name: "f2".to_owned(),
-                new_name_key: "f2".to_owned(),
+                new_name_key: NameKey::parse("f2").expect("valid name key"),
                 unbind_delta_index: 1,
                 bind_delta_index: 2,
             },

--- a/crates/loonfs-core/src/commit/plan.rs
+++ b/crates/loonfs-core/src/commit/plan.rs
@@ -5,7 +5,9 @@ use super::ResolvedBinding;
 use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::{ChangeSeq, CommitId, ContentRef, InodeId, NamePolicy, NamespaceId, RevisionNo};
+use loonfs_api::{
+    ChangeSeq, CommitId, ContentRef, InodeId, NameKey, NamePolicy, NamespaceId, RevisionNo,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,7 +27,7 @@ pub(crate) enum ValidatedOp {
         op_index: u32,
         parent_inode_id: InodeId,
         display_name: String,
-        name_key: String,
+        name_key: NameKey,
         child_inode_id: InodeId,
         create_inode_delta_index: u32,
         bind_delta_index: u32,
@@ -34,7 +36,7 @@ pub(crate) enum ValidatedOp {
         op_index: u32,
         parent_inode_id: InodeId,
         display_name: String,
-        name_key: String,
+        name_key: NameKey,
         child_inode_id: InodeId,
         content_ref: ContentRef,
         create_inode_delta_index: u32,
@@ -69,7 +71,7 @@ pub(crate) enum ValidatedOp {
         source_binding: ResolvedBinding,
         new_parent_inode_id: InodeId,
         new_display_name: String,
-        new_name_key: String,
+        new_name_key: NameKey,
         unbind_delta_index: u32,
         bind_delta_index: u32,
     },
@@ -85,7 +87,7 @@ pub(crate) enum ValidatedOp {
         inode_id: InodeId,
         parent_inode_id: InodeId,
         display_name: String,
-        name_key: String,
+        name_key: NameKey,
         /// The exact deletion generation validation resolved and pinned:
         /// the active tombstone's own event coordinates.
         target_seq: ChangeSeq,

--- a/crates/loonfs-core/src/commit/precondition.rs
+++ b/crates/loonfs-core/src/commit/precondition.rs
@@ -1,6 +1,6 @@
 //! [`Precondition`]: the core form of one commit precondition.
 
-use loonfs_api::{ChangeSeq, InodeId, RevisionNo};
+use loonfs_api::{ChangeSeq, InodeId, NameKey, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 /// Core form of a commit precondition.
@@ -40,7 +40,7 @@ pub enum Precondition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolvedBinding {
     pub parent_inode_id: InodeId,
-    pub name_key: String,
+    pub name_key: NameKey,
     pub display_name: String,
     pub child_inode_id: InodeId,
     pub bind_seq: ChangeSeq,

--- a/crates/loonfs-core/src/commit/prepared.rs
+++ b/crates/loonfs-core/src/commit/prepared.rs
@@ -84,6 +84,7 @@ mod tests {
     use super::*;
     use crate::commit::{materialize_commit, CommitOp, CommitOpResult, ValidatedOp};
     use loonfs_api::wire::wal::WalDelta;
+    use loonfs_api::NameKey;
     use loonfs_api::{ChangeSeq, CommitId, InodeId};
 
     fn request() -> CommitRequest {
@@ -112,7 +113,7 @@ mod tests {
                 op_index: 0,
                 parent_inode_id: InodeId(1),
                 display_name: "docs".to_owned(),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 create_inode_delta_index: 0,
                 bind_delta_index: 1,

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -11,9 +11,7 @@ use super::super::{
 use super::view::CommitValidationView;
 use crate::invariants::InvariantId;
 use crate::metadata::{BindingIdentity, InodeRecord, RevisionRecord, SubtreeTombstoneRecord};
-use loonfs_api::{
-    name_key_for_display_name, ChangeSeq, DisplayName, InodeId, InodeKind, NamePolicy, RevisionNo,
-};
+use loonfs_api::{ChangeSeq, DisplayName, InodeId, InodeKind, NameKey, NamePolicy, RevisionNo};
 
 pub(super) struct ValidatedMetadataOps {
     pub(super) validated_ops: Vec<ValidatedOp>,
@@ -529,8 +527,8 @@ async fn validate_name_absent<V: CommitValidationView>(
     parent_missing: impl FnOnce() -> CommitValidationError,
     parent_not_directory: impl FnOnce(InodeKind) -> CommitValidationError,
     collision: impl FnOnce(String, InodeId) -> CommitValidationError,
-) -> Result<String, V::Error> {
-    validate_display_name(display_name)?;
+) -> Result<NameKey, V::Error> {
+    let display_name = validate_display_name(display_name)?;
     validate_inode_kind(
         metadata_state,
         parent_inode_id,
@@ -540,12 +538,12 @@ async fn validate_name_absent<V: CommitValidationView>(
     )
     .await?;
 
-    let name_key = name_key_for_display_name(name_policy, display_name);
+    let name_key = NameKey::for_display_name(name_policy, &display_name);
     if let Some(existing) = metadata_state
-        .visible_child(parent_inode_id, &name_key)
+        .visible_child(parent_inode_id, name_key.as_str())
         .await?
     {
-        return Err(collision(name_key, existing.child_inode_id).into());
+        return Err(collision(name_key.as_str().to_owned(), existing.child_inode_id).into());
     }
 
     Ok(name_key)
@@ -556,7 +554,7 @@ async fn validate_child_name_absent<V: CommitValidationView>(
     parent_inode_id: InodeId,
     display_name: &str,
     name_policy: NamePolicy,
-) -> Result<String, V::Error> {
+) -> Result<NameKey, V::Error> {
     validate_name_absent(
         metadata_state,
         parent_inode_id,
@@ -581,7 +579,7 @@ async fn validate_rename_target_name_absent<V: CommitValidationView>(
     parent_inode_id: InodeId,
     display_name: &str,
     name_policy: NamePolicy,
-) -> Result<String, V::Error> {
+) -> Result<NameKey, V::Error> {
     validate_name_absent(
         metadata_state,
         parent_inode_id,
@@ -860,11 +858,9 @@ async fn validate_rename_does_not_cycle<V: CommitValidationView>(
     Ok(())
 }
 
-fn validate_display_name(display_name: &str) -> Result<(), CommitValidationError> {
-    DisplayName::parse(display_name)
-        .map(|_| ())
-        .map_err(|error| CommitValidationError::InvalidDisplayName {
-            display_name: error.invalid_path_input().to_owned(),
-            reason: error.to_string(),
-        })
+fn validate_display_name(display_name: &str) -> Result<DisplayName, CommitValidationError> {
+    DisplayName::parse(display_name).map_err(|error| CommitValidationError::InvalidDisplayName {
+        display_name: error.invalid_path_input().to_owned(),
+        reason: error.to_string(),
+    })
 }

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -6,7 +6,7 @@ use super::{
     CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
     SubtreeTombstoneAction, SubtreeTombstoneRecord,
 };
-use loonfs_api::{ChangeSeq, CommitId, InodeId};
+use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,7 +60,7 @@ impl MetadataIndexes {
             indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
             replace_if_newer_bind(
                 &mut latest_by_parent_name,
-                (bind.parent_inode_id, bind.name_key.clone()),
+                (bind.parent_inode_id, bind.name_key.as_str().to_owned()),
                 bind.clone(),
             );
             replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
@@ -80,9 +80,10 @@ impl MetadataIndexes {
             if !bind.same_binding(latest_child_bind) {
                 continue;
             }
-            indexes
-                .active_child_by_parent_name
-                .insert((bind.parent_inode_id, bind.name_key.clone()), bind.clone());
+            indexes.active_child_by_parent_name.insert(
+                (bind.parent_inode_id, bind.name_key.as_str().to_owned()),
+                bind.clone(),
+            );
             indexes
                 .active_parent_by_child
                 .insert(bind.child_inode_id, bind.clone());
@@ -167,7 +168,7 @@ impl MetadataIndexes {
 
     pub(super) fn record_bind(&mut self, record: &DirentryBindRecord) {
         self.indexed_seq = self.indexed_seq.max(record.bind_seq);
-        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+        let parent_name_key = (record.parent_inode_id, record.name_key.as_str().to_owned());
         replace_if_newer_bind(
             &mut self.latest_bind_by_parent_name,
             parent_name_key.clone(),
@@ -202,7 +203,7 @@ impl MetadataIndexes {
         self.unbound_binding_keys
             .insert(BindingKey::from_unbind(record));
 
-        let parent_name_key = (record.parent_inode_id, record.name_key.clone());
+        let parent_name_key = (record.parent_inode_id, record.name_key.as_str().to_owned());
         if self
             .active_child_by_parent_name
             .get(&parent_name_key)
@@ -254,7 +255,7 @@ impl MetadataIndexes {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BindingKey {
     parent_inode_id: InodeId,
-    name_key: String,
+    name_key: NameKey,
     child_inode_id: InodeId,
     bind_seq: ChangeSeq,
     bind_delta_index: u32,
@@ -343,7 +344,7 @@ fn remove_active_child_if_same(
     active_child_by_parent_name: &mut BTreeMap<(InodeId, String), DirentryBindRecord>,
     record: &DirentryBindRecord,
 ) {
-    let key = (record.parent_inode_id, record.name_key.clone());
+    let key = (record.parent_inode_id, record.name_key.as_str().to_owned());
     if active_child_by_parent_name
         .get(&key)
         .map(|active| active.same_binding(record))

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -122,10 +122,10 @@ pub(super) async fn direntry_unbinds_for_binding<S: ObjectStore + ?Sized>(
     direntry: &DirentryBindRecord,
 ) -> Result<Vec<DirentryUnbindRecord>> {
     let filter_probe =
-        lookup_keys::direntry_unbind_probe(direntry.parent_inode_id, &direntry.name_key);
+        lookup_keys::direntry_unbind_probe(direntry.parent_inode_id, direntry.name_key.as_str());
     let prefix = lookup_keys::direntry_unbind_binding_prefix(
         direntry.parent_inode_id,
-        &direntry.name_key,
+        direntry.name_key.as_str(),
         direntry.bind_seq,
         direntry.bind_delta_index,
     );

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -39,7 +39,6 @@ pub use self::rows::{
     RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
 };
 
-pub(crate) use self::rows::record_name_key;
 pub(crate) use self::view::{
     DurableVisibilityCache, InMemoryMetadataView, MetadataView, MetadataViewSession,
     VisibleChildEntry,

--- a/crates/loonfs-core/src/metadata/queries.rs
+++ b/crates/loonfs-core/src/metadata/queries.rs
@@ -82,7 +82,7 @@ impl MetadataState {
             .iter()
             .filter(|direntry| {
                 direntry.parent_inode_id == parent_inode_id
-                    && direntry.name_key == name_key
+                    && direntry.name_key.as_str() == name_key
                     && direntry.bind_seq <= base_seq
             })
             .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -48,7 +48,7 @@ pub(crate) fn direntry_bind_from_manifest_row(
             bind_delta_index,
         } => Ok(DirentryBindRecord {
             parent_inode_id,
-            name_key: name_key.as_str().to_owned(),
+            name_key,
             display_name,
             child_inode_id,
             bind_seq,
@@ -72,7 +72,7 @@ pub(crate) fn direntry_unbind_from_manifest_row(
             unbind_delta_index,
         } => Ok(DirentryUnbindRecord {
             parent_inode_id,
-            name_key: name_key.as_str().to_owned(),
+            name_key,
             child_inode_id,
             bind_seq,
             bind_delta_index,

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -75,16 +75,6 @@ impl<'de> Deserialize<'de> for MetadataState {
     }
 }
 
-/// Converts a metadata record name key back to the wire [`NameKey`] type.
-///
-/// Record name keys only enter [`MetadataState`] from validated sources:
-/// typed manifest rows, commit plans built from typed [`NameKey`]s, and WAL
-/// deltas whose name keys replay validation checks before applying. An
-/// invalid key here is therefore a logic bug, not untrusted input.
-pub(crate) fn record_name_key(name_key: &str) -> NameKey {
-    NameKey::parse(name_key).expect("metadata record name keys are validated on ingress")
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InodeRecord {
     pub inode_id: InodeId,
@@ -95,7 +85,7 @@ pub struct InodeRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirentryBindRecord {
     pub parent_inode_id: InodeId,
-    pub name_key: String,
+    pub name_key: NameKey,
     pub display_name: String,
     pub child_inode_id: InodeId,
     pub bind_seq: ChangeSeq,
@@ -105,7 +95,7 @@ pub struct DirentryBindRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirentryUnbindRecord {
     pub parent_inode_id: InodeId,
-    pub name_key: String,
+    pub name_key: NameKey,
     pub child_inode_id: InodeId,
     pub bind_seq: ChangeSeq,
     pub bind_delta_index: u32,
@@ -416,11 +406,11 @@ fn metadata_decoded_bytes(
 }
 
 fn direntry_bind_decoded_bytes(record: &DirentryBindRecord) -> usize {
-    size_of::<DirentryBindRecord>() + record.name_key.len() + record.display_name.len()
+    size_of::<DirentryBindRecord>() + record.name_key.as_str().len() + record.display_name.len()
 }
 
 fn direntry_unbind_decoded_bytes(record: &DirentryUnbindRecord) -> usize {
-    size_of::<DirentryUnbindRecord>() + record.name_key.len()
+    size_of::<DirentryUnbindRecord>() + record.name_key.as_str().len()
 }
 
 fn revision_decoded_bytes(record: &RevisionRecord) -> usize {

--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -4,7 +4,8 @@
 use super::*;
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
-    AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NamePolicy, RevisionNo,
+    AbsolutePath, ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey, NamePolicy,
+    RevisionNo,
 };
 
 #[test]
@@ -15,7 +16,7 @@ fn bind_direntry_replay_uses_persisted_name_key() {
         &[WalDelta::BindDirentry {
             delta_index: 7,
             parent_inode_id: InodeId(1),
-            name_key: "persisted-key".to_owned(),
+            name_key: NameKey::parse("persisted-key").expect("valid name key"),
             display_name: "Report.TXT".to_owned(),
             child_inode_id: InodeId(2),
         }],
@@ -23,7 +24,7 @@ fn bind_direntry_replay_uses_persisted_name_key() {
 
     assert_eq!(applied.metadata_state.direntry_binds().len(), 1);
     let bind = &applied.metadata_state.direntry_binds()[0];
-    assert_eq!(bind.name_key, "persisted-key");
+    assert_eq!(bind.name_key.as_str(), "persisted-key");
     assert_eq!(bind.display_name, "Report.TXT");
     assert_eq!(bind.bind_delta_index, 7);
 }
@@ -45,7 +46,7 @@ fn child_lookup_uses_persisted_name_key_without_recanonicalizing() {
         ],
         vec![DirentryBindRecord {
             parent_inode_id: InodeId(1),
-            name_key: "persisted-key".to_owned(),
+            name_key: NameKey::parse("persisted-key").expect("valid name key"),
             display_name: "Report.TXT".to_owned(),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(1),
@@ -88,7 +89,7 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
         vec![
             DirentryBindRecord {
                 parent_inode_id: InodeId(1),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 display_name: "docs".to_owned(),
                 child_inode_id: InodeId(2),
                 bind_seq: ChangeSeq(1),
@@ -96,7 +97,7 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
             },
             DirentryBindRecord {
                 parent_inode_id: InodeId(2),
-                name_key: "report.txt".to_owned(),
+                name_key: NameKey::parse("report.txt").expect("valid name key"),
                 display_name: "report.txt".to_owned(),
                 child_inode_id: InodeId(3),
                 bind_seq: ChangeSeq(2),
@@ -133,7 +134,7 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
             &[WalDelta::UnbindDirentry {
                 delta_index: 0,
                 parent_inode_id: InodeId(1),
-                name_key: "docs".to_owned(),
+                name_key: NameKey::parse("docs").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 0,
@@ -154,7 +155,7 @@ fn maintained_indexes_track_bind_unbind_rename_and_tombstone() {
             &[WalDelta::BindDirentry {
                 delta_index: 0,
                 parent_inode_id: InodeId(1),
-                name_key: "renamed".to_owned(),
+                name_key: NameKey::parse("renamed").expect("valid name key"),
                 display_name: "renamed".to_owned(),
                 child_inode_id: InodeId(2),
             }],
@@ -210,7 +211,7 @@ fn rebuilt_indexes_answer_current_head_queries_after_deserialize() {
         ],
         vec![DirentryBindRecord {
             parent_inode_id: InodeId(1),
-            name_key: "file.txt".to_owned(),
+            name_key: NameKey::parse("file.txt").expect("valid name key"),
             display_name: "file.txt".to_owned(),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(1),
@@ -263,7 +264,7 @@ fn stale_binding_is_not_active_after_newer_bind_claims_same_name() {
         vec![
             DirentryBindRecord {
                 parent_inode_id: InodeId(1),
-                name_key: "report".to_owned(),
+                name_key: NameKey::parse("report").expect("valid name key"),
                 display_name: "report".to_owned(),
                 child_inode_id: InodeId(2),
                 bind_seq: ChangeSeq(1),
@@ -271,7 +272,7 @@ fn stale_binding_is_not_active_after_newer_bind_claims_same_name() {
             },
             DirentryBindRecord {
                 parent_inode_id: InodeId(1),
-                name_key: "report".to_owned(),
+                name_key: NameKey::parse("report").expect("valid name key"),
                 display_name: "report".to_owned(),
                 child_inode_id: InodeId(3),
                 bind_seq: ChangeSeq(2),
@@ -313,7 +314,7 @@ fn resolve_visible_path_uses_explicit_name_policy_and_stored_display_name() {
         ],
         vec![DirentryBindRecord {
             parent_inode_id: InodeId(1),
-            name_key: "report.txt".to_owned(),
+            name_key: NameKey::parse("report.txt").expect("valid name key"),
             display_name: "Report.TXT".to_owned(),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(1),
@@ -547,7 +548,7 @@ fn churned_binding_state() -> MetadataState {
             WalDelta::BindDirentry {
                 delta_index: 1,
                 parent_inode_id: InodeId(1),
-                name_key: "contested".to_owned(),
+                name_key: NameKey::parse("contested").expect("valid name key"),
                 display_name: "contested".to_owned(),
                 child_inode_id: InodeId(2),
             },
@@ -559,7 +560,7 @@ fn churned_binding_state() -> MetadataState {
             WalDelta::BindDirentry {
                 delta_index: 3,
                 parent_inode_id: InodeId(1),
-                name_key: "deleted".to_owned(),
+                name_key: NameKey::parse("deleted").expect("valid name key"),
                 display_name: "deleted".to_owned(),
                 child_inode_id: InodeId(4),
             },
@@ -572,7 +573,7 @@ fn churned_binding_state() -> MetadataState {
             WalDelta::UnbindDirentry {
                 delta_index: 0,
                 parent_inode_id: InodeId(1),
-                name_key: "contested".to_owned(),
+                name_key: NameKey::parse("contested").expect("valid name key"),
                 child_inode_id: InodeId(2),
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 1,
@@ -580,14 +581,14 @@ fn churned_binding_state() -> MetadataState {
             WalDelta::BindDirentry {
                 delta_index: 1,
                 parent_inode_id: InodeId(1),
-                name_key: "renamed-away".to_owned(),
+                name_key: NameKey::parse("renamed-away").expect("valid name key"),
                 display_name: "renamed-away".to_owned(),
                 child_inode_id: InodeId(2),
             },
             WalDelta::UnbindDirentry {
                 delta_index: 2,
                 parent_inode_id: InodeId(1),
-                name_key: "deleted".to_owned(),
+                name_key: NameKey::parse("deleted").expect("valid name key"),
                 child_inode_id: InodeId(4),
                 bind_seq: ChangeSeq(1),
                 bind_delta_index: 3,
@@ -606,7 +607,7 @@ fn churned_binding_state() -> MetadataState {
             WalDelta::BindDirentry {
                 delta_index: 1,
                 parent_inode_id: InodeId(1),
-                name_key: "contested".to_owned(),
+                name_key: NameKey::parse("contested").expect("valid name key"),
                 display_name: "contested".to_owned(),
                 child_inode_id: InodeId(3),
             },
@@ -725,7 +726,7 @@ fn has_visible_children_sees_through_unbinds() {
         ],
         vec![DirentryBindRecord {
             parent_inode_id: dir,
-            name_key: "doc.txt".to_owned(),
+            name_key: NameKey::parse("doc.txt").expect("valid name key"),
             display_name: "doc.txt".to_owned(),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(2),
@@ -753,7 +754,7 @@ fn has_visible_children_sees_through_unbinds() {
         state.direntry_binds().to_vec(),
         vec![DirentryUnbindRecord {
             parent_inode_id: dir,
-            name_key: "doc.txt".to_owned(),
+            name_key: NameKey::parse("doc.txt").expect("valid name key"),
             child_inode_id: InodeId(2),
             bind_seq: ChangeSeq(2),
             bind_delta_index: 0,

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -517,7 +517,8 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                     .direntry_binds()
                     .iter()
                     .filter(move |direntry| {
-                        direntry.parent_inode_id == parent_inode_id && direntry.name_key == name_key
+                        direntry.parent_inode_id == parent_inode_id
+                            && direntry.name_key.as_str() == name_key
                     })
                     .cloned()
             }));
@@ -536,7 +537,8 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 .direntry_binds()
                 .iter()
                 .filter(move |direntry| {
-                    direntry.parent_inode_id == parent_inode_id && direntry.name_key == name_key
+                    direntry.parent_inode_id == parent_inode_id
+                        && direntry.name_key.as_str() == name_key
                 })
                 .cloned()
         }));
@@ -1014,7 +1016,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             };
 
             match groups.last_mut() {
-                Some(group) if group.name_key == candidate.record.name_key => {
+                Some(group) if group.name_key == candidate.record.name_key.as_str() => {
                     group.rows.push(candidate.record);
                 }
                 _ => {
@@ -1025,7 +1027,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                         break;
                     }
                     groups.push(DirentryBindNameGroup {
-                        name_key: candidate.record.name_key.clone(),
+                        name_key: candidate.record.name_key.as_str().to_owned(),
                         rows: vec![candidate.record],
                     });
                 }
@@ -1695,7 +1697,7 @@ struct ParentNameCacheKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BindingCacheKey {
     parent_inode_id: InodeId,
-    name_key: String,
+    name_key: NameKey,
     child_inode_id: InodeId,
     bind_seq: loonfs_api::ChangeSeq,
     bind_delta_index: u32,
@@ -1766,7 +1768,7 @@ struct DirentryBindPageCandidate {
 fn direntry_bind_row_key(record: &DirentryBindRecord) -> String {
     MetadataRow::DirentryBind {
         parent_inode_id: record.parent_inode_id,
-        name_key: crate::metadata::record_name_key(&record.name_key),
+        name_key: record.name_key.clone(),
         display_name: record.display_name.clone(),
         child_inode_id: record.child_inode_id,
         bind_seq: record.bind_seq,

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -53,7 +53,7 @@ impl<'a> From<&'a DirentryBindRecord> for BindingIdentity<'a> {
     fn from(record: &'a DirentryBindRecord) -> Self {
         Self {
             parent_inode_id: record.parent_inode_id,
-            name_key: &record.name_key,
+            name_key: record.name_key.as_str(),
             child_inode_id: record.child_inode_id,
             bind_seq: record.bind_seq,
             bind_delta_index: record.bind_delta_index,
@@ -65,7 +65,7 @@ impl<'a> From<&'a DirentryUnbindRecord> for BindingIdentity<'a> {
     fn from(record: &'a DirentryUnbindRecord) -> Self {
         Self {
             parent_inode_id: record.parent_inode_id,
-            name_key: &record.name_key,
+            name_key: record.name_key.as_str(),
             child_inode_id: record.child_inode_id,
             bind_seq: record.bind_seq,
             bind_delta_index: record.bind_delta_index,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -35,8 +35,8 @@ use loonfs_api::{
     decode_grep_cursor, encode_grep_cursor, AbsolutePath, AuthoritativeFileBytes,
     AuthoritativePathEntry, ContentStoreId, DirectoryPageCursor, DisplayName, FileRevision,
     FileRevisionsPageCursor, GrepMatch, GrepPageCursor, GrepRequest, GrepResponse, InodeId,
-    InodeKind, ListFileRevisionsResponse, ManifestId, NameKey, NamePolicy, NamespaceId, Page,
-    PageRequest, PaginationPolicy, RevisionNo,
+    InodeKind, ListFileRevisionsResponse, ManifestId, NamePolicy, NamespaceId, Page, PageRequest,
+    PaginationPolicy, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -985,9 +985,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             Some(DirectoryPageCursor {
                 head_seq: self.head.seq,
                 dir_inode_id: resolved.inode_id,
-                last_name_key: NameKey::parse(&last.binding.name_key).map_err(|error| {
-                    CoreError::NamespaceCorrupt(format!("invalid stored name_key: {error}"))
-                })?,
+                last_name_key: last.binding.name_key.clone(),
             })
         } else {
             None

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -271,12 +271,6 @@ pub(crate) async fn plan_path_mutation_against_publish_view<S: ObjectStore + ?Si
     })
 }
 
-#[cfg(test)]
-struct PathPlanningView<'a> {
-    head: &'a HeadState,
-    metadata_state: &'a MetadataState,
-}
-
 struct PublishPathPlanningView<'a, 'b, 'store, S: ObjectStore + ?Sized> {
     head: &'a HeadState,
     metadata_state: &'a MetadataView<'b, 'store, S>,
@@ -299,9 +293,7 @@ async fn publish_binding_is_precondition<S: ObjectStore + ?Sized>(
     }
     Ok(ApiCommitPrecondition::BindingIs {
         parent_inode_id,
-        name_key: NameKey::parse(&binding.name_key).map_err(|err| {
-            CoreError::NamespaceCorrupt(format!("invalid metadata name_key: {err}"))
-        })?,
+        name_key: binding.name_key.clone(),
         child_inode_id: binding.child_inode_id,
         bind_seq: binding.bind_seq,
         bind_delta_index: binding.bind_delta_index,
@@ -926,38 +918,10 @@ async fn publish_resolve_parent_directory<S: ObjectStore + ?Sized>(
 }
 
 #[cfg(test)]
-fn binding_is_precondition(
-    view: &PathPlanningView<'_>,
-    resolved: &ResolvedVisiblePath,
-) -> Result<ApiCommitPrecondition, CoreError> {
-    let parent_inode_id = resolved
-        .parent_inode_id
-        .ok_or(CoreError::RootMutationForbidden)?;
-    let binding = view
-        .metadata_state
-        .current_parent_binding_for_child(resolved.inode_id, view.head.seq)
-        .ok_or_else(|| CoreError::PathNotFound(resolved.absolute_path.clone()))?;
-    if binding.parent_inode_id != parent_inode_id {
-        return Err(CoreError::PathNotFound(resolved.absolute_path.clone()));
-    }
-    Ok(ApiCommitPrecondition::BindingIs {
-        parent_inode_id,
-        name_key: NameKey::parse(&binding.name_key).map_err(|err| {
-            CoreError::NamespaceCorrupt(format!("invalid metadata name_key: {err}"))
-        })?,
-        child_inode_id: binding.child_inode_id,
-        bind_seq: binding.bind_seq,
-        bind_delta_index: binding.bind_delta_index,
-    })
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::commit::core_commit_fingerprint_for_v0_request;
     use crate::context::MutationContext;
-    use crate::error::ErrorCode;
-    use crate::metadata::{DirentryBindRecord, InodeRecord};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::path::write::ops::{delete_path, put_file_bytes};
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
@@ -1255,55 +1219,6 @@ mod tests {
                 precondition,
                 CommitPrecondition::ChildNameAbsent { name_key, .. } if name_key.as_str() == "b.txt"
             )));
-    }
-
-    #[tokio::test]
-    async fn binding_is_precondition_reports_invalid_durable_name_key_as_namespace_corrupt() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut head = HeadState::initial(namespace_id);
-        head.seq = ChangeSeq(1);
-        let metadata_state = MetadataState::from_rows(
-            vec![
-                InodeRecord {
-                    inode_id: InodeId(1),
-                    inode_kind: InodeKind::Directory,
-                    created_seq: ChangeSeq(0),
-                },
-                InodeRecord {
-                    inode_id: InodeId(2),
-                    inode_kind: InodeKind::File,
-                    created_seq: ChangeSeq(1),
-                },
-            ],
-            vec![DirentryBindRecord {
-                parent_inode_id: InodeId(1),
-                name_key: "bad/key".to_owned(),
-                display_name: "file.txt".to_owned(),
-                child_inode_id: InodeId(2),
-                bind_seq: ChangeSeq(1),
-                bind_delta_index: 0,
-            }],
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-        );
-        let view = PathPlanningView {
-            head: &head,
-            metadata_state: &metadata_state,
-        };
-        let resolved = ResolvedVisiblePath {
-            absolute_path: "/file.txt".to_owned(),
-            inode_id: InodeId(2),
-            inode_kind: InodeKind::File,
-            parent_inode_id: Some(InodeId(1)),
-            display_name: "file.txt".to_owned(),
-        };
-
-        let error =
-            binding_is_precondition(&view, &resolved).expect_err("invalid durable name key");
-
-        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -8,7 +8,7 @@ use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::v0::{ChangesResponse, CommitDelta, CommittedChange};
 use loonfs_api::wire::control::NamespaceState;
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta};
-use loonfs_api::{ChangeSeq, EffectiveLimit, NameKey, NamespaceId};
+use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
@@ -127,9 +127,7 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta> {
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode_id: *parent_inode_id,
-            name_key: NameKey::parse(name_key).map_err(|err| {
-                CoreError::NamespaceCorrupt(format!("invalid WAL name_key: {err}"))
-            })?,
+            name_key: name_key.clone(),
             display_name: display_name.clone(),
             child_inode_id: *child_inode_id,
         },
@@ -144,9 +142,7 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta> {
             semantic_op_index,
             delta_index: *delta_index,
             parent_inode_id: *parent_inode_id,
-            name_key: NameKey::parse(name_key).map_err(|err| {
-                CoreError::NamespaceCorrupt(format!("invalid WAL name_key: {err}"))
-            })?,
+            name_key: name_key.clone(),
             child_inode_id: *child_inode_id,
             bind_seq: *bind_seq,
             bind_delta_index: *bind_delta_index,
@@ -184,48 +180,4 @@ fn commit_delta_from_wal(delta: &WalCommitDelta) -> Result<CommitDelta> {
             target_delta_index: *target_delta_index,
         },
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::error::ErrorCode;
-    use loonfs_api::{ChangeSeq, InodeId};
-
-    #[test]
-    fn invalid_wal_delta_name_key_is_namespace_corrupt() {
-        let delta = WalCommitDelta {
-            semantic_op_index: 0,
-            delta: WalDelta::BindDirentry {
-                delta_index: 0,
-                parent_inode_id: InodeId(1),
-                name_key: "bad/key".to_owned(),
-                display_name: "file.txt".to_owned(),
-                child_inode_id: InodeId(2),
-            },
-        };
-
-        let error = commit_delta_from_wal(&delta).expect_err("invalid durable WAL name key");
-
-        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
-    }
-
-    #[test]
-    fn invalid_wal_unbind_name_key_is_namespace_corrupt() {
-        let delta = WalCommitDelta {
-            semantic_op_index: 0,
-            delta: WalDelta::UnbindDirentry {
-                delta_index: 0,
-                parent_inode_id: InodeId(1),
-                name_key: "bad/key".to_owned(),
-                child_inode_id: InodeId(2),
-                bind_seq: ChangeSeq(1),
-                bind_delta_index: 0,
-            },
-        };
-
-        let error = commit_delta_from_wal(&delta).expect_err("invalid durable WAL name key");
-
-        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
-    }
 }

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -6,7 +6,7 @@ use crate::invariants::InvariantId;
 use crate::metadata::MetadataState;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta, WalSegmentEnvelope};
-use loonfs_api::{ChangeSeq, InodeId, NameKey, NamespaceId, WriterEpoch};
+use loonfs_api::{ChangeSeq, InodeId, NamespaceId, WriterEpoch};
 use loonfs_objectstore::keys::wal_segment;
 
 pub(crate) fn project_validated_wal_tail(
@@ -176,18 +176,6 @@ pub(super) fn validate_wal_segment_for_replay(
                 expected,
                 actual: record.seq,
             });
-        }
-        // Replay is the choke point where WAL name keys enter metadata
-        // records, so reject malformed keys here: everything downstream
-        // (checkpoint row building, view row keys) relies on record name
-        // keys converting back to typed `NameKey`s infallibly.
-        for delta in &record.deltas {
-            if let WalDelta::BindDirentry { name_key, .. }
-            | WalDelta::UnbindDirentry { name_key, .. } = &delta.delta
-            {
-                NameKey::parse(name_key)
-                    .map_err(|err| WalReplayError::Codec(format!("invalid WAL name_key: {err}")))?;
-            }
         }
     }
 

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -8,7 +8,7 @@ use crate::commit::{
 use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentEnvelope};
-use loonfs_api::{ChangeSeq, CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch};
+use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WalSegmentId, WriterEpoch};
 use loonfs_objectstore::keys::wal_segment;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
@@ -40,7 +40,7 @@ async fn build_wal_record_payload_matches_segment_record_payload() {
             op_index: 0,
             parent_inode_id: InodeId(1),
             display_name: "docs".to_owned(),
-            name_key: "docs".to_owned(),
+            name_key: NameKey::parse("docs").expect("valid name key"),
             child_inode_id: InodeId(2),
             create_inode_delta_index: 0,
             bind_delta_index: 1,
@@ -386,10 +386,11 @@ fn materialized_create_directory(
             op_index: 0,
             parent_inode_id: InodeId(1),
             display_name: display_name.to_owned(),
-            name_key: loonfs_api::name_key_for_display_name(
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
                 loonfs_api::NamePolicy::default(),
                 display_name,
-            ),
+            ))
+            .expect("derived name key"),
             child_inode_id: InodeId(2),
             create_inode_delta_index: 0,
             bind_delta_index: 1,

--- a/crates/loonfs-core/tests/differential.rs
+++ b/crates/loonfs-core/tests/differential.rs
@@ -1,6 +1,6 @@
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
-    sha256_digest, ChangeSeq, ContentRef, ContentRefKind, InodeId, InodeKind, RevisionNo,
+    sha256_digest, ChangeSeq, ContentRef, ContentRefKind, InodeId, InodeKind, NameKey, RevisionNo,
 };
 use loonfs_core::metadata::MetadataState as CoreMetadataState;
 use loonfs_model::metadata::MetadataState as ModelMetadataState;
@@ -39,10 +39,11 @@ fn create_directory(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode_id,
-            name_key: loonfs_api::name_key_for_display_name(
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
                 loonfs_api::NamePolicy::default(),
                 display_name,
-            ),
+            ))
+            .expect("derived name key"),
             display_name: display_name.to_owned(),
             child_inode_id: inode_id,
         },
@@ -65,10 +66,11 @@ fn create_file(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode_id,
-            name_key: loonfs_api::name_key_for_display_name(
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
                 loonfs_api::NamePolicy::default(),
                 display_name,
-            ),
+            ))
+            .expect("derived name key"),
             display_name: display_name.to_owned(),
             child_inode_id: inode_id,
         },
@@ -104,10 +106,11 @@ fn bind(
     vec![WalDelta::BindDirentry {
         delta_index,
         parent_inode_id,
-        name_key: loonfs_api::name_key_for_display_name(
+        name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
             loonfs_api::NamePolicy::default(),
             display_name,
-        ),
+        ))
+        .expect("derived name key"),
         display_name: display_name.to_owned(),
         child_inode_id: inode_id,
     }]

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -647,10 +647,11 @@ fn wal_create_directory(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode_id,
-            name_key: loonfs_api::name_key_for_display_name(
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
                 loonfs_api::NamePolicy::default(),
                 &display_name,
-            ),
+            ))
+            .expect("derived name key"),
             display_name,
             child_inode_id: inode_id,
         },
@@ -673,10 +674,11 @@ fn wal_create_file(
         WalDelta::BindDirentry {
             delta_index: delta_index.saturating_add(1),
             parent_inode_id,
-            name_key: loonfs_api::name_key_for_display_name(
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(
                 loonfs_api::NamePolicy::default(),
                 &display_name,
-            ),
+            ))
+            .expect("derived name key"),
             display_name,
             child_inode_id: inode_id,
         },
@@ -2497,7 +2499,7 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
             display_name,
             ..
         } => {
-            assert_eq!(name_key, "alpha");
+            assert_eq!(name_key.as_str(), "alpha");
             assert_eq!(display_name, "alpha");
         }
         delta => panic!("expected bind delta, got {delta:?}"),

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -122,7 +122,7 @@ impl MetadataState {
                 } => {
                     metadata_state.direntry_binds.push(DirentryBindRecord {
                         parent_inode_id: *parent_inode_id,
-                        name_key: name_key.clone(),
+                        name_key: name_key.as_str().to_owned(),
                         display_name: display_name.clone(),
                         child_inode_id: *child_inode_id,
                         bind_seq: committed_seq,
@@ -143,7 +143,7 @@ impl MetadataState {
                 } => {
                     metadata_state.direntry_unbinds.push(DirentryUnbindRecord {
                         parent_inode_id: *parent_inode_id,
-                        name_key: name_key.clone(),
+                        name_key: name_key.as_str().to_owned(),
                         child_inode_id: *child_inode_id,
                         bind_seq: *bind_seq,
                         bind_delta_index: *bind_delta_index,
@@ -231,6 +231,7 @@ fn push_unique_invariant(invariants: &mut Vec<String>, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use loonfs_api::NameKey;
 
     #[test]
     fn bind_direntry_replay_uses_persisted_name_key() {
@@ -239,7 +240,7 @@ mod tests {
             &[WalDelta::BindDirentry {
                 delta_index: 7,
                 parent_inode_id: InodeId(1),
-                name_key: "persisted-key".to_owned(),
+                name_key: NameKey::parse("persisted-key").expect("valid name key"),
                 display_name: "Report.TXT".to_owned(),
                 child_inode_id: InodeId(2),
             }],


### PR DESCRIPTION
WAL deltas and the in-memory bind/unbind records carried name_key as a plain String while the manifest rows and the API surface used the validated NameKey type. Every seam between the two worlds re-parsed — and every re-parse was either an expect() (a hidden crash path on durable data) or a NamespaceCorrupt error arm for a state that validated ingress should have made unrepresentable.

What is typed now: WalDelta bind/unbind, DirentryBindRecord/DirentryUnbindRecord, ValidatedOp's name-key fields, and ResolvedBinding. Name-key validation happens at exactly two places — wire decode (serde parse on the typed field) and display-name derivation (NameKey::for_display_name over a parsed DisplayName, which validate_display_name now returns instead of discarding).