### PR TITLE
fix(server): carry content token rejections into publication

### DIFF
--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -3,13 +3,18 @@
 //! semantic commits, and the committed-change feed.
 
 use super::error::ApiResponseError;
-use super::handlers_uploads::{current_unix_ms, prepared_content_for_put};
+use super::handlers_uploads::{
+    content_preparation_for_put, current_unix_ms, PutContentPreparation,
+};
 use super::{authorize, AppJson, AppPath, AppQuery, AppState, CommitAppJson, NamespaceIdPath};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use loonfs::publish::{parse_mutation_path, PathMutationIntent};
+use loonfs::publish::{
+    parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
+    PathMutationIntent,
+};
 use loonfs::{payload_class, ErrorCode, ListChangesOptions, TraceStoreKind};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -470,15 +475,15 @@ pub(super) async fn filesystem_operation(
         )),
         _ => None,
     };
-    let prepared_content = match &operation {
-        FilesystemOperation::PutFile { content_ref, .. } => prepared_content_for_put(
+    let put_content_preparation = match &operation {
+        FilesystemOperation::PutFile { content_ref, .. } => Some(content_preparation_for_put(
             &state.config,
             &namespace_id,
             content_ref,
             &content_tokens,
             current_unix_ms()?,
-        ),
-        _ => Vec::new(),
+        )),
+        _ => None,
     };
     // Wire paths are raw strings; the intent carries validated paths, so
     // this is the convert-once point for the whole remote mutation path.
@@ -562,21 +567,22 @@ pub(super) async fn filesystem_operation(
             payload_class,
         );
         async {
-            if prepared_content.is_empty() {
-                state
-                    .publisher
-                    .submit_path_intent(namespace_id.clone(), intent)
-                    .await
-            } else {
-                state
-                    .publisher
-                    .submit_path_intent_with_prepared_content(
-                        namespace_id.clone(),
-                        intent,
-                        prepared_content,
-                    )
-                    .await
-            }
+            let candidate = match put_content_preparation
+                .expect("put payload class should carry content preparation")
+            {
+                PutContentPreparation::Absent => NamespaceMutationCandidate::path(intent),
+                PutContentPreparation::Ready(prepared_content) => {
+                    NamespaceMutationCandidate::path_prepared(intent, prepared_content)
+                }
+                PutContentPreparation::Rejected(error) => NamespaceMutationCandidate::rejected(
+                    NamespaceMutation::Path(intent),
+                    ContentPreparationError::ContentToken(error),
+                ),
+            };
+            state
+                .publisher
+                .submit_candidate(namespace_id.clone(), candidate)
+                .await
         }
         .instrument(span)
         .await

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -27,6 +27,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const DIRECT_PUT_URL_TTL: Duration = Duration::from_secs(15 * 60);
 
+pub(super) enum PutContentPreparation {
+    Absent,
+    Ready(Vec<PreparedContent>),
+    Rejected(ContentTokenError),
+}
+
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct UploadPathParams {
     upload_id: String,
@@ -144,32 +150,40 @@ fn direct_put_presign_time() -> SystemTime {
     SystemTime::now()
 }
 
-pub(super) fn prepared_content_for_put(
+pub(super) fn content_preparation_for_put(
     config: &ServerConfig,
     namespace_id: &NamespaceId,
     content_ref: &ContentRef,
     tokens: &[ValidatedContentToken],
     now_ms: u64,
-) -> Vec<PreparedContent> {
-    tokens
+) -> PutContentPreparation {
+    let mut prepared_content = Vec::new();
+    let mut first_error = None;
+    for token in tokens
         .iter()
         .filter(|token| token.content_ref == *content_ref)
-        .filter_map(|token| {
-            match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
-                Ok(prepared) => Some(prepared),
-                Err(error) => {
-                    // A rejected token contributes no prepared proof, so a put
-                    // with no other matching token fails as unprepared.
-                    tracing::debug!(
-                        namespace_id = %namespace_id,
-                        error = %error,
-                        "content token rejected"
-                    );
-                    None
-                }
+    {
+        match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
+            Ok(prepared) => prepared_content.push(prepared),
+            Err(error) => {
+                tracing::debug!(
+                    namespace_id = %namespace_id,
+                    content_ref_digest = %content_ref.digest,
+                    error = %error,
+                    "content token rejected during put preparation"
+                );
+                first_error.get_or_insert(error);
             }
-        })
-        .collect()
+        }
+    }
+
+    if !prepared_content.is_empty() {
+        PutContentPreparation::Ready(prepared_content)
+    } else if let Some(error) = first_error {
+        PutContentPreparation::Rejected(error)
+    } else {
+        PutContentPreparation::Absent
+    }
 }
 
 fn content_token_error(error: ContentTokenError) -> ApiResponseError {

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use loonfs::content_tokens::mint_content_token;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
@@ -18,6 +19,8 @@ use serde_json::json;
 use std::future::Future;
 use std::path::PathBuf;
 use tempfile::tempdir;
+
+const TEST_CONTENT_TOKEN_SECRET: &str = "test-content-token-secret";
 
 fn block_on<T>(future: impl Future<Output = T>) -> T {
     tokio::runtime::Builder::new_current_thread()
@@ -812,6 +815,7 @@ async fn path_put_with_bad_content_token_fails_content_not_prepared() {
         assert_content_not_prepared_response(
             send_filesystem_operation(&harness.server_url, &namespace, &request),
             &request,
+            "content token was rejected: content token is malformed",
         );
     })
     .await
@@ -850,6 +854,7 @@ async fn path_put_without_content_token_fails_content_not_prepared() {
         assert_content_not_prepared_response(
             send_filesystem_operation(&harness.server_url, &namespace, &request),
             &request,
+            &missing_content_proof_message(&request),
         );
     })
     .await
@@ -909,7 +914,7 @@ async fn path_put_with_valid_content_token_succeeds() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn landed_path_put_replays_after_content_token_is_absent() {
+async fn landed_path_put_replays_after_content_token_is_absent_expired_or_garbage() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -925,6 +930,7 @@ async fn landed_path_put_replays_after_content_token_is_absent() {
             .create_namespace(&namespace)
             .expect("create namespace");
         let completed = stage_uploaded_content(&harness.client, &namespace, b"token replay");
+        let content_ref = completed.content_ref.clone();
         let mut request = FilesystemOperationRequest {
             commit_id: CommitId::parse("token-replay-put").expect("valid commit id"),
             content_tokens: vec![ValidatedContentToken {
@@ -939,17 +945,74 @@ async fn landed_path_put_replays_after_content_token_is_absent() {
                 behavior: DestinationBehavior::NoReplace,
             },
         };
-        let original = send_filesystem_operation(&harness.server_url, &namespace, &request)
-            .expect("original admitted put");
-        let original: CommitResponse =
-            serde_json::from_reader(original.into_reader()).expect("decode original response");
+        let send = |request: &FilesystemOperationRequest| {
+            let response = send_filesystem_operation(&harness.server_url, &namespace, request)
+                .expect("landed put should replay");
+            serde_json::from_reader::<_, CommitResponse>(response.into_reader())
+                .expect("decode operation response")
+        };
+        let original = send(&request);
 
         request.content_tokens.clear();
-        let replay = send_filesystem_operation(&harness.server_url, &namespace, &request)
-            .expect("landed put replays without token");
-        let replay: CommitResponse =
-            serde_json::from_reader(replay.into_reader()).expect("decode replay response");
-        assert_eq!(replay, original);
+        assert_eq!(send(&request), original);
+
+        request.content_tokens = vec![ValidatedContentToken {
+            content_ref: content_ref.clone(),
+            token: mint_content_token(TEST_CONTENT_TOKEN_SECRET, &namespace, &content_ref, 0)
+                .expect("mint expired content token"),
+        }];
+        assert_eq!(send(&request), original);
+
+        request.content_tokens = vec![ValidatedContentToken {
+            content_ref,
+            token: "not.a.valid.token".to_owned(),
+        }];
+        assert_eq!(send(&request), original);
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn path_put_with_only_an_irrelevant_token_reports_the_missing_put_proof() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-current",
+        "http-irrelevant-content-token",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let target = stage_uploaded_content(&harness.client, &namespace, b"target content");
+        let irrelevant = stage_uploaded_content(&harness.client, &namespace, b"irrelevant content");
+        let request = FilesystemOperationRequest {
+            commit_id: CommitId::parse("irrelevant-token-put").expect("valid commit id"),
+            content_tokens: vec![ValidatedContentToken {
+                content_ref: irrelevant.content_ref,
+                token: irrelevant
+                    .validated_content_token
+                    .expect("completed upload carries token"),
+            }],
+            operation: FilesystemOperation::PutFile {
+                path: "/irrelevant-token.txt".to_owned(),
+                content_ref: target.content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+        };
+
+        assert_content_not_prepared_response(
+            send_filesystem_operation(&harness.server_url, &namespace, &request),
+            &request,
+            &missing_content_proof_message(&request),
+        );
     })
     .await
     .expect("blocking task");
@@ -2146,7 +2209,7 @@ fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str
     ServerConfig {
         bind: "127.0.0.1:0".to_owned(),
         auth_token: Some("test-token".into()),
-        content_token_secret: "test-content-token-secret".into(),
+        content_token_secret: TEST_CONTENT_TOKEN_SECRET.into(),
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
@@ -2337,6 +2400,7 @@ fn send_filesystem_operation(
 fn assert_content_not_prepared_response(
     result: Result<ureq::Response, Box<ureq::Error>>,
     request: &FilesystemOperationRequest,
+    expected_message: &str,
 ) {
     match result {
         Err(error) if matches!(error.as_ref(), ureq::Error::Status(_, _)) => {
@@ -2347,10 +2411,7 @@ fn assert_content_not_prepared_response(
             let error: ApiError =
                 serde_json::from_reader(response.into_reader()).expect("decode api error");
             assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
-            let FilesystemOperation::PutFile { content_ref, .. } = &request.operation else {
-                unreachable!("content preparation assertion requires a put request");
-            };
-            assert!(error.message.contains(&content_ref.digest));
+            assert_eq!(error.message, expected_message);
             assert_eq!(
                 error.details.and_then(|details| details.commit_id),
                 Some(request.commit_id.clone())
@@ -2358,6 +2419,16 @@ fn assert_content_not_prepared_response(
         }
         other => unreachable!("expected content_not_prepared response, got {other:?}"),
     }
+}
+
+fn missing_content_proof_message(request: &FilesystemOperationRequest) -> String {
+    let FilesystemOperation::PutFile { content_ref, .. } = &request.operation else {
+        unreachable!("content preparation assertion requires a put request");
+    };
+    format!(
+        "content ref `{}` is not prepared for publication",
+        content_ref.digest
+    )
 }
 
 fn stage_uploaded_content(

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -204,7 +204,7 @@ impl PublisherRegistry {
 
     /// Submits one already-classified candidate; the runtime's direct
     /// mutation paths funnel through this.
-    pub(crate) async fn submit_candidate(
+    pub async fn submit_candidate(
         &self,
         namespace_id: NamespaceId,
         candidate: NamespaceMutationCandidate,


### PR DESCRIPTION
A path put whose token failed verification used to have the failure dropped with a debug log; the request then went into publication bare and failed with the generic missing-proof error, losing what actually went wrong. Returning the token error straight from the handler would be worse: a retry of an already-landed put would fail on its stale token instead of replaying, breaking idempotent recovery after a lost response.

The handler now partitions supplied tokens by whether they name the put's content ref. Any verified relevant token submits the candidate `Ready`, exactly as before. When relevant tokens exist and all fail, the first failure rides into publication as a `Rejected` candidate, so the publisher's ordering decides: a commit ID with a durable receipt replays it, and only a genuinely new put returns the token failure (`content_not_prepared`, now with the token-specific message). Irrelevant tokens stay ignored, non-put operations are untouched, and authorization, malformed JSON, and path syntax still fail before anything is enqueued. `PublisherRegistry::submit_candidate` became public so the server enqueues envelopes directly — safe now that candidates are constructor-gated.

New wire coverage pins the flagship property: a landed put retried with an absent, genuinely expired (valid signature, past expiry), or garbage token replays the original response byte-for-byte; a new put with an invalid token gets the 409 with the token message; an irrelevant-ref token still yields the missing-proof error naming the digest.
