### PR TITLE
refactor(core,loonfs): unify publish candidate envelope

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -718,9 +718,11 @@ mod tests {
 
         assert_eq!(error.code, ErrorCode::RevisionNotFound.as_str());
 
-        let error = map_core_error(CoreError::ContentNotPrepared {
-            content_ref_digest: "abc123".to_owned(),
-        });
+        let error = map_core_error(CoreError::ContentPreparation(
+            loonfs::publish::ContentPreparationError::ContentNotPrepared {
+                content_ref_digest: "abc123".to_owned(),
+            },
+        ));
         assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
         assert!(error.message.contains("abc123"));
     }

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -13,45 +13,117 @@ use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceC
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PathMutationIntent};
 use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
-use crate::storage::content_admission::ContentAdmission;
+use crate::storage::content_admission::{ContentAdmission, ContentTokenError, PreparedContent};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};
 use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::sync::{Arc, Mutex};
+use thiserror::Error;
 
+/// One namespace mutation together with the result of preparing any content
+/// it references.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NamespaceMutationCandidate {
+pub struct NamespaceMutationCandidate {
+    mutation: NamespaceMutation,
+    content: ContentPreparation,
+}
+
+/// The semantic mutation carried by a publication candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceMutation {
     Commit(ApiCommitRequest),
     Path(PathMutationIntent),
-    PathWithContentAdmission {
-        intent: PathMutationIntent,
-        admissions: Vec<ContentAdmission>,
-    },
+}
+
+/// The result of preparing external content referenced by a mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentPreparation {
+    Ready(Vec<ContentAdmission>),
+    Rejected(ContentPreparationError),
+}
+
+/// A typed failure to prepare content referenced by a mutation candidate.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ContentPreparationError {
+    /// A supplied wire token was rejected before publication.
+    #[error("content token was rejected: {0}")]
+    ContentToken(#[from] ContentTokenError),
+    /// No prepared proof covers the referenced content.
+    #[error("content ref `{content_ref_digest}` is not prepared for publication")]
+    ContentNotPrepared { content_ref_digest: String },
 }
 
 impl NamespaceMutationCandidate {
-    pub fn commit_id(&self) -> &CommitId {
-        match self {
-            Self::Commit(request) => &request.commit_id,
-            Self::Path(intent) | Self::PathWithContentAdmission { intent, .. } => {
-                intent.commit_id()
-            }
+    /// Wraps an explicit semantic commit with no attached content proofs.
+    pub fn commit(request: ApiCommitRequest) -> Self {
+        Self {
+            mutation: NamespaceMutation::Commit(request),
+            content: ContentPreparation::Ready(Vec::new()),
         }
     }
 
+    /// Wraps a path mutation with no attached content proofs.
+    pub fn path(intent: PathMutationIntent) -> Self {
+        Self {
+            mutation: NamespaceMutation::Path(intent),
+            content: ContentPreparation::Ready(Vec::new()),
+        }
+    }
+
+    /// Wraps a path mutation with opaque proofs for its prepared content.
+    pub fn path_prepared(intent: PathMutationIntent, content: Vec<PreparedContent>) -> Self {
+        Self {
+            mutation: NamespaceMutation::Path(intent),
+            content: ContentPreparation::Ready(
+                content
+                    .into_iter()
+                    .map(PreparedContent::into_admission)
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Wraps a semantic mutation whose content preparation failed.
+    pub fn rejected(mutation: NamespaceMutation, error: ContentPreparationError) -> Self {
+        Self {
+            mutation,
+            content: ContentPreparation::Rejected(error),
+        }
+    }
+
+    pub(crate) fn mutation(&self) -> &NamespaceMutation {
+        &self.mutation
+    }
+
+    pub(crate) fn content_preparation(&self) -> &ContentPreparation {
+        &self.content
+    }
+
+    /// Returns the idempotency key carried by the semantic mutation.
+    pub fn commit_id(&self) -> &CommitId {
+        match &self.mutation {
+            NamespaceMutation::Commit(request) => &request.commit_id,
+            NamespaceMutation::Path(intent) => intent.commit_id(),
+        }
+    }
+
+    /// Computes semantic identity from the mutation alone.
     pub fn semantic_identity(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<SemanticMutationIdentity> {
-        match self {
-            Self::Commit(request) => core_commit_fingerprint_for_v0_request(namespace_id, request)
-                .map(SemanticMutationIdentity::CoreCommit)
-                .map_err(|err| {
-                    CoreError::Internal(format!("failed to fingerprint commit request: {err}"))
-                }),
-            Self::Path(intent) | Self::PathWithContentAdmission { intent, .. } => {
+        match &self.mutation {
+            NamespaceMutation::Commit(request) => {
+                core_commit_fingerprint_for_v0_request(namespace_id, request)
+                    .map(SemanticMutationIdentity::CoreCommit)
+                    .map_err(|err| {
+                        CoreError::Internal(format!("failed to fingerprint commit request: {err}"))
+                    })
+            }
+            NamespaceMutation::Path(intent) => {
                 path_intent_fingerprint_for_path_intent(namespace_id, intent)
                     .map(SemanticMutationIdentity::PathIntent)
             }
@@ -469,8 +541,28 @@ mod tests {
         }
     }
 
+    #[test]
+    fn semantic_identity_excludes_content_preparation() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let intent = PathMutationIntent::CreateDir {
+            commit_id: CommitId::parse("same-mutation").expect("valid commit id"),
+            absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("path"),
+            parents: false,
+        };
+        let ready = NamespaceMutationCandidate::path(intent.clone());
+        let rejected = NamespaceMutationCandidate::rejected(
+            NamespaceMutation::Path(intent),
+            ContentPreparationError::ContentToken(ContentTokenError::Expired),
+        );
+
+        assert_eq!(
+            ready.semantic_identity(&namespace_id).expect("identity"),
+            rejected.semantic_identity(&namespace_id).expect("identity")
+        );
+    }
+
     fn create_dir(commit_id: &str, display_name: &str) -> NamespaceMutationCandidate {
-        NamespaceMutationCandidate::Commit(ApiCommitRequest {
+        NamespaceMutationCandidate::commit(ApiCommitRequest {
             commit_id: CommitId::parse(commit_id).expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![loonfs_api::v0::CommitOp::CreateDirectory {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -7,6 +7,7 @@
 
 use crate::checkpoint::ManifestLoadError;
 use crate::commit::{CommitConversionError, CommitHeadPublishError, CommitValidationError};
+use crate::commit_engine::ContentPreparationError;
 use crate::metadata::VisiblePathError;
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::namespace::control::ControlObjectLoadError;
@@ -95,8 +96,8 @@ pub enum CoreError {
     DestinationExists(String),
     #[error("commit id conflict for `{0}`")]
     CommitIdReuseConflict(String),
-    #[error("content ref `{content_ref_digest}` is not prepared for publication")]
-    ContentNotPrepared { content_ref_digest: String },
+    #[error(transparent)]
+    ContentPreparation(#[from] ContentPreparationError),
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
     /// The serving front-end closed admission for shutdown. New work is
@@ -361,7 +362,7 @@ impl CoreError {
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
             CoreError::NamespacePartiallyInitialized { .. } => ErrorCode::NamespacePartial,
             CoreError::CommitIdReuseConflict(_) => ErrorCode::CommitIdReuseConflict,
-            CoreError::ContentNotPrepared { .. } => ErrorCode::ContentNotPrepared,
+            CoreError::ContentPreparation(_) => ErrorCode::ContentNotPrepared,
             CoreError::CommitQueueFull => ErrorCode::CommitQueueFull,
             CoreError::ShuttingDown => ErrorCode::ShuttingDown,
             CoreError::CheckpointUnavailable(_) => ErrorCode::CheckpointUnavailable,
@@ -713,6 +714,8 @@ mod tests {
     use super::{
         CommitValidationError, CoreError, ErrorCode, ErrorKind, MetadataViewError, WriterFence,
     };
+    use crate::commit_engine::ContentPreparationError;
+    use crate::storage::content_admission::ContentTokenError;
     use loonfs_api::{
         ChangeSeq, CommitId, InodeId, ManifestId, NamespaceId, RevisionNo, WriterEpoch,
     };
@@ -754,12 +757,21 @@ mod tests {
         assert_eq!(error.code().as_str(), "namespace_exists");
         assert!(error.message().contains("already exists"));
 
-        let error = CoreError::ContentNotPrepared {
+        let error = CoreError::ContentPreparation(ContentPreparationError::ContentNotPrepared {
             content_ref_digest: "abc123".to_owned(),
-        };
+        });
         assert_eq!(error.kind(), ErrorKind::Conflict);
         assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
         assert!(error.message().contains("abc123"));
+    }
+
+    #[test]
+    fn rejected_content_token_maps_to_content_not_prepared() {
+        let error = CoreError::from(ContentPreparationError::ContentToken(
+            ContentTokenError::Expired,
+        ));
+
+        assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
     }
 
     #[test]

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -44,8 +44,7 @@ use crate::namespace::fork::fork_namespace;
 use crate::options::DeleteNamespaceOptions;
 use crate::path::read::{load_metadata_view, ReadLoadContext};
 use crate::publish::PathMutationIntent;
-use crate::storage::content::store_bytes_as_content;
-use crate::storage::content_admission::ContentAdmission;
+use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior};
@@ -102,25 +101,23 @@ async fn write_file<S: ObjectStore>(
     commit_id: &str,
     context: &MutationContext,
 ) {
-    let content_ref = store_bytes_as_content(store, namespace_id, b"body\n")
+    let stored = store_bytes_as_content(store, namespace_id, b"body\n")
         .await
-        .expect("store content")
-        .content_ref;
+        .expect("store content");
+    let content_ref = stored.content_ref.clone();
+    let prepared = prepare_stored_content(namespace_id.clone(), stored);
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
-            vec![NamespaceMutationCandidate::PathWithContentAdmission {
-                intent: PathMutationIntent::PutFile {
+            vec![NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
                     commit_id: CommitId::parse(commit_id).expect("commit id"),
                     absolute_path: AbsolutePath::parse(path).expect("path"),
                     content_ref: content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
                 },
-                admissions: vec![ContentAdmission::for_durable_content_write(
-                    namespace_id.clone(),
-                    content_ref,
-                )],
-            }],
+                vec![prepared],
+            )],
             context,
         )
         .await

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -43,7 +43,7 @@
 //! let mut publisher = NamespaceCommitEngine::new(namespace);
 //! let _ = publisher.publish_batch(
 //!     &publish_store,
-//!     vec![NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
+//!     vec![NamespaceMutationCandidate::path(PathMutationIntent::CreateDir {
 //!         commit_id: CommitId::generate(),
 //!         absolute_path: AbsolutePath::parse("/plans").expect("path"),
 //!         parents: false,
@@ -101,12 +101,13 @@ pub mod control {
 pub mod publish {
     pub use crate::commit::{CommitHeadPublishError, SemanticMutationIdentity};
     pub use crate::commit_engine::{
-        NamespaceCommitEngine, NamespaceCommitEnginePublishResult, NamespaceMutationCandidate,
+        ContentPreparation, ContentPreparationError, NamespaceCommitEngine,
+        NamespaceCommitEnginePublishResult, NamespaceMutation, NamespaceMutationCandidate,
         ResultingReadState, SharedWriterSessionState, WalTailPolicy, WriterSessionState,
     };
     pub use crate::path::write::PathMutationIntent;
     pub use crate::protocol::PublishTailOptions;
-    pub use crate::storage::content_admission::ContentAdmission;
+    pub use crate::storage::content_admission::PreparedContent;
 }
 
 pub use checkpoint::{

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -536,7 +536,7 @@ mod tests {
         engine
             .publish_batch(
                 store,
-                vec![NamespaceMutationCandidate::Commit(ApiCommitRequest {
+                vec![NamespaceMutationCandidate::commit(ApiCommitRequest {
                     commit_id: CommitId::generate(),
                     preconditions: Vec::new(),
                     ops: vec![ApiCommitOp::CreateDirectory {

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -167,7 +167,7 @@ mod tests {
         engine
             .publish_batch(
                 store,
-                vec![NamespaceMutationCandidate::Commit(request)],
+                vec![NamespaceMutationCandidate::commit(request)],
                 context,
             )
             .await

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -7,7 +7,7 @@ use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::path::helpers::parse_mutation_path;
-use crate::storage::content_admission::{ContentAdmission, PreparedContent};
+use crate::storage::content_admission::PreparedContent;
 use loonfs_api::{
     CommitId, CommitResponse, DeleteDirectoryBehavior, DestinationBehavior, NamespaceId, RevisionNo,
 };
@@ -21,13 +21,13 @@ async fn submit_path_intent<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     intent: PathMutationIntent,
-    admissions: Vec<ContentAdmission>,
+    prepared_content: Vec<PreparedContent>,
     context: &MutationContext,
 ) -> Result<CommitResponse, CoreError> {
-    let candidate = if admissions.is_empty() {
-        NamespaceMutationCandidate::Path(intent)
+    let candidate = if prepared_content.is_empty() {
+        NamespaceMutationCandidate::path(intent)
     } else {
-        NamespaceMutationCandidate::PathWithContentAdmission { intent, admissions }
+        NamespaceMutationCandidate::path_prepared(intent, prepared_content)
     };
     let mut results = crate::commit_engine::publish_namespace_mutations_batch(
         store,
@@ -109,7 +109,7 @@ async fn put_prepared_file_content<S: ObjectStore + ?Sized>(
             content_ref,
             behavior,
         },
-        vec![prepared_content.into_admission()],
+        vec![prepared_content],
         context,
     )
     .await

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -79,7 +79,7 @@ mod tests {
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
-    use crate::storage::content_admission::ContentAdmission;
+    use crate::storage::content_admission::{ContentAdmission, PreparedContent};
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
@@ -114,18 +114,19 @@ mod tests {
         absolute_path: &str,
         content_ref: loonfs_api::ContentRef,
     ) -> NamespaceMutationCandidate {
-        NamespaceMutationCandidate::PathWithContentAdmission {
-            intent: PathMutationIntent::PutFile {
+        let admission = ContentAdmission::for_durable_content_write(
+            NamespaceId::parse("demo").expect("valid namespace id"),
+            content_ref.clone(),
+        );
+        NamespaceMutationCandidate::path_prepared(
+            PathMutationIntent::PutFile {
                 commit_id: CommitId::parse(commit_id).expect("valid commit id"),
                 absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                 content_ref: content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
             },
-            admissions: vec![ContentAdmission::for_durable_content_write(
-                NamespaceId::parse("demo").expect("valid namespace id"),
-                content_ref,
-            )],
-        }
+            vec![PreparedContent::from_admission(content_ref, admission)],
+        )
     }
 
     /// Two plans through one session share the durable-layer memo: the
@@ -278,7 +279,7 @@ mod tests {
                     "/docs/doomed.txt",
                     staged.content_ref.clone(),
                 ),
-                NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+                NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                     commit_id: CommitId::parse("delete-doomed").expect("valid commit id"),
                     absolute_path: AbsolutePath::parse("/docs/doomed.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -7,7 +7,9 @@ use crate::commit::{
     commit_request_from_v0, core_commit_fingerprint, CommitExecutionContext, CommitIdentitySource,
     CommitOp, CommitRequest as CoreCommitRequest, SemanticMutationIdentity,
 };
-use crate::commit_engine::NamespaceMutationCandidate;
+use crate::commit_engine::{
+    ContentPreparation, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
+};
 use crate::error::{CoreError, Result};
 use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PublishPlanningSession};
@@ -138,8 +140,8 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         writer_session_id: acquired_writer.writer_session_id.clone(),
         writer_epoch: acquired_writer.writer_epoch,
     };
-    match candidate {
-        NamespaceMutationCandidate::Commit(request) => {
+    match candidate.mutation() {
+        NamespaceMutation::Commit(request) => {
             validate_commit_id(&request.commit_id)?;
             let request = commit_request_from_v0(conversion_context, request.clone())
                 .map_err(CoreError::from)?;
@@ -159,13 +161,13 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             {
                 return Ok(admission);
             }
+            reject_failed_content_preparation(candidate)?;
             Ok(CandidateAdmission::Prepared(CandidateCoreRequest {
                 request,
                 identity_source: CommitIdentitySource::CoreCommitRequest,
             }))
         }
-        NamespaceMutationCandidate::Path(intent)
-        | NamespaceMutationCandidate::PathWithContentAdmission { intent, .. } => {
+        NamespaceMutation::Path(intent) => {
             validate_commit_id(intent.commit_id())?;
             let path_intent_fingerprint =
                 path_intent_fingerprint_for_path_intent(namespace_id, intent)?;
@@ -183,6 +185,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             {
                 return Ok(admission);
             }
+            reject_failed_content_preparation(candidate)?;
             let planned = session
                 .plan_path_mutation(namespace_id, intent, view.metadata_view())
                 .await?;
@@ -193,6 +196,13 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
                 identity_source: CommitIdentitySource::PathIntent(planned.path_intent_fingerprint),
             }))
         }
+    }
+}
+
+fn reject_failed_content_preparation(candidate: &NamespaceMutationCandidate) -> Result<()> {
+    match candidate.content_preparation() {
+        ContentPreparation::Ready(_) => Ok(()),
+        ContentPreparation::Rejected(error) => Err(error.clone().into()),
     }
 }
 
@@ -262,8 +272,8 @@ pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
     candidate: &NamespaceMutationCandidate,
     content_validation: &mut ContentValidationTracker,
 ) -> Result<()> {
-    match candidate {
-        NamespaceMutationCandidate::Commit(_) => {
+    match candidate.mutation() {
+        NamespaceMutation::Commit(_) => {
             for op in &request.ops {
                 let content_ref = match op {
                     CommitOp::CreateFile { content_ref, .. }
@@ -277,29 +287,29 @@ pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
                     .await?;
             }
         }
-        NamespaceMutationCandidate::Path(intent)
-        | NamespaceMutationCandidate::PathWithContentAdmission { intent, .. } => {
+        NamespaceMutation::Path(intent) => {
             let crate::path::write::PathMutationIntent::PutFile { content_ref, .. } = intent else {
                 return Ok(());
             };
             let admissions = CommitContentAdmissions {
                 namespace_id: &request.namespace_id,
-                admissions: candidate_content_admissions(candidate),
+                admissions: match candidate.content_preparation() {
+                    ContentPreparation::Ready(admissions) => admissions,
+                    ContentPreparation::Rejected(_) => {
+                        return Err(CoreError::Internal(
+                            "rejected content preparation reached coverage validation".to_owned(),
+                        ));
+                    }
+                },
             };
             if !admissions.admits(content_ref) {
-                return Err(CoreError::ContentNotPrepared {
+                return Err(ContentPreparationError::ContentNotPrepared {
                     content_ref_digest: content_ref.digest.clone(),
-                });
+                }
+                .into());
             }
         }
     }
 
     Ok(())
-}
-
-fn candidate_content_admissions(candidate: &NamespaceMutationCandidate) -> &[ContentAdmission] {
-    match candidate {
-        NamespaceMutationCandidate::PathWithContentAdmission { admissions, .. } => admissions,
-        NamespaceMutationCandidate::Commit(_) | NamespaceMutationCandidate::Path(_) => &[],
-    }
 }

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -1,9 +1,10 @@
 //! Producer-only content preparation proofs and short-lived wire tokens.
 //!
 //! A serving session verifies token expiry once when turning a signed wire
-//! token into an in-process [`ContentAdmission`]. Admissions then remain valid
-//! for the process lifetime: they record accepted authoritative evidence that
-//! the identified content is durable, rather than carrying another clock.
+//! token into an opaque [`PreparedContent`]. Its internal admission then
+//! remains valid for the process lifetime: it records accepted authoritative
+//! evidence that the identified content is durable, rather than carrying
+//! another clock.
 
 use base64::Engine as _;
 use loonfs_api::v0::ValidatedContentToken;
@@ -57,8 +58,7 @@ impl PreparedContent {
         &self.content_ref
     }
 
-    /// Consumes the proof and returns its publisher admission.
-    pub fn into_admission(self) -> ContentAdmission {
+    pub(crate) fn into_admission(self) -> ContentAdmission {
         self.admission
     }
 }
@@ -116,7 +116,7 @@ pub fn verify_content_token(
     namespace_id: &NamespaceId,
     token: &ValidatedContentToken,
     now_ms: u64,
-) -> Result<ContentAdmission, ContentTokenError> {
+) -> Result<PreparedContent, ContentTokenError> {
     let (payload_part, signature_part) = token
         .token
         .split_once('.')
@@ -147,10 +147,10 @@ pub fn verify_content_token(
         return Err(ContentTokenError::Expired);
     }
 
-    Ok(ContentAdmission::for_durable_content_write(
-        payload.namespace_id,
-        payload.content_ref,
-    ))
+    let content_ref = payload.content_ref;
+    let admission =
+        ContentAdmission::for_durable_content_write(payload.namespace_id, content_ref.clone());
+    Ok(PreparedContent::from_admission(content_ref, admission))
 }
 
 fn base64_url(bytes: &[u8]) -> String {
@@ -208,10 +208,11 @@ mod tests {
             token,
         };
 
-        let admission =
+        let prepared =
             verify_content_token("secret", &namespace, &token, 1_000).expect("verify token");
 
-        assert!(admission.admits(&namespace, &content));
+        assert_eq!(prepared.content_ref(), &content);
+        assert!(prepared.into_admission().admits(&namespace, &content));
     }
 
     #[test]
@@ -224,7 +225,7 @@ mod tests {
             content_ref: content.clone(),
             token,
         };
-        let admission = verify_content_token(
+        let prepared = verify_content_token(
             "secret",
             &namespace,
             &token,
@@ -232,9 +233,9 @@ mod tests {
         )
         .expect("verify token before expiry");
 
-        // The admission carries no clock: expiry was the token's concern,
-        // checked exactly once by the verification above.
-        assert!(admission.admits(&namespace, &content));
+        // The prepared proof carries no clock: expiry was the token's
+        // concern, checked exactly once by the verification above.
+        assert!(prepared.into_admission().admits(&namespace, &content));
     }
 
     #[test]

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -50,15 +50,15 @@ async fn put_file<S: ObjectStore + ?Sized>(
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,
-            vec![NamespaceMutationCandidate::PathWithContentAdmission {
-                intent: PathMutationIntent::PutFile {
+            vec![NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
                     commit_id: loonfs_api::CommitId::generate(),
                     absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                     content_ref,
                     behavior: loonfs_api::DestinationBehavior::NoReplace,
                 },
-                admissions: vec![prepared.into_admission()],
-            }],
+                vec![prepared],
+            )],
             context,
         )
         .await

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -131,7 +131,7 @@ fn commit_operations<S: ObjectStore + ?Sized>(
     publish_namespace_mutations_batch(
         store,
         namespace_id,
-        vec![NamespaceMutationCandidate::Commit(request)],
+        vec![NamespaceMutationCandidate::commit(request)],
         context,
     )
     .into_iter()
@@ -150,7 +150,7 @@ fn commit_operations_batch<S: ObjectStore + ?Sized>(
         namespace_id,
         requests
             .into_iter()
-            .map(NamespaceMutationCandidate::Commit)
+            .map(NamespaceMutationCandidate::commit)
             .collect(),
         context,
     )
@@ -270,20 +270,16 @@ fn admitted_candidate<S: ObjectStore + ?Sized>(
         PathMutationIntent::PutFile { content_ref, .. } => {
             let content_store_id =
                 load_namespace_descriptor_state(store, namespace_id).content_store_id;
-            let admission = block_on(prepare_existing_content_ref(
+            let prepared = block_on(prepare_existing_content_ref(
                 store,
                 namespace_id,
                 &content_store_id,
                 content_ref.clone(),
             ))
-            .expect("prepare existing content")
-            .into_admission();
-            NamespaceMutationCandidate::PathWithContentAdmission {
-                admissions: vec![admission],
-                intent,
-            }
+            .expect("prepare existing content");
+            NamespaceMutationCandidate::path_prepared(intent, vec![prepared])
         }
-        _ => NamespaceMutationCandidate::Path(intent),
+        _ => NamespaceMutationCandidate::path(intent),
     }
 }
 
@@ -1686,7 +1682,7 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
     let responses = publish_namespace_mutations_batch(
         &store,
         &namespace_id,
-        vec![NamespaceMutationCandidate::Path(
+        vec![NamespaceMutationCandidate::path(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-cold-content").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/docs/hello.txt").expect("path"),
@@ -1724,13 +1720,13 @@ async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
         &store,
         &namespace_id,
         vec![
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+            NamespaceMutationCandidate::path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-a").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
             }),
-            NamespaceMutationCandidate::Path(PathMutationIntent::PutFile {
+            NamespaceMutationCandidate::path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-b").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 content_ref: content.content_ref,
@@ -1769,7 +1765,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
         )
         .expect("mint token"),
     };
-    let admission = verify_content_token(
+    let prepared = verify_content_token(
         "test-content-token-secret",
         &namespace_id,
         &token,
@@ -1781,15 +1777,15 @@ async fn valid_content_admission_skips_durable_content_validation() {
     let responses = publish_namespace_mutations_batch(
         &store,
         &namespace_id,
-        vec![NamespaceMutationCandidate::PathWithContentAdmission {
-            intent: PathMutationIntent::PutFile {
+        vec![NamespaceMutationCandidate::path_prepared(
+            PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-admitted-content").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/docs/admitted.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },
-            admissions: vec![admission],
-        }],
+            vec![prepared],
+        )],
         &context,
     );
 
@@ -2050,7 +2046,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
     .expect("stage recreated content");
     let results = block_on(
         namespace_engine(&store, &namespace_id, &context).publish_namespace_mutations_batch(vec![
-            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+            NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
@@ -3019,7 +3015,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     let batch = || {
         vec![
             // Rejected against the durable materialization: nothing was accepted yet.
-            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+            NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
@@ -3049,7 +3045,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 },
             ),
             // Alias of the materialization-decided rejection.
-            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+            NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
@@ -3117,7 +3113,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
 
     let batch = || {
         vec![
-            NamespaceMutationCandidate::Path(PathMutationIntent::DeletePath {
+            NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
@@ -3641,7 +3637,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
                     behavior: DestinationBehavior::NoReplace,
                 },
             ),
-            NamespaceMutationCandidate::Path(PathMutationIntent::MovePath {
+            NamespaceMutationCandidate::path(PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-batched-path").expect("valid commit id"),
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
@@ -4647,7 +4643,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
     let retry = publish_namespace_mutations_batch(
         &store,
         &namespace_id(),
-        vec![NamespaceMutationCandidate::Path(
+        vec![NamespaceMutationCandidate::path(
             PathMutationIntent::PutFile {
                 commit_id,
                 absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -3,7 +3,7 @@
 //! semantic commits, and the committed-change feed.
 
 use super::error::ApiResponseError;
-use super::handlers_uploads::{content_admissions_for_put, current_unix_ms};
+use super::handlers_uploads::{current_unix_ms, prepared_content_for_put};
 use super::{authorize, AppJson, AppPath, AppQuery, AppState, CommitAppJson, NamespaceIdPath};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -470,8 +470,8 @@ pub(super) async fn filesystem_operation(
         )),
         _ => None,
     };
-    let content_admissions = match &operation {
-        FilesystemOperation::PutFile { content_ref, .. } => content_admissions_for_put(
+    let prepared_content = match &operation {
+        FilesystemOperation::PutFile { content_ref, .. } => prepared_content_for_put(
             &state.config,
             &namespace_id,
             content_ref,
@@ -562,7 +562,7 @@ pub(super) async fn filesystem_operation(
             payload_class,
         );
         async {
-            if content_admissions.is_empty() {
+            if prepared_content.is_empty() {
                 state
                     .publisher
                     .submit_path_intent(namespace_id.clone(), intent)
@@ -570,10 +570,10 @@ pub(super) async fn filesystem_operation(
             } else {
                 state
                     .publisher
-                    .submit_path_intent_with_content_admission(
+                    .submit_path_intent_with_prepared_content(
                         namespace_id.clone(),
                         intent,
-                        content_admissions,
+                        prepared_content,
                     )
                     .await
             }

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -10,7 +10,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use loonfs::content_tokens::{mint_content_token, verify_content_token, ContentTokenError};
-use loonfs::publish::ContentAdmission;
+use loonfs::publish::PreparedContent;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::ErrorCode;
@@ -144,21 +144,21 @@ fn direct_put_presign_time() -> SystemTime {
     SystemTime::now()
 }
 
-pub(super) fn content_admissions_for_put(
+pub(super) fn prepared_content_for_put(
     config: &ServerConfig,
     namespace_id: &NamespaceId,
     content_ref: &ContentRef,
     tokens: &[ValidatedContentToken],
     now_ms: u64,
-) -> Vec<ContentAdmission> {
+) -> Vec<PreparedContent> {
     tokens
         .iter()
         .filter(|token| token.content_ref == *content_ref)
         .filter_map(|token| {
             match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
-                Ok(admission) => Some(admission),
+                Ok(prepared) => Some(prepared),
                 Err(error) => {
-                    // A rejected token contributes no admission, so a put
+                    // A rejected token contributes no prepared proof, so a put
                     // with no other matching token fails as unprepared.
                     tracing::debug!(
                         namespace_id = %namespace_id,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -69,18 +69,17 @@ impl FsCore {
         let prepared_content =
             loonfs_core::content::prepare_stored_content(namespace_id.clone(), stored);
         let content_ref = prepared_content.content_ref().clone();
-        let content_admission = prepared_content.into_admission();
         self.publish_candidate(
             namespace_id,
-            NamespaceMutationCandidate::PathWithContentAdmission {
-                intent: PathMutationIntent::PutFile {
+            NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
                     absolute_path,
                     content_ref,
                     behavior: options.behavior,
                 },
-                admissions: vec![content_admission],
-            },
+                vec![prepared_content],
+            ),
         )
         .await
     }
@@ -137,18 +136,17 @@ impl FsCore {
         .await
         .map_err(CoreError::from)?;
         let content_ref = prepared_content.content_ref().clone();
-        let content_admission = prepared_content.into_admission();
         self.publish_candidate(
             namespace_id,
-            NamespaceMutationCandidate::PathWithContentAdmission {
-                intent: PathMutationIntent::PutFile {
+            NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
                     absolute_path,
                     content_ref,
                     behavior: options.behavior,
                 },
-                admissions: vec![content_admission],
-            },
+                vec![prepared_content],
+            ),
         )
         .await
     }
@@ -316,7 +314,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_candidate(namespace_id, NamespaceMutationCandidate::Commit(request))
+        self.publish_candidate(namespace_id, NamespaceMutationCandidate::commit(request))
             .await
     }
 
@@ -332,7 +330,7 @@ impl FsCore {
             namespace_id,
             requests
                 .into_iter()
-                .map(NamespaceMutationCandidate::Commit)
+                .map(NamespaceMutationCandidate::commit)
                 .collect(),
         )
         .await
@@ -343,7 +341,7 @@ impl FsCore {
         namespace_id: &NamespaceId,
         intent: PathMutationIntent,
     ) -> Result<CommitResponse> {
-        self.publish_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
+        self.publish_candidate(namespace_id, NamespaceMutationCandidate::path(intent))
             .await
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -76,16 +76,17 @@ pub use loonfs_core::{
 pub mod publish {
     pub use loonfs_core::path::parse_mutation_path;
     pub use loonfs_core::publish::{
-        ContentAdmission, NamespaceMutationCandidate, PathMutationIntent,
+        ContentPreparation, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
+        PathMutationIntent, PreparedContent,
     };
 }
 
-/// Server-integration seam for producer-only content admissions.
+/// Server-integration seam for producer-only content preparation proofs.
 ///
 /// A serving session mints short-lived wire tokens after durable preparation
-/// and verifies expiry once before yielding an opaque publisher admission.
-/// The in-process admission records accepted durability evidence and does not
-/// expire. Most embedded users never need this module.
+/// and verifies expiry once before yielding opaque prepared content. Its
+/// internal admission records accepted durability evidence and does not expire.
+/// Most embedded users never need this module.
 pub mod content_tokens {
     pub use loonfs_core::content::{mint_content_token, verify_content_token, ContentTokenError};
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -48,7 +48,7 @@
 //! drains without closing, so the handle stays usable.
 
 use crate::fs::{FsCore, FsInner};
-use crate::publish::{ContentAdmission, NamespaceMutationCandidate, PathMutationIntent};
+use crate::publish::{NamespaceMutationCandidate, PathMutationIntent, PreparedContent};
 use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeError};
 use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse};
 use loonfs_api::{CommitId, NamespaceId};
@@ -160,7 +160,7 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         request: ApiCommitRequest,
     ) -> CommitResult {
-        self.submit_candidate(namespace_id, NamespaceMutationCandidate::Commit(request))
+        self.submit_candidate(namespace_id, NamespaceMutationCandidate::commit(request))
             .await
     }
 
@@ -171,21 +171,21 @@ impl PublisherRegistry {
         namespace_id: NamespaceId,
         intent: PathMutationIntent,
     ) -> CommitResult {
-        self.submit_candidate(namespace_id, NamespaceMutationCandidate::Path(intent))
+        self.submit_candidate(namespace_id, NamespaceMutationCandidate::path(intent))
             .await
     }
 
-    /// Submits a path-level mutation intent together with the content
-    /// admissions vouching for its already-validated direct-put content.
-    pub async fn submit_path_intent_with_content_admission(
+    /// Submits a path-level mutation intent together with opaque proofs for
+    /// its already-prepared content.
+    pub async fn submit_path_intent_with_prepared_content(
         &self,
         namespace_id: NamespaceId,
         intent: PathMutationIntent,
-        admissions: Vec<ContentAdmission>,
+        content: Vec<PreparedContent>,
     ) -> CommitResult {
         self.submit_candidate(
             namespace_id,
-            NamespaceMutationCandidate::PathWithContentAdmission { intent, admissions },
+            NamespaceMutationCandidate::path_prepared(intent, content),
         )
         .await
     }
@@ -408,9 +408,9 @@ impl NamespacePublisher {
     /// task.
     async fn submit(&self, candidate: NamespaceMutationCandidate) -> CommitResult {
         let commit_id = candidate.commit_id().clone();
-        let operation_class = operation_class(&candidate);
         let enqueued_at = Instant::now();
         let semantic_identity = candidate.semantic_identity(&self.namespace_id)?;
+        let operation_class = operation_class(&semantic_identity);
         let (sender, receiver) = oneshot::channel();
         self.admit(
             commit_id,
@@ -1012,11 +1012,10 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
     }
 }
 
-fn operation_class(candidate: &NamespaceMutationCandidate) -> &'static str {
-    match candidate {
-        NamespaceMutationCandidate::Commit(_) => "explicit_commit",
-        NamespaceMutationCandidate::Path(_)
-        | NamespaceMutationCandidate::PathWithContentAdmission { .. } => "path_mutation",
+fn operation_class(semantic_identity: &SemanticMutationIdentity) -> &'static str {
+    match semantic_identity {
+        SemanticMutationIdentity::CoreCommit(_) => "explicit_commit",
+        SemanticMutationIdentity::PathIntent(_) => "path_mutation",
     }
 }
 
@@ -1067,6 +1066,8 @@ mod tests {
     use super::*;
     use crate::background::{BackgroundWork, FsBackgroundWork};
     use crate::config::FsConfig;
+    use crate::content_tokens::ContentTokenError;
+    use crate::publish::{ContentPreparationError, NamespaceMutation};
     use crate::{
         BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
         SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
@@ -1524,10 +1525,18 @@ mod tests {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
-        let commit_id = request.commit_id.clone();
-        let candidate = NamespaceMutationCandidate::Commit(request);
-        let operation_class = operation_class(&candidate);
+        let candidate = NamespaceMutationCandidate::commit(request);
+        try_admit_candidate(publisher, namespace_id, candidate)
+    }
+
+    fn try_admit_candidate(
+        publisher: &NamespacePublisher,
+        namespace_id: &NamespaceId,
+        candidate: NamespaceMutationCandidate,
+    ) -> Result<oneshot::Receiver<CommitResult>, CoreError> {
+        let commit_id = candidate.commit_id().clone();
         let semantic_identity = candidate.semantic_identity(namespace_id)?;
+        let operation_class = operation_class(&semantic_identity);
         let (sender, receiver) = oneshot::channel();
         publisher.admit(
             commit_id,
@@ -1552,18 +1561,25 @@ mod tests {
 
     #[test]
     fn publisher_trace_labels_are_low_cardinality() {
-        let commit = NamespaceMutationCandidate::Commit(create_directory_request(
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let commit = NamespaceMutationCandidate::commit(create_directory_request(
             "commit-trace",
             "private-name",
         ));
-        let path = NamespaceMutationCandidate::Path(PathMutationIntent::CreateDir {
+        let path = NamespaceMutationCandidate::path(PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("path-trace").expect("valid commit id"),
             absolute_path: AbsolutePath::parse("/private/path").expect("path"),
             parents: false,
         });
 
-        assert_eq!(operation_class(&commit), "explicit_commit");
-        assert_eq!(operation_class(&path), "path_mutation");
+        assert_eq!(
+            operation_class(&commit.semantic_identity(&namespace_id).expect("identity")),
+            "explicit_commit"
+        );
+        assert_eq!(
+            operation_class(&path.semantic_identity(&namespace_id).expect("identity")),
+            "path_mutation"
+        );
         assert_eq!(result_label(&Ok::<_, CoreError>(())), "ok");
         assert_eq!(
             result_label(&Err::<(), _>(CoreError::Internal(
@@ -1572,6 +1588,85 @@ mod tests {
             "error"
         );
         assert_eq!(usize_to_u64(7), 7);
+    }
+
+    #[tokio::test]
+    async fn rejected_duplicate_joins_ready_in_flight_primary() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer = test_writer(store).await;
+        create_namespace(writer.core(), &namespace_id).await;
+        let registry = writer.publisher();
+        let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+        let intent = PathMutationIntent::CreateDir {
+            commit_id: CommitId::parse("ready-primary").expect("valid commit id"),
+            absolute_path: AbsolutePath::parse("/ready-primary").expect("path"),
+            parents: false,
+        };
+
+        let primary = try_admit_candidate(
+            &publisher,
+            &namespace_id,
+            NamespaceMutationCandidate::path(intent.clone()),
+        )
+        .expect("admit ready primary");
+        let duplicate = try_admit_candidate(
+            &publisher,
+            &namespace_id,
+            NamespaceMutationCandidate::rejected(
+                NamespaceMutation::Path(intent),
+                ContentPreparationError::ContentToken(ContentTokenError::Expired),
+            ),
+        )
+        .expect("join rejected duplicate");
+
+        let primary = primary.await.expect("primary result channel");
+        let duplicate = duplicate.await.expect("duplicate result channel");
+        assert_eq!(
+            duplicate.as_ref().expect("duplicate success"),
+            primary.as_ref().expect("primary success")
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_duplicate_joins_rejected_in_flight_primary() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer = test_writer(store).await;
+        create_namespace(writer.core(), &namespace_id).await;
+        let registry = writer.publisher();
+        let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+        let intent = PathMutationIntent::CreateDir {
+            commit_id: CommitId::parse("rejected-primary").expect("valid commit id"),
+            absolute_path: AbsolutePath::parse("/rejected-primary").expect("path"),
+            parents: false,
+        };
+
+        let primary = try_admit_candidate(
+            &publisher,
+            &namespace_id,
+            NamespaceMutationCandidate::rejected(
+                NamespaceMutation::Path(intent.clone()),
+                ContentPreparationError::ContentToken(ContentTokenError::Expired),
+            ),
+        )
+        .expect("admit rejected primary");
+        let duplicate = try_admit_candidate(
+            &publisher,
+            &namespace_id,
+            NamespaceMutationCandidate::path(intent),
+        )
+        .expect("join ready duplicate");
+
+        let primary = primary.await.expect("primary result channel");
+        let duplicate = duplicate.await.expect("duplicate result channel");
+        let primary_error = primary.expect_err("primary preparation error");
+        let duplicate_error = duplicate.expect_err("duplicate inherits preparation error");
+        assert_eq!(primary_error.code(), ErrorCode::ContentNotPrepared);
+        assert_eq!(duplicate_error.code(), primary_error.code());
+        assert_eq!(duplicate_error.to_string(), primary_error.to_string());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2116,14 +2211,12 @@ mod tests {
             content_ref: prepared_content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
         };
-        let content_admission = prepared_content.into_admission();
-
         let (explicit_response, path_response) = tokio::join!(
             registry.submit_commit(namespace_id.clone(), explicit),
-            registry.submit_path_intent_with_content_admission(
+            registry.submit_path_intent_with_prepared_content(
                 namespace_id.clone(),
                 path_intent,
-                vec![content_admission]
+                vec![prepared_content]
             )
         );
         assert_eq!(

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -152,20 +152,18 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             .await
             .expect("prepare existing content");
             let content_ref = prepared.content_ref().clone();
-            candidates.push(
-                loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
-                    intent: loonfs::publish::PathMutationIntent::PutFile {
-                        commit_id: loonfs::CommitId::generate(),
-                        absolute_path: AbsolutePath::parse(format!(
-                            "/tree/dir-000000/file-{index:09}.txt"
-                        ))
-                        .expect("path"),
-                        content_ref: content_ref.clone(),
-                        behavior: loonfs::DestinationBehavior::NoReplace,
-                    },
-                    admissions: vec![prepared.into_admission()],
+            candidates.push(loonfs::publish::NamespaceMutationCandidate::path_prepared(
+                loonfs::publish::PathMutationIntent::PutFile {
+                    commit_id: loonfs::CommitId::generate(),
+                    absolute_path: AbsolutePath::parse(format!(
+                        "/tree/dir-000000/file-{index:09}.txt"
+                    ))
+                    .expect("path"),
+                    content_ref: content_ref.clone(),
+                    behavior: loonfs::DestinationBehavior::NoReplace,
                 },
-            );
+                vec![prepared],
+            ));
         }
         for outcome in writer
             .publish_namespace_mutations_batch(&namespace_id, candidates)

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -3,7 +3,11 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs::publish::{parse_mutation_path, ContentAdmission, PathMutationIntent};
+use loonfs::content_tokens::ContentTokenError;
+use loonfs::publish::{
+    parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
+    PathMutationIntent, PreparedContent,
+};
 use loonfs::{
     CommitId, CommitOp, CommitRequest, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ErrorCode, FsWriter, InodeId, NamespaceId, PutFileOptions, RevisionNo,
@@ -419,11 +423,11 @@ async fn build_initialized_writer(
 }
 
 /// Full external preparation performs one content HEAD and one full GET.
-async fn prepare_admission(
+async fn prepare_content(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
     content_ref: &loonfs::ContentRef,
-) -> ContentAdmission {
+) -> PreparedContent {
     let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");
@@ -435,7 +439,6 @@ async fn prepare_admission(
     )
     .await
     .expect("prepare existing content")
-    .into_admission()
 }
 
 fn put_intent(commit_id: &str, path: &str, content_ref: loonfs::ContentRef) -> PathMutationIntent {
@@ -466,9 +469,9 @@ fn assert_content_not_prepared(error: CoreError, content_ref: &loonfs::ContentRe
     assert!(
         matches!(
             error,
-            CoreError::ContentNotPrepared {
+            CoreError::ContentPreparation(ContentPreparationError::ContentNotPrepared {
                 ref content_ref_digest
-            } if content_ref_digest == &content_ref.digest
+            }) if content_ref_digest == &content_ref.digest
         ),
         "content-not-prepared error should carry the rejected digest"
     );
@@ -681,14 +684,14 @@ async fn commit_id_replay_performs_no_content_operations() {
     let harness = TestHarness::new("receipt-replay").await;
     let content_ref = harness.stage_content(b"replayed content").await;
     let intent = put_intent("replayed-put", "/file.txt", content_ref.clone());
-    let admission = prepare_admission(&harness.store, &harness.namespace_id, &content_ref).await;
+    let prepared = prepare_content(&harness.store, &harness.namespace_id, &content_ref).await;
     let original = harness
         .writer
         .publisher()
-        .submit_path_intent_with_content_admission(
+        .submit_path_intent_with_prepared_content(
             harness.namespace_id.clone(),
             intent.clone(),
-            vec![admission],
+            vec![prepared],
         )
         .await
         .expect("publish original put");
@@ -702,6 +705,83 @@ async fn commit_id_replay_performs_no_content_operations() {
         .expect("replay put");
 
     assert_eq!(replay, original);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn rejected_preparation_replays_durable_receipt_without_content_operations() {
+    let harness = TestHarness::new("rejected-receipt-replay").await;
+    let content_ref = harness.stage_content(b"replayed rejected content").await;
+    let intent = put_intent("rejected-replayed-put", "/file.txt", content_ref.clone());
+    let prepared = prepare_content(&harness.store, &harness.namespace_id, &content_ref).await;
+    let original = harness
+        .writer
+        .publisher()
+        .submit_path_intent_with_prepared_content(
+            harness.namespace_id.clone(),
+            intent.clone(),
+            vec![prepared],
+        )
+        .await
+        .expect("publish original put");
+    harness.recording.reset();
+
+    let replay = harness
+        .writer
+        .publish_namespace_mutations_batch(
+            &harness.namespace_id,
+            vec![NamespaceMutationCandidate::rejected(
+                NamespaceMutation::Path(intent),
+                ContentPreparationError::ContentToken(ContentTokenError::Expired),
+            )],
+        )
+        .await
+        .pop()
+        .expect("one replay result")
+        .expect("rejected preparation must replay the durable receipt");
+
+    assert_eq!(replay, original);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn new_rejected_preparation_fails_before_path_planning_without_content_operations() {
+    let harness = TestHarness::new("new-rejected-preparation").await;
+    harness.recording.reset();
+    let intent = PathMutationIntent::CreateDir {
+        commit_id: CommitId::parse("new-rejected").expect("valid commit id"),
+        absolute_path: parse_mutation_path("/missing/child").expect("valid mutation path"),
+        parents: false,
+    };
+
+    let error = harness
+        .writer
+        .publish_namespace_mutations_batch(
+            &harness.namespace_id,
+            vec![NamespaceMutationCandidate::rejected(
+                NamespaceMutation::Path(intent),
+                ContentPreparationError::ContentToken(ContentTokenError::Expired),
+            )],
+        )
+        .await
+        .pop()
+        .expect("one rejected result")
+        .expect_err("new rejected preparation must fail");
+    assert!(
+        matches!(error, loonfs::Error::Core(_)),
+        "expected core content-preparation error"
+    );
+    let loonfs::Error::Core(error) = error else {
+        return;
+    };
+
+    assert_eq!(error.code(), ErrorCode::ContentNotPrepared);
+    assert!(matches!(
+        error,
+        CoreError::ContentPreparation(ContentPreparationError::ContentToken(
+            ContentTokenError::Expired
+        ))
+    ));
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
@@ -725,7 +805,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
     let intent = put_intent("in-flight-put", "/file.txt", content_ref.clone());
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates publication and duplicate join.
-    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
+    let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
     blocking.arm_next_head_cas();
@@ -733,10 +813,10 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
         let registry = writer.publisher();
         let namespace_id = namespace_id.clone();
         let intent = intent.clone();
-        let admission = admission.clone();
+        let prepared = prepared.clone();
         tokio::spawn(async move {
             registry
-                .submit_path_intent_with_content_admission(namespace_id, intent, vec![admission])
+                .submit_path_intent_with_prepared_content(namespace_id, intent, vec![prepared])
                 .await
         })
     };
@@ -745,10 +825,10 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
     assert_content_counts(primary_counts, 0, 0, 0, 0);
 
     let registry = writer.publisher();
-    let mut duplicate = Box::pin(registry.submit_path_intent_with_content_admission(
+    let mut duplicate = Box::pin(registry.submit_path_intent_with_prepared_content(
         namespace_id.clone(),
         intent,
-        vec![admission],
+        vec![prepared],
     ));
     assert!(
         futures::poll!(duplicate.as_mut()).is_pending(),
@@ -792,13 +872,13 @@ async fn stale_head_retry_preserves_content_admission() {
     let intent = put_intent("retry-put", "/file.txt", content_ref.clone());
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates publication retries.
-    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
+    let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
     conflicting.fail_next_head_cas();
 
     writer
         .publisher()
-        .submit_path_intent_with_content_admission(namespace_id, intent, vec![admission])
+        .submit_path_intent_with_prepared_content(namespace_id, intent, vec![prepared])
         .await
         .expect("publish after stale-head retry");
 
@@ -826,7 +906,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
             .content_ref;
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates mixed-batch publication.
-    let admission = prepare_admission(&store, &namespace_id, &content_ref).await;
+    let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
     blocking.arm_next_head_cas();
@@ -849,10 +929,10 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
     blocking.wait_for_blocked_head_cas().await;
 
     let registry = writer.publisher();
-    let mut admitted = Box::pin(registry.submit_path_intent_with_content_admission(
+    let mut admitted = Box::pin(registry.submit_path_intent_with_prepared_content(
         namespace_id.clone(),
         put_intent("mixed-admitted", "/admitted.txt", content_ref.clone()),
-        vec![admission],
+        vec![prepared],
     ));
     assert!(
         futures::poll!(admitted.as_mut()).is_pending(),

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -193,7 +193,6 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     .await
     .expect("prepare second put content");
     let prepared_content_ref = prepared.content_ref().clone();
-    let admission = prepared.into_admission();
 
     store_impl.arm();
     let first = {
@@ -221,7 +220,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         };
         Box::pin(async move {
             registry
-                .submit_path_intent_with_content_admission(namespace_id, intent, vec![admission])
+                .submit_path_intent_with_prepared_content(namespace_id, intent, vec![prepared])
                 .await
         })
     };

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -232,18 +232,16 @@ async fn warm_phase_request_accounting() {
             .await
             .expect("prepare existing content");
             let content_ref = prepared.content_ref().clone();
-            candidates.push(
-                loonfs::publish::NamespaceMutationCandidate::PathWithContentAdmission {
-                    intent: loonfs::publish::PathMutationIntent::PutFile {
-                        commit_id: loonfs::CommitId::generate(),
-                        absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
-                            .expect("path"),
-                        content_ref: content_ref.clone(),
-                        behavior: loonfs::DestinationBehavior::NoReplace,
-                    },
-                    admissions: vec![prepared.into_admission()],
+            candidates.push(loonfs::publish::NamespaceMutationCandidate::path_prepared(
+                loonfs::publish::PathMutationIntent::PutFile {
+                    commit_id: loonfs::CommitId::generate(),
+                    absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
+                        .expect("path"),
+                    content_ref: content_ref.clone(),
+                    behavior: loonfs::DestinationBehavior::NoReplace,
                 },
-            );
+                vec![prepared],
+            ));
             index += 1;
         }
         for outcome in writer

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2548,7 +2548,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                         content_ref,
                         behavior: DestinationBehavior::NoReplace,
                     },
-                    vec![prepared.into_admission()],
+                    vec![prepared],
                 )
             };
         let put_a = admitted_put("batch-a", "/docs/a.txt", content_a);
@@ -2558,22 +2558,22 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         let publisher = fs.writer.publisher();
 
         let puts = tokio::join!(
-            publisher.submit_path_intent_with_content_admission(
+            publisher.submit_path_intent_with_prepared_content(
                 namespace_id.clone(),
                 put_a.0,
                 put_a.1,
             ),
-            publisher.submit_path_intent_with_content_admission(
+            publisher.submit_path_intent_with_prepared_content(
                 namespace_id.clone(),
                 put_b.0,
                 put_b.1,
             ),
-            publisher.submit_path_intent_with_content_admission(
+            publisher.submit_path_intent_with_prepared_content(
                 namespace_id.clone(),
                 put_c.0,
                 put_c.1,
             ),
-            publisher.submit_path_intent_with_content_admission(
+            publisher.submit_path_intent_with_prepared_content(
                 namespace_id.clone(),
                 put_d.0,
                 put_d.1,


### PR DESCRIPTION
The candidate had grown three variants whose names conflated what a mutation is with how its content was prepared, and admissions rode as public fields on one of them. The candidate is now one envelope: a semantic mutation (`Commit` or `Path`) paired with an orthogonal `ContentPreparation` that is either `Ready` (admissions extracted from opaque `PreparedContent`) or `Rejected` (a typed preparation error). Fields are private and construction goes through constructors, so loose admissions can no longer be placed into a candidate from outside; `ContentAdmission` stops being exported at all, and token verification now yields `PreparedContent` directly.

`Rejected` is checked after receipt replay and same-batch dedup and before path planning, so a retry of an already-landed commit replays its receipt even when the retry's preparation failed — that ordering is the reason the state exists. Nothing produces `Rejected` in production yet; the server still drops bad tokens with a debug log, and the next PR carries those failures into candidates instead. Semantic identity is computed from the mutation alone (now structurally — preparation state cannot participate), and first-admitted duplicate behavior is pinned in both directions: a rejected duplicate joins a ready primary and receives its success; a ready duplicate joins a rejected primary and receives its error, with no upgrade. B2's `content_not_prepared` core variant folded into the new `ContentPreparationError`, mapping to the same wire code.