### PR TITLE
refactor(api,client,cli): ids and paths parse once at the client boundary

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -91,7 +91,7 @@ pub struct ErrorDetails {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateNamespaceRequest {
     /// Durable namespace id to create.
-    pub namespace_id: String,
+    pub namespace_id: NamespaceId,
 }
 
 /// Request to fork a namespace.
@@ -99,7 +99,7 @@ pub struct CreateNamespaceRequest {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ForkNamespaceRequest {
     /// Durable namespace id for the fork target.
-    pub new_namespace_id: String,
+    pub new_namespace_id: NamespaceId,
 }
 
 /// Short namespace identifier returned by namespace create/fork operations.

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -83,7 +83,7 @@ impl EmbeddedBackend {
     /// cannot double-apply.
     async fn publish_with_maintenance_recovery<T, F, Fut>(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         attempt: F,
     ) -> Result<T, BackendError>
     where
@@ -106,18 +106,21 @@ impl EmbeddedBackend {
                 .map_err(map_runtime_error)?;
             result = attempt().await;
         }
-        let result = result.map_err(|error| map_namespace_scoped_runtime_error(namespace, error));
+        let result =
+            result.map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error));
         self.settle_background_work_after(result).await
     }
 }
 
 #[async_trait]
 impl Backend for EmbeddedBackend {
-    async fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError> {
-        let namespace_id = parse_namespace_id(namespace_id)?;
+    async fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceSummary, BackendError> {
         let result = self
             .writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
             .map_err(map_runtime_error);
         self.settle_background_work_after(result).await
@@ -125,16 +128,15 @@ impl Backend for EmbeddedBackend {
 
     async fn delete_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         expected_head_seq: Option<u64>,
     ) -> Result<DeleteNamespaceResponse, BackendError> {
-        let namespace_id = parse_namespace_id(namespace_id)?;
         let options = DeleteNamespaceOptions {
             expected_head_seq: expected_head_seq.map(ChangeSeq),
         };
         let result = self
             .writer
-            .delete_namespace(&namespace_id, options)
+            .delete_namespace(namespace_id, options)
             .await
             .map_err(map_runtime_error);
         self.settle_background_work_after(result).await
@@ -142,14 +144,12 @@ impl Backend for EmbeddedBackend {
 
     async fn fork_namespace(
         &self,
-        source: &str,
-        new_namespace_id: &str,
+        source_namespace_id: &NamespaceId,
+        new_namespace_id: &NamespaceId,
     ) -> Result<NamespaceSummary, BackendError> {
-        let source_namespace_id = parse_namespace_id(source)?;
-        let new_namespace_id = parse_namespace_id(new_namespace_id)?;
         let result = self
             .writer
-            .fork_namespace(&source_namespace_id, &new_namespace_id)
+            .fork_namespace(source_namespace_id, new_namespace_id)
             .await
             .map_err(map_runtime_error);
         self.settle_background_work_after(result).await
@@ -157,11 +157,10 @@ impl Backend for EmbeddedBackend {
 
     async fn namespace_status(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.admin
-            .namespace_status(&parsed)
+            .namespace_status(namespace_id)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
@@ -170,12 +169,11 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
     ) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
         Ok(self
             .reader
-            .list_path_entries_all(&namespace_id, &spec.absolute_path)
+            .list_path_entries_all(spec.namespace(), spec.absolute_path().as_str())
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?
             .entries)
     }
 
@@ -183,53 +181,48 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
     ) -> Result<AuthoritativePathEntry, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
         self.reader
-            .stat_path(&namespace_id, &spec.absolute_path)
+            .stat_path(spec.namespace(), spec.absolute_path().as_str())
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
     async fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
         let result = self
             .reader
-            .read_file_bytes(&namespace_id, &spec.absolute_path)
+            .read_file_bytes(spec.namespace(), spec.absolute_path().as_str())
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
         Ok(result.bytes)
     }
 
     async fn grep(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: &GrepRequest,
     ) -> Result<GrepResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.reader
-            .grep(&parsed, request)
+            .grep(namespace_id, request)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn enable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<EnableGramsIndexResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.admin
-            .enable_grams_index(&parsed)
+            .enable_grams_index(namespace_id)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn disable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<DisableGramsIndexResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.admin
-            .disable_grams_index(&parsed)
+            .disable_grams_index(namespace_id)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
@@ -239,12 +232,11 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
         let result = self
             .reader
-            .read_file_revision_bytes(&namespace_id, &spec.absolute_path, revision_no)
+            .read_file_revision_bytes(spec.namespace(), spec.absolute_path().as_str(), revision_no)
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))?;
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
         Ok(result.bytes)
     }
 
@@ -254,7 +246,6 @@ impl Backend for EmbeddedBackend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
         let request = loonfs_api::PageRequest {
             limit: resolve_cli_page_limit(limit)?,
             cursor: cursor
@@ -265,9 +256,9 @@ impl Backend for EmbeddedBackend {
                 })?,
         };
         self.reader
-            .list_file_revisions_page(&namespace_id, &spec.absolute_path, request)
+            .list_file_revisions_page(spec.namespace(), spec.absolute_path().as_str(), request)
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(&spec.namespace, error))
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
     async fn put_file_bytes(
@@ -277,11 +268,10 @@ impl Backend for EmbeddedBackend {
         behavior: DestinationBehavior,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
-        self.publish_with_maintenance_recovery(&spec.namespace, || {
+        self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.put_file_bytes(
-                &namespace_id,
-                &spec.absolute_path,
+                spec.namespace(),
+                spec.absolute_path().as_str(),
                 bytes,
                 PutFileOptions {
                     behavior,
@@ -298,11 +288,10 @@ impl Backend for EmbeddedBackend {
         expected_inode_id: Option<InodeId>,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
-        self.publish_with_maintenance_recovery(&spec.namespace, || {
+        self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.delete_path(
-                &namespace_id,
-                &spec.absolute_path,
+                spec.namespace(),
+                spec.absolute_path().as_str(),
                 DeleteOptions {
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     commit_id: commit_id.clone(),
@@ -319,11 +308,10 @@ impl Backend for EmbeddedBackend {
         parents: bool,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
-        self.publish_with_maintenance_recovery(&spec.namespace, || {
+        self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.create_directory(
-                &namespace_id,
-                &spec.absolute_path,
+                spec.namespace(),
+                spec.absolute_path().as_str(),
                 CreateDirectoryOptions {
                     commit_id: commit_id.clone(),
                     parents,
@@ -340,12 +328,11 @@ impl Backend for EmbeddedBackend {
         behavior: DestinationBehavior,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&from.namespace)?;
-        self.publish_with_maintenance_recovery(&from.namespace, || {
+        self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.move_path(
-                &namespace_id,
-                &from.absolute_path,
-                &to.absolute_path,
+                from.namespace(),
+                from.absolute_path().as_str(),
+                to.absolute_path().as_str(),
                 MoveOptions {
                     behavior,
                     commit_id: commit_id.clone(),
@@ -362,12 +349,11 @@ impl Backend for EmbeddedBackend {
         behavior: DestinationBehavior,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&from.namespace)?;
-        self.publish_with_maintenance_recovery(&from.namespace, || {
+        self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.copy_path(
-                &namespace_id,
-                &from.absolute_path,
-                &to.absolute_path,
+                from.namespace(),
+                from.absolute_path().as_str(),
+                to.absolute_path().as_str(),
                 CopyOptions {
                     behavior,
                     commit_id: commit_id.clone(),
@@ -383,11 +369,10 @@ impl Backend for EmbeddedBackend {
         source_revision_no: RevisionNo,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
-        self.publish_with_maintenance_recovery(&spec.namespace, || {
+        self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.restore_file_revision(
-                &namespace_id,
-                &spec.absolute_path,
+                spec.namespace(),
+                spec.absolute_path().as_str(),
                 source_revision_no,
                 RestoreRevisionOptions {
                     commit_id: commit_id.clone(),
@@ -404,13 +389,12 @@ impl Backend for EmbeddedBackend {
         deleted_at_seq: ChangeSeq,
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
-        let namespace_id = parse_namespace_id(&spec.namespace)?;
-        self.publish_with_maintenance_recovery(&spec.namespace, || {
+        self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.undelete(
-                &namespace_id,
+                spec.namespace(),
                 inode_id,
                 deleted_at_seq,
-                &spec.absolute_path,
+                spec.absolute_path().as_str(),
                 UndeleteOptions {
                     commit_id: commit_id.clone(),
                 },
@@ -425,59 +409,57 @@ impl Backend for EmbeddedBackend {
 
     async fn create_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: CreateCheckpointRequest,
     ) -> Result<CreateCheckpointResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.admin
-            .create_checkpoint(&parsed, CreateCheckpointOptions::from_request(request))
+            .create_checkpoint(namespace_id, CreateCheckpointOptions::from_request(request))
             .await
             .map_err(map_runtime_error)
     }
 
     async fn release_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         checkpoint_id: &str,
     ) -> Result<ReleaseCheckpointResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         let checkpoint_id = CheckpointId::parse(checkpoint_id).map_err(|error| {
             BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
         })?;
         self.admin
-            .release_checkpoint(&parsed, &checkpoint_id)
+            .release_checkpoint(namespace_id, &checkpoint_id)
             .await
             .map_err(map_runtime_error)
     }
 
-    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
+    async fn flush_wal(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<FlushWalResponse, BackendError> {
         self.admin
-            .flush_wal(&parsed)
+            .flush_wal(namespace_id)
             .await
             .map_err(map_runtime_error)
     }
 
     async fn advance_retention(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         self.admin
-            .advance_retention_floor(&parsed)
+            .advance_retention_floor(namespace_id)
             .await
             .map_err(map_runtime_error)
     }
 
     async fn maintenance_tick(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: MaintenanceTickRequest,
     ) -> Result<MaintenanceTickResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         let options = MaintenanceTickOptions::from_request(request);
         self.admin
-            .maintenance_tick_namespace(&parsed, options)
+            .maintenance_tick_namespace(namespace_id, options)
             .await
             .map(MaintenanceTickResult::into_response)
             .map_err(map_runtime_error)
@@ -485,40 +467,33 @@ impl Backend for EmbeddedBackend {
 
     async fn gc_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: GcRequest,
     ) -> Result<GcResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         let config = gc_config_from_request(request);
         self.admin
-            .gc_namespace(&parsed, &config)
+            .gc_namespace(namespace_id, &config)
             .await
-            .map(|report| gc_response_from_report(parsed, report))
+            .map(|report| gc_response_from_report(namespace_id.clone(), report))
             .map_err(map_runtime_error)
     }
 
     async fn list_changes_page(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
     ) -> Result<ChangesResponse, BackendError> {
-        let parsed = parse_namespace_id(namespace_id)?;
         let limit = resolve_cli_page_limit(limit)?;
         self.reader
             .list_changes_after(
-                &parsed,
+                namespace_id,
                 after_seq,
                 ListChangesOptions { limit: Some(limit) },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
-}
-
-fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, BackendError> {
-    NamespaceId::parse(namespace)
-        .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
 }
 
 fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendError> {
@@ -539,9 +514,12 @@ fn map_runtime_error(error: RuntimeError) -> BackendError {
     }
 }
 
-fn map_namespace_scoped_runtime_error(namespace: &str, error: RuntimeError) -> BackendError {
+fn map_namespace_scoped_runtime_error(
+    namespace_id: &NamespaceId,
+    error: RuntimeError,
+) -> BackendError {
     match error {
-        RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace, error),
+        RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace_id, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
@@ -557,11 +535,11 @@ fn map_core_error(error: CoreError) -> BackendError {
     BackendError::new(error.code().as_str(), error.to_string())
 }
 
-fn map_namespace_scoped_core_error(namespace: &str, error: CoreError) -> BackendError {
+fn map_namespace_scoped_core_error(namespace_id: &NamespaceId, error: CoreError) -> BackendError {
     if matches!(error.code(), ErrorCode::NamespaceNotFound) {
         return BackendError::new(
             ErrorCode::NamespaceNotFound.as_str(),
-            format!("namespace `{namespace}` does not exist"),
+            format!("namespace `{namespace_id}` does not exist"),
         );
     }
 
@@ -726,6 +704,10 @@ mod tests {
     use std::sync::Arc;
     use tempfile::tempdir;
 
+    fn namespace_id(value: &str) -> NamespaceId {
+        NamespaceId::parse(value).expect("valid namespace id")
+    }
+
     #[test]
     fn map_core_error_surfaces_registry_codes_verbatim() {
         let error = map_core_error(CoreError::RevisionNotFound {
@@ -777,17 +759,14 @@ mod tests {
             .expect("build embedded target");
         target
             .backend
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .await
             .expect("create namespace");
 
         let response = target
             .backend
             .put_file_bytes(
-                &NamespacePath {
-                    namespace: "demo".to_owned(),
-                    absolute_path: "/file.txt".to_owned(),
-                },
+                &NamespacePath::parse("demo", "/file.txt").expect("namespace path"),
                 b"hello",
                 DestinationBehavior::NoReplace,
                 None,
@@ -798,7 +777,7 @@ mod tests {
 
         let changes = target
             .backend
-            .list_changes_page("demo", ChangeSeq(0), None)
+            .list_changes_page(&namespace_id("demo"), ChangeSeq(0), None)
             .await
             .expect("list changes");
         assert_eq!(changes.changes.len(), 1);
@@ -819,7 +798,7 @@ mod tests {
         let checkpoint = target
             .backend
             .create_checkpoint(
-                "missing",
+                &namespace_id("missing"),
                 CreateCheckpointRequest {
                     name: "nightly".to_owned(),
                     ttl_ms: None,
@@ -831,7 +810,7 @@ mod tests {
 
         let changes = target
             .backend
-            .list_changes_page("missing", ChangeSeq(0), None)
+            .list_changes_page(&namespace_id("missing"), ChangeSeq(0), None)
             .await
             .expect_err("changes on missing namespace");
         assert_eq!(changes.code, ErrorCode::NamespaceNotFound.as_str());
@@ -850,7 +829,7 @@ mod tests {
             .expect("build embedded target");
         target
             .backend
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .await
             .expect("create namespace");
 
@@ -862,10 +841,8 @@ mod tests {
             target
                 .backend
                 .put_file_bytes(
-                    &NamespacePath {
-                        namespace: "demo".to_owned(),
-                        absolute_path: format!("/files/f{index}.txt"),
-                    },
+                    &NamespacePath::parse("demo", &format!("/files/f{index}.txt"))
+                        .expect("namespace path"),
                     b"payload",
                     DestinationBehavior::NoReplace,
                     None,
@@ -940,10 +917,7 @@ mod tests {
         target
             .backend
             .put_file_bytes(
-                &NamespacePath {
-                    namespace: "demo".to_owned(),
-                    absolute_path: "/recovered.txt".to_owned(),
-                },
+                &NamespacePath::parse("demo", "/recovered.txt").expect("namespace path"),
                 b"payload",
                 DestinationBehavior::NoReplace,
                 None,

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -4,14 +4,14 @@ use super::output::CommandFailure;
 use crate::args::{CommandKind, TargetSelectorArgs};
 use crate::error::CliError;
 use crate::resolve::{load_cli_config, resolve_namespace, resolve_target_profile_from_config};
-use loonfs_api::{ErrorCode, NamespaceId};
+use loonfs_api::{AbsolutePath, NamespaceId};
 use loonfs_client::NamespacePath;
 use std::path::{Path, PathBuf};
 
 pub(crate) struct CommandContext {
     pub(crate) profile_name: String,
     pub(crate) mode: String,
-    pub(crate) namespace: String,
+    pub(crate) namespace: NamespaceId,
     pub(crate) target: crate::backend::ResolvedTarget,
 }
 
@@ -85,63 +85,43 @@ pub(crate) async fn resolve_command_context(
 
 // --- general helpers ---
 
-pub(crate) fn validate_namespace_id(namespace: &str) -> Result<(), CliError> {
-    // A malformed namespace id surfaces its registry code so both profile
-    // modes report the same code the server would serve for it.
-    NamespaceId::parse(namespace)
-        .map(|_| ())
-        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
-}
-
 pub(crate) fn namespace_path(
-    namespace: &str,
+    namespace_id: &NamespaceId,
     path: &str,
     allow_root: bool,
 ) -> Result<NamespacePath, CliError> {
-    validate_namespace_id(namespace)?;
-    Ok(NamespacePath {
-        namespace: namespace.to_owned(),
-        absolute_path: normalize_absolute_path(path, allow_root)?,
-    })
+    Ok(NamespacePath::new(
+        namespace_id.clone(),
+        normalize_absolute_path(path, allow_root)?,
+    ))
 }
 
-pub(crate) fn normalize_absolute_path(path: &str, allow_root: bool) -> Result<String, CliError> {
-    if !path.starts_with('/') {
-        return Err(CliError::invalid_input(format!(
-            "filesystem paths must be absolute: `{path}`"
-        )));
-    }
-    let mut components = Vec::new();
-    for component in path.split('/') {
-        if component.is_empty() {
-            continue;
-        }
-        if component == "." || component == ".." {
-            return Err(CliError::invalid_input(format!(
-                "invalid filesystem path `{path}`"
-            )));
-        }
-        components.push(component);
-    }
-    if components.is_empty() {
-        if allow_root {
-            return Ok("/".to_owned());
-        }
+/// Parses a CLI path argument through the API's absolute-path grammar, so
+/// the CLI rejects exactly what the server would. `allow_root` is the only
+/// CLI-local policy on top.
+pub(crate) fn normalize_absolute_path(
+    path: &str,
+    allow_root: bool,
+) -> Result<AbsolutePath, CliError> {
+    let path =
+        AbsolutePath::parse(path).map_err(|error| CliError::invalid_input(error.to_string()))?;
+    if !allow_root && path.is_root() {
         return Err(CliError::invalid_input(
             "root path is not allowed for this command",
         ));
     }
-    Ok(format!("/{}", components.join("/")))
+    Ok(path)
 }
 
-pub(crate) fn default_remote_put_path(local_path: &Path) -> Result<String, CliError> {
+pub(crate) fn default_remote_put_path(local_path: &Path) -> Result<AbsolutePath, CliError> {
     let file_name = local_path.file_name().ok_or_else(|| {
         CliError::invalid_input(format!(
             "unable to derive remote target from `{}`",
             local_path.display()
         ))
     })?;
-    Ok(format!("/{}", file_name.to_string_lossy()))
+    AbsolutePath::parse(format!("/{}", file_name.to_string_lossy()))
+        .map_err(|error| CliError::invalid_input(error.to_string()))
 }
 
 pub(crate) fn destination_path_for_get(
@@ -161,8 +141,8 @@ pub(crate) fn destination_path_for_get(
     }
 }
 
-pub(crate) fn render_target(namespace: &str, path: &str) -> String {
-    format!("{namespace}:{path}")
+pub(crate) fn render_target(namespace_id: &NamespaceId, absolute_path: &AbsolutePath) -> String {
+    format!("{namespace_id}:{absolute_path}")
 }
 
 pub(crate) fn fail(

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -14,6 +14,7 @@ use crate::args::{
 };
 use crate::error::CliError;
 use loonfs_api::{CommitId, DestinationBehavior, InodeKind, RevisionNo};
+use loonfs_client::NamespacePath;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -214,7 +215,7 @@ pub(crate) async fn run_filesystem_get(
             kind,
             CliError::invalid_input(format!(
                 "directory operations are not available for `{}`",
-                spec.absolute_path
+                spec.absolute_path()
             )),
         ));
     }
@@ -235,7 +236,7 @@ pub(crate) async fn run_filesystem_get(
         Some("-") => CommandData::StreamBytes(bytes),
         other => {
             let derived_name = other.is_none();
-            let destination = destination_path_for_get(&spec.absolute_path, other)
+            let destination = destination_path_for_get(spec.absolute_path().as_str(), other)
                 .map_err(|error| context.fail(kind, error))?;
             // The local working copy is the one thing this CLI touches
             // that has no revision history behind it, so clobbering it is
@@ -255,7 +256,7 @@ pub(crate) async fn run_filesystem_get(
                 context.fail(kind, error)
             })?;
             CommandData::FileTransfer {
-                target: render_target(&context.namespace, &spec.absolute_path),
+                target: render_target(&context.namespace, spec.absolute_path()),
                 destination: destination.display().to_string(),
                 bytes_written: bytes.len() as u64,
             }
@@ -289,7 +290,7 @@ pub(crate) async fn run_filesystem_revisions(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileRevisions {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             revisions: response.revisions,
             next_cursor: response.next_cursor,
         },
@@ -328,8 +329,7 @@ pub(crate) async fn run_filesystem_put(
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;
-    let spec = namespace_path(&context.namespace, &remote_path, false)
-        .map_err(|error| context.fail(kind, error))?;
+    let spec = NamespacePath::new(context.namespace.clone(), remote_path);
     let bytes = fs::read(&local_path).map_err(|error| context.fail(kind, CliError::io(error)))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
@@ -350,7 +350,7 @@ pub(crate) async fn run_filesystem_put(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
             inode_id: None,
@@ -390,7 +390,7 @@ pub(crate) async fn run_filesystem_rm(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
             inode_id: Some(deleted_inode.0),
@@ -419,7 +419,7 @@ pub(crate) async fn run_filesystem_restore(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
             inode_id: None,
@@ -453,7 +453,7 @@ pub(crate) async fn run_filesystem_undelete(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
             inode_id: Some(args.inode),
@@ -482,7 +482,7 @@ pub(crate) async fn run_filesystem_mkdir(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, &spec.absolute_path),
+            target: render_target(&context.namespace, spec.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
             inode_id: None,
@@ -529,7 +529,7 @@ async fn run_filesystem_transfer(
                 kind,
                 CliError::invalid_input(format!(
                     "directory operations are not available for `{}`",
-                    from.absolute_path
+                    from.absolute_path()
                 )),
             ));
         }
@@ -562,8 +562,8 @@ async fn run_filesystem_transfer(
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::PathMove {
-            from: render_target(&context.namespace, &from.absolute_path),
-            to: render_target(&context.namespace, &to.absolute_path),
+            from: render_target(&context.namespace, from.absolute_path()),
+            to: render_target(&context.namespace, to.absolute_path()),
             committed_seq: result.committed_seq.0,
             commit_id: result.commit_id.to_string(),
         },

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -1,6 +1,6 @@
 //! `loon namespace` commands: create, fork, delete, use, and current.
 
-use super::context::{fail, fail_for, validate_namespace_id};
+use super::context::{fail, fail_for};
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
@@ -10,7 +10,9 @@ use crate::config::save_config;
 use crate::error::CliError;
 use crate::profiles::{default_namespace, set_default_namespace};
 use crate::prompt::prompt_line;
-use crate::resolve::{load_cli_config, resolve_target_profile, resolve_target_profile_from_config};
+use crate::resolve::{
+    load_cli_config, parse_namespace_id, resolve_target_profile, resolve_target_profile_from_config,
+};
 
 // --- namespace ---
 
@@ -35,12 +37,12 @@ async fn run_namespace_create(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace_id)
+    let namespace_id = parse_namespace_id(&args.namespace_id)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
         .backend()
-        .create_namespace(&args.namespace_id)
+        .create_namespace(&namespace_id)
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -62,7 +64,7 @@ async fn run_namespace_delete(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace_id)
+    let namespace_id = parse_namespace_id(&args.namespace_id)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     if !args.yes {
@@ -103,7 +105,7 @@ async fn run_namespace_delete(
     let response = resolved
         .target
         .backend()
-        .delete_namespace(&args.namespace_id, args.expected_head_seq)
+        .delete_namespace(&namespace_id, args.expected_head_seq)
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -124,14 +126,14 @@ async fn run_namespace_fork(
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.source)
+    let source_namespace_id = parse_namespace_id(&args.source)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
-    validate_namespace_id(&args.new_namespace_id)
+    let new_namespace_id = parse_namespace_id(&args.new_namespace_id)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
         .backend()
-        .fork_namespace(&args.source, &args.new_namespace_id)
+        .fork_namespace(&source_namespace_id, &new_namespace_id)
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
@@ -155,13 +157,13 @@ pub(crate) async fn run_namespace_use(
             .await
             .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
-    validate_namespace_id(&args.namespace)
+    let namespace_id = parse_namespace_id(&args.namespace)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     resolved
         .target
         .backend()
-        .namespace_status(&args.namespace)
+        .namespace_status(&namespace_id)
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -18,7 +18,7 @@ pub(crate) struct ResolvedProfile {
 }
 
 pub(crate) struct ResolvedNamespace {
-    pub namespace: String,
+    pub namespace: NamespaceId,
 }
 
 pub(crate) fn load_cli_config() -> Result<LoadedConfig, CliError> {
@@ -54,18 +54,22 @@ pub(crate) fn resolve_namespace(
     explicit_namespace: Option<&str>,
 ) -> Result<ResolvedNamespace, CliError> {
     if let Some(namespace) = explicit_namespace {
-        return validate_namespace(namespace);
+        return Ok(ResolvedNamespace {
+            namespace: parse_namespace_id(namespace)?,
+        });
     }
     let (profile_name, profile) = resolve_profile(config, explicit_profile)?;
     let namespace =
         default_namespace(profile).ok_or_else(|| CliError::no_default_namespace(profile_name))?;
-    validate_namespace(namespace)
+    Ok(ResolvedNamespace {
+        namespace: parse_namespace_id(namespace)?,
+    })
 }
 
-fn validate_namespace(namespace: &str) -> Result<ResolvedNamespace, CliError> {
+/// Parses a namespace argument once at the CLI boundary. A malformed id
+/// surfaces its registry code so both profile modes report the same code
+/// the server would serve for it.
+pub(crate) fn parse_namespace_id(namespace: &str) -> Result<NamespaceId, CliError> {
     NamespaceId::parse(namespace)
-        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))?;
-    Ok(ResolvedNamespace {
-        namespace: namespace.to_owned(),
-    })
+        .map_err(|error| CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
 }

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -23,7 +23,7 @@ use loonfs_api::{
     CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
     DestinationBehavior, DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode,
     ErrorDetails, FlushWalResponse, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse,
+    ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
 };
 use thiserror::Error;
@@ -139,24 +139,27 @@ impl From<ClientError> for BackendError {
 #[async_trait]
 pub trait Backend {
     /// Creates a new empty namespace.
-    async fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError>;
+    async fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceSummary, BackendError>;
     /// Marks a namespace deleted; `expected_head_seq` guards against deleting
     /// a namespace that moved since the caller last observed it.
     async fn delete_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         expected_head_seq: Option<u64>,
     ) -> Result<DeleteNamespaceResponse, BackendError>;
     /// Creates a new namespace as a fork of the source's durable view.
     async fn fork_namespace(
         &self,
-        source: &str,
-        new_namespace_id: &str,
+        source_namespace_id: &NamespaceId,
+        new_namespace_id: &NamespaceId,
     ) -> Result<NamespaceSummary, BackendError>;
     /// Summarizes a namespace's current head state.
     async fn namespace_status(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse, BackendError>;
     /// Lists the entries of a directory.
     async fn list_path_all(
@@ -171,18 +174,18 @@ pub trait Backend {
     /// Content search over a namespace's gram index.
     async fn grep(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: &GrepRequest,
     ) -> Result<GrepResponse, BackendError>;
     /// Enables the gram index on a namespace (admin plane).
     async fn enable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<EnableGramsIndexResponse, BackendError>;
     /// Disables the gram index on a namespace (admin plane).
     async fn disable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<DisableGramsIndexResponse, BackendError>;
     /// Reads a retained file revision's content.
     async fn read_file_revision_bytes(
@@ -266,42 +269,43 @@ pub trait Backend {
     /// namespace's current view.
     async fn create_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: CreateCheckpointRequest,
     ) -> Result<CreateCheckpointResponse, BackendError>;
     /// Releases a user-owned checkpoint pin by id. Idempotent.
     async fn release_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         checkpoint_id: &str,
     ) -> Result<ReleaseCheckpointResponse, BackendError>;
     /// Flushes the WAL tail and advances the metadata root, creating no
     /// checkpoint record.
-    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError>;
+    async fn flush_wal(&self, namespace_id: &NamespaceId)
+        -> Result<FlushWalResponse, BackendError>;
     /// Advances the namespace retention floor. Irreversible: WAL history
     /// before the floor stops being replayable.
     async fn advance_retention(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse, BackendError>;
     /// Runs one bounded maintenance step: a root advancement once the WAL
     /// tail reaches the threshold, optionally followed by a GC pass.
     async fn maintenance_tick(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: MaintenanceTickRequest,
     ) -> Result<MaintenanceTickResponse, BackendError>;
     /// Runs one mark-and-sweep garbage-collection pass. Nothing sweeps
     /// without this explicit call or a maintenance-tick opt-in.
     async fn gc_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: GcRequest,
     ) -> Result<GcResponse, BackendError>;
     /// Reads the ordered change feed after the `after_seq` cursor.
     async fn list_changes_page(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
     ) -> Result<ChangesResponse, BackendError>;
@@ -317,13 +321,6 @@ impl RemoteBackend {
     /// Wraps a configured HTTP client.
     pub fn new(client: Client) -> Self {
         Self { client }
-    }
-}
-
-/// Carries a backend-level commit id into the wire client's options.
-fn mutation_options(commit_id: Option<CommitId>) -> MutationOptions {
-    MutationOptions {
-        commit_id: commit_id.map(|id| id.to_string()),
     }
 }
 
@@ -345,18 +342,21 @@ impl RemoteBackend {
 
 #[async_trait]
 impl Backend for RemoteBackend {
-    async fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+    async fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceSummary, BackendError> {
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.create_namespace(&namespace_id))
             .await
     }
 
     async fn delete_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         expected_head_seq: Option<u64>,
     ) -> Result<DeleteNamespaceResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| {
             client.delete_namespace(&namespace_id, expected_head_seq.map(ChangeSeq))
         })
@@ -365,20 +365,20 @@ impl Backend for RemoteBackend {
 
     async fn fork_namespace(
         &self,
-        source: &str,
-        new_namespace_id: &str,
+        source_namespace_id: &NamespaceId,
+        new_namespace_id: &NamespaceId,
     ) -> Result<NamespaceSummary, BackendError> {
-        let source = source.to_owned();
-        let new_namespace_id = new_namespace_id.to_owned();
-        self.wire(move |client| client.fork_namespace(&source, &new_namespace_id))
+        let source_namespace_id = source_namespace_id.clone();
+        let new_namespace_id = new_namespace_id.clone();
+        self.wire(move |client| client.fork_namespace(&source_namespace_id, &new_namespace_id))
             .await
     }
 
     async fn namespace_status(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.namespace_status(&namespace_id))
             .await
     }
@@ -409,10 +409,10 @@ impl Backend for RemoteBackend {
 
     async fn grep(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: &GrepRequest,
     ) -> Result<GrepResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         let request = request.clone();
         self.wire(move |client| client.grep(&namespace_id, &request))
             .await
@@ -420,18 +420,18 @@ impl Backend for RemoteBackend {
 
     async fn enable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<EnableGramsIndexResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.enable_grams_index(&namespace_id))
             .await
     }
 
     async fn disable_grams_index(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<DisableGramsIndexResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.disable_grams_index(&namespace_id))
             .await
     }
@@ -467,7 +467,7 @@ impl Backend for RemoteBackend {
     ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
         let bytes = bytes.to_vec();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.put_file_bytes(&spec, &bytes, behavior, &options))
             .await
     }
@@ -479,7 +479,7 @@ impl Backend for RemoteBackend {
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.create_directory(&spec, parents, &options))
             .await
     }
@@ -491,7 +491,7 @@ impl Backend for RemoteBackend {
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| match expected_inode_id {
             Some(expected) => client.delete_path_expecting(&spec, expected, &options),
             None => client.delete_path(&spec, &options),
@@ -508,7 +508,7 @@ impl Backend for RemoteBackend {
     ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.move_path(&from, &to, behavior, &options))
             .await
     }
@@ -522,7 +522,7 @@ impl Backend for RemoteBackend {
     ) -> Result<CommitResponse, BackendError> {
         let from = from.clone();
         let to = to.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.copy_path(&from, &to, behavior, &options))
             .await
     }
@@ -534,7 +534,7 @@ impl Backend for RemoteBackend {
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.restore_file_revision(&spec, source_revision_no, &options))
             .await
     }
@@ -547,74 +547,77 @@ impl Backend for RemoteBackend {
         commit_id: Option<CommitId>,
     ) -> Result<CommitResponse, BackendError> {
         let spec = spec.clone();
-        let options = mutation_options(commit_id);
+        let options = MutationOptions { commit_id };
         self.wire(move |client| client.undelete(&spec, inode_id, deleted_at_seq, &options))
             .await
     }
 
     async fn create_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: CreateCheckpointRequest,
     ) -> Result<CreateCheckpointResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.create_checkpoint(&namespace_id, &request))
             .await
     }
 
     async fn release_checkpoint(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         checkpoint_id: &str,
     ) -> Result<ReleaseCheckpointResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         let checkpoint_id = checkpoint_id.to_owned();
         self.wire(move |client| client.release_checkpoint(&namespace_id, &checkpoint_id))
             .await
     }
 
-    async fn flush_wal(&self, namespace_id: &str) -> Result<FlushWalResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+    async fn flush_wal(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<FlushWalResponse, BackendError> {
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.flush_wal(&namespace_id))
             .await
     }
 
     async fn advance_retention(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.advance_retention(&namespace_id))
             .await
     }
 
     async fn maintenance_tick(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: MaintenanceTickRequest,
     ) -> Result<MaintenanceTickResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.maintenance_tick(&namespace_id, &request))
             .await
     }
 
     async fn gc_namespace(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         request: GcRequest,
     ) -> Result<GcResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.gc_namespace(&namespace_id, &request))
             .await
     }
 
     async fn list_changes_page(
         &self,
-        namespace_id: &str,
+        namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
     ) -> Result<ChangesResponse, BackendError> {
-        let namespace_id = namespace_id.to_owned();
+        let namespace_id = namespace_id.clone();
         self.wire(move |client| client.list_changes_page(&namespace_id, after_seq, limit))
             .await
     }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -20,9 +20,9 @@ use loonfs_api::{
         CompleteUploadRequest, CompleteUploadResponse, ObjectTransferAccess, UploadContentResponse,
         UploadMode, ValidatedContentToken,
     },
-    AdvanceRetentionResponse, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CommitId,
-    ContentRef, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
+    AbsolutePath, AdvanceRetentionResponse, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
+    CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode, FilesystemOperation,
     FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
     GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
@@ -55,12 +55,14 @@ struct StagedContent {
 }
 
 /// A path qualified by namespace.
+///
+/// Both parts are validated at construction — [`NamespacePath::parse`] for
+/// strings, [`NamespacePath::new`] for already-typed parts — so a value of
+/// this type always names a well-formed target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamespacePath {
-    /// Namespace id as text.
-    pub namespace: String,
-    /// Absolute path inside the namespace.
-    pub absolute_path: String,
+    namespace: NamespaceId,
+    absolute_path: AbsolutePath,
 }
 
 /// Options shared by every client mutation, mirroring the runtime's
@@ -70,22 +72,19 @@ pub struct MutationOptions {
     /// Idempotency key for the commit; retrying with the same id replays
     /// the committed mutation instead of double-committing. A fresh id is
     /// generated when absent.
-    pub commit_id: Option<String>,
+    pub commit_id: Option<CommitId>,
 }
 
 impl MutationOptions {
     /// Retry with a caller-chosen idempotency key.
-    pub fn with_commit_id(commit_id: impl Into<String>) -> Self {
+    pub fn with_commit_id(commit_id: CommitId) -> Self {
         Self {
-            commit_id: Some(commit_id.into()),
+            commit_id: Some(commit_id),
         }
     }
 
-    fn resolve_commit_id(&self) -> Result<CommitId, ClientError> {
-        match &self.commit_id {
-            Some(value) => parse_commit_id(value),
-            None => parse_commit_id(&generated_commit_id()),
-        }
+    fn resolve_commit_id(&self) -> CommitId {
+        self.commit_id.clone().unwrap_or_else(CommitId::generate)
     }
 }
 
@@ -132,23 +131,26 @@ impl Client {
             .clone())
     }
 
-    pub fn create_namespace(&self, namespace_id: &str) -> Result<NamespaceSummary, ClientError> {
-        let namespace_id = NamespaceId::parse(namespace_id).map_err(invalid_namespace_id_error)?;
+    pub fn create_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<NamespaceSummary, ClientError> {
         let url = format!("{}/v0/namespaces", self.base_url);
         self.request_json::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&CreateNamespaceRequest {
-                namespace_id: namespace_id.as_str().to_owned(),
+                namespace_id: namespace_id.clone(),
             }),
         )
     }
 
     pub fn namespace_status(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/namespaces/{namespace}", self.base_url);
+        // Validated namespace ids are URL-safe by construction, like the
+        // other parsed id segments interpolated into paths here and below.
+        let url = format!("{}/v0/namespaces/{namespace_id}", self.base_url);
         self.request_json::<(), NamespaceStatusResponse>(self.agent.get(&url), None)
     }
 
@@ -159,11 +161,10 @@ impl Client {
     /// fails with `namespace_deleted`.
     pub fn delete_namespace(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         expected_head_seq: Option<ChangeSeq>,
     ) -> Result<DeleteNamespaceResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let mut url = format!("{}/v0/namespaces/{namespace}", self.base_url);
+        let mut url = format!("{}/v0/namespaces/{namespace_id}", self.base_url);
         if let Some(expected) = expected_head_seq {
             url.push_str(&format!("?expected_head_seq={}", expected.0));
         }
@@ -172,17 +173,17 @@ impl Client {
 
     pub fn fork_namespace(
         &self,
-        source_namespace: &str,
-        new_namespace_id: &str,
+        source_namespace_id: &NamespaceId,
+        new_namespace_id: &NamespaceId,
     ) -> Result<NamespaceSummary, ClientError> {
-        let source_namespace = namespace_url_segment(source_namespace)?;
-        let new_namespace_id =
-            NamespaceId::parse(new_namespace_id).map_err(invalid_namespace_id_error)?;
-        let url = format!("{}/v0/namespaces/{source_namespace}/forks", self.base_url);
+        let url = format!(
+            "{}/v0/namespaces/{source_namespace_id}/forks",
+            self.base_url
+        );
         self.request_json::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&ForkNamespaceRequest {
-                new_namespace_id: new_namespace_id.as_str().to_owned(),
+                new_namespace_id: new_namespace_id.clone(),
             }),
         )
     }
@@ -244,35 +245,32 @@ impl Client {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListPathEntriesResponse, ClientError> {
-        let namespace = namespace_url_segment(&spec.namespace)?;
         let mut url = format!(
             "{}/v0/namespaces/{}/filesystem/list?path={}",
             self.base_url,
-            namespace,
-            urlencoding::encode(&spec.absolute_path)
+            spec.namespace().as_str(),
+            urlencoding::encode(spec.absolute_path().as_str())
         );
         append_optional_pagination_query(&mut url, true, limit, cursor);
         self.request_json::<(), ListPathEntriesResponse>(self.agent.get(&url), None)
     }
 
     pub fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry, ClientError> {
-        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/stat?path={}",
             self.base_url,
-            namespace,
-            urlencoding::encode(&spec.absolute_path)
+            spec.namespace().as_str(),
+            urlencoding::encode(spec.absolute_path().as_str())
         );
         self.request_json::<(), AuthoritativePathEntry>(self.agent.get(&url), None)
     }
 
     pub fn read_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>, ClientError> {
-        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/content?path={}",
             self.base_url,
-            namespace,
-            urlencoding::encode(&spec.absolute_path)
+            spec.namespace().as_str(),
+            urlencoding::encode(spec.absolute_path().as_str())
         );
         self.request_bytes(&url)
     }
@@ -282,12 +280,11 @@ impl Client {
         spec: &NamespacePath,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>, ClientError> {
-        let namespace = namespace_url_segment(&spec.namespace)?;
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/content?path={}&revision_no={}",
             self.base_url,
-            namespace,
-            urlencoding::encode(&spec.absolute_path),
+            spec.namespace().as_str(),
+            urlencoding::encode(spec.absolute_path().as_str()),
             revision_no.0
         );
         self.request_bytes(&url)
@@ -299,12 +296,11 @@ impl Client {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, ClientError> {
-        let namespace = namespace_url_segment(&spec.namespace)?;
         let mut url = format!(
             "{}/v0/namespaces/{}/filesystem/revisions?path={}",
             self.base_url,
-            namespace,
-            urlencoding::encode(&spec.absolute_path)
+            spec.namespace().as_str(),
+            urlencoding::encode(spec.absolute_path().as_str())
         );
         append_optional_pagination_query(&mut url, true, limit, cursor);
         self.request_json::<(), ListFileRevisionsResponse>(self.agent.get(&url), None)
@@ -312,14 +308,13 @@ impl Client {
 
     pub fn list_file_revisions_for_inode_page(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let mut url = format!(
-            "{}/v0/namespaces/{namespace}/inodes/{}/revisions",
+            "{}/v0/namespaces/{namespace_id}/inodes/{}/revisions",
             self.base_url, inode_id.0
         );
         append_optional_pagination_query(&mut url, false, limit, cursor);
@@ -328,13 +323,12 @@ impl Client {
 
     pub fn read_file_revision_bytes_for_inode(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/namespaces/{namespace}/inodes/{}/revisions/{}/content",
+            "{}/v0/namespaces/{namespace_id}/inodes/{}/revisions/{}/content",
             self.base_url, inode_id.0, revision_no.0
         );
         self.request_bytes(&url)
@@ -349,21 +343,20 @@ impl Client {
 
     pub fn begin_upload(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &BeginUploadRequest,
     ) -> Result<BeginUploadResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/namespaces/{namespace}/uploads", self.base_url);
+        let url = format!("{}/v0/namespaces/{namespace_id}/uploads", self.base_url);
         self.request_json::<_, BeginUploadResponse>(self.agent.post(&url), Some(request))
     }
 
     pub fn begin_direct_put(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         content_ref: ContentRef,
     ) -> Result<BeginUploadResponse, ClientError> {
         self.begin_upload(
-            namespace,
+            namespace_id,
             &BeginUploadRequest {
                 mode: Some(UploadMode::DirectPut),
                 content_ref: Some(content_ref),
@@ -401,13 +394,12 @@ impl Client {
 
     pub fn upload_content(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         upload_id: &str,
         bytes: &[u8],
     ) -> Result<UploadContentResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
             self.base_url
         );
         let request = self
@@ -422,13 +414,12 @@ impl Client {
 
     pub fn complete_upload(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         upload_id: &str,
         request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+            "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
             self.base_url
         );
         self.request_json::<_, CompleteUploadResponse>(self.agent.post(&url), Some(request))
@@ -436,23 +427,21 @@ impl Client {
 
     pub fn commit_operations(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &ApiCommitRequest,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/namespaces/{namespace}/commits", self.base_url);
+        let url = format!("{}/v0/namespaces/{namespace_id}/commits", self.base_url);
         self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
     pub fn list_changes_page(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         limit: Option<u32>,
     ) -> Result<ChangesResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let mut url = format!(
-            "{}/v0/namespaces/{namespace}/changes?after_seq={}",
+            "{}/v0/namespaces/{namespace_id}/changes?after_seq={}",
             self.base_url, after_seq.0
         );
         if let Some(limit) = limit {
@@ -467,12 +456,11 @@ impl Client {
     /// root until released or expired.
     pub fn create_checkpoint(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &CreateCheckpointRequest,
     ) -> Result<CreateCheckpointResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/checkpoints",
+            "{}/v0/admin/namespaces/{namespace_id}/checkpoints",
             self.base_url
         );
         self.request_json(self.agent.post(&url), Some(request))
@@ -482,13 +470,12 @@ impl Client {
     /// releasing an already-released or reaped record succeeds.
     pub fn release_checkpoint(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         checkpoint_id: &str,
     ) -> Result<ReleaseCheckpointResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let checkpoint_id = checkpoint_id_url_segment(checkpoint_id)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
+            "{}/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
             self.base_url
         );
         self.request_json::<(), ReleaseCheckpointResponse>(self.agent.post(&url), None)
@@ -497,10 +484,9 @@ impl Client {
     /// Flushes the WAL tail and advances the metadata root to a manifest
     /// covering the current head (admin plane). The latest-state maintenance operation: no checkpoint
     /// record is created. The request carries no body.
-    pub fn flush_wal(&self, namespace: &str) -> Result<FlushWalResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
+    pub fn flush_wal(&self, namespace_id: &NamespaceId) -> Result<FlushWalResponse, ClientError> {
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/wal/flush",
+            "{}/v0/admin/namespaces/{namespace_id}/wal/flush",
             self.base_url
         );
         self.request_json::<(), FlushWalResponse>(self.agent.post(&url), None)
@@ -511,11 +497,10 @@ impl Client {
     /// replayable. The request carries no body.
     pub fn advance_retention(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/retention/advance",
+            "{}/v0/admin/namespaces/{namespace_id}/retention/advance",
             self.base_url
         );
         self.request_json::<(), AdvanceRetentionResponse>(self.agent.post(&url), None)
@@ -526,12 +511,11 @@ impl Client {
     /// runs only when the request opts in.
     pub fn maintenance_tick(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &MaintenanceTickRequest,
     ) -> Result<MaintenanceTickResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/maintenance/tick",
+            "{}/v0/admin/namespaces/{namespace_id}/maintenance/tick",
             self.base_url
         );
         self.request_json(self.agent.post(&url), Some(request))
@@ -542,11 +526,10 @@ impl Client {
     /// opt-in.
     pub fn gc_namespace(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &GcRequest,
     ) -> Result<GcResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/admin/namespaces/{namespace}/gc", self.base_url);
+        let url = format!("{}/v0/admin/namespaces/{namespace_id}/gc", self.base_url);
         self.request_json(self.agent.post(&url), Some(request))
     }
 
@@ -556,11 +539,10 @@ impl Client {
     /// materialized or the server answers `not_supported`.
     pub fn grep(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &GrepRequest,
     ) -> Result<GrepResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let url = format!("{}/v0/namespaces/{namespace}/query/grep", self.base_url);
+        let url = format!("{}/v0/namespaces/{namespace_id}/query/grep", self.base_url);
         self.request_json(self.agent.post(&url), Some(request))
     }
 
@@ -568,11 +550,10 @@ impl Client {
     /// runs through maintenance ticks. Idempotent.
     pub fn enable_grams_index(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<EnableGramsIndexResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/index/grams/enable",
+            "{}/v0/admin/namespaces/{namespace_id}/index/grams/enable",
             self.base_url
         );
         self.request_json::<(), EnableGramsIndexResponse>(self.agent.post(&url), None)
@@ -582,11 +563,10 @@ impl Client {
     /// collection reclaims the segments. Idempotent.
     pub fn disable_grams_index(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
     ) -> Result<DisableGramsIndexResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/admin/namespaces/{namespace}/index/grams/disable",
+            "{}/v0/admin/namespaces/{namespace_id}/index/grams/disable",
             self.base_url
         );
         self.request_json::<(), DisableGramsIndexResponse>(self.agent.post(&url), None)
@@ -594,12 +574,11 @@ impl Client {
 
     fn apply_filesystem_operation(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         request: &FilesystemOperationRequest,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
         let url = format!(
-            "{}/v0/namespaces/{namespace}/filesystem/operations",
+            "{}/v0/namespaces/{namespace_id}/filesystem/operations",
             self.base_url
         );
         self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
@@ -607,13 +586,13 @@ impl Client {
 
     fn stage_bytes_as_content_ref(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         bytes: &[u8],
     ) -> Result<StagedContent, ClientError> {
-        let upload = self.begin_upload(namespace, &BeginUploadRequest::default())?;
-        let staged = self.upload_content(namespace, upload.upload_id.as_str(), bytes)?;
+        let upload = self.begin_upload(namespace_id, &BeginUploadRequest::default())?;
+        let staged = self.upload_content(namespace_id, upload.upload_id.as_str(), bytes)?;
         let response = self.complete_upload(
-            namespace,
+            namespace_id,
             upload.upload_id.as_str(),
             &CompleteUploadRequest {
                 content_ref: staged.content_ref,
@@ -639,15 +618,15 @@ impl Client {
         behavior: DestinationBehavior,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let commit_id = options.resolve_commit_id()?;
-        let staged = self.stage_bytes_as_content_ref(&spec.namespace, bytes)?;
+        let commit_id = options.resolve_commit_id();
+        let staged = self.stage_bytes_as_content_ref(spec.namespace(), bytes)?;
         let response = self.apply_filesystem_operation(
-            &spec.namespace,
+            spec.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: staged.validated_content_token.into_iter().collect(),
                 operation: FilesystemOperation::PutFile {
-                    path: spec.absolute_path.clone(),
+                    path: spec.absolute_path().as_str().to_owned(),
                     content_ref: staged.content_ref,
                     behavior,
                 },
@@ -671,14 +650,14 @@ impl Client {
         parents: bool,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &spec.namespace,
+            spec.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::CreateDirectory {
-                    path: spec.absolute_path.clone(),
+                    path: spec.absolute_path().as_str().to_owned(),
                     parents,
                 },
             },
@@ -726,14 +705,14 @@ impl Client {
         expected_inode_id: Option<InodeId>,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &spec.namespace,
+            spec.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::DeletePath {
-                    path: spec.absolute_path.clone(),
+                    path: spec.absolute_path().as_str().to_owned(),
                     behavior,
                     expected_inode_id,
                 },
@@ -749,21 +728,22 @@ impl Client {
         behavior: DestinationBehavior,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        if from.namespace != to.namespace {
+        if from.namespace() != to.namespace() {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot move across namespaces: {} -> {}",
-                from.namespace, to.namespace
+                from.namespace(),
+                to.namespace()
             )));
         }
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &from.namespace,
+            from.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::MovePath {
-                    from_path: from.absolute_path.clone(),
-                    to_path: to.absolute_path.clone(),
+                    from_path: from.absolute_path().as_str().to_owned(),
+                    to_path: to.absolute_path().as_str().to_owned(),
                     behavior,
                 },
             },
@@ -778,21 +758,22 @@ impl Client {
         behavior: DestinationBehavior,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        if from.namespace != to.namespace {
+        if from.namespace() != to.namespace() {
             return Err(ClientError::InvalidNamespacePath(format!(
                 "cannot copy across namespaces: {} -> {}",
-                from.namespace, to.namespace
+                from.namespace(),
+                to.namespace()
             )));
         }
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &from.namespace,
+            from.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::CopyPath {
-                    from_path: from.absolute_path.clone(),
-                    to_path: to.absolute_path.clone(),
+                    from_path: from.absolute_path().as_str().to_owned(),
+                    to_path: to.absolute_path().as_str().to_owned(),
                     behavior,
                 },
             },
@@ -810,16 +791,16 @@ impl Client {
         deleted_at_seq: ChangeSeq,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &spec.namespace,
+            spec.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::Undelete {
                     inode_id,
                     deleted_at_seq,
-                    path: spec.absolute_path.clone(),
+                    path: spec.absolute_path().as_str().to_owned(),
                 },
             },
         )?;
@@ -832,14 +813,14 @@ impl Client {
         source_revision_no: RevisionNo,
         options: &MutationOptions,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let commit_id = options.resolve_commit_id()?;
+        let commit_id = options.resolve_commit_id();
         let response = self.apply_filesystem_operation(
-            &spec.namespace,
+            spec.namespace(),
             &FilesystemOperationRequest {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::RestoreRevision {
-                    path: spec.absolute_path.clone(),
+                    path: spec.absolute_path().as_str().to_owned(),
                     source_revision_no,
                 },
             },
@@ -849,22 +830,20 @@ impl Client {
 
     pub fn restore_file_revision_for_inode(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         source_revision_no: RevisionNo,
         base_revision_no: RevisionNo,
-        commit_id: &str,
+        commit_id: &CommitId,
     ) -> Result<ApiCommitResponse, ClientError> {
-        let namespace = namespace_url_segment(namespace)?;
-        let commit_id = parse_commit_id(commit_id)?;
         let url = format!(
-            "{}/v0/namespaces/{namespace}/inodes/{}/revisions/{}/restore",
+            "{}/v0/namespaces/{namespace_id}/inodes/{}/revisions/{}/restore",
             self.base_url, inode_id.0, source_revision_no.0
         );
         self.request_json::<_, ApiCommitResponse>(
             self.agent.post(&url),
             Some(&RestoreFileRevisionRequest {
-                commit_id,
+                commit_id: commit_id.clone(),
                 base_revision_no,
             }),
         )
@@ -872,26 +851,35 @@ impl Client {
 }
 
 impl NamespacePath {
-    pub fn parse(value: &str) -> Result<Self, ClientError> {
-        let (namespace, path) = value
-            .split_once(':')
-            .ok_or_else(|| ClientError::InvalidNamespacePath(value.to_owned()))?;
-        NamespaceId::parse(namespace)
-            .map_err(|err| ClientError::InvalidNamespacePath(err.to_string()))?;
-        if !path.starts_with('/') {
-            return Err(ClientError::InvalidNamespacePath(value.to_owned()));
-        }
+    /// Parses and validates both parts of a namespace-qualified path.
+    pub fn parse(namespace: &str, absolute_path: &str) -> Result<Self, ClientError> {
+        let namespace = NamespaceId::parse(namespace)
+            .map_err(|error| ClientError::InvalidNamespacePath(error.to_string()))?;
+        let absolute_path = AbsolutePath::parse(absolute_path)
+            .map_err(|error| ClientError::InvalidNamespacePath(error.to_string()))?;
         Ok(Self {
-            namespace: namespace.to_owned(),
-            absolute_path: path.to_owned(),
+            namespace,
+            absolute_path,
         })
     }
-}
 
-fn namespace_url_segment(namespace: &str) -> Result<&str, ClientError> {
-    NamespaceId::parse(namespace)
-        .map(|_| namespace)
-        .map_err(invalid_namespace_id_error)
+    /// Pairs already-validated parts without re-parsing.
+    pub fn new(namespace: NamespaceId, absolute_path: AbsolutePath) -> Self {
+        Self {
+            namespace,
+            absolute_path,
+        }
+    }
+
+    /// Namespace the path is scoped to.
+    pub fn namespace(&self) -> &NamespaceId {
+        &self.namespace
+    }
+
+    /// Absolute path inside the namespace.
+    pub fn absolute_path(&self) -> &AbsolutePath {
+        &self.absolute_path
+    }
 }
 
 /// Validated checkpoint ids are URL-safe by construction, like the other
@@ -900,10 +888,6 @@ fn checkpoint_id_url_segment(checkpoint_id: &str) -> Result<&str, ClientError> {
     loonfs_api::CheckpointId::parse(checkpoint_id)
         .map(|_| checkpoint_id)
         .map_err(|error| ClientError::InvalidCheckpointId(error.to_string()))
-}
-
-fn invalid_namespace_id_error(error: loonfs_api::NamespaceIdValidationError) -> ClientError {
-    ClientError::InvalidNamespacePath(error.to_string())
 }
 
 fn append_optional_pagination_query(
@@ -927,14 +911,6 @@ fn append_query_param(url: &mut String, has_query: &mut bool, name: &str, value:
     url.push_str(name);
     url.push('=');
     url.push_str(&urlencoding::encode(value));
-}
-
-fn parse_commit_id(commit_id: &str) -> Result<CommitId, ClientError> {
-    CommitId::parse(commit_id).map_err(|error| ClientError::InvalidCommitId(error.to_string()))
-}
-
-fn generated_commit_id() -> String {
-    CommitId::generate().to_string()
 }
 
 #[cfg(test)]
@@ -1014,6 +990,7 @@ mod tests {
             }
         });
 
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let retrying = Client::new(ClientConfig {
             server_url: format!("http://{addr}"),
             auth_token: None,
@@ -1021,7 +998,7 @@ mod tests {
             disable_transient_retry: false,
         });
         let error = retrying
-            .namespace_status("demo")
+            .namespace_status(&namespace_id)
             .expect_err("dropped connections must fail");
         assert!(matches!(error, ClientError::Http(_)), "{error:?}");
         assert_eq!(
@@ -1036,7 +1013,7 @@ mod tests {
             disable_transient_retry: true,
         });
         single_shot
-            .namespace_status("demo")
+            .namespace_status(&namespace_id)
             .expect_err("dropped connection must fail without retry");
         assert_eq!(
             accepted.load(Ordering::SeqCst),
@@ -1065,10 +1042,7 @@ mod tests {
         assert!(message.contains("502"), "{message}");
         assert!(message.contains("non-envelope body"), "{message}");
     }
-    use super::{
-        BeginUploadRequest, Client, ClientConfig, ClientError, CreateCheckpointRequest, ErrorCode,
-        NamespacePath,
-    };
+    use super::{Client, ClientConfig, ClientError, ErrorCode, NamespacePath};
     use crate::transport::{transient_failure, MAX_TRANSIENT_ATTEMPTS};
     use loonfs_api::ErrorKind;
     use std::fs;
@@ -1176,53 +1150,30 @@ auth_token = "   "
 
     #[test]
     fn namespace_path_parse_rejects_invalid_namespace_id() {
-        for value in [
-            "bad/name:/notes.txt",
-            "Demo:/notes.txt",
-            "..:/notes.txt",
-            "demo?:/notes.txt",
-        ] {
+        for namespace in ["bad/name", "Demo", "..", "demo?"] {
             assert!(
                 matches!(
-                    NamespacePath::parse(value),
+                    NamespacePath::parse(namespace, "/notes.txt"),
                     Err(ClientError::InvalidNamespacePath(_))
                 ),
-                "expected invalid namespace path {value:?}"
+                "expected invalid namespace path for id {namespace:?}"
             );
         }
     }
 
+    /// Construction is the only door: the fields are private, so a bad id
+    /// or a bad path fails `parse` with the same error the string-shuttling
+    /// client surfaced before the fields were typed.
     #[test]
-    fn client_rejects_invalid_namespace_ids_before_http_requests() {
-        let client = Client::new(ClientConfig {
-            server_url: "http://127.0.0.1:9".to_owned(),
-            auth_token: None,
-            request_timeout_ms: None,
-            disable_transient_retry: false,
-        });
-
-        for result in [
-            client.create_namespace("bad/name").map(|_| ()),
-            client.fork_namespace("demo", "bad/name").map(|_| ()),
-            client
-                .begin_upload("bad/name", &BeginUploadRequest::default())
-                .map(|_| ()),
-            client
-                .create_checkpoint(
-                    "bad/name",
-                    &CreateCheckpointRequest {
-                        name: "nightly".to_owned(),
-                        ttl_ms: None,
-                    },
-                )
-                .map(|_| ()),
-            client
-                .release_checkpoint("bad/name", "chk_00000000000000000000000000000001")
-                .map(|_| ()),
-            client.flush_wal("bad/name").map(|_| ()),
-            client.advance_retention("bad/name").map(|_| ()),
-        ] {
-            assert!(matches!(result, Err(ClientError::InvalidNamespacePath(_))));
+    fn namespace_path_parse_rejects_invalid_paths() {
+        for path in ["notes.txt", "", "/docs/../a.txt", "/docs/./a.txt"] {
+            assert!(
+                matches!(
+                    NamespacePath::parse("demo", path),
+                    Err(ClientError::InvalidNamespacePath(_))
+                ),
+                "expected invalid namespace path for path {path:?}"
+            );
         }
     }
 

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,10 +2,7 @@
 //! handlers.
 
 use super::error::ApiResponseError;
-use super::{
-    authorize, parse_namespace_id, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath,
-    OptionalAppJson,
-};
+use super::{authorize, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, OptionalAppJson};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
@@ -103,10 +100,9 @@ pub(super) async fn create_namespace(
     AppJson(request): AppJson<CreateNamespaceRequest>,
 ) -> Result<Json<loonfs_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
-    let namespace_id = parse_namespace_id(request.namespace_id)?;
     let summary = state
         .writer
-        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .create_namespace(&request.namespace_id, CreateNamespaceOptions::default())
         .await
         .map_err(ApiResponseError::runtime)?;
     Ok(Json(summary))
@@ -215,10 +211,9 @@ pub(super) async fn fork_namespace(
 ) -> Result<Json<loonfs_api::NamespaceSummary>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let source_namespace_id = namespace.into_id()?;
-    let new_namespace_id = parse_namespace_id(request.new_namespace_id)?;
     let summary = state
         .writer
-        .fork_namespace(&source_namespace_id, &new_namespace_id)
+        .fork_namespace(&source_namespace_id, &request.new_namespace_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&source_namespace_id, error))?;
     Ok(Json(summary))

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -200,7 +200,7 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
     });
     tokio::task::spawn_blocking(move || {
         client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace over http");
     })
     .await
@@ -242,7 +242,7 @@ async fn runtime_created_state_is_readable_through_http() {
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("demo:/notes/hello.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/notes/hello.txt").expect("target");
         let stat = harness.client.stat_path(&target).expect("stat file");
         assert_eq!(stat.absolute_path, "/notes/hello.txt");
         assert_eq!(stat.size_bytes, Some(18));
@@ -265,9 +265,9 @@ async fn http_created_state_is_readable_through_runtime() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace through http");
-        let target = NamespacePath::parse("demo:/notes/from-http.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/notes/from-http.txt").expect("target");
         harness
             .client
             .write_file_bytes(&target, b"hello from http", &MutationOptions::default())
@@ -296,7 +296,7 @@ async fn http_missing_namespace_mutations_return_namespace_not_found() {
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("missing:/notes/hello.txt").expect("target");
+        let target = NamespacePath::parse("missing", "/notes/hello.txt").expect("target");
         assert_api_error(
             harness
                 .client
@@ -313,7 +313,7 @@ async fn http_missing_namespace_mutations_return_namespace_not_found() {
             "namespace_not_found",
             Some("namespace `missing` does not exist"),
         );
-        let destination = NamespacePath::parse("missing:/notes/renamed.txt").expect("target");
+        let destination = NamespacePath::parse("missing", "/notes/renamed.txt").expect("target");
         assert_api_error(
             harness.client.move_path(
                 &target,
@@ -339,7 +339,7 @@ async fn http_missing_namespace_reads_return_namespace_not_found() {
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("missing:/").expect("target");
+        let target = NamespacePath::parse("missing", "/").expect("target");
         assert_api_error(
             harness.client.list_path_all(&target),
             404,
@@ -361,7 +361,7 @@ async fn http_delete_missing_path_returns_path_not_found() {
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("demo:/missing.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/missing.txt").expect("target");
         assert_api_error(
             harness
                 .client
@@ -409,7 +409,7 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     tokio::task::spawn_blocking(move || {
-        let dir_target = NamespacePath::parse("demo:/docs").expect("dir target");
+        let dir_target = NamespacePath::parse("demo", "/docs").expect("dir target");
         assert_api_error(
             harness.client.write_file_bytes(
                 &dir_target,
@@ -421,8 +421,8 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
             None,
         );
 
-        let from = NamespacePath::parse("demo:/tmp/a.txt").expect("from");
-        let to = NamespacePath::parse("demo:/docs/a.txt").expect("to");
+        let from = NamespacePath::parse("demo", "/tmp/a.txt").expect("from");
+        let to = NamespacePath::parse("demo", "/docs/a.txt").expect("to");
         assert_api_error(
             harness.client.move_path(
                 &from,
@@ -468,12 +468,12 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
     tokio::task::spawn_blocking(move || {
         // The deleted name is invisible and immediately reusable; the
         // dead subtree's children stay dead.
-        let put_target = NamespacePath::parse("demo:/docs/new.txt").expect("put target");
+        let put_target = NamespacePath::parse("demo", "/docs/new.txt").expect("put target");
         harness
             .client
             .write_file_bytes(&put_target, b"new", &MutationOptions::default())
             .expect("put recreates the subtree");
-        let old_child = NamespacePath::parse("demo:/docs/old.txt").expect("old child");
+        let old_child = NamespacePath::parse("demo", "/docs/old.txt").expect("old child");
         assert_api_error(
             harness.client.stat_path(&old_child),
             404,
@@ -481,8 +481,8 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
             None,
         );
 
-        let from = NamespacePath::parse("demo:/tmp/source.txt").expect("from");
-        let to = NamespacePath::parse("demo:/docs/source.txt").expect("to");
+        let from = NamespacePath::parse("demo", "/tmp/source.txt").expect("from");
+        let to = NamespacePath::parse("demo", "/docs/source.txt").expect("to");
         harness
             .client
             .move_path(
@@ -507,7 +507,7 @@ async fn http_path_mutation_retries_transient_stale_head_cas() {
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("demo:/notes/race.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/notes/race.txt").expect("target");
         let result = harness
             .client
             .write_file_bytes(&target, b"race", &MutationOptions::default())
@@ -531,7 +531,7 @@ async fn http_first_write_takes_over_a_namespace_owned_by_another_writer() {
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     tokio::task::spawn_blocking(move || {
-        let target = NamespacePath::parse("demo:/notes/taken-over.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/notes/taken-over.txt").expect("target");
         let result = harness
             .client
             .write_file_bytes(&target, b"taken over", &MutationOptions::default())
@@ -584,7 +584,7 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
                 disable_transient_retry: false,
             });
             assert_api_error(
-                client.namespace_status("demo"),
+                client.namespace_status(&namespace_id("demo")),
                 401,
                 "unauthorized",
                 Some("missing or invalid bearer token"),
@@ -693,7 +693,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
             request_timeout_ms: None,
             disable_transient_retry: false,
         });
-        let target = NamespacePath::parse("demo:/big.bin").expect("target");
+        let target = NamespacePath::parse("demo", "/big.bin").expect("target");
         assert_api_error(
             client.write_file_bytes(&target, &[0u8; 4096], &MutationOptions::default()),
             413,
@@ -991,7 +991,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     let config_for_busy = client_config.clone();
     tokio::task::spawn_blocking(move || {
         let client = Client::new(config_for_busy);
-        let target = NamespacePath::parse("demo:/one.bin").expect("target");
+        let target = NamespacePath::parse("demo", "/one.bin").expect("target");
         assert_api_error(
             client.write_file_bytes(&target, &[0u8; 64], &MutationOptions::default()),
             503,
@@ -1005,7 +1005,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     drop(held);
     tokio::task::spawn_blocking(move || {
         let client = Client::new(client_config);
-        let target = NamespacePath::parse("demo:/one.bin").expect("target");
+        let target = NamespacePath::parse("demo", "/one.bin").expect("target");
         client
             .write_file_bytes(&target, &[0u8; 64], &MutationOptions::default())
             .expect("a freed slot admits the upload");
@@ -1055,7 +1055,7 @@ async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
             request_timeout_ms: None,
             disable_transient_retry: false,
         });
-        let target = NamespacePath::parse("demo:/retried.bin").expect("target");
+        let target = NamespacePath::parse("demo", "/retried.bin").expect("target");
         client
             .write_file_bytes(&target, &[0u8; 64], &MutationOptions::default())
             .expect("transient retry rides out the briefly full slot");
@@ -1109,7 +1109,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     let config_for_busy = client_config.clone();
     tokio::task::spawn_blocking(move || {
         let client = Client::new(config_for_busy);
-        let target = NamespacePath::parse("demo:/note.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/note.txt").expect("target");
         assert_api_error(
             client.read_file_bytes(&target),
             503,
@@ -1123,7 +1123,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     drop(held);
     tokio::task::spawn_blocking(move || {
         let client = Client::new(client_config);
-        let target = NamespacePath::parse("demo:/note.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/note.txt").expect("target");
         let bytes = client
             .read_file_bytes(&target)
             .expect("a freed slot admits the read");
@@ -1175,14 +1175,14 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
             disable_transient_retry: false,
         });
         assert_api_error(
-            client.read_file_bytes(&NamespacePath::parse("demo:/big.bin").expect("target")),
+            client.read_file_bytes(&NamespacePath::parse("demo", "/big.bin").expect("target")),
             413,
             "content_too_large",
             None,
         );
         // Content inside the limit still reads through the same route.
         let bytes = client
-            .read_file_bytes(&NamespacePath::parse("demo:/small.bin").expect("target"))
+            .read_file_bytes(&NamespacePath::parse("demo", "/small.bin").expect("target"))
             .expect("small content fits under the limit");
         assert_eq!(bytes.len(), 8);
     })

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -3,7 +3,7 @@
 use loonfs_api::{
     v0::{CompleteUploadRequest, ObjectTransferAccess, ValidatedContentToken},
     ChangeSeq, CommitId, CommitResponse, ContentRef, DestinationBehavior, FilesystemOperation,
-    FilesystemOperationRequest,
+    FilesystemOperationRequest, NamespaceId,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
 use loonfs_server::{
@@ -90,8 +90,9 @@ async fn direct_put_round_trip(config: ServerConfig) {
 
     tokio::task::spawn_blocking(move || {
         let namespace = "direct-put-e2e";
-        let target = NamespacePath::parse(&format!("{namespace}:/direct-put.txt"))
-            .expect("parse direct-put target");
+        let namespace_id = NamespaceId::parse(namespace).expect("valid namespace id");
+        let target =
+            NamespacePath::parse(namespace, "/direct-put.txt").expect("parse direct-put target");
         let bytes = b"direct put through a real provider\n";
         let content_ref = ContentRef::whole_file_v0(bytes);
 
@@ -100,16 +101,16 @@ async fn direct_put_round_trip(config: ServerConfig) {
 
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace_id)
             .expect("create namespace");
 
-        assert_wrong_direct_put_bytes_rejected(&harness.client, namespace);
-        assert_direct_put_requires_signed_checksum_header(&harness.client, namespace);
-        assert_direct_put_is_no_replace(&harness.client, namespace);
+        assert_wrong_direct_put_bytes_rejected(&harness.client, &namespace_id);
+        assert_direct_put_requires_signed_checksum_header(&harness.client, &namespace_id);
+        assert_direct_put_is_no_replace(&harness.client, &namespace_id);
 
         let begin = harness
             .client
-            .begin_direct_put(namespace, content_ref.clone())
+            .begin_direct_put(&namespace_id, content_ref.clone())
             .expect("begin direct put");
         let direct_put = begin.direct_put.expect("direct-put access");
         assert_eq!(direct_put.content_ref, content_ref);
@@ -122,7 +123,7 @@ async fn direct_put_round_trip(config: ServerConfig) {
         let complete = harness
             .client
             .complete_upload(
-                namespace,
+                &namespace_id,
                 begin.upload_id.as_str(),
                 &CompleteUploadRequest {
                     content_ref: content_ref.clone(),
@@ -144,7 +145,7 @@ async fn direct_put_round_trip(config: ServerConfig) {
                     token: validated_content_token,
                 }],
                 operation: FilesystemOperation::PutFile {
-                    path: target.absolute_path.clone(),
+                    path: target.absolute_path().as_str().to_owned(),
                     content_ref,
                     behavior: DestinationBehavior::NoReplace,
                 },
@@ -159,12 +160,12 @@ async fn direct_put_round_trip(config: ServerConfig) {
     .expect("join blocking task");
 }
 
-fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace: &str) {
+fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace_id: &NamespaceId) {
     let bytes = b"expected direct put bytes\n";
     let wrong_bytes = b"wrong direct put bytes\n";
     let content_ref = ContentRef::whole_file_v0(bytes);
     let begin = client
-        .begin_direct_put(namespace, content_ref.clone())
+        .begin_direct_put(namespace_id, content_ref.clone())
         .expect("begin wrong-bytes direct put");
     let direct_put = begin.direct_put.expect("wrong-bytes direct-put access");
     assert_eq!(direct_put.content_ref, content_ref);
@@ -175,7 +176,7 @@ fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace: &str) {
     );
     expect_client_rejection(
         client.complete_upload(
-            namespace,
+            namespace_id,
             begin.upload_id.as_str(),
             &CompleteUploadRequest { content_ref },
         ),
@@ -183,11 +184,11 @@ fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace: &str) {
     );
 }
 
-fn assert_direct_put_requires_signed_checksum_header(client: &Client, namespace: &str) {
+fn assert_direct_put_requires_signed_checksum_header(client: &Client, namespace_id: &NamespaceId) {
     let bytes = b"direct put bytes without checksum header\n";
     let content_ref = ContentRef::whole_file_v0(bytes);
     let begin = client
-        .begin_direct_put(namespace, content_ref.clone())
+        .begin_direct_put(namespace_id, content_ref.clone())
         .expect("begin missing-checksum direct put");
     let direct_put = begin
         .direct_put
@@ -202,7 +203,7 @@ fn assert_direct_put_requires_signed_checksum_header(client: &Client, namespace:
     );
     expect_client_rejection(
         client.complete_upload(
-            namespace,
+            namespace_id,
             begin.upload_id.as_str(),
             &CompleteUploadRequest { content_ref },
         ),
@@ -210,11 +211,11 @@ fn assert_direct_put_requires_signed_checksum_header(client: &Client, namespace:
     );
 }
 
-fn assert_direct_put_is_no_replace(client: &Client, namespace: &str) {
+fn assert_direct_put_is_no_replace(client: &Client, namespace_id: &NamespaceId) {
     let bytes = b"duplicate direct put bytes\n";
     let content_ref = ContentRef::whole_file_v0(bytes);
     let begin = client
-        .begin_direct_put(namespace, content_ref.clone())
+        .begin_direct_put(namespace_id, content_ref.clone())
         .expect("begin duplicate direct put");
     let direct_put = begin.direct_put.expect("duplicate direct-put access");
     assert_eq!(direct_put.content_ref, content_ref);
@@ -229,7 +230,7 @@ fn assert_direct_put_is_no_replace(client: &Client, namespace: &str) {
 
     let complete = client
         .complete_upload(
-            namespace,
+            namespace_id,
             begin.upload_id.as_str(),
             &CompleteUploadRequest { content_ref },
         )

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -38,11 +38,12 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
     .await;
 
     tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("doomed");
         harness
             .client
-            .create_namespace("doomed")
+            .create_namespace(&namespace)
             .expect("create namespace");
-        let target = NamespacePath::parse("doomed:/note.txt").expect("parse path");
+        let target = NamespacePath::parse("doomed", "/note.txt").expect("parse path");
         harness
             .client
             .write_file_bytes(&target, b"last words", &MutationOptions::default())
@@ -51,7 +52,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         // A stale precondition refuses the delete and deletes nothing.
         let stale = harness
             .client
-            .delete_namespace("doomed", Some(ChangeSeq(0)))
+            .delete_namespace(&namespace, Some(ChangeSeq(0)))
             .expect_err("stale precondition");
         match stale {
             ClientError::Api { status, code, .. } => {
@@ -62,12 +63,12 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         }
         harness
             .client
-            .namespace_status("doomed")
+            .namespace_status(&namespace)
             .expect("still alive after failed precondition");
 
         let response = harness
             .client
-            .delete_namespace("doomed", None)
+            .delete_namespace(&namespace, None)
             .expect("delete namespace");
         assert_eq!(response.namespace_id.as_str(), "doomed");
         assert_eq!(response.head_seq, ChangeSeq(1));
@@ -76,7 +77,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         // deleted, and the id is retired.
         let status = harness
             .client
-            .namespace_status("doomed")
+            .namespace_status(&namespace)
             .expect_err("deleted namespace has no status");
         match status {
             ClientError::Api { status, code, .. } => {
@@ -95,7 +96,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         }
         let again = harness
             .client
-            .delete_namespace("doomed", None)
+            .delete_namespace(&namespace, None)
             .expect_err("repeat delete");
         match again {
             ClientError::Api { status, code, .. } => {
@@ -106,7 +107,7 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         }
         let recreate = harness
             .client
-            .create_namespace("doomed")
+            .create_namespace(&namespace)
             .expect_err("the id is retired");
         match recreate {
             ClientError::Api { status, code, .. } => {
@@ -169,10 +170,10 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let docs = NamespacePath::parse("demo:/docs").expect("docs path");
-        let other = NamespacePath::parse("demo:/other").expect("other path");
+        let docs = NamespacePath::parse("demo", "/docs").expect("docs path");
+        let other = NamespacePath::parse("demo", "/other").expect("other path");
         harness
             .client
             .create_directory(&docs, false, &MutationOptions::default())
@@ -182,7 +183,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
             .create_directory(&other, false, &MutationOptions::default())
             .expect("create other dir");
         for name in ["a.txt", "b.txt", "c.txt"] {
-            let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
+            let path = NamespacePath::parse("demo", &format!("/docs/{name}")).expect("file path");
             harness
                 .client
                 .write_file_bytes(&path, name.as_bytes(), &MutationOptions::default())
@@ -266,15 +267,15 @@ async fn http_client_listing_preserves_canonical_name_key_order() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let docs = NamespacePath::parse("demo:/docs").expect("docs path");
+        let docs = NamespacePath::parse("demo", "/docs").expect("docs path");
         harness
             .client
             .create_directory(&docs, false, &MutationOptions::default())
             .expect("create docs dir");
         for name in ["B.txt", "a.txt", "c.txt"] {
-            let path = NamespacePath::parse(&format!("demo:/docs/{name}")).expect("file path");
+            let path = NamespacePath::parse("demo", &format!("/docs/{name}")).expect("file path");
             harness
                 .client
                 .write_file_bytes(&path, name.as_bytes(), &MutationOptions::default())
@@ -303,9 +304,9 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let directory = NamespacePath::parse("demo:/notes").expect("parse directory path");
+        let directory = NamespacePath::parse("demo", "/notes").expect("parse directory path");
         harness
             .client
             .create_directory(&directory, false, &MutationOptions::default())
@@ -316,13 +317,16 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
             .expect("stat directory");
         assert_eq!(directory_entry.inode_kind, InodeKind::Directory);
 
-        let target = NamespacePath::parse("demo:/notes/hello.txt").expect("parse namespace path");
+        let target =
+            NamespacePath::parse("demo", "/notes/hello.txt").expect("parse namespace path");
         let written = harness
             .client
             .write_file_bytes(
                 &target,
                 b"hello over http\n",
-                &MutationOptions::with_commit_id("smoke-write-1"),
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("smoke-write-1").expect("valid commit id"),
+                ),
             )
             .expect("write bytes");
         // Path operations echo the commit id they committed under.
@@ -337,14 +341,14 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
 
         let status = harness
             .client
-            .namespace_status("demo")
+            .namespace_status(&namespace_id("demo"))
             .expect("namespace status");
         assert_eq!(status.namespace_id.as_str(), "demo");
         assert_eq!(status.head_seq, ChangeSeq(2));
 
         let missing = harness
             .client
-            .namespace_status("absent")
+            .namespace_status(&namespace_id("absent"))
             .expect_err("missing namespace status");
         match missing {
             ClientError::Api { status, code, .. } => {
@@ -373,7 +377,7 @@ async fn http_namespace_listing_route_is_not_exposed() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create demo");
 
         let response = ureq::get(&format!("{}/v0/namespaces", harness.server_url))
@@ -441,13 +445,13 @@ async fn http_upload_content_rejects_invalid_upload_id() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
 
         let invalid_upload_id = ["upl", "123"].join("-");
         match harness
             .client
-            .upload_content("demo", &invalid_upload_id, b"hello")
+            .upload_content(&namespace_id("demo"), &invalid_upload_id, b"hello")
         {
             Err(ClientError::Api { status, code, .. }) => {
                 assert_eq!(status, 400);
@@ -475,9 +479,9 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let source = NamespacePath::parse("demo:/docs/hello.txt").expect("source");
+        let source = NamespacePath::parse("demo", "/docs/hello.txt").expect("source");
         harness
             .client
             .put_file_bytes(
@@ -508,7 +512,7 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
             )
             .expect("forced overwrite");
 
-        let destination = NamespacePath::parse("demo:/docs/copy.txt").expect("destination");
+        let destination = NamespacePath::parse("demo", "/docs/copy.txt").expect("destination");
         harness
             .client
             .copy_path(
@@ -548,10 +552,10 @@ async fn http_namespace_fork_shares_content_and_diverges() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let source_path = NamespacePath::parse("demo:/docs/shared.txt").expect("source path");
-        let clone_path = NamespacePath::parse("clone:/docs/shared.txt").expect("clone path");
+        let source_path = NamespacePath::parse("demo", "/docs/shared.txt").expect("source path");
+        let clone_path = NamespacePath::parse("clone", "/docs/shared.txt").expect("clone path");
         harness
             .client
             .write_file_bytes(&source_path, b"base\n", &MutationOptions::default())
@@ -559,7 +563,7 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
         let forked = harness
             .client
-            .fork_namespace("demo", "clone")
+            .fork_namespace(&namespace_id("demo"), &namespace_id("clone"))
             .expect("fork namespace");
         assert_eq!(forked.namespace_id.as_str(), "clone");
 
@@ -616,14 +620,14 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
         match harness
             .client
-            .list_changes_page("clone", ChangeSeq(0), None)
+            .list_changes_page(&namespace_id("clone"), ChangeSeq(0), None)
         {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "rebootstrap_required"),
             other => unreachable!("expected rebootstrap_required, got {other:?}"),
         }
         let clone_changes = harness
             .client
-            .list_changes_page("clone", ChangeSeq(1), None)
+            .list_changes_page(&namespace_id("clone"), ChangeSeq(1), None)
             .expect("clone changes");
         assert_eq!(clone_changes.changes.len(), 1);
         assert_eq!(clone_changes.changes[0].seq, ChangeSeq(2));
@@ -645,49 +649,50 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         let file_bytes = b"phase-2a over http\n";
-        let target = NamespacePath::parse("demo:/uploaded.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/uploaded.txt").expect("target");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
 
         let begin = harness
             .client
-            .begin_upload(namespace, &BeginUploadRequest::default())
+            .begin_upload(&namespace, &BeginUploadRequest::default())
             .expect("begin upload");
         let first_content = harness
             .client
-            .upload_content(namespace, begin.upload_id.as_str(), file_bytes)
+            .upload_content(&namespace, begin.upload_id.as_str(), file_bytes)
             .expect("upload content");
         let repeated_content = harness
             .client
-            .upload_content(namespace, begin.upload_id.as_str(), file_bytes)
+            .upload_content(&namespace, begin.upload_id.as_str(), file_bytes)
             .expect("repeat upload content");
         assert_eq!(first_content, repeated_content);
-        match harness
-            .client
-            .upload_content(namespace, begin.upload_id.as_str(), b"different bytes")
-        {
+        match harness.client.upload_content(
+            &namespace,
+            begin.upload_id.as_str(),
+            b"different bytes",
+        ) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "upload_content_conflict"),
             other => unreachable!("expected upload_content_conflict, got {other:?}"),
         }
 
         let mismatch_upload = harness
             .client
-            .begin_upload(namespace, &BeginUploadRequest::default())
+            .begin_upload(&namespace, &BeginUploadRequest::default())
             .expect("begin mismatch upload");
         let staged = harness
             .client
-            .upload_content(namespace, mismatch_upload.upload_id.as_str(), file_bytes)
+            .upload_content(&namespace, mismatch_upload.upload_id.as_str(), file_bytes)
             .expect("stage mismatch upload content");
         assert_ne!(
             staged.content_ref,
             ContentRef::whole_file_v0(b"other bytes")
         );
         match harness.client.complete_upload(
-            namespace,
+            &namespace,
             mismatch_upload.upload_id.as_str(),
             &CompleteUploadRequest {
                 content_ref: ContentRef::whole_file_v0(b"other bytes"),
@@ -697,7 +702,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             other => unreachable!("expected upload content rejection, got {other:?}"),
         }
 
-        let content_ref = stage_uploaded_content_ref(&harness.client, namespace, file_bytes);
+        let content_ref = stage_uploaded_content_ref(&harness.client, &namespace, file_bytes);
 
         let commit_request = ApiCommitRequest {
             commit_id: CommitId::parse("req-phase-2a-create-file").expect("valid commit id"),
@@ -711,7 +716,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         };
         let commit = harness
             .client
-            .commit_operations(namespace, &commit_request)
+            .commit_operations(&namespace, &commit_request)
             .expect("commit uploaded file");
         assert_eq!(
             commit.commit_id,
@@ -721,7 +726,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
         let repeated_commit = harness
             .client
-            .commit_operations(namespace, &commit_request)
+            .commit_operations(&namespace, &commit_request)
             .expect("repeat commit");
         assert_eq!(repeated_commit, commit);
 
@@ -739,9 +744,9 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
         let changes = harness
             .client
-            .list_changes_page(namespace, ChangeSeq(0), None)
+            .list_changes_page(&namespace, ChangeSeq(0), None)
             .expect("list changes");
-        assert_eq!(changes.namespace_id.as_str(), namespace);
+        assert_eq!(changes.namespace_id, namespace);
         assert_eq!(changes.after_seq, ChangeSeq(0));
         assert_eq!(changes.through_seq, commit.committed_seq);
         assert_eq!(changes.changes.len(), 1);
@@ -764,7 +769,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
         let empty = harness
             .client
-            .list_changes_page(namespace, commit.committed_seq, None)
+            .list_changes_page(&namespace, commit.committed_seq, None)
             .expect("list changes after head");
         assert_eq!(empty.changes, Vec::new());
     })
@@ -785,23 +790,23 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
         let begin = harness
             .client
-            .begin_upload(namespace, &BeginUploadRequest::default())
+            .begin_upload(&namespace, &BeginUploadRequest::default())
             .expect("begin upload");
         let staged = harness
             .client
-            .upload_content(namespace, begin.upload_id.as_str(), b"token fallback")
+            .upload_content(&namespace, begin.upload_id.as_str(), b"token fallback")
             .expect("upload content");
         let completed = harness
             .client
             .complete_upload(
-                namespace,
+                &namespace,
                 begin.upload_id.as_str(),
                 &CompleteUploadRequest {
                     content_ref: staged.content_ref,
@@ -838,7 +843,7 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
 
-        let target = NamespacePath::parse("demo:/bad-token.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/bad-token.txt").expect("target");
         assert_eq!(
             harness.client.read_file_bytes(&target).expect("read file"),
             b"token fallback"
@@ -861,19 +866,19 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
-        let target = NamespacePath::parse("demo:/restore.txt").expect("target");
+        let namespace = namespace_id("demo");
+        let target = NamespacePath::parse("demo", "/restore.txt").expect("target");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
 
         let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, namespace, b"first bytes\n");
+            stage_uploaded_content_ref(&harness.client, &namespace, b"first bytes\n");
         harness
             .client
             .commit_operations(
-                namespace,
+                &namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::parse("req-restore-create").expect("valid commit id"),
                     preconditions: Vec::new(),
@@ -893,11 +898,11 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .inode_id;
 
         let second_content_ref =
-            stage_uploaded_content_ref(&harness.client, namespace, b"second bytes\n");
+            stage_uploaded_content_ref(&harness.client, &namespace, b"second bytes\n");
         let replace = harness
             .client
             .commit_operations(
-                namespace,
+                &namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::parse("req-restore-replace").expect("valid commit id"),
                     preconditions: Vec::new(),
@@ -915,7 +920,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
         let restore = harness
             .client
             .commit_operations(
-                namespace,
+                &namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::parse("req-restore-restore").expect("valid commit id"),
                     preconditions: Vec::new(),
@@ -944,7 +949,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
 
         let changes = harness
             .client
-            .list_changes_page(namespace, ChangeSeq(0), None)
+            .list_changes_page(&namespace, ChangeSeq(0), None)
             .expect("list changes");
         assert_eq!(changes.changes.len(), 3);
         assert_eq!(
@@ -966,7 +971,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
 
         let first_page = harness
             .client
-            .list_changes_page(namespace, ChangeSeq(0), Some(2))
+            .list_changes_page(&namespace, ChangeSeq(0), Some(2))
             .expect("list first changes page");
         assert_eq!(first_page.after_seq, ChangeSeq(0));
         assert_eq!(first_page.through_seq, ChangeSeq(2));
@@ -976,7 +981,7 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
         let second_page = harness
             .client
             .list_changes_page(
-                namespace,
+                &namespace,
                 first_page.next_after_seq.expect("next page"),
                 Some(2),
             )
@@ -1010,12 +1015,12 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
-        let target = NamespacePath::parse("demo:/docs/rev.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/docs/rev.txt").expect("target");
         harness
             .client
             .put_file_bytes(
@@ -1050,7 +1055,7 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
             b"one"
         );
 
-        let moved = NamespacePath::parse("demo:/docs/moved.txt").expect("moved");
+        let moved = NamespacePath::parse("demo", "/docs/moved.txt").expect("moved");
         harness
             .client
             .move_path(
@@ -1066,13 +1071,13 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
         ));
         let inode_revisions = harness
             .client
-            .list_file_revisions_for_inode_page(namespace, entry.inode_id, None, None)
+            .list_file_revisions_for_inode_page(&namespace, entry.inode_id, None, None)
             .expect("inode revisions");
         assert_eq!(inode_revisions.revisions.len(), 2);
         assert_eq!(
             harness
                 .client
-                .read_file_revision_bytes_for_inode(namespace, entry.inode_id, RevisionNo(2))
+                .read_file_revision_bytes_for_inode(&namespace, entry.inode_id, RevisionNo(2))
                 .expect("read inode revision"),
             b"two"
         );
@@ -1091,11 +1096,11 @@ async fn http_revision_routes_list_read_and_restore_by_path_and_inode() {
         harness
             .client
             .restore_file_revision_for_inode(
-                namespace,
+                &namespace,
                 entry.inode_id,
                 RevisionNo(2),
                 RevisionNo(3),
-                "c_restore_inode_revision_0001",
+                &CommitId::parse("c_restore_inode_revision_0001").expect("valid commit id"),
             )
             .expect("inode restore");
         assert_eq!(
@@ -1123,19 +1128,19 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
-        let target = NamespacePath::parse("demo:/restore.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/restore.txt").expect("target");
 
         let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, namespace, b"first bytes\n");
+            stage_uploaded_content_ref(&harness.client, &namespace, b"first bytes\n");
         harness
             .client
             .commit_operations(
-                namespace,
+                &namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::parse("req-restore-missing-source-create")
                         .expect("valid commit id"),
@@ -1156,7 +1161,7 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             .inode_id;
 
         match harness.client.commit_operations(
-            namespace,
+            &namespace,
             &ApiCommitRequest {
                 commit_id: CommitId::parse("req-restore-missing-source-restore")
                     .expect("valid commit id"),
@@ -1193,14 +1198,14 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
 
         let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, namespace, b"first payload\n");
+            stage_uploaded_content_ref(&harness.client, &namespace, b"first payload\n");
         let first_request = ApiCommitRequest {
             commit_id: CommitId::parse("req-phase-2a-conflict").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -1213,11 +1218,11 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
         };
         harness
             .client
-            .commit_operations(namespace, &first_request)
+            .commit_operations(&namespace, &first_request)
             .expect("first commit");
 
         let second_content_ref =
-            stage_uploaded_content_ref(&harness.client, namespace, b"second payload\n");
+            stage_uploaded_content_ref(&harness.client, &namespace, b"second payload\n");
         let conflicting_request = ApiCommitRequest {
             commit_id: first_request.commit_id.clone(),
             preconditions: first_request.preconditions.clone(),
@@ -1231,7 +1236,7 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
 
         match harness
             .client
-            .commit_operations(namespace, &conflicting_request)
+            .commit_operations(&namespace, &conflicting_request)
         {
             Err(ClientError::Api {
                 code,
@@ -1268,17 +1273,17 @@ async fn http_commit_name_collision_reports_readable_error_message() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         harness
             .client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
 
-        let content_ref = stage_uploaded_content_ref(&harness.client, namespace, b"taken bytes\n");
+        let content_ref = stage_uploaded_content_ref(&harness.client, &namespace, b"taken bytes\n");
         harness
             .client
             .commit_operations(
-                namespace,
+                &namespace,
                 &ApiCommitRequest {
                     commit_id: CommitId::parse("req-collision-create").expect("valid commit id"),
                     preconditions: Vec::new(),
@@ -1293,7 +1298,7 @@ async fn http_commit_name_collision_reports_readable_error_message() {
             .expect("create file");
 
         match harness.client.commit_operations(
-            namespace,
+            &namespace,
             &ApiCommitRequest {
                 commit_id: CommitId::parse("req-collision-repeat").expect("valid commit id"),
                 preconditions: Vec::new(),
@@ -1346,10 +1351,10 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let target = NamespacePath::parse("demo:/docs/retry.txt").expect("target");
-        let commit_id = "req-v1-put";
+        let target = NamespacePath::parse("demo", "/docs/retry.txt").expect("target");
+        let commit_id = CommitId::parse("req-v1-put").expect("valid commit id");
 
         let first = harness
             .client
@@ -1357,7 +1362,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
                 &target,
                 b"stable bytes\n",
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id(commit_id),
+                &MutationOptions::with_commit_id(commit_id.clone()),
             )
             .expect("first put");
         assert!(first.committed_seq.0 >= 1);
@@ -1368,7 +1373,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
                 &target,
                 b"stable bytes\n",
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id(commit_id),
+                &MutationOptions::with_commit_id(commit_id.clone()),
             )
             .expect("repeat put");
         assert_eq!(repeated, first);
@@ -1409,22 +1414,24 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let source = NamespacePath::parse("demo:/docs/source.txt").expect("source");
+        let source = NamespacePath::parse("demo", "/docs/source.txt").expect("source");
         harness
             .client
             .write_file_bytes(&source, b"source bytes\n", &MutationOptions::default())
             .expect("seed source");
 
-        let copied = NamespacePath::parse("demo:/docs/copied.txt").expect("copied");
+        let copied = NamespacePath::parse("demo", "/docs/copied.txt").expect("copied");
         let copy_first = harness
             .client
             .copy_path(
                 &source,
                 &copied,
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id("req-v1-copy"),
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-copy").expect("valid commit id"),
+                ),
             )
             .expect("copy first");
         let copy_repeated = harness
@@ -1433,7 +1440,9 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
                 &source,
                 &copied,
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id("req-v1-copy"),
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-copy").expect("valid commit id"),
+                ),
             )
             .expect("copy repeat");
         assert_eq!(copy_repeated, copy_first);
@@ -1442,14 +1451,16 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         assert_ne!(source_entry.inode_id, copied_entry.inode_id);
         assert_eq!(source_entry.content_ref, copied_entry.content_ref);
 
-        let moved = NamespacePath::parse("demo:/docs/moved.txt").expect("moved");
+        let moved = NamespacePath::parse("demo", "/docs/moved.txt").expect("moved");
         let move_first = harness
             .client
             .move_path(
                 &copied,
                 &moved,
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id("req-v1-move"),
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-move").expect("valid commit id"),
+                ),
             )
             .expect("move first");
         let move_repeated = harness
@@ -1458,7 +1469,9 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
                 &copied,
                 &moved,
                 DestinationBehavior::NoReplace,
-                &MutationOptions::with_commit_id("req-v1-move"),
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-move").expect("valid commit id"),
+                ),
             )
             .expect("move repeat");
         assert_eq!(move_repeated, move_first);
@@ -1471,11 +1484,21 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
 
         let delete_first = harness
             .client
-            .delete_path(&moved, &MutationOptions::with_commit_id("req-v1-delete"))
+            .delete_path(
+                &moved,
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-delete").expect("valid commit id"),
+                ),
+            )
             .expect("delete first");
         let delete_repeated = harness
             .client
-            .delete_path(&moved, &MutationOptions::with_commit_id("req-v1-delete"))
+            .delete_path(
+                &moved,
+                &MutationOptions::with_commit_id(
+                    CommitId::parse("req-v1-delete").expect("valid commit id"),
+                ),
+            )
             .expect("delete repeat");
         assert_eq!(delete_repeated, delete_first);
         match harness.client.stat_path(&moved) {
@@ -1502,15 +1525,15 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let child = NamespacePath::parse("demo:/docs/child.txt").expect("child path");
+        let child = NamespacePath::parse("demo", "/docs/child.txt").expect("child path");
         harness
             .client
             .write_file_bytes(&child, b"child", &MutationOptions::default())
             .expect("write child");
 
-        let dir = NamespacePath::parse("demo:/docs").expect("dir path");
+        let dir = NamespacePath::parse("demo", "/docs").expect("dir path");
         let non_recursive = harness
             .client
             .delete_path(&dir, &MutationOptions::default())
@@ -1551,9 +1574,9 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
     tokio::task::spawn_blocking(move || {
         harness
             .client
-            .create_namespace("demo")
+            .create_namespace(&namespace_id("demo"))
             .expect("create namespace");
-        let source = NamespacePath::parse("demo:/docs/source.txt").expect("source");
+        let source = NamespacePath::parse("demo", "/docs/source.txt").expect("source");
         harness
             .client
             .write_file_bytes(&source, b"source", &MutationOptions::default())
@@ -1626,36 +1649,43 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     let server_url = harness.server_url.clone();
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
-        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        let namespace = namespace_id("demo");
+        let target = NamespacePath::parse("demo", "/docs/hello.txt").expect("target");
         client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
         client
             .write_file_bytes(&target, b"hello admin\n", &MutationOptions::default())
             .expect("write file");
 
-        let first = post_checkpoint(&server_url, namespace).expect("first checkpoint");
+        let first = post_checkpoint(&server_url, namespace.as_str()).expect("first checkpoint");
         assert!(CheckpointId::parse(first.checkpoint_id.as_str()).is_ok());
         assert_eq!(first.checkpoint_seq, ChangeSeq(1));
         assert_eq!(first.manifest_id, ManifestId(1));
         assert_eq!(first.current_manifest_id, Some(first.manifest_id));
 
-        let repeated = post_checkpoint(&server_url, namespace).expect("repeat checkpoint");
+        let repeated = post_checkpoint(&server_url, namespace.as_str()).expect("repeat checkpoint");
         assert_eq!(repeated, first);
 
         // Release is idempotent the same way: the first call flips the
         // record, the repeat observes the settled end state.
-        let released =
-            post_checkpoint_release(&server_url, namespace, first.checkpoint_id.as_str())
-                .expect("release checkpoint");
+        let released = post_checkpoint_release(
+            &server_url,
+            namespace.as_str(),
+            first.checkpoint_id.as_str(),
+        )
+        .expect("release checkpoint");
         assert!(released.was_active);
-        let released_again =
-            post_checkpoint_release(&server_url, namespace, first.checkpoint_id.as_str())
-                .expect("repeat release");
+        let released_again = post_checkpoint_release(
+            &server_url,
+            namespace.as_str(),
+            first.checkpoint_id.as_str(),
+        )
+        .expect("repeat release");
         assert!(!released_again.was_active);
-        let bogus_release = post_checkpoint_release(&server_url, namespace, "not-a-checkpoint-id")
-            .expect_err("malformed checkpoint id");
+        let bogus_release =
+            post_checkpoint_release(&server_url, namespace.as_str(), "not-a-checkpoint-id")
+                .expect_err("malformed checkpoint id");
         assert_eq!(bogus_release.code, "invalid_request");
 
         // The GC grace window's derived safety floor is enforced at the API:
@@ -1669,23 +1699,24 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
         assert_eq!(unsafe_gc.code, "invalid_request");
         assert!(unsafe_gc.message.contains("derived safety minimum"));
 
-        let advanced = post_retention_advance(&server_url, namespace).expect("advance retention");
+        let advanced =
+            post_retention_advance(&server_url, namespace.as_str()).expect("advance retention");
         assert_eq!(advanced.retention_floor_seq, ChangeSeq(1));
 
         let repeated_advance =
-            post_retention_advance(&server_url, namespace).expect("repeat retention");
+            post_retention_advance(&server_url, namespace.as_str()).expect("repeat retention");
         assert_eq!(repeated_advance, advanced);
 
         let bytes = client.read_file_bytes(&target).expect("read file");
         assert_eq!(bytes, b"hello admin\n");
 
-        match client.list_changes_page(namespace, ChangeSeq(0), None) {
+        match client.list_changes_page(&namespace, ChangeSeq(0), None) {
             Err(ClientError::Api { code, .. }) => assert_eq!(code, "rebootstrap_required"),
             other => unreachable!("expected rebootstrap_required, got {other:?}"),
         }
 
         let empty = client
-            .list_changes_page(namespace, ChangeSeq(1), None)
+            .list_changes_page(&namespace, ChangeSeq(1), None)
             .expect("changes after floor");
         assert_eq!(empty.changes, Vec::new());
     })
@@ -1708,19 +1739,19 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
     let server_url = harness.server_url.clone();
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
-        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/docs/hello.txt").expect("target");
         client
             .write_file_bytes(&target, b"hello gc\n", &MutationOptions::default())
             .expect("write file");
-        post_checkpoint(&server_url, namespace).expect("checkpoint");
+        post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
         // A freshly written namespace sits entirely inside the grace
         // window: the pass runs, deletes nothing, and reads keep working.
-        let report = post_gc(&server_url, namespace).expect("gc pass");
+        let report = post_gc(&server_url, namespace.as_str()).expect("gc pass");
         assert_eq!(report.deleted_wal_segments, 0);
         assert_eq!(report.deleted_metadata_tables, 0);
         assert_eq!(report.deleted_manifests, 0);
@@ -1749,18 +1780,18 @@ async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
     let server_url = harness.server_url.clone();
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
-        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/docs/hello.txt").expect("target");
         client
             .write_file_bytes(&target, b"hello tick\n", &MutationOptions::default())
             .expect("write file");
 
         // One WAL segment sits far below the default threshold.
-        let idle = post_maintenance_tick(&server_url, namespace).expect("idle tick");
-        assert_eq!(idle.namespace_id.as_str(), namespace);
+        let idle = post_maintenance_tick(&server_url, namespace.as_str()).expect("idle tick");
+        assert_eq!(idle.namespace_id, namespace);
         assert_eq!(idle.status_before.wal_tail_segments, 1);
         assert_eq!(idle.outcome, loonfs_api::MaintenanceTickOutcome::NotNeeded);
         assert!(idle.gc.is_none());
@@ -1769,7 +1800,7 @@ async fn http_admin_maintenance_tick_reports_outcomes_not_errors() {
         // and runs the opted-in GC pass.
         let forced: loonfs_api::MaintenanceTickResponse = client
             .maintenance_tick(
-                namespace,
+                &namespace,
                 &loonfs_api::MaintenanceTickRequest {
                     max_wal_tail_segments: Some(1),
                     gc: Some(loonfs_api::GcRequest::default()),
@@ -1808,12 +1839,13 @@ async fn http_admin_retention_advance_uses_initial_manifest_after_create() {
     let server_url = harness.server_url.clone();
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
+        let namespace = namespace_id("demo");
         client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
 
-        let advanced = post_retention_advance(&server_url, namespace).expect("advance retention");
+        let advanced =
+            post_retention_advance(&server_url, namespace.as_str()).expect("advance retention");
         assert_eq!(advanced.retention_floor_seq, ChangeSeq(0));
     })
     .await
@@ -1849,26 +1881,24 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
     let store_key_prefix = harness.store_key_prefix.clone();
 
     tokio::task::spawn_blocking(move || {
-        let namespace = "demo";
-        let target = NamespacePath::parse("demo:/docs/hello.txt").expect("target");
+        let namespace = namespace_id("demo");
+        let target = NamespacePath::parse("demo", "/docs/hello.txt").expect("target");
         client
-            .create_namespace(namespace)
+            .create_namespace(&namespace)
             .expect("create namespace");
         client
             .write_file_bytes(&target, b"hello\n", &MutationOptions::default())
             .expect("write file");
-        post_checkpoint(&server_url, namespace).expect("checkpoint");
+        post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
         let store = ConfiguredObjectStore::local_fs(&store_root, store_key_prefix.as_deref())
             .expect("construct store");
-        let namespace_id = NamespaceId::parse(namespace).expect("valid namespace id");
         let root = block_on(loonfs_core::control::load_namespace_metadata_root_control(
-            &store,
-            &namespace_id,
+            &store, &namespace,
         ))
         .expect("metadata root");
         block_on(store.put_overwrite(
-            &metadata_manifest_object(namespace, &root.state.manifest_object_id),
+            &metadata_manifest_object(namespace.as_str(), &root.state.manifest_object_id),
             Bytes::from_static(br#"{"bad":"json"}"#),
         ))
         .expect("corrupt manifest");
@@ -1910,15 +1940,19 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
     let client_b = server_b.client.clone();
 
     tokio::task::spawn_blocking(move || {
-        client_a.create_namespace("demo").expect("create namespace");
-        let host_a_target = NamespacePath::parse("demo:/docs/host-a.txt").expect("host a target");
+        client_a
+            .create_namespace(&namespace_id("demo"))
+            .expect("create namespace");
+        let host_a_target =
+            NamespacePath::parse("demo", "/docs/host-a.txt").expect("host a target");
         client_a
             .write_file_bytes(&host_a_target, b"host a\n", &MutationOptions::default())
             .expect("host a write");
 
         // Server B's first semantic write acquires the epoch immediately:
         // there is no lease to wait out, only last-writer-wins fencing.
-        let host_b_target = NamespacePath::parse("demo:/docs/host-b.txt").expect("host b target");
+        let host_b_target =
+            NamespacePath::parse("demo", "/docs/host-b.txt").expect("host b target");
         let moved = client_b
             .move_path(
                 &host_a_target,
@@ -1935,7 +1969,8 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
 
         // Server A's session is fenced terminally: its writes fail with
         // `writer_fenced` and keep failing, with no silent reacquisition.
-        let host_c_target = NamespacePath::parse("demo:/docs/host-c.txt").expect("host c target");
+        let host_c_target =
+            NamespacePath::parse("demo", "/docs/host-c.txt").expect("host c target");
         for attempt in 0..2 {
             match client_a.write_file_bytes(
                 &host_c_target,
@@ -2179,21 +2214,29 @@ fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>
     }
 }
 
-fn stage_uploaded_content_ref(client: &Client, namespace: &str, file_bytes: &[u8]) -> ContentRef {
+fn namespace_id(value: &str) -> NamespaceId {
+    NamespaceId::parse(value).expect("valid namespace id")
+}
+
+fn stage_uploaded_content_ref(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    file_bytes: &[u8],
+) -> ContentRef {
     let begin = client
-        .begin_upload(namespace, &BeginUploadRequest::default())
+        .begin_upload(namespace_id, &BeginUploadRequest::default())
         .expect("begin upload");
     let staged = client
-        .upload_content(namespace, begin.upload_id.as_str(), file_bytes)
+        .upload_content(namespace_id, begin.upload_id.as_str(), file_bytes)
         .expect("upload content");
     let complete_request = CompleteUploadRequest {
         content_ref: staged.content_ref,
     };
     let complete = client
-        .complete_upload(namespace, begin.upload_id.as_str(), &complete_request)
+        .complete_upload(namespace_id, begin.upload_id.as_str(), &complete_request)
         .expect("complete upload");
     let repeated = client
-        .complete_upload(namespace, begin.upload_id.as_str(), &complete_request)
+        .complete_upload(namespace_id, begin.upload_id.as_str(), &complete_request)
         .expect("repeat complete upload");
     assert_eq!(repeated.namespace_id, complete.namespace_id);
     assert_eq!(repeated.upload_id, complete.upload_id);

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3632,7 +3632,7 @@
         ],
         "properties": {
           "namespace_id": {
-            "type": "string",
+            "$ref": "#/components/schemas/NamespaceId",
             "description": "Durable namespace id to create."
           }
         }
@@ -4156,7 +4156,7 @@
         ],
         "properties": {
           "new_namespace_id": {
-            "type": "string",
+            "$ref": "#/components/schemas/NamespaceId",
             "description": "Durable namespace id for the fork target."
           }
         }


### PR DESCRIPTION
The server already parses ids and paths once at its extractors, but the client and CLI still shuttled strings: NamespacePath held two public Strings, MutationOptions carried Option<String> for its commit id, every client method re-validated the namespace id per call (27 parse-and-discard sites), and the CLI hand-rolled a second path grammar that missed the control-character and length checks. Now NamespacePath holds a private NamespaceId and AbsolutePath pair, Client and Backend methods take &NamespaceId, the commit id is typed end to end, and the two remaining String wire fields (the create and fork request ids) become NamespaceId — wire JSON is unchanged, and the OpenAPI document just swaps two inline strings for schema refs (regenerated). The CLI parses each id and path exactly once at command resolution, and its path normalizer now delegates to the API grammar, so control characters and oversized names are rejected up front under the same rules the server applies. Stacks on conor/pagination-honesty.