### PR TITLE
chore(loonfs): the root exports product vocabulary, not integration internals

### DIFF
--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -52,10 +52,11 @@ use axum::middleware::{self, Next};
 use axum::response::Response;
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
+use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::publisher::PublisherRegistry;
 use loonfs::{
-    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, JsonlObjectStoreMetricsRecorder,
-    ObjectStoreMetricsRecorder, SharedObjectStore, TraceMode, TraceStoreKind,
+    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, SharedObjectStore, TraceMode,
+    TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::presign::ObjectTransferIssuer;

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -6,21 +6,21 @@ use crate::{GramIndexBuildPolicy, MetadataTableCacheConfig, Result, RuntimeError
 
 /// Default visible WAL-tail length, in segments, at which a maintenance tick
 /// publishes a checkpoint.
-pub const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
+pub(crate) const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
 /// Default maximum namespaces retained in runtime caches.
-pub const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
+pub(crate) const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
 /// Default maximum metadata rows retained across cached WAL-tail projections.
-pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize =
+pub(crate) const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS: usize =
     loonfs_core::cache::DEFAULT_WAL_TAIL_PROJECTION_ROWS;
 /// Default decoded-byte budget for cached WAL-tail projections.
-pub const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize =
+pub(crate) const DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES: usize =
     loonfs_core::cache::DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES;
 /// Default minimum interval, in milliseconds, between publication starts
 /// for one namespace (see [`crate::publisher`]). A cold namespace
 /// publishes immediately; the interval only paces follow-up batches, so
 /// concurrent submissions amortize into fewer, larger WAL segments. Zero
 /// keeps only the batching that in-flight publications force.
-pub const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
+pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
 /// Default cap on concurrently running writer-scheduled maintenance ticks,
 /// across all namespaces of one handle. Each namespace already runs at most
 /// one tick at a time; this bounds how many namespaces may tick at once, so

--- a/crates/loonfs/src/fs/tests.rs
+++ b/crates/loonfs/src/fs/tests.rs
@@ -1,9 +1,9 @@
 //! Behavior tests for the runtime core.
 
 use crate::{
-    ChangeSeq, CommitId, CommitOp, CommitPrecondition, CommitRequest, DisplayName, InodeId,
-    NameKey, NamePolicy, RevisionNo,
+    ChangeSeq, CommitId, CommitOp, CommitPrecondition, CommitRequest, InodeId, NameKey, RevisionNo,
 };
+use loonfs_api::{DisplayName, NamePolicy};
 
 /// Runs build steps until the index reports up to date, so each call
 /// after one write lands that write's revisions as one delta run. Fails

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -1,10 +1,11 @@
 //! Staged uploads and direct-put targets.
 
 use super::core::FsCore;
+use crate::uploads::BeginDirectPutUploadTargetResponse;
 use crate::Result;
 use crate::{
-    BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse,
-    CompleteUploadRequest, CompleteUploadResponse, ContentRef, NamespaceId, UploadContentResponse,
+    BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
+    ContentRef, NamespaceId, UploadContentResponse,
 };
 use loonfs_api::UploadId;
 

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -4,13 +4,13 @@ use super::HandleBuilderCore;
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
 use crate::fs::FsCore;
+use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, FlushWalResponse, GcConfig, GcReport,
     GramIndexBuildPolicy, MaintenanceTickOptions, MaintenanceTickResult, NamespaceId,
-    NamespaceStatusResponse, ObjectStoreMetricsRecorder, ReleaseCheckpointResponse, Result,
-    RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
-    TraceStoreKind,
+    NamespaceStatusResponse, ReleaseCheckpointResponse, Result, RuntimeCacheConfig,
+    RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -4,9 +4,10 @@
 use crate::background::BackgroundWork;
 use crate::config::FsConfig;
 use crate::fs::FsCore;
+use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::{
-    GramIndexBuildPolicy, ObjectStoreMetricsRecorder, Result, RuntimeCacheConfig, RuntimeError,
-    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    GramIndexBuildPolicy, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
+    TraceMode, TraceStoreKind,
 };
 use loonfs_core::cache::MetadataTableCache;
 use loonfs_objectstore::metrics::InstrumentedObjectStore;

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -4,12 +4,13 @@ use super::HandleBuilderCore;
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
 use crate::fs::FsCore;
+use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::{
     AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, ChangesResponse,
     DirectoryPageCursor, FileRevisionsPageCursor, GrepRequest, GrepResponse, InodeId,
     ListChangesOptions, ListFileRevisionsResponse, ListPathEntriesResponse, NamespaceId,
-    ObjectStoreMetricsRecorder, PageRequest, Result, RevisionNo, RuntimeCacheConfig,
-    RuntimeCacheStats, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    PageRequest, Result, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
+    StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -4,14 +4,15 @@ use super::{owning_runtime, FsReader, HandleBuilderCore};
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
 use crate::fs::FsCore;
+use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::publish::NamespaceMutationCandidate;
+use crate::uploads::BeginDirectPutUploadTargetResponse;
 use crate::{
-    BeginDirectPutUploadTargetResponse, BeginUploadRequest, BeginUploadResponse,
-    CapabilityDocument, ChangeSeq, CommitRequest, CommitResponse, CompleteUploadRequest,
-    CompleteUploadResponse, ContentRef, CopyOptions, CreateDirectoryOptions,
-    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    GramIndexBuildPolicy, InodeId, MoveOptions, NamespaceId, NamespaceSummary,
-    ObjectStoreMetricsRecorder, PutFileOptions, RestoreRevisionOptions, Result, RevisionNo,
+    BeginUploadRequest, BeginUploadResponse, CapabilityDocument, ChangeSeq, CommitRequest,
+    CommitResponse, CompleteUploadRequest, CompleteUploadResponse, ContentRef, CopyOptions,
+    CreateDirectoryOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
+    DeleteNamespaceResponse, DeleteOptions, GramIndexBuildPolicy, InodeId, MoveOptions,
+    NamespaceId, NamespaceSummary, PutFileOptions, RestoreRevisionOptions, Result, RevisionNo,
     RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind, UndeleteOptions, UploadContentResponse, UploadId,
 };
@@ -462,8 +463,7 @@ impl FsWriterBuilder {
     /// A cold namespace publishes immediately; the interval only paces
     /// follow-up batches, so concurrent publishes amortize into fewer,
     /// larger WAL segments — with each caller still awaiting its own
-    /// durable, visible result. Defaults to
-    /// [`crate::DEFAULT_MIN_PUBLISH_INTERVAL_MS`]; zero keeps only the
+    /// durable, visible result. Defaults to 15 ms; zero keeps only the
     /// batching that in-flight publications force.
     pub fn min_publish_interval_ms(mut self, min_publish_interval_ms: u64) -> Self {
         self.core.min_publish_interval_ms = min_publish_interval_ms;

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -51,11 +51,11 @@ pub use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, CapabilityDocument,
     ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteDirectoryBehavior, DeleteNamespaceResponse,
-    DestinationBehavior, DirectoryPageCursor, DisableGramsIndexResponse, DisplayName,
-    EffectiveLimit, EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor,
-    FlushWalOutcome, FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
-    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, NameKey, NamePolicy,
-    NamespaceId, NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy,
+    DestinationBehavior, DirectoryPageCursor, DisableGramsIndexResponse, EffectiveLimit,
+    EnableGramsIndexResponse, FileRevision, FileRevisionsPageCursor, FlushWalOutcome,
+    FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, NameKey, NamespaceId,
+    NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy,
     ReleaseCheckpointResponse, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
     FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
     FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
@@ -63,9 +63,8 @@ pub use loonfs_api::{
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{
-    BeginDirectPutUploadTargetResponse, BootstrapNamespaceError, DeleteNamespaceOptions,
-    DirectPutUploadTarget, Error as CoreError, ErrorCode, ErrorKind, GcConfig, GcReport,
-    GramIndexBuildPolicy, WriterFence,
+    BootstrapNamespaceError, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind,
+    GcConfig, GcReport, GramIndexBuildPolicy, WriterFence,
 };
 
 /// Integration seam: the vocabulary for handing classified mutation work to
@@ -87,20 +86,20 @@ pub mod content_tokens {
         mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
     };
 }
-pub use loonfs_objectstore::metrics::{
-    JsonlObjectStoreMetricsRecorder, KeyClass, ObjectStoreMetricSample, ObjectStoreMetricsRecorder,
-    ObjectStoreOperation, ObjectStoreResultClass, PutModeClass, RangeClass,
-};
+
+/// Server-integration seam: the resolved direct-put upload target a serving
+/// session turns into a presigned URL for client-side object PUT. Most
+/// embedded users never need this module.
+pub mod uploads {
+    pub use loonfs_core::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
+}
+
+pub use loonfs_objectstore::metrics;
 pub use loonfs_objectstore::{ObjectStore, ObjectStoreError, SharedObjectStore, StoreConfig};
 
 pub use background::FsBackgroundWork;
 pub use cache::RuntimeCacheStats;
-pub use config::{
-    RuntimeCacheConfig, DEFAULT_MAX_CACHED_NAMESPACES,
-    DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_DECODED_BYTES,
-    DEFAULT_MAX_CACHED_WAL_TAIL_PROJECTION_ROWS, DEFAULT_MAX_CONCURRENT_MAINTENANCE,
-    DEFAULT_MAX_WAL_TAIL_SEGMENTS, DEFAULT_MIN_PUBLISH_INTERVAL_MS,
-};
+pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use options::{
     gc_config_from_request, gc_response_from_report, CopyOptions, CreateCheckpointOptions,

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -2,7 +2,7 @@
 //! plus the wire conversions the server and embedded hosts share so both
 //! transports report identical maintenance shapes.
 
-use crate::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
+use crate::config::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, EffectiveLimit, GcConfig,
     GcReport, InodeId, ManifestId, NamespaceId, NamespaceStatusResponse,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1429,7 +1429,7 @@ mod tests {
     }
 
     async fn test_writer(store: SharedStore) -> crate::FsWriter {
-        test_writer_with_interval(store, crate::DEFAULT_MIN_PUBLISH_INTERVAL_MS).await
+        test_writer_with_interval(store, crate::config::DEFAULT_MIN_PUBLISH_INTERVAL_MS).await
     }
 
     async fn test_writer_with_interval(

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -198,7 +198,7 @@ impl TestRuntime {
         &self,
         namespace_id: &NamespaceId,
         content_ref: ContentRef,
-    ) -> loonfs::Result<loonfs::BeginDirectPutUploadTargetResponse> {
+    ) -> loonfs::Result<loonfs::uploads::BeginDirectPutUploadTargetResponse> {
         self.writer
             .begin_direct_put_upload_target(namespace_id, content_ref)
             .await


### PR DESCRIPTION
The loonfs crate root re-exported 128 flat names, mixing the product surface with things no embedded user touches: eight object-store metrics types, the direct-put seam pair, two name-policy types that belong to loonfs-api, and five internal default constants. This trims the root: the dead re-exports are gone, the metrics vocabulary is reachable as loonfs::metrics, and the direct-put target types move behind a documented uploads seam module, mirroring the existing publisher, publish, and content_tokens seams. No behavior change. Stacks on conor/destination-behavior.