### PR TITLE
feat(api,core): provider auth failures reach the wire as permission_denied

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -120,6 +120,7 @@ macro_rules! error_codes {
 error_codes! {
     InvalidRequest => "invalid_request",
     Unauthorized => "unauthorized",
+    PermissionDenied => "permission_denied",
     ContentTooLarge => "content_too_large",
     NotSupported => "not_supported",
     RouteNotFound => "route_not_found",
@@ -167,6 +168,10 @@ impl ErrorCode {
             // into a capped scan.
             ErrorCode::InvalidRequest | ErrorCode::QueryUnindexable => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
+            // Produced when the backing object store rejects the
+            // deployment's credentials: operator-actionable and never
+            // transient, exactly the kind's contract.
+            ErrorCode::PermissionDenied => ErrorKind::PermissionDenied,
             ErrorCode::ContentTooLarge => ErrorKind::ContentTooLarge,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -1,7 +1,7 @@
 //! Read-modify-write loops for control objects: load, edit, and
 //! compare-and-swap the head or an upload session on its etag.
 
-use crate::error::CoreError;
+use crate::error::{CoreError, StoreFailureClass};
 use crate::namespace::control::{read_head_object, ControlObjectLoadError, LoadedHeadObject};
 use bytes::Bytes;
 use loonfs_api::wire::control::{
@@ -173,6 +173,7 @@ fn required_etag_core<'a>(
     metadata.etag.as_deref().ok_or_else(|| CoreError::Store {
         object_key: object_key.to_owned(),
         message: "missing control object etag".to_owned(),
+        class: StoreFailureClass::Other,
     })
 }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -56,7 +56,11 @@ pub enum CoreError {
     #[error("head publish failed: {0}")]
     HeadPublish(#[from] CommitHeadPublishError),
     #[error("failed to write wal object `{object_key}`: {message}")]
-    WalWrite { object_key: String, message: String },
+    WalWrite {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("invalid absolute path `{0}`")]
     InvalidPath(String),
     #[error(transparent)]
@@ -153,7 +157,11 @@ pub enum CoreError {
     #[error("writer session fenced: {0}")]
     WriterFenced(WriterFence),
     #[error("object store error for `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     /// Non-store internal failure (codec, overflow, invariant breach). Same
     /// wire code as [`ErrorCode::ServerError`]; the message is the detail.
     #[error("internal error: {0}")]
@@ -270,11 +278,43 @@ impl From<ImmutableObjectWriteError> for CoreError {
             ImmutableObjectWriteError::Store {
                 object_key,
                 message,
+                class,
             } => Self::Store {
                 object_key,
                 message,
+                class,
             },
         }
+    }
+}
+
+/// What a failed provider operation says about who can fix it, preserved
+/// across the message-flattening seams so the wire code can distinguish
+/// "fix the storage credentials" from "unclassified internal failure".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum StoreFailureClass {
+    /// The provider rejected the deployment's credentials: operator work,
+    /// never transient. Served as `permission_denied`.
+    PermissionDenied,
+    /// Everything else is internal from the caller's point of view.
+    Other,
+}
+
+impl StoreFailureClass {
+    /// Classifies a provider error at the seam where its message is
+    /// flattened into a carrier's `message` field.
+    pub fn of(error: &ObjectStoreError) -> Self {
+        match error {
+            ObjectStoreError::PermissionDenied { .. } => Self::PermissionDenied,
+            _ => Self::Other,
+        }
+    }
+}
+
+fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
+    match class {
+        StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+        StoreFailureClass::Other => ErrorCode::ServerError,
     }
 }
 
@@ -285,6 +325,7 @@ impl CoreError {
         Self::Store {
             object_key: object_key.into(),
             message: error.message(),
+            class: StoreFailureClass::of(error),
         }
     }
 
@@ -300,10 +341,10 @@ impl CoreError {
             CoreError::DurableContent(error) => classify_durable_content_error(error),
             CoreError::WriterEpoch(error) => classify_writer_epoch_acquire_error(error),
             CoreError::CommitValidation(error) => classify_commit_validation_error(error),
-            CoreError::WalBuild(_)
-            | CoreError::WalWrite { .. }
-            | CoreError::Store { .. }
-            | CoreError::Internal(_) => ErrorCode::ServerError,
+            CoreError::WalBuild(_) | CoreError::Internal(_) => ErrorCode::ServerError,
+            CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
+                classify_store_failure(*class)
+            }
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
             CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
                 ErrorCode::InvalidRequest
@@ -672,6 +713,7 @@ mod tests {
     use loonfs_api::{
         ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, RevisionNo, WriterEpoch,
     };
+    use loonfs_objectstore::ObjectStoreError;
 
     #[test]
     fn public_error_kind_groups_detailed_codes() {
@@ -786,5 +828,23 @@ mod tests {
 
         // Errors without machine-usable identity stay detail-free.
         assert!(CoreError::Internal("boom".to_owned()).details().is_none());
+    }
+
+    /// Provider auth failures keep their class across the message-flattening
+    /// seams and reach the wire as `permission_denied`; every other store
+    /// failure stays `server_error`.
+    #[test]
+    fn store_permission_denied_classifies_to_its_wire_code() {
+        let denied = ObjectStoreError::PermissionDenied {
+            object_key: "namespaces/demo/wal/head.json".to_owned(),
+            message: "AccessDenied: bucket policy".to_owned(),
+        };
+        let error = CoreError::store("namespaces/demo/wal/head.json", &denied);
+        assert_eq!(error.code(), ErrorCode::PermissionDenied);
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+
+        let transport = ObjectStoreError::transport("namespaces/demo/wal/head.json", "timed out");
+        let error = CoreError::store("namespaces/demo/wal/head.json", &transport);
+        assert_eq!(error.code(), ErrorCode::ServerError);
     }
 }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -120,7 +120,7 @@ pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
-    WriterFence,
+    StoreFailureClass, WriterFence,
 };
 pub use gc::{gc_namespace, GcConfig, GcReport};
 pub use namespace::BootstrapNamespaceError;

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -97,14 +97,17 @@ impl From<NamespaceInitializationError> for BootstrapNamespaceError {
             NamespaceInitializationError::InspectNamespaceDescriptor {
                 object_key,
                 message,
+                ..
             } => Self::DescriptorWrite(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::InspectNamespaceHead {
                 object_key,
                 message,
+                ..
             } => Self::HeadWrite(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::InspectNamespaceControl {
                 object_key,
                 message,
+                ..
             } => Self::DebrisCleanup(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::LoadNamespaceDescriptor(error)
             | NamespaceInitializationError::LoadContentStoreDescriptor(error) => {

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -1,6 +1,7 @@
 //! The namespace catalog: the immutable descriptor pair (namespace config
 //! and content-store descriptor) loaded once and reused for a session.
 
+use crate::error::StoreFailureClass;
 use crate::namespace::control::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
@@ -56,11 +57,23 @@ pub(crate) enum NamespaceInitializationError {
     #[error(transparent)]
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("failed to inspect namespace descriptor object `{object_key}`: {message}")]
-    InspectNamespaceDescriptor { object_key: String, message: String },
+    InspectNamespaceDescriptor {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to inspect namespace head object `{object_key}`: {message}")]
-    InspectNamespaceHead { object_key: String, message: String },
+    InspectNamespaceHead {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to inspect namespace control object `{object_key}`: {message}")]
-    InspectNamespaceControl { object_key: String, message: String },
+    InspectNamespaceControl {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to load namespace descriptor: {0}")]
     LoadNamespaceDescriptor(ControlObjectLoadError),
     #[error("failed to load content store descriptor: {0}")]
@@ -118,6 +131,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
             |err| NamespaceInitializationError::InspectNamespaceDescriptor {
                 object_key: descriptor_key.clone(),
                 message: err.message(),
+                class: StoreFailureClass::of(&err),
             },
         )?
         .is_some();
@@ -127,6 +141,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
         .map_err(|err| NamespaceInitializationError::InspectNamespaceHead {
             object_key: head_key.clone(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         })?
         .is_some();
 
@@ -148,6 +163,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
                         |err| NamespaceInitializationError::InspectNamespaceControl {
                             object_key: probe_key.clone(),
                             message: err.message(),
+                            class: StoreFailureClass::of(&err),
                         },
                     )?
                     .is_some();

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -1,6 +1,7 @@
 //! Typed loaders for the namespace's control objects: head, metadata root,
 //! WAL floor, and the descriptor pair.
 
+use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{
     decode_control_object, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
     ControlCodecError, ControlObjectKind, HeadState, HeadStateEnvelope, MetadataRootEnvelope,
@@ -135,7 +136,11 @@ pub enum ControlObjectLoadError {
     #[error("control object codec error for `{object_key}`: {message}")]
     Codec { object_key: String, message: String },
     #[error("control object store error for `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
 }
 
 pub(crate) async fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
@@ -407,6 +412,7 @@ fn control_identity(
         .ok_or_else(|| ControlObjectLoadError::Store {
             object_key: object_key.to_owned(),
             message: "missing control object etag".to_owned(),
+            class: StoreFailureClass::Other,
         })?;
     Ok(ControlObjectIdentity { etag })
 }
@@ -474,5 +480,6 @@ fn map_store_load_error(object_key: &str, err: ObjectStoreError) -> ControlObjec
     ControlObjectLoadError::Store {
         object_key: object_key.to_owned(),
         message: err.message(),
+        class: StoreFailureClass::of(&err),
     }
 }

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -9,7 +9,7 @@ use crate::checkpoint::{
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::namespace::catalog::{
     load_namespace_descriptor, namespace_initialization_state, NamespaceInitializationError,
     NamespaceInitializationState,
@@ -453,6 +453,7 @@ async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
                 NamespaceInitializationState::Absent => Err(CoreError::Store {
                     object_key: object_key.to_owned(),
                     message: "control object write failed, but namespace remains absent".to_owned(),
+                    class: StoreFailureClass::Other,
                 }),
             }
         }

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -140,20 +140,25 @@ fn map_namespace_initialization_error_to_core(error: NamespaceInitializationErro
         NamespaceInitializationError::InspectNamespaceControl {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
         NamespaceInitializationError::InspectNamespaceDescriptor {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceHead {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
     }
 }

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -14,7 +14,7 @@ use crate::commit::{
 };
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::path::write::PublishPlanningSession;
 use crate::storage::content::ContentValidationTracker;
 use crate::timing::MonotonicTimer;
@@ -359,6 +359,7 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
             .map_err(|error| CoreError::WalWrite {
                 object_key: wal.object_key.clone(),
                 message: error.message(),
+                class: StoreFailureClass::of(&error),
             })?;
         Ok(wal)
     }

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -7,7 +7,7 @@ use crate::checkpoint::{
     VerifiedMetadataTables,
 };
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
@@ -309,6 +309,7 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
                 ControlObjectLoadError::Store {
                     object_key: object_key.clone(),
                     message: error.message(),
+                    class: StoreFailureClass::of(&error),
                 },
             ))
         })?

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -194,17 +194,21 @@ fn map_upload_namespace_initialization_error(error: NamespaceInitializationError
         NamespaceInitializationError::InspectNamespaceDescriptor {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceHead {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceControl {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
     }
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -1,7 +1,7 @@
 //! Content blob reads and writes: content-addressed storage, reference
 //! validation, and verified read-back.
 
-use crate::error::CoreError;
+use crate::error::{CoreError, StoreFailureClass};
 use crate::invariants::InvariantId;
 use crate::namespace::catalog::load_namespace_content_store_id;
 use bytes::Bytes;
@@ -87,7 +87,11 @@ pub enum DurableContentValidationError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub(crate) enum ImmutableObjectWriteError {
     #[error("failed to write immutable object `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
 }
 
 pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
@@ -272,6 +276,7 @@ pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
             Err(ImmutableObjectWriteError::Store {
                 object_key: object_key.to_owned(),
                 message: "object already exists with different bytes".to_owned(),
+                class: StoreFailureClass::Other,
             })
         }
         Err(err @ ObjectStoreError::Transport { .. }) => {
@@ -283,18 +288,21 @@ pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
                     message: format!(
                         "{original}; immutable object exists with different bytes after transport error"
                     ),
+                    class: StoreFailureClass::Other,
                 }),
                 Err(verify_err) => Err(ImmutableObjectWriteError::Store {
                     object_key: object_key.to_owned(),
                     message: format!(
                         "{original}; failed to verify immutable write after transport error: {verify_err}"
                     ),
+                    class: StoreFailureClass::Other,
                 }),
             }
         }
         Err(err) => Err(ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         }),
     }
 }
@@ -312,6 +320,7 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
             .map_err(|err| ImmutableObjectWriteError::Store {
                 object_key: object_key.to_owned(),
                 message: err.message(),
+                class: StoreFailureClass::of(&err),
             })?
     {
         if metadata.size_bytes != expected_size {
@@ -325,10 +334,12 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
         .map_err(|err| ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         })?
         .ok_or_else(|| ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: "object is missing while verifying immutable write".to_owned(),
+            class: StoreFailureClass::Other,
         })?;
     Ok(existing == expected_bytes)
 }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -18,7 +18,7 @@ use loonfs_core::control::{
     VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::publish::{NamespaceCommitEngine, SharedWriterSessionState};
-use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext};
+use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::{namespace_config, wal_head};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -355,6 +355,7 @@ impl FsCore {
                 return RuntimeError::Core(CoreError::Store {
                     object_key: descriptor_key,
                     message: error.message(),
+                    class: StoreFailureClass::of(&error),
                 })
             }
         };
@@ -387,6 +388,7 @@ impl FsCore {
             .map_err(|error| ControlObjectLoadError::Store {
                 object_key: object_key.to_owned(),
                 message: error.message(),
+                class: StoreFailureClass::of(&error),
             })?
             .ok_or_else(|| ControlObjectLoadError::MissingObject {
                 object_key: object_key.to_owned(),
@@ -395,6 +397,7 @@ impl FsCore {
             return Err(ControlObjectLoadError::Store {
                 object_key: object_key.to_owned(),
                 message: "missing control object etag".to_owned(),
+                class: StoreFailureClass::Other,
             });
         };
         Ok(etag == identity.etag)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -209,6 +209,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | --- | --- | --- |
 | `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, or configuration value fails validation. The message names the offending field. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
+| `permission_denied` | 403 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; retrying unchanged will not succeed. |
 | `content_too_large` | 413 | The request body exceeds the deployment's limit: `upload.max_content_bytes` for proxied uploads, `commit.max_body_bytes` for commit bodies. Served file content past `download.max_content_bytes` reports it too. For uploads, send a smaller payload or use `direct_put`; for commits, split the batch; for reads, the deployment limit must be raised. |
 | `route_not_found` | 404 | No route matches the request path. |
 | `method_not_allowed` | 405 | The path exists but does not serve this HTTP method. |


### PR DESCRIPTION
A rejected bucket policy or expired storage credential surfaced as server_error — a 500 that says "capture details and report it" and invites retries, when the honest answer is "fix the credentials; retrying cannot help." The classification existed at the provider boundary since #299 but was erased one line later: CoreError::store() flattened the ObjectStoreError to a message string, and ErrorKind::PermissionDenied plus the server's 403 arm sat unreachable because no registry code mapped to them.

- The registry gains permission_denied (403), with the api.md row wording it precisely: the backing object store rejected the deployment's storage credentials — operator-actionable, never transient. The server's spec-table sync test passes with the new row; no server code changes, the dead 403 arm is simply live now.
- A two-variant StoreFailureClass (PermissionDenied | Other) rides across every message-flattening seam: CoreError::Store and WalWrite, ControlObjectLoadError::Store (head/root loads — the first store op of every request), NamespaceInitializationError's three inspect variants, ImmutableObjectWriteError::Store and the content-validation store arm, plus the runtime cache's own construction sites. Classification happens where the ObjectStoreError is still in hand (StoreFailureClass::of); synthesized failures (missing etag, mismatched immutable bytes) are explicitly Other.
- Coverage is deliberately complete across the data plane so read-only credentials cannot yield permission_denied on reads but server_error on writes — the same-failure-same-code rule this workstream exists to enforce. One known seam remains: the create/fork bootstrap path string-flattens its inspect failures into its own error vocabulary, so an auth failure during namespace creation still reports through the bootstrap codes with the provider message in the text; the same credentials fail with a clean permission_denied on the first data-plane operation.
