### PR TITLE
fix(server): malformed requests answer in the error envelope, behind authorization

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -120,6 +120,7 @@ macro_rules! error_codes {
 error_codes! {
     InvalidRequest => "invalid_request",
     Unauthorized => "unauthorized",
+    PermissionDenied => "permission_denied",
     ContentTooLarge => "content_too_large",
     NotSupported => "not_supported",
     RouteNotFound => "route_not_found",
@@ -167,6 +168,10 @@ impl ErrorCode {
             // into a capped scan.
             ErrorCode::InvalidRequest | ErrorCode::QueryUnindexable => ErrorKind::InvalidRequest,
             ErrorCode::Unauthorized => ErrorKind::Unauthorized,
+            // Produced when the backing object store rejects the
+            // deployment's credentials: operator-actionable and never
+            // transient, exactly the kind's contract.
+            ErrorCode::PermissionDenied => ErrorKind::PermissionDenied,
             ErrorCode::ContentTooLarge => ErrorKind::ContentTooLarge,
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -1,7 +1,7 @@
 //! Read-modify-write loops for control objects: load, edit, and
 //! compare-and-swap the head or an upload session on its etag.
 
-use crate::error::CoreError;
+use crate::error::{CoreError, StoreFailureClass};
 use crate::namespace::control::{read_head_object, ControlObjectLoadError, LoadedHeadObject};
 use bytes::Bytes;
 use loonfs_api::wire::control::{
@@ -173,6 +173,7 @@ fn required_etag_core<'a>(
     metadata.etag.as_deref().ok_or_else(|| CoreError::Store {
         object_key: object_key.to_owned(),
         message: "missing control object etag".to_owned(),
+        class: StoreFailureClass::Other,
     })
 }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -56,7 +56,11 @@ pub enum CoreError {
     #[error("head publish failed: {0}")]
     HeadPublish(#[from] CommitHeadPublishError),
     #[error("failed to write wal object `{object_key}`: {message}")]
-    WalWrite { object_key: String, message: String },
+    WalWrite {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("invalid absolute path `{0}`")]
     InvalidPath(String),
     #[error(transparent)]
@@ -153,7 +157,11 @@ pub enum CoreError {
     #[error("writer session fenced: {0}")]
     WriterFenced(WriterFence),
     #[error("object store error for `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     /// Non-store internal failure (codec, overflow, invariant breach). Same
     /// wire code as [`ErrorCode::ServerError`]; the message is the detail.
     #[error("internal error: {0}")]
@@ -270,11 +278,43 @@ impl From<ImmutableObjectWriteError> for CoreError {
             ImmutableObjectWriteError::Store {
                 object_key,
                 message,
+                class,
             } => Self::Store {
                 object_key,
                 message,
+                class,
             },
         }
+    }
+}
+
+/// What a failed provider operation says about who can fix it, preserved
+/// across the message-flattening seams so the wire code can distinguish
+/// "fix the storage credentials" from "unclassified internal failure".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum StoreFailureClass {
+    /// The provider rejected the deployment's credentials: operator work,
+    /// never transient. Served as `permission_denied`.
+    PermissionDenied,
+    /// Everything else is internal from the caller's point of view.
+    Other,
+}
+
+impl StoreFailureClass {
+    /// Classifies a provider error at the seam where its message is
+    /// flattened into a carrier's `message` field.
+    pub fn of(error: &ObjectStoreError) -> Self {
+        match error {
+            ObjectStoreError::PermissionDenied { .. } => Self::PermissionDenied,
+            _ => Self::Other,
+        }
+    }
+}
+
+fn classify_store_failure(class: StoreFailureClass) -> ErrorCode {
+    match class {
+        StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+        StoreFailureClass::Other => ErrorCode::ServerError,
     }
 }
 
@@ -285,6 +325,7 @@ impl CoreError {
         Self::Store {
             object_key: object_key.into(),
             message: error.message(),
+            class: StoreFailureClass::of(error),
         }
     }
 
@@ -300,10 +341,10 @@ impl CoreError {
             CoreError::DurableContent(error) => classify_durable_content_error(error),
             CoreError::WriterEpoch(error) => classify_writer_epoch_acquire_error(error),
             CoreError::CommitValidation(error) => classify_commit_validation_error(error),
-            CoreError::WalBuild(_)
-            | CoreError::WalWrite { .. }
-            | CoreError::Store { .. }
-            | CoreError::Internal(_) => ErrorCode::ServerError,
+            CoreError::WalBuild(_) | CoreError::Internal(_) => ErrorCode::ServerError,
+            CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
+                classify_store_failure(*class)
+            }
             CoreError::HeadPublish(error) => classify_head_publish_error(error),
             CoreError::InvalidPath(_) | CoreError::RootMutationForbidden => {
                 ErrorCode::InvalidRequest
@@ -672,6 +713,7 @@ mod tests {
     use loonfs_api::{
         ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, RevisionNo, WriterEpoch,
     };
+    use loonfs_objectstore::ObjectStoreError;
 
     #[test]
     fn public_error_kind_groups_detailed_codes() {
@@ -786,5 +828,23 @@ mod tests {
 
         // Errors without machine-usable identity stay detail-free.
         assert!(CoreError::Internal("boom".to_owned()).details().is_none());
+    }
+
+    /// Provider auth failures keep their class across the message-flattening
+    /// seams and reach the wire as `permission_denied`; every other store
+    /// failure stays `server_error`.
+    #[test]
+    fn store_permission_denied_classifies_to_its_wire_code() {
+        let denied = ObjectStoreError::PermissionDenied {
+            object_key: "namespaces/demo/wal/head.json".to_owned(),
+            message: "AccessDenied: bucket policy".to_owned(),
+        };
+        let error = CoreError::store("namespaces/demo/wal/head.json", &denied);
+        assert_eq!(error.code(), ErrorCode::PermissionDenied);
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+
+        let transport = ObjectStoreError::transport("namespaces/demo/wal/head.json", "timed out");
+        let error = CoreError::store("namespaces/demo/wal/head.json", &transport);
+        assert_eq!(error.code(), ErrorCode::ServerError);
     }
 }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -120,7 +120,7 @@ pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};
 pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, Result,
-    WriterFence,
+    StoreFailureClass, WriterFence,
 };
 pub use gc::{gc_namespace, GcConfig, GcReport};
 pub use namespace::BootstrapNamespaceError;

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -97,14 +97,17 @@ impl From<NamespaceInitializationError> for BootstrapNamespaceError {
             NamespaceInitializationError::InspectNamespaceDescriptor {
                 object_key,
                 message,
+                ..
             } => Self::DescriptorWrite(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::InspectNamespaceHead {
                 object_key,
                 message,
+                ..
             } => Self::HeadWrite(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::InspectNamespaceControl {
                 object_key,
                 message,
+                ..
             } => Self::DebrisCleanup(format!("failed to inspect `{object_key}`: {message}")),
             NamespaceInitializationError::LoadNamespaceDescriptor(error)
             | NamespaceInitializationError::LoadContentStoreDescriptor(error) => {

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -1,6 +1,7 @@
 //! The namespace catalog: the immutable descriptor pair (namespace config
 //! and content-store descriptor) loaded once and reused for a session.
 
+use crate::error::StoreFailureClass;
 use crate::namespace::control::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
@@ -56,11 +57,23 @@ pub(crate) enum NamespaceInitializationError {
     #[error(transparent)]
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("failed to inspect namespace descriptor object `{object_key}`: {message}")]
-    InspectNamespaceDescriptor { object_key: String, message: String },
+    InspectNamespaceDescriptor {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to inspect namespace head object `{object_key}`: {message}")]
-    InspectNamespaceHead { object_key: String, message: String },
+    InspectNamespaceHead {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to inspect namespace control object `{object_key}`: {message}")]
-    InspectNamespaceControl { object_key: String, message: String },
+    InspectNamespaceControl {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("failed to load namespace descriptor: {0}")]
     LoadNamespaceDescriptor(ControlObjectLoadError),
     #[error("failed to load content store descriptor: {0}")]
@@ -118,6 +131,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
             |err| NamespaceInitializationError::InspectNamespaceDescriptor {
                 object_key: descriptor_key.clone(),
                 message: err.message(),
+                class: StoreFailureClass::of(&err),
             },
         )?
         .is_some();
@@ -127,6 +141,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
         .map_err(|err| NamespaceInitializationError::InspectNamespaceHead {
             object_key: head_key.clone(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         })?
         .is_some();
 
@@ -148,6 +163,7 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
                         |err| NamespaceInitializationError::InspectNamespaceControl {
                             object_key: probe_key.clone(),
                             message: err.message(),
+                            class: StoreFailureClass::of(&err),
                         },
                     )?
                     .is_some();

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -1,6 +1,7 @@
 //! Typed loaders for the namespace's control objects: head, metadata root,
 //! WAL floor, and the descriptor pair.
 
+use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{
     decode_control_object, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
     ControlCodecError, ControlObjectKind, HeadState, HeadStateEnvelope, MetadataRootEnvelope,
@@ -135,7 +136,11 @@ pub enum ControlObjectLoadError {
     #[error("control object codec error for `{object_key}`: {message}")]
     Codec { object_key: String, message: String },
     #[error("control object store error for `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
 }
 
 pub(crate) async fn read_namespace_descriptor_object<S: ObjectStore + ?Sized>(
@@ -407,6 +412,7 @@ fn control_identity(
         .ok_or_else(|| ControlObjectLoadError::Store {
             object_key: object_key.to_owned(),
             message: "missing control object etag".to_owned(),
+            class: StoreFailureClass::Other,
         })?;
     Ok(ControlObjectIdentity { etag })
 }
@@ -474,5 +480,6 @@ fn map_store_load_error(object_key: &str, err: ObjectStoreError) -> ControlObjec
     ControlObjectLoadError::Store {
         object_key: object_key.to_owned(),
         message: err.message(),
+        class: StoreFailureClass::of(&err),
     }
 }

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -9,7 +9,7 @@ use crate::checkpoint::{
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::namespace::catalog::{
     load_namespace_descriptor, namespace_initialization_state, NamespaceInitializationError,
     NamespaceInitializationState,
@@ -453,6 +453,7 @@ async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
                 NamespaceInitializationState::Absent => Err(CoreError::Store {
                     object_key: object_key.to_owned(),
                     message: "control object write failed, but namespace remains absent".to_owned(),
+                    class: StoreFailureClass::Other,
                 }),
             }
         }

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -140,20 +140,25 @@ fn map_namespace_initialization_error_to_core(error: NamespaceInitializationErro
         NamespaceInitializationError::InspectNamespaceControl {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
         NamespaceInitializationError::InspectNamespaceDescriptor {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceHead {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
     }
 }

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -14,7 +14,7 @@ use crate::commit::{
 };
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::path::write::PublishPlanningSession;
 use crate::storage::content::ContentValidationTracker;
 use crate::timing::MonotonicTimer;
@@ -359,6 +359,7 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
             .map_err(|error| CoreError::WalWrite {
                 object_key: wal.object_key.clone(),
                 message: error.message(),
+                class: StoreFailureClass::of(&error),
             })?;
         Ok(wal)
     }

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -7,7 +7,7 @@ use crate::checkpoint::{
     VerifiedMetadataTables,
 };
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
@@ -309,6 +309,7 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
                 ControlObjectLoadError::Store {
                     object_key: object_key.clone(),
                     message: error.message(),
+                    class: StoreFailureClass::of(&error),
                 },
             ))
         })?

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -194,17 +194,21 @@ fn map_upload_namespace_initialization_error(error: NamespaceInitializationError
         NamespaceInitializationError::InspectNamespaceDescriptor {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceHead {
             object_key,
             message,
+            class,
         }
         | NamespaceInitializationError::InspectNamespaceControl {
             object_key,
             message,
+            class,
         } => CoreError::Store {
             object_key,
             message,
+            class,
         },
     }
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -1,7 +1,7 @@
 //! Content blob reads and writes: content-addressed storage, reference
 //! validation, and verified read-back.
 
-use crate::error::CoreError;
+use crate::error::{CoreError, StoreFailureClass};
 use crate::invariants::InvariantId;
 use crate::namespace::catalog::load_namespace_content_store_id;
 use bytes::Bytes;
@@ -87,7 +87,11 @@ pub enum DurableContentValidationError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub(crate) enum ImmutableObjectWriteError {
     #[error("failed to write immutable object `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
 }
 
 pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
@@ -272,6 +276,7 @@ pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
             Err(ImmutableObjectWriteError::Store {
                 object_key: object_key.to_owned(),
                 message: "object already exists with different bytes".to_owned(),
+                class: StoreFailureClass::Other,
             })
         }
         Err(err @ ObjectStoreError::Transport { .. }) => {
@@ -283,18 +288,21 @@ pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
                     message: format!(
                         "{original}; immutable object exists with different bytes after transport error"
                     ),
+                    class: StoreFailureClass::Other,
                 }),
                 Err(verify_err) => Err(ImmutableObjectWriteError::Store {
                     object_key: object_key.to_owned(),
                     message: format!(
                         "{original}; failed to verify immutable write after transport error: {verify_err}"
                     ),
+                    class: StoreFailureClass::Other,
                 }),
             }
         }
         Err(err) => Err(ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         }),
     }
 }
@@ -312,6 +320,7 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
             .map_err(|err| ImmutableObjectWriteError::Store {
                 object_key: object_key.to_owned(),
                 message: err.message(),
+                class: StoreFailureClass::of(&err),
             })?
     {
         if metadata.size_bytes != expected_size {
@@ -325,10 +334,12 @@ async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
         .map_err(|err| ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: err.message(),
+            class: StoreFailureClass::of(&err),
         })?
         .ok_or_else(|| ImmutableObjectWriteError::Store {
             object_key: object_key.to_owned(),
             message: "object is missing while verifying immutable write".to_owned(),
+            class: StoreFailureClass::Other,
         })?;
     Ok(existing == expected_bytes)
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -4,8 +4,8 @@
 
 use super::error::ApiResponseError;
 use super::handlers_uploads::{content_admissions_for_put, current_unix_ms};
-use super::{authorize, AppJson, AppState, CommitAppJson, NamespaceIdPath};
-use axum::extract::{Path as AxumPath, Query, State};
+use super::{authorize, AppJson, AppPath, AppQuery, AppState, CommitAppJson, NamespaceIdPath};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -96,10 +96,11 @@ pub(super) async fn list_entries(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    Query(query): Query<PathPageQuery>,
+    query: AppQuery<PathPageQuery>,
 ) -> Result<Json<loonfs_api::ListPathEntriesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     let path = query.path;
     let listing = state
         .reader
@@ -141,10 +142,11 @@ pub(super) async fn stat_entry(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    Query(query): Query<PathQuery>,
+    query: AppQuery<PathQuery>,
 ) -> Result<Json<loonfs_api::AuthoritativePathEntry>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     let path = query.path;
     let entry = state
         .reader
@@ -182,10 +184,11 @@ pub(super) async fn get_content(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    Query(query): Query<ContentQuery>,
+    query: AppQuery<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     // Held for the read below: content reads buffer the whole file, so the
     // permit is what bounds how many such buffers exist at once.
     let _permit = state
@@ -239,10 +242,11 @@ pub(super) async fn list_path_revisions(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    Query(query): Query<PathPageQuery>,
+    query: AppQuery<PathPageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     let path = query.path;
     let response = state
         .reader
@@ -285,12 +289,14 @@ pub(super) async fn list_path_revisions(
 pub(super) async fn list_inode_revisions(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(InodePathParams { inode_id }): AxumPath<InodePathParams>,
+    path: AppPath<InodePathParams>,
     headers: HeaderMap,
-    Query(query): Query<PageQuery>,
+    query: AppQuery<PageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let InodePathParams { inode_id } = path.into_params()?;
+    let query = query.into_params()?;
     let inode_id = parse_inode_id(&inode_id)?;
     let response = state
         .reader
@@ -334,14 +340,15 @@ pub(super) async fn list_inode_revisions(
 pub(super) async fn get_inode_revision_content(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(InodeRevisionPathParams {
-        inode_id,
-        revision_no,
-    }): AxumPath<InodeRevisionPathParams>,
+    path: AppPath<InodeRevisionPathParams>,
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let InodeRevisionPathParams {
+        inode_id,
+        revision_no,
+    } = path.into_params()?;
     let _permit = state
         .download_permits
         .clone()
@@ -384,15 +391,16 @@ pub(super) async fn get_inode_revision_content(
 pub(super) async fn restore_inode_revision(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(InodeRestorePathParams {
-        inode_id,
-        source_revision_no,
-    }): AxumPath<InodeRestorePathParams>,
+    path: AppPath<InodeRestorePathParams>,
     headers: HeaderMap,
     AppJson(request): AppJson<RestoreFileRevisionRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let InodeRestorePathParams {
+        inode_id,
+        source_revision_no,
+    } = path.into_params()?;
     let inode_id = parse_inode_id(&inode_id)?;
     let source_revision_no = parse_revision_no(&source_revision_no)?;
     let commit = ApiCommitRequest {
@@ -650,10 +658,11 @@ pub(super) async fn list_changes(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    Query(query): Query<ChangesQuery>,
+    query: AppQuery<ChangesQuery>,
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     let after_seq = loonfs_api::ChangeSeq(query.after_seq);
     let limit = resolve_page_limit(query.limit)?;
     let response = state

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,13 +2,17 @@
 //! handlers.
 
 use super::error::ApiResponseError;
-use super::{authorize, parse_namespace_id, AppJson, AppState, NamespaceIdPath, OptionalAppJson};
-use axum::extract::{Path as AxumPath, Query, State};
+use super::{
+    authorize, parse_namespace_id, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath,
+    OptionalAppJson,
+};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use loonfs::{ChangeSeq, CreateNamespaceOptions, DeleteNamespaceOptions};
+use loonfs::{CreateNamespaceOptions, DeleteNamespaceOptions};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
+use loonfs_api::ChangeSeq;
 use loonfs_api::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, ErrorCode, FlushWalResponse, ForkNamespaceRequest, GcRequest,
@@ -162,11 +166,12 @@ pub(super) async fn namespace_status(
 pub(super) async fn delete_namespace(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    Query(query): Query<DeleteNamespaceQuery>,
+    query: AppQuery<DeleteNamespaceQuery>,
     headers: HeaderMap,
-) -> Result<Json<loonfs::DeleteNamespaceResponse>, ApiResponseError> {
+) -> Result<Json<loonfs_api::DeleteNamespaceResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let query = query.into_params()?;
     let options = DeleteNamespaceOptions {
         expected_head_seq: query.expected_head_seq.map(ChangeSeq),
     };
@@ -277,11 +282,12 @@ pub(super) async fn create_checkpoint(
 pub(super) async fn release_checkpoint(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(CheckpointPathParams { checkpoint_id }): AxumPath<CheckpointPathParams>,
+    path: AppPath<CheckpointPathParams>,
     headers: HeaderMap,
 ) -> Result<Json<ReleaseCheckpointResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let CheckpointPathParams { checkpoint_id } = path.into_params()?;
     let checkpoint_id = parse_checkpoint_id(&checkpoint_id)?;
     let response = state
         .admin

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -5,11 +5,11 @@ use crate::http::error::ApiResponseError;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
-#[cfg(feature = "openapi")]
-use loonfs_api::v0::ApiError;
 use loonfs_api::v0::{
     DisableGramsIndexResponse, EnableGramsIndexResponse, GrepRequest, GrepResponse,
 };
+#[cfg(feature = "openapi")]
+use loonfs_api::ApiError;
 
 #[cfg_attr(
     feature = "openapi",

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -2,17 +2,19 @@
 //! backing them.
 
 use super::error::ApiResponseError;
-use super::{authorize, AppJson, AppState, NamespaceIdPath, OptionalAppJson, UploadBodyBytes};
+use super::{
+    authorize, AppJson, AppPath, AppState, NamespaceIdPath, OptionalAppJson, UploadBodyBytes,
+};
 use crate::config::ServerConfig;
-use axum::extract::{Path as AxumPath, State};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use loonfs::content_tokens::{
     mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
 };
-use loonfs::ErrorCode;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
+use loonfs_api::ErrorCode;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
@@ -215,12 +217,13 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
 pub(super) async fn upload_content(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(UploadPathParams { upload_id }): AxumPath<UploadPathParams>,
+    path: AppPath<UploadPathParams>,
     headers: HeaderMap,
     body: UploadBodyBytes,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let response = state
         .writer
@@ -256,12 +259,13 @@ pub(super) async fn upload_content(
 pub(super) async fn complete_upload(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    AxumPath(UploadPathParams { upload_id }): AxumPath<UploadPathParams>,
+    path: AppPath<UploadPathParams>,
     headers: HeaderMap,
     AppJson(request): AppJson<CompleteUploadRequest>,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
+    let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let mut response = state
         .writer

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -44,7 +44,7 @@ use axum::async_trait;
 use axum::body::Bytes;
 use axum::extract::rejection::PathRejection;
 use axum::extract::{
-    DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath, Request, State,
+    DefaultBodyLimit, FromRequest, FromRequestParts, Path as AxumPath, Query, Request, State,
 };
 use axum::http::request::Parts;
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
@@ -59,6 +59,7 @@ use loonfs::{
 };
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::presign::ObjectTransferIssuer;
+use std::convert::Infallible;
 use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -622,18 +623,89 @@ impl<S> FromRequestParts<S> for NamespaceIdPath
 where
     S: Send + Sync,
 {
-    type Rejection = PathRejection;
+    type Rejection = Infallible;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let AxumPath(NamespaceSegment { namespace }) =
-            AxumPath::<NamespaceSegment>::from_request_parts(parts, state).await?;
-        Ok(Self(parse_namespace_id(namespace)))
+        match AxumPath::<NamespaceSegment>::from_request_parts(parts, state).await {
+            Ok(AxumPath(NamespaceSegment { namespace })) => Ok(Self(parse_namespace_id(namespace))),
+            Err(rejection) => Ok(Self(Err(invalid_path_params(&rejection)))),
+        }
+    }
+}
+
+fn invalid_path_params(rejection: &PathRejection) -> ApiResponseError {
+    ApiResponseError::new(
+        StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+        &format!("invalid path parameters: {rejection}"),
+    )
+}
+
+/// Path extractor that never rejects at extraction: the parse outcome is
+/// surfaced through [`AppPath::into_params`] inside the handler, after
+/// `authorize`, so malformed path parameters answer inside the JSON error
+/// envelope and never turn an unauthorized request's 401 into a 400.
+struct AppPath<T>(Result<T, ApiResponseError>);
+
+impl<T> AppPath<T> {
+    fn into_params(self) -> Result<T, ApiResponseError> {
+        self.0
+    }
+}
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for AppPath<T>
+where
+    S: Send + Sync,
+    T: serde::de::DeserializeOwned + Send,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match AxumPath::<T>::from_request_parts(parts, state).await {
+            Ok(AxumPath(value)) => Ok(Self(Ok(value))),
+            Err(rejection) => Ok(Self(Err(invalid_path_params(&rejection)))),
+        }
+    }
+}
+
+/// [`AppPath`]'s query-string twin: missing required parameters, values that
+/// fail their field types (`after_seq=abc`), and undecodable query strings
+/// all surface through [`AppQuery::into_params`] after `authorize`, inside
+/// the envelope.
+struct AppQuery<T>(Result<T, ApiResponseError>);
+
+impl<T> AppQuery<T> {
+    fn into_params(self) -> Result<T, ApiResponseError> {
+        self.0
+    }
+}
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for AppQuery<T>
+where
+    S: Send + Sync,
+    T: serde::de::DeserializeOwned,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match Query::<T>::from_request_parts(parts, state).await {
+            Ok(Query(value)) => Ok(Self(Ok(value))),
+            Err(rejection) => Ok(Self(Err(ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &format!("invalid query parameters: {rejection}"),
+            )))),
+        }
     }
 }
 
 /// A `Json` extractor whose rejections stay inside the error contract:
 /// malformed bodies answer 400 with an `invalid_request` `ApiError` body
-/// instead of the raw framework rejection.
+/// instead of the raw framework rejection, and authorization runs before
+/// the body is read so a malformed body never turns an unauthorized
+/// request's 401 into a 400.
 struct AppJson<T>(T);
 
 async fn extract_json<S, T>(
@@ -659,14 +731,17 @@ where
 }
 
 #[async_trait]
-impl<S, T> FromRequest<S> for AppJson<T>
+impl<T> FromRequest<AppState> for AppJson<T>
 where
     T: serde::de::DeserializeOwned,
-    S: Send + Sync,
 {
     type Rejection = ApiResponseError;
 
-    async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        authorize(&state.config, req.headers())?;
         extract_json(req, state, json_body_too_large_error)
             .await
             .map(AppJson)
@@ -783,17 +858,17 @@ struct OptionalAppJson<T>(Option<T>);
 const MAX_OPTIONAL_JSON_BODY_BYTES: usize = 1024 * 1024;
 
 #[async_trait]
-impl<S, T> FromRequest<S> for OptionalAppJson<T>
+impl<T> FromRequest<AppState> for OptionalAppJson<T>
 where
     T: serde::de::DeserializeOwned,
-    S: Send + Sync,
 {
     type Rejection = ApiResponseError;
 
     async fn from_request(
         req: axum::extract::Request,
-        _state: &S,
+        state: &AppState,
     ) -> Result<Self, Self::Rejection> {
+        authorize(&state.config, req.headers())?;
         let body = axum::body::to_bytes(req.into_body(), MAX_OPTIONAL_JSON_BODY_BYTES)
             .await
             .map_err(|error| {

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -6,7 +6,7 @@
 //! name, so renaming a handler changes the published id — regenerate
 //! `docs/specs/openapi.json` deliberately when that happens.
 
-use loonfs::ChangeSeq;
+use loonfs_api::ChangeSeq;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -69,11 +69,11 @@ use crate::{ServerConfig, StoreConfig};
 use async_trait::async_trait;
 use axum::body::Bytes;
 use futures::stream::BoxStream;
-use loonfs::ErrorCode;
 use loonfs::{
     CreateNamespaceOptions, DeleteOptions, FsAdmin, FsWriter, MaintenanceTickOptions,
     PutFileOptions, TraceMode, TraceStoreKind,
 };
+use loonfs_api::ErrorCode;
 use loonfs_api::MoveBehavior;
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, NamespaceId, PutBehavior};
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
@@ -590,6 +590,79 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
                 Some("missing or invalid bearer token"),
             );
         }
+    })
+    .await
+    .expect("join blocking task");
+
+    server.abort();
+}
+
+/// Malformed query strings, path parameters, and JSON bodies answer inside
+/// the JSON error envelope as `invalid_request` — never as a framework
+/// plain-text rejection — and authorization is checked first, so the same
+/// malformed request without credentials answers 401.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let config = test_config(temp_dir.path(), "server-writer");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let router = app_with_store(config, store).await.expect("build app");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve app");
+    });
+
+    tokio::task::spawn_blocking(move || {
+        let expect_enveloped = |error: ureq::Error, status: u16, code: &str| {
+            let ureq::Error::Status(actual_status, response) = error else {
+                panic!("expected a status error, got {error:?}");
+            };
+            assert_eq!(actual_status, status);
+            assert!(response.header("x-request-id").is_some());
+            let body = response.into_string().expect("read error body");
+            let body: serde_json::Value =
+                serde_json::from_str(&body).unwrap_or_else(|_| panic!("json body, got: {body}"));
+            assert_eq!(body["code"], code);
+        };
+
+        // A query value that fails its field type: enveloped invalid_request.
+        let changes_url = format!("http://{addr}/v0/namespaces/demo/changes?after_seq=abc");
+        let error = ureq::get(&changes_url)
+            .set("authorization", "Bearer test-token")
+            .call()
+            .expect_err("malformed after_seq should answer 400");
+        expect_enveloped(error, 400, "invalid_request");
+
+        // The same malformed query without credentials: 401 wins.
+        let error = ureq::get(&changes_url)
+            .call()
+            .expect_err("unauthorized should answer 401");
+        expect_enveloped(error, 401, "unauthorized");
+
+        // A missing required query parameter: enveloped invalid_request.
+        let error = ureq::get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
+            .set("authorization", "Bearer test-token")
+            .call()
+            .expect_err("missing path parameter should answer 400");
+        expect_enveloped(error, 400, "invalid_request");
+
+        // A malformed JSON body: enveloped invalid_request with credentials,
+        // 401 without — the body is not read before authorization.
+        let create_url = format!("http://{addr}/v0/namespaces");
+        let error = ureq::post(&create_url)
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string("{not json")
+            .expect_err("malformed body should answer 400");
+        expect_enveloped(error, 400, "invalid_request");
+        let error = ureq::post(&create_url)
+            .set("content-type", "application/json")
+            .send_string("{not json")
+            .expect_err("unauthorized malformed body should answer 401");
+        expect_enveloped(error, 401, "unauthorized");
     })
     .await
     .expect("join blocking task");

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -18,7 +18,7 @@ use loonfs_core::control::{
     VerifiedNamespaceCatalogEntry,
 };
 use loonfs_core::publish::{NamespaceCommitEngine, SharedWriterSessionState};
-use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext};
+use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::{namespace_config, wal_head};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -355,6 +355,7 @@ impl FsCore {
                 return RuntimeError::Core(CoreError::Store {
                     object_key: descriptor_key,
                     message: error.message(),
+                    class: StoreFailureClass::of(&error),
                 })
             }
         };
@@ -387,6 +388,7 @@ impl FsCore {
             .map_err(|error| ControlObjectLoadError::Store {
                 object_key: object_key.to_owned(),
                 message: error.message(),
+                class: StoreFailureClass::of(&error),
             })?
             .ok_or_else(|| ControlObjectLoadError::MissingObject {
                 object_key: object_key.to_owned(),
@@ -395,6 +397,7 @@ impl FsCore {
             return Err(ControlObjectLoadError::Store {
                 object_key: object_key.to_owned(),
                 message: "missing control object etag".to_owned(),
+                class: StoreFailureClass::Other,
             });
         };
         Ok(etag == identity.etag)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -209,6 +209,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | --- | --- | --- |
 | `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, or configuration value fails validation. The message names the offending field. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
+| `permission_denied` | 403 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; retrying unchanged will not succeed. |
 | `content_too_large` | 413 | The request body exceeds the deployment's limit: `upload.max_content_bytes` for proxied uploads, `commit.max_body_bytes` for commit bodies. Served file content past `download.max_content_bytes` reports it too. For uploads, send a smaller payload or use `direct_put`; for commits, split the batch; for reads, the deployment limit must be raised. |
 | `route_not_found` | 404 | No route matches the request path. |
 | `method_not_allowed` | 405 | The path exists but does not serve this HTTP method. |

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -179,6 +179,12 @@ and names the capability-document key the client should reconcile against.
 Clients must branch on `code`, must tolerate codes they do not recognize, and
 must not parse `message`.
 
+This contract covers request-shape failures too: a query string, path
+parameter, or JSON body the server cannot parse answers `invalid_request`
+inside this envelope, never a framework plain-text rejection — and
+authorization is checked first, so a malformed request without valid
+credentials answers `unauthorized`.
+
 `request_id` is the correlation id the server assigned to the request; every
 response — success or error — also carries it as the `x-request-id` header,
 so a caller's log line and the server's trace can be joined.


### PR DESCRIPTION
api.md section 3 promises every error is a JSON envelope, and the server documents 401-before-400 ordering — but axum extractor rejections escaped both. A malformed after_seq answered a plain-text 400 with no code and no request id (while the limit field two lines over was hand-parsed as Option<String> precisely to stay enveloped — two error shapes on one endpoint), and any extractor rejection short-circuited authorize, turning an unauthorized request's 401 into a 400.