### PR TITLE
perf(core): direct_put completion proves uploads by metadata, not a re-download

### DIFF
--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -14,7 +14,7 @@ use crate::namespace::control::{
     load_content_store_descriptor_control, load_namespace_descriptor_control,
     load_namespace_head_control,
 };
-use crate::storage::content::{validate_durable_content_reference, write_immutable_object};
+use crate::storage::content::{probe_durable_content_reference, write_immutable_object};
 use bytes::Bytes;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
@@ -362,10 +362,15 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
         ));
     }
 
-    // Bytes bypassed the LoonFS server; completion is the authority point where
-    // the server proves the object is durable and matches the signed content ref.
+    // Bytes bypassed the LoonFS server; completion is the authority point
+    // where the server proves the upload actually happened. Digest
+    // integrity needs no re-proof: the transfer capability signed the
+    // digest into the provider write and the key derives from it, so no
+    // object can exist at this key with bytes that do not hash to the
+    // content ref. One HEAD proves existence and the declared size without
+    // pulling the payload back through the server.
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
-    validate_durable_content_reference(store, &content_store_id, &request.content_ref)
+    probe_durable_content_reference(store, &content_store_id, &request.content_ref)
         .await
         .map_err(|err| CoreError::InvalidUploadContent(err.to_string()))?;
     Ok(request.content_ref.clone())

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -106,6 +106,29 @@ pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     validate_loaded_content_bytes(object_key, content_ref, &bytes)
 }
 
+/// Proves a content reference is durable — the object exists and carries the
+/// declared size — from one HEAD, without reading the content.
+///
+/// This is the completion check for writes whose digest integrity the
+/// provider already enforced at upload time (a `direct_put` transfer
+/// capability signs the digest into the write, and the provider refuses a
+/// body that does not hash to it — see
+/// [`ObjectTransferIssuer`](loonfs_objectstore::presign::ObjectTransferIssuer)).
+/// Re-hashing here would re-download the payload through the server and
+/// prove nothing the write path has not already proven; the size check
+/// stays because the declared `size_bytes` rides the reference, not the
+/// digest, so a mis-declared size must fail completion. Callers without a
+/// write-time digest guarantee use [`validate_durable_content_reference`],
+/// which reads and hashes.
+pub(crate) async fn probe_durable_content_reference<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    content_ref: &ContentRef,
+) -> Result<(), DurableContentValidationError> {
+    let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
+    validate_content_size(store, &object_key, content_ref).await
+}
+
 pub async fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
@@ -173,10 +196,13 @@ fn validate_loaded_content_bytes(
     })
 }
 
-/// Cheap prevalidation before the authoritative read-and-hash: existence
-/// and size come from one HEAD, so a wrong-sized object fails fast without
-/// downloading it. Digest verification always reads the bytes — provider
-/// checksums are not part of the read contract anywhere in the fleet.
+/// Existence and size from one HEAD, serving two roles: the authoritative
+/// read-and-hash uses it as cheap prevalidation, so a wrong-sized object
+/// fails fast without downloading it, and the durability probe uses it as
+/// the whole check, because the probe's callers hold a write-time digest
+/// guarantee. When this crate itself verifies a digest it always reads the
+/// bytes — provider checksums are not part of the read contract anywhere
+/// in the fleet.
 async fn validate_content_size<S: ObjectStore + ?Sized>(
     store: &S,
     object_key: &str,
@@ -363,8 +389,9 @@ async fn load_required_object<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::{
-        read_durable_content_bytes, validate_durable_content_reference, write_immutable_object,
-        DurableContentValidationError, ImmutableObjectWriteError,
+        probe_durable_content_reference, read_durable_content_bytes,
+        validate_durable_content_reference, write_immutable_object, DurableContentValidationError,
+        ImmutableObjectWriteError,
     };
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -465,6 +492,55 @@ mod tests {
         assert!(matches!(
             err,
             DurableContentValidationError::ContentDigestMismatch { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn probe_whole_file_content_ref_proves_durability_without_reading() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = GetCountingStore::new(inner);
+        let bytes = b"provider-verified bytes";
+        let content_ref = ContentRef::whole_file_v0(bytes);
+        put_content_object(&store, &content_store_id, &content_ref, bytes).await;
+
+        store.reset_content_blob_get_count();
+        probe_durable_content_reference(&store, &content_store_id, &content_ref)
+            .await
+            .expect("probe content ref");
+        assert_eq!(
+            store.content_blob_get_count(),
+            0,
+            "the probe proves durability from metadata alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_whole_file_content_ref_rejects_missing_object() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let content_ref = ContentRef::whole_file_v0(b"missing");
+
+        let err = probe_durable_content_reference(&store, &content_store_id, &content_ref)
+            .await
+            .expect_err("missing object");
+        assert!(matches!(
+            err,
+            DurableContentValidationError::MissingContentObject { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn probe_whole_file_content_ref_rejects_size_mismatch() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let mut content_ref = ContentRef::whole_file_v0(b"abc");
+        put_content_object(&store, &content_store_id, &content_ref, b"abc").await;
+        content_ref.size_bytes += 1;
+
+        let err = probe_durable_content_reference(&store, &content_store_id, &content_ref)
+            .await
+            .expect_err("size mismatch");
+        assert!(matches!(
+            err,
+            DurableContentValidationError::ContentLengthMismatch { .. }
         ));
     }
 

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -25,6 +25,25 @@ pub struct PresignedUrl {
     pub expires_at_ms: u64,
 }
 
+/// Issues short-lived transfer capabilities for `direct_put` uploads, and in
+/// doing so carries the write-time enforcement contract the rest of the
+/// system leans on:
+///
+/// - The signed request must make the provider verify that the uploaded
+///   body hashes to the content ref's digest and reject anything else
+///   (S3-family: a signed `x-amz-checksum-sha256` header).
+/// - The signed request must be create-only, so an existing object is never
+///   replaced through a transfer capability (S3-family: a signed
+///   `if-none-match: *` header).
+/// - Both requirements ride the signature: a client cannot drop or alter
+///   them without invalidating the capability.
+///
+/// Because every issuer guarantees this, `direct_put` completion proves an
+/// upload by existence and size alone — it never reads content back. A
+/// provider that cannot enforce digest verification and create-only
+/// preconditions in a presigned request must not implement this trait; the
+/// deployment then reports `direct_put` as unsupported instead of falling
+/// back to weaker verification.
 pub trait ObjectTransferIssuer: Send + Sync + std::fmt::Debug {
     fn presign_put(
         &self,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -337,7 +337,10 @@ impl ProviderObjectStore {
     /// upload: fixed-size parts uploaded through a bounded window, each part
     /// retried in place on transient failures (part indices are stable, so a
     /// retry re-sends the same part), and a best-effort abort so a failed
-    /// upload does not strand parts.
+    /// upload does not strand parts. An ambiguous completion — a transport
+    /// failure whose attempt may have landed — is resolved by reading the
+    /// object back and comparing bytes
+    /// ([`MultipartWrite::resolve_ambiguous_completion`]).
     ///
     /// There is deliberately no whole-operation clock: every part attempt is
     /// individually bounded and every retry loop is count-bounded, so a
@@ -503,7 +506,7 @@ impl MultipartWrite<'_> {
             .into_iter()
             .map(|part_id| part_id.expect("every part completed before the window drained"))
             .collect();
-        self.complete(upload_id, parts, bytes.len() as u64).await
+        self.complete(upload_id, parts, bytes).await
     }
 
     async fn upload_part(
@@ -549,9 +552,13 @@ impl MultipartWrite<'_> {
         &self,
         upload_id: &provider_store::MultipartId,
         parts: Vec<PartId>,
-        size_bytes: u64,
+        bytes: &Bytes,
     ) -> Result<ObjectMetadata> {
+        let size_bytes = bytes.len() as u64;
         let mut retries: u32 = 0;
+        // True once an attempt failed after possibly reaching the store, so
+        // no later failure can rule out that this completion landed.
+        let mut ambiguous_outcome = false;
         loop {
             let err = match self
                 .multipart
@@ -562,17 +569,19 @@ impl MultipartWrite<'_> {
                 Err(err) => err,
             };
             if !provider_transport_retryable(&err) {
-                return Err(map_provider_error(self.key, err));
-            }
-            // Ambiguous outcome: the completion may have landed before the
-            // transport failure. The payload is too large to read back, so
-            // landed-write detection is by size identity, which the caller's
-            // content addressing makes sufficient.
-            if let Ok(Some(metadata)) = self.store.head(self.key).await {
-                if metadata.size_bytes == size_bytes {
-                    return Ok(metadata);
+                if !ambiguous_outcome {
+                    return Err(map_provider_error(self.key, err));
                 }
+                // A definite refusal after an ambiguous attempt is not a
+                // definite failure: the ambiguous attempt may have landed
+                // and taken the upload id with it, in which case the
+                // provider reports the completed upload as gone. Only the
+                // object can say which happened.
+                return self
+                    .resolve_ambiguous_completion(upload_id, bytes, err)
+                    .await;
             }
+            ambiguous_outcome = true;
             let Some(backoff) = self.store.next_write_backoff(
                 self.key,
                 "complete_multipart",
@@ -581,23 +590,92 @@ impl MultipartWrite<'_> {
                 None,
                 &err,
             ) else {
-                return Err(map_provider_error(self.key, err));
+                return self
+                    .resolve_ambiguous_completion(upload_id, bytes, err)
+                    .await;
             };
             transport_retry_pause(backoff).await;
+        }
+    }
+
+    /// Decides an ambiguous completion by reading the object back: byte
+    /// equality with the payload is the only accepted proof that the write
+    /// landed. Size or etag agreement is never identity — this store serves
+    /// generic overwrite keys, so a stale object of the same length must
+    /// not pass as the new write. The payload is still in memory, so the
+    /// read-back costs one GET on this failure path and proves the put's
+    /// postcondition itself.
+    ///
+    /// A proven completion still aborts the upload id: when this upload's
+    /// completion landed the id is already gone and the abort is a no-op,
+    /// and when the proof came from an identical object some earlier writer
+    /// committed, the abort reclaims this upload's stranded parts.
+    async fn resolve_ambiguous_completion(
+        &self,
+        upload_id: &provider_store::MultipartId,
+        bytes: &Bytes,
+        final_err: provider_store::Error,
+    ) -> Result<ObjectMetadata> {
+        match self.store.get_with_metadata(self.key).await {
+            Ok(Some(body)) if body.bytes.as_slice() == bytes.as_ref() => {
+                self.abort(upload_id).await;
+                Ok(body.metadata)
+            }
+            Ok(readback) => {
+                let outcome = match readback {
+                    Some(_) => "the object at the key does not hold the payload bytes",
+                    None => "no object exists at the key",
+                };
+                tracing::warn!(
+                    object_key = self.key,
+                    operation = "complete_multipart",
+                    outcome,
+                    "ambiguous multipart completion did not land",
+                );
+                // An upload-gone rejection maps to `NotFound`, which would
+                // misreport this write failure as a missing object; it
+                // surfaces as transport instead, so callers classify the
+                // unproven outcome as safe to retry. Every other final
+                // error keeps its own classification.
+                Err(match map_provider_error(self.key, final_err) {
+                    ObjectStoreError::NotFound { .. } => ObjectStoreError::transport(
+                        self.key,
+                        format!(
+                            "multipart upload is gone without a provable completion: {outcome}"
+                        ),
+                    ),
+                    other => other,
+                })
+            }
+            Err(verify_err) => {
+                let original = map_provider_error(self.key, final_err).message();
+                Err(ObjectStoreError::transport(
+                    self.key,
+                    format!(
+                        "{original}; failed to verify multipart completion outcome: {verify_err}"
+                    ),
+                ))
+            }
         }
     }
 
     async fn abort(&self, upload_id: &provider_store::MultipartId) {
         // Best effort: an unaborted upload only strands parts until the
         // bucket's lifecycle rule for incomplete multipart uploads collects
-        // them, so an abort failure is logged rather than surfaced.
-        if let Err(err) = self.multipart.abort_multipart(self.path, upload_id).await {
-            tracing::warn!(
-                object_key = self.key,
-                operation = "abort_multipart",
-                error = %err,
-                "failed to abort multipart upload after a write failure",
-            );
+        // them, so an abort failure is logged rather than surfaced. An
+        // already-gone upload is the no-op success it reads as — typically
+        // its completion landed.
+        match self.multipart.abort_multipart(self.path, upload_id).await {
+            Ok(()) => {}
+            Err(err) if provider_not_found(&err) => {}
+            Err(err) => {
+                tracing::warn!(
+                    object_key = self.key,
+                    operation = "abort_multipart",
+                    error = %err,
+                    "failed to abort multipart upload; parts remain until the bucket lifecycle rule collects them",
+                );
+            }
         }
     }
 }
@@ -1154,11 +1232,16 @@ mod tests {
         FailWithoutLanding,
         LandThenFail,
         FailAuth,
+        /// The upload vanishes (as a lifecycle rule reaping it would make
+        /// it) and the attempt reports a transport failure. Only meaningful
+        /// as a completion script.
+        VanishThenFail,
     }
 
     #[derive(Debug)]
     enum ReadScript {
         NotFound,
+        Transport,
     }
 
     /// Provider double that fails scripted attempts before delegating to an
@@ -1230,6 +1313,9 @@ mod tests {
                     Err(transport_glitch())
                 }
                 Some(WriteScript::FailAuth) => Err(auth_rejection(location)),
+                Some(WriteScript::VanishThenFail) => {
+                    unreachable!("VanishThenFail is a completion script")
+                }
                 None => self.inner.put_opts(location, payload, opts).await,
             }
         }
@@ -1254,6 +1340,7 @@ mod tests {
                     path: location.to_string(),
                     source: "scripted not found".into(),
                 }),
+                Some(ReadScript::Transport) => Err(transport_glitch()),
                 None => self.inner.get_opts(location, options).await,
             }
         }
@@ -1272,6 +1359,9 @@ mod tests {
                     Err(transport_glitch())
                 }
                 Some(WriteScript::FailAuth) => Err(auth_rejection(location)),
+                Some(WriteScript::VanishThenFail) => {
+                    unreachable!("VanishThenFail is a completion script")
+                }
                 None => self.inner.delete(location).await,
             }
         }
@@ -1396,6 +1486,9 @@ mod tests {
                     Err(transport_glitch())
                 }
                 Some(WriteScript::FailAuth) => Err(auth_rejection(path)),
+                Some(WriteScript::VanishThenFail) => {
+                    unreachable!("VanishThenFail is a completion script")
+                }
                 None => {
                     self.store_part(id, part_idx, data)?;
                     Ok(PartId {
@@ -1424,6 +1517,13 @@ mod tests {
                     Err(transport_glitch())
                 }
                 Some(WriteScript::FailAuth) => Err(auth_rejection(path)),
+                Some(WriteScript::VanishThenFail) => {
+                    self.multipart_uploads
+                        .lock()
+                        .expect("uploads")
+                        .remove(id.as_str());
+                    Err(transport_glitch())
+                }
                 None => self.land_completion(path, id, &parts).await,
             }
         }
@@ -1842,6 +1942,27 @@ mod tests {
             .unwrap_or(0)
     }
 
+    fn script_complete(flaky: &FlakyStore, script: impl IntoIterator<Item = WriteScript>) {
+        flaky
+            .complete_script
+            .lock()
+            .expect("complete script")
+            .extend(script);
+    }
+
+    /// Places an object at `key` directly on the inner store, bypassing the
+    /// scripted transport and its counters.
+    async fn seed_scoped_object(flaky: &FlakyStore, key: &str, bytes: Bytes) {
+        provider_store::ObjectStore::put_opts(
+            &flaky.inner,
+            &Path::from(format!("tenant-a/{key}")),
+            bytes.into(),
+            PutOptions::default(),
+        )
+        .await
+        .expect("seed object");
+    }
+
     #[tokio::test]
     async fn large_put_routes_through_multipart_and_preserves_bytes() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2003,11 +2124,7 @@ mod tests {
     async fn multipart_complete_transport_failure_resolves_landed_completion() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
-        flaky
-            .complete_script
-            .lock()
-            .expect("complete script")
-            .push_back(WriteScript::LandThenFail);
+        script_complete(&flaky, [WriteScript::LandThenFail]);
         let payload = multipart_payload(1300);
 
         let metadata = store
@@ -2015,9 +2132,31 @@ mod tests {
             .await
             .expect("landed completion reported as the success it was");
 
-        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
-        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            flaky.multipart_completes.load(Ordering::SeqCst),
+            2,
+            "the retry finds the landed completion's upload gone"
+        );
+        assert_eq!(
+            flaky.gets.load(Ordering::SeqCst),
+            1,
+            "one read-back proves the landed write by byte identity"
+        );
+        assert_eq!(
+            flaky.multipart_aborts.load(Ordering::SeqCst),
+            1,
+            "the proven completion still aborts the gone upload id best-effort"
+        );
         assert_eq!(metadata.size_bytes, 1300);
+        let head = store
+            .head(MULTIPART_KEY)
+            .await
+            .expect("head")
+            .expect("object exists");
+        assert_eq!(
+            metadata.etag, head.etag,
+            "resolution reports the landed object's own metadata"
+        );
         assert_eq!(
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))
@@ -2028,11 +2167,7 @@ mod tests {
     async fn multipart_complete_failure_without_landing_retries_the_completion() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
-        flaky
-            .complete_script
-            .lock()
-            .expect("complete script")
-            .push_back(WriteScript::FailWithoutLanding);
+        script_complete(&flaky, [WriteScript::FailWithoutLanding]);
         let payload = multipart_payload(1300);
 
         store
@@ -2043,9 +2178,194 @@ mod tests {
         assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 0);
         assert_eq!(
+            flaky.gets.load(Ordering::SeqCst),
+            0,
+            "a completion that succeeds on retry needs no read-back"
+        );
+        assert_eq!(
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))
         );
+    }
+
+    /// The regression this fix exists for: an unproven completion must
+    /// never adopt a pre-existing object of the same size. The pre-fix code
+    /// reconciled by size identity and reported success for bytes that were
+    /// never written.
+    #[tokio::test]
+    async fn multipart_complete_exhaustion_rejects_stale_same_size_object() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let stale = Bytes::from(vec![0xAA_u8; 1300]);
+        seed_scoped_object(&flaky, MULTIPART_KEY, stale.clone()).await;
+        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+
+        let error = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
+            .await
+            .expect_err("an unproven completion fails instead of adopting the stale object");
+
+        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        assert_eq!(
+            flaky.multipart_completes.load(Ordering::SeqCst),
+            5,
+            "1 attempt + max_retries"
+        );
+        assert_eq!(
+            flaky.gets.load(Ordering::SeqCst),
+            1,
+            "one read-back tested the outcome"
+        );
+        assert_eq!(
+            flaky.multipart_aborts.load(Ordering::SeqCst),
+            1,
+            "the failed upload is aborted so no parts are stranded"
+        );
+        assert_eq!(
+            store.get(MULTIPART_KEY, None).await.expect("get"),
+            Some(stale),
+            "the stale object is untouched"
+        );
+    }
+
+    /// The content-addressed re-put shape: when the object already holds
+    /// exactly the payload bytes, byte identity proves the put's
+    /// postcondition even though this upload's completion never landed —
+    /// and the dangling upload is reclaimed rather than stranded.
+    #[tokio::test]
+    async fn multipart_complete_exhaustion_accepts_identical_object_and_aborts() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let payload = multipart_payload(1300);
+        seed_scoped_object(&flaky, MULTIPART_KEY, Bytes::from(payload.clone())).await;
+        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+
+        let metadata = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(payload))
+            .await
+            .expect("byte-identical object proves the outcome");
+
+        assert_eq!(metadata.size_bytes, 1300);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            flaky.multipart_aborts.load(Ordering::SeqCst),
+            1,
+            "the dangling upload is aborted on proven success"
+        );
+        assert!(
+            flaky.multipart_uploads.lock().expect("uploads").is_empty(),
+            "no parts remain stranded"
+        );
+    }
+
+    /// The lifecycle-abort race: the upload vanishes while the completion's
+    /// outcome is ambiguous and a stale object sits at the key. The gone
+    /// upload maps to not-found, which must surface as a retry-safe
+    /// transport failure about this write — not as a missing object, and
+    /// never as success.
+    #[tokio::test]
+    async fn multipart_complete_gone_upload_with_stale_object_fails_as_transport() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let stale = Bytes::from(vec![0xAA_u8; 1300]);
+        seed_scoped_object(&flaky, MULTIPART_KEY, stale.clone()).await;
+        script_complete(&flaky, [WriteScript::VanishThenFail]);
+
+        let error = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
+            .await
+            .expect_err("a vanished upload with a stale object is a failed write");
+
+        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        let message = error.message();
+        assert!(
+            message.contains("without a provable completion"),
+            "message names the unproven outcome: {message}"
+        );
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store.get(MULTIPART_KEY, None).await.expect("get"),
+            Some(stale),
+            "the stale object is untouched"
+        );
+    }
+
+    /// A definite refusal that follows an ambiguous attempt verifies before
+    /// failing, and a disproven completion surfaces the refusal under its
+    /// own classification instead of as network weather.
+    #[tokio::test]
+    async fn multipart_complete_definite_rejection_after_ambiguity_keeps_its_class() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        seed_scoped_object(&flaky, MULTIPART_KEY, Bytes::from(vec![0xAA_u8; 1300])).await;
+        script_complete(
+            &flaky,
+            [WriteScript::FailWithoutLanding, WriteScript::FailAuth],
+        );
+
+        let error = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
+            .await
+            .expect_err("auth rejection surfaces after the outcome is disproven");
+
+        assert!(matches!(error, ObjectStoreError::PermissionDenied { .. }));
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            flaky.gets.load(Ordering::SeqCst),
+            1,
+            "the ambiguous prior attempt forces a read-back first"
+        );
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+    }
+
+    /// A first-attempt refusal is definite: nothing can have landed, so no
+    /// read-back runs and the refusal surfaces directly.
+    #[tokio::test]
+    async fn multipart_complete_first_attempt_rejection_skips_verification() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        script_complete(&flaky, [WriteScript::FailAuth]);
+
+        let error = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
+            .await
+            .expect_err("auth rejection surfaces immediately");
+
+        assert!(matches!(error, ObjectStoreError::PermissionDenied { .. }));
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 0);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+    }
+
+    /// When the read-back itself fails, the outcome stays unknown and
+    /// surfaces as a transport error carrying both failures — never as a
+    /// success the store cannot prove.
+    #[tokio::test]
+    async fn multipart_complete_unverifiable_outcome_surfaces_both_failures() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+        flaky
+            .get_script
+            .lock()
+            .expect("get script")
+            .push_back(ReadScript::Transport);
+
+        let error = store
+            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
+            .await
+            .expect_err("an unverifiable outcome is an error, not a success");
+
+        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        let message = error.message();
+        assert!(
+            message.contains("failed to verify multipart completion outcome"),
+            "message names the verification failure: {message}"
+        );
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }
 
     /// Multipart transfers carry no whole-operation clock: with a stepping

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -48,6 +48,10 @@ pub(super) async fn config(
 ) -> Result<Json<loonfs_api::CapabilityDocument>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let mut capabilities = state.reader.capabilities();
+    // An issuer's existence is the capability: `ObjectTransferIssuer` is
+    // only implemented where the provider enforces the digest and
+    // create-only preconditions inside the signed request, which is what
+    // lets completion verify a direct_put without reading content back.
     capabilities.features.insert(
         FEATURE_UPLOADS_DIRECT_PUT.to_owned(),
         state.transfer_issuer.is_some(),

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2111,6 +2111,77 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
 }
 
 #[test]
+fn direct_put_completion_proves_upload_without_reading_content() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = open_runtime(object_store, "direct-put-probe-test");
+    let bytes = b"direct uploaded, provider verified";
+    let content_ref = ContentRef::whole_file_v0(bytes);
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let begin = block_on(fs.begin_direct_put_upload_target(&namespace_id, content_ref.clone()))
+        .expect("begin direct put");
+
+    // Stands in for the provider-verified presigned upload.
+    let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
+    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+        .expect("write direct object");
+
+    raw_store.reset_content_blob_counters();
+    let completed = fs
+        .complete_upload_blocking(
+            &namespace_id,
+            &begin.upload_id,
+            &CompleteUploadRequest {
+                content_ref: content_ref.clone(),
+            },
+        )
+        .expect("complete direct put");
+    assert_eq!(completed.content_ref, content_ref);
+    assert_eq!(
+        raw_store.content_blob_get_count(),
+        0,
+        "completion proves the upload from object metadata alone"
+    );
+}
+
+#[test]
+fn direct_put_completion_rejects_a_mis_declared_size() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "direct-put-size-test");
+    let namespace_id = namespace_id();
+    let bytes = b"direct put bytes with a lying size";
+    // The digest names the object; the declared size rides the reference
+    // unchecked by the provider, so completion's size check must catch it.
+    let mut content_ref = ContentRef::whole_file_v0(bytes);
+    content_ref.size_bytes += 1;
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let begin = block_on(fs.begin_direct_put_upload_target(&namespace_id, content_ref.clone()))
+        .expect("begin direct put");
+
+    let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
+    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+        .expect("write direct object");
+
+    let error = fs
+        .complete_upload_blocking(
+            &namespace_id,
+            &begin.upload_id,
+            &CompleteUploadRequest { content_ref },
+        )
+        .expect_err("mis-declared size must fail completion");
+    assert!(
+        error.to_string().contains("content length mismatch"),
+        "completion names the size mismatch: {error}"
+    );
+}
+
+#[test]
 fn stat_and_list_use_initial_manifest_without_checkpoint() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -456,13 +456,19 @@ The response includes only a short-lived transfer capability, never raw object-s
 The signed headers are part of the transfer capability. In the S3-compatible
 example, `if-none-match: *` keeps the immutable object create-only, and
 `x-amz-checksum-sha256` binds the object-store write to the SHA-256 digest in
-`content_ref`. Other providers may use different headers or decline
-`direct_put` support.
+`content_ref`. Because both requirements ride the signature, the provider —
+not the server — proves digest integrity at write time; a deployment only
+advertises `core.uploads.direct_put` when its provider can enforce this, and
+otherwise reports the mode as unsupported. Other providers may use different
+headers or decline `direct_put` support.
 
 After the client uploads bytes to the presigned URL, it calls complete with the
-same `content_ref`. Completion validates that the durable object exists and
-matches. A server may return a short-lived `validated_content_token` for the
-completed content ref; the token is opaque to clients.
+same `content_ref`. Completion proves the durable object exists and carries the
+declared size from object metadata alone; the digest needs no re-proof because
+the provider enforced it during the upload, so completion never reads the
+content back through the server. A server may return a short-lived
+`validated_content_token` for the completed content ref; the token is opaque to
+clients.
 
 ```json
 {


### PR DESCRIPTION
Completing a `direct_put` upload called `validate_durable_content_reference`, which downloads the entire object through the server and re-hashes it — unbounded (the declared size is not capped at begin, and a single presigned PUT can carry 5 GiB), inside the session-update closure, so a CAS conflict repeated the download. The feature that exists to keep large payloads off the server ended every upload by pulling the payload back through the server.

The digest was already proven before completion ran: the transfer capability signs `x-amz-checksum-sha256` (the provider rejects a body that does not hash to it) and `if-none-match: *` (create-only) into the presigned request, a client cannot drop either without invalidating the signature, and the object key itself derives from the digest. Re-hashing at completion proved nothing the write path had not already proven — and ranged reads already serve bytes without re-hashing, so write-time enforcement was already the integrity authority.

- Completion now uses `probe_durable_content_reference`: one HEAD proving existence and the declared size. The size check stays because `size_bytes` rides the reference, not the digest, so a mis-declared size must still fail completion. The full read-and-hash `validate_durable_content_reference` remains for callers without a write-time guarantee — bare content refs in commits that miss the admission tokens.
- The enforcement contract now lives where it belongs: `ObjectTransferIssuer`'s docs state that implementing the trait asserts provider-enforced digest verification and create-only preconditions in the signed request, and that a provider which cannot enforce both must not implement it — the deployment then reports `direct_put` unsupported instead of degrading to weaker verification. The capability advertisement (`transfer_issuer.is_some()`) cites this, and api.md states the mechanism.