### PR TITLE
refactor(core,loonfs): one WAL-tail policy owns the checkpoint and backpressure thresholds

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -436,7 +436,8 @@ pub struct AdvanceRetentionResponse {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MaintenanceTickRequest {
     /// Flush the visible WAL tail into metadata tables when it reaches this
-    /// many segments.
+    /// many segments. Values above the write-rejection threshold are
+    /// rejected as `invalid_request`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_wal_tail_segments: Option<u64>,
     /// Run the mark-and-sweep garbage collector after the tick's

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -1425,7 +1425,9 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
-    let limit = u32::try_from(crate::commit_engine::WAL_TAIL_BACKPRESSURE_SEGMENTS).expect("limit");
+    let limit =
+        u32::try_from(crate::commit_engine::WalTailPolicy::DEFAULT.reject_writes_at_segments)
+            .expect("limit");
     for round in 0..=limit {
         write_file_bytes(
             &store,

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -59,11 +59,44 @@ impl NamespaceMutationCandidate {
     }
 }
 
-/// Publishes stop being accepted once the WAL tail is far past the default
-/// maintenance checkpoint threshold (4x at defaults). Reads never gate; this
-/// only asks writers to wait for the maintenance a deployment failed to run
-/// (format spec, "Maintenance operations").
-pub(crate) const WAL_TAIL_BACKPRESSURE_SEGMENTS: u64 = 128;
+/// The WAL-tail maintenance policy: one authority for "when do we
+/// checkpoint?" and "when do we stop accepting writes?", so the two
+/// thresholds cannot drift apart.
+///
+/// Reads never gate on tail length; the rejection only asks writers to wait
+/// for the maintenance a deployment failed to run (format spec,
+/// "Maintenance operations").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalTailPolicy {
+    /// Visible WAL-tail length, in segments, at which a maintenance tick
+    /// publishes a checkpoint. The tick fires at or past this length.
+    pub checkpoint_at_segments: u64,
+    /// Visible WAL-tail length past which (strictly greater than) every
+    /// publish surface rejects with `maintenance_required`.
+    pub reject_writes_at_segments: u64,
+}
+
+impl WalTailPolicy {
+    /// The workspace policy: checkpoint at 32 segments, reject past 128.
+    pub const DEFAULT: Self = Self {
+        checkpoint_at_segments: 32,
+        reject_writes_at_segments: 128,
+    };
+}
+
+impl Default for WalTailPolicy {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+// The ordering invariant `0 < checkpoint < reject` holds by construction:
+// a tick must be able to relieve backpressure before writes stop.
+const _: () = assert!(
+    0 < WalTailPolicy::DEFAULT.checkpoint_at_segments
+        && WalTailPolicy::DEFAULT.checkpoint_at_segments
+            < WalTailPolicy::DEFAULT.reject_writes_at_segments,
+);
 
 #[derive(Debug, Clone)]
 pub struct NamespaceCommitEnginePublishResult {
@@ -308,13 +341,14 @@ impl NamespaceCommitEngine {
             }
         };
 
-        if projection.wal_tail_segments > WAL_TAIL_BACKPRESSURE_SEGMENTS {
+        let reject_writes_at_segments = WalTailPolicy::DEFAULT.reject_writes_at_segments;
+        if projection.wal_tail_segments > reject_writes_at_segments {
             let wal_tail_segments = projection.wal_tail_segments;
             self.publish_tail_projection = Some(projection);
             let error = MetadataViewError::MaintenanceRequired {
                 namespace_id: self.namespace_id.clone(),
                 reason: format!(
-                    "wal tail has {wal_tail_segments} segments; publishes resume once maintenance brings it back under {WAL_TAIL_BACKPRESSURE_SEGMENTS}"
+                    "wal tail has {wal_tail_segments} segments; publishes resume once maintenance brings it back under {reject_writes_at_segments}"
                 ),
             };
             return NamespaceCommitEnginePublishResult {

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -102,7 +102,7 @@ pub mod publish {
     pub use crate::commit::{CommitHeadPublishError, SemanticMutationIdentity};
     pub use crate::commit_engine::{
         NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
-        ResultingReadState, SharedWriterSessionState, WriterSessionState,
+        ResultingReadState, SharedWriterSessionState, WalTailPolicy, WriterSessionState,
     };
     pub use crate::path::write::PathMutationIntent;
     pub use crate::protocol::PublishTailOptions;

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -4,9 +4,6 @@
 use crate::trace::{TraceMode, TraceStoreKind};
 use crate::{GramIndexBuildPolicy, MetadataTableCacheConfig, Result, RuntimeError};
 
-/// Default visible WAL-tail length, in segments, at which a maintenance tick
-/// publishes a checkpoint.
-pub(crate) const DEFAULT_MAX_WAL_TAIL_SEGMENTS: u64 = 32;
 /// Default maximum namespaces retained in runtime caches.
 pub(crate) const DEFAULT_MAX_CACHED_NAMESPACES: usize = 64;
 /// Default maximum metadata rows retained across cached WAL-tail projections.

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -40,6 +40,17 @@ impl FsCore {
                 "max_wal_tail_segments must be greater than zero".to_owned(),
             ));
         }
+        // A threshold above the write-rejection cap would make the tick
+        // answer `not needed` while every publish is being rejected — the
+        // one tool that relieves backpressure refusing to act.
+        let reject_writes_at_segments =
+            loonfs_core::publish::WalTailPolicy::DEFAULT.reject_writes_at_segments;
+        if options.max_wal_tail_segments > reject_writes_at_segments {
+            return Err(RuntimeError::Config(format!(
+                "max_wal_tail_segments may not exceed the write-rejection threshold \
+                 ({reject_writes_at_segments})"
+            )));
+        }
 
         let status_before = self.namespace_status(namespace_id).await?;
         let observed_head_seq = status_before.head_seq;

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -2,7 +2,6 @@
 //! plus the wire conversions the server and embedded hosts share so both
 //! transports report identical maintenance shapes.
 
-use crate::config::DEFAULT_MAX_WAL_TAIL_SEGMENTS;
 use crate::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, EffectiveLimit, GcConfig,
     GcReport, InodeId, ManifestId, NamespaceId, NamespaceStatusResponse,
@@ -12,6 +11,7 @@ use loonfs_api::v0::{
     MaintenanceTickOutcome as WireMaintenanceTickOutcome, MaintenanceTickRequest,
     MaintenanceTickResponse,
 };
+use loonfs_core::publish::WalTailPolicy;
 
 /// Options for one maintenance tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,7 +27,7 @@ pub struct MaintenanceTickOptions {
 impl Default for MaintenanceTickOptions {
     fn default() -> Self {
         Self {
-            max_wal_tail_segments: DEFAULT_MAX_WAL_TAIL_SEGMENTS,
+            max_wal_tail_segments: WalTailPolicy::DEFAULT.checkpoint_at_segments,
             gc: None,
         }
     }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -3341,6 +3341,34 @@ fn maintenance_tick_rejects_zero_threshold() {
 }
 
 #[test]
+fn maintenance_tick_rejects_thresholds_above_the_write_rejection_cap() {
+    // A threshold above the cap would make the tick report `not needed`
+    // while every publish is rejected with `maintenance_required`.
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "tick-config-test");
+    let namespace_id = namespace_id();
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let error = fs
+        .maintenance_tick_namespace_blocking(
+            &namespace_id,
+            MaintenanceTickOptions {
+                max_wal_tail_segments: 129,
+                gc: None,
+            },
+        )
+        .expect_err("over-cap threshold should fail");
+    match error {
+        RuntimeError::Config(message) => assert!(
+            message.contains("write-rejection threshold"),
+            "unexpected message: {message}"
+        ),
+        other => panic!("expected config error, got {other:?}"),
+    }
+}
+
+#[test]
 fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -407,7 +407,7 @@ A representative v0 binding is shown below.
 | Release a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent; fork-owned records are rejected) |
 | Flush the WAL tail | `POST /v0/admin/namespaces/{ns}/wal/flush` (folds the visible WAL tail into metadata tables and advances the metadata root; creates no checkpoint record) |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
-| Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; flush races surface as outcomes, not errors) |
+| Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; an override above the write-rejection threshold is rejected as `invalid_request`; flush races surface as outcomes, not errors) |
 | Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; a grace window below the derived safety floor is rejected as `invalid_request`; nothing sweeps without an explicit call) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires the namespace's `index.grams` feature entry) |
 | Enable the gram index | `POST /v0/admin/namespaces/{ns}/index/grams/enable` (publishes the `index.grams` feature entry; backfill and upkeep run through maintenance ticks; idempotent) |

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1385,10 +1385,11 @@ Maintenance **effects** are normative format semantics; maintenance
 **scheduling and triggering** are not. Two behaviors keep an un-administered
 deployment's read costs bounded regardless of scheduling: the reference
 implementation schedules a background maintenance tick after any runtime
-publish that observes the WAL tail at or past the WAL-flush threshold
-(32 segments at defaults), and every publish surface rejects with
-`maintenance_required` once the tail exceeds four times that threshold
-(128 at defaults). Reads never gate on tail length. Bounded reads are the
+publish that observes the WAL tail at or past the WAL-tail policy's
+checkpoint threshold (32 segments at defaults), and every publish surface
+rejects with `maintenance_required` once the tail exceeds the same policy's
+write-rejection threshold (128 at defaults). Reads never gate on tail
+length. Bounded reads are the
 automatic half only: the retention floor never advances on its own, so
 history retention — and the row reclamation that follows it — remains an
 explicit operator decision. An embedded engine where an operator

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4603,7 +4603,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Flush the visible WAL tail into metadata tables when it reaches this\nmany segments.",
+            "description": "Flush the visible WAL tail into metadata tables when it reaches this\nmany segments. Values above the write-rejection threshold are\nrejected as `invalid_request`.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
The checkpoint threshold (32) and the write-rejection cap (128) lived in different crates — the cap was pub(crate) inside loonfs-core, so the two constants could not even see each other, and their 4x relationship existed only in a comment. Both now live in one WalTailPolicy in loonfs-core with the ordering invariant (0 < checkpoint < reject) enforced at compile time, and both comparison directions are preserved exactly (tick at >=, reject strictly past). This also closes a real hole: a maintenance-tick override above the cap previously made the tick answer not_needed while every publish was rejected with maintenance_required — the one tool that relieves backpressure refusing to act; such overrides are now rejected as invalid_request, documented in api.md and the wire field doc (OpenAPI regenerated). The policy stays non-configurable; the spec wording now points at the single policy instead of restating two numbers. Stacks on conor/construction-validation.