### PR TITLE
fix(core,loonfs,server): require prepared content for path publication

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -129,6 +129,7 @@ error_codes! {
     NamespaceDeleted => "namespace_deleted",
     NamespaceExists => "namespace_exists",
     NamespacePartial => "namespace_partial",
+    ContentNotPrepared => "content_not_prepared",
     PathNotFound => "path_not_found",
     RevisionNotFound => "revision_not_found",
     PathConflict => "path_conflict",
@@ -198,6 +199,7 @@ impl ErrorCode {
             // 409 resource-state conflicts, not 412 (api.md, "Standard error
             // contract").
             ErrorCode::NamespacePartial
+            | ErrorCode::ContentNotPrepared
             | ErrorCode::PathConflict
             | ErrorCode::DirectoryNotEmpty
             | ErrorCode::StaleHead

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -717,6 +717,12 @@ mod tests {
         });
 
         assert_eq!(error.code, ErrorCode::RevisionNotFound.as_str());
+
+        let error = map_core_error(CoreError::ContentNotPrepared {
+            content_ref_digest: "abc123".to_owned(),
+        });
+        assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
+        assert!(error.message.contains("abc123"));
     }
 
     #[test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1094,6 +1094,10 @@ mod tests {
         assert_eq!(error.error_code(), Some(ErrorCode::StaleRevision));
         assert_eq!(error.kind(), Some(ErrorKind::Conflict));
 
+        let error = api_error(409, "content_not_prepared");
+        assert_eq!(error.error_code(), Some(ErrorCode::ContentNotPrepared));
+        assert_eq!(error.kind(), Some(ErrorKind::Conflict));
+
         let error = api_error(410, "namespace_deleted");
         assert_eq!(error.error_code(), Some(ErrorCode::NamespaceDeleted));
         assert_eq!(error.kind(), Some(ErrorKind::Gone));

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -44,10 +44,7 @@ pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 pub use self::publish_error::CommitHeadPublishError;
 pub use self::request::CommitRequest;
 pub use self::validate::build_commit_plan;
-pub(crate) use self::validate::{
-    build_commit_plan_for_publish, resolve_restore_content_refs_for_publish,
-    PublishCommitValidationContext,
-};
+pub(crate) use self::validate::{build_commit_plan_for_publish, PublishCommitValidationContext};
 pub use self::validate_error::CommitValidationError;
 
 pub(crate) fn push_unique_invariant(invariants: &mut Vec<InvariantId>, id: InvariantId) {

--- a/crates/loonfs-core/src/commit/validate/mod.rs
+++ b/crates/loonfs-core/src/commit/validate/mod.rs
@@ -16,7 +16,4 @@ mod plan_build;
 mod view;
 
 pub use plan_build::build_commit_plan;
-pub(crate) use plan_build::{
-    build_commit_plan_for_publish, resolve_restore_content_refs_for_publish,
-    PublishCommitValidationContext,
-};
+pub(crate) use plan_build::{build_commit_plan_for_publish, PublishCommitValidationContext};

--- a/crates/loonfs-core/src/commit/validate/plan_build.rs
+++ b/crates/loonfs-core/src/commit/validate/plan_build.rs
@@ -12,9 +12,8 @@ use crate::error::CoreError;
 use crate::invariants::InvariantId;
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::{ChangeSeq, ContentRef, InodeId, NamePolicy, RevisionNo};
+use loonfs_api::{ChangeSeq, InodeId, NamePolicy};
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeMap;
 struct CommitShape {
     assigned_seq: ChangeSeq,
     allocated_inode_ids: Vec<InodeId>,
@@ -26,64 +25,6 @@ pub(crate) struct PublishCommitValidationContext<'a, S: ObjectStore + ?Sized> {
     pub(crate) head: &'a HeadState,
     pub(crate) metadata_view: MetadataView<'a, 'a, S>,
     pub(crate) accepted_rows: &'a MetadataState,
-}
-
-impl<S: ObjectStore + ?Sized> PublishCommitValidationContext<'_, S> {
-    fn metadata_view(&self) -> MetadataView<'_, '_, S> {
-        self.metadata_view
-            .with_overlay(self.accepted_rows, self.head.seq)
-    }
-}
-
-pub(crate) async fn resolve_restore_content_refs_for_publish<S: ObjectStore + ?Sized>(
-    request: &CommitRequest,
-    context: &PublishCommitValidationContext<'_, S>,
-) -> Result<Vec<Option<ContentRef>>, CoreError> {
-    let mut resolved_request_revisions = BTreeMap::<(InodeId, RevisionNo), ContentRef>::new();
-    let metadata_view = context.metadata_view();
-    let mut resolved = Vec::with_capacity(request.ops.len());
-
-    for op in &request.ops {
-        match op {
-            CommitOp::ReplaceFile {
-                inode_id,
-                base_revision_no,
-                content_ref,
-            } => {
-                if let Some(next_revision) = base_revision_no.0.checked_add(1).map(RevisionNo) {
-                    resolved_request_revisions
-                        .insert((*inode_id, next_revision), content_ref.clone());
-                }
-                resolved.push(None);
-            }
-            CommitOp::RestoreRevision {
-                inode_id,
-                source_revision_no,
-                base_revision_no,
-            } => {
-                let content_ref = if let Some(content_ref) =
-                    resolved_request_revisions.get(&(*inode_id, *source_revision_no))
-                {
-                    Some(content_ref.clone())
-                } else {
-                    metadata_view
-                        .revision_at_head(*inode_id, *source_revision_no)
-                        .await?
-                        .map(|revision| revision.content_ref)
-                };
-                if let (Some(next_revision), Some(content_ref)) = (
-                    base_revision_no.0.checked_add(1).map(RevisionNo),
-                    content_ref.clone(),
-                ) {
-                    resolved_request_revisions.insert((*inode_id, next_revision), content_ref);
-                }
-                resolved.push(content_ref);
-            }
-            _ => resolved.push(None),
-        }
-    }
-
-    Ok(resolved)
 }
 
 pub async fn build_commit_plan(

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -95,6 +95,8 @@ pub enum CoreError {
     DestinationExists(String),
     #[error("commit id conflict for `{0}`")]
     CommitIdReuseConflict(String),
+    #[error("content ref `{content_ref_digest}` is not prepared for publication")]
+    ContentNotPrepared { content_ref_digest: String },
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
     /// The serving front-end closed admission for shutdown. New work is
@@ -359,6 +361,7 @@ impl CoreError {
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
             CoreError::NamespacePartiallyInitialized { .. } => ErrorCode::NamespacePartial,
             CoreError::CommitIdReuseConflict(_) => ErrorCode::CommitIdReuseConflict,
+            CoreError::ContentNotPrepared { .. } => ErrorCode::ContentNotPrepared,
             CoreError::CommitQueueFull => ErrorCode::CommitQueueFull,
             CoreError::ShuttingDown => ErrorCode::ShuttingDown,
             CoreError::CheckpointUnavailable(_) => ErrorCode::CheckpointUnavailable,
@@ -724,6 +727,7 @@ mod tests {
         // Precondition failures are 409 resource-state conflicts in v0
         // (api.md, "Standard error contract"), so the kind is Conflict.
         assert_eq!(ErrorCode::StaleRevision.kind(), ErrorKind::Conflict);
+        assert_eq!(ErrorCode::ContentNotPrepared.kind(), ErrorKind::Conflict);
         assert_eq!(ErrorCode::CommitQueueFull.kind(), ErrorKind::Unavailable);
         assert_eq!(
             ErrorCode::MaintenanceRequired.kind(),
@@ -749,6 +753,13 @@ mod tests {
         assert_eq!(error.code(), ErrorCode::NamespaceExists);
         assert_eq!(error.code().as_str(), "namespace_exists");
         assert!(error.message().contains("already exists"));
+
+        let error = CoreError::ContentNotPrepared {
+            content_ref_digest: "abc123".to_owned(),
+        };
+        assert_eq!(error.kind(), ErrorKind::Conflict);
+        assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
+        assert!(error.message().contains("abc123"));
     }
 
     #[test]

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -38,6 +38,7 @@ async fn create_checkpoint<S: ObjectStore + ?Sized>(
     .await
 }
 use crate::commit_engine::{NamespaceCommitEngine, NamespaceMutationCandidate};
+use crate::content::ContentAdmission;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::delete::delete_namespace;
 use crate::namespace::fork::fork_namespace;
@@ -108,14 +109,19 @@ async fn write_file<S: ObjectStore>(
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
-            vec![NamespaceMutationCandidate::Path(
-                PathMutationIntent::PutFile {
+            vec![NamespaceMutationCandidate::PathWithContentAdmission {
+                intent: PathMutationIntent::PutFile {
                     commit_id: CommitId::parse(commit_id).expect("commit id"),
                     absolute_path: AbsolutePath::parse(path).expect("path"),
-                    content_ref,
+                    content_ref: content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
                 },
-            )],
+                admissions: vec![ContentAdmission::for_durable_content_write(
+                    namespace_id.clone(),
+                    content_ref,
+                    context.now_ms,
+                )],
+            }],
             context,
         )
         .await

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -4,6 +4,7 @@
 use super::content_write::store_file_bytes_before_metadata_publish;
 use super::intent::PathMutationIntent;
 use crate::commit_engine::NamespaceMutationCandidate;
+use crate::content::ContentAdmission;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::path::helpers::parse_mutation_path;
@@ -21,12 +22,18 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
+    admissions: Vec<ContentAdmission>,
     context: &MutationContext,
 ) -> Result<CommitResponse, CoreError> {
+    let candidate = if admissions.is_empty() {
+        NamespaceMutationCandidate::Path(intent)
+    } else {
+        NamespaceMutationCandidate::PathWithContentAdmission { intent, admissions }
+    };
     let mut results = crate::commit_engine::publish_namespace_mutations_batch(
         store,
         namespace_id,
-        vec![NamespaceMutationCandidate::Path(intent)],
+        vec![candidate],
         context,
     )
     .await;
@@ -93,16 +100,21 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse, CoreError> {
-    let commit_id = normalized_commit_id(commit_id);
+    let admission = ContentAdmission::for_durable_content_write(
+        namespace_id.clone(),
+        content_ref.clone(),
+        context.now_ms,
+    );
     submit_path_intent(
         store,
         namespace_id,
         PathMutationIntent::PutFile {
-            commit_id,
+            commit_id: normalized_commit_id(commit_id),
             absolute_path: parse_mutation_path(absolute_path)?,
             content_ref,
             behavior,
         },
+        vec![admission],
         context,
     )
     .await
@@ -144,6 +156,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
             behavior,
             expected_inode_id: None,
         },
+        Vec::new(),
         context,
     )
     .await
@@ -167,6 +180,7 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
             to_path: parse_mutation_path(to_path)?,
             behavior: DestinationBehavior::NoReplace,
         },
+        Vec::new(),
         context,
     )
     .await
@@ -189,6 +203,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
             absolute_path: parse_mutation_path(absolute_path)?,
             source_revision_no,
         },
+        Vec::new(),
         context,
     )
     .await

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -74,6 +74,7 @@ impl PublishPlanningSession {
 mod tests {
     use super::*;
     use crate::commit_engine::{publish_namespace_mutations_batch, NamespaceMutationCandidate};
+    use crate::content::ContentAdmission;
     use crate::context::MutationContext;
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
@@ -113,12 +114,19 @@ mod tests {
         absolute_path: &str,
         content_ref: loonfs_api::ContentRef,
     ) -> NamespaceMutationCandidate {
-        NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
-            content_ref,
-            behavior: DestinationBehavior::NoReplace,
-        })
+        NamespaceMutationCandidate::PathWithContentAdmission {
+            intent: PathMutationIntent::PutFile {
+                commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+                absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+                content_ref: content_ref.clone(),
+                behavior: DestinationBehavior::NoReplace,
+            },
+            admissions: vec![ContentAdmission::for_durable_content_write(
+                NamespaceId::parse("demo").expect("valid namespace id"),
+                content_ref,
+                u64::MAX,
+            )],
+        }
     }
 
     /// Two plans through one session share the durable-layer memo: the

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -8,9 +8,8 @@ use super::candidates::{
 use super::publish_view::PublishMetadataView;
 use crate::commit::{
     build_commit_plan_for_publish, materialize_commit, prepare_commit_head_publish,
-    publish_commit_head, resolve_restore_content_refs_for_publish,
-    wal_payload_from_materialized_commit, CommitHeadPublishError, MaterializedCommit,
-    PreparedCommit, PreparedCommitHeadPublish, PublishCommitValidationContext,
+    publish_commit_head, wal_payload_from_materialized_commit, CommitHeadPublishError,
+    MaterializedCommit, PreparedCommit, PreparedCommitHeadPublish, PublishCommitValidationContext,
 };
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
@@ -145,19 +144,10 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 accepted_rows: session.accepted_rows(),
             };
             let request = candidate_request.request;
-            let resolved_restore_content_refs =
-                match resolve_restore_content_refs_for_publish(&request, &validation).await {
-                    Ok(value) => value,
-                    Err(error) => {
-                        outcomes[index] = Some(Err(error));
-                        continue;
-                    }
-                };
             if let Err(error) = validate_commit_content_references(
                 store,
                 &view.content_store_id,
                 &request,
-                &resolved_restore_content_refs,
                 candidate,
                 context.now_ms,
                 &mut content_validation,

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -253,52 +253,48 @@ impl CommitContentAdmissions<'_> {
     }
 }
 
-/// Validates that every content ref a candidate commits either was admitted
-/// by the request's presigned content admissions or is provably durable.
+/// Checks external content refs without reading content for path candidates;
+/// explicit commits retain durable validation until their endpoint accepts
+/// content admissions.
 pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     request: &CoreCommitRequest,
-    resolved_restore_content_refs: &[Option<ContentRef>],
     candidate: &NamespaceMutationCandidate,
     now_ms: u64,
     content_validation: &mut ContentValidationTracker,
 ) -> Result<()> {
-    let admissions = CommitContentAdmissions {
-        namespace_id: &request.namespace_id,
-        admissions: candidate_content_admissions(candidate),
-        now_ms,
-    };
-    let mut content_refs = Vec::new();
-    for (index, op) in request.ops.iter().enumerate() {
-        match op {
-            CommitOp::CreateFile { content_ref, .. }
-            | CommitOp::ReplaceFile { content_ref, .. } => {
-                content_refs.push(content_ref);
+    match candidate {
+        NamespaceMutationCandidate::Commit(_) => {
+            for op in &request.ops {
+                let content_ref = match op {
+                    CommitOp::CreateFile { content_ref, .. }
+                    | CommitOp::ReplaceFile { content_ref, .. } => content_ref,
+                    // Restore content is resolved from retained namespace
+                    // metadata, whose durability is already guaranteed.
+                    _ => continue,
+                };
+                content_validation
+                    .ensure_validated(store, content_store_id, content_ref)
+                    .await?;
             }
-            CommitOp::RestoreRevision { .. } => {
-                if let Some(content_ref) = resolved_restore_content_refs
-                    .get(index)
-                    .and_then(|content_ref| content_ref.as_ref())
-                {
-                    content_refs.push(content_ref);
-                }
+        }
+        NamespaceMutationCandidate::Path(intent)
+        | NamespaceMutationCandidate::PathWithContentAdmission { intent, .. } => {
+            let crate::path::write::PathMutationIntent::PutFile { content_ref, .. } = intent else {
+                return Ok(());
+            };
+            let admissions = CommitContentAdmissions {
+                namespace_id: &request.namespace_id,
+                admissions: candidate_content_admissions(candidate),
+                now_ms,
+            };
+            if !admissions.admits(content_ref) {
+                return Err(CoreError::ContentNotPrepared {
+                    content_ref_digest: content_ref.digest.clone(),
+                });
             }
-            _ => {}
         }
-    }
-
-    if content_refs.is_empty() {
-        return Ok(());
-    }
-
-    for content_ref in content_refs {
-        if admissions.admits(content_ref) {
-            continue;
-        }
-        content_validation
-            .ensure_validated(store, content_store_id, content_ref)
-            .await?;
     }
 
     Ok(())

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -34,8 +34,8 @@ impl ContentAdmission {
             namespace_id,
             content_ref,
             // Generous on purpose: it must outlive batched publications
-            // and stale-head retries. An expired admission only downgrades
-            // to a durable-validation probe, never to a weaker check.
+            // and stale-head retries. An expired admission no longer covers
+            // the publication.
             expires_at_ms: now_ms.saturating_add(DEFAULT_TOKEN_TTL_MS),
         }
     }

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -14,7 +14,7 @@ use loonfs_core::cache::{
     WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
     DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
-use loonfs_core::content::store_bytes_as_content;
+use loonfs_core::content::{store_bytes_as_content, ContentAdmission};
 use loonfs_core::control::load_namespace_read_anchor;
 use loonfs_core::gc::{gc_namespace, GcConfig};
 use loonfs_core::publish::{NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent};
@@ -41,14 +41,19 @@ async fn put_file<S: ObjectStore + ?Sized>(
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
-            vec![NamespaceMutationCandidate::Path(
-                PathMutationIntent::PutFile {
+            vec![NamespaceMutationCandidate::PathWithContentAdmission {
+                intent: PathMutationIntent::PutFile {
                     commit_id: loonfs_api::CommitId::generate(),
                     absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
-                    content_ref: content.content_ref,
+                    content_ref: content.content_ref.clone(),
                     behavior: loonfs_api::DestinationBehavior::NoReplace,
                 },
-            )],
+                admissions: vec![ContentAdmission::for_durable_content_write(
+                    namespace_id.clone(),
+                    content.content_ref,
+                    context.now_ms,
+                )],
+            }],
             context,
         )
         .await

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -36,7 +36,9 @@ use loonfs_core::commit::{
     build_commit_plan, materialize_commit, CommitOp, CommitOpResult, CommitRequest,
     CommitValidationContext, CommitValidationError, PreparedCommit,
 };
-use loonfs_core::content::{mint_content_token, store_bytes_as_content, verify_content_token};
+use loonfs_core::content::{
+    mint_content_token, store_bytes_as_content, verify_content_token, ContentAdmission,
+};
 use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anchor};
 use loonfs_core::metadata::MetadataState;
 use loonfs_core::publish::{NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent};
@@ -259,18 +261,34 @@ fn read_context<S: ObjectStore + ?Sized>(
 
 /// Publishes one path intent through the commit engine — the single publish
 /// pipeline.
+fn admitted_candidate(
+    namespace_id: &NamespaceId,
+    intent: PathMutationIntent,
+) -> NamespaceMutationCandidate {
+    match &intent {
+        PathMutationIntent::PutFile { content_ref, .. } => {
+            NamespaceMutationCandidate::PathWithContentAdmission {
+                admissions: vec![ContentAdmission::for_durable_content_write(
+                    namespace_id.clone(),
+                    content_ref.clone(),
+                    u64::MAX,
+                )],
+                intent,
+            }
+        }
+        _ => NamespaceMutationCandidate::Path(intent),
+    }
+}
+
 async fn submit_intent_async<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
     context: &MutationContext,
 ) -> Result<loonfs_api::CommitResponse, CoreError> {
+    let candidate = admitted_candidate(namespace_id, intent);
     NamespaceCommitEngine::new(namespace_id.clone())
-        .publish_batch(
-            store,
-            vec![NamespaceMutationCandidate::Path(intent)],
-            context,
-        )
+        .publish_batch(store, vec![candidate], context)
         .await
         .results
         .pop()
@@ -1646,7 +1664,7 @@ async fn complete_upload_rejects_direct_put_session_without_bound_target() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn path_put_file_validates_content_by_reading_it_once() {
+async fn path_put_file_without_admission_fails_without_reading_content() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1672,14 +1690,18 @@ async fn path_put_file_validates_content_by_reading_it_once() {
         &context,
     );
 
-    assert!(responses[0].is_ok());
-    // Durable validation is read-and-hash: one content GET, no provider
-    // checksum shortcut anywhere in the fleet.
-    assert_eq!(store.content_blob_get_count(), 1);
+    assert_eq!(
+        responses[0]
+            .as_ref()
+            .expect_err("unadmitted path put must fail")
+            .code(),
+        ErrorCode::ContentNotPrepared
+    );
+    assert_eq!(store.content_blob_get_count(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn path_batch_validates_a_repeated_content_ref_once() {
+async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1711,10 +1733,12 @@ async fn path_batch_validates_a_repeated_content_ref_once() {
         &context,
     );
 
-    assert!(responses.iter().all(Result::is_ok));
-    // Two puts share one content ref: the batch tracker validates it once
-    // (one read-and-hash), and the second candidate reuses the verdict.
-    assert_eq!(store.content_blob_get_count(), 1);
+    assert!(responses.iter().all(|response| {
+        response
+            .as_ref()
+            .is_err_and(|error| error.code() == ErrorCode::ContentNotPrepared)
+    }));
+    assert_eq!(store.content_blob_get_count(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1768,7 +1792,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn expired_content_admission_falls_back_to_durable_validation() {
+async fn expired_content_admission_fails_without_durable_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1814,10 +1838,14 @@ async fn expired_content_admission_falls_back_to_durable_validation() {
         &expired_context,
     );
 
-    assert!(responses[0].is_ok());
-    // An expired admission falls back to durable validation, which reads
-    // the bytes.
-    assert_eq!(store.content_blob_get_count(), 1);
+    assert_eq!(
+        responses[0]
+            .as_ref()
+            .expect_err("expired admission must not cover publication")
+            .code(),
+        ErrorCode::ContentNotPrepared
+    );
+    assert_eq!(store.content_blob_get_count(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2078,12 +2106,15 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
             }),
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
-                content_ref: staged.content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            }),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
+                    content_ref: staged.content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
         ]),
     );
     results[0]
@@ -3044,20 +3075,26 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 expected_inode_id: None,
             }),
             // Accepted into the batch.
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: content.content_ref.clone(),
-                behavior: DestinationBehavior::NoReplace,
-            }),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                    content_ref: content.content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
             // Rejected only because of the accepted candidate's speculative
             // in-batch create.
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: content.content_ref.clone(),
-                behavior: DestinationBehavior::NoReplace,
-            }),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                    content_ref: content.content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
             // Alias of the materialization-decided rejection.
             NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
@@ -3133,18 +3170,24 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
             }),
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("accept-a").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: content.content_ref.clone(),
-                behavior: DestinationBehavior::NoReplace,
-            }),
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: content.content_ref.clone(),
-                behavior: DestinationBehavior::NoReplace,
-            }),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                    content_ref: content.content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                    content_ref: content.content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
         ]
     };
 
@@ -3633,12 +3676,15 @@ async fn path_intents_in_one_batch_see_tentative_state() {
         &store,
         &namespace_id,
         vec![
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: content.content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            }),
+            admitted_candidate(
+                &namespace_id,
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
+                    absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                    content_ref: content.content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                },
+            ),
             NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-batched-path").expect("valid commit id"),
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
@@ -4303,7 +4349,7 @@ async fn fork_target_control_conflict_rechecks_complete_namespace() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn restore_revision_revalidates_durable_content_before_publish() {
+async fn restore_revision_does_not_revalidate_retained_content_before_publish() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -4360,7 +4406,7 @@ async fn restore_revision_revalidates_durable_content_before_publish() {
         .await
         .expect("delete first content");
 
-    let error = commit_operations(
+    let response = commit_operations(
         &store,
         &namespace_id(),
         ApiCommitRequest {
@@ -4375,13 +4421,8 @@ async fn restore_revision_revalidates_durable_content_before_publish() {
         },
         &context,
     )
-    .expect_err("restore missing durable content");
-    assert!(matches!(
-        error,
-        CoreError::DurableContent(
-            loonfs_core::content::DurableContentValidationError::MissingContentObject { .. }
-        )
-    ));
+    .expect("restore trusts retained content metadata");
+    assert_eq!(response.committed_seq, ChangeSeq(3));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4626,7 +4667,8 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
     let first = publish_namespace_mutations_batch(
         &store,
         &namespace_id(),
-        vec![NamespaceMutationCandidate::Path(
+        vec![admitted_candidate(
+            &namespace_id(),
             PathMutationIntent::PutFile {
                 commit_id: commit_id.clone(),
                 absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -159,12 +159,12 @@ pub(super) fn content_admissions_for_put(
             match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
                 Ok(admission) => Some(admission),
                 Err(error) => {
-                    // A rejected token only loses its fast path: admission
-                    // falls back to durable content validation.
+                    // A rejected token contributes no admission, so a put
+                    // with no other matching token fails as unprepared.
                     tracing::debug!(
                         namespace_id = %namespace_id,
                         error = %error,
-                        "content token rejected; falling back to durable validation"
+                        "content token rejected"
                     );
                     None
                 }

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -2,10 +2,10 @@ use bytes::Bytes;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
-        CompleteUploadRequest, ValidatedContentToken,
+        CompleteUploadRequest, CompleteUploadResponse, ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, CommitResponse,
-    ContentRef, CreateCheckpointResponse, DestinationBehavior, FilesystemOperation,
+    ContentRef, CreateCheckpointResponse, DestinationBehavior, ErrorCode, FilesystemOperation,
     FilesystemOperationRequest, InodeId, InodeKind, ListPathEntriesResponse, ManifestId,
     NamespaceId, RevisionNo, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, LIMIT_PAGINATION_DEFAULT,
     LIMIT_PAGINATION_MAX,
@@ -780,7 +780,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
+async fn path_put_with_bad_content_token_fails_content_not_prepared() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -795,24 +795,7 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
             .client
             .create_namespace(&namespace)
             .expect("create namespace");
-        let begin = harness
-            .client
-            .begin_upload(&namespace, &BeginUploadRequest::default())
-            .expect("begin upload");
-        let staged = harness
-            .client
-            .upload_content(&namespace, begin.upload_id.as_str(), b"token fallback")
-            .expect("upload content");
-        let completed = harness
-            .client
-            .complete_upload(
-                &namespace,
-                begin.upload_id.as_str(),
-                &CompleteUploadRequest {
-                    content_ref: staged.content_ref,
-                },
-            )
-            .expect("complete upload");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"token rejected");
 
         let request = FilesystemOperationRequest {
             commit_id: CommitId::parse("bad-token-put").expect("valid commit id"),
@@ -826,28 +809,147 @@ async fn path_put_with_bad_content_token_falls_back_to_durable_validation() {
                 behavior: DestinationBehavior::NoReplace,
             },
         };
-        let response = ureq::post(&format!(
-            "{}/v0/namespaces/{namespace}/filesystem/operations",
-            harness.server_url
-        ))
-        .set("authorization", "Bearer test-token")
-        .send_json(request)
-        .expect("bad token should fall back to content validation");
-        // Every response carries the correlation id header, success included.
-        let request_id = response
-            .header("x-request-id")
-            .expect("x-request-id header")
-            .to_owned();
-        assert!(request_id.starts_with("req_"), "got `{request_id}`");
+        assert_content_not_prepared_response(
+            send_filesystem_operation(&harness.server_url, &namespace, &request),
+            &request,
+        );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn path_put_without_content_token_fails_content_not_prepared() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-current",
+        "http-missing-content-token",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"token missing");
+        let request = FilesystemOperationRequest {
+            commit_id: CommitId::parse("missing-token-put").expect("valid commit id"),
+            content_tokens: Vec::new(),
+            operation: FilesystemOperation::PutFile {
+                path: "/missing-token.txt".to_owned(),
+                content_ref: completed.content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+        };
+
+        assert_content_not_prepared_response(
+            send_filesystem_operation(&harness.server_url, &namespace, &request),
+            &request,
+        );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn path_put_with_valid_content_token_succeeds() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-current",
+        "http-valid-content-token",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let bytes = b"valid token";
+        let completed = stage_uploaded_content(&harness.client, &namespace, bytes);
+        let request = FilesystemOperationRequest {
+            commit_id: CommitId::parse("valid-token-put").expect("valid commit id"),
+            content_tokens: vec![ValidatedContentToken {
+                content_ref: completed.content_ref.clone(),
+                token: completed
+                    .validated_content_token
+                    .expect("completed upload carries token"),
+            }],
+            operation: FilesystemOperation::PutFile {
+                path: "/valid-token.txt".to_owned(),
+                content_ref: completed.content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+        };
+        let response = send_filesystem_operation(&harness.server_url, &namespace, &request)
+            .expect("valid token put");
         let response: CommitResponse =
             serde_json::from_reader(response.into_reader()).expect("decode operation response");
         assert_eq!(response.committed_seq, ChangeSeq(1));
 
-        let target = NamespacePath::parse("demo", "/bad-token.txt").expect("target");
+        let target = NamespacePath::parse("demo", "/valid-token.txt").expect("target");
         assert_eq!(
             harness.client.read_file_bytes(&target).expect("read file"),
-            b"token fallback"
+            bytes
         );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn landed_path_put_replays_after_content_token_is_absent() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-current",
+        "http-content-token-replay",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"token replay");
+        let mut request = FilesystemOperationRequest {
+            commit_id: CommitId::parse("token-replay-put").expect("valid commit id"),
+            content_tokens: vec![ValidatedContentToken {
+                content_ref: completed.content_ref.clone(),
+                token: completed
+                    .validated_content_token
+                    .expect("completed upload carries token"),
+            }],
+            operation: FilesystemOperation::PutFile {
+                path: "/token-replay.txt".to_owned(),
+                content_ref: completed.content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+        };
+        let original = send_filesystem_operation(&harness.server_url, &namespace, &request)
+            .expect("original admitted put");
+        let original: CommitResponse =
+            serde_json::from_reader(original.into_reader()).expect("decode original response");
+
+        request.content_tokens.clear();
+        let replay = send_filesystem_operation(&harness.server_url, &namespace, &request)
+            .expect("landed put replays without token");
+        let replay: CommitResponse =
+            serde_json::from_reader(replay.into_reader()).expect("decode replay response");
+        assert_eq!(replay, original);
     })
     .await
     .expect("blocking task");
@@ -2219,11 +2321,50 @@ fn namespace_id(value: &str) -> NamespaceId {
     NamespaceId::parse(value).expect("valid namespace id")
 }
 
-fn stage_uploaded_content_ref(
+fn send_filesystem_operation(
+    server_url: &str,
+    namespace_id: &NamespaceId,
+    request: &FilesystemOperationRequest,
+) -> Result<ureq::Response, Box<ureq::Error>> {
+    ureq::post(&format!(
+        "{server_url}/v0/namespaces/{namespace_id}/filesystem/operations"
+    ))
+    .set("authorization", "Bearer test-token")
+    .send_json(request)
+    .map_err(Box::new)
+}
+
+fn assert_content_not_prepared_response(
+    result: Result<ureq::Response, Box<ureq::Error>>,
+    request: &FilesystemOperationRequest,
+) {
+    match result {
+        Err(error) if matches!(error.as_ref(), ureq::Error::Status(_, _)) => {
+            let ureq::Error::Status(status, response) = *error else {
+                unreachable!("guard requires an HTTP status error");
+            };
+            assert_eq!(status, 409);
+            let error: ApiError =
+                serde_json::from_reader(response.into_reader()).expect("decode api error");
+            assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
+            let FilesystemOperation::PutFile { content_ref, .. } = &request.operation else {
+                unreachable!("content preparation assertion requires a put request");
+            };
+            assert!(error.message.contains(&content_ref.digest));
+            assert_eq!(
+                error.details.and_then(|details| details.commit_id),
+                Some(request.commit_id.clone())
+            );
+        }
+        other => unreachable!("expected content_not_prepared response, got {other:?}"),
+    }
+}
+
+fn stage_uploaded_content(
     client: &Client,
     namespace_id: &NamespaceId,
     file_bytes: &[u8],
-) -> ContentRef {
+) -> CompleteUploadResponse {
     let begin = client
         .begin_upload(namespace_id, &BeginUploadRequest::default())
         .expect("begin upload");
@@ -2244,5 +2385,13 @@ fn stage_uploaded_content_ref(
     assert_eq!(repeated.content_ref, complete.content_ref);
     assert!(complete.validated_content_token.is_some());
     assert!(repeated.validated_content_token.is_some());
-    complete.content_ref
+    complete
+}
+
+fn stage_uploaded_content_ref(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    file_bytes: &[u8],
+) -> ContentRef {
+    stage_uploaded_content(client, namespace_id, file_bytes).content_ref
 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -88,11 +88,11 @@ impl FsCore {
         .await
     }
 
-    /// Publishes a file revision that points at an already-durable content
-    /// ref.
+    /// Publishes a file revision that points at an already-durable content ref.
     ///
-    /// Use this when content was staged separately, for example through the
-    /// upload protocol.
+    /// This explicitly slow helper reads the full object to prove durability
+    /// before publication. Callers that already hold proof should prefer the
+    /// admitted path.
     #[tracing::instrument(
         level = "info",
         name = "loon.put",
@@ -120,13 +120,39 @@ impl FsCore {
                 usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
             ),
         );
-        self.publish_path_intent(
+        let absolute_path = loonfs_core::path::parse_mutation_path(absolute_path)?;
+        let content_store_id = match self.load_namespace_catalog_cached(namespace_id).await? {
+            Some(catalog) => catalog.content_store_id().clone(),
+            None => {
+                loonfs_core::control::load_namespace_catalog_entry(&self.inner.store, namespace_id)
+                    .await
+                    .map_err(CoreError::from)?
+                    .content_store_id()
+                    .clone()
+            }
+        };
+        loonfs_core::content::validate_durable_content_reference(
+            &self.inner.store,
+            &content_store_id,
+            &content_ref,
+        )
+        .await
+        .map_err(CoreError::from)?;
+        let content_admission = ContentAdmission::for_durable_content_write(
+            namespace_id.clone(),
+            content_ref.clone(),
+            current_time_ms()?,
+        );
+        self.publish_candidate(
             namespace_id,
-            PathMutationIntent::PutFile {
-                commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                content_ref,
-                behavior: options.behavior,
+            NamespaceMutationCandidate::PathWithContentAdmission {
+                intent: PathMutationIntent::PutFile {
+                    commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                    absolute_path,
+                    content_ref,
+                    behavior: options.behavior,
+                },
+                admissions: vec![content_admission],
             },
         )
         .await

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -142,11 +142,11 @@ impl FsWriter {
             .await
     }
 
-    /// Publishes a file revision that points at an already-durable content
-    /// ref.
+    /// Publishes a file revision that points at an already-durable content ref.
     ///
-    /// Use this when content was staged separately, for example through the
-    /// upload protocol.
+    /// This explicitly slow helper reads the full object to prove durability
+    /// before publication. Callers that already hold proof should prefer the
+    /// admitted path.
     pub async fn put_file_content_ref(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -2103,13 +2103,22 @@ mod tests {
         let path_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("path-put").expect("valid commit id"),
             absolute_path: AbsolutePath::parse("/file.txt").expect("path"),
-            content_ref: staged.content_ref,
+            content_ref: staged.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
         };
+        let content_admission = ContentAdmission::for_durable_content_write(
+            namespace_id.clone(),
+            staged.content_ref,
+            u64::MAX,
+        );
 
         let (explicit_response, path_response) = tokio::join!(
             registry.submit_commit(namespace_id.clone(), explicit),
-            registry.submit_path_intent(namespace_id.clone(), path_intent)
+            registry.submit_path_intent_with_content_admission(
+                namespace_id.clone(),
+                path_intent,
+                vec![content_admission]
+            )
         );
         assert_eq!(
             explicit_response.expect("explicit response").committed_seq,

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -11,6 +11,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use loonfs::content_tokens::ContentAdmission;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
 };
@@ -144,17 +145,24 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             .await
             .expect("stage content")
             .content_ref;
-            candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
-                loonfs::publish::PathMutationIntent::PutFile {
-                    commit_id: loonfs::CommitId::generate(),
-                    absolute_path: AbsolutePath::parse(format!(
-                        "/tree/dir-000000/file-{index:09}.txt"
-                    ))
-                    .expect("path"),
-                    content_ref,
-                    behavior: loonfs::DestinationBehavior::NoReplace,
+            candidates.push(
+                loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
+                    intent: loonfs::publish::PathMutationIntent::PutFile {
+                        commit_id: loonfs::CommitId::generate(),
+                        absolute_path: AbsolutePath::parse(format!(
+                            "/tree/dir-000000/file-{index:09}.txt"
+                        ))
+                        .expect("path"),
+                        content_ref: content_ref.clone(),
+                        behavior: loonfs::DestinationBehavior::NoReplace,
+                    },
+                    admissions: vec![ContentAdmission::for_durable_content_write(
+                        namespace_id.clone(),
+                        content_ref,
+                        u64::MAX,
+                    )],
                 },
-            ));
+            );
         }
         for outcome in writer
             .publish_namespace_mutations_batch(&namespace_id, candidates)

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -6,8 +6,8 @@ use futures::stream::BoxStream;
 use loonfs::content_tokens::ContentAdmission;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
-    CommitId, CommitOp, CommitRequest, CreateDirectoryOptions, CreateNamespaceOptions,
-    DestinationBehavior, FsWriter, InodeId, NamespaceId, PutFileOptions, RevisionNo,
+    CommitId, CommitOp, CommitRequest, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
+    DestinationBehavior, ErrorCode, FsWriter, InodeId, NamespaceId, PutFileOptions, RevisionNo,
     SharedObjectStore,
 };
 use loonfs_objectstore::keys::wal_head;
@@ -449,14 +449,30 @@ fn assert_content_counts(
     assert_eq!(counts.content_get_bytes, bytes_read);
 }
 
+fn assert_content_not_prepared(error: CoreError, content_ref: &loonfs::ContentRef) {
+    assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
+    assert!(
+        matches!(
+            error,
+            CoreError::ContentNotPrepared {
+                ref content_ref_digest
+            } if content_ref_digest == &content_ref.digest
+        ),
+        "content-not-prepared error should carry the rejected digest"
+    );
+}
+
 #[tokio::test]
-async fn put_file_content_ref_publication_downloads_unadmitted_content() {
-    let harness = TestHarness::new("content-ref-fallback").await;
+async fn put_file_content_ref_validates_content_before_publication() {
+    let harness = TestHarness::new("content-ref-validation").await;
     let bytes = b"pre-staged content";
     let content_ref = harness.stage_content(bytes).await;
     harness.recording.reset();
 
-    // PR B2 deletes this fallback; this case will instead expect a typed content-not-prepared error.
+    // These global counts show the explicitly slow helper still validates
+    // exactly once, but not where. The plain-candidate seam below proves the
+    // publisher itself performs no content-key I/O, locating this read before
+    // publication.
     harness
         .writer
         .put_file_content_ref(
@@ -472,13 +488,34 @@ async fn put_file_content_ref_publication_downloads_unadmitted_content() {
 }
 
 #[tokio::test]
+async fn plain_path_put_fails_unprepared_without_content_io() {
+    let harness = TestHarness::new("plain-path-unprepared").await;
+    let content_ref = harness.stage_content(b"unprepared path content").await;
+    harness.recording.reset();
+
+    let error = harness
+        .writer
+        .publisher()
+        .submit_path_intent(
+            harness.namespace_id.clone(),
+            put_intent("plain-unprepared-put", "/file.txt", content_ref.clone()),
+        )
+        .await
+        .expect_err("plain path put must require prepared content");
+
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
 async fn explicit_create_file_publication_downloads_unadmitted_content() {
     let harness = TestHarness::new("create-fallback").await;
     let bytes = b"explicit create content";
     let content_ref = harness.stage_content(bytes).await;
     harness.recording.reset();
 
-    // PR B2 deletes this fallback; this case will instead expect a typed content-not-prepared error.
+    // Explicit commit candidates retain durable validation until the later
+    // commit-endpoint admission PR.
     harness
         .writer
         .commit_operations(
@@ -524,7 +561,8 @@ async fn explicit_replace_file_publication_downloads_unadmitted_content() {
     let content_ref = harness.stage_content(bytes).await;
     harness.recording.reset();
 
-    // PR B2 deletes this fallback; this case will instead expect a typed content-not-prepared error.
+    // Explicit commit candidates retain durable validation until the later
+    // commit-endpoint admission PR.
     harness
         .writer
         .commit_operations(
@@ -547,8 +585,8 @@ async fn explicit_replace_file_publication_downloads_unadmitted_content() {
 }
 
 #[tokio::test]
-async fn explicit_restore_revision_publication_downloads_retained_content() {
-    let harness = TestHarness::new("restore-fallback").await;
+async fn explicit_restore_revision_uses_retained_metadata_without_content_io() {
+    let harness = TestHarness::new("restore-retained").await;
     let first = b"first revision";
     harness
         .writer
@@ -582,7 +620,8 @@ async fn explicit_restore_revision_publication_downloads_retained_content() {
         .inode_id;
     harness.recording.reset();
 
-    // PR B2 deletes this fallback; this case will instead expect a typed content-not-prepared error.
+    // Restore resolves content from retained namespace metadata, so
+    // re-downloading the retained blob would prove nothing.
     harness
         .writer
         .commit_operations(
@@ -601,7 +640,7 @@ async fn explicit_restore_revision_publication_downloads_retained_content() {
         .await
         .expect("publish explicit restore");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, first.len());
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
 #[tokio::test]
@@ -750,8 +789,80 @@ async fn stale_head_retry_preserves_content_admission() {
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
+/// Holds one publication at its head CAS so the next two candidates are
+/// deterministically collected into the same batch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_content_io() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("mixed-preparation").expect("valid namespace id");
+    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
+    let blocking = Arc::new(BlockingHeadCasStore::new(
+        Arc::clone(&recording),
+        &namespace_id,
+    ));
+    let store: SharedObjectStore = blocking.clone();
+    let writer = build_initialized_writer(store.clone(), &namespace_id, "mixed-writer").await;
+    let content_ref =
+        loonfs_core::content::store_bytes_as_content(&store, &namespace_id, b"mixed content")
+            .await
+            .expect("stage content")
+            .content_ref;
+    recording.reset();
+
+    blocking.arm_next_head_cas();
+    let blocker = {
+        let registry = writer.publisher();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_path_intent(
+                    namespace_id,
+                    PathMutationIntent::CreateDir {
+                        commit_id: CommitId::parse("mixed-blocker").expect("valid commit id"),
+                        absolute_path: parse_mutation_path("/hold").expect("valid mutation path"),
+                        parents: false,
+                    },
+                )
+                .await
+        })
+    };
+    blocking.wait_for_blocked_head_cas().await;
+
+    let registry = writer.publisher();
+    let mut admitted = Box::pin(registry.submit_path_intent_with_content_admission(
+        namespace_id.clone(),
+        put_intent("mixed-admitted", "/admitted.txt", content_ref.clone()),
+        vec![durable_admission(&namespace_id, &content_ref)],
+    ));
+    assert!(
+        futures::poll!(admitted.as_mut()).is_pending(),
+        "admitted put must queue behind the blocked publication"
+    );
+    let mut unprepared = Box::pin(registry.submit_path_intent(
+        namespace_id.clone(),
+        put_intent("mixed-unprepared", "/unprepared.txt", content_ref.clone()),
+    ));
+    assert!(
+        futures::poll!(unprepared.as_mut()).is_pending(),
+        "unprepared put must join the pending batch"
+    );
+
+    blocking.release_head_cas();
+    blocker
+        .await
+        .expect("blocker task")
+        .expect("blocker publication");
+    admitted.await.expect("admitted put publishes");
+    let error = unprepared
+        .await
+        .expect_err("unprepared put must fail independently");
+
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
+}
+
 #[tokio::test]
-async fn expired_content_admission_downloads_content() {
+async fn expired_content_admission_fails_without_content_io() {
     let harness = TestHarness::new("expired-admission").await;
     let bytes = b"expired admission content";
     let content_ref = harness.stage_content(bytes).await;
@@ -762,17 +873,19 @@ async fn expired_content_admission_downloads_content() {
     );
     harness.recording.reset();
 
-    // PR B2 deletes this fallback; this case will instead expect a typed content-not-prepared error.
-    harness
+    // Expiry still makes an admission uncovered in this narrow cut. A later
+    // PR removes internal admission expiry and will make this succeed again.
+    let error = harness
         .writer
         .publisher()
         .submit_path_intent_with_content_admission(
             harness.namespace_id.clone(),
-            put_intent("expired-put", "/file.txt", content_ref),
+            put_intent("expired-put", "/file.txt", content_ref.clone()),
             vec![expired_admission],
         )
         .await
-        .expect("publish with expired admission fallback");
+        .expect_err("expired admission must not cover publication");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
+use loonfs::content_tokens::ContentAdmission;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     BeginUploadRequest, CommitId, CommitResponse, CoreError, CreateNamespaceOptions,
@@ -203,10 +204,19 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         let intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("parked-second").expect("valid commit id"),
             absolute_path: parse_mutation_path("/b.txt").expect("mutation path"),
-            content_ref: staged.content_ref,
+            content_ref: staged.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
         };
-        Box::pin(async move { registry.submit_path_intent(namespace_id, intent).await })
+        let admission = ContentAdmission::for_durable_content_write(
+            namespace_id.clone(),
+            staged.content_ref,
+            u64::MAX,
+        );
+        Box::pin(async move {
+            registry
+                .submit_path_intent_with_content_admission(namespace_id, intent, vec![admission])
+                .await
+        })
     };
     assert!(
         futures::poll!(second.as_mut()).is_pending(),

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -10,6 +10,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs::content_tokens::ContentAdmission;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
     PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
@@ -222,15 +223,22 @@ async fn warm_phase_request_accounting() {
             .await
             .expect("stage content")
             .content_ref;
-            candidates.push(loonfs::publish::NamespaceMutationCandidate::Path(
-                loonfs::publish::PathMutationIntent::PutFile {
-                    commit_id: loonfs::CommitId::generate(),
-                    absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
-                        .expect("path"),
-                    content_ref,
-                    behavior: loonfs::DestinationBehavior::NoReplace,
+            candidates.push(
+                loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
+                    intent: loonfs::publish::PathMutationIntent::PutFile {
+                        commit_id: loonfs::CommitId::generate(),
+                        absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
+                            .expect("path"),
+                        content_ref: content_ref.clone(),
+                        behavior: loonfs::DestinationBehavior::NoReplace,
+                    },
+                    admissions: vec![ContentAdmission::for_durable_content_write(
+                        namespace_id.clone(),
+                        content_ref,
+                        u64::MAX,
+                    )],
                 },
-            ));
+            );
             index += 1;
         }
         for outcome in writer

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -4,6 +4,8 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs::content_tokens::ContentAdmission;
+use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
     BeginUploadResponse, ChangeSeq, ChangesResponse, CommitId, CommitOp, CommitRequest,
@@ -2523,31 +2525,48 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         }
         let [ref_a, ref_b, ref_c, ref_d] = content_refs.try_into().expect("four staged refs");
         let segments_before = wal_segment_count(&object_store, &namespace_id).await;
+        let admitted_put = |commit_id: &str, path: &str, content_ref: ContentRef| {
+            let admission = ContentAdmission::for_durable_content_write(
+                namespace_id.clone(),
+                content_ref.clone(),
+                u64::MAX,
+            );
+            (
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+                    absolute_path: parse_mutation_path(path).expect("valid mutation path"),
+                    content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                vec![admission],
+            )
+        };
+        let put_a = admitted_put("batch-a", "/docs/a.txt", ref_a);
+        let put_b = admitted_put("batch-b", "/docs/b.txt", ref_b);
+        let put_c = admitted_put("batch-c", "/docs/c.txt", ref_c);
+        let put_d = admitted_put("batch-d", "/docs/d.txt", ref_d);
+        let publisher = fs.writer.publisher();
 
         let puts = tokio::join!(
-            fs.put_file_content_ref(
-                &namespace_id,
-                "/docs/a.txt",
-                ref_a,
-                PutFileOptions::default()
+            publisher.submit_path_intent_with_content_admission(
+                namespace_id.clone(),
+                put_a.0,
+                put_a.1,
             ),
-            fs.put_file_content_ref(
-                &namespace_id,
-                "/docs/b.txt",
-                ref_b,
-                PutFileOptions::default()
+            publisher.submit_path_intent_with_content_admission(
+                namespace_id.clone(),
+                put_b.0,
+                put_b.1,
             ),
-            fs.put_file_content_ref(
-                &namespace_id,
-                "/docs/c.txt",
-                ref_c,
-                PutFileOptions::default()
+            publisher.submit_path_intent_with_content_admission(
+                namespace_id.clone(),
+                put_c.0,
+                put_c.1,
             ),
-            fs.put_file_content_ref(
-                &namespace_id,
-                "/docs/d.txt",
-                ref_d,
-                PutFileOptions::default()
+            publisher.submit_path_intent_with_content_admission(
+                namespace_id.clone(),
+                put_d.0,
+                put_d.1,
             ),
         );
         puts.0.expect("put a");
@@ -2555,9 +2574,10 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         puts.2.expect("put c");
         puts.3.expect("put d");
 
-        // All four submissions were admitted before the publish task's
-        // first take and published as one batch: one WAL segment, one
-        // head CAS.
+        // The already-proven candidates reach publisher admission together
+        // and publish as one batch: one WAL segment, one head CAS. The slow
+        // content-ref helper validates before admission and is intentionally
+        // outside this batching seam.
         let segments_after = wal_segment_count(&object_store, &namespace_id).await;
         assert_eq!(segments_after - segments_before, 1);
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -226,6 +226,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `upload_not_found` | 404 | No upload session with this id. |
 | `namespace_exists` | 409 | The create target already exists. |
 | `namespace_partial` | 409 | The namespace is partially initialized and unusable. |
+| `content_not_prepared` | 409 | A path put references external content without a matching unexpired admission. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
 | `stale_head` | 409 | The write raced a head advance; retry against fresh state. |


### PR DESCRIPTION
When a path put reached the publisher without a matching content admission, batch preparation "rescued it" by downloading and hashing the object inside the per-namespace serialized section, so one slow or large download stalled every commit on the namespace. Path candidates now get a pure in-memory coverage check instead: an external ref without an unexpired admission fails that candidate with the new `content_not_prepared` code (409, alongside the other resolve-by-changing-state conflicts), and the rest of its batch lands normally. Only `PutFile` intents introduce external refs, so copies, moves, and deletes need no proof by construction. Explicit commits keep the durable-validation fallback until the commit endpoint can carry content proofs; that later PR also removes `ContentValidationTracker`.

Restores stop being content-validated for both candidate kinds: a restore's source ref comes from the namespace's own retained metadata, so re-downloading it proved nothing, and the validation-only restore resolver (a metadata walk per restore commit) is deleted with it. This deliberately flips one pinned behavior worth reviewing: restoring a revision whose blob was removed out-of-band used to fail at publish with `MissingContentObject`; it now publishes, and the missing blob surfaces on read. `put_file_content_ref` keeps working as the documented explicitly-slow helper — it fully validates on the caller's task and then submits an admitted candidate, so its request count is unchanged but the read no longer runs inside the publisher.