### PR TITLE
chore(api,core,objectstore): one hex codec and one vetted HMAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,6 @@ version = "0.1.1"
 dependencies = [
  "loonfs-api",
  "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -698,6 +699,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hostname"
@@ -1154,6 +1164,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures",
+ "hmac",
  "loonfs-api",
  "loonfs-model",
  "loonfs-objectstore",
@@ -1185,6 +1196,7 @@ dependencies = [
  "bytes",
  "fs4",
  "futures",
+ "hmac",
  "http",
  "http-body",
  "loonfs-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
 sha2 = "0.10"
+hmac = "0.12"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -539,12 +539,9 @@ pub struct NamespaceManifestPayload {
     /// Values are feature-owned JSON objects; readers ignore unknown keys.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub features: BTreeMap<String, serde_json::Value>,
-    // TODO: split this flat list into structured run/table/index roots when
-    // compaction and GC need richer reachability decisions.
     pub metadata_files: Vec<MetadataFileRef>,
     /// Derived-index segments materialized on this file-set version, empty
-    /// (and omitted) when no derived index exists. Additive: readers that
-    /// predate derived indexes ignore the field, and the paired `features`
+    /// (and omitted) when no derived index exists. The paired `features`
     /// entry — not this list — says what the segments mean.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub index_files: Vec<IndexFileRef>,

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -430,34 +430,11 @@ pub enum PageCursorError {
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
-    for byte in bytes {
-        encoded.push(HEX[(byte >> 4) as usize] as char);
-        encoded.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    encoded
+    crate::manifest::hex_encode_bytes(bytes)
 }
 
 fn hex_decode(value: &str) -> Result<Vec<u8>, PageCursorError> {
-    if value.len() % 2 != 0 {
-        return Err(PageCursorError::InvalidEncoding);
-    }
-    let mut decoded = Vec::with_capacity(value.len() / 2);
-    for pair in value.as_bytes().chunks_exact(2) {
-        let high = hex_value(pair[0])?;
-        let low = hex_value(pair[1])?;
-        decoded.push((high << 4) | low);
-    }
-    Ok(decoded)
-}
-
-fn hex_value(byte: u8) -> Result<u8, PageCursorError> {
-    match byte {
-        b'0'..=b'9' => Ok(byte - b'0'),
-        b'a'..=b'f' => Ok(byte - b'a' + 10),
-        _ => Err(PageCursorError::InvalidEncoding),
-    }
+    crate::manifest::hex_decode_bytes(value).map_err(|_| PageCursorError::InvalidEncoding)
 }
 
 fn hard_coded_nonzero(value: u32) -> NonZeroU32 {

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -57,7 +57,10 @@ pub const FILTER_HASH_COUNT: u32 = 7;
 
 const FILTER_HASH_SEED_ONE: u64 = 0;
 const FILTER_HASH_SEED_TWO: u64 = 0x9e37_79b9_7f4a_7c15;
-const ZSTD_LEVEL: i32 = 3;
+/// One compression level for every zstd-compressed durable artifact (SST
+/// blocks and WAL segment envelopes). 3 is also the library default, so
+/// this pins in a name what an implicit `0` would choose silently.
+pub(crate) const ZSTD_LEVEL: i32 = 3;
 
 /// Where one stored section lives inside a segment object, and how to
 /// verify it: the CRC32C of the stored bytes and their decoded length.

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -236,7 +236,7 @@ pub fn encode_wal_segment_envelope_zstd(
     let mut encoded = Vec::new();
     into_writer(&document, &mut encoded)
         .map_err(|err| WalCodecError::EnvelopeEncode(err.to_string()))?;
-    zstd::stream::encode_all(encoded.as_slice(), 0)
+    zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
         .map_err(|err| WalCodecError::Compress(err.to_string()))
 }
 

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -141,8 +141,8 @@ pub(crate) enum ProfileCommand {
     Show { name: Option<String> },
     /// Update fields of an existing profile.
     Update(ProfileUpdateArgs),
-    /// Remove a profile from the config file.
-    Remove { name: String },
+    /// Delete a profile from the config file.
+    Delete { name: String },
     /// Make a profile the default.
     Use { name: String },
 }
@@ -577,7 +577,7 @@ pub(crate) enum CommandKind {
     ProfileList,
     ProfileShow,
     ProfileUpdate,
-    ProfileRemove,
+    ProfileDelete,
     ProfileUse,
     NamespaceCreate,
     NamespaceDelete,
@@ -619,7 +619,7 @@ impl CommandKind {
             CommandKind::ProfileList => "profile_list",
             CommandKind::ProfileShow => "profile_show",
             CommandKind::ProfileUpdate => "profile_update",
-            CommandKind::ProfileRemove => "profile_remove",
+            CommandKind::ProfileDelete => "profile_delete",
             CommandKind::ProfileUse => "profile_use",
             CommandKind::NamespaceCreate => "namespace_create",
             CommandKind::NamespaceDelete => "namespace_delete",
@@ -668,7 +668,7 @@ impl Cli {
                 ProfileCommand::List => CommandKind::ProfileList,
                 ProfileCommand::Show { .. } => CommandKind::ProfileShow,
                 ProfileCommand::Update(_) => CommandKind::ProfileUpdate,
-                ProfileCommand::Remove { .. } => CommandKind::ProfileRemove,
+                ProfileCommand::Delete { .. } => CommandKind::ProfileDelete,
                 ProfileCommand::Use { .. } => CommandKind::ProfileUse,
             },
             Command::Namespace { command } => match command {

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,7 +1,7 @@
 //! `loon admin` commands: status, checkpoints, retention, gc, indexes,
 //! and the change feed.
 
-use super::context::{fail, resolve_command_context};
+use super::context::resolve_command_context;
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs, AdminNamespaceArgs,
@@ -41,14 +41,7 @@ async fn run_admin_tick(
         .backend()
         .maintenance_tick(&context.namespace, request)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -72,14 +65,7 @@ async fn run_admin_gc(
         .backend()
         .gc_namespace(&context.namespace, request)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -103,14 +89,7 @@ async fn run_admin_checkpoint(
         .backend()
         .create_checkpoint(&context.namespace, request)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -130,14 +109,7 @@ async fn run_admin_checkpoint_release(
         .backend()
         .release_checkpoint(&context.namespace, &args.checkpoint_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -157,14 +129,7 @@ async fn run_admin_flush(
         .backend()
         .flush_wal(&context.namespace)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -184,14 +149,7 @@ async fn run_admin_retention_advance(
         .backend()
         .advance_retention(&context.namespace)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -212,14 +170,7 @@ pub(crate) async fn run_admin_changes(
         .backend()
         .list_changes(&context.namespace, after_seq, args.limit)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -239,14 +190,7 @@ async fn run_admin_index_enable(
         .backend()
         .enable_grams_index(&context.namespace)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
     // An enabled index is only queryable once maintenance builds it; kick a
     // tick here instead of leaving search unavailable until someone
     // discovers `loon admin tick`. Run it even when the feature was already
@@ -258,14 +202,7 @@ async fn run_admin_index_enable(
             .backend()
             .maintenance_tick(&context.namespace, MaintenanceTickRequest::default())
             .await
-            .map_err(|error| {
-                fail(
-                    kind,
-                    Some(context.profile_name.clone()),
-                    Some(context.mode.clone()),
-                    error,
-                )
-            })?,
+            .map_err(|error| context.fail(kind, error))?,
     );
     Ok(CommandOutput {
         kind,
@@ -288,14 +225,7 @@ async fn run_admin_index_disable(
         .backend()
         .disable_grams_index(&context.namespace)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -15,6 +15,35 @@ pub(crate) struct CommandContext {
     pub(crate) target: crate::backend::ResolvedTarget,
 }
 
+/// Attributes a failure to a resolved profile and mode, for command paths
+/// that run before (or without) a full [`CommandContext`].
+pub(crate) fn fail_for(
+    kind: CommandKind,
+    profile_name: &str,
+    mode: &str,
+    error: impl Into<CliError>,
+) -> CommandFailure {
+    fail(
+        kind,
+        Some(profile_name.to_owned()),
+        Some(mode.to_owned()),
+        error,
+    )
+}
+
+impl CommandContext {
+    /// Attributes a failure to this resolved context: the profile and mode
+    /// that produced it ride with the error.
+    pub(crate) fn fail(&self, kind: CommandKind, error: impl Into<CliError>) -> CommandFailure {
+        fail(
+            kind,
+            Some(self.profile_name.clone()),
+            Some(self.mode.clone()),
+            error,
+        )
+    }
+}
+
 pub(crate) async fn resolve_command_context(
     kind: CommandKind,
     target: &TargetSelectorArgs,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -69,27 +69,13 @@ pub(crate) async fn run_filesystem_ls(
         args.path.as_deref().unwrap_or("/"),
         true,
     )
-    .map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    .map_err(|error| context.fail(kind, error))?;
     let entries = context
         .target
         .backend()
         .list_path(&spec)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
@@ -103,27 +89,14 @@ pub(crate) async fn run_filesystem_stat(
     args: FilesystemPathArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
     let entry = context
         .target
         .backend()
         .stat_path(&spec)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -155,14 +128,7 @@ pub(crate) async fn run_filesystem_grep(
             .backend()
             .grep(&context.namespace, &request)
             .await
-            .map_err(|error| {
-                fail(
-                    kind,
-                    Some(context.profile_name.clone()),
-                    Some(context.mode.clone()),
-                    error,
-                )
-            })?;
+            .map_err(|error| context.fail(kind, error))?;
         matches.extend(response.matches);
         tail_scanned &= response.tail_scanned;
         match response.next_cursor {
@@ -197,14 +163,8 @@ pub(crate) async fn run_filesystem_cat(
     args: FilesystemCatArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
     let revision_no = args.revision.map(RevisionNo);
     let bytes = match revision_no {
         Some(revision_no) => {
@@ -216,14 +176,7 @@ pub(crate) async fn run_filesystem_cat(
         }
         None => context.target.backend().read_file_bytes(&spec).await,
     }
-    .map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -248,32 +201,17 @@ pub(crate) async fn run_filesystem_get(
         ));
     }
 
-    let spec = namespace_path(&context.namespace, &args.remote_path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.remote_path, false)
+        .map_err(|error| context.fail(kind, error))?;
     let entry = context
         .target
         .backend()
         .stat_path(&spec)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
     if entry.inode_kind == InodeKind::Directory {
-        return Err(fail(
+        return Err(context.fail(
             kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
             CliError::invalid_input(format!(
                 "directory operations are not available for `{}`",
                 spec.absolute_path
@@ -292,39 +230,20 @@ pub(crate) async fn run_filesystem_get(
         }
         None => context.target.backend().read_file_bytes(&spec).await,
     }
-    .map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    .map_err(|error| context.fail(kind, error))?;
     let data = match args.local_destination.as_deref() {
         Some("-") => CommandData::StreamBytes(bytes),
         other => {
             let derived_name = other.is_none();
-            let destination =
-                destination_path_for_get(&spec.absolute_path, other).map_err(|error| {
-                    fail(
-                        kind,
-                        Some(context.profile_name.clone()),
-                        Some(context.mode.clone()),
-                        error,
-                    )
-                })?;
+            let destination = destination_path_for_get(&spec.absolute_path, other)
+                .map_err(|error| context.fail(kind, error))?;
             // The local working copy is the one thing this CLI touches
             // that has no revision history behind it, so clobbering it is
             // opt-in. `persist_noclobber` closes the race between checking
             // and installing the completed temporary file.
             write_local_file_atomically(&destination, &bytes, args.force).map_err(|error| {
                 if !args.force && error.kind() == std::io::ErrorKind::AlreadyExists {
-                    return fail(
-                        kind,
-                        Some(context.profile_name.clone()),
-                        Some(context.mode.clone()),
-                        CliError::destination_exists(&destination),
-                    );
+                    return context.fail(kind, CliError::destination_exists(&destination));
                 }
                 let mut error = CliError::io(error);
                 if derived_name {
@@ -333,12 +252,7 @@ pub(crate) async fn run_filesystem_get(
                          explicit destination or `-` for stdout",
                     );
                 }
-                fail(
-                    kind,
-                    Some(context.profile_name.clone()),
-                    Some(context.mode.clone()),
-                    error,
-                )
+                context.fail(kind, error)
             })?;
             CommandData::FileTransfer {
                 target: render_target(&context.namespace, &spec.absolute_path),
@@ -361,27 +275,14 @@ pub(crate) async fn run_filesystem_revisions(
     args: FilesystemRevisionsArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
     let response = context
         .target
         .backend()
         .list_file_revisions(&spec, args.limit, args.cursor.as_deref())
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -410,19 +311,11 @@ pub(crate) async fn run_filesystem_put(
         ));
     }
 
-    let metadata = fs::metadata(&local_path).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            CliError::io(error),
-        )
-    })?;
+    let metadata =
+        fs::metadata(&local_path).map_err(|error| context.fail(kind, CliError::io(error)))?;
     if metadata.is_dir() {
-        return Err(fail(
+        return Err(context.fail(
             kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
             CliError::invalid_input(format!(
                 "directory operations are not available for `{}`",
                 local_path.display()
@@ -434,38 +327,12 @@ pub(crate) async fn run_filesystem_put(
         Some(path) => normalize_absolute_path(&path, false),
         None => default_remote_put_path(&local_path),
     }
-    .map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let spec = namespace_path(&context.namespace, &remote_path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let bytes = fs::read(&local_path).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            CliError::io(error),
-        )
-    })?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    .map_err(|error| context.fail(kind, error))?;
+    let spec = namespace_path(&context.namespace, &remote_path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let bytes = fs::read(&local_path).map_err(|error| context.fail(kind, CliError::io(error)))?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let behavior = if args.force {
         PutBehavior::Replace
     } else {
@@ -476,14 +343,7 @@ pub(crate) async fn run_filesystem_put(
         .backend()
         .put_file_bytes(&spec, &bytes, behavior, commit_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -503,22 +363,10 @@ pub(crate) async fn run_filesystem_rm(
     args: FilesystemPathMutationArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     // Resolve the inode before deleting: the id is half of the recovery
     // handle `loon undelete` needs. The delete then carries it as an
     // expectation, so a rebinding racing this command fails the delete
@@ -528,28 +376,14 @@ pub(crate) async fn run_filesystem_rm(
         .backend()
         .stat_path(&spec)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?
+        .map_err(|error| context.fail(kind, error))?
         .inode_id;
     let result = context
         .target
         .backend()
         .delete_path(&spec, Some(deleted_inode), commit_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -569,35 +403,16 @@ pub(crate) async fn run_filesystem_restore(
     args: FilesystemRestoreArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .backend()
         .restore_file_revision(&spec, RevisionNo(args.revision), commit_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -617,22 +432,10 @@ pub(crate) async fn run_filesystem_undelete(
     args: FilesystemUndeleteArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .backend()
@@ -643,14 +446,7 @@ pub(crate) async fn run_filesystem_undelete(
             commit_id,
         )
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -670,35 +466,16 @@ pub(crate) async fn run_filesystem_mkdir(
     args: FilesystemMkdirArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let spec = namespace_path(&context.namespace, &args.path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let spec = namespace_path(&context.namespace, &args.path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .backend()
         .create_directory(&spec, args.parents, commit_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -733,50 +510,23 @@ async fn run_filesystem_transfer(
     copy: bool,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let from = namespace_path(&context.namespace, &args.source_path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
-    let to = namespace_path(&context.namespace, &args.dest_path, false).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let from = namespace_path(&context.namespace, &args.source_path, false)
+        .map_err(|error| context.fail(kind, error))?;
+    let to = namespace_path(&context.namespace, &args.dest_path, false)
+        .map_err(|error| context.fail(kind, error))?;
 
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref()).map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
+        .map_err(|error| context.fail(kind, error))?;
     let result = if copy {
         let entry = context
             .target
             .backend()
             .stat_path(&from)
             .await
-            .map_err(|error| {
-                fail(
-                    kind,
-                    Some(context.profile_name.clone()),
-                    Some(context.mode.clone()),
-                    error,
-                )
-            })?;
+            .map_err(|error| context.fail(kind, error))?;
         if entry.inode_kind == InodeKind::Directory {
-            return Err(fail(
+            return Err(context.fail(
                 kind,
-                Some(context.profile_name.clone()),
-                Some(context.mode.clone()),
                 CliError::invalid_input(format!(
                     "directory operations are not available for `{}`",
                     from.absolute_path
@@ -805,14 +555,7 @@ async fn run_filesystem_transfer(
             .move_path(&from, &to, behavior, commit_id)
             .await
     }
-    .map_err(|error| {
-        fail(
-            kind,
-            Some(context.profile_name.clone()),
-            Some(context.mode.clone()),
-            error,
-        )
-    })?;
+    .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -1,6 +1,6 @@
 //! `loon namespace` commands: create, fork, delete, use, and current.
 
-use super::context::{fail, validate_namespace_id};
+use super::context::{fail, fail_for, validate_namespace_id};
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
@@ -35,27 +35,14 @@ async fn run_namespace_create(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace_id).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
+    validate_namespace_id(&args.namespace_id)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
         .backend()
         .create_namespace(&args.namespace_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -75,14 +62,8 @@ async fn run_namespace_delete(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace_id).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
+    validate_namespace_id(&args.namespace_id)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     if !args.yes {
         // Without a terminal (or under --no-input / --json) there is no
@@ -105,14 +86,7 @@ async fn run_namespace_delete(
             "deleting `{}` is permanent and retires the id; type the namespace id to confirm",
             args.namespace_id
         ))
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
         if typed.trim() != args.namespace_id {
             return Err(fail(
                 kind,
@@ -131,14 +105,7 @@ async fn run_namespace_delete(
         .backend()
         .delete_namespace(&args.namespace_id, args.expected_head_seq)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -157,35 +124,16 @@ async fn run_namespace_fork(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.source).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
-    validate_namespace_id(&args.new_namespace_id).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
+    validate_namespace_id(&args.source)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    validate_namespace_id(&args.new_namespace_id)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
         .backend()
         .fork_namespace(&args.source, &args.new_namespace_id)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,
@@ -207,47 +155,20 @@ pub(crate) async fn run_namespace_use(
             .await
             .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
+    validate_namespace_id(&args.namespace)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     resolved
         .target
         .backend()
         .namespace_status(&args.namespace)
         .await
-        .map_err(|error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        })?;
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
-    set_default_namespace(&mut loaded.config, &resolved.profile_name, &args.namespace).map_err(
-        |error| {
-            fail(
-                kind,
-                Some(resolved.profile_name.clone()),
-                Some(mode.clone()),
-                error,
-            )
-        },
-    )?;
-    save_config(&loaded.path, &loaded.config).map_err(|error| {
-        fail(
-            kind,
-            Some(resolved.profile_name.clone()),
-            Some(mode.clone()),
-            error,
-        )
-    })?;
+    set_default_namespace(&mut loaded.config, &resolved.profile_name, &args.namespace)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    save_config(&loaded.path, &loaded.config)
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -11,7 +11,7 @@ use crate::config::{
 };
 use crate::error::CliError;
 use crate::profiles::{
-    add_profile, list_profiles, make_default_profile, remove_profile, show_profile, update_profile,
+    add_profile, delete_profile, list_profiles, make_default_profile, show_profile, update_profile,
 };
 use crate::prompt;
 use std::path::Path;
@@ -52,7 +52,7 @@ pub(crate) fn run_profile_command(
             })
         }
         ProfileCommand::Update(args) => run_profile_update(kind, &config_path, args, runtime),
-        ProfileCommand::Remove { name } => run_profile_remove(kind, &config_path, &name, runtime),
+        ProfileCommand::Delete { name } => run_profile_delete(kind, &config_path, &name, runtime),
         ProfileCommand::Use { name } => run_profile_use(kind, &config_path, &name),
     }
 }
@@ -136,14 +136,14 @@ fn run_profile_update(
     })
 }
 
-fn run_profile_remove(
+fn run_profile_delete(
     kind: CommandKind,
     config_path: &Path,
     name: &str,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     if runtime.interactive {
-        let confirmed = prompt::prompt_confirm(&format!("remove profile `{name}`?"))
+        let confirmed = prompt::prompt_confirm(&format!("delete profile `{name}`?"))
             .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
         if !confirmed {
             return Err(fail(
@@ -157,7 +157,7 @@ fn run_profile_remove(
 
     let mut config =
         load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    let removed = remove_profile(&mut config, name)
+    let removed = delete_profile(&mut config, name)
         .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
     let mode = removed.mode.clone();
     save_config(config_path, &config)

--- a/crates/loonfs-cli/src/profiles.rs
+++ b/crates/loonfs-cli/src/profiles.rs
@@ -76,7 +76,7 @@ pub(crate) fn update_profile(
     Ok((name.to_owned(), redacted))
 }
 
-pub(crate) fn remove_profile(
+pub(crate) fn delete_profile(
     config: &mut CliConfig,
     name: &str,
 ) -> Result<ProfileSummary, CliError> {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -131,7 +131,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             }
         }
         CommandData::ProfileSummary(profile) => match output.kind {
-            CommandKind::ProfileRemove => format!("removed profile {}", profile.name),
+            CommandKind::ProfileDelete => format!("deleted profile {}", profile.name),
             _ => {
                 let store = profile
                     .store_kind

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
-// CLI integration tests use concise JSON/path assertions and explicit server polling.
-
 use serde_json::Value;
 use std::env;
 use std::fs;
@@ -25,7 +22,7 @@ fn profile_create_list_show_remove_work() {
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("default").to_str().unwrap(),
+        harness.store_root("default").to_str().expect("utf-8 path"),
     ]);
     assert_success(&add_embedded);
     assert_eq!(json_data(&add_embedded)["mode"], "embedded");
@@ -50,7 +47,7 @@ fn profile_create_list_show_remove_work() {
     let list = harness.run(&["--json", "profile", "list"]);
     assert_success(&list);
     let list_data = json_data(&list);
-    let profiles = list_data["profiles"].as_array().unwrap();
+    let profiles = list_data["profiles"].as_array().expect("json array");
     assert_eq!(profiles.len(), 2);
     assert_eq!(profiles[0]["name"], "default");
     assert_eq!(profiles[1]["name"], "prod");
@@ -107,7 +104,7 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
     let put = harness.run(&[
         "--json",
         "put",
-        upload_path.to_str().unwrap(),
+        upload_path.to_str().expect("utf-8 path"),
         "/docs/hello.txt",
     ]);
     assert_success(&put);
@@ -116,7 +113,7 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
     let put_conflict = harness.run(&[
         "--json",
         "put",
-        upload_path.to_str().unwrap(),
+        upload_path.to_str().expect("utf-8 path"),
         "/docs/hello.txt",
     ]);
     assert_failure(&put_conflict);
@@ -125,7 +122,7 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
     let put_force = harness.run(&[
         "--json",
         "put",
-        update_path.to_str().unwrap(),
+        update_path.to_str().expect("utf-8 path"),
         "/docs/hello.txt",
         "--force",
     ]);
@@ -134,7 +131,10 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
     let revisions = harness.run(&["--json", "revisions", "/docs/hello.txt"]);
     assert_success(&revisions);
     assert_eq!(
-        json_data(&revisions)["revisions"].as_array().unwrap().len(),
+        json_data(&revisions)["revisions"]
+            .as_array()
+            .expect("json array")
+            .len(),
         2
     );
 
@@ -171,7 +171,7 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
         "--json",
         "get",
         "/docs/hello.txt",
-        download_path.to_str().unwrap(),
+        download_path.to_str().expect("utf-8 path"),
     ]);
     assert_success(&get_file);
     assert_eq!(
@@ -208,7 +208,11 @@ fn embedded_profile_namespace_fork_reads_shared_content_and_diverges() {
 
     assert_success(&harness.run(&["namespace", "create", "demo"]));
     assert_success(&harness.run(&["use", "demo"]));
-    assert_success(&harness.run(&["put", upload_path.to_str().unwrap(), "/docs/shared.txt"]));
+    assert_success(&harness.run(&[
+        "put",
+        upload_path.to_str().expect("utf-8 path"),
+        "/docs/shared.txt",
+    ]));
 
     let fork = harness.run(&["--json", "namespace", "fork", "demo", "clone"]);
     assert_success(&fork);
@@ -227,7 +231,7 @@ fn embedded_profile_namespace_fork_reads_shared_content_and_diverges() {
         "put",
         "--namespace",
         "clone",
-        clone_upload_path.to_str().unwrap(),
+        clone_upload_path.to_str().expect("utf-8 path"),
         "/docs/shared.txt",
         "--force",
     ]));
@@ -254,7 +258,7 @@ fn init_creates_embedded_profile_and_current_reports_namespace_unset() {
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("mystore").to_str().unwrap(),
+        harness.store_root("mystore").to_str().expect("utf-8 path"),
     ]);
     assert_success(&init);
     assert_eq!(json_data(&init)["mode"], "embedded");
@@ -288,13 +292,13 @@ fn invalid_profile_mode_is_rejected() {
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("default").to_str().unwrap(),
+        harness.store_root("default").to_str().expect("utf-8 path"),
     ]);
 
     assert_failure(&result);
     let error = json_error(&result);
     assert_eq!(error["code"], "invalid_input");
-    let message = error["message"].as_str().unwrap();
+    let message = error["message"].as_str().expect("json string");
     assert!(message.contains("expected embedded or remote"));
 }
 
@@ -310,7 +314,7 @@ fn removing_last_profile_leaves_empty_config() {
     assert_success(&list);
     let data = json_data(&list);
     assert!(data["default_profile"].is_null());
-    assert_eq!(data["profiles"].as_array().unwrap().len(), 0);
+    assert_eq!(data["profiles"].as_array().expect("json array").len(), 0);
 
     let show_config = harness.run(&["config", "show"]);
     assert_success(&show_config);
@@ -334,7 +338,7 @@ fn removing_default_profile_requires_explicit_reselection() {
     assert_success(&list);
     let data = json_data(&list);
     assert!(data["default_profile"].is_null());
-    assert_eq!(data["profiles"].as_array().unwrap().len(), 1);
+    assert_eq!(data["profiles"].as_array().expect("json array").len(), 1);
 
     let current = harness.run(&["--json", "current"]);
     assert_failure(&current);
@@ -368,14 +372,14 @@ fn profile_update_changes_fields() {
         "update",
         "default",
         "--root",
-        new_root.to_str().unwrap(),
+        new_root.to_str().expect("utf-8 path"),
     ]);
     assert_success(&update);
 
     let show = harness.run(&["--json", "profile", "show", "default"]);
     assert_success(&show);
     let store = &json_data(&show)["store"];
-    assert_eq!(store["root"], new_root.to_str().unwrap());
+    assert_eq!(store["root"], new_root.to_str().expect("utf-8 path"));
 }
 
 #[test]
@@ -418,7 +422,10 @@ fn profile_names_matching_top_level_config_keys_are_allowed() {
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("default_profile").to_str().unwrap(),
+        harness
+            .store_root("default_profile")
+            .to_str()
+            .expect("utf-8 path"),
     ]);
     assert_success(&init);
 
@@ -432,7 +439,10 @@ fn profile_names_matching_top_level_config_keys_are_allowed() {
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("config_version").to_str().unwrap(),
+        harness
+            .store_root("config_version")
+            .to_str()
+            .expect("utf-8 path"),
     ]);
     assert_success(&create);
 
@@ -476,12 +486,12 @@ root = "{}"
         "--store-kind",
         "local-fs",
         "--root",
-        harness.store_root("mystore").to_str().unwrap(),
+        harness.store_root("mystore").to_str().expect("utf-8 path"),
     ]);
     assert_failure(&init);
     let error = json_error(&init);
     assert_eq!(error["code"], "config_already_exists");
-    let message = error["message"].as_str().unwrap();
+    let message = error["message"].as_str().expect("json string");
     assert!(message.contains("loon profile create"));
     assert!(message.contains("loon profile update"));
     assert!(message.contains("loon profile use"));
@@ -529,7 +539,7 @@ default_profile = ""
     assert_eq!(error["code"], "invalid_config");
     assert!(error["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("default_profile"));
 }
 
@@ -549,7 +559,7 @@ default_profile = "   "
     assert_eq!(error["code"], "invalid_config");
     assert!(error["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("default_profile"));
 }
 
@@ -576,7 +586,7 @@ root = ""
     assert_eq!(error["code"], "invalid_config");
     assert!(error["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("default.store.root"));
 }
 
@@ -605,7 +615,7 @@ root = "{}"
     assert_eq!(error["code"], "invalid_config");
     assert!(error["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("default.default_namespace"));
 }
 
@@ -619,7 +629,7 @@ fn embedded_namespace_commands_reject_invalid_namespace_ids() {
     assert_eq!(json_error(&create)["code"], "invalid_request");
     assert!(json_error(&create)["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("invalid namespace_id"));
 
     assert_success(&harness.run(&["namespace", "create", "demo"]));
@@ -678,7 +688,7 @@ fn invalid_remote_urls_are_rejected() {
     assert_eq!(json_error(&missing_host_http)["code"], "invalid_config");
     assert!(json_error(&missing_host_http)["message"]
         .as_str()
-        .unwrap()
+        .expect("json string")
         .contains("default.server_url"));
 
     let missing_host_https = harness.run(&[
@@ -908,10 +918,14 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
     let payload_two = harness.temp_dir.path().join("two.txt");
     fs::write(&payload_one, b"draft one").expect("payload one");
     fs::write(&payload_two, b"draft two").expect("payload two");
-    assert_success(&harness.run(&["put", payload_one.to_str().unwrap(), "/docs/report.txt"]));
     assert_success(&harness.run(&[
         "put",
-        payload_two.to_str().unwrap(),
+        payload_one.to_str().expect("utf-8 path"),
+        "/docs/report.txt",
+    ]));
+    assert_success(&harness.run(&[
+        "put",
+        payload_two.to_str().expect("utf-8 path"),
         "/docs/report.txt",
         "--force",
     ]));
@@ -948,7 +962,10 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
     let revisions = harness.run(&["--json", "revisions", "/docs/report.txt"]);
     assert_success(&revisions);
     assert_eq!(
-        json_data(&revisions)["revisions"].as_array().unwrap().len(),
+        json_data(&revisions)["revisions"]
+            .as_array()
+            .expect("json array")
+            .len(),
         2
     );
 
@@ -988,7 +1005,7 @@ fn remote_undelete_recovers_through_http() {
 
     let payload = harness.temp_dir.path().join("wire.txt");
     fs::write(&payload, b"over the wire").expect("payload");
-    assert_success(&harness.run(&["put", payload.to_str().unwrap(), "/wire.txt"]));
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/wire.txt"]));
     let removed = harness.run(&["--json", "rm", "/wire.txt"]);
     assert_success(&removed);
     let inode_id = json_data(&removed)["inode_id"]
@@ -1034,14 +1051,25 @@ fn mkdir_parents_get_noclobber_and_version_metadata() {
     // get refuses to clobber a local file unless forced.
     let payload = harness.temp_dir.path().join("f.txt");
     fs::write(&payload, b"remote bytes").expect("payload");
-    assert_success(&harness.run(&["put", payload.to_str().unwrap(), "/f.txt"]));
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/f.txt"]));
     let dest = harness.temp_dir.path().join("dest.txt");
     fs::write(&dest, b"precious local bytes").expect("existing local file");
-    let refused = harness.run(&["--json", "get", "/f.txt", dest.to_str().unwrap()]);
+    let refused = harness.run(&[
+        "--json",
+        "get",
+        "/f.txt",
+        dest.to_str().expect("utf-8 path"),
+    ]);
     assert_failure(&refused);
     assert_eq!(json_error(&refused)["code"], "destination_exists");
     assert_eq!(fs::read(&dest).expect("unchanged"), b"precious local bytes");
-    let forced = harness.run(&["--json", "get", "/f.txt", dest.to_str().unwrap(), "--force"]);
+    let forced = harness.run(&[
+        "--json",
+        "get",
+        "/f.txt",
+        dest.to_str().expect("utf-8 path"),
+        "--force",
+    ]);
     assert_success(&forced);
     assert_eq!(fs::read(&dest).expect("replaced"), b"remote bytes");
 
@@ -1177,7 +1205,7 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
             .iter()
             .find(|(advertised, _)| *advertised == profile.as_str())
             .unwrap_or_else(|| {
-                panic!(
+                unreachable!(
                     "capability profile `{profile}` has no CLI command mapping; \
                      add its command paths to PROFILE_COMMAND_PATHS"
                 )
@@ -1192,7 +1220,7 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
             .iter()
             .find(|(advertised, _)| *advertised == feature.as_str())
             .unwrap_or_else(|| {
-                panic!(
+                unreachable!(
                     "capability feature `{feature}` has no CLI command mapping; \
                      add its command path to FEATURE_COMMAND_PATHS"
                 )
@@ -1236,14 +1264,14 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             "put",
             "--profile",
             profile,
-            first_payload.to_str().unwrap(),
+            first_payload.to_str().expect("utf-8 path"),
             "/first.txt",
         ]));
         assert_success(&harness.run(&[
             "put",
             "--profile",
             profile,
-            second_payload.to_str().unwrap(),
+            second_payload.to_str().expect("utf-8 path"),
             "/second.txt",
         ]));
 
@@ -1255,17 +1283,26 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(changes_data["after_seq"], 0);
         assert_eq!(changes_data["through_seq"], 2);
         assert!(changes_data["next_after_seq"].is_null());
-        let listed = changes_data["changes"].as_array().unwrap();
+        let listed = changes_data["changes"].as_array().expect("json array");
         assert_eq!(listed.len(), 2);
         assert_eq!(listed[0]["seq"], 1);
         assert_eq!(listed[1]["seq"], 2);
-        assert!(listed[0]["commit_id"].as_str().unwrap().starts_with("c_"));
-        assert!(!listed[1]["deltas"].as_array().unwrap().is_empty());
+        assert!(listed[0]["commit_id"]
+            .as_str()
+            .expect("json string")
+            .starts_with("c_"));
+        assert!(!listed[1]["deltas"]
+            .as_array()
+            .expect("json array")
+            .is_empty());
 
         let paged = harness.run(&["--json", "changes", "--profile", profile, "--limit", "1"]);
         assert_success(&paged);
         let paged_data = json_data(&paged);
-        assert_eq!(paged_data["changes"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            paged_data["changes"].as_array().expect("json array").len(),
+            1
+        );
         assert_eq!(paged_data["changes"][0]["seq"], 1);
         assert_eq!(paged_data["next_after_seq"], 1);
 
@@ -1273,7 +1310,13 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_success(&resumed);
         let resumed_data = json_data(&resumed);
         assert_eq!(resumed_data["after_seq"], 1);
-        assert_eq!(resumed_data["changes"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            resumed_data["changes"]
+                .as_array()
+                .expect("json array")
+                .len(),
+            1
+        );
         assert_eq!(resumed_data["changes"][0]["seq"], 2);
 
         let checkpoint = harness.run(&[
@@ -1292,7 +1335,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(checkpoint_data["checkpoint_seq"], 2);
         let checkpoint_id = checkpoint_data["checkpoint_id"]
             .as_str()
-            .unwrap()
+            .expect("json string")
             .to_owned();
         assert!(checkpoint_id.starts_with("chk_"));
 
@@ -1428,7 +1471,7 @@ impl Harness {
             "--store-kind",
             "local-fs",
             "--root",
-            self.store_root(name).to_str().unwrap(),
+            self.store_root(name).to_str().expect("utf-8 path"),
         ]);
         assert_success(&output);
     }
@@ -1483,7 +1526,7 @@ key_prefix = "{key_prefix}"
             rewrite_server_bind(&server_config_path, available_port());
         }
 
-        panic!(
+        unreachable!(
             "timed out waiting for external server from {}",
             server_config_path.display()
         );
@@ -1555,6 +1598,10 @@ fn server_url_from_config(path: &Path) -> String {
     format!("http://{bind}")
 }
 
+// Polls a spawned server binary for readiness; a wall-clock deadline is the
+// point, so the timer methods the workspace otherwise disallows are scoped
+// to this helper.
+#[allow(clippy::disallowed_methods)]
 fn wait_for_health_ready(server_url: &str) -> bool {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 #[test]
-fn profile_create_list_show_remove_work() {
+fn profile_create_list_show_delete_work() {
     let harness = Harness::new();
 
     let add_embedded = harness.run(&[
@@ -63,7 +63,7 @@ fn profile_create_list_show_remove_work() {
     assert_success(&show_default);
     assert_eq!(json_data(&show_default)["mode"], "embedded");
 
-    let remove_default = harness.run(&["--json", "profile", "remove", "default"]);
+    let remove_default = harness.run(&["--json", "profile", "delete", "default"]);
     assert_success(&remove_default);
     assert_eq!(json_data(&remove_default)["name"], "default");
 
@@ -307,7 +307,7 @@ fn removing_last_profile_leaves_empty_config() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
 
-    let remove = harness.run(&["--json", "--no-input", "profile", "remove", "default"]);
+    let remove = harness.run(&["--json", "--no-input", "profile", "delete", "default"]);
     assert_success(&remove);
 
     let list = harness.run(&["--json", "profile", "list"]);
@@ -331,7 +331,7 @@ fn removing_default_profile_requires_explicit_reselection() {
     harness.add_embedded_profile("alpha");
     harness.add_embedded_profile("beta");
 
-    let remove = harness.run(&["--json", "--no-input", "profile", "remove", "alpha"]);
+    let remove = harness.run(&["--json", "--no-input", "profile", "delete", "alpha"]);
     assert_success(&remove);
 
     let list = harness.run(&["--json", "profile", "list"]);

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -35,7 +35,12 @@ use std::sync::{Arc, OnceLock};
 use thiserror::Error;
 
 /// Client configuration loaded from TOML or built by the caller.
+///
+/// Strict like every config struct in the workspace: an unknown key is a
+/// decode error, so a typo (`auth_tokn`) fails loudly instead of silently
+/// producing an unauthenticated client.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ClientConfig {
     /// Base URL for the LoonFS server.
     pub server_url: String,
@@ -1290,6 +1295,22 @@ fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), Cl
 
 #[cfg(test)]
 mod tests {
+
+    /// Configs are strict like everywhere else in the workspace: a typo'd
+    /// key fails decode instead of silently producing an unauthenticated
+    /// client.
+    #[test]
+    fn client_config_rejects_unknown_keys() {
+        let error = toml::from_str::<ClientConfig>(
+            "server_url = \"http://localhost:1\"\nauth_tokn = \"oops\"\n",
+        )
+        .expect_err("unknown key must fail decode");
+        assert!(error.to_string().contains("auth_tokn"), "{error}");
+
+        let config: ClientConfig =
+            toml::from_str("server_url = \"http://localhost:1\"\n").expect("minimal config");
+        assert!(config.auth_token.is_none());
+    }
     use super::*;
 
     /// The retry policy in one place: network-level transport failures and

--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -19,6 +19,7 @@ regex.workspace = true
 regex-syntax.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+hmac.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 # sync-only: single-flight primitives; core stays executor-agnostic.

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -651,7 +651,7 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
     if walk_complete && !budget_reached {
         unit.backfill_cursor = None;
     }
-    fetch_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
+    load_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
     Ok(unit)
 }
 
@@ -763,7 +763,7 @@ async fn collect_wal_unit<S: ObjectStore + ?Sized>(
     if unit.built_through_seq == feature.built_through_seq {
         return Ok(None);
     }
-    fetch_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
+    load_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
     Ok(Some(unit))
 }
 
@@ -782,7 +782,7 @@ struct PendingRevisionContent {
 /// oversized revisions, so every entry here costs one content read; the
 /// text sniff still runs on the fetched bytes and drops non-text files
 /// after the read, exactly as the serial path did.
-async fn fetch_and_fold_revision_contents<S: ObjectStore + ?Sized>(
+async fn load_and_fold_revision_contents<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     pending: &[PendingRevisionContent],

--- a/crates/loonfs-core/src/checkpoint/index_read.rs
+++ b/crates/loonfs-core/src/checkpoint/index_read.rs
@@ -51,7 +51,7 @@ fn index_section_cache_key(
 
 /// Fetches exactly the byte range a handle names, refusing handles whose
 /// bounds do not fit the address space.
-async fn fetch_index_section_bytes<S: ObjectStore + ?Sized>(
+async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     handle: &BlockHandle,
@@ -95,7 +95,7 @@ pub(crate) async fn load_index_segment_filter_block<S: ObjectStore + ?Sized>(
     let cache_key =
         index_section_cache_key(payload_checksum, MetadataTableBlockKind::Filter, handle);
     let fetch = || async {
-        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let bytes = load_index_section_bytes(store, object_key, handle).await?;
         let filter = decode_filter_block(&bytes, handle)
             .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?;
         Ok::<_, CoreError>(DecodedMetadataTableBlock::Filter {
@@ -132,7 +132,7 @@ pub(crate) async fn load_index_segment_index_block<S: ObjectStore + ?Sized>(
     let cache_key =
         index_section_cache_key(payload_checksum, MetadataTableBlockKind::Index, handle);
     let fetch = || async {
-        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let bytes = load_index_section_bytes(store, object_key, handle).await?;
         let entries = decode_index_block(&bytes, handle)
             .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?;
         Ok::<_, CoreError>(DecodedMetadataTableBlock::Index {
@@ -176,7 +176,7 @@ pub(crate) async fn load_index_segment_data_block<S: ObjectStore + ?Sized>(
 ) -> Result<Arc<DecodedDataBlock<IndexRow>>> {
     let cache_key = index_section_cache_key(payload_checksum, MetadataTableBlockKind::Data, handle);
     let fetch = || async {
-        let bytes = fetch_index_section_bytes(store, object_key, handle).await?;
+        let bytes = load_index_section_bytes(store, object_key, handle).await?;
         let block = decode_data_block_rows::<IndexRow>(&bytes, handle)
             .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?;
         Ok::<_, CoreError>(DecodedMetadataTableBlock::IndexData {

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -716,7 +716,7 @@ fn segment_block_cache_key(
 }
 
 /// Fetches exactly the byte range a handle names.
-async fn fetch_section_bytes<S: ObjectStore + ?Sized>(
+async fn load_section_bytes<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
     offset: u64,
@@ -777,7 +777,7 @@ fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
 /// filter that is the filter plus the index that directly follows it
 /// (manifest loading rejects any other layout), and for an index exactly the
 /// index, which ends the object. Returns the requested block.
-async fn fetch_and_publish_segment_sections<S: ObjectStore + ?Sized>(
+async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
@@ -799,7 +799,7 @@ async fn fetch_and_publish_segment_sections<S: ObjectStore + ?Sized>(
         MetadataTableBlockKind::Filter => filter_handle.offset,
         MetadataTableBlockKind::Index => index_handle.offset,
     };
-    let bytes = fetch_section_bytes(
+    let bytes = load_section_bytes(
         store,
         &descriptor.object_key,
         fetch_offset,
@@ -920,7 +920,7 @@ async fn load_segment_index<S: ObjectStore + ?Sized>(
         return Ok(entries);
     }
     let fetch = || async {
-        fetch_and_publish_segment_sections(
+        load_and_publish_segment_sections(
             store,
             table_cache,
             memo,
@@ -982,7 +982,7 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         return Ok(filter);
     }
     let fetch = || async {
-        fetch_and_publish_segment_sections(
+        load_and_publish_segment_sections(
             store,
             table_cache,
             memo,
@@ -1023,7 +1023,7 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         return Ok(block);
     }
     let fetch = || async {
-        let bytes = fetch_section_bytes(
+        let bytes = load_section_bytes(
             store,
             &descriptor.object_key,
             handle.offset,
@@ -1129,7 +1129,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 span[0].block.offset,
             );
             let fetch = || async {
-                fetch_and_publish_span(store, table_cache, memo, family, descriptor, span).await
+                load_and_publish_span(store, table_cache, memo, family, descriptor, span).await
             };
             match table_cache {
                 Some(cache) => {
@@ -1165,7 +1165,7 @@ async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
 /// block, and publishes them to the per-view memo and (when populating) the
 /// shared cache. Returns the first block's cache entry for the
 /// single-flight cell.
-async fn fetch_and_publish_span<S: ObjectStore + ?Sized>(
+async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
@@ -1176,7 +1176,7 @@ async fn fetch_and_publish_span<S: ObjectStore + ?Sized>(
     let first = &span[0].block;
     let last = &span[span.len() - 1].block;
     let span_len = last.offset + u64::from(last.stored_len) - first.offset;
-    let bytes = fetch_section_bytes(store, &descriptor.object_key, first.offset, span_len).await?;
+    let bytes = load_section_bytes(store, &descriptor.object_key, first.offset, span_len).await?;
     let mut first_block = None;
     for entry in span {
         let handle = entry.block;

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -146,7 +146,7 @@ impl NamespaceCommitEngine {
 
     /// Attaches the runtime's session state for this namespace, so the
     /// acquired epoch and fencing outlive this engine instance.
-    pub fn with_writer_session(mut self, session: SharedWriterSessionState) -> Self {
+    pub fn writer_session(mut self, session: SharedWriterSessionState) -> Self {
         self.session = session;
         self
     }
@@ -166,12 +166,12 @@ impl NamespaceCommitEngine {
         self
     }
 
-    pub fn with_table_cache(mut self, table_cache: Arc<MetadataTableCache>) -> Self {
+    pub fn table_cache(mut self, table_cache: Arc<MetadataTableCache>) -> Self {
         self.table_cache = Some(table_cache);
         self
     }
 
-    pub fn with_catalog_entry(mut self, catalog_entry: VerifiedNamespaceCatalogEntry) -> Self {
+    pub fn catalog_entry(mut self, catalog_entry: VerifiedNamespaceCatalogEntry) -> Self {
         self.catalog_entry = Some(catalog_entry);
         self
     }
@@ -522,8 +522,8 @@ mod tests {
             .expect("bootstrap");
 
         let session = SharedWriterSessionState::default();
-        let mut engine_a1 = NamespaceCommitEngine::new(namespace_id.clone())
-            .with_writer_session(Arc::clone(&session));
+        let mut engine_a1 =
+            NamespaceCommitEngine::new(namespace_id.clone()).writer_session(Arc::clone(&session));
         engine_a1
             .publish_batch(&store, vec![create_dir("from-a-first", "alpha")], &writer_a)
             .await
@@ -561,7 +561,7 @@ mod tests {
         // never touches the head.
         drop(engine_a1);
         let mut engine_a2 =
-            NamespaceCommitEngine::new(namespace_id.clone()).with_writer_session(session);
+            NamespaceCommitEngine::new(namespace_id.clone()).writer_session(session);
         let still_fenced = engine_a2
             .publish_batch(&store, vec![create_dir("from-a-third", "delta")], &writer_a)
             .await;
@@ -712,7 +712,7 @@ mod tests {
         );
 
         let cache = Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default()));
-        let mut cached = NamespaceCommitEngine::new(namespace_id.clone()).with_table_cache(cache);
+        let mut cached = NamespaceCommitEngine::new(namespace_id.clone()).table_cache(cache);
         store.reset_metadata_sst_gets();
         cached
             .publish_batch(&store, vec![create_dir("cached-a", "gamma")], &writer)

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -31,7 +31,13 @@ use thiserror::Error;
 /// The pinned inputs the runtime resolves once per read: the head anchored
 /// to its manifest, the shared caches, and (when the runtime has it) the
 /// namespace's immutable catalog pair.
-#[doc(hidden)]
+///
+/// This is the runtime seam: the `loonfs` crate pins one context per
+/// request and fans every read of that request through it, so the whole
+/// request observes a single snapshot and shares the caches. It is a
+/// sanctioned public hook (STYLE, "Harness hooks are sanctioned"), not an
+/// application API — embedded applications use the `loonfs` handles, which
+/// drive this seam internally.
 #[derive(Debug, Clone)]
 pub struct RuntimeReadContext {
     pub head: HeadState,
@@ -163,7 +169,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    #[doc(hidden)]
+    /// Stats one path against the pinned runtime read context.
     pub async fn resolve_path_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -173,7 +179,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    #[doc(hidden)]
+    /// Lists one directory page against the pinned runtime read context.
     pub async fn list_path_page_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -184,7 +190,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    #[doc(hidden)]
+    /// Reads file content against the pinned runtime read context.
     pub async fn read_file_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -199,7 +205,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    #[doc(hidden)]
+    /// Runs one content-search page against the pinned runtime read context.
     pub async fn grep_with_runtime_context(
         &self,
         request: &GrepRequest,
@@ -211,7 +217,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         view.grep(&self.store, request).await
     }
 
-    #[doc(hidden)]
+    /// Lists one revision page for a path against the pinned runtime read context.
     pub async fn list_file_revisions_page_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -226,7 +232,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    #[doc(hidden)]
+    /// Lists one revision page for an inode against the pinned runtime read context.
     pub async fn list_file_revisions_for_inode_page_with_runtime_context(
         &self,
         inode_id: InodeId,
@@ -241,7 +247,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    #[doc(hidden)]
+    /// Reads one revision's content by path against the pinned runtime
+    /// read context.
     pub async fn read_file_revision_with_runtime_context(
         &self,
         path: impl AsRef<str>,
@@ -258,7 +265,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    #[doc(hidden)]
+    /// Reads one revision's content against the pinned runtime read context.
     pub async fn read_file_revision_for_inode_with_runtime_context(
         &self,
         inode_id: InodeId,
@@ -640,7 +647,8 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
         self
     }
 
-    #[doc(hidden)]
+    /// Pins the writer session id instead of generating one — the runtime
+    /// seam for hosts that manage session identity themselves.
     pub fn writer_session_id(mut self, writer_session_id: impl Into<String>) -> Self {
         self.writer_session_id = Some(writer_session_id.into());
         self

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -114,7 +114,6 @@ pub use checkpoint::{
     MetadataReorganizeReport,
 };
 pub use context::MutationContext;
-#[doc(hidden)]
 pub use engine::RuntimeReadContext;
 pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 pub use engine::{NamespaceEngine, NamespaceEngineBuildError, NamespaceEngineBuilder};

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -6,12 +6,11 @@ use base64::Engine as _;
 use loonfs_api::v0::ValidatedContentToken;
 use loonfs_api::{ContentRef, NamespaceId};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use thiserror::Error;
 
 const TOKEN_VERSION: &str = "vct0";
 const DEFAULT_TOKEN_TTL_MS: u64 = 60 * 60 * 1000;
-const SHA256_BLOCK_BYTES: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentAdmission {
@@ -149,27 +148,10 @@ fn base64_url(bytes: &[u8]) -> String {
 }
 
 fn hmac_sha256(key: &[u8], value: &[u8]) -> Vec<u8> {
-    let mut normalized_key = if key.len() > SHA256_BLOCK_BYTES {
-        Sha256::digest(key).to_vec()
-    } else {
-        key.to_vec()
-    };
-    normalized_key.resize(SHA256_BLOCK_BYTES, 0);
-    let mut outer = [0x5c; SHA256_BLOCK_BYTES];
-    let mut inner = [0x36; SHA256_BLOCK_BYTES];
-    for (idx, byte) in normalized_key.iter().enumerate() {
-        outer[idx] ^= *byte;
-        inner[idx] ^= *byte;
-    }
-    let inner_hash = Sha256::new()
-        .chain_update(inner)
-        .chain_update(value)
-        .finalize();
-    Sha256::new()
-        .chain_update(outer)
-        .chain_update(inner_hash)
-        .finalize()
-        .to_vec()
+    use hmac::{Hmac, Mac};
+    let mut mac = <Hmac<Sha256>>::new_from_slice(key).expect("HMAC accepts keys of any length");
+    mac.update(value);
+    mac.finalize().into_bytes().to_vec()
 }
 
 fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
@@ -185,6 +167,23 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// RFC 4231 test vectors pin the HMAC-SHA256 construction across
+    /// implementation changes.
+    #[test]
+    fn hmac_sha256_matches_rfc_4231_vectors() {
+        let case_one = hmac_sha256(&[0x0b; 20], b"Hi There");
+        assert_eq!(
+            loonfs_api::wire::manifest::hex_encode_bytes(&case_one),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+        let case_two = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            loonfs_api::wire::manifest::hex_encode_bytes(&case_two),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
     use super::{mint_content_token, verify_content_token};
     use loonfs_api::v0::ValidatedContentToken;
     use loonfs_api::{ContentRef, NamespaceId};

--- a/crates/loonfs-model/Cargo.toml
+++ b/crates/loonfs-model/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 [dependencies]
 loonfs-api = { path = "../loonfs-api" }
 serde.workspace = true
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -19,6 +19,7 @@ loonfs-api = { path = "../loonfs-api" }
 object_store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+hmac.workspace = true
 sha2.workspace = true
 tokio.workspace = true
 thiserror.workspace = true

--- a/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
+++ b/crates/loonfs-objectstore/src/presign/aws_sigv4.rs
@@ -2,12 +2,9 @@
 
 use crate::object_store::Result;
 use crate::ObjectStoreError;
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use std::collections::BTreeMap;
-use std::fmt::Write as _;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-const SHA256_BLOCK_BYTES: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AwsSigV4Dates {
@@ -70,35 +67,14 @@ pub(crate) fn normalize_header_value(value: &str) -> String {
 }
 
 pub(crate) fn hmac_sha256(key: &[u8], value: &[u8]) -> Vec<u8> {
-    let mut normalized_key = if key.len() > SHA256_BLOCK_BYTES {
-        Sha256::digest(key).to_vec()
-    } else {
-        key.to_vec()
-    };
-    normalized_key.resize(SHA256_BLOCK_BYTES, 0);
-    let mut outer = [0x5c; SHA256_BLOCK_BYTES];
-    let mut inner = [0x36; SHA256_BLOCK_BYTES];
-    for (idx, byte) in normalized_key.iter().enumerate() {
-        outer[idx] ^= *byte;
-        inner[idx] ^= *byte;
-    }
-    let inner_hash = Sha256::new()
-        .chain_update(inner)
-        .chain_update(value)
-        .finalize();
-    Sha256::new()
-        .chain_update(outer)
-        .chain_update(inner_hash)
-        .finalize()
-        .to_vec()
+    use hmac::{Hmac, Mac};
+    let mut mac = <Hmac<Sha256>>::new_from_slice(key).expect("HMAC accepts keys of any length");
+    mac.update(value);
+    mac.finalize().into_bytes().to_vec()
 }
 
 pub(crate) fn hex_lower(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
-    }
-    out
+    loonfs_api::wire::manifest::hex_encode_bytes(bytes)
 }
 
 fn percent_encode_query(value: &str) -> String {
@@ -130,4 +106,25 @@ fn civil_from_days(days: i64) -> (i64, i64, i64) {
     let d = doy - (153 * mp + 2) / 5 + 1;
     let m = mp + if mp < 10 { 3 } else { -9 };
     (y + if m <= 2 { 1 } else { 0 }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 4231 test vectors pin the HMAC-SHA256 construction across
+    /// implementation changes.
+    #[test]
+    fn hmac_sha256_matches_rfc_4231_vectors() {
+        let case_one = hmac_sha256(&[0x0b; 20], b"Hi There");
+        assert_eq!(
+            hex_lower(&case_one),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+        let case_two = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            hex_lower(&case_two),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -66,7 +66,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-type SharedStore = SharedObjectStore;
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
 
 /// Response header carrying the request's correlation id.
@@ -147,7 +146,7 @@ impl ServerLifecycle {
 pub async fn app(config: ServerConfig) -> Result<(Router, ServerLifecycle), ServerConfigError> {
     let store = config.object_store()?;
     let transfer_issuer = store.transfer_issuer();
-    let store = Arc::new(store) as SharedStore;
+    let store = Arc::new(store) as SharedObjectStore;
     let (router, lifecycle, _state) =
         app_with_store_and_transfer_issuer(config, store, transfer_issuer).await?;
     Ok((router, lifecycle))
@@ -156,7 +155,7 @@ pub async fn app(config: ServerConfig) -> Result<(Router, ServerLifecycle), Serv
 #[cfg(test)]
 async fn app_with_store(
     config: ServerConfig,
-    store: SharedStore,
+    store: SharedObjectStore,
 ) -> Result<Router, ServerConfigError> {
     Ok(app_with_store_and_transfer_issuer(config, store, None)
         .await?
@@ -168,7 +167,7 @@ async fn app_with_store(
 #[cfg(test)]
 async fn app_with_store_and_state(
     config: ServerConfig,
-    store: SharedStore,
+    store: SharedObjectStore,
 ) -> Result<(Router, AppState), ServerConfigError> {
     let (router, _lifecycle, state) =
         app_with_store_and_transfer_issuer(config, store, None).await?;
@@ -177,7 +176,7 @@ async fn app_with_store_and_state(
 
 async fn app_with_store_and_transfer_issuer(
     config: ServerConfig,
-    store: SharedStore,
+    store: SharedObjectStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<(Router, ServerLifecycle, AppState), ServerConfigError> {
     let (writer, reader, admin) = build_handles(&config, store).await?;
@@ -331,7 +330,7 @@ async fn method_not_allowed() -> ApiResponseError {
 /// inside this one runtime ownership domain.
 async fn build_handles(
     config: &ServerConfig,
-    store: SharedStore,
+    store: SharedObjectStore,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     build_handles_with_metrics_jsonl_path(
         config,
@@ -343,7 +342,7 @@ async fn build_handles(
 
 async fn build_handles_with_metrics_jsonl_path(
     config: &ServerConfig,
-    store: SharedStore,
+    store: SharedObjectStore,
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     let metrics_recorder = object_store_metrics_recorder(metrics_jsonl_path)?;

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -62,7 +62,8 @@ fn error_status_mapping_matches_the_api_spec_table() {
 
 use super::error::status_for_core_error_code;
 use super::{
-    app_with_store, app_with_store_and_state, build_handles_with_metrics_jsonl_path, SharedStore,
+    app_with_store, app_with_store_and_state, build_handles_with_metrics_jsonl_path,
+    SharedObjectStore,
 };
 use crate::config::RuntimeCacheConfigOverrides;
 use crate::{ServerConfig, StoreConfig};
@@ -155,7 +156,7 @@ impl ObjectStore for StaleHeadOnceStore {
 async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
     let store_dir = tempdir().expect("store tempdir");
     let metrics_dir = tempdir().expect("metrics tempdir");
-    let store = Arc::new(LocalFsStore::new(store_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(store_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(store_dir.path(), "server-writer");
     let metrics_path = metrics_dir.path().join("object-store.ndjson");
 
@@ -222,7 +223,7 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runtime_created_state_is_readable_through_http() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let fs = test_runtime(store.clone(), "runtime-writer").await;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -258,7 +259,7 @@ async fn runtime_created_state_is_readable_through_http() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_created_state_is_readable_through_runtime() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let fs = test_runtime(store.clone(), "runtime-reader").await;
     let harness = start_server(store.clone(), temp_dir.path(), "server-writer").await;
 
@@ -292,7 +293,7 @@ async fn http_created_state_is_readable_through_runtime() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_missing_namespace_mutations_return_namespace_not_found() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
@@ -335,7 +336,7 @@ async fn http_missing_namespace_mutations_return_namespace_not_found() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_missing_namespace_reads_return_namespace_not_found() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
@@ -356,7 +357,7 @@ async fn http_missing_namespace_reads_return_namespace_not_found() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_delete_missing_path_returns_path_not_found() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
@@ -380,7 +381,7 @@ async fn http_delete_missing_path_returns_path_not_found() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_over_directory_and_move_into_existing_target_return_path_conflict() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let seeder = bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
     write_file_bytes(
         &seeder,
@@ -444,7 +445,7 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let seeder = bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
     write_file_bytes(
         &seeder,
@@ -502,7 +503,7 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_path_mutation_retries_transient_stale_head_cas() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(StaleHeadOnceStore::new(temp_dir.path(), "demo")) as SharedStore;
+    let store = Arc::new(StaleHeadOnceStore::new(temp_dir.path(), "demo")) as SharedObjectStore;
     bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
@@ -525,7 +526,7 @@ async fn http_first_write_takes_over_a_namespace_owned_by_another_writer() {
     // With no lease, the server's first semantic write acquires the
     // epoch immediately and fences the previous session.
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "other-writer", &namespace_id("demo")).await;
     let store_for_check = store.clone();
 
@@ -564,7 +565,7 @@ struct TestHarness {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "server-writer");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -604,7 +605,7 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "server-writer");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -673,7 +674,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_upload_body_over_the_limit_answers_content_too_large() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_upload_bytes = 1024;
@@ -714,7 +715,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn capability_document_advertises_the_upload_limit() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
@@ -771,7 +772,7 @@ async fn capability_document_advertises_the_upload_limit() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_unknown_routes_and_methods_answer_in_envelope() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "server-writer");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -817,7 +818,7 @@ async fn http_unknown_routes_and_methods_answer_in_envelope() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_commit_body_over_the_limit_answers_content_too_large() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_commit_body_bytes = 1024;
@@ -870,7 +871,7 @@ async fn http_commit_body_over_the_limit_answers_content_too_large() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let fs = bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     write_file_bytes(
         &fs,
@@ -957,7 +958,7 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_concurrent_uploads = 1;
@@ -1019,7 +1020,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_concurrent_uploads = 1;
@@ -1069,7 +1070,7 @@ async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let seed_writer = bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     write_file_bytes(
         &seed_writer,
@@ -1138,7 +1139,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_content_read_over_the_download_limit_answers_content_too_large() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let seed_writer = bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
     write_file_bytes(
         &seed_writer,
@@ -1195,7 +1196,7 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let config = test_config(temp_dir.path(), "server-writer");
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -1284,7 +1285,7 @@ fn flush_everything_tick() -> MaintenanceTickOptions {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn explicit_maintenance_honors_a_zero_configured_cache_budget() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.background_maintenance = false;
     config.runtime_cache.metadata_table_cache_max_decoded_bytes = Some(0);
@@ -1319,7 +1320,7 @@ async fn explicit_maintenance_honors_a_zero_configured_cache_budget() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn explicit_maintenance_populates_the_writer_visible_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.background_maintenance = false;
     let (writer, _reader, admin) = build_handles_with_metrics_jsonl_path(&config, store, None)
@@ -1353,7 +1354,7 @@ async fn explicit_maintenance_populates_the_writer_visible_cache() {
     writer.shutdown_background().await.expect("writer shutdown");
 }
 
-async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestHarness {
+async fn start_server(store: SharedObjectStore, root: &Path, writer_id: &str) -> TestHarness {
     let config = test_config(root, writer_id);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -1375,7 +1376,7 @@ async fn start_server(store: SharedStore, root: &Path, writer_id: &str) -> TestH
     }
 }
 
-async fn test_runtime(store: SharedStore, writer_id: &str) -> FsWriter {
+async fn test_runtime(store: SharedObjectStore, writer_id: &str) -> FsWriter {
     FsWriter::builder_with_store(store)
         .writer_id(writer_id)
         .writer_version(format!("{writer_id}/0.1.0"))
@@ -1415,7 +1416,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
 /// durable state as `writer_id` would from another process — and returns
 /// that runtime for follow-up seed writes.
 async fn bootstrap_namespace(
-    store: &SharedStore,
+    store: &SharedObjectStore,
     writer_id: &str,
     namespace_id: &NamespaceId,
 ) -> FsWriter {

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::panic, clippy::disallowed_methods)]
 // Ignored real-provider tests exercise the full server/client/direct-object-store path.
 
 use loonfs_api::{
@@ -266,9 +265,11 @@ fn presigned_access_without_header(
 
 fn expect_client_rejection<T>(result: Result<T, ClientError>, context: &str) {
     match result {
-        Ok(_) => panic!("{context} unexpectedly succeeded"),
+        Ok(_) => unreachable!("{context} unexpectedly succeeded"),
         Err(ClientError::Api { .. } | ClientError::Http(_)) => {}
-        Err(error) => panic!("{context} failed with unexpected client-side error: {error}"),
+        Err(error) => {
+            unreachable!("{context} failed with unexpected client-side error: {error}")
+        }
     }
 }
 

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::panic, clippy::disallowed_methods)]
-// Smoke tests use explicit polling and panic-heavy match assertions for readable diagnostics.
-
 use bytes::Bytes;
 use loonfs_api::{
     v0::{
@@ -61,7 +58,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
                 assert_eq!(status, 409);
                 assert_eq!(code, "stale_head");
             }
-            other => panic!("expected stale_head, got {other:?}"),
+            other => unreachable!("expected stale_head, got {other:?}"),
         }
         harness
             .client
@@ -86,7 +83,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
                 assert_eq!(status, 410);
                 assert_eq!(code, "namespace_deleted");
             }
-            other => panic!("expected namespace_deleted, got {other:?}"),
+            other => unreachable!("expected namespace_deleted, got {other:?}"),
         }
         let read = harness
             .client
@@ -94,7 +91,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
             .expect_err("reads observe the deleted namespace");
         match read {
             ClientError::Api { code, .. } => assert_eq!(code, "namespace_deleted"),
-            other => panic!("expected namespace_deleted, got {other:?}"),
+            other => unreachable!("expected namespace_deleted, got {other:?}"),
         }
         let again = harness
             .client
@@ -105,7 +102,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
                 assert_eq!(status, 410);
                 assert_eq!(code, "namespace_deleted");
             }
-            other => panic!("expected namespace_deleted, got {other:?}"),
+            other => unreachable!("expected namespace_deleted, got {other:?}"),
         }
         let recreate = harness
             .client
@@ -116,7 +113,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
                 assert_eq!(status, 410);
                 assert_eq!(code, "namespace_deleted");
             }
-            other => panic!("expected namespace_deleted, got {other:?}"),
+            other => unreachable!("expected namespace_deleted, got {other:?}"),
         }
     })
     .await
@@ -222,7 +219,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
                 assert_eq!(status, 400);
                 assert_eq!(code, "invalid_request");
             }
-            other => panic!("expected cursor rejection, got {other:?}"),
+            other => unreachable!("expected cursor rejection, got {other:?}"),
         }
 
         let raw_first_page: ListPathEntriesResponse = get_json(
@@ -354,7 +351,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
                 assert_eq!(status, 404);
                 assert_eq!(code, "namespace_not_found");
             }
-            other => panic!("expected API error for missing namespace, got {other:?}"),
+            other => unreachable!("expected API error for missing namespace, got {other:?}"),
         }
     })
     .await
@@ -389,8 +386,8 @@ async fn http_namespace_listing_route_is_not_exposed() {
                     "GET /v0/namespaces should be missing or method-not-allowed, got {status}"
                 );
             }
-            Ok(_) => panic!("GET /v0/namespaces must not return a namespace list"),
-            Err(error) => panic!("unexpected transport error: {error}"),
+            Ok(_) => unreachable!("GET /v0/namespaces must not return a namespace list"),
+            Err(error) => unreachable!("unexpected transport error: {error}"),
         }
     })
     .await
@@ -456,7 +453,7 @@ async fn http_upload_content_rejects_invalid_upload_id() {
                 assert_eq!(status, 400);
                 assert_eq!(code, "invalid_request");
             }
-            other => panic!("expected upload id rejection, got {other:?}"),
+            other => unreachable!("expected upload id rejection, got {other:?}"),
         }
     })
     .await
@@ -498,7 +495,7 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
             &MutationOptions::default(),
         ) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_conflict"),
-            other => panic!("expected path_conflict, got {other:?}"),
+            other => unreachable!("expected path_conflict, got {other:?}"),
         }
 
         harness
@@ -619,7 +616,7 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
         match harness.client.list_changes("clone", ChangeSeq(0)) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "rebootstrap_required"),
-            other => panic!("expected rebootstrap_required, got {other:?}"),
+            other => unreachable!("expected rebootstrap_required, got {other:?}"),
         }
         let clone_changes = harness
             .client
@@ -671,7 +668,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             .upload_content(namespace, begin.upload_id.as_str(), b"different bytes")
         {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "upload_content_conflict"),
-            other => panic!("expected upload_content_conflict, got {other:?}"),
+            other => unreachable!("expected upload_content_conflict, got {other:?}"),
         }
 
         let mismatch_upload = harness
@@ -694,7 +691,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             },
         ) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "invalid_request"),
-            other => panic!("expected upload content rejection, got {other:?}"),
+            other => unreachable!("expected upload content rejection, got {other:?}"),
         }
 
         let content_ref = stage_uploaded_content_ref(&harness.client, namespace, file_bytes);
@@ -1173,7 +1170,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
                 assert_eq!(status, 404);
                 assert_eq!(code, "revision_not_found");
             }
-            other => panic!("expected revision_not_found, got {other:?}"),
+            other => unreachable!("expected revision_not_found, got {other:?}"),
         }
     })
     .await
@@ -1248,7 +1245,7 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
                 let request_id = request_id.expect("request id");
                 assert!(request_id.starts_with("req_"), "got `{request_id}`");
             }
-            other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
+            other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
         }
     })
     .await
@@ -1324,7 +1321,7 @@ async fn http_commit_name_collision_reports_readable_error_message() {
                     "expected no Debug formatting in message, got {message:?}"
                 );
             }
-            other => panic!("expected path_conflict, got {other:?}"),
+            other => unreachable!("expected path_conflict, got {other:?}"),
         }
     })
     .await
@@ -1387,7 +1384,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
             Err(ClientError::Api { code, .. }) => {
                 assert_eq!(code, "commit_id_reuse_conflict")
             }
-            other => panic!("expected commit_id_reuse_conflict, got {other:?}"),
+            other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
         }
     })
     .await
@@ -1464,7 +1461,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         assert_eq!(move_repeated, move_first);
         match harness.client.stat_path(&copied) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
-            other => panic!("expected path_not_found for moved-from path, got {other:?}"),
+            other => unreachable!("expected path_not_found for moved-from path, got {other:?}"),
         }
         let moved_entry = harness.client.stat_path(&moved).expect("moved stat");
         assert_eq!(moved_entry.inode_id, copied_entry.inode_id);
@@ -1480,7 +1477,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         assert_eq!(delete_repeated, delete_first);
         match harness.client.stat_path(&moved) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
-            other => panic!("expected path_not_found for deleted path, got {other:?}"),
+            other => unreachable!("expected path_not_found for deleted path, got {other:?}"),
         }
     })
     .await
@@ -1520,7 +1517,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
                 assert_eq!(status, 409);
                 assert_eq!(code, "directory_not_empty");
             }
-            other => panic!("expected directory_not_empty, got {other:?}"),
+            other => unreachable!("expected directory_not_empty, got {other:?}"),
         }
 
         harness
@@ -1529,7 +1526,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
             .expect("recursive delete succeeds");
         match harness.client.stat_path(&child) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
-            other => panic!("expected path_not_found after recursive delete, got {other:?}"),
+            other => unreachable!("expected path_not_found after recursive delete, got {other:?}"),
         }
     })
     .await
@@ -1584,7 +1581,7 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
                         serde_json::from_reader(response.into_reader()).expect("decode api error");
                     assert_eq!(error.code, "invalid_request");
                 }
-                other => panic!("expected rejected move behavior, got {other:?}"),
+                other => unreachable!("expected rejected move behavior, got {other:?}"),
             }
         }
 
@@ -1604,7 +1601,7 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
                     serde_json::from_reader(response.into_reader()).expect("decode api error");
                 assert_eq!(error.code, "invalid_request");
             }
-            other => panic!("expected rejected upload body, got {other:?}"),
+            other => unreachable!("expected rejected upload body, got {other:?}"),
         }
     })
     .await
@@ -1681,7 +1678,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
 
         match client.list_changes(namespace, ChangeSeq(0)) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "rebootstrap_required"),
-            other => panic!("expected rebootstrap_required, got {other:?}"),
+            other => unreachable!("expected rebootstrap_required, got {other:?}"),
         }
 
         let empty = client
@@ -1875,7 +1872,7 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
 
         match cold_client.stat_path(&target) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "namespace_corrupt"),
-            other => panic!("expected namespace_corrupt, got {other:?}"),
+            other => unreachable!("expected namespace_corrupt, got {other:?}"),
         }
         // The warm server keeps serving its pinned pair; the corruption is
         // surfaced by whoever actually consumes the manifest.
@@ -1945,7 +1942,7 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
                 Err(ClientError::Api { code, .. }) => {
                     assert_eq!(code, "writer_fenced", "attempt {attempt}")
                 }
-                other => panic!("expected writer_fenced on attempt {attempt}, got {other:?}"),
+                other => unreachable!("expected writer_fenced on attempt {attempt}, got {other:?}"),
             }
         }
 
@@ -1977,7 +1974,7 @@ struct TestServer {
 async fn start_server(config: ServerConfig) -> TestServer {
     let (store_root, store_key_prefix) = match &config.store {
         StoreConfig::LocalFs { root, key_prefix } => (PathBuf::from(root), key_prefix.clone()),
-        other => panic!("test harness requires local fs store, got {other:?}"),
+        other => unreachable!("test harness requires local fs store, got {other:?}"),
     };
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -2175,7 +2172,7 @@ fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>
             assert_eq!(error.code, "invalid_request");
             assert!(error.message.contains("invalid namespace_id"));
         }
-        other => panic!("expected invalid_namespace_id response, got {other:?}"),
+        other => unreachable!("expected invalid_namespace_id response, got {other:?}"),
     }
 }
 

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -229,8 +229,8 @@ impl RuntimeControlCache {
             // a cache and never gets disabled.
             return Arc::new(AsyncMutex::new(
                 NamespaceCommitEngine::new(namespace_id.clone())
-                    .with_table_cache(table_cache)
-                    .with_writer_session(session),
+                    .table_cache(table_cache)
+                    .writer_session(session),
             ));
         }
         let entry = self.namespace_entry(namespace_id, max_cached_namespaces);
@@ -238,10 +238,10 @@ impl RuntimeControlCache {
             return Arc::clone(engine);
         }
         let mut engine = NamespaceCommitEngine::new(namespace_id.clone())
-            .with_table_cache(table_cache)
-            .with_writer_session(session);
+            .table_cache(table_cache)
+            .writer_session(session);
         if let Some(catalog) = &entry.catalog {
-            engine = engine.with_catalog_entry(catalog.clone());
+            engine = engine.catalog_entry(catalog.clone());
         }
         let engine = Arc::new(AsyncMutex::new(engine));
         entry.engine = Some(Arc::clone(&engine));

--- a/crates/loonfs/src/fs.rs
+++ b/crates/loonfs/src/fs.rs
@@ -1450,7 +1450,7 @@ impl FsCore {
         // but the session's epoch and fencing still come from the registry —
         // no cache configuration disables session state.
         let mut engine = loonfs_core::publish::NamespaceCommitEngine::new(namespace_id.clone())
-            .with_writer_session(self.inner.writer_sessions.state(namespace_id));
+            .writer_session(self.inner.writer_sessions.state(namespace_id));
         let context = self.mutation_context();
         // Boxed for the same type-recursion reason as the cached-engine path.
         let results: Vec<_> = Box::pin(engine.publish_batch(&store, candidates, &context))

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1761,8 +1761,7 @@ mod tests {
 
     /// A submission to a cold namespace is taken immediately: after one
     /// poll of the publish task there is no open batch parked behind a
-    /// timer. The old fixed coalescing delay left the candidate in the
-    /// open batch for its full 100ms window.
+    /// timer, so a lone candidate never waits out a coalescing window.
     #[tokio::test(flavor = "current_thread")]
     async fn cold_submission_publishes_without_a_coalescing_delay() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -3,10 +3,6 @@
 //! one, or all of them — abandons only result delivery, never the
 //! publication itself.
 
-#![allow(clippy::panic, clippy::disallowed_methods)]
-// Cancellation tests park a real publication at a blocked head
-// compare-and-swap and poll for that state with short sleeps.
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
@@ -132,7 +128,10 @@ struct ParkedPuts {
 }
 
 /// Parks one publication at the blocked head CAS with a second put queued
-/// behind it, so tests can cancel callers at both positions.
+/// behind it, so tests can cancel callers at both positions. The settle
+/// sleep is the point of the fixture, so the timer method the workspace
+/// otherwise disallows is scoped to this helper.
+#[allow(clippy::disallowed_methods)]
 async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     let namespace_id = NamespaceId::parse("parked").expect("valid namespace id");
     let store_impl = Arc::new(BlockingHeadCasStore::new(temp_dir, &namespace_id));


### PR DESCRIPTION
- One HMAC-SHA256. Both hand-rolled implementations — the sigv4 presigner's and the content-admission token's, ~50 lines each of key normalization and ipad/opad padding — are replaced by the RustCrypto hmac crate (the one new dependency this wave adds, pairing with the sha2 we already use). Hand-rolling a crypto primitive twice is the canonical thing this codebase's inspirations would not ship; the crate removes the class of bug rather than deduplicating it. The swap is proven identical two ways: RFC 4231 test vectors were added first and run against the hand-rolls, then re-run against the crate; and the seven presign pinned-signature tests pass unchanged.
- One lowercase-hex codec. pagination.rs carried a private byte-identical copy of the hex pair its own crate exports from manifest.rs; it now delegates, mapping decode failures into its cursor error. The sigv4 hex_lower delegates to the same shared helper (objectstore already depends on loonfs-api).
