### PR TITLE
chore(core,loonfs): the paged revision listing is the only revision listing

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -19,9 +19,9 @@ use loonfs_api::EffectiveLimit;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     CheckpointId, ContentRef, CreateCheckpointResponse, DirectoryPageCursor, FileRevision,
-    FileRevisionsPageCursor, FlushWalResponse, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, ManifestId, ManifestObjectId, NamespaceId, NamespaceSummary, Page,
-    PageRequest, ReleaseCheckpointResponse, RevisionNo, UploadId,
+    FileRevisionsPageCursor, FlushWalResponse, GrepRequest, GrepResponse, InodeId, ManifestId,
+    ManifestObjectId, NamespaceId, NamespaceSummary, Page, PageRequest, ReleaseCheckpointResponse,
+    RevisionNo, UploadId,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -212,16 +212,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     }
 
     #[doc(hidden)]
-    pub async fn list_file_revisions_with_runtime_context(
-        &self,
-        path: impl AsRef<str>,
-        options: &RuntimeReadContext,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        self.list_file_revisions_with_context(path.as_ref(), runtime_read_load_context(options))
-            .await
-    }
-
-    #[doc(hidden)]
     pub async fn list_file_revisions_page_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -231,19 +221,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         self.list_file_revisions_page_with_context(
             path.as_ref(),
             request,
-            runtime_read_load_context(options),
-        )
-        .await
-    }
-
-    #[doc(hidden)]
-    pub async fn list_file_revisions_for_inode_with_runtime_context(
-        &self,
-        inode_id: InodeId,
-        options: &RuntimeReadContext,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        self.list_file_revisions_for_inode_with_context(
-            inode_id,
             runtime_read_load_context(options),
         )
         .await
@@ -335,15 +312,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    async fn list_file_revisions_with_context(
-        &self,
-        path: &str,
-        context: ReadLoadContext<'_>,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        let view = self.load_read_view(context).await?;
-        view.list_file_revisions(path).await
-    }
-
     async fn list_file_revisions_page_with_context(
         &self,
         path: &str,
@@ -352,15 +320,6 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ) -> CoreResult<Page<FileRevision, FileRevisionsPageCursor>> {
         let view = self.load_read_view(context).await?;
         view.list_file_revisions_page(path, request).await
-    }
-
-    async fn list_file_revisions_for_inode_with_context(
-        &self,
-        inode_id: InodeId,
-        context: ReadLoadContext<'_>,
-    ) -> CoreResult<ListFileRevisionsResponse> {
-        let view = self.load_read_view(context).await?;
-        view.list_file_revisions_for_inode(inode_id).await
     }
 
     async fn list_file_revisions_for_inode_page_with_context(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -35,8 +35,7 @@ use loonfs_api::{
     decode_grep_cursor, encode_grep_cursor, AbsolutePath, AuthoritativeFileBytes,
     AuthoritativePathEntry, ContentStoreId, DirectoryPageCursor, DisplayName, FileRevision,
     FileRevisionsPageCursor, GrepMatch, GrepPageCursor, GrepRequest, GrepResponse, InodeId,
-    InodeKind, ListFileRevisionsResponse, ManifestId, NamePolicy, NamespaceId, Page, PageRequest,
-    PaginationPolicy, RevisionNo,
+    InodeKind, ManifestId, NamePolicy, NamespaceId, Page, PageRequest, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -741,20 +740,6 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         Ok(inodes)
     }
 
-    pub(crate) async fn list_file_revisions(
-        &self,
-        absolute_path: &str,
-    ) -> Result<ListFileRevisionsResponse, CoreError> {
-        let entry = self.resolve_path(absolute_path).await?;
-        if entry.inode_kind != InodeKind::File {
-            return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path,
-                kind: entry.inode_kind,
-            });
-        }
-        self.list_file_revisions_for_inode(entry.inode_id).await
-    }
-
     pub(crate) async fn list_file_revisions_page(
         &self,
         absolute_path: &str,
@@ -769,39 +754,6 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         }
         self.list_file_revisions_for_inode_page(entry.inode_id, request)
             .await
-    }
-
-    pub(crate) async fn list_file_revisions_for_inode(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<ListFileRevisionsResponse, CoreError> {
-        let limit = PaginationPolicy::default()
-            .resolve_limit(None)
-            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
-        let mut cursor = None;
-        let mut revisions = Vec::new();
-        loop {
-            let page = self
-                .list_file_revisions_for_inode_page(
-                    inode_id,
-                    PageRequest {
-                        limit,
-                        cursor: cursor.clone(),
-                    },
-                )
-                .await?;
-            revisions.extend(page.items);
-            cursor = page.next_cursor;
-            if cursor.is_none() {
-                return Ok(ListFileRevisionsResponse {
-                    namespace_id: self.namespace_id.clone(),
-                    inode_id,
-                    head_seq: self.head.seq,
-                    revisions,
-                    next_cursor: None,
-                });
-            }
-        }
     }
 
     pub(crate) async fn list_file_revisions_for_inode_page(

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -527,16 +527,15 @@ fn read_file_bytes<S: ObjectStore + ?Sized>(
     )
 }
 
+/// Drains the paged revision listing — the only revision-listing operation
+/// the stack exposes — so guards can assert over a file's full history.
 fn list_file_revisions<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     absolute_path: &str,
 ) -> Result<loonfs_api::ListFileRevisionsResponse, CoreError> {
-    let context = read_context(store, namespace_id);
-    block_on(
-        namespace_engine(store, namespace_id, &mutation_context())
-            .list_file_revisions_with_runtime_context(absolute_path, &context),
-    )
+    let entry = resolve_path(store, namespace_id, absolute_path)?;
+    list_file_revisions_for_inode(store, namespace_id, entry.inode_id)
 }
 
 fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
@@ -545,10 +544,32 @@ fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
 ) -> Result<loonfs_api::ListFileRevisionsResponse, CoreError> {
     let context = read_context(store, namespace_id);
-    block_on(
-        namespace_engine(store, namespace_id, &mutation_context())
-            .list_file_revisions_for_inode_with_runtime_context(inode_id, &context),
-    )
+    let engine = namespace_engine(store, namespace_id, &mutation_context());
+    let mut revisions = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = block_on(
+            engine.list_file_revisions_for_inode_page_with_runtime_context(
+                inode_id,
+                PageRequest {
+                    limit: page_limit(2),
+                    cursor: cursor.clone(),
+                },
+                &context,
+            ),
+        )?;
+        revisions.extend(page.items);
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            return Ok(loonfs_api::ListFileRevisionsResponse {
+                namespace_id: namespace_id.clone(),
+                inode_id,
+                head_seq: context.head.seq,
+                revisions,
+                next_cursor: None,
+            });
+        }
+    }
 }
 
 fn read_file_revision_bytes<S: ObjectStore + ?Sized>(

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -882,20 +882,6 @@ impl FsCore {
         Ok(response)
     }
 
-    /// Lists the revision history of a file path.
-    pub(crate) async fn list_file_revisions(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<ListFileRevisionsResponse> {
-        let (engine, read_context) = self.pinned_read(namespace_id).await?;
-        let revisions = engine
-            .list_file_revisions_with_runtime_context(absolute_path, &read_context)
-            .await?;
-        self.inner.cache_stats.record_latest_metadata_view_read();
-        Ok(revisions)
-    }
-
     /// Lists one page of a file path's revision history.
     pub(crate) async fn list_file_revisions_page(
         &self,
@@ -915,21 +901,6 @@ impl FsCore {
             page,
             fallback_inode_id,
         )?)
-    }
-
-    /// Lists a file's revision history by inode id, independent of its
-    /// current path.
-    pub(crate) async fn list_file_revisions_for_inode(
-        &self,
-        namespace_id: &NamespaceId,
-        inode_id: InodeId,
-    ) -> Result<ListFileRevisionsResponse> {
-        let (engine, read_context) = self.pinned_read(namespace_id).await?;
-        let revisions = engine
-            .list_file_revisions_for_inode_with_runtime_context(inode_id, &read_context)
-            .await?;
-        self.inner.cache_stats.record_latest_metadata_view_read();
-        Ok(revisions)
     }
 
     /// Lists one page of a file inode's revision history.

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -131,17 +131,6 @@ impl FsReader {
         self.core.grep(namespace_id, request).await
     }
 
-    /// Lists the revision history of a file path.
-    pub async fn list_file_revisions(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<ListFileRevisionsResponse> {
-        self.core
-            .list_file_revisions(namespace_id, absolute_path)
-            .await
-    }
-
     /// Lists one page of a file path's revision history.
     pub async fn list_file_revisions_page(
         &self,
@@ -151,18 +140,6 @@ impl FsReader {
     ) -> Result<ListFileRevisionsResponse> {
         self.core
             .list_file_revisions_page(namespace_id, absolute_path, request)
-            .await
-    }
-
-    /// Lists a file's revision history by inode id, independent of its
-    /// current path.
-    pub async fn list_file_revisions_for_inode(
-        &self,
-        namespace_id: &NamespaceId,
-        inode_id: InodeId,
-    ) -> Result<ListFileRevisionsResponse> {
-        self.core
-            .list_file_revisions_for_inode(namespace_id, inode_id)
             .await
     }
 


### PR DESCRIPTION
Every layer of the runtime path carried two ways to list a file's revisions: the paged operation the server actually serves, and an unbounded twin whose view-level implementation drained every page into one response with next_cursor hardcoded to None. A file with a long history made that a cost proportional to its entire past, on a method whose signature promised a page-shaped response.

Deleted top to bottom: FsReader::list_file_revisions and ::list_file_revisions_for_inode, the Fs internals behind them, the engine's non-paged context methods, and the view's list_file_revisions plus the drain-all loop in list_file_revisions_for_inode. The _page variants remain at every layer and are unchanged; the client and CLI already spoke only the paged server endpoint and are untouched.