### PR TITLE
fix(core,loonfs): make content admissions producer-only

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -4,7 +4,6 @@
 
 use crate::checkpoint::MetadataTableCache;
 use crate::commit::{core_commit_fingerprint_for_v0_request, SemanticMutationIdentity};
-use crate::content::ContentAdmission;
 use crate::context::MutationContext;
 use crate::error::{
     CoreError, MetadataProjectionLoadError, MetadataViewError, Result, WriterFence,
@@ -14,6 +13,7 @@ use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceC
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PathMutationIntent};
 use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
+use crate::storage::content_admission::ContentAdmission;
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};

--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -1,10 +1,11 @@
 //! Public facade over the durable content storage helpers.
 
 pub use crate::storage::content::{
-    read_durable_content_bytes, store_bytes_as_content, store_bytes_as_content_with_store_id,
+    prepare_existing_content_ref, prepare_stored_content, read_durable_content_bytes,
+    store_bytes_as_content, store_bytes_as_content_with_store_id,
     validate_durable_content_reference, DurableContentValidationError, ReadDurableContent,
     StoredContent, ValidatedDurableContent,
 };
 pub use crate::storage::content_admission::{
-    mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
+    mint_content_token, verify_content_token, ContentTokenError, PreparedContent,
 };

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -38,7 +38,6 @@ async fn create_checkpoint<S: ObjectStore + ?Sized>(
     .await
 }
 use crate::commit_engine::{NamespaceCommitEngine, NamespaceMutationCandidate};
-use crate::content::ContentAdmission;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::delete::delete_namespace;
 use crate::namespace::fork::fork_namespace;
@@ -46,6 +45,7 @@ use crate::options::DeleteNamespaceOptions;
 use crate::path::read::{load_metadata_view, ReadLoadContext};
 use crate::publish::PathMutationIntent;
 use crate::storage::content::store_bytes_as_content;
+use crate::storage::content_admission::ContentAdmission;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior};
@@ -119,7 +119,6 @@ async fn write_file<S: ObjectStore>(
                 admissions: vec![ContentAdmission::for_durable_content_write(
                     namespace_id.clone(),
                     content_ref,
-                    context.now_ms,
                 )],
             }],
             context,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -106,6 +106,7 @@ pub mod publish {
     };
     pub use crate::path::write::PathMutationIntent;
     pub use crate::protocol::PublishTailOptions;
+    pub use crate::storage::content_admission::ContentAdmission;
 }
 
 pub use checkpoint::{

--- a/crates/loonfs-core/src/path/write/content_write.rs
+++ b/crates/loonfs-core/src/path/write/content_write.rs
@@ -2,8 +2,9 @@
 
 use crate::error::Result;
 use crate::path::helpers::validate_path_for_mutation;
-use crate::storage::content::store_bytes_as_content;
-use loonfs_api::{ContentRef, NamespaceId};
+use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
+use crate::storage::content_admission::PreparedContent;
+use loonfs_api::NamespaceId;
 use loonfs_objectstore::ObjectStore;
 
 pub(super) async fn store_file_bytes_before_metadata_publish<S: ObjectStore + ?Sized>(
@@ -11,8 +12,8 @@ pub(super) async fn store_file_bytes_before_metadata_publish<S: ObjectStore + ?S
     namespace_id: &NamespaceId,
     absolute_path: &str,
     bytes: &[u8],
-) -> Result<ContentRef> {
+) -> Result<PreparedContent> {
     validate_path_for_mutation(absolute_path)?;
     let stored = store_bytes_as_content(store, namespace_id, bytes).await?;
-    Ok(stored.content_ref)
+    Ok(prepare_stored_content(namespace_id.clone(), stored))
 }

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -4,13 +4,12 @@
 use super::content_write::store_file_bytes_before_metadata_publish;
 use super::intent::PathMutationIntent;
 use crate::commit_engine::NamespaceMutationCandidate;
-use crate::content::ContentAdmission;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::path::helpers::parse_mutation_path;
+use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use loonfs_api::{
-    CommitId, CommitResponse, ContentRef, DeleteDirectoryBehavior, DestinationBehavior,
-    NamespaceId, RevisionNo,
+    CommitId, CommitResponse, DeleteDirectoryBehavior, DestinationBehavior, NamespaceId, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 
@@ -57,13 +56,13 @@ pub(crate) async fn put_file_bytes<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse, CoreError> {
-    let content_ref =
+    let prepared_content =
         store_file_bytes_before_metadata_publish(store, namespace_id, absolute_path, bytes).await?;
-    put_file_content_ref(
+    put_prepared_file_content(
         store,
         namespace_id,
         absolute_path,
-        content_ref,
+        prepared_content,
         behavior,
         context,
         commit_id,
@@ -91,20 +90,16 @@ pub(crate) async fn write_file_bytes<S: ObjectStore + ?Sized>(
     .await
 }
 
-pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
+async fn put_prepared_file_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     absolute_path: &str,
-    content_ref: ContentRef,
+    prepared_content: PreparedContent,
     behavior: DestinationBehavior,
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse, CoreError> {
-    let admission = ContentAdmission::for_durable_content_write(
-        namespace_id.clone(),
-        content_ref.clone(),
-        context.now_ms,
-    );
+    let content_ref = prepared_content.content_ref().clone();
     submit_path_intent(
         store,
         namespace_id,
@@ -114,7 +109,7 @@ pub(crate) async fn put_file_content_ref<S: ObjectStore + ?Sized>(
             content_ref,
             behavior,
         },
-        vec![admission],
+        vec![prepared_content.into_admission()],
         context,
     )
     .await

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -74,12 +74,12 @@ impl PublishPlanningSession {
 mod tests {
     use super::*;
     use crate::commit_engine::{publish_namespace_mutations_batch, NamespaceMutationCandidate};
-    use crate::content::ContentAdmission;
     use crate::context::MutationContext;
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
+    use crate::storage::content_admission::ContentAdmission;
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
@@ -124,7 +124,6 @@ mod tests {
             admissions: vec![ContentAdmission::for_durable_content_write(
                 NamespaceId::parse("demo").expect("valid namespace id"),
                 content_ref,
-                u64::MAX,
             )],
         }
     }

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -149,7 +149,6 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 &view.content_store_id,
                 &request,
                 candidate,
-                context.now_ms,
                 &mut content_validation,
             )
             .await

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -8,11 +8,11 @@ use crate::commit::{
     CommitOp, CommitRequest as CoreCommitRequest, SemanticMutationIdentity,
 };
 use crate::commit_engine::NamespaceMutationCandidate;
-use crate::content::ContentAdmission;
 use crate::error::{CoreError, Result};
 use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PublishPlanningSession};
 use crate::storage::content::ContentValidationTracker;
+use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{CommitId, ContentRef, ContentStoreId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
@@ -242,14 +242,13 @@ fn commit_response_from_commit_receipt(
 struct CommitContentAdmissions<'a> {
     namespace_id: &'a NamespaceId,
     admissions: &'a [ContentAdmission],
-    now_ms: u64,
 }
 
 impl CommitContentAdmissions<'_> {
     fn admits(&self, content_ref: &ContentRef) -> bool {
         self.admissions
             .iter()
-            .any(|admission| admission.admits(self.namespace_id, content_ref, self.now_ms))
+            .any(|admission| admission.admits(self.namespace_id, content_ref))
     }
 }
 
@@ -261,7 +260,6 @@ pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
     request: &CoreCommitRequest,
     candidate: &NamespaceMutationCandidate,
-    now_ms: u64,
     content_validation: &mut ContentValidationTracker,
 ) -> Result<()> {
     match candidate {
@@ -287,7 +285,6 @@ pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
             let admissions = CommitContentAdmissions {
                 namespace_id: &request.namespace_id,
                 admissions: candidate_content_admissions(candidate),
-                now_ms,
             };
             if !admissions.admits(content_ref) {
                 return Err(CoreError::ContentNotPrepared {

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -15,6 +15,7 @@ use crate::namespace::control::{
     load_namespace_head_control,
 };
 use crate::storage::content::{probe_durable_content_reference, write_immutable_object};
+use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
@@ -270,9 +271,10 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
 
                 let staged_content_ref = match state.staged_content_ref.clone() {
                     Some(content_ref) => content_ref,
-                    None => {
-                        stage_direct_put_content_ref(store, &namespace_id, &state, &request).await?
-                    }
+                    None => stage_direct_put_content_ref(store, &namespace_id, &state, &request)
+                        .await?
+                        .content_ref()
+                        .clone(),
                 };
                 if staged_content_ref != request.content_ref {
                     return Err(CoreError::InvalidUploadContent(
@@ -307,7 +309,7 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     state: &UploadSessionState,
     request: &CompleteUploadRequest,
-) -> Result<ContentRef> {
+) -> Result<PreparedContent> {
     if state.mode != UploadMode::DirectPut {
         return Err(CoreError::InvalidUploadContent(
             "upload content has not been staged".to_owned(),
@@ -336,5 +338,8 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     probe_durable_content_reference(store, &content_store_id, &request.content_ref)
         .await
         .map_err(|err| CoreError::InvalidUploadContent(err.to_string()))?;
-    Ok(request.content_ref.clone())
+    let content_ref = request.content_ref.clone();
+    let admission =
+        ContentAdmission::for_durable_content_write(namespace_id.clone(), content_ref.clone());
+    Ok(PreparedContent::from_admission(content_ref, admission))
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -4,6 +4,7 @@
 use crate::error::{CoreError, StoreFailureClass};
 use crate::invariants::InvariantId;
 use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::content_blob;
@@ -27,14 +28,19 @@ pub struct ReadDurableContent {
     pub bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct StoredContent {
     pub content_store_id: ContentStoreId,
     pub object_key: String,
     pub content_ref: ContentRef,
     pub file_digest_sha256: String,
     pub file_size_bytes: u64,
+    #[serde(skip)]
+    _write_acknowledged: StoredContentWriteAcknowledgement,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StoredContentWriteAcknowledgement;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ContentValidationTracker {
@@ -104,6 +110,34 @@ pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
 
     let bytes = load_required_object(store, &object_key).await?;
     validate_loaded_content_bytes(object_key, content_ref, &bytes)
+}
+
+/// Prepares content from an acknowledged LoonFS-managed durable write.
+///
+/// Consuming [`StoredContent`] ties the proof to the successful return from
+/// [`store_bytes_as_content`] or [`store_bytes_as_content_with_store_id`].
+pub fn prepare_stored_content(
+    namespace_id: NamespaceId,
+    stored_content: StoredContent,
+) -> PreparedContent {
+    let content_ref = stored_content.content_ref;
+    let admission = ContentAdmission::for_durable_content_write(namespace_id, content_ref.clone());
+    PreparedContent::from_admission(content_ref, admission)
+}
+
+/// Fully validates an existing durable content reference for publication.
+///
+/// This performs one object HEAD followed by one full GET and digest check.
+pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
+    content_ref: ContentRef,
+) -> Result<PreparedContent, DurableContentValidationError> {
+    validate_durable_content_reference(store, content_store_id, &content_ref).await?;
+    let admission =
+        ContentAdmission::for_durable_content_write(namespace_id.clone(), content_ref.clone());
+    Ok(PreparedContent::from_admission(content_ref, admission))
 }
 
 /// Proves a content reference is durable — the object exists and carries the
@@ -267,6 +301,7 @@ pub async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
         file_digest_sha256: content_ref.digest.clone(),
         file_size_bytes: content_ref.size_bytes,
         content_ref,
+        _write_acknowledged: StoredContentWriteAcknowledgement,
     })
 }
 

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -1,6 +1,9 @@
-//! Short-lived content tokens: a serving session mints one after
-//! validating direct-put content, and batch validation accepts it instead
-//! of re-probing object storage for the blob.
+//! Producer-only content preparation proofs and short-lived wire tokens.
+//!
+//! A serving session verifies token expiry once when turning a signed wire
+//! token into an in-process [`ContentAdmission`]. Admissions then remain valid
+//! for the process lifetime: they record accepted authoritative evidence that
+//! the identified content is durable, rather than carrying another clock.
 
 use base64::Engine as _;
 use loonfs_api::v0::ValidatedContentToken;
@@ -16,39 +19,47 @@ const DEFAULT_TOKEN_TTL_MS: u64 = 60 * 60 * 1000;
 pub struct ContentAdmission {
     namespace_id: NamespaceId,
     content_ref: ContentRef,
-    expires_at_ms: u64,
 }
 
 impl ContentAdmission {
-    /// Admits a content ref the caller itself wrote durably (and had acked)
-    /// before submitting the publish, so batch validation does not re-probe
-    /// object storage for a blob this process just stored. The caller's own
-    /// completed write is the durability authority, exactly like a token
-    /// minted after upload validation.
-    pub fn for_durable_content_write(
+    pub(crate) fn for_durable_content_write(
         namespace_id: NamespaceId,
         content_ref: ContentRef,
-        now_ms: u64,
     ) -> Self {
         Self {
             namespace_id,
             content_ref,
-            // Generous on purpose: it must outlive batched publications
-            // and stale-head retries. An expired admission no longer covers
-            // the publication.
-            expires_at_ms: now_ms.saturating_add(DEFAULT_TOKEN_TTL_MS),
         }
     }
 
-    pub(crate) fn admits(
-        &self,
-        namespace_id: &NamespaceId,
-        content_ref: &ContentRef,
-        now_ms: u64,
-    ) -> bool {
-        self.namespace_id == *namespace_id
-            && self.content_ref == *content_ref
-            && self.expires_at_ms >= now_ms
+    pub(crate) fn admits(&self, namespace_id: &NamespaceId, content_ref: &ContentRef) -> bool {
+        self.namespace_id == *namespace_id && self.content_ref == *content_ref
+    }
+}
+
+/// Opaque evidence that a content reference was prepared for publication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedContent {
+    content_ref: ContentRef,
+    admission: ContentAdmission,
+}
+
+impl PreparedContent {
+    pub(crate) fn from_admission(content_ref: ContentRef, admission: ContentAdmission) -> Self {
+        Self {
+            content_ref,
+            admission,
+        }
+    }
+
+    /// Returns the prepared content reference.
+    pub fn content_ref(&self) -> &ContentRef {
+        &self.content_ref
+    }
+
+    /// Consumes the proof and returns its publisher admission.
+    pub fn into_admission(self) -> ContentAdmission {
+        self.admission
     }
 }
 
@@ -136,11 +147,10 @@ pub fn verify_content_token(
         return Err(ContentTokenError::Expired);
     }
 
-    Ok(ContentAdmission {
-        namespace_id: payload.namespace_id,
-        content_ref: payload.content_ref,
-        expires_at_ms: payload.expires_at_ms,
-    })
+    Ok(ContentAdmission::for_durable_content_write(
+        payload.namespace_id,
+        payload.content_ref,
+    ))
 }
 
 fn base64_url(bytes: &[u8]) -> String {
@@ -201,7 +211,30 @@ mod tests {
         let admission =
             verify_content_token("secret", &namespace, &token, 1_000).expect("verify token");
 
-        assert!(admission.admits(&namespace, &content, 1_000));
+        assert!(admission.admits(&namespace, &content));
+    }
+
+    #[test]
+    fn verified_token_admission_does_not_decay_after_token_expiry() {
+        let namespace = NamespaceId::parse("demo").expect("namespace");
+        let content = ContentRef::whole_file_v0(b"hello");
+        let issued_at_ms = 1_000;
+        let token = mint_content_token("secret", &namespace, &content, issued_at_ms).expect("mint");
+        let token = ValidatedContentToken {
+            content_ref: content.clone(),
+            token,
+        };
+        let admission = verify_content_token(
+            "secret",
+            &namespace,
+            &token,
+            issued_at_ms + DEFAULT_TOKEN_TTL_MS,
+        )
+        .expect("verify token before expiry");
+
+        // The admission carries no clock: expiry was the token's concern,
+        // checked exactly once by the verification above.
+        assert!(admission.admits(&namespace, &content));
     }
 
     #[test]

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -14,7 +14,7 @@ use loonfs_core::cache::{
     WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
     DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
-use loonfs_core::content::{store_bytes_as_content, ContentAdmission};
+use loonfs_core::content::{prepare_existing_content_ref, store_bytes_as_content};
 use loonfs_core::control::load_namespace_read_anchor;
 use loonfs_core::gc::{gc_namespace, GcConfig};
 use loonfs_core::publish::{NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent};
@@ -38,6 +38,15 @@ async fn put_file<S: ObjectStore + ?Sized>(
     let content = store_bytes_as_content(store, namespace_id, bytes)
         .await
         .expect("stage content");
+    let prepared = prepare_existing_content_ref(
+        store,
+        namespace_id,
+        &content.content_store_id,
+        content.content_ref,
+    )
+    .await
+    .expect("prepare existing content");
+    let content_ref = prepared.content_ref().clone();
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
@@ -45,14 +54,10 @@ async fn put_file<S: ObjectStore + ?Sized>(
                 intent: PathMutationIntent::PutFile {
                     commit_id: loonfs_api::CommitId::generate(),
                     absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
-                    content_ref: content.content_ref.clone(),
+                    content_ref,
                     behavior: loonfs_api::DestinationBehavior::NoReplace,
                 },
-                admissions: vec![ContentAdmission::for_durable_content_write(
-                    namespace_id.clone(),
-                    content.content_ref,
-                    context.now_ms,
-                )],
+                admissions: vec![prepared.into_admission()],
             }],
             context,
         )

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -37,7 +37,7 @@ use loonfs_core::commit::{
     CommitValidationContext, CommitValidationError, PreparedCommit,
 };
 use loonfs_core::content::{
-    mint_content_token, store_bytes_as_content, verify_content_token, ContentAdmission,
+    mint_content_token, prepare_existing_content_ref, store_bytes_as_content, verify_content_token,
 };
 use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anchor};
 use loonfs_core::metadata::MetadataState;
@@ -261,18 +261,25 @@ fn read_context<S: ObjectStore + ?Sized>(
 
 /// Publishes one path intent through the commit engine — the single publish
 /// pipeline.
-fn admitted_candidate(
+fn admitted_candidate<S: ObjectStore + ?Sized>(
+    store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
 ) -> NamespaceMutationCandidate {
     match &intent {
         PathMutationIntent::PutFile { content_ref, .. } => {
+            let content_store_id =
+                load_namespace_descriptor_state(store, namespace_id).content_store_id;
+            let admission = block_on(prepare_existing_content_ref(
+                store,
+                namespace_id,
+                &content_store_id,
+                content_ref.clone(),
+            ))
+            .expect("prepare existing content")
+            .into_admission();
             NamespaceMutationCandidate::PathWithContentAdmission {
-                admissions: vec![ContentAdmission::for_durable_content_write(
-                    namespace_id.clone(),
-                    content_ref.clone(),
-                    u64::MAX,
-                )],
+                admissions: vec![admission],
                 intent,
             }
         }
@@ -286,7 +293,7 @@ async fn submit_intent_async<S: ObjectStore + ?Sized>(
     intent: PathMutationIntent,
     context: &MutationContext,
 ) -> Result<loonfs_api::CommitResponse, CoreError> {
-    let candidate = admitted_candidate(namespace_id, intent);
+    let candidate = admitted_candidate(store, namespace_id, intent);
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(store, vec![candidate], context)
         .await
@@ -1792,63 +1799,6 @@ async fn valid_content_admission_skips_durable_content_validation() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn expired_content_admission_fails_without_durable_validation() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = mutation_context();
-
-    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
-    let content = store_bytes_as_content(&store, &namespace_id, b"expired")
-        .await
-        .expect("stage content");
-    let token = ValidatedContentToken {
-        content_ref: content.content_ref.clone(),
-        token: mint_content_token(
-            "test-content-token-secret",
-            &namespace_id,
-            &content.content_ref,
-            context.now_ms,
-        )
-        .expect("mint token"),
-    };
-    let admission = verify_content_token(
-        "test-content-token-secret",
-        &namespace_id,
-        &token,
-        context.now_ms,
-    )
-    .expect("verify token");
-    let mut expired_context = context.clone();
-    expired_context.now_ms += 60 * 60 * 1000 + 1;
-
-    store.reset_content_blob_counters();
-    let responses = publish_namespace_mutations_batch(
-        &store,
-        &namespace_id,
-        vec![NamespaceMutationCandidate::PathWithContentAdmission {
-            intent: PathMutationIntent::PutFile {
-                commit_id: CommitId::parse("put-expired-admission").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs/expired.txt").expect("path"),
-                content_ref: content.content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            },
-            admissions: vec![admission],
-        }],
-        &expired_context,
-    );
-
-    assert_eq!(
-        responses[0]
-            .as_ref()
-            .expect_err("expired admission must not cover publication")
-            .code(),
-        ErrorCode::ContentNotPrepared
-    );
-    assert_eq!(store.content_blob_get_count(), 0);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
     let temp_dir = tempdir().expect("tempdir");
     let store = ContentBlobGetCountingStore::new(temp_dir.path());
@@ -2107,6 +2057,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
                 expected_inode_id: None,
             }),
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
@@ -3076,6 +3027,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             }),
             // Accepted into the batch.
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("accept-a").expect("valid commit id"),
@@ -3087,6 +3039,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             // Rejected only because of the accepted candidate's speculative
             // in-batch create.
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
@@ -3171,6 +3124,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 expected_inode_id: None,
             }),
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("accept-a").expect("valid commit id"),
@@ -3180,6 +3134,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 },
             ),
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
@@ -3677,6 +3632,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
         &namespace_id,
         vec![
             admitted_candidate(
+                &store,
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
@@ -4668,6 +4624,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
         &store,
         &namespace_id(),
         vec![admitted_candidate(
+            &store,
             &namespace_id(),
             PathMutationIntent::PutFile {
                 commit_id: commit_id.clone(),

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -9,9 +9,8 @@ use crate::config::ServerConfig;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use loonfs::content_tokens::{
-    mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
-};
+use loonfs::content_tokens::{mint_content_token, verify_content_token, ContentTokenError};
+use loonfs::publish::ContentAdmission;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::ErrorCode;

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -1,9 +1,7 @@
 //! Path mutations, commits, and the publication pipeline.
 
 use super::core::{BackgroundTickClaim, FsCore};
-use crate::content_tokens::ContentAdmission;
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
-use crate::time::current_time_ms;
 use crate::{
     ChangeSeq, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse, ContentRef,
     CopyOptions, CoreError, CreateDirectoryOptions, DeleteOptions, InodeId, MaintenanceTickOptions,
@@ -66,20 +64,19 @@ impl FsCore {
                     .await?
             }
         };
-        // The admission tells batch validation not to re-probe for the blob
-        // whose acked write this handle just observed.
-        let content_admission = ContentAdmission::for_durable_content_write(
-            namespace_id.clone(),
-            stored.content_ref.clone(),
-            current_time_ms()?,
-        );
+        // The acknowledged write is the authority for the prepared proof, so
+        // batch validation does not re-probe the blob this handle just stored.
+        let prepared_content =
+            loonfs_core::content::prepare_stored_content(namespace_id.clone(), stored);
+        let content_ref = prepared_content.content_ref().clone();
+        let content_admission = prepared_content.into_admission();
         self.publish_candidate(
             namespace_id,
             NamespaceMutationCandidate::PathWithContentAdmission {
                 intent: PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
                     absolute_path,
-                    content_ref: stored.content_ref,
+                    content_ref,
                     behavior: options.behavior,
                 },
                 admissions: vec![content_admission],
@@ -131,18 +128,16 @@ impl FsCore {
                     .clone()
             }
         };
-        loonfs_core::content::validate_durable_content_reference(
+        let prepared_content = loonfs_core::content::prepare_existing_content_ref(
             &self.inner.store,
+            namespace_id,
             &content_store_id,
-            &content_ref,
+            content_ref,
         )
         .await
         .map_err(CoreError::from)?;
-        let content_admission = ContentAdmission::for_durable_content_write(
-            namespace_id.clone(),
-            content_ref.clone(),
-            current_time_ms()?,
-        );
+        let content_ref = prepared_content.content_ref().clone();
+        let content_admission = prepared_content.into_admission();
         self.publish_candidate(
             namespace_id,
             NamespaceMutationCandidate::PathWithContentAdmission {

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -75,16 +75,19 @@ pub use loonfs_core::{
 /// never need this module.
 pub mod publish {
     pub use loonfs_core::path::parse_mutation_path;
-    pub use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+    pub use loonfs_core::publish::{
+        ContentAdmission, NamespaceMutationCandidate, PathMutationIntent,
+    };
 }
 
-/// Server-integration seam: mint/verify surface for the short-lived content
-/// tokens a serving session uses to admit already-validated direct-put
-/// content. Most embedded users never need this module.
+/// Server-integration seam for producer-only content admissions.
+///
+/// A serving session mints short-lived wire tokens after durable preparation
+/// and verifies expiry once before yielding an opaque publisher admission.
+/// The in-process admission records accepted durability evidence and does not
+/// expire. Most embedded users never need this module.
 pub mod content_tokens {
-    pub use loonfs_core::content::{
-        mint_content_token, verify_content_token, ContentAdmission, ContentTokenError,
-    };
+    pub use loonfs_core::content::{mint_content_token, verify_content_token, ContentTokenError};
 }
 
 /// Server-integration seam: the resolved direct-put upload target a serving

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -47,9 +47,8 @@
 //! [`FsWriter::shutdown_background`](crate::FsWriter::shutdown_background)
 //! drains without closing, so the handle stays usable.
 
-use crate::content_tokens::ContentAdmission;
 use crate::fs::{FsCore, FsInner};
-use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use crate::publish::{ContentAdmission, NamespaceMutationCandidate, PathMutationIntent};
 use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeError};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, NamespaceId};
@@ -2079,6 +2078,17 @@ mod tests {
             .upload_content(&namespace_id, &upload.upload_id, b"hello")
             .await
             .expect("stage content");
+        let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+            .await
+            .expect("load namespace catalog");
+        let prepared_content = loonfs_core::content::prepare_existing_content_ref(
+            &store,
+            &namespace_id,
+            catalog.content_store_id(),
+            staged.content_ref,
+        )
+        .await
+        .expect("prepare existing content");
         let registry = writer.publisher();
 
         // Warm the namespace so the pacing interval deterministically holds
@@ -2103,14 +2113,10 @@ mod tests {
         let path_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("path-put").expect("valid commit id"),
             absolute_path: AbsolutePath::parse("/file.txt").expect("path"),
-            content_ref: staged.content_ref.clone(),
+            content_ref: prepared_content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
         };
-        let content_admission = ContentAdmission::for_durable_content_write(
-            namespace_id.clone(),
-            staged.content_ref,
-            u64::MAX,
-        );
+        let content_admission = prepared_content.into_admission();
 
         let (explicit_response, path_response) = tokio::join!(
             registry.submit_commit(namespace_id.clone(), explicit),

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -11,7 +11,6 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use loonfs::content_tokens::ContentAdmission;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
 };
@@ -137,14 +136,22 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         let mut candidates = Vec::new();
         for index in (0..FILES).filter(|index| index % RUNS == run) {
             let bytes = format!("body {index}");
-            let content_ref = loonfs_core::content::store_bytes_as_content(
+            let stored = loonfs_core::content::store_bytes_as_content(
                 &store,
                 &namespace_id,
                 bytes.as_bytes(),
             )
             .await
-            .expect("stage content")
-            .content_ref;
+            .expect("stage content");
+            let prepared = loonfs_core::content::prepare_existing_content_ref(
+                &store,
+                &namespace_id,
+                &stored.content_store_id,
+                stored.content_ref,
+            )
+            .await
+            .expect("prepare existing content");
+            let content_ref = prepared.content_ref().clone();
             candidates.push(
                 loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
                     intent: loonfs::publish::PathMutationIntent::PutFile {
@@ -156,11 +163,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
                         content_ref: content_ref.clone(),
                         behavior: loonfs::DestinationBehavior::NoReplace,
                     },
-                    admissions: vec![ContentAdmission::for_durable_content_write(
-                        namespace_id.clone(),
-                        content_ref,
-                        u64::MAX,
-                    )],
+                    admissions: vec![prepared.into_admission()],
                 },
             );
         }

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -3,8 +3,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs::content_tokens::ContentAdmission;
-use loonfs::publish::{parse_mutation_path, PathMutationIntent};
+use loonfs::publish::{parse_mutation_path, ContentAdmission, PathMutationIntent};
 use loonfs::{
     CommitId, CommitOp, CommitRequest, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ErrorCode, FsWriter, InodeId, NamespaceId, PutFileOptions, RevisionNo,
@@ -419,11 +418,24 @@ async fn build_initialized_writer(
     writer
 }
 
-fn durable_admission(
+/// Full external preparation performs one content HEAD and one full GET.
+async fn prepare_admission(
+    store: &SharedObjectStore,
     namespace_id: &NamespaceId,
     content_ref: &loonfs::ContentRef,
 ) -> ContentAdmission {
-    ContentAdmission::for_durable_content_write(namespace_id.clone(), content_ref.clone(), u64::MAX)
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    loonfs_core::content::prepare_existing_content_ref(
+        store,
+        namespace_id,
+        catalog.content_store_id(),
+        content_ref.clone(),
+    )
+    .await
+    .expect("prepare existing content")
+    .into_admission()
 }
 
 fn put_intent(commit_id: &str, path: &str, content_ref: loonfs::ContentRef) -> PathMutationIntent {
@@ -669,13 +681,14 @@ async fn commit_id_replay_performs_no_content_operations() {
     let harness = TestHarness::new("receipt-replay").await;
     let content_ref = harness.stage_content(b"replayed content").await;
     let intent = put_intent("replayed-put", "/file.txt", content_ref.clone());
+    let admission = prepare_admission(&harness.store, &harness.namespace_id, &content_ref).await;
     let original = harness
         .writer
         .publisher()
         .submit_path_intent_with_content_admission(
             harness.namespace_id.clone(),
             intent.clone(),
-            vec![durable_admission(&harness.namespace_id, &content_ref)],
+            vec![admission],
         )
         .await
         .expect("publish original put");
@@ -710,7 +723,9 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
             .expect("stage content")
             .content_ref;
     let intent = put_intent("in-flight-put", "/file.txt", content_ref.clone());
-    let admission = durable_admission(&namespace_id, &content_ref);
+    // Full preparation deliberately costs one content HEAD and one GET; do it
+    // before the reset so this phase isolates publication and duplicate join.
+    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
     blocking.arm_next_head_cas();
@@ -775,7 +790,9 @@ async fn stale_head_retry_preserves_content_admission() {
             .expect("stage content")
             .content_ref;
     let intent = put_intent("retry-put", "/file.txt", content_ref.clone());
-    let admission = durable_admission(&namespace_id, &content_ref);
+    // Full preparation deliberately costs one content HEAD and one GET; do it
+    // before the reset so this phase isolates publication retries.
+    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
     recording.reset();
     conflicting.fail_next_head_cas();
 
@@ -807,6 +824,9 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
             .await
             .expect("stage content")
             .content_ref;
+    // Full preparation deliberately costs one content HEAD and one GET; do it
+    // before the reset so this phase isolates mixed-batch publication.
+    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
     blocking.arm_next_head_cas();
@@ -832,7 +852,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
     let mut admitted = Box::pin(registry.submit_path_intent_with_content_admission(
         namespace_id.clone(),
         put_intent("mixed-admitted", "/admitted.txt", content_ref.clone()),
-        vec![durable_admission(&namespace_id, &content_ref)],
+        vec![admission],
     ));
     assert!(
         futures::poll!(admitted.as_mut()).is_pending(),
@@ -859,33 +879,4 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
 
     assert_content_not_prepared(error, &content_ref);
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
-}
-
-#[tokio::test]
-async fn expired_content_admission_fails_without_content_io() {
-    let harness = TestHarness::new("expired-admission").await;
-    let bytes = b"expired admission content";
-    let content_ref = harness.stage_content(bytes).await;
-    let expired_admission = ContentAdmission::for_durable_content_write(
-        harness.namespace_id.clone(),
-        content_ref.clone(),
-        0,
-    );
-    harness.recording.reset();
-
-    // Expiry still makes an admission uncovered in this narrow cut. A later
-    // PR removes internal admission expiry and will make this succeed again.
-    let error = harness
-        .writer
-        .publisher()
-        .submit_path_intent_with_content_admission(
-            harness.namespace_id.clone(),
-            put_intent("expired-put", "/file.txt", content_ref.clone()),
-            vec![expired_admission],
-        )
-        .await
-        .expect_err("expired admission must not cover publication");
-
-    assert_content_not_prepared(error, &content_ref);
-    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
-use loonfs::content_tokens::ContentAdmission;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     BeginUploadRequest, CommitId, CommitResponse, CoreError, CreateNamespaceOptions,
@@ -182,6 +181,19 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         .upload_content(&namespace_id, &upload.upload_id, b"b")
         .await
         .expect("stage second put content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = loonfs_core::content::prepare_existing_content_ref(
+        &store,
+        &namespace_id,
+        catalog.content_store_id(),
+        staged.content_ref,
+    )
+    .await
+    .expect("prepare second put content");
+    let prepared_content_ref = prepared.content_ref().clone();
+    let admission = prepared.into_admission();
 
     store_impl.arm();
     let first = {
@@ -204,14 +216,9 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         let intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("parked-second").expect("valid commit id"),
             absolute_path: parse_mutation_path("/b.txt").expect("mutation path"),
-            content_ref: staged.content_ref.clone(),
+            content_ref: prepared_content_ref,
             behavior: DestinationBehavior::NoReplace,
         };
-        let admission = ContentAdmission::for_durable_content_write(
-            namespace_id.clone(),
-            staged.content_ref,
-            u64::MAX,
-        );
         Box::pin(async move {
             registry
                 .submit_path_intent_with_content_admission(namespace_id, intent, vec![admission])

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -10,7 +10,6 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs::content_tokens::ContentAdmission;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
     PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
@@ -215,14 +214,24 @@ async fn warm_phase_request_accounting() {
         let mut candidates = Vec::with_capacity(BATCH);
         for _ in 0..BATCH.min(FILES - index) {
             let bytes = format!("body {index}");
-            let content_ref = loonfs_core::content::store_bytes_as_content(
+            let stored = loonfs_core::content::store_bytes_as_content(
                 &store,
                 &namespace_id,
                 bytes.as_bytes(),
             )
             .await
-            .expect("stage content")
-            .content_ref;
+            .expect("stage content");
+            // External tests prepare through the validating producer: one
+            // content HEAD and one full GET by design.
+            let prepared = loonfs_core::content::prepare_existing_content_ref(
+                &store,
+                &namespace_id,
+                &stored.content_store_id,
+                stored.content_ref,
+            )
+            .await
+            .expect("prepare existing content");
+            let content_ref = prepared.content_ref().clone();
             candidates.push(
                 loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
                     intent: loonfs::publish::PathMutationIntent::PutFile {
@@ -232,11 +241,7 @@ async fn warm_phase_request_accounting() {
                         content_ref: content_ref.clone(),
                         behavior: loonfs::DestinationBehavior::NoReplace,
                     },
-                    admissions: vec![ContentAdmission::for_durable_content_write(
-                        namespace_id.clone(),
-                        content_ref,
-                        u64::MAX,
-                    )],
+                    admissions: vec![prepared.into_admission()],
                 },
             );
             index += 1;

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -4,7 +4,6 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs::content_tokens::ContentAdmission;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
@@ -2498,7 +2497,11 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         // Stage every file's content first: a put publishes only after its
         // bytes are durable, so racing already-staged publishes is what
         // reaches the publication queue together deterministically.
-        let mut content_refs = Vec::new();
+        let catalog =
+            loonfs_core::control::load_namespace_catalog_entry(&object_store, &namespace_id)
+                .await
+                .expect("load namespace catalog");
+        let mut prepared_contents = Vec::new();
         for bytes in [b"alpha" as &[u8], b"beta", b"gamma", b"delta"] {
             let begin = fs
                 .writer
@@ -2521,30 +2524,37 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                 )
                 .await
                 .expect("complete upload");
-            content_refs.push(completed.content_ref);
-        }
-        let [ref_a, ref_b, ref_c, ref_d] = content_refs.try_into().expect("four staged refs");
-        let segments_before = wal_segment_count(&object_store, &namespace_id).await;
-        let admitted_put = |commit_id: &str, path: &str, content_ref: ContentRef| {
-            let admission = ContentAdmission::for_durable_content_write(
-                namespace_id.clone(),
-                content_ref.clone(),
-                u64::MAX,
+            prepared_contents.push(
+                loonfs_core::content::prepare_existing_content_ref(
+                    &object_store,
+                    &namespace_id,
+                    catalog.content_store_id(),
+                    completed.content_ref,
+                )
+                .await
+                .expect("prepare completed content"),
             );
-            (
-                PathMutationIntent::PutFile {
-                    commit_id: CommitId::parse(commit_id).expect("valid commit id"),
-                    absolute_path: parse_mutation_path(path).expect("valid mutation path"),
-                    content_ref,
-                    behavior: DestinationBehavior::NoReplace,
-                },
-                vec![admission],
-            )
-        };
-        let put_a = admitted_put("batch-a", "/docs/a.txt", ref_a);
-        let put_b = admitted_put("batch-b", "/docs/b.txt", ref_b);
-        let put_c = admitted_put("batch-c", "/docs/c.txt", ref_c);
-        let put_d = admitted_put("batch-d", "/docs/d.txt", ref_d);
+        }
+        let [content_a, content_b, content_c, content_d] =
+            prepared_contents.try_into().expect("four prepared refs");
+        let segments_before = wal_segment_count(&object_store, &namespace_id).await;
+        let admitted_put =
+            |commit_id: &str, path: &str, prepared: loonfs_core::content::PreparedContent| {
+                let content_ref = prepared.content_ref().clone();
+                (
+                    PathMutationIntent::PutFile {
+                        commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+                        absolute_path: parse_mutation_path(path).expect("valid mutation path"),
+                        content_ref,
+                        behavior: DestinationBehavior::NoReplace,
+                    },
+                    vec![prepared.into_admission()],
+                )
+            };
+        let put_a = admitted_put("batch-a", "/docs/a.txt", content_a);
+        let put_b = admitted_put("batch-b", "/docs/b.txt", content_b);
+        let put_c = admitted_put("batch-c", "/docs/c.txt", content_c);
+        let put_d = admitted_put("batch-d", "/docs/d.txt", content_d);
         let publisher = fs.writer.publisher();
 
         let puts = tokio::join!(

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -226,7 +226,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `upload_not_found` | 404 | No upload session with this id. |
 | `namespace_exists` | 409 | The create target already exists. |
 | `namespace_partial` | 409 | The namespace is partially initialized and unusable. |
-| `content_not_prepared` | 409 | A path put references external content without a matching unexpired admission. Prepare the content and retry with its proof. |
+| `content_not_prepared` | 409 | A path put references external content without a matching admission. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
 | `stale_head` | 409 | The write raced a head advance; retry against fresh state. |


### PR DESCRIPTION
A `ContentAdmission` could be forged and could expire. `ContentAdmission::for_durable_content_write` was public and took arbitrary parts, so an embedder could mint an admission for bytes nobody wrote and the publisher would trust it. And the admission carried its own one-hour clock, so a sufficiently delayed queue could turn a prepared publication into a failure even though durable bytes do not stop being durable.

Admissions are now producer-only and clockless. The constructor is crate-private, and every admission originates from one of four events: an acknowledged LoonFS-managed content write (`prepare_stored_content`, which consumes the `StoredContent` returned by the write — `StoredContent` is now sealed against literal construction and deserialization), full durable validation (`prepare_existing_content_ref`, the one new public producer, used by `put_file_content_ref` and by tests that previously forged admissions), direct-put HEAD completion, and signed-token verification. Wire-token expiry is unchanged and checked exactly once at verification; the resulting in-process admission never expires, and the clock parameter is gone from the admission check end to end. Producers return the opaque `PreparedContent` pair; the candidate envelope that will carry it through the publisher is the next PR's work. The two expired-admission tests are deleted because the concept they pinned no longer exists; a new unit test pins that a verified token's admission outlives the token itself. No wire-visible changes.

One known edge deliberately left for the envelope PR: `StoredContent`'s fields stay public, so a caller holding a legitimate instance could still overwrite its `content_ref` before preparing it. Closing that fully means making `PreparedContent` the only currency through the seam, which is the next restructuring anyway.
