### PR TITLE
fix(client,server,cli): every construction path runs the same validation

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -679,7 +679,8 @@ impl RemoteTarget {
             auth_token: auth_token.map(ToOwned::to_owned),
             request_timeout_ms: None,
             disable_transient_retry: no_retry,
-        });
+        })
+        .map_err(|error| CliError::invalid_config(error.to_string()))?;
         Ok(Self {
             backend: RemoteBackend::new(client),
         })

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -1,8 +1,8 @@
 //! The CLI config file: profiles, defaults, and strict TOML loading.
 
 use crate::error::CliError;
-use http::Uri;
 use loonfs_api::NamespaceId;
+use loonfs_client::ClientConfig;
 use loonfs_objectstore::{SecretString, StoreConfigError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -307,25 +307,15 @@ fn validate_default_namespace(field: &str, value: &str) -> Result<(), CliError> 
 }
 
 fn validate_http_url(field: &str, value: &str) -> Result<(), CliError> {
-    require_non_empty(field, value)?;
-    let uri = value
-        .trim()
-        .parse::<Uri>()
-        .map_err(|err| CliError::invalid_config(format!("invalid `{field}`: {err}")))?;
-    let scheme = uri
-        .scheme_str()
-        .ok_or_else(|| CliError::invalid_config(format!("invalid `{field}`: missing scheme")))?;
-    if !matches!(scheme, "http" | "https") {
-        return Err(CliError::invalid_config(format!(
-            "invalid `{field}`: scheme must be http or https, got `{scheme}`"
-        )));
+    // One URL grammar authority: the client's own config validation.
+    ClientConfig {
+        server_url: value.to_owned(),
+        auth_token: None,
+        request_timeout_ms: None,
+        disable_transient_retry: false,
     }
-    if uri.host().is_none() {
-        return Err(CliError::invalid_config(format!(
-            "invalid `{field}`: missing host"
-        )));
-    }
-    Ok(())
+    .validate()
+    .map_err(|error| CliError::invalid_config(format!("invalid `{field}`: {error}")))
 }
 
 #[cfg(test)]

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -52,7 +52,10 @@ impl ClientConfig {
         Ok(config)
     }
 
-    fn validate(&self) -> Result<(), ClientError> {
+    /// Validates field invariants. [`Self::load`] and
+    /// [`Client::new`](crate::Client::new) both run this, so a file-loaded
+    /// config and a directly built one cannot diverge in what they accept.
+    pub fn validate(&self) -> Result<(), ClientError> {
         validate_absolute_http_url("server_url", &self.server_url)?;
         if let Some(token) = &self.auth_token {
             if token.trim().is_empty() {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -89,21 +89,24 @@ impl MutationOptions {
 }
 
 impl Client {
-    /// Creates a client from validated config.
-    pub fn new(config: ClientConfig) -> Self {
+    /// Creates a client, validating the config exactly as
+    /// [`ClientConfig::load`] does — direct Rust construction cannot bypass
+    /// validation.
+    pub fn new(config: ClientConfig) -> Result<Self, ClientError> {
+        config.validate()?;
         let mut agent = ureq::AgentBuilder::new()
             .timeout_read(IO_INACTIVITY_TIMEOUT)
             .timeout_write(IO_INACTIVITY_TIMEOUT);
         if let Some(timeout_ms) = config.request_timeout_ms {
             agent = agent.timeout(std::time::Duration::from_millis(timeout_ms));
         }
-        Self {
+        Ok(Self {
             base_url: config.server_url.trim().trim_end_matches('/').to_owned(),
             auth_token: config.auth_token,
             agent: agent.build(),
             transient_retry: !config.disable_transient_retry,
             capabilities: Arc::new(OnceLock::new()),
-        }
+        })
     }
 
     /// Returns the server's capability document, fetched once and cached for
@@ -916,6 +919,29 @@ fn append_query_param(url: &mut String, has_query: &mut bool, name: &str, value:
 #[cfg(test)]
 mod tests {
 
+    /// `Client::new` runs the same validation as `ClientConfig::load`, so a
+    /// directly built config cannot bypass it.
+    #[test]
+    fn construction_validates_config_like_load_does() {
+        let error = super::Client::new(super::ClientConfig {
+            server_url: "ftp://example.com".to_owned(),
+            auth_token: None,
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+        })
+        .expect_err("ftp scheme must be rejected");
+        assert!(
+            matches!(
+                &error,
+                super::ClientError::ConfigValidation {
+                    field: "server_url",
+                    ..
+                }
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+
     /// Configs are strict like everywhere else in the workspace: a typo'd
     /// key fails decode instead of silently producing an unauthenticated
     /// client.
@@ -996,7 +1022,8 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: false,
-        });
+        })
+        .expect("valid client config");
         let error = retrying
             .namespace_status(&namespace_id)
             .expect_err("dropped connections must fail");
@@ -1011,7 +1038,8 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: true,
-        });
+        })
+        .expect("valid client config");
         single_shot
             .namespace_status(&namespace_id)
             .expect_err("dropped connection must fail without retry");
@@ -1032,7 +1060,8 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: true,
-        });
+        })
+        .expect("valid client config");
         let response = ureq::Response::new(502, "Bad Gateway", "<html>upstream error</html>")
             .expect("synthetic response");
         let error = client.map_error(ureq::Error::Status(502, response));

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -254,8 +254,14 @@ impl ServerConfig {
             })
     }
 
-    fn validate(&self) -> Result<(), ServerConfigError> {
-        let bind = validate_socket_addr("bind", &self.bind)?;
+    /// Parses the bind address; the one authority for that conversion, used
+    /// by validation and by serving.
+    pub(crate) fn bind_addr(&self) -> Result<SocketAddr, ServerConfigError> {
+        validate_socket_addr("bind", &self.bind)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), ServerConfigError> {
+        let bind = self.bind_addr()?;
         require_non_empty("writer_id", &self.writer_id)?;
         require_non_empty("writer_version", &self.writer_version)?;
 

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -145,6 +145,10 @@ impl ServerLifecycle {
 /// Builds the HTTP application: the router that serves requests, and the
 /// lifecycle handle its host must shut down after draining the listener.
 pub async fn app(config: ServerConfig) -> Result<(Router, ServerLifecycle), ServerConfigError> {
+    // The one unavoidable validation point: configs that skipped
+    // `load_server_config` (direct Rust construction) fail here exactly as
+    // file-loaded ones fail at load.
+    config.validate()?;
     let store = config.object_store()?;
     let transfer_issuer = store.transfer_issuer();
     let store = Arc::new(store) as SharedObjectStore;
@@ -417,12 +421,6 @@ fn object_store_metrics_recorder(
 /// Failure starting or running the HTTP server.
 #[derive(Debug, Error)]
 pub enum ServeError {
-    #[error("invalid bind address `{addr}`: {source}")]
-    BindAddr {
-        addr: String,
-        #[source]
-        source: std::net::AddrParseError,
-    },
     #[error("invalid server config: {0}")]
     Config(#[from] ServerConfigError),
     #[error("failed to bind `{addr}`: {source}")]
@@ -451,10 +449,7 @@ pub async fn serve_with_shutdown(
     config: ServerConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), ServeError> {
-    let bind: SocketAddr = config.bind.parse().map_err(|source| ServeError::BindAddr {
-        addr: config.bind.clone(),
-        source,
-    })?;
+    let bind = config.bind_addr()?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -178,6 +178,20 @@ async fn build_handles_installs_jsonl_object_store_metrics_recorder() {
     assert!(!jsonl.contains("namespaces/metrics"));
 }
 
+#[tokio::test]
+async fn app_validates_directly_built_configs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let mut config = test_config(temp_dir.path(), "app-validate-writer");
+    config.max_concurrent_uploads = 0;
+    match super::app(config).await {
+        Err(crate::config::ServerConfigError::InvalidField { field, .. }) => {
+            assert_eq!(field, "max_concurrent_uploads");
+        }
+        Err(other) => panic!("expected invalid field error, got {other:?}"),
+        Ok(_) => panic!("app must reject a zero upload bound"),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
     let temp_dir = tempdir().expect("tempdir");
@@ -197,7 +211,8 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
         auth_token: Some("test-token".to_owned()),
         request_timeout_ms: None,
         disable_transient_retry: false,
-    });
+    })
+    .expect("valid client config");
     tokio::task::spawn_blocking(move || {
         client
             .create_namespace(&namespace_id("demo"))
@@ -582,7 +597,8 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
                 auth_token,
                 request_timeout_ms: None,
                 disable_transient_retry: false,
-            });
+            })
+            .expect("valid client config");
             assert_api_error(
                 client.namespace_status(&namespace_id("demo")),
                 401,
@@ -692,7 +708,8 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        });
+        })
+        .expect("valid client config");
         let target = NamespacePath::parse("demo", "/big.bin").expect("target");
         assert_api_error(
             client.write_file_bytes(&target, &[0u8; 4096], &MutationOptions::default()),
@@ -990,7 +1007,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     };
     let config_for_busy = client_config.clone();
     tokio::task::spawn_blocking(move || {
-        let client = Client::new(config_for_busy);
+        let client = Client::new(config_for_busy).expect("valid client config");
         let target = NamespacePath::parse("demo", "/one.bin").expect("target");
         assert_api_error(
             client.write_file_bytes(&target, &[0u8; 64], &MutationOptions::default()),
@@ -1004,7 +1021,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
 
     drop(held);
     tokio::task::spawn_blocking(move || {
-        let client = Client::new(client_config);
+        let client = Client::new(client_config).expect("valid client config");
         let target = NamespacePath::parse("demo", "/one.bin").expect("target");
         client
             .write_file_bytes(&target, &[0u8; 64], &MutationOptions::default())
@@ -1054,7 +1071,8 @@ async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        });
+        })
+        .expect("valid client config");
         let target = NamespacePath::parse("demo", "/retried.bin").expect("target");
         client
             .write_file_bytes(&target, &[0u8; 64], &MutationOptions::default())
@@ -1108,7 +1126,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     };
     let config_for_busy = client_config.clone();
     tokio::task::spawn_blocking(move || {
-        let client = Client::new(config_for_busy);
+        let client = Client::new(config_for_busy).expect("valid client config");
         let target = NamespacePath::parse("demo", "/note.txt").expect("target");
         assert_api_error(
             client.read_file_bytes(&target),
@@ -1122,7 +1140,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
 
     drop(held);
     tokio::task::spawn_blocking(move || {
-        let client = Client::new(client_config);
+        let client = Client::new(client_config).expect("valid client config");
         let target = NamespacePath::parse("demo", "/note.txt").expect("target");
         let bytes = client
             .read_file_bytes(&target)
@@ -1173,7 +1191,8 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        });
+        })
+        .expect("valid client config");
         assert_api_error(
             client.read_file_bytes(&NamespacePath::parse("demo", "/big.bin").expect("target")),
             413,
@@ -1370,7 +1389,8 @@ async fn start_server(store: SharedObjectStore, root: &Path, writer_id: &str) ->
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        }),
+        })
+        .expect("valid client config"),
         server,
     }
 }

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -305,7 +305,8 @@ async fn start_server(config: ServerConfig) -> TestServer {
             auth_token: Some(AUTH_TOKEN.to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        }),
+        })
+        .expect("valid client config"),
         server_url,
         server,
     }

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -2031,7 +2031,8 @@ async fn start_server(config: ServerConfig) -> TestServer {
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
-        }),
+        })
+        .expect("valid client config"),
         server_url: format!("http://{}", addr),
         store_root,
         store_key_prefix,


### PR DESCRIPTION
Validation depended on how a config was constructed: file-loaded client and server configs were validated, but Client::new accepted anything (its doc just asserted the config was "validated"), and a directly built ServerConfig reached app() unchecked — a zero upload bound became a permanently busy server instead of a startup error. Client::new now returns Result and runs the same ClientConfig::validate that load() runs, app() validates before building anything, and the bind address gets one parsing authority shared by validation and serving (the serve path previously re-parsed it with its own error variant, now deleted). The CLI's hand-rolled URL validator is replaced by a delegation to the client's, so both surfaces accept exactly the same URLs. Stacks on conor/typed-client-surface.