### PR TITLE
refactor(api): one envelope codec authority for control, manifest, and WAL objects

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -2,8 +2,7 @@
 //! checkpoint records, upload sessions, and their envelopes (format spec,
 //! "Control objects").
 
-use crate::digest::sha256_digest;
-use crate::envelope::EnvelopeProbe;
+use crate::envelope::EnvelopeCodecError;
 use crate::v0::UploadMode;
 use crate::WriterEpoch;
 use crate::{
@@ -12,8 +11,6 @@ use crate::{
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
-use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -325,7 +322,7 @@ where
         kind: ControlObjectKind,
         writer_version: impl Into<String>,
         state: T,
-    ) -> Result<Self, ControlCodecError> {
+    ) -> Result<Self, EnvelopeCodecError> {
         Ok(Self {
             kind,
             format_version: kind.format_version(),
@@ -344,144 +341,66 @@ pub type WalFloorEnvelope = ControlObjectEnvelope<WalFloorState>;
 pub type CheckpointRecordEnvelope = ControlObjectEnvelope<CheckpointRecordState>;
 pub type ContentStoreDescriptorEnvelope = ControlObjectEnvelope<ContentStoreDescriptorState>;
 
-/// Durable layout of a control object: the envelope fields plus the payload
-/// as a raw JSON fragment. The payload stays inline (rather than as encoded
-/// bytes) so control objects remain directly readable JSON, while
-/// `payload_checksum` covers the exact fragment bytes as stored.
-#[derive(Serialize, Deserialize)]
-struct ControlObjectDocument {
-    kind: String,
-    format_version: u32,
-    writer_version: String,
-    payload_checksum: String,
-    payload: Box<RawValue>,
-}
-
-#[derive(Debug, Error)]
-pub enum ControlCodecError {
-    #[error("failed to encode control object payload to JSON: {0}")]
-    PayloadEncode(String),
-    #[error("failed to encode control object envelope to JSON: {0}")]
-    EnvelopeEncode(String),
-    #[error("failed to decode control object envelope from JSON: {0}")]
-    EnvelopeDecode(String),
-    #[error("failed to decode control object payload from JSON: {0}")]
-    PayloadDecode(String),
-    #[error("unknown control object kind `{found}`")]
-    UnknownKind { found: String },
-    #[error("control object kind mismatch: expected `{expected}`, found `{found}`")]
-    KindMismatch { expected: String, found: String },
-    #[error(
-        "unsupported `{kind}` control object format version `{found}`: \
-         this build supports `{supported}`"
-    )]
-    UnsupportedFormatVersion {
-        kind: String,
-        found: u32,
-        supported: u32,
-    },
-    #[error("control object payload checksum mismatch: expected {expected}, actual {actual}")]
-    ChecksumMismatch { expected: String, actual: String },
-    #[error(
-        "control object envelope checksum `{checksum}` does not match its payload `{actual}`: \
-         rebuild the envelope with `ControlObjectEnvelope::from_state`"
-    )]
-    StalePayloadChecksum { checksum: String, actual: String },
-}
-
-pub fn control_payload_checksum<T>(state: &T) -> Result<String, ControlCodecError>
+pub fn control_payload_checksum<T>(state: &T) -> Result<String, EnvelopeCodecError>
 where
     T: Serialize,
 {
-    let bytes = serde_json::to_vec(state)
-        .map_err(|err| ControlCodecError::PayloadEncode(err.to_string()))?;
-    Ok(sha256_digest(&bytes))
+    crate::envelope::json_payload_checksum(state)
 }
 
 pub fn encode_control_object<T>(
     envelope: &ControlObjectEnvelope<T>,
-) -> Result<Vec<u8>, ControlCodecError>
+) -> Result<Vec<u8>, EnvelopeCodecError>
 where
     T: Serialize,
 {
-    if envelope.format_version != envelope.kind.format_version() {
-        return Err(ControlCodecError::UnsupportedFormatVersion {
-            kind: envelope.kind.as_str().to_owned(),
-            found: envelope.format_version,
-            supported: envelope.kind.format_version(),
-        });
-    }
-    let payload_json = serde_json::to_string(&envelope.state)
-        .map_err(|err| ControlCodecError::PayloadEncode(err.to_string()))?;
-    let actual = sha256_digest(payload_json.as_bytes());
-    if actual != envelope.payload_checksum {
-        return Err(ControlCodecError::StalePayloadChecksum {
-            checksum: envelope.payload_checksum.clone(),
-            actual,
-        });
-    }
-
-    let document = ControlObjectDocument {
-        kind: envelope.kind.as_str().to_owned(),
-        format_version: envelope.format_version,
-        writer_version: envelope.writer_version.clone(),
-        payload_checksum: envelope.payload_checksum.clone(),
-        payload: RawValue::from_string(payload_json)
-            .map_err(|err| ControlCodecError::PayloadEncode(err.to_string()))?,
-    };
-    serde_json::to_vec(&document).map_err(|err| ControlCodecError::EnvelopeEncode(err.to_string()))
+    crate::envelope::encode_json_envelope(
+        envelope.kind.as_str(),
+        envelope.format_version,
+        envelope.kind.format_version(),
+        &envelope.writer_version,
+        &envelope.payload_checksum,
+        &envelope.state,
+    )
 }
 
 pub fn decode_control_object<T>(
     bytes: &[u8],
     expected_kind: ControlObjectKind,
-) -> Result<ControlObjectEnvelope<T>, ControlCodecError>
+) -> Result<ControlObjectEnvelope<T>, EnvelopeCodecError>
 where
     T: DeserializeOwned,
 {
-    let probe: EnvelopeProbe = serde_json::from_slice(bytes)
-        .map_err(|err| ControlCodecError::EnvelopeDecode(err.to_string()))?;
-    let Some(kind) = ControlObjectKind::parse(&probe.kind) else {
-        return Err(ControlCodecError::UnknownKind { found: probe.kind });
-    };
-    if kind != expected_kind {
-        return Err(ControlCodecError::KindMismatch {
-            expected: expected_kind.as_str().to_owned(),
-            found: probe.kind,
-        });
-    }
-    if probe.format_version != kind.format_version() {
-        return Err(ControlCodecError::UnsupportedFormatVersion {
-            kind: kind.as_str().to_owned(),
-            found: probe.format_version,
-            supported: kind.format_version(),
-        });
-    }
-
-    let document: ControlObjectDocument = serde_json::from_slice(bytes)
-        .map_err(|err| ControlCodecError::EnvelopeDecode(err.to_string()))?;
-    let actual = sha256_digest(document.payload.get().as_bytes());
-    if actual != document.payload_checksum {
-        return Err(ControlCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
-            actual,
-        });
-    }
-    let state: T = serde_json::from_str(document.payload.get())
-        .map_err(|err| ControlCodecError::PayloadDecode(err.to_string()))?;
+    let decoded = crate::envelope::decode_json_envelope(
+        bytes,
+        expected_kind.format_version(),
+        // The kind registry reports unknown kinds distinctly from
+        // registered-but-mismatched ones.
+        |found| match ControlObjectKind::parse(found) {
+            None => Err(EnvelopeCodecError::UnknownKind {
+                found: found.to_owned(),
+            }),
+            Some(kind) if kind != expected_kind => Err(EnvelopeCodecError::KindMismatch {
+                expected: expected_kind.as_str().to_owned(),
+                found: found.to_owned(),
+            }),
+            Some(_) => Ok(()),
+        },
+    )?;
 
     Ok(ControlObjectEnvelope {
-        kind,
-        format_version: document.format_version,
-        writer_version: document.writer_version,
-        payload_checksum: document.payload_checksum,
-        state,
+        kind: expected_kind,
+        format_version: decoded.format_version,
+        writer_version: decoded.writer_version,
+        payload_checksum: decoded.payload_checksum,
+        state: decoded.payload,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::digest::sha256_digest;
 
     #[test]
     fn control_object_kind_strings_round_trip_and_match_serde() {
@@ -525,7 +444,7 @@ mod tests {
             ControlObjectKind::NamespaceConfig,
         )
         .expect_err("kind mismatch");
-        assert!(matches!(mismatch, ControlCodecError::KindMismatch { .. }));
+        assert!(matches!(mismatch, EnvelopeCodecError::KindMismatch { .. }));
     }
 
     #[test]

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -1,13 +1,24 @@
-//! Shared pieces of the durable envelope layout.
+//! The durable envelope layout, decided once.
 //!
 //! Every durable LoonFS object is an envelope document with the same leading
 //! fields — `kind`, `format_version`, `writer_version`, `payload_checksum` —
-//! followed by the payload as an opaque sub-document (a CBOR byte string or a
-//! raw JSON fragment). `payload_checksum` is always computed over the exact
-//! payload bytes as stored, never over a re-encoding, so checksum failures
-//! mean corruption and version skew surfaces as a version error.
+//! followed by the payload as an opaque sub-document. This module owns the
+//! whole contract: the probe, the one error vocabulary, the kind/version/
+//! checksum validation rules, and the generic JSON codec that control
+//! objects and namespace manifests parameterize. The WAL segment codec keeps
+//! its CBOR-plus-zstd transport but validates through the same rules and
+//! reports through the same errors, so no envelope family can drift from
+//! the others.
+//!
+//! `payload_checksum` is always computed over the exact payload bytes as
+//! stored, never over a re-encoding, so checksum failures mean corruption
+//! and version skew surfaces as a version error.
 
-use serde::Deserialize;
+use crate::digest::sha256_digest;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use thiserror::Error;
 
 /// Identifying prefix of a durable envelope document.
 ///
@@ -19,4 +30,194 @@ use serde::Deserialize;
 pub(crate) struct EnvelopeProbe {
     pub(crate) kind: String,
     pub(crate) format_version: u32,
+}
+
+/// Failure vocabulary shared by every envelope codec. Messages are
+/// envelope-generic; the wrapping error names the object (and its key) the
+/// bytes came from.
+#[derive(Debug, Error)]
+pub enum EnvelopeCodecError {
+    #[error("failed to encode envelope payload: {0}")]
+    PayloadEncode(String),
+    #[error("failed to encode envelope document: {0}")]
+    EnvelopeEncode(String),
+    #[error("failed to decode envelope document: {0}")]
+    EnvelopeDecode(String),
+    #[error("failed to decode envelope payload: {0}")]
+    PayloadDecode(String),
+    #[error("failed to compress envelope: {0}")]
+    Compress(String),
+    #[error("failed to decompress envelope: {0}")]
+    Decompress(String),
+    #[error("unknown envelope kind `{found}`")]
+    UnknownKind { found: String },
+    #[error("envelope kind mismatch: expected `{expected}`, found `{found}`")]
+    KindMismatch { expected: String, found: String },
+    #[error(
+        "unsupported `{kind}` envelope format version `{found}`: \
+         this build supports `{supported}`"
+    )]
+    UnsupportedFormatVersion {
+        kind: String,
+        found: u32,
+        supported: u32,
+    },
+    #[error("envelope payload checksum mismatch: expected {expected}, actual {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+    #[error(
+        "envelope checksum `{checksum}` does not match its payload `{actual}`: \
+         rebuild the envelope from its payload"
+    )]
+    StalePayloadChecksum { checksum: String, actual: String },
+}
+
+/// Requires the probed kind to be exactly `expected`.
+pub(crate) fn verify_kind(expected: &str, found: &str) -> Result<(), EnvelopeCodecError> {
+    if found != expected {
+        return Err(EnvelopeCodecError::KindMismatch {
+            expected: expected.to_owned(),
+            found: found.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Requires the probed format version to be exactly what this build writes
+/// for `kind` — no envelope family tolerates version skew.
+pub(crate) fn verify_version(
+    kind: &str,
+    found: u32,
+    supported: u32,
+) -> Result<(), EnvelopeCodecError> {
+    if found != supported {
+        return Err(EnvelopeCodecError::UnsupportedFormatVersion {
+            kind: kind.to_owned(),
+            found,
+            supported,
+        });
+    }
+    Ok(())
+}
+
+/// Requires the stored checksum to match the payload bytes as stored.
+pub(crate) fn verify_payload_checksum(
+    expected: &str,
+    payload_bytes: &[u8],
+) -> Result<(), EnvelopeCodecError> {
+    let actual = sha256_digest(payload_bytes);
+    if actual != expected {
+        return Err(EnvelopeCodecError::ChecksumMismatch {
+            expected: expected.to_owned(),
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Requires an in-memory envelope's recorded checksum to still match its
+/// payload before encoding — a stale checksum means the caller mutated the
+/// payload without rebuilding the envelope.
+pub(crate) fn verify_checksum_fresh(
+    checksum: &str,
+    payload_bytes: &[u8],
+) -> Result<(), EnvelopeCodecError> {
+    let actual = sha256_digest(payload_bytes);
+    if actual != checksum {
+        return Err(EnvelopeCodecError::StalePayloadChecksum {
+            checksum: checksum.to_owned(),
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Durable layout of a JSON-bodied envelope: the shared fields plus the
+/// payload as a raw JSON fragment, kept inline so the object remains
+/// directly readable JSON while `payload_checksum` covers the exact
+/// fragment bytes as stored.
+#[derive(Serialize, Deserialize)]
+struct JsonEnvelopeDocument {
+    kind: String,
+    format_version: u32,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+/// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
+/// canonical serialization.
+pub(crate) fn json_payload_checksum<T: Serialize>(
+    payload: &T,
+) -> Result<String, EnvelopeCodecError> {
+    let bytes = serde_json::to_vec(payload)
+        .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
+    Ok(sha256_digest(&bytes))
+}
+
+/// Encodes one JSON-bodied envelope, validating that the recorded version is
+/// what this build writes for `kind` and that the recorded checksum still
+/// matches the payload.
+pub(crate) fn encode_json_envelope<T: Serialize>(
+    kind: &str,
+    format_version: u32,
+    supported_version: u32,
+    writer_version: &str,
+    payload_checksum: &str,
+    payload: &T,
+) -> Result<Vec<u8>, EnvelopeCodecError> {
+    verify_version(kind, format_version, supported_version)?;
+    let payload_json = serde_json::to_string(payload)
+        .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
+    verify_checksum_fresh(payload_checksum, payload_json.as_bytes())?;
+    let document = JsonEnvelopeDocument {
+        kind: kind.to_owned(),
+        format_version,
+        writer_version: writer_version.to_owned(),
+        payload_checksum: payload_checksum.to_owned(),
+        payload: RawValue::from_string(payload_json)
+            .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?,
+    };
+    serde_json::to_vec(&document).map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))
+}
+
+/// A decoded JSON-bodied envelope's shared fields plus its parsed payload.
+pub(crate) struct DecodedJsonEnvelope<T> {
+    pub(crate) format_version: u32,
+    pub(crate) writer_version: String,
+    pub(crate) payload_checksum: String,
+    pub(crate) payload: T,
+}
+
+/// Decodes one JSON-bodied envelope: probe first (kind through
+/// `classify_kind`, then version), then the checksum over the stored
+/// payload fragment, then the payload itself.
+///
+/// `classify_kind` lets a family with a kind registry report unknown kinds
+/// distinctly from mismatched ones; families with one kind pass
+/// [`verify_kind`] directly.
+pub(crate) fn decode_json_envelope<T: DeserializeOwned>(
+    bytes: &[u8],
+    supported_version: u32,
+    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
+) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    let probe: EnvelopeProbe = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    classify_kind(&probe.kind)?;
+    verify_version(&probe.kind, probe.format_version, supported_version)?;
+
+    let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    verify_payload_checksum(
+        &document.payload_checksum,
+        document.payload.get().as_bytes(),
+    )?;
+    let payload: T = serde_json::from_str(document.payload.get())
+        .map_err(|err| EnvelopeCodecError::PayloadDecode(err.to_string()))?;
+
+    Ok(DecodedJsonEnvelope {
+        format_version: document.format_version,
+        writer_version: document.writer_version,
+        payload_checksum: document.payload_checksum,
+        payload,
+    })
 }

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -40,6 +40,10 @@ pub mod wire {
         pub use crate::control::*;
     }
 
+    pub mod envelope {
+        pub use crate::envelope::EnvelopeCodecError;
+    }
+
     pub mod sst_blocks {
         pub use crate::sst_blocks::*;
     }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -2,8 +2,7 @@
 //! metadata SST runs and index segments that materialize one namespace
 //! file-set version (format spec, "Namespace manifests").
 
-use crate::digest::sha256_digest;
-use crate::envelope::EnvelopeProbe;
+use crate::envelope::EnvelopeCodecError;
 use crate::sst_blocks::BlockHandle;
 use crate::WriterEpoch;
 use crate::{
@@ -11,9 +10,7 @@ use crate::{
     ManifestObjectId, MetadataTableId, NameKey, NamespaceId, RevisionNo,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
 use std::collections::BTreeMap;
-use thiserror::Error;
 
 /// Version 1: an uncompressed JSON envelope document carrying the payload as
 /// a raw JSON fragment. `payload_checksum` covers the fragment's exact bytes.
@@ -567,7 +564,7 @@ impl NamespaceManifestEnvelope {
     pub fn from_payload(
         writer_version: impl Into<String>,
         payload: NamespaceManifestPayload,
-    ) -> Result<Self, NamespaceManifestCodecError> {
+    ) -> Result<Self, EnvelopeCodecError> {
         Ok(Self {
             kind: NamespaceManifestKind::NamespaceManifest,
             format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
@@ -578,119 +575,40 @@ impl NamespaceManifestEnvelope {
     }
 }
 
-/// Durable layout of a namespace manifest object: the envelope fields plus
-/// the payload as a raw JSON fragment. Keeping the payload inline (rather
-/// than as encoded bytes) preserves the operational property that manifests
-/// are directly readable JSON, while `payload_checksum` still covers the
-/// exact fragment bytes as stored.
-#[derive(Serialize, Deserialize)]
-struct NamespaceManifestDocument {
-    kind: String,
-    format_version: u32,
-    writer_version: String,
-    payload_checksum: String,
-    payload: Box<RawValue>,
-}
-
-#[derive(Debug, Error)]
-pub enum NamespaceManifestCodecError {
-    #[error("failed to encode namespace manifest payload to JSON: {0}")]
-    PayloadEncode(String),
-    #[error("failed to encode namespace manifest envelope to JSON: {0}")]
-    EnvelopeEncode(String),
-    #[error("failed to decode namespace manifest envelope from JSON: {0}")]
-    EnvelopeDecode(String),
-    #[error("failed to decode namespace manifest payload from JSON: {0}")]
-    PayloadDecode(String),
-    #[error("unexpected namespace manifest kind `{found}`: expected `{expected}`")]
-    UnexpectedKind { expected: String, found: String },
-    #[error("unsupported namespace manifest format version `{found}`: this build supports `{supported}`")]
-    UnsupportedFormatVersion { found: u32, supported: u32 },
-    #[error("namespace manifest payload checksum mismatch: expected {expected}, actual {actual}")]
-    ChecksumMismatch { expected: String, actual: String },
-    #[error(
-        "namespace manifest envelope checksum `{checksum}` does not match its payload `{actual}`: \
-         rebuild the envelope with `NamespaceManifestEnvelope::from_payload`"
-    )]
-    StalePayloadChecksum { checksum: String, actual: String },
-}
-
 fn namespace_manifest_payload_checksum(
     payload: &NamespaceManifestPayload,
-) -> Result<String, NamespaceManifestCodecError> {
-    let bytes = serde_json::to_vec(payload)
-        .map_err(|err| NamespaceManifestCodecError::PayloadEncode(err.to_string()))?;
-    Ok(sha256_digest(&bytes))
+) -> Result<String, EnvelopeCodecError> {
+    crate::envelope::json_payload_checksum(payload)
 }
 
 pub fn encode_namespace_manifest_json(
     envelope: &NamespaceManifestEnvelope,
-) -> Result<Vec<u8>, NamespaceManifestCodecError> {
-    if envelope.format_version != NAMESPACE_MANIFEST_FORMAT_VERSION {
-        return Err(NamespaceManifestCodecError::UnsupportedFormatVersion {
-            found: envelope.format_version,
-            supported: NAMESPACE_MANIFEST_FORMAT_VERSION,
-        });
-    }
-    let payload_json = serde_json::to_string(&envelope.payload)
-        .map_err(|err| NamespaceManifestCodecError::PayloadEncode(err.to_string()))?;
-    let actual = sha256_digest(payload_json.as_bytes());
-    if actual != envelope.payload_checksum {
-        return Err(NamespaceManifestCodecError::StalePayloadChecksum {
-            checksum: envelope.payload_checksum.clone(),
-            actual,
-        });
-    }
-
-    let document = NamespaceManifestDocument {
-        kind: envelope.kind.as_str().to_owned(),
-        format_version: envelope.format_version,
-        writer_version: envelope.writer_version.clone(),
-        payload_checksum: envelope.payload_checksum.clone(),
-        payload: RawValue::from_string(payload_json)
-            .map_err(|err| NamespaceManifestCodecError::PayloadEncode(err.to_string()))?,
-    };
-    serde_json::to_vec(&document)
-        .map_err(|err| NamespaceManifestCodecError::EnvelopeEncode(err.to_string()))
+) -> Result<Vec<u8>, EnvelopeCodecError> {
+    crate::envelope::encode_json_envelope(
+        envelope.kind.as_str(),
+        envelope.format_version,
+        NAMESPACE_MANIFEST_FORMAT_VERSION,
+        &envelope.writer_version,
+        &envelope.payload_checksum,
+        &envelope.payload,
+    )
 }
 
 pub fn decode_namespace_manifest_json(
     bytes: &[u8],
-) -> Result<NamespaceManifestEnvelope, NamespaceManifestCodecError> {
-    let probe: EnvelopeProbe = serde_json::from_slice(bytes)
-        .map_err(|err| NamespaceManifestCodecError::EnvelopeDecode(err.to_string()))?;
+) -> Result<NamespaceManifestEnvelope, EnvelopeCodecError> {
     let expected_kind = NamespaceManifestKind::NamespaceManifest;
-    if probe.kind != expected_kind.as_str() {
-        return Err(NamespaceManifestCodecError::UnexpectedKind {
-            expected: expected_kind.as_str().to_owned(),
-            found: probe.kind,
-        });
-    }
-    if probe.format_version != NAMESPACE_MANIFEST_FORMAT_VERSION {
-        return Err(NamespaceManifestCodecError::UnsupportedFormatVersion {
-            found: probe.format_version,
-            supported: NAMESPACE_MANIFEST_FORMAT_VERSION,
-        });
-    }
-
-    let document: NamespaceManifestDocument = serde_json::from_slice(bytes)
-        .map_err(|err| NamespaceManifestCodecError::EnvelopeDecode(err.to_string()))?;
-    let actual = sha256_digest(document.payload.get().as_bytes());
-    if actual != document.payload_checksum {
-        return Err(NamespaceManifestCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
-            actual,
-        });
-    }
-    let payload: NamespaceManifestPayload = serde_json::from_str(document.payload.get())
-        .map_err(|err| NamespaceManifestCodecError::PayloadDecode(err.to_string()))?;
+    let decoded =
+        crate::envelope::decode_json_envelope(bytes, NAMESPACE_MANIFEST_FORMAT_VERSION, |found| {
+            crate::envelope::verify_kind(expected_kind.as_str(), found)
+        })?;
 
     Ok(NamespaceManifestEnvelope {
         kind: expected_kind,
-        format_version: document.format_version,
-        writer_version: document.writer_version,
-        payload_checksum: document.payload_checksum,
-        payload,
+        format_version: decoded.format_version,
+        writer_version: decoded.writer_version,
+        payload_checksum: decoded.payload_checksum,
+        payload: decoded.payload,
     })
 }
 

--- a/crates/loonfs-api/src/wal.rs
+++ b/crates/loonfs-api/src/wal.rs
@@ -3,14 +3,13 @@
 
 use crate::control::WalSegmentPointer;
 use crate::digest::sha256_digest;
-use crate::envelope::EnvelopeProbe;
+use crate::envelope::{self, EnvelopeCodecError, EnvelopeProbe};
 use crate::{
     ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo,
     WalSegmentId, WriterEpoch,
 };
 use ciborium::{de::from_reader, ser::into_writer};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 /// Version 1: a zstd-compressed CBOR envelope document carrying the payload
 /// as an opaque CBOR byte string. `payload_checksum` covers exactly those
@@ -132,7 +131,7 @@ impl WalSegmentEnvelope {
     pub fn from_payload(
         writer_version: impl Into<String>,
         payload: WalSegmentPayload,
-    ) -> Result<Self, WalCodecError> {
+    ) -> Result<Self, EnvelopeCodecError> {
         Ok(Self {
             kind: WalEnvelopeKind::NamespaceWalSegment,
             format_version: WAL_FORMAT_VERSION,
@@ -168,63 +167,31 @@ struct WalSegmentDocument {
     payload: Vec<u8>,
 }
 
-#[derive(Debug, Error)]
-pub enum WalCodecError {
-    #[error("failed to encode WAL payload to CBOR: {0}")]
-    PayloadEncode(String),
-    #[error("failed to encode WAL envelope to CBOR: {0}")]
-    EnvelopeEncode(String),
-    #[error("failed to decode WAL envelope from CBOR: {0}")]
-    EnvelopeDecode(String),
-    #[error("failed to decode WAL payload from CBOR: {0}")]
-    PayloadDecode(String),
-    #[error("failed to compress WAL envelope: {0}")]
-    Compress(String),
-    #[error("failed to decompress WAL envelope: {0}")]
-    Decompress(String),
-    #[error("unexpected WAL envelope kind `{found}`: expected `{expected}`")]
-    UnexpectedKind { expected: String, found: String },
-    #[error("unsupported WAL format version `{found}`: this build supports `{supported}`")]
-    UnsupportedFormatVersion { found: u32, supported: u32 },
-    #[error("WAL payload checksum mismatch: expected {expected}, actual {actual}")]
-    ChecksumMismatch { expected: String, actual: String },
-    #[error(
-        "WAL envelope checksum `{checksum}` does not match its payload `{actual}`: \
-         rebuild the envelope with `WalSegmentEnvelope::from_payload`"
-    )]
-    StalePayloadChecksum { checksum: String, actual: String },
-}
-
-pub(crate) fn wal_payload_checksum(payload: &WalSegmentPayload) -> Result<String, WalCodecError> {
+pub(crate) fn wal_payload_checksum(
+    payload: &WalSegmentPayload,
+) -> Result<String, EnvelopeCodecError> {
     Ok(sha256_digest(&encode_wal_payload_cbor(payload)?))
 }
 
 pub(crate) fn encode_wal_payload_cbor(
     payload: &WalSegmentPayload,
-) -> Result<Vec<u8>, WalCodecError> {
+) -> Result<Vec<u8>, EnvelopeCodecError> {
     let mut encoded = Vec::new();
     into_writer(payload, &mut encoded)
-        .map_err(|err| WalCodecError::PayloadEncode(err.to_string()))?;
+        .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
     Ok(encoded)
 }
 
 pub fn encode_wal_segment_envelope_zstd(
     envelope: &WalSegmentEnvelope,
-) -> Result<Vec<u8>, WalCodecError> {
-    if envelope.format_version != WAL_FORMAT_VERSION {
-        return Err(WalCodecError::UnsupportedFormatVersion {
-            found: envelope.format_version,
-            supported: WAL_FORMAT_VERSION,
-        });
-    }
+) -> Result<Vec<u8>, EnvelopeCodecError> {
+    envelope::verify_version(
+        envelope.kind.as_str(),
+        envelope.format_version,
+        WAL_FORMAT_VERSION,
+    )?;
     let payload_bytes = encode_wal_payload_cbor(&envelope.payload)?;
-    let actual = sha256_digest(&payload_bytes);
-    if actual != envelope.payload_checksum {
-        return Err(WalCodecError::StalePayloadChecksum {
-            checksum: envelope.payload_checksum.clone(),
-            actual,
-        });
-    }
+    envelope::verify_checksum_fresh(&envelope.payload_checksum, &payload_bytes)?;
 
     let document = WalSegmentDocument {
         kind: envelope.kind.as_str().to_owned(),
@@ -235,41 +202,27 @@ pub fn encode_wal_segment_envelope_zstd(
     };
     let mut encoded = Vec::new();
     into_writer(&document, &mut encoded)
-        .map_err(|err| WalCodecError::EnvelopeEncode(err.to_string()))?;
+        .map_err(|err| EnvelopeCodecError::EnvelopeEncode(err.to_string()))?;
     zstd::stream::encode_all(encoded.as_slice(), crate::sst_blocks::ZSTD_LEVEL)
-        .map_err(|err| WalCodecError::Compress(err.to_string()))
+        .map_err(|err| EnvelopeCodecError::Compress(err.to_string()))
 }
 
-pub fn decode_wal_segment_envelope_zstd(bytes: &[u8]) -> Result<WalSegmentEnvelope, WalCodecError> {
+pub fn decode_wal_segment_envelope_zstd(
+    bytes: &[u8],
+) -> Result<WalSegmentEnvelope, EnvelopeCodecError> {
     let decompressed = zstd::stream::decode_all(bytes)
-        .map_err(|err| WalCodecError::Decompress(err.to_string()))?;
+        .map_err(|err| EnvelopeCodecError::Decompress(err.to_string()))?;
     let probe: EnvelopeProbe = from_reader(decompressed.as_slice())
-        .map_err(|err| WalCodecError::EnvelopeDecode(err.to_string()))?;
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     let expected_kind = WalEnvelopeKind::NamespaceWalSegment;
-    if probe.kind != expected_kind.as_str() {
-        return Err(WalCodecError::UnexpectedKind {
-            expected: expected_kind.as_str().to_owned(),
-            found: probe.kind,
-        });
-    }
-    if probe.format_version != WAL_FORMAT_VERSION {
-        return Err(WalCodecError::UnsupportedFormatVersion {
-            found: probe.format_version,
-            supported: WAL_FORMAT_VERSION,
-        });
-    }
+    envelope::verify_kind(expected_kind.as_str(), &probe.kind)?;
+    envelope::verify_version(&probe.kind, probe.format_version, WAL_FORMAT_VERSION)?;
 
     let document: WalSegmentDocument = from_reader(decompressed.as_slice())
-        .map_err(|err| WalCodecError::EnvelopeDecode(err.to_string()))?;
-    let actual = sha256_digest(&document.payload);
-    if actual != document.payload_checksum {
-        return Err(WalCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
-            actual,
-        });
-    }
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    envelope::verify_payload_checksum(&document.payload_checksum, &document.payload)?;
     let payload: WalSegmentPayload = from_reader(document.payload.as_slice())
-        .map_err(|err| WalCodecError::PayloadDecode(err.to_string()))?;
+        .map_err(|err| EnvelopeCodecError::PayloadDecode(err.to_string()))?;
 
     Ok(WalSegmentEnvelope {
         kind: expected_kind,

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -20,22 +20,23 @@
 
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordLifecycle,
-    CheckpointRecordState, CompletedUpload, ContentStoreDescriptorState, ControlCodecError,
-    ControlObjectEnvelope, ControlObjectKind, HeadState, MetadataRootState, NamespaceConfigState,
-    NamespaceState, UploadSessionState, WalFloorState, WalSegmentPointer, WriterBlock,
+    CheckpointRecordState, CompletedUpload, ContentStoreDescriptorState, ControlObjectEnvelope,
+    ControlObjectKind, HeadState, MetadataRootState, NamespaceConfigState, NamespaceState,
+    UploadSessionState, WalFloorState, WalSegmentPointer, WriterBlock,
 };
+use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::index_grams::{
     decode_gram_postings, encode_gram_postings, Gram, GramIndexFoldState, GramPosting,
     IndexGramsFeature, IndexRow, INDEX_FAMILY_GRAMS, INDEX_GRAMS_FEATURE_KEY,
 };
 use loonfs_api::wire::manifest::{
     decode_namespace_manifest_json, encode_namespace_manifest_json, IndexFileRef, MetadataFileRef,
-    MetadataRow, MetadataTableFamily, NamespaceManifestCodecError, NamespaceManifestEnvelope,
-    NamespaceManifestFork, NamespaceManifestPayload, TombstoneRowAction,
+    MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope, NamespaceManifestFork,
+    NamespaceManifestPayload, TombstoneRowAction,
 };
 use loonfs_api::wire::wal::{
-    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, WalCodecError,
-    WalCommitDelta, WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
+    decode_wal_segment_envelope_zstd, encode_wal_segment_envelope_zstd, WalCommitDelta,
+    WalCommitPayload, WalDelta, WalSegmentEnvelope, WalSegmentPayload,
 };
 use loonfs_api::{
     sha256_digest, v0::UploadMode, ChangeSeq, CheckpointId, CommitId, ContentRef, ContentStoreId,
@@ -619,9 +620,10 @@ fn wal_decode_rejects_future_format_version_cleanly() {
     assert!(
         matches!(
             err,
-            WalCodecError::UnsupportedFormatVersion {
+            EnvelopeCodecError::UnsupportedFormatVersion {
                 found: 2,
                 supported: 1,
+                ..
             }
         ),
         "unexpected error: {err}"
@@ -638,7 +640,7 @@ fn wal_decode_rejects_unknown_kind_cleanly() {
     let err = decode_wal_segment_envelope_zstd(&rezstd(&rekinded))
         .expect_err("unknown kind must be rejected");
     assert!(
-        matches!(err, WalCodecError::UnexpectedKind { .. }),
+        matches!(err, EnvelopeCodecError::KindMismatch { .. }),
         "unexpected error: {err}"
     );
 }
@@ -658,7 +660,7 @@ fn wal_decode_rejects_tampered_payload_bytes_as_checksum_mismatch() {
     let err = decode_wal_segment_envelope_zstd(&rezstd(&tampered))
         .expect_err("tampered payload must be rejected");
     assert!(
-        matches!(err, WalCodecError::ChecksumMismatch { .. }),
+        matches!(err, EnvelopeCodecError::ChecksumMismatch { .. }),
         "unexpected error: {err}"
     );
 }
@@ -719,7 +721,7 @@ fn control_object_decode_rejects_tampered_payload_as_checksum_mismatch() {
     let err = decode_control_object::<HeadState>(&tampered, ControlObjectKind::WalHead)
         .expect_err("tampered payload must be rejected");
     assert!(
-        matches!(err, ControlCodecError::ChecksumMismatch { .. }),
+        matches!(err, EnvelopeCodecError::ChecksumMismatch { .. }),
         "unexpected error: {err}"
     );
 }
@@ -736,9 +738,10 @@ fn namespace_manifest_decode_rejects_future_format_version_cleanly() {
     assert!(
         matches!(
             err,
-            NamespaceManifestCodecError::UnsupportedFormatVersion {
+            EnvelopeCodecError::UnsupportedFormatVersion {
                 found: 2,
                 supported: 1,
+                ..
             }
         ),
         "unexpected error: {err}"
@@ -756,7 +759,7 @@ fn namespace_manifest_decode_rejects_tampered_payload_as_checksum_mismatch() {
     let err =
         decode_namespace_manifest_json(&tampered).expect_err("tampered payload must be rejected");
     assert!(
-        matches!(err, NamespaceManifestCodecError::ChecksumMismatch { .. }),
+        matches!(err, EnvelopeCodecError::ChecksumMismatch { .. }),
         "unexpected error: {err}"
     );
 }

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -4,9 +4,10 @@
 use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{
     decode_control_object, ContentStoreDescriptorEnvelope, ContentStoreDescriptorState,
-    ControlCodecError, ControlObjectKind, HeadState, HeadStateEnvelope, MetadataRootEnvelope,
-    MetadataRootState, NamespaceConfigEnvelope, NamespaceConfigState, WalFloorEnvelope,
+    ControlObjectKind, HeadState, HeadStateEnvelope, MetadataRootEnvelope, MetadataRootState,
+    NamespaceConfigEnvelope, NamespaceConfigState, WalFloorEnvelope,
 };
+use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::{ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::{
     content_store_descriptor, metadata_root, namespace_config, wal_floor, wal_head,
@@ -459,10 +460,10 @@ fn validate_expected_namespace(
 
 pub(crate) fn map_control_codec_error(
     object_key: &str,
-    err: ControlCodecError,
+    err: EnvelopeCodecError,
 ) -> ControlObjectLoadError {
     match err {
-        ControlCodecError::ChecksumMismatch { expected, actual } => {
+        EnvelopeCodecError::ChecksumMismatch { expected, actual } => {
             ControlObjectLoadError::ChecksumMismatch {
                 object_key: object_key.to_owned(),
                 expected,


### PR DESCRIPTION
Three envelope codecs each carried their own copy of the probe → kind → version → checksum → decode sequence with three parallel ~5-variant error enums — the triplication that let the P0 namespace_manifest kind-string drift ride in undetected. envelope.rs (previously 22 lines holding just the probe) is now the single authority:

- One error vocabulary: EnvelopeCodecError replaces ControlCodecError, NamespaceManifestCodecError, and WalCodecError, exported once from wire::envelope. Messages are envelope-generic; the wrapping errors keep naming the object and its key. The version variant now always carries the kind (the control enum had it; manifest and WAL gain the precision).
- One set of validation rules: verify_kind, verify_version, verify_payload_checksum, and verify_checksum_fresh are the only implementations of the four checks, used by all three codecs.
- One JSON codec: encode_json_envelope / decode_json_envelope own the raw-fragment document layout; the control and manifest codecs are now thin parameterizations (control keeps its unknown-kind-versus-mismatch distinction through the kind-classifier hook, exactly as before). Their private document structs are deleted.
- The WAL codec keeps its transport (CBOR document, zstd stream, byte-string payload) but every validation decision routes through the shared rules, and its UnexpectedKind naming folds into the shared KindMismatch.