### PR TITLE
fix(core): create and fork share one install conflict policy and error mapping

### DIFF
--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -5,10 +5,12 @@ use crate::checkpoint::{
     build_initial_namespace_manifest, load_namespace_manifest_envelope, write_namespace_manifest,
 };
 use crate::context::MutationContext;
+use crate::error::CoreError;
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use crate::metadata::{InodeRecord, MetadataState};
 use crate::namespace::catalog::{
-    namespace_initialization_state, NamespaceInitializationError, NamespaceInitializationState,
+    map_namespace_initialization_error_to_core, namespace_initialization_state,
+    put_completion_descriptor, put_target_namespace_control_object, NamespaceInitializationState,
 };
 use crate::namespace::control::ControlObjectLoadError;
 use crate::namespace::control::{read_head_object, read_metadata_root_object};
@@ -21,7 +23,7 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{
     ChangeSeq, ContentStoreId, ErrorCode, InodeId, InodeKind, NamePolicy, NamespaceId,
-    NamespaceIdValidationError, NamespaceSummary,
+    NamespaceSummary,
 };
 use loonfs_objectstore::keys::{
     content_store_descriptor, metadata_root, namespace_config, wal_floor, wal_head,
@@ -29,12 +31,8 @@ use loonfs_objectstore::keys::{
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
-// Descriptor and Head both wrap ControlObjectLoadError; conversion stays
-// explicit so `?` cannot pick a variant silently.
 #[derive(Debug, Clone, Error)]
 pub enum BootstrapNamespaceError {
-    #[error(transparent)]
-    InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error("holder id must not be empty")]
     EmptyHolderId,
     #[error("writer version must not be empty")]
@@ -46,23 +44,14 @@ pub enum BootstrapNamespaceError {
     #[error("namespace `{namespace_id}` is deleted and its id is retired")]
     NamespaceDeleted { namespace_id: NamespaceId },
     #[error(transparent)]
-    Descriptor(ControlObjectLoadError),
-    #[error("failed to write namespace descriptor object: {0}")]
-    DescriptorWrite(String),
-    #[error("failed to write content store descriptor object: {0}")]
-    ContentStoreWrite(String),
+    Head(#[from] ControlObjectLoadError),
+    /// A failure inside the installation protocol shared with fork — the
+    /// classification probe, a control-object install, debris recovery — or
+    /// engine plumbing such as assembling the mutation context. The wire
+    /// code delegates to [`CoreError::code`](crate::Error::code), so store
+    /// failures keep their failure class.
     #[error(transparent)]
-    Head(ControlObjectLoadError),
-    #[error("failed to write head object: {0}")]
-    HeadWrite(String),
-    #[error("failed to write initial namespace manifest: {0}")]
-    ManifestWrite(String),
-    #[error("failed to clean pre-head debris: {0}")]
-    DebrisCleanup(String),
-    /// An engine failure outside the bootstrap protocol itself, such as
-    /// assembling the mutation context.
-    #[error(transparent)]
-    Core(#[from] crate::error::CoreError),
+    Core(#[from] CoreError),
 }
 
 impl BootstrapNamespaceError {
@@ -73,51 +62,15 @@ impl BootstrapNamespaceError {
     /// [`CoreError::code`](crate::Error::code).
     pub fn code(&self) -> ErrorCode {
         match self {
-            BootstrapNamespaceError::InvalidNamespaceId(_)
-            | BootstrapNamespaceError::EmptyHolderId
+            BootstrapNamespaceError::EmptyHolderId
             | BootstrapNamespaceError::EmptyWriterVersion => ErrorCode::InvalidRequest,
             BootstrapNamespaceError::NamespaceAlreadyExists { .. } => ErrorCode::NamespaceExists,
             BootstrapNamespaceError::NamespacePartiallyInitialized { .. } => {
                 ErrorCode::NamespacePartial
             }
             BootstrapNamespaceError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
-            BootstrapNamespaceError::Descriptor(_)
-            | BootstrapNamespaceError::DescriptorWrite(_)
-            | BootstrapNamespaceError::ContentStoreWrite(_)
-            | BootstrapNamespaceError::Head(_)
-            | BootstrapNamespaceError::HeadWrite(_)
-            | BootstrapNamespaceError::ManifestWrite(_)
-            | BootstrapNamespaceError::DebrisCleanup(_) => ErrorCode::ServerError,
+            BootstrapNamespaceError::Head(_) => ErrorCode::ServerError,
             BootstrapNamespaceError::Core(error) => error.code(),
-        }
-    }
-}
-
-impl From<NamespaceInitializationError> for BootstrapNamespaceError {
-    fn from(value: NamespaceInitializationError) -> Self {
-        match value {
-            NamespaceInitializationError::InvalidNamespaceId(error) => {
-                Self::InvalidNamespaceId(error)
-            }
-            NamespaceInitializationError::InspectNamespaceDescriptor {
-                object_key,
-                message,
-                ..
-            } => Self::DescriptorWrite(format!("failed to inspect `{object_key}`: {message}")),
-            NamespaceInitializationError::InspectNamespaceHead {
-                object_key,
-                message,
-                ..
-            } => Self::HeadWrite(format!("failed to inspect `{object_key}`: {message}")),
-            NamespaceInitializationError::InspectNamespaceControl {
-                object_key,
-                message,
-                ..
-            } => Self::DebrisCleanup(format!("failed to inspect `{object_key}`: {message}")),
-            NamespaceInitializationError::LoadNamespaceDescriptor(error)
-            | NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
-                Self::Descriptor(error)
-            }
         }
     }
 }
@@ -137,11 +90,12 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
 
     let mut recovered_debris = false;
     loop {
-        match namespace_initialization_state(store, namespace_id).await? {
+        match namespace_initialization_state(store, namespace_id)
+            .await
+            .map_err(map_namespace_initialization_error_to_core)?
+        {
             NamespaceInitializationState::Complete => {
-                let head = read_head_object(store, namespace_id)
-                    .await
-                    .map_err(BootstrapNamespaceError::Head)?;
+                let head = read_head_object(store, namespace_id).await?;
                 // A deleted namespace retires its id permanently; re-creation is
                 // refused as deleted, not as existing.
                 if head.envelope.state.state == NamespaceState::Deleted {
@@ -194,11 +148,10 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         &initial_head,
         &context.writer_version,
     )
-    .await
-    .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
+    .await?;
     write_namespace_manifest(store, &initial_manifest)
         .await
-        .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
+        .map_err(CoreError::MetadataProjection)?;
 
     let root_envelope = MetadataRootEnvelope::from_state(
         ControlObjectKind::MetadataRoot,
@@ -212,16 +165,16 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
             updated_at_ms: context.now_ms,
         },
     )
-    .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
-    let root_bytes = encode_control_object(&root_envelope)
-        .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
-    store
-        .put_if_absent(
-            &metadata_root(namespace_id.as_str()),
-            Bytes::from(root_bytes),
-        )
-        .await
-        .map_err(|err| pre_head_write_error(namespace_id, err))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build metadata root envelope: {err}")))?;
+    put_target_namespace_control_object(
+        store,
+        namespace_id,
+        &metadata_root(namespace_id.as_str()),
+        &encode_control_object(&root_envelope).map_err(|err| {
+            CoreError::Internal(format!("failed to encode metadata root object: {err}"))
+        })?,
+    )
+    .await?;
 
     let floor_envelope = WalFloorEnvelope::from_state(
         ControlObjectKind::WalFloor,
@@ -233,28 +186,31 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
             updated_at_ms: context.now_ms,
         },
     )
-    .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
-    let floor_bytes = encode_control_object(&floor_envelope)
-        .map_err(|err| BootstrapNamespaceError::ManifestWrite(err.to_string()))?;
-    store
-        .put_if_absent(&wal_floor(namespace_id.as_str()), Bytes::from(floor_bytes))
-        .await
-        .map_err(|err| pre_head_write_error(namespace_id, err))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build wal floor envelope: {err}")))?;
+    put_target_namespace_control_object(
+        store,
+        namespace_id,
+        &wal_floor(namespace_id.as_str()),
+        &encode_control_object(&floor_envelope).map_err(|err| {
+            CoreError::Internal(format!("failed to encode wal floor object: {err}"))
+        })?,
+    )
+    .await?;
 
     let head_envelope = HeadStateEnvelope::from_state(
         ControlObjectKind::WalHead,
         &context.writer_version,
         initial_head,
     )
-    .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
-    let head_bytes = encode_control_object(&head_envelope)
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
-
-    let head_key = wal_head(namespace_id.as_str());
-    store
-        .put_if_absent(&head_key, Bytes::from(head_bytes))
-        .await
-        .map_err(|err| BootstrapNamespaceError::HeadWrite(err.to_string()))?;
+    .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
+    put_target_namespace_control_object(
+        store,
+        namespace_id,
+        &wal_head(namespace_id.as_str()),
+        &encode_control_object(&head_envelope)
+            .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?,
+    )
+    .await?;
 
     let content_store_id = create_new_content_store(store, context).await?;
     let namespace_descriptor_envelope = NamespaceConfigEnvelope::from_state(
@@ -266,35 +222,26 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
             name_policy: NamePolicy::default(),
         },
     )
-    .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
-    let namespace_descriptor_bytes = encode_control_object(&namespace_descriptor_envelope)
-        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
-
-    let descriptor_key = namespace_config(namespace_id.as_str());
-    store
-        .put_if_absent(&descriptor_key, Bytes::from(namespace_descriptor_bytes))
-        .await
-        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace descriptor envelope: {err}"
+        ))
+    })?;
+    put_target_namespace_control_object(
+        store,
+        namespace_id,
+        &namespace_config(namespace_id.as_str()),
+        &encode_control_object(&namespace_descriptor_envelope).map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to encode namespace descriptor object: {err}"
+            ))
+        })?,
+    )
+    .await?;
 
     Ok(NamespaceSummary {
         namespace_id: namespace_id.clone(),
     })
-}
-
-/// Losing a pre-head put-if-absent means another create is mid-flight (or
-/// crashed moments ago): the id is partially initialized, not broken.
-fn pre_head_write_error(
-    namespace_id: &NamespaceId,
-    error: ObjectStoreError,
-) -> BootstrapNamespaceError {
-    match error {
-        ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. } => {
-            BootstrapNamespaceError::NamespacePartiallyInitialized {
-                namespace_id: namespace_id.clone(),
-            }
-        }
-        other => BootstrapNamespaceError::ManifestWrite(other.to_string()),
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -316,19 +263,19 @@ pub(super) async fn recover_pre_head_debris<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     now_ms: u64,
-) -> Result<PreHeadRecovery, BootstrapNamespaceError> {
+) -> Result<PreHeadRecovery, CoreError> {
     let prefix = format!("namespaces/{}/", namespace_id.as_str());
     let head_key = wal_head(namespace_id.as_str());
     let keys = store
         .list_prefix(&prefix)
         .await
-        .map_err(|err| BootstrapNamespaceError::DebrisCleanup(err.to_string()))?;
+        .map_err(|err| CoreError::store(&prefix, &err))?;
     let mut newest = 0u64;
     for key in &keys {
         let Some(metadata) = store
             .head(key)
             .await
-            .map_err(|err| BootstrapNamespaceError::DebrisCleanup(err.to_string()))?
+            .map_err(|err| CoreError::store(key.as_str(), &err))?
         else {
             continue;
         };
@@ -345,7 +292,7 @@ pub(super) async fn recover_pre_head_debris<S: ObjectStore + ?Sized>(
         let head_exists = store
             .head(&head_key)
             .await
-            .map_err(|err| BootstrapNamespaceError::DebrisCleanup(err.to_string()))?
+            .map_err(|err| CoreError::store(&head_key, &err))?
             .is_some();
         if head_exists {
             // A concurrent attempt linearized while this one was cleaning;
@@ -355,7 +302,7 @@ pub(super) async fn recover_pre_head_debris<S: ObjectStore + ?Sized>(
         store
             .delete(key)
             .await
-            .map_err(|err| BootstrapNamespaceError::DebrisCleanup(err.to_string()))?;
+            .map_err(|err| CoreError::store(key.as_str(), &err))?;
     }
     Ok(PreHeadRecovery::Cleaned)
 }
@@ -418,22 +365,18 @@ async fn complete_post_head_bootstrap<S: ObjectStore + ?Sized>(
             name_policy: NamePolicy::default(),
         },
     )
-    .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
+    .map_err(|err| {
+        CoreError::Internal(format!(
+            "failed to build namespace descriptor envelope: {err}"
+        ))
+    })?;
     let namespace_descriptor_bytes = encode_control_object(&namespace_descriptor_envelope)
-        .map_err(|err| BootstrapNamespaceError::DescriptorWrite(err.to_string()))?;
-    match store
-        .put_if_absent(
-            &namespace_config(namespace_id.as_str()),
-            Bytes::from(namespace_descriptor_bytes),
-        )
-        .await
-    {
-        // A raced completion wrote it first; the namespace is complete
-        // either way.
-        Ok(_)
-        | Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {}
-        Err(err) => return Err(BootstrapNamespaceError::DescriptorWrite(err.to_string())),
-    }
+        .map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to encode namespace descriptor object: {err}"
+            ))
+        })?;
+    put_completion_descriptor(store, namespace_id, &namespace_descriptor_bytes).await?;
     Ok(NamespaceSummary {
         namespace_id: namespace_id.clone(),
     })
@@ -444,7 +387,7 @@ const CONTENT_STORE_ID_RETRY_LIMIT: usize = 8;
 async fn create_new_content_store<S: ObjectStore + ?Sized>(
     store: &S,
     context: &MutationContext,
-) -> Result<ContentStoreId, BootstrapNamespaceError> {
+) -> Result<ContentStoreId, CoreError> {
     for _attempt in 0..CONTENT_STORE_ID_RETRY_LIMIT {
         let content_store_id = ContentStoreId::generate();
         let descriptor = ContentStoreDescriptorEnvelope::from_state(
@@ -454,20 +397,27 @@ async fn create_new_content_store<S: ObjectStore + ?Sized>(
                 content_store_id: content_store_id.clone(),
             },
         )
-        .map_err(|err| BootstrapNamespaceError::ContentStoreWrite(err.to_string()))?;
-        let bytes = encode_control_object(&descriptor)
-            .map_err(|err| BootstrapNamespaceError::ContentStoreWrite(err.to_string()))?;
+        .map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to build content store descriptor envelope: {err}"
+            ))
+        })?;
+        let bytes = encode_control_object(&descriptor).map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to encode content store descriptor object: {err}"
+            ))
+        })?;
         let key = content_store_descriptor(content_store_id.as_str());
         match store.put_if_absent(&key, Bytes::from(bytes)).await {
             Ok(_) => return Ok(content_store_id),
             Err(
                 ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. },
             ) => continue,
-            Err(err) => return Err(BootstrapNamespaceError::ContentStoreWrite(err.to_string())),
+            Err(err) => return Err(CoreError::store(&key, &err)),
         }
     }
 
-    Err(BootstrapNamespaceError::ContentStoreWrite(
+    Err(CoreError::Internal(
         "content store id generation collided repeatedly".to_owned(),
     ))
 }

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -1,14 +1,17 @@
 //! The namespace catalog: the immutable descriptor pair (namespace config
-//! and content-store descriptor) loaded once and reused for a session.
+//! and content-store descriptor) loaded once and reused for a session, the
+//! initialization-state probe over that pair, and the installation writes
+//! namespace create and fork share.
 
-use crate::error::StoreFailureClass;
+use crate::error::{CoreError, MetadataProjectionLoadError, StoreFailureClass};
 use crate::namespace::control::{
     read_content_store_descriptor_object, read_namespace_descriptor_object, ControlObjectLoadError,
 };
+use bytes::Bytes;
 use loonfs_api::wire::control::NamespaceConfigState;
 use loonfs_api::{ContentStoreId, NamespaceId, NamespaceIdValidationError};
 use loonfs_objectstore::keys::{metadata_root, namespace_config, wal_floor, wal_head};
-use loonfs_objectstore::ObjectStore;
+use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 use thiserror::Error;
 
 // Both variants share ControlObjectLoadError; conversion stays explicit so
@@ -186,5 +189,113 @@ pub(crate) async fn namespace_initialization_state<S: ObjectStore + ?Sized>(
             Ok(NamespaceInitializationState::Complete)
         }
         _ => Ok(NamespaceInitializationState::Partial),
+    }
+}
+
+/// The one classification-probe failure mapping every entry point (create,
+/// fork, status, uploads) shares: store failures keep their
+/// [`StoreFailureClass`], so the same probe failure answers the same wire
+/// code — `permission_denied` for rejected credentials — regardless of which
+/// operation ran the probe.
+pub(crate) fn map_namespace_initialization_error_to_core(
+    error: NamespaceInitializationError,
+) -> CoreError {
+    match error {
+        NamespaceInitializationError::InvalidNamespaceId(error) => {
+            CoreError::InvalidNamespaceId(error)
+        }
+        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadNamespaceDescriptor(
+                error,
+            ))
+        }
+        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadContentStoreDescriptor(
+                error,
+            ))
+        }
+        NamespaceInitializationError::InspectNamespaceDescriptor {
+            object_key,
+            message,
+            class,
+        }
+        | NamespaceInitializationError::InspectNamespaceHead {
+            object_key,
+            message,
+            class,
+        }
+        | NamespaceInitializationError::InspectNamespaceControl {
+            object_key,
+            message,
+            class,
+        } => CoreError::Store {
+            object_key,
+            message,
+            class,
+        },
+    }
+}
+
+/// Installs one control object of a namespace being created or forked.
+///
+/// Losing the put-if-absent race re-classifies the target instead of
+/// guessing at the winner: a complete target answers `namespace_exists`, a
+/// partial or pre-head tree answers `namespace_partial`, and an absent
+/// target reports the write failure itself. Non-conflict failures keep
+/// their [`StoreFailureClass`].
+pub(crate) async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    object_key: &str,
+    bytes: &[u8],
+) -> Result<(), CoreError> {
+    match store
+        .put_if_absent(object_key, Bytes::copy_from_slice(bytes))
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
+            match namespace_initialization_state(store, namespace_id)
+                .await
+                .map_err(map_namespace_initialization_error_to_core)?
+            {
+                NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
+                    namespace_id: namespace_id.clone(),
+                }),
+                NamespaceInitializationState::Partial
+                | NamespaceInitializationState::PreHeadDebris => {
+                    Err(CoreError::NamespacePartiallyInitialized {
+                        namespace_id: namespace_id.clone(),
+                    })
+                }
+                NamespaceInitializationState::Absent => Err(CoreError::Store {
+                    object_key: object_key.to_owned(),
+                    message: "control object write failed, but namespace remains absent".to_owned(),
+                    class: StoreFailureClass::Other,
+                }),
+            }
+        }
+        Err(err) => Err(CoreError::store(object_key, &err)),
+    }
+}
+
+/// Publishes the namespace descriptor — the completion marker — for a
+/// post-head completion retry, tolerating the race: a conflict means another
+/// completion wrote it first and the namespace is complete either way.
+pub(crate) async fn put_completion_descriptor<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    bytes: &[u8],
+) -> Result<(), CoreError> {
+    let descriptor_key = namespace_config(namespace_id.as_str());
+    match store
+        .put_if_absent(&descriptor_key, Bytes::copy_from_slice(bytes))
+        .await
+    {
+        Ok(_)
+        | Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
+            Ok(())
+        }
+        Err(err) => Err(CoreError::store(&descriptor_key, &err)),
     }
 }

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -2,20 +2,20 @@
 //! source checkpoint, sharing content bytes and copying metadata
 //! references.
 
-use super::bootstrap::{recover_pre_head_debris, BootstrapNamespaceError, PreHeadRecovery};
+use super::bootstrap::{recover_pre_head_debris, PreHeadRecovery};
 use crate::checkpoint::{
     create_checkpoint, freshen_fork_checkpoint, load_namespace_manifest_envelope,
     load_verified_manifest_tables, read_checkpoint_record, write_namespace_manifest,
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
-use crate::error::{CoreError, Result, StoreFailureClass};
+use crate::error::{CoreError, Result};
 use crate::namespace::catalog::{
-    load_namespace_descriptor, namespace_initialization_state, NamespaceInitializationError,
+    load_namespace_descriptor, map_namespace_initialization_error_to_core,
+    namespace_initialization_state, put_completion_descriptor, put_target_namespace_control_object,
     NamespaceInitializationState,
 };
 use crate::namespace::control::{read_head_object, read_metadata_root_object};
-use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_object, CheckpointOwner, CheckpointRecordState, ControlObjectKind, HeadState,
     HeadStateEnvelope, MetadataRootEnvelope, MetadataRootState, NamespaceConfigEnvelope,
@@ -29,7 +29,7 @@ use loonfs_api::wire::manifest::{
 };
 use loonfs_api::{ManifestId, ManifestObjectId, NamespaceId, NamespaceSummary, WriterEpoch};
 use loonfs_objectstore::keys::{metadata_root, namespace_config, wal_head};
-use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use loonfs_objectstore::ObjectStore;
 
 pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     store: &S,
@@ -75,10 +75,7 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
                         namespace_id: new_namespace_id.clone(),
                     });
                 }
-                match recover_pre_head_debris(store, new_namespace_id, context.now_ms)
-                    .await
-                    .map_err(bootstrap_recovery_error_to_core)?
-                {
+                match recover_pre_head_debris(store, new_namespace_id, context.now_ms).await? {
                     PreHeadRecovery::Cleaned => {
                         recovered_debris = true;
                         continue;
@@ -261,10 +258,6 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     })
 }
 
-fn bootstrap_recovery_error_to_core(error: BootstrapNamespaceError) -> CoreError {
-    CoreError::Internal(format!("pre-head debris recovery failed: {error}"))
-}
-
 /// Finishes a fork that crashed after its target head write. The head is
 /// the linearization point and everything before it exists, so the retry
 /// only writes the missing descriptor — derived, exactly as the crashed
@@ -331,16 +324,7 @@ async fn complete_post_head_fork<S: ObjectStore + ?Sized>(
                 "failed to encode namespace descriptor object: {err}"
             ))
         })?;
-    let descriptor_key = namespace_config(new_namespace_id.as_str());
-    match store
-        .put_if_absent(&descriptor_key, Bytes::copy_from_slice(&descriptor_bytes))
-        .await
-    {
-        // A raced completion wrote it first; complete either way.
-        Ok(_)
-        | Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {}
-        Err(err) => return Err(CoreError::store(&descriptor_key, &err)),
-    }
+    put_completion_descriptor(store, new_namespace_id, &descriptor_bytes).await?;
     Ok(NamespaceSummary {
         namespace_id: new_namespace_id.clone(),
     })
@@ -423,51 +407,6 @@ fn fork_target_manifest_payload(
         metadata_files: source_manifest.payload.metadata_files.clone(),
         index_files: source_manifest.payload.index_files.clone(),
     })
-}
-
-async fn put_target_namespace_control_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    object_key: &str,
-    bytes: &[u8],
-) -> Result<()> {
-    match store
-        .put_if_absent(object_key, Bytes::copy_from_slice(bytes))
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
-            match namespace_initialization_state(store, namespace_id)
-                .await
-                .map_err(map_namespace_initialization_error_to_core)?
-            {
-                NamespaceInitializationState::Complete => Err(CoreError::NamespaceAlreadyExists {
-                    namespace_id: namespace_id.clone(),
-                }),
-                NamespaceInitializationState::Partial
-                | NamespaceInitializationState::PreHeadDebris => {
-                    Err(CoreError::NamespacePartiallyInitialized {
-                        namespace_id: namespace_id.clone(),
-                    })
-                }
-                NamespaceInitializationState::Absent => Err(CoreError::Store {
-                    object_key: object_key.to_owned(),
-                    message: "control object write failed, but namespace remains absent".to_owned(),
-                    class: StoreFailureClass::Other,
-                }),
-            }
-        }
-        Err(err) => Err(CoreError::store(object_key, &err)),
-    }
-}
-
-fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {
-    match error {
-        NamespaceInitializationError::InvalidNamespaceId(error) => {
-            CoreError::InvalidNamespaceId(error)
-        }
-        other => CoreError::Internal(BootstrapNamespaceError::from(other).to_string()),
-    }
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -5,7 +5,8 @@ use crate::checkpoint::load_namespace_manifest_envelope;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::catalog::{
-    namespace_initialization_state, NamespaceInitializationError, NamespaceInitializationState,
+    map_namespace_initialization_error_to_core, namespace_initialization_state,
+    NamespaceInitializationState,
 };
 use crate::namespace::control::{
     read_head_and_metadata_root, read_wal_floor_seq_or_zero, ControlObjectLoadError,
@@ -120,45 +121,4 @@ async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
         .count();
     u64::try_from(tail_segments)
         .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))
-}
-
-fn map_namespace_initialization_error_to_core(error: NamespaceInitializationError) -> CoreError {
-    match error {
-        NamespaceInitializationError::InvalidNamespaceId(error) => {
-            CoreError::InvalidNamespaceId(error)
-        }
-        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadNamespaceDescriptor(
-                error,
-            ))
-        }
-        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadContentStoreDescriptor(
-                error,
-            ))
-        }
-        NamespaceInitializationError::InspectNamespaceControl {
-            object_key,
-            message,
-            class,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class,
-        },
-        NamespaceInitializationError::InspectNamespaceDescriptor {
-            object_key,
-            message,
-            class,
-        }
-        | NamespaceInitializationError::InspectNamespaceHead {
-            object_key,
-            message,
-            class,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class,
-        },
-    }
 }

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -7,8 +7,8 @@ use crate::engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::catalog::{
-    load_namespace_content_store_id, namespace_initialization_state, NamespaceInitializationError,
-    NamespaceInitializationState,
+    load_namespace_content_store_id, map_namespace_initialization_error_to_core,
+    namespace_initialization_state, NamespaceInitializationState,
 };
 use crate::namespace::control::{
     load_content_store_descriptor_control, load_namespace_descriptor_control,
@@ -172,44 +172,7 @@ async fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
                 namespace_id: namespace_id.clone(),
             })
         }
-        Err(error) => Err(map_upload_namespace_initialization_error(error)),
-    }
-}
-
-fn map_upload_namespace_initialization_error(error: NamespaceInitializationError) -> CoreError {
-    match error {
-        NamespaceInitializationError::InvalidNamespaceId(error) => {
-            CoreError::InvalidNamespaceId(error)
-        }
-        NamespaceInitializationError::LoadNamespaceDescriptor(error) => {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadNamespaceDescriptor(
-                error,
-            ))
-        }
-        NamespaceInitializationError::LoadContentStoreDescriptor(error) => {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadContentStoreDescriptor(
-                error,
-            ))
-        }
-        NamespaceInitializationError::InspectNamespaceDescriptor {
-            object_key,
-            message,
-            class,
-        }
-        | NamespaceInitializationError::InspectNamespaceHead {
-            object_key,
-            message,
-            class,
-        }
-        | NamespaceInitializationError::InspectNamespaceControl {
-            object_key,
-            message,
-            class,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class,
-        },
+        Err(error) => Err(map_namespace_initialization_error_to_core(error)),
     }
 }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -13,9 +13,9 @@ use loonfs_api::{
     },
     wire::control::{
         decode_control_object, encode_control_object, CheckpointOwner,
-        ContentStoreDescriptorEnvelope, ControlObjectKind, HeadState, HeadStateEnvelope,
-        NamespaceConfigEnvelope, NamespaceConfigState, UploadSessionEnvelope, UploadSessionState,
-        WriterBlock,
+        ContentStoreDescriptorEnvelope, ContentStoreDescriptorState, ControlObjectKind, HeadState,
+        HeadStateEnvelope, NamespaceConfigEnvelope, NamespaceConfigState, UploadSessionEnvelope,
+        UploadSessionState, WriterBlock,
     },
     wire::manifest::{
         decode_namespace_manifest_json, encode_namespace_manifest_json, MetadataTableFamily,
@@ -23,9 +23,9 @@ use loonfs_api::{
     },
     wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
     AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
-    DeleteDirectoryBehavior, DestinationBehavior, DirectoryPageCursor, EffectiveLimit, InodeId,
-    InodeKind, ManifestId, NameKey, NamespaceId, Page, PageRequest, RevisionNo, UploadId,
-    WriterEpoch,
+    ContentStoreId, DeleteDirectoryBehavior, DestinationBehavior, DirectoryPageCursor,
+    EffectiveLimit, InodeId, InodeKind, ManifestId, NameKey, NamespaceId, Page, PageRequest,
+    RevisionNo, UploadId, WriterEpoch,
 };
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
@@ -1368,11 +1368,14 @@ async fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
     );
 
     let error = bootstrap_namespace(&store, &namespace_id, &context, false)
-        .expect_err("target head precondition should fail bootstrap");
+        .expect_err("target head precondition should re-check partial namespace");
+    // The lost ack left the head written and the descriptor absent, so the
+    // shared install re-check answers partial — the same policy fork pins.
     assert!(matches!(
-        error,
-        loonfs_core::BootstrapNamespaceError::HeadWrite(_)
+        &error,
+        loonfs_core::BootstrapNamespaceError::Core(CoreError::NamespacePartiallyInitialized { .. })
     ));
+    assert_eq!(error.code(), ErrorCode::NamespacePartial);
     assert!(
         store
             .list_prefix("content-stores/")
@@ -1386,6 +1389,61 @@ async fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
     // the genesis tree instead of wedging on namespace_partial.
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .expect("retry completes the ack-lost create");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bootstrap_head_conflict_rechecks_complete_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id();
+    let context = mutation_context();
+    // The injected conflict simulates a racing create that completed the
+    // namespace: its head wins the reservation and its descriptor pair is
+    // already published when this attempt re-checks.
+    let content_store_id = ContentStoreId::generate();
+    let content_store_descriptor_envelope = ContentStoreDescriptorEnvelope::from_state(
+        ControlObjectKind::ContentStoreDescriptor,
+        &context.writer_version,
+        ContentStoreDescriptorState {
+            content_store_id: content_store_id.clone(),
+        },
+    )
+    .expect("content store descriptor envelope");
+    let descriptor = NamespaceConfigEnvelope::from_state(
+        ControlObjectKind::NamespaceConfig,
+        &context.writer_version,
+        NamespaceConfigState {
+            namespace_id: namespace_id.clone(),
+            content_store_id: content_store_id.clone(),
+            name_policy: loonfs_api::NamePolicy::default(),
+        },
+    )
+    .expect("descriptor envelope");
+    let store = InjectCreateFailureStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyMatcher::Exact(wal_head(namespace_id.as_str())),
+        InjectedCreateFailure::Conflict {
+            write_attempted_object: true,
+            additional_writes: vec![
+                (
+                    content_store_descriptor(content_store_id.as_str()),
+                    encode_control_object(&content_store_descriptor_envelope)
+                        .expect("content store descriptor bytes"),
+                ),
+                (
+                    namespace_config(namespace_id.as_str()),
+                    encode_control_object(&descriptor).expect("descriptor bytes"),
+                ),
+            ],
+        },
+    );
+
+    let error = bootstrap_namespace(&store, &namespace_id, &context, false)
+        .expect_err("target head conflict should re-check complete namespace");
+    assert!(matches!(
+        &error,
+        loonfs_core::BootstrapNamespaceError::Core(CoreError::NamespaceAlreadyExists { .. })
+    ));
+    assert_eq!(error.code(), ErrorCode::NamespaceExists);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Create and fork had drifted implementations of the same installation protocol: the same provider auth failure answered permission_denied through fork but server_error through create (four different mappers existed for the shared classification probe, with two behaviors), and a lost head write answered an unconditional server_error through create while fork re-checked the target and answered namespace_exists or namespace_partial. Fork's re-checking control-object writer and a single class-preserving probe mapper are now shared namespace code used by both paths — and by status and uploads, which already had the correct behavior and now just deduplicate onto it. Create's answers deliberately change to the fork-side policy (namespace_partial / namespace_exists on conflicts, permission_denied on rejected credentials); the create-side test pins are updated to that unified policy with a new pin for the raced-competitor-completed case, and the five stringly write-error variants of BootstrapNamespaceError are deleted. Write order, the separate create and fork completion guards, and the content-store-after-head-reservation invariant are unchanged. Stacks on conor/cache-performance-only.