### PR TITLE
feat(commits): require prepared content tokens

### DIFF
--- a/crates/loonfs-api/src/capability.rs
+++ b/crates/loonfs-api/src/capability.rs
@@ -43,6 +43,8 @@ pub const LIMIT_DOWNLOAD_MAX_CONCURRENT: &str = "download.max_concurrent";
 /// Advisory limit: the largest JSON body the commits endpoint accepts.
 /// Metadata-only; file bytes ride uploads, not commit bodies.
 pub const LIMIT_COMMIT_MAX_BODY_BYTES: &str = "commit.max_body_bytes";
+/// Advisory limit: the most semantic operations one explicit commit accepts.
+pub const LIMIT_COMMIT_MAX_OPERATIONS: &str = "commit.max_operations";
 /// Advisory limit: the smallest accepted `grace_window_ms` on a `gc`
 /// request; smaller values answer `invalid_request`. Derived from the
 /// publication budgets, not tuned.

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -56,11 +56,12 @@ pub mod wire {
 pub use capability::{
     CapabilityDocument, CapabilityDocumentError, FEATURE_NAMESPACES_CREATE,
     FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_BODY_BYTES, LIMIT_DOWNLOAD_MAX_CONCURRENT,
-    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_GC_MIN_GRACE_WINDOW_MS, LIMIT_QUERY_GREP_DEFAULT,
-    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
-    LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_BODY_BYTES, LIMIT_COMMIT_MAX_OPERATIONS,
+    LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_GC_MIN_GRACE_WINDOW_MS,
+    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, LIMIT_UPLOAD_MAX_CONCURRENT,
+    LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
+    PROTOCOL_VERSION,
 };
 pub use content::{ContentRef, ContentRefKind};
 pub use digest::sha256_digest;
@@ -86,8 +87,8 @@ pub use path::{AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_
 // in `v0`; add here only what most consumers touch.
 pub use v0::{
     AdvanceRetentionResponse, ApiError, AuthoritativeFileBytes, AuthoritativePathEntry,
-    CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
+    CommitResponse, CommitSubmissionRequest, CreateCheckpointRequest, CreateCheckpointResponse,
+    CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
     DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorDetails, FileRevision,
     FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse,
     ForkNamespaceRequest, GcRequest, GcResponse, GrepMatch, GrepRequest, GrepResponse,

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -3,6 +3,7 @@
 //! deltas those commits produce, and the ordered change feed that exposes
 //! them. Path-oriented convenience operations live in [`super::operations`].
 
+use super::ValidatedContentToken;
 use crate::{
     ChangeSeq, CommitId, ContentRef, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo,
 };
@@ -25,6 +26,22 @@ pub struct CommitRequest {
     /// Optional human-readable note.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+/// Transport wrapper for submitting an explicit semantic commit.
+///
+/// The flattened commit fields preserve the original bare request shape,
+/// while `content_tokens` carries transport-only preparation proofs that do
+/// not participate in the semantic commit fingerprint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CommitSubmissionRequest {
+    /// Semantic commit whose fields remain at the top level on the wire.
+    #[serde(flatten)]
+    pub commit: CommitRequest,
+    /// Proofs for new external content refs introduced by the commit.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content_tokens: Vec<ValidatedContentToken>,
 }
 
 /// Result of one committed mutation.
@@ -243,8 +260,32 @@ pub struct ChangesResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommitDelta, CommitOp, CommitPrecondition};
-    use crate::{ChangeSeq, InodeId, InodeKind, NameKey};
+    use super::{CommitDelta, CommitOp, CommitPrecondition, CommitSubmissionRequest};
+    use crate::{ChangeSeq, CommitId, InodeId, InodeKind, NameKey};
+
+    #[test]
+    fn bare_commit_body_without_content_tokens_parses_as_submission() {
+        let body = br#"{
+            "commit_id":"commit-a",
+            "preconditions":[],
+            "ops":[{
+                "kind":"create_directory",
+                "parent_inode_id":1,
+                "display_name":"docs"
+            }],
+            "message":"existing body"
+        }"#;
+
+        let submission: CommitSubmissionRequest =
+            serde_json::from_slice(body).expect("parse pre-token commit body");
+
+        assert_eq!(
+            submission.commit.commit_id,
+            CommitId::parse("commit-a").expect("valid commit id")
+        );
+        assert_eq!(submission.commit.ops.len(), 1);
+        assert!(submission.content_tokens.is_empty());
+    }
 
     #[test]
     fn commit_precondition_name_key_serializes_as_plain_string() {

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -21,7 +21,7 @@ mod uploads;
 
 pub use commits::{
     ChangesResponse, CommitDelta, CommitOp, CommitPrecondition, CommitRequest, CommitResponse,
-    CommittedChange,
+    CommitSubmissionRequest, CommittedChange,
 };
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CreateCheckpointRequest, CreateCheckpointResponse,

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -16,9 +16,9 @@ mod transport;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,
-        CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
-        CompleteUploadRequest, CompleteUploadResponse, ObjectTransferAccess, UploadContentResponse,
-        UploadMode, ValidatedContentToken,
+        CommitResponse as ApiCommitResponse, CommitSubmissionRequest, CompleteUploadRequest,
+        CompleteUploadResponse, ObjectTransferAccess, UploadContentResponse, UploadMode,
+        ValidatedContentToken,
     },
     AbsolutePath, AdvanceRetentionResponse, AuthoritativePathEntry, CapabilityDocument, ChangeSeq,
     CommitId, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
@@ -431,7 +431,7 @@ impl Client {
     pub fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
-        request: &ApiCommitRequest,
+        request: &CommitSubmissionRequest,
     ) -> Result<ApiCommitResponse, ClientError> {
         let url = format!("{}/v0/namespaces/{namespace_id}/commits", self.base_url);
         self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -19,6 +19,7 @@ use loonfs_api::v0::{CommitRequest as ApiCommitRequest, CommitResponse as ApiCom
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};
 use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
@@ -62,6 +63,20 @@ impl NamespaceMutationCandidate {
         Self {
             mutation: NamespaceMutation::Commit(request),
             content: ContentPreparation::Ready(Vec::new()),
+        }
+    }
+
+    /// Wraps an explicit semantic commit with opaque proofs for its prepared
+    /// content.
+    pub fn commit_prepared(request: ApiCommitRequest, content: Vec<PreparedContent>) -> Self {
+        Self {
+            mutation: NamespaceMutation::Commit(request),
+            content: ContentPreparation::Ready(
+                content
+                    .into_iter()
+                    .map(PreparedContent::into_admission)
+                    .collect(),
+            ),
         }
     }
 
@@ -115,6 +130,7 @@ impl NamespaceMutationCandidate {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<SemanticMutationIdentity> {
+        self.validate_request_limits()?;
         match &self.mutation {
             NamespaceMutation::Commit(request) => {
                 core_commit_fingerprint_for_v0_request(namespace_id, request)
@@ -128,6 +144,46 @@ impl NamespaceMutationCandidate {
                     .map(SemanticMutationIdentity::PathIntent)
             }
         }
+    }
+
+    pub(crate) fn validate_request_limits(&self) -> Result<()> {
+        let NamespaceMutation::Commit(request) = &self.mutation else {
+            return Ok(());
+        };
+        if request.ops.len() > crate::limits::MAX_COMMIT_OPERATIONS {
+            return Err(CoreError::InvalidCommitRequest(format!(
+                "commit has {} operations; maximum is {}",
+                request.ops.len(),
+                crate::limits::MAX_COMMIT_OPERATIONS
+            )));
+        }
+        let prepared_count = match &self.content {
+            ContentPreparation::Ready(content) => content.len(),
+            ContentPreparation::Rejected(_) => 0,
+        };
+        if prepared_count > crate::limits::MAX_COMMIT_CONTENT_TOKENS {
+            return Err(CoreError::InvalidCommitRequest(format!(
+                "commit has {prepared_count} prepared content proofs; maximum is {}",
+                crate::limits::MAX_COMMIT_CONTENT_TOKENS
+            )));
+        }
+        let distinct_content_refs = request
+            .ops
+            .iter()
+            .filter_map(|op| match op {
+                loonfs_api::v0::CommitOp::CreateFile { content_ref, .. }
+                | loonfs_api::v0::CommitOp::ReplaceFile { content_ref, .. } => Some(content_ref),
+                _ => None,
+            })
+            .collect::<HashSet<_>>()
+            .len();
+        if distinct_content_refs > crate::limits::MAX_COMMIT_EXTERNAL_CONTENT_REFS {
+            return Err(CoreError::InvalidCommitRequest(format!(
+                "commit references {distinct_content_refs} distinct external content refs; maximum is {}",
+                crate::limits::MAX_COMMIT_EXTERNAL_CONTENT_REFS
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -521,11 +577,13 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::content::{mint_content_token, verify_content_token};
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::namespace::control::read_head_object;
     use futures::StreamExt;
-    use loonfs_api::{ChangeSeq, InodeId, WriterEpoch};
+    use loonfs_api::v0::ValidatedContentToken;
+    use loonfs_api::{ChangeSeq, ContentRef, InodeId, WriterEpoch};
     use loonfs_objectstore::keys::wal_segment_prefix;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
@@ -559,6 +617,53 @@ mod tests {
             ready.semantic_identity(&namespace_id).expect("identity"),
             rejected.semantic_identity(&namespace_id).expect("identity")
         );
+    }
+
+    #[test]
+    fn candidate_validation_rejects_commit_operation_and_prepared_proof_limits() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let oversized_ops = NamespaceMutationCandidate::commit(ApiCommitRequest {
+            commit_id: CommitId::parse("too-many-ops").expect("valid commit id"),
+            preconditions: Vec::new(),
+            ops: (0..=crate::limits::MAX_COMMIT_OPERATIONS)
+                .map(|index| loonfs_api::v0::CommitOp::CreateDirectory {
+                    parent_inode_id: InodeId(1),
+                    display_name: format!("dir-{index}"),
+                })
+                .collect(),
+            message: None,
+        });
+        let operations_error = oversized_ops
+            .semantic_identity(&namespace_id)
+            .expect_err("operation limit must reject before admission");
+        assert_eq!(operations_error.code(), ErrorCode::InvalidRequest);
+
+        let content_ref = ContentRef::whole_file_v0(b"proof");
+        let token =
+            mint_content_token("secret", &namespace_id, &content_ref, 1_000).expect("mint token");
+        let prepared = verify_content_token(
+            "secret",
+            &namespace_id,
+            &ValidatedContentToken { content_ref, token },
+            1_000,
+        )
+        .expect("verify token");
+        let oversized_proofs = NamespaceMutationCandidate::commit_prepared(
+            ApiCommitRequest {
+                commit_id: CommitId::parse("too-many-proofs").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![loonfs_api::v0::CommitOp::CreateDirectory {
+                    parent_inode_id: InodeId(1),
+                    display_name: "docs".to_owned(),
+                }],
+                message: None,
+            },
+            vec![prepared; crate::limits::MAX_COMMIT_CONTENT_TOKENS + 1],
+        );
+        let proofs_error = oversized_proofs
+            .semantic_identity(&namespace_id)
+            .expect_err("prepared proof limit must reject before admission");
+        assert_eq!(proofs_error.code(), ErrorCode::InvalidRequest);
     }
 
     fn create_dir(commit_id: &str, display_name: &str) -> NamespaceMutationCandidate {

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -68,6 +68,8 @@ pub enum CoreError {
     InvalidNamespaceId(#[from] NamespaceIdValidationError),
     #[error(transparent)]
     InvalidCommitId(#[from] CommitIdValidationError),
+    #[error("invalid commit request: {0}")]
+    InvalidCommitRequest(String),
     #[error(transparent)]
     InvalidUploadId(#[from] GeneratedIdValidationError),
     #[error("path not found `{0}`")]
@@ -354,6 +356,7 @@ impl CoreError {
             }
             CoreError::InvalidNamespaceId(_) => ErrorCode::InvalidRequest,
             CoreError::InvalidCommitId(_) => ErrorCode::InvalidRequest,
+            CoreError::InvalidCommitRequest(_) => ErrorCode::InvalidRequest,
             CoreError::InvalidUploadId(_) => ErrorCode::InvalidRequest,
             CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
             CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -11,6 +11,20 @@
 
 use loonfs_objectstore::{PROVIDER_ATTEMPT_TIMEOUT, PROVIDER_OP_DEADLINE};
 
+/// Maximum semantic operations in one explicit commit, bounding how long one
+/// request can occupy the serialized publisher during planning and
+/// materialization.
+pub const MAX_COMMIT_OPERATIONS: usize = 4096;
+
+/// Maximum content-token or prepared-proof entries carried by one explicit
+/// commit, bounding its preparation work and retained publisher admission
+/// state.
+pub const MAX_COMMIT_CONTENT_TOKENS: usize = 4096;
+
+/// Maximum distinct new external content refs in one explicit commit, bounding
+/// its in-memory coverage work while it occupies the serialized publisher.
+pub const MAX_COMMIT_EXTERNAL_CONTENT_REFS: usize = 4096;
+
 /// Provider operation deadline, in milliseconds (`loonfs-objectstore`
 /// consumes it across every retry of one single-request operation).
 /// Multipart transfers of large immutable payloads carry no

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -15,7 +15,6 @@ use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::path::write::PublishPlanningSession;
-use crate::storage::content::ContentValidationTracker;
 use crate::timing::MonotonicTimer;
 use crate::wal::{prepare_wal_segment, PreparedWalSegment};
 use bytes::Bytes;
@@ -104,7 +103,6 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
     let mut session = PublishPlanningSession::new(&view.head);
     let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
     let mut dedup = BatchDedup::default();
-    let mut content_validation = ContentValidationTracker::default();
 
     let prepare_span = tracing::info_span!(
         "publisher.batch_prepare",
@@ -144,15 +142,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 accepted_rows: session.accepted_rows(),
             };
             let request = candidate_request.request;
-            if let Err(error) = validate_commit_content_references(
-                store,
-                &view.content_store_id,
-                &request,
-                candidate,
-                &mut content_validation,
-            )
-            .await
-            {
+            if let Err(error) = validate_commit_content_references(&request, candidate) {
                 outcomes[index] = Some(Err(error));
                 continue;
             }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -13,10 +13,9 @@ use crate::commit_engine::{
 use crate::error::{CoreError, Result};
 use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PublishPlanningSession};
-use crate::storage::content::ContentValidationTracker;
 use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
-use loonfs_api::{CommitId, ContentRef, ContentStoreId, NamespaceId};
+use loonfs_api::{CommitId, ContentRef, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
@@ -130,6 +129,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     index: usize,
     dedup: &mut BatchDedup,
 ) -> Result<CandidateAdmission> {
+    candidate.validate_request_limits()?;
     let acquired_writer = view
         .acquired_writer
         .as_ref()
@@ -262,54 +262,53 @@ impl CommitContentAdmissions<'_> {
     }
 }
 
-/// Checks external content refs without reading content for path candidates;
-/// explicit commits retain durable validation until their endpoint accepts
-/// content admissions.
-pub(super) async fn validate_commit_content_references<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: &ContentStoreId,
+/// Checks every new external content ref against in-memory preparation proofs.
+pub(super) fn validate_commit_content_references(
     request: &CoreCommitRequest,
     candidate: &NamespaceMutationCandidate,
-    content_validation: &mut ContentValidationTracker,
 ) -> Result<()> {
+    let admissions = CommitContentAdmissions {
+        namespace_id: &request.namespace_id,
+        admissions: match candidate.content_preparation() {
+            ContentPreparation::Ready(admissions) => admissions,
+            ContentPreparation::Rejected(_) => {
+                return Err(CoreError::Internal(
+                    "rejected content preparation reached coverage validation".to_owned(),
+                ));
+            }
+        },
+    };
     match candidate.mutation() {
         NamespaceMutation::Commit(_) => {
-            for op in &request.ops {
-                let content_ref = match op {
-                    CommitOp::CreateFile { content_ref, .. }
-                    | CommitOp::ReplaceFile { content_ref, .. } => content_ref,
-                    // Restore content is resolved from retained namespace
-                    // metadata, whose durability is already guaranteed.
-                    _ => continue,
-                };
-                content_validation
-                    .ensure_validated(store, content_store_id, content_ref)
-                    .await?;
+            for content_ref in request.ops.iter().filter_map(|op| match op {
+                CommitOp::CreateFile { content_ref, .. }
+                | CommitOp::ReplaceFile { content_ref, .. } => Some(content_ref),
+                // Restore content is resolved from retained namespace metadata,
+                // whose durability is already guaranteed.
+                _ => None,
+            }) {
+                require_content_admission(&admissions, content_ref)?;
             }
         }
-        NamespaceMutation::Path(intent) => {
-            let crate::path::write::PathMutationIntent::PutFile { content_ref, .. } = intent else {
-                return Ok(());
-            };
-            let admissions = CommitContentAdmissions {
-                namespace_id: &request.namespace_id,
-                admissions: match candidate.content_preparation() {
-                    ContentPreparation::Ready(admissions) => admissions,
-                    ContentPreparation::Rejected(_) => {
-                        return Err(CoreError::Internal(
-                            "rejected content preparation reached coverage validation".to_owned(),
-                        ));
-                    }
-                },
-            };
-            if !admissions.admits(content_ref) {
-                return Err(ContentPreparationError::ContentNotPrepared {
-                    content_ref_digest: content_ref.digest.clone(),
-                }
-                .into());
-            }
-        }
+        NamespaceMutation::Path(crate::path::write::PathMutationIntent::PutFile {
+            content_ref,
+            ..
+        }) => require_content_admission(&admissions, content_ref)?,
+        NamespaceMutation::Path(_) => return Ok(()),
     }
 
     Ok(())
+}
+
+fn require_content_admission(
+    admissions: &CommitContentAdmissions<'_>,
+    content_ref: &ContentRef,
+) -> Result<()> {
+    if admissions.admits(content_ref) {
+        return Ok(());
+    }
+    Err(ContentPreparationError::ContentNotPrepared {
+        content_ref_digest: content_ref.digest.clone(),
+    }
+    .into())
 }

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -13,14 +13,11 @@ use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceC
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
-use loonfs_api::{
-    ChangeSeq, CommitId, ContentStoreId, ManifestId, ManifestObjectId, NamePolicy, NamespaceId,
-};
+use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamePolicy, NamespaceId};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
-    pub(super) content_store_id: ContentStoreId,
     name_policy: NamePolicy,
     pub(super) head: HeadState,
     pub(super) head_etag: String,
@@ -197,7 +194,6 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
 
     Ok((
         PublishMetadataView {
-            content_store_id: catalog_entry.content_store_id,
             name_policy: catalog_entry.namespace_config.name_policy,
             head,
             head_etag,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -10,7 +10,6 @@ use loonfs_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId, Name
 use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::{ObjectStore, ObjectStoreError, PROVIDER_MULTIPART_THRESHOLD_BYTES};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,28 +40,6 @@ pub struct StoredContent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StoredContentWriteAcknowledgement;
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct ContentValidationTracker {
-    validated: HashSet<(ContentStoreId, ContentRef)>,
-}
-
-impl ContentValidationTracker {
-    pub(crate) async fn ensure_validated<S: ObjectStore + ?Sized>(
-        &mut self,
-        store: &S,
-        content_store_id: &ContentStoreId,
-        content_ref: &ContentRef,
-    ) -> Result<(), DurableContentValidationError> {
-        let key = (content_store_id.clone(), content_ref.clone());
-        if self.validated.contains(&key) {
-            return Ok(());
-        }
-        validate_durable_content_reference(store, content_store_id, content_ref).await?;
-        self.validated.insert(key);
-        Ok(())
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum DurableContentValidationError {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -54,6 +54,7 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use std::collections::HashSet;
 use std::future::Future;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -128,15 +129,11 @@ fn commit_operations<S: ObjectStore + ?Sized>(
     request: ApiCommitRequest,
     context: &MutationContext,
 ) -> Result<loonfs_api::v0::CommitResponse, CoreError> {
-    publish_namespace_mutations_batch(
-        store,
-        namespace_id,
-        vec![NamespaceMutationCandidate::commit(request)],
-        context,
-    )
-    .into_iter()
-    .next()
-    .expect("single commit result")
+    let candidate = prepared_commit_candidate(store, namespace_id, request)?;
+    publish_namespace_mutations_batch(store, namespace_id, vec![candidate], context)
+        .into_iter()
+        .next()
+        .expect("single commit result")
 }
 
 fn commit_operations_batch<S: ObjectStore + ?Sized>(
@@ -145,15 +142,43 @@ fn commit_operations_batch<S: ObjectStore + ?Sized>(
     requests: Vec<ApiCommitRequest>,
     context: &MutationContext,
 ) -> Vec<Result<loonfs_api::v0::CommitResponse, CoreError>> {
-    publish_namespace_mutations_batch(
-        store,
-        namespace_id,
-        requests
-            .into_iter()
-            .map(NamespaceMutationCandidate::commit)
-            .collect(),
-        context,
-    )
+    let request_count = requests.len();
+    let candidates = requests
+        .into_iter()
+        .map(|request| prepared_commit_candidate(store, namespace_id, request))
+        .collect::<Result<Vec<_>, _>>();
+    let candidates = match candidates {
+        Ok(candidates) => candidates,
+        Err(error) => return (0..request_count).map(|_| Err(error.clone())).collect(),
+    };
+    publish_namespace_mutations_batch(store, namespace_id, candidates, context)
+}
+
+fn prepared_commit_candidate<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    request: ApiCommitRequest,
+) -> Result<NamespaceMutationCandidate, CoreError> {
+    let content_store_id = load_namespace_descriptor_state(store, namespace_id).content_store_id;
+    let mut seen = HashSet::new();
+    let mut prepared = Vec::new();
+    for content_ref in request.ops.iter().filter_map(|op| match op {
+        ApiCommitOp::CreateFile { content_ref, .. }
+        | ApiCommitOp::ReplaceFile { content_ref, .. } => Some(content_ref),
+        _ => None,
+    }) {
+        if seen.insert(content_ref.clone()) {
+            prepared.push(block_on(prepare_existing_content_ref(
+                store,
+                namespace_id,
+                &content_store_id,
+                content_ref.clone(),
+            ))?);
+        }
+    }
+    Ok(NamespaceMutationCandidate::commit_prepared(
+        request, prepared,
+    ))
 }
 
 fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
@@ -4419,39 +4444,47 @@ async fn metadata_only_commit_does_not_validate_content_store_refs() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn create_file_prioritizes_missing_durable_content_over_missing_parent() {
+async fn explicit_create_file_fails_unprepared_before_parent_validation_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
     bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
 
-    let error = commit_operations(
-        &store,
+    let guarded_store = ContentStoreAccessLimitStore::new(temp_dir.path(), 1);
+    let missing_content = content_ref("missing-content");
+    let error = publish_namespace_mutations_batch(
+        &guarded_store,
         &namespace_id(),
-        ApiCommitRequest {
-            commit_id: CommitId::parse("create-missing-parent-missing-content")
+        vec![NamespaceMutationCandidate::commit(ApiCommitRequest {
+            commit_id: CommitId::parse("create-missing-parent-unprepared-content")
                 .expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::CreateFile {
                 parent_inode_id: InodeId(99),
                 display_name: "missing.txt".to_owned(),
-                content_ref: content_ref("missing-content"),
+                content_ref: missing_content.clone(),
             }],
             message: None,
-        },
+        })],
         &context,
     )
-    .expect_err("missing content should win before missing parent");
+    .into_iter()
+    .next()
+    .expect("one result")
+    .expect_err("unprepared content should win before missing parent");
     assert!(matches!(
         error,
-        CoreError::DurableContent(
-            loonfs_core::content::DurableContentValidationError::MissingContentObject { .. }
-        )
+        CoreError::ContentPreparation(
+            loonfs_core::publish::ContentPreparationError::ContentNotPrepared {
+                content_ref_digest
+            }
+        ) if content_ref_digest == missing_content.digest
     ));
+    assert_eq!(guarded_store.content_store_access_count(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn replace_file_prioritizes_missing_durable_content_over_stale_revision() {
+async fn explicit_replace_file_fails_unprepared_before_revision_validation_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
@@ -4469,28 +4502,36 @@ async fn replace_file_prioritizes_missing_durable_content_over_stale_revision() 
         .expect("resolve path")
         .inode_id;
 
-    let error = commit_operations(
-        &store,
+    let guarded_store = ContentStoreAccessLimitStore::new(temp_dir.path(), 1);
+    let missing_content = content_ref("missing-content");
+    let error = publish_namespace_mutations_batch(
+        &guarded_store,
         &namespace_id(),
-        ApiCommitRequest {
+        vec![NamespaceMutationCandidate::commit(ApiCommitRequest {
             commit_id: CommitId::parse("replace-stale-missing-content").expect("valid commit id"),
             preconditions: Vec::new(),
             ops: vec![ApiCommitOp::ReplaceFile {
                 inode_id,
                 base_revision_no: RevisionNo(99),
-                content_ref: content_ref("missing-content"),
+                content_ref: missing_content.clone(),
             }],
             message: None,
-        },
+        })],
         &context,
     )
-    .expect_err("missing content should win before stale revision");
+    .into_iter()
+    .next()
+    .expect("one result")
+    .expect_err("unprepared content should win before stale revision");
     assert!(matches!(
         error,
-        CoreError::DurableContent(
-            loonfs_core::content::DurableContentValidationError::MissingContentObject { .. }
-        )
+        CoreError::ContentPreparation(
+            loonfs_core::publish::ContentPreparationError::ContentNotPrepared {
+                content_ref_digest
+            }
+        ) if content_ref_digest == missing_content.digest
     ));
+    assert_eq!(guarded_store.content_store_access_count(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4529,80 +4570,6 @@ async fn restore_revision_missing_source_is_revision_not_found() {
     )
     .expect_err("missing restore source should fail");
     assert_eq!(error.code(), ErrorCode::RevisionNotFound);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn restore_revision_resolves_same_request_source_before_durable_content_validation() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false).expect("bootstrap namespace");
-
-    let first = store_bytes_as_content(&store, &namespace_id(), b"first")
-        .await
-        .expect("stage first");
-    commit_operations(
-        &store,
-        &namespace_id(),
-        ApiCommitRequest {
-            commit_id: CommitId::parse("resolve-before-durable-check-create")
-                .expect("valid commit id"),
-            preconditions: Vec::new(),
-            ops: vec![ApiCommitOp::CreateFile {
-                parent_inode_id: InodeId(1),
-                display_name: "restore.txt".to_owned(),
-                content_ref: first.content_ref.clone(),
-            }],
-            message: None,
-        },
-        &context,
-    )
-    .expect("create file");
-    let inode_id = resolve_path(&store, &namespace_id(), "/restore.txt")
-        .expect("resolve created file")
-        .inode_id;
-
-    let second = store_bytes_as_content(&store, &namespace_id(), b"second")
-        .await
-        .expect("stage second");
-    store
-        .delete(
-            &content_blob(second.content_store_id.as_str(), &second.content_ref.digest)
-                .expect("second content key"),
-        )
-        .await
-        .expect("delete second content");
-
-    let error = commit_operations(
-        &store,
-        &namespace_id(),
-        ApiCommitRequest {
-            commit_id: CommitId::parse("resolve-before-durable-check-commit")
-                .expect("valid commit id"),
-            preconditions: Vec::new(),
-            ops: vec![
-                ApiCommitOp::ReplaceFile {
-                    inode_id,
-                    base_revision_no: RevisionNo(1),
-                    content_ref: second.content_ref.clone(),
-                },
-                ApiCommitOp::RestoreRevision {
-                    inode_id,
-                    source_revision_no: RevisionNo(2),
-                    base_revision_no: RevisionNo(2),
-                },
-            ],
-            message: None,
-        },
-        &context,
-    )
-    .expect_err("missing same-request content should fail durable-content validation");
-    assert!(matches!(
-        error,
-        CoreError::DurableContent(
-            loonfs_core::content::DurableContentValidationError::MissingContentObject { .. }
-        )
-    ));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -13,18 +13,26 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::publish::{
     parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
-    PathMutationIntent,
+    PathMutationIntent, PreparedContent, MAX_COMMIT_CONTENT_TOKENS,
+    MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_OPERATIONS,
 };
-use loonfs::{payload_class, ErrorCode, ListChangesOptions, TraceStoreKind};
+use loonfs::{
+    content_tokens::{verify_content_token, ContentTokenError},
+    payload_class, CoreError, ErrorCode, ListChangesOptions, TraceStoreKind,
+};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::{
     decode_directory_cursor, decode_file_revisions_cursor,
-    v0::{ChangesResponse, CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse},
-    DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation, FilesystemOperationRequest,
-    InodeId, LimitError, ListFileRevisionsResponse, PageCursorError, PageRequest, PaginationPolicy,
-    RestoreFileRevisionRequest, RevisionNo,
+    v0::{
+        ChangesResponse, CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
+        CommitSubmissionRequest, ValidatedContentToken,
+    },
+    ContentRef, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
+    FilesystemOperationRequest, InodeId, LimitError, ListFileRevisionsResponse, PageCursorError,
+    PageRequest, PaginationPolicy, RestoreFileRevisionRequest, RevisionNo,
 };
+use std::collections::HashSet;
 use tracing::Instrument;
 
 #[derive(Debug, serde::Deserialize)]
@@ -608,7 +616,7 @@ pub(super) async fn filesystem_operation(
         summary = "Commit operations",
         description = "Applies an explicit semantic commit containing ordered inode-level operations and optional preconditions. Use this for advanced cases that require inode-specificity, preconditions, or batch transactions.",
         params(("namespace" = String, Path, description = "Namespace id")),
-        request_body = ApiCommitRequest,
+        request_body = CommitSubmissionRequest,
         responses(
             (status = 200, description = "Commit accepted", body = ApiCommitResponse),
             (status = 400, description = "Invalid commit request", body = ApiError),
@@ -624,18 +632,138 @@ pub(super) async fn filesystem_operation(
 pub(super) async fn commit_operations(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
-    CommitAppJson(request): CommitAppJson<ApiCommitRequest>,
+    CommitAppJson(submission): CommitAppJson<CommitSubmissionRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
+    let CommitSubmissionRequest {
+        commit: request,
+        content_tokens,
+    } = submission;
     let namespace_id = namespace.into_id()?;
     let commit_id = request.commit_id.clone();
+    let external_content_refs = distinct_external_content_refs(&request);
+    validate_commit_submission_limits(&request, content_tokens.len(), external_content_refs.len())
+        .map_err(|error| {
+            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
+        })?;
+    let content_preparation = prepare_commit_content(
+        &state.config,
+        &namespace_id,
+        &external_content_refs,
+        &content_tokens,
+    )?;
+    let candidate = match content_preparation {
+        CommitContentPreparation::Ready(content) => {
+            NamespaceMutationCandidate::commit_prepared(request, content)
+        }
+        CommitContentPreparation::Rejected(error) => NamespaceMutationCandidate::rejected(
+            NamespaceMutation::Commit(request),
+            ContentPreparationError::ContentToken(error),
+        ),
+    };
     let response = state
         .publisher
-        .submit_commit(namespace_id.clone(), request)
+        .submit_candidate(namespace_id.clone(), candidate)
         .await
         .map_err(|error| {
             ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
         })?;
     Ok(Json(response))
+}
+
+enum CommitContentPreparation {
+    Ready(Vec<PreparedContent>),
+    Rejected(ContentTokenError),
+}
+
+fn distinct_external_content_refs(request: &ApiCommitRequest) -> Vec<ContentRef> {
+    let mut seen = HashSet::new();
+    let mut refs = Vec::new();
+    for content_ref in request.ops.iter().filter_map(|op| match op {
+        loonfs_api::v0::CommitOp::CreateFile { content_ref, .. }
+        | loonfs_api::v0::CommitOp::ReplaceFile { content_ref, .. } => Some(content_ref),
+        _ => None,
+    }) {
+        if seen.insert(content_ref.clone()) {
+            refs.push(content_ref.clone());
+        }
+    }
+    refs
+}
+
+fn validate_commit_submission_limits(
+    request: &ApiCommitRequest,
+    content_token_count: usize,
+    external_content_ref_count: usize,
+) -> Result<(), CoreError> {
+    if request.ops.len() > MAX_COMMIT_OPERATIONS {
+        return Err(CoreError::InvalidCommitRequest(format!(
+            "commit has {} operations; maximum is {MAX_COMMIT_OPERATIONS}",
+            request.ops.len()
+        )));
+    }
+    if content_token_count > MAX_COMMIT_CONTENT_TOKENS {
+        return Err(CoreError::InvalidCommitRequest(format!(
+            "commit has {content_token_count} content token entries; maximum is {MAX_COMMIT_CONTENT_TOKENS}"
+        )));
+    }
+    if external_content_ref_count > MAX_COMMIT_EXTERNAL_CONTENT_REFS {
+        return Err(CoreError::InvalidCommitRequest(format!(
+            "commit references {external_content_ref_count} distinct external content refs; maximum is {MAX_COMMIT_EXTERNAL_CONTENT_REFS}"
+        )));
+    }
+    Ok(())
+}
+
+fn prepare_commit_content(
+    config: &crate::config::ServerConfig,
+    namespace_id: &loonfs_api::NamespaceId,
+    external_content_refs: &[ContentRef],
+    content_tokens: &[ValidatedContentToken],
+) -> Result<CommitContentPreparation, ApiResponseError> {
+    let relevant_refs = external_content_refs
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let relevant_tokens = content_tokens
+        .iter()
+        .filter(|token| relevant_refs.contains(&token.content_ref));
+    let mut relevant_tokens = relevant_tokens.peekable();
+    if relevant_tokens.peek().is_none() {
+        return Ok(CommitContentPreparation::Ready(Vec::new()));
+    }
+
+    let now_ms = current_unix_ms()?;
+    let mut prepared = Vec::new();
+    let mut prepared_refs = HashSet::new();
+    let mut first_error = None;
+    for token in relevant_tokens {
+        match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
+            Ok(content) => {
+                prepared_refs.insert(content.content_ref().clone());
+                prepared.push(content);
+            }
+            Err(error) => {
+                tracing::debug!(
+                    namespace_id = %namespace_id,
+                    content_ref_digest = %token.content_ref.digest,
+                    error = %error,
+                    "content token rejected during commit preparation"
+                );
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+
+    if external_content_refs
+        .iter()
+        .all(|content_ref| prepared_refs.contains(content_ref))
+    {
+        Ok(CommitContentPreparation::Ready(prepared))
+    } else if let Some(error) = first_error {
+        Ok(CommitContentPreparation::Rejected(error))
+    } else {
+        Ok(CommitContentPreparation::Ready(prepared))
+    }
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -11,8 +11,8 @@ use loonfs_api::{
     v0::{
         BeginUploadRequest, BeginUploadResponse, ChangesResponse,
         CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
-        CompleteUploadRequest, CompleteUploadResponse, DirectPutUpload, ObjectTransferAccess,
-        UploadContentResponse, UploadMode, ValidatedContentToken,
+        CommitSubmissionRequest, CompleteUploadRequest, CompleteUploadResponse, DirectPutUpload,
+        ObjectTransferAccess, UploadContentResponse, UploadMode, ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ContentRef, CreateCheckpointRequest,
     CreateCheckpointResponse, CreateNamespaceRequest, FilesystemOperation,
@@ -116,6 +116,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         ObjectTransferAccess,
         UploadMode,
         ValidatedContentToken,
+        CommitSubmissionRequest,
         ApiCommitRequest,
         ApiCommitResponse,
         loonfs_api::v0::CommitOp,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -765,6 +765,10 @@ async fn capability_document_advertises_the_upload_limit() {
             Some(8 * 1024 * 1024)
         );
         assert_eq!(
+            capabilities.limits.get("commit.max_operations").copied(),
+            Some(4096)
+        );
+        assert_eq!(
             capabilities
                 .limits
                 .get("query.grep.scan_budget_files")

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -3,7 +3,8 @@ use loonfs::content_tokens::mint_content_token;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
-        CompleteUploadRequest, CompleteUploadResponse, ValidatedContentToken,
+        CommitSubmissionRequest, CompleteUploadRequest, CompleteUploadResponse,
+        ValidatedContentToken,
     },
     AdvanceRetentionResponse, ApiError, ChangeSeq, CheckpointId, CommitId, CommitResponse,
     ContentRef, CreateCheckpointResponse, DestinationBehavior, ErrorCode, FilesystemOperation,
@@ -17,6 +18,7 @@ use loonfs_objectstore::{ConfiguredObjectStore, ObjectStore};
 use loonfs_server::{app, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
 use serde_json::json;
 use std::future::Future;
+use std::io::Read as _;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -705,17 +707,21 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             other => unreachable!("expected upload content rejection, got {other:?}"),
         }
 
-        let content_ref = stage_uploaded_content_ref(&harness.client, &namespace, file_bytes);
+        let completed = stage_uploaded_content(&harness.client, &namespace, file_bytes);
+        let content_ref = completed.content_ref.clone();
 
-        let commit_request = ApiCommitRequest {
-            commit_id: CommitId::parse("req-phase-2a-create-file").expect("valid commit id"),
-            preconditions: Vec::new(),
-            ops: vec![CommitOp::CreateFile {
-                parent_inode_id: InodeId(1),
-                display_name: "uploaded.txt".to_owned(),
-                content_ref: content_ref.clone(),
-            }],
-            message: Some("upload over http".to_owned()),
+        let commit_request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("req-phase-2a-create-file").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "uploaded.txt".to_owned(),
+                    content_ref: content_ref.clone(),
+                }],
+                message: Some("upload over http".to_owned()),
+            },
+            content_tokens: vec![validated_content_token(&completed)],
         };
         let commit = harness
             .client
@@ -756,7 +762,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         let change = &changes.changes[0];
         assert_eq!(change.seq, commit.committed_seq);
         assert_eq!(change.commit_id, commit.commit_id);
-        assert_eq!(change.commit_id, commit_request.commit_id);
+        assert_eq!(change.commit_id, commit_request.commit.commit_id);
         assert_eq!(change.message.as_deref(), Some("upload over http"));
         assert_eq!(change.deltas.len(), 3);
         assert!(matches!(
@@ -1021,6 +1027,358 @@ async fn path_put_with_only_an_irrelevant_token_reports_the_missing_put_proof() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_with_valid_tokens_for_all_distinct_refs_succeeds() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-tokens",
+        "http-commit-valid-tokens",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let first = stage_uploaded_content(&harness.client, &namespace, b"first");
+        let second = stage_uploaded_content(&harness.client, &namespace, b"second");
+        let third = stage_uploaded_content(&harness.client, &namespace, b"third");
+        let request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-all-proofs").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "first.txt".to_owned(),
+                        content_ref: first.content_ref.clone(),
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "first-copy.txt".to_owned(),
+                        content_ref: first.content_ref.clone(),
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "second.txt".to_owned(),
+                        content_ref: second.content_ref.clone(),
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "third.txt".to_owned(),
+                        content_ref: third.content_ref.clone(),
+                    },
+                ],
+                message: None,
+            },
+            content_tokens: vec![
+                validated_content_token(&first),
+                validated_content_token(&second),
+                validated_content_token(&third),
+                ValidatedContentToken {
+                    content_ref: ContentRef::whole_file_v0(b"irrelevant"),
+                    token: "irrelevant.garbage".to_owned(),
+                },
+            ],
+        };
+
+        let response = harness
+            .client
+            .commit_operations(&namespace, &request)
+            .expect("all distinct refs are prepared");
+        assert_eq!(response.committed_seq, ChangeSeq(1));
+        assert_eq!(
+            harness
+                .client
+                .stat_path(&NamespacePath::parse("demo", "/first-copy.txt").expect("path"))
+                .expect("repeated ref file")
+                .content_ref,
+            Some(first.content_ref)
+        );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_with_one_missing_proof_reports_first_uncovered_digest() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-missing-token",
+        "http-commit-missing-token",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let covered = stage_uploaded_content(&harness.client, &namespace, b"covered");
+        let uncovered = stage_uploaded_content(&harness.client, &namespace, b"uncovered");
+        let request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-missing-proof").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "covered.txt".to_owned(),
+                        content_ref: covered.content_ref.clone(),
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "uncovered.txt".to_owned(),
+                        content_ref: uncovered.content_ref.clone(),
+                    },
+                ],
+                message: None,
+            },
+            content_tokens: vec![validated_content_token(&covered)],
+        };
+
+        assert_commit_content_not_prepared_response(
+            send_commit_submission(&harness.server_url, &namespace, &request),
+            &request.commit.commit_id,
+            &format!(
+                "content ref `{}` is not prepared for publication",
+                uncovered.content_ref.digest
+            ),
+        );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_with_invalid_relevant_token_reports_token_failure() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-invalid-token",
+        "http-commit-invalid-token",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"invalid token");
+        let request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-invalid-token").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "invalid.txt".to_owned(),
+                    content_ref: completed.content_ref.clone(),
+                }],
+                message: None,
+            },
+            content_tokens: vec![ValidatedContentToken {
+                content_ref: completed.content_ref,
+                token: "not.a.valid.token".to_owned(),
+            }],
+        };
+
+        assert_commit_content_not_prepared_response(
+            send_commit_submission(&harness.server_url, &namespace, &request),
+            &request.commit.commit_id,
+            "content token was rejected: content token is malformed",
+        );
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn landed_commit_replays_byte_for_byte_with_absent_expired_or_garbage_tokens() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-token-replay",
+        "http-commit-token-replay",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"commit replay");
+        let content_ref = completed.content_ref.clone();
+        let mut request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-token-replay").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "replay.txt".to_owned(),
+                    content_ref: content_ref.clone(),
+                }],
+                message: None,
+            },
+            content_tokens: vec![validated_content_token(&completed)],
+        };
+        let send = |request: &CommitSubmissionRequest| {
+            response_bytes(
+                send_commit_submission(&harness.server_url, &namespace, request)
+                    .expect("landed commit should replay"),
+            )
+        };
+        let original = send(&request);
+
+        request.content_tokens.clear();
+        assert_eq!(send(&request), original);
+
+        request.content_tokens = vec![ValidatedContentToken {
+            content_ref: content_ref.clone(),
+            token: mint_content_token(TEST_CONTENT_TOKEN_SECRET, &namespace, &content_ref, 0)
+                .expect("mint expired token"),
+        }];
+        assert_eq!(send(&request), original);
+
+        request.content_tokens = vec![ValidatedContentToken {
+            content_ref,
+            token: "not.a.valid.token".to_owned(),
+        }];
+        assert_eq!(send(&request), original);
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bare_commit_body_without_content_tokens_still_parses_and_commits_mkdir() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-bare-commit",
+        "http-bare-commit",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let body = json!({
+            "commit_id": "bare-commit-mkdir",
+            "preconditions": [],
+            "ops": [{
+                "kind": "create_directory",
+                "parent_inode_id": 1,
+                "display_name": "docs"
+            }],
+            "message": null
+        });
+
+        let response =
+            send_commit_json(&harness.server_url, &namespace, &body).expect("bare commit body");
+        let response: CommitResponse =
+            serde_json::from_reader(response.into_reader()).expect("decode response");
+        assert_eq!(response.committed_seq, ChangeSeq(1));
+        harness
+            .client
+            .stat_path(&NamespacePath::parse("demo", "/docs").expect("path"))
+            .expect("mkdir committed");
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_operation_and_content_token_limits_reject_before_admission() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-commit-limits",
+        "http-commit-limits",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        let namespace = namespace_id("demo");
+        harness
+            .client
+            .create_namespace(&namespace)
+            .expect("create namespace");
+        let oversized_ops = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-too-many-ops").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: (0..4097)
+                    .map(|index| CommitOp::CreateDirectory {
+                        parent_inode_id: InodeId(1),
+                        display_name: format!("dir-{index}"),
+                    })
+                    .collect(),
+                message: None,
+            },
+            content_tokens: Vec::new(),
+        };
+        assert_invalid_commit_limit_response(
+            send_commit_submission(&harness.server_url, &namespace, &oversized_ops),
+            "4097 operations",
+        );
+
+        let irrelevant_ref = ContentRef::whole_file_v0(b"irrelevant");
+        let oversized_tokens = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("commit-too-many-tokens").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateDirectory {
+                    parent_inode_id: InodeId(1),
+                    display_name: "never-admitted".to_owned(),
+                }],
+                message: None,
+            },
+            content_tokens: (0..4097)
+                .map(|_| ValidatedContentToken {
+                    content_ref: irrelevant_ref.clone(),
+                    token: "irrelevant".to_owned(),
+                })
+                .collect(),
+        };
+        assert_invalid_commit_limit_response(
+            send_commit_submission(&harness.server_url, &namespace, &oversized_tokens),
+            "4097 content token entries",
+        );
+
+        let changes = harness
+            .client
+            .list_changes_page(&namespace, ChangeSeq(0), None)
+            .expect("list changes");
+        assert!(changes.changes.is_empty());
+    })
+    .await
+    .expect("blocking task");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
@@ -1038,21 +1396,24 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .create_namespace(&namespace)
             .expect("create namespace");
 
-        let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, &namespace, b"first bytes\n");
+        let first = stage_uploaded_content(&harness.client, &namespace, b"first bytes\n");
+        let first_content_ref = first.content_ref.clone();
         harness
             .client
             .commit_operations(
                 &namespace,
-                &ApiCommitRequest {
-                    commit_id: CommitId::parse("req-restore-create").expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![CommitOp::CreateFile {
-                        parent_inode_id: InodeId(1),
-                        display_name: "restore.txt".to_owned(),
-                        content_ref: first_content_ref.clone(),
-                    }],
-                    message: None,
+                &CommitSubmissionRequest {
+                    commit: ApiCommitRequest {
+                        commit_id: CommitId::parse("req-restore-create").expect("valid commit id"),
+                        preconditions: Vec::new(),
+                        ops: vec![CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "restore.txt".to_owned(),
+                            content_ref: first_content_ref.clone(),
+                        }],
+                        message: None,
+                    },
+                    content_tokens: vec![validated_content_token(&first)],
                 },
             )
             .expect("create file");
@@ -1062,21 +1423,24 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .expect("stat created file")
             .inode_id;
 
-        let second_content_ref =
-            stage_uploaded_content_ref(&harness.client, &namespace, b"second bytes\n");
+        let second = stage_uploaded_content(&harness.client, &namespace, b"second bytes\n");
+        let second_content_ref = second.content_ref.clone();
         let replace = harness
             .client
             .commit_operations(
                 &namespace,
-                &ApiCommitRequest {
-                    commit_id: CommitId::parse("req-restore-replace").expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![CommitOp::ReplaceFile {
-                        inode_id,
-                        base_revision_no: RevisionNo(1),
-                        content_ref: second_content_ref.clone(),
-                    }],
-                    message: None,
+                &CommitSubmissionRequest {
+                    commit: ApiCommitRequest {
+                        commit_id: CommitId::parse("req-restore-replace").expect("valid commit id"),
+                        preconditions: Vec::new(),
+                        ops: vec![CommitOp::ReplaceFile {
+                            inode_id,
+                            base_revision_no: RevisionNo(1),
+                            content_ref: second_content_ref.clone(),
+                        }],
+                        message: None,
+                    },
+                    content_tokens: vec![validated_content_token(&second)],
                 },
             )
             .expect("replace file");
@@ -1086,15 +1450,18 @@ async fn http_commit_restore_revision_appends_new_head_and_reports_change() {
             .client
             .commit_operations(
                 &namespace,
-                &ApiCommitRequest {
-                    commit_id: CommitId::parse("req-restore-restore").expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![CommitOp::RestoreRevision {
-                        inode_id,
-                        source_revision_no: RevisionNo(1),
-                        base_revision_no: RevisionNo(2),
-                    }],
-                    message: Some("restore revision".to_owned()),
+                &CommitSubmissionRequest {
+                    commit: ApiCommitRequest {
+                        commit_id: CommitId::parse("req-restore-restore").expect("valid commit id"),
+                        preconditions: Vec::new(),
+                        ops: vec![CommitOp::RestoreRevision {
+                            inode_id,
+                            source_revision_no: RevisionNo(1),
+                            base_revision_no: RevisionNo(2),
+                        }],
+                        message: Some("restore revision".to_owned()),
+                    },
+                    content_tokens: Vec::new(),
                 },
             )
             .expect("restore revision");
@@ -1300,22 +1667,24 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
             .expect("create namespace");
         let target = NamespacePath::parse("demo", "/restore.txt").expect("target");
 
-        let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, &namespace, b"first bytes\n");
+        let first = stage_uploaded_content(&harness.client, &namespace, b"first bytes\n");
         harness
             .client
             .commit_operations(
                 &namespace,
-                &ApiCommitRequest {
-                    commit_id: CommitId::parse("req-restore-missing-source-create")
-                        .expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![CommitOp::CreateFile {
-                        parent_inode_id: InodeId(1),
-                        display_name: "restore.txt".to_owned(),
-                        content_ref: first_content_ref,
-                    }],
-                    message: None,
+                &CommitSubmissionRequest {
+                    commit: ApiCommitRequest {
+                        commit_id: CommitId::parse("req-restore-missing-source-create")
+                            .expect("valid commit id"),
+                        preconditions: Vec::new(),
+                        ops: vec![CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "restore.txt".to_owned(),
+                            content_ref: first.content_ref.clone(),
+                        }],
+                        message: None,
+                    },
+                    content_tokens: vec![validated_content_token(&first)],
                 },
             )
             .expect("create file");
@@ -1327,16 +1696,19 @@ async fn http_commit_restore_revision_missing_source_returns_revision_not_found(
 
         match harness.client.commit_operations(
             &namespace,
-            &ApiCommitRequest {
-                commit_id: CommitId::parse("req-restore-missing-source-restore")
-                    .expect("valid commit id"),
-                preconditions: Vec::new(),
-                ops: vec![CommitOp::RestoreRevision {
-                    inode_id,
-                    source_revision_no: RevisionNo(99),
-                    base_revision_no: RevisionNo(1),
-                }],
-                message: None,
+            &CommitSubmissionRequest {
+                commit: ApiCommitRequest {
+                    commit_id: CommitId::parse("req-restore-missing-source-restore")
+                        .expect("valid commit id"),
+                    preconditions: Vec::new(),
+                    ops: vec![CommitOp::RestoreRevision {
+                        inode_id,
+                        source_revision_no: RevisionNo(99),
+                        base_revision_no: RevisionNo(1),
+                    }],
+                    message: None,
+                },
+                content_tokens: Vec::new(),
             },
         ) {
             Err(ClientError::Api { status, code, .. }) => {
@@ -1369,34 +1741,38 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
             .create_namespace(&namespace)
             .expect("create namespace");
 
-        let first_content_ref =
-            stage_uploaded_content_ref(&harness.client, &namespace, b"first payload\n");
-        let first_request = ApiCommitRequest {
-            commit_id: CommitId::parse("req-phase-2a-conflict").expect("valid commit id"),
-            preconditions: Vec::new(),
-            ops: vec![CommitOp::CreateFile {
-                parent_inode_id: InodeId(1),
-                display_name: "first.txt".to_owned(),
-                content_ref: first_content_ref,
-            }],
-            message: Some("first commit".to_owned()),
+        let first = stage_uploaded_content(&harness.client, &namespace, b"first payload\n");
+        let first_request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: CommitId::parse("req-phase-2a-conflict").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "first.txt".to_owned(),
+                    content_ref: first.content_ref.clone(),
+                }],
+                message: Some("first commit".to_owned()),
+            },
+            content_tokens: vec![validated_content_token(&first)],
         };
         harness
             .client
             .commit_operations(&namespace, &first_request)
             .expect("first commit");
 
-        let second_content_ref =
-            stage_uploaded_content_ref(&harness.client, &namespace, b"second payload\n");
-        let conflicting_request = ApiCommitRequest {
-            commit_id: first_request.commit_id.clone(),
-            preconditions: first_request.preconditions.clone(),
-            ops: vec![CommitOp::CreateFile {
-                parent_inode_id: InodeId(1),
-                display_name: "second.txt".to_owned(),
-                content_ref: second_content_ref,
-            }],
-            message: Some("second commit".to_owned()),
+        let second = stage_uploaded_content(&harness.client, &namespace, b"second payload\n");
+        let conflicting_request = CommitSubmissionRequest {
+            commit: ApiCommitRequest {
+                commit_id: first_request.commit.commit_id.clone(),
+                preconditions: first_request.commit.preconditions.clone(),
+                ops: vec![CommitOp::CreateFile {
+                    parent_inode_id: InodeId(1),
+                    display_name: "second.txt".to_owned(),
+                    content_ref: second.content_ref.clone(),
+                }],
+                message: Some("second commit".to_owned()),
+            },
+            content_tokens: vec![validated_content_token(&second)],
         };
 
         match harness
@@ -1414,7 +1790,10 @@ async fn http_commit_rejects_same_commit_id_with_different_payload() {
                 // structured fields, not prose (API spec, "Standard error
                 // contract").
                 let details = details.expect("structured details");
-                assert_eq!(details.commit_id, Some(first_request.commit_id.clone()));
+                assert_eq!(
+                    details.commit_id,
+                    Some(first_request.commit.commit_id.clone())
+                );
                 let request_id = request_id.expect("request id");
                 assert!(request_id.starts_with("req_"), "got `{request_id}`");
             }
@@ -1444,35 +1823,43 @@ async fn http_commit_name_collision_reports_readable_error_message() {
             .create_namespace(&namespace)
             .expect("create namespace");
 
-        let content_ref = stage_uploaded_content_ref(&harness.client, &namespace, b"taken bytes\n");
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"taken bytes\n");
+        let content_ref = completed.content_ref.clone();
         harness
             .client
             .commit_operations(
                 &namespace,
-                &ApiCommitRequest {
-                    commit_id: CommitId::parse("req-collision-create").expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![CommitOp::CreateFile {
-                        parent_inode_id: InodeId(1),
-                        display_name: "taken.txt".to_owned(),
-                        content_ref: content_ref.clone(),
-                    }],
-                    message: None,
+                &CommitSubmissionRequest {
+                    commit: ApiCommitRequest {
+                        commit_id: CommitId::parse("req-collision-create")
+                            .expect("valid commit id"),
+                        preconditions: Vec::new(),
+                        ops: vec![CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "taken.txt".to_owned(),
+                            content_ref: content_ref.clone(),
+                        }],
+                        message: None,
+                    },
+                    content_tokens: vec![validated_content_token(&completed)],
                 },
             )
             .expect("create file");
 
         match harness.client.commit_operations(
             &namespace,
-            &ApiCommitRequest {
-                commit_id: CommitId::parse("req-collision-repeat").expect("valid commit id"),
-                preconditions: Vec::new(),
-                ops: vec![CommitOp::CreateFile {
-                    parent_inode_id: InodeId(1),
-                    display_name: "taken.txt".to_owned(),
-                    content_ref,
-                }],
-                message: None,
+            &CommitSubmissionRequest {
+                commit: ApiCommitRequest {
+                    commit_id: CommitId::parse("req-collision-repeat").expect("valid commit id"),
+                    preconditions: Vec::new(),
+                    ops: vec![CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "taken.txt".to_owned(),
+                        content_ref,
+                    }],
+                    message: None,
+                },
+                content_tokens: vec![validated_content_token(&completed)],
             },
         ) {
             Err(ClientError::Api {
@@ -2397,6 +2784,83 @@ fn send_filesystem_operation(
     .map_err(Box::new)
 }
 
+fn send_commit_submission(
+    server_url: &str,
+    namespace_id: &NamespaceId,
+    request: &CommitSubmissionRequest,
+) -> Result<ureq::Response, Box<ureq::Error>> {
+    send_commit_json(server_url, namespace_id, request)
+}
+
+fn send_commit_json(
+    server_url: &str,
+    namespace_id: &NamespaceId,
+    request: &impl serde::Serialize,
+) -> Result<ureq::Response, Box<ureq::Error>> {
+    ureq::post(&format!(
+        "{server_url}/v0/namespaces/{namespace_id}/commits"
+    ))
+    .set("authorization", "Bearer test-token")
+    .send_json(request)
+    .map_err(Box::new)
+}
+
+fn response_bytes(response: ureq::Response) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut bytes)
+        .expect("read response bytes");
+    bytes
+}
+
+fn assert_commit_content_not_prepared_response(
+    result: Result<ureq::Response, Box<ureq::Error>>,
+    commit_id: &CommitId,
+    expected_message: &str,
+) {
+    match result {
+        Err(error) if matches!(error.as_ref(), ureq::Error::Status(_, _)) => {
+            let ureq::Error::Status(status, response) = *error else {
+                unreachable!("guard requires an HTTP status error");
+            };
+            assert_eq!(status, 409);
+            let error: ApiError =
+                serde_json::from_reader(response.into_reader()).expect("decode api error");
+            assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
+            assert_eq!(error.message, expected_message);
+            assert_eq!(
+                error.details.and_then(|details| details.commit_id),
+                Some(commit_id.clone())
+            );
+        }
+        other => unreachable!("expected content_not_prepared response, got {other:?}"),
+    }
+}
+
+fn assert_invalid_commit_limit_response(
+    result: Result<ureq::Response, Box<ureq::Error>>,
+    expected_message_fragment: &str,
+) {
+    match result {
+        Err(error) if matches!(error.as_ref(), ureq::Error::Status(_, _)) => {
+            let ureq::Error::Status(status, response) = *error else {
+                unreachable!("guard requires an HTTP status error");
+            };
+            assert_eq!(status, 400);
+            let error: ApiError =
+                serde_json::from_reader(response.into_reader()).expect("decode api error");
+            assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+            assert!(
+                error.message.contains(expected_message_fragment),
+                "expected `{expected_message_fragment}` in `{}`",
+                error.message
+            );
+        }
+        other => unreachable!("expected invalid_request response, got {other:?}"),
+    }
+}
+
 fn assert_content_not_prepared_response(
     result: Result<ureq::Response, Box<ureq::Error>>,
     request: &FilesystemOperationRequest,
@@ -2459,10 +2923,12 @@ fn stage_uploaded_content(
     complete
 }
 
-fn stage_uploaded_content_ref(
-    client: &Client,
-    namespace_id: &NamespaceId,
-    file_bytes: &[u8],
-) -> ContentRef {
-    stage_uploaded_content(client, namespace_id, file_bytes).content_ref
+fn validated_content_token(completed: &CompleteUploadResponse) -> ValidatedContentToken {
+    ValidatedContentToken {
+        content_ref: completed.content_ref.clone(),
+        token: completed
+            .validated_content_token
+            .clone()
+            .expect("completed upload carries token"),
+    }
 }

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -16,9 +16,10 @@ use loonfs_api::{
     encode_file_revisions_cursor, generated_id, CapabilityDocument, EffectiveLimit, FileRevision,
     FileRevisionsPageCursor, Page, PaginationPolicy, FEATURE_NAMESPACES_CREATE,
     FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_GC_MIN_GRACE_WINDOW_MS, LIMIT_QUERY_GREP_DEFAULT,
-    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
-    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0, PROTOCOL_VERSION,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS,
+    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
+    PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
     MetadataTableCache, WalTailProjectionCache, WalTailProjectionCacheConfig,
@@ -188,6 +189,10 @@ impl FsCore {
                 limits.insert(
                     LIMIT_GC_MIN_GRACE_WINDOW_MS.to_owned(),
                     loonfs_core::limits::GC_MIN_GRACE_WINDOW_MS,
+                );
+                limits.insert(
+                    LIMIT_COMMIT_MAX_OPERATIONS.to_owned(),
+                    loonfs_core::limits::MAX_COMMIT_OPERATIONS as u64,
                 );
                 limits
             },

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -74,6 +74,9 @@ pub use loonfs_core::{
 /// [`publish::NamespaceMutationCandidate`]s directly. Most embedded users
 /// never need this module.
 pub mod publish {
+    pub use loonfs_core::limits::{
+        MAX_COMMIT_CONTENT_TOKENS, MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_OPERATIONS,
+    };
     pub use loonfs_core::path::parse_mutation_path;
     pub use loonfs_core::publish::{
         ContentPreparation, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -523,38 +523,39 @@ async fn plain_path_put_fails_unprepared_without_content_io() {
 }
 
 #[tokio::test]
-async fn explicit_create_file_publication_downloads_unadmitted_content() {
-    let harness = TestHarness::new("create-fallback").await;
-    let bytes = b"explicit create content";
-    let content_ref = harness.stage_content(bytes).await;
+async fn explicit_create_file_fails_unprepared_without_content_io() {
+    let harness = TestHarness::new("create-unprepared").await;
+    let content_ref = harness.stage_content(b"explicit create content").await;
     harness.recording.reset();
 
-    // Explicit commit candidates retain durable validation until the later
-    // commit-endpoint admission PR.
-    harness
+    // Explicit commits use the same in-memory proof coverage as path puts;
+    // publication never rescues an unprepared ref with content I/O.
+    let error = harness
         .writer
-        .commit_operations(
-            &harness.namespace_id,
+        .publisher()
+        .submit_commit(
+            harness.namespace_id.clone(),
             CommitRequest {
                 commit_id: CommitId::parse("explicit-create").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![CommitOp::CreateFile {
                     parent_inode_id: InodeId(1),
                     display_name: "file.txt".to_owned(),
-                    content_ref,
+                    content_ref: content_ref.clone(),
                 }],
                 message: None,
             },
         )
         .await
-        .expect("publish explicit create");
+        .expect_err("unprepared explicit create must fail");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
 #[tokio::test]
-async fn explicit_replace_file_publication_downloads_unadmitted_content() {
-    let harness = TestHarness::new("replace-fallback").await;
+async fn explicit_replace_file_fails_unprepared_without_content_io() {
+    let harness = TestHarness::new("replace-unprepared").await;
     harness
         .writer
         .put_file_bytes(
@@ -572,31 +573,87 @@ async fn explicit_replace_file_publication_downloads_unadmitted_content() {
         .await
         .expect("stat seeded file")
         .inode_id;
-    let bytes = b"explicit replacement content";
-    let content_ref = harness.stage_content(bytes).await;
+    let content_ref = harness.stage_content(b"explicit replacement content").await;
     harness.recording.reset();
 
-    // Explicit commit candidates retain durable validation until the later
-    // commit-endpoint admission PR.
-    harness
+    // The existing inode does not change proof coverage: a replacement's
+    // external ref must already be prepared before publication.
+    let error = harness
         .writer
-        .commit_operations(
-            &harness.namespace_id,
+        .publisher()
+        .submit_commit(
+            harness.namespace_id.clone(),
             CommitRequest {
                 commit_id: CommitId::parse("explicit-replace").expect("valid commit id"),
                 preconditions: Vec::new(),
                 ops: vec![CommitOp::ReplaceFile {
                     inode_id,
                     base_revision_no: RevisionNo(1),
-                    content_ref,
+                    content_ref: content_ref.clone(),
                 }],
                 message: None,
             },
         )
         .await
-        .expect("publish explicit replacement");
+        .expect_err("unprepared explicit replacement must fail");
 
-    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn explicit_commit_with_prepared_distinct_and_repeated_refs_uses_no_publication_content_io() {
+    let harness = TestHarness::new("prepared-explicit-many").await;
+    let first = harness.stage_content(b"first prepared content").await;
+    let second = harness.stage_content(b"second prepared content").await;
+    let third = harness.stage_content(b"third prepared content").await;
+    let prepared = vec![
+        prepare_content(&harness.store, &harness.namespace_id, &first).await,
+        prepare_content(&harness.store, &harness.namespace_id, &second).await,
+        prepare_content(&harness.store, &harness.namespace_id, &third).await,
+    ];
+    harness.recording.reset();
+
+    harness
+        .writer
+        .publisher()
+        .submit_candidate(
+            harness.namespace_id.clone(),
+            NamespaceMutationCandidate::commit_prepared(
+                CommitRequest {
+                    commit_id: CommitId::parse("prepared-explicit-many").expect("valid commit id"),
+                    preconditions: Vec::new(),
+                    ops: vec![
+                        CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "first.txt".to_owned(),
+                            content_ref: first.clone(),
+                        },
+                        CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "first-copy.txt".to_owned(),
+                            content_ref: first,
+                        },
+                        CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "second.txt".to_owned(),
+                            content_ref: second,
+                        },
+                        CommitOp::CreateFile {
+                            parent_inode_id: InodeId(1),
+                            display_name: "third.txt".to_owned(),
+                            content_ref: third,
+                        },
+                    ],
+                    message: None,
+                },
+                prepared,
+            ),
+        )
+        .await
+        .expect("publish prepared explicit commit");
+
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
 #[tokio::test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -77,6 +77,7 @@ therefore identical for both backends.
     "query.grep": true
   },
   "limits": {
+    "commit.max_operations": 4096,
     "maintenance.gc.min_grace_window_ms": 1230000,
     "pagination.default_limit": 1000,
     "pagination.max_limit": 1000,
@@ -118,6 +119,7 @@ Registered limit keys:
 | `upload.max_concurrent` | How many service-proxied upload bodies the deployment buffers at once; requests past the cap answer `server_busy`. |
 | `download.max_concurrent` | How many service-proxied content reads the deployment materializes at once; requests past the cap answer `server_busy`. |
 | `commit.max_body_bytes` | Largest JSON body accepted by `POST .../commits`. Commit bodies are metadata only — file bytes ride uploads — so over-limit commits should be split into smaller batches, not routed through `direct_put`. |
+| `commit.max_operations` | Largest number of semantic operations accepted in one explicit commit. Larger transactions answer `invalid_request`; the whole request is rejected and must be split before retry. |
 | `maintenance.gc.min_grace_window_ms` | Smallest accepted `grace_window_ms` on a `gc` request; smaller values answer `invalid_request`. Derived from the publication budgets, not tuned. |
 | `query.grep.default_limit` | Matches per grep page when the request omits `limit`. |
 | `query.grep.max_limit` | Largest accepted grep page limit; invalid limits are rejected as `invalid_request`. Distinct from the pagination keys because a grep item costs a verified file read, not a row. |
@@ -213,7 +215,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 
 | Code | HTTP status | Meaning |
 | --- | --- | --- |
-| `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, or configuration value fails validation. The message names the offending field. |
+| `invalid_request` | 400 | The request is malformed: a path, id, cursor, parameter, staged content reference, configuration value, or commit request limit fails validation. The message names the offending field or limit. |
 | `unauthorized` | 401 | Missing or wrong credentials. |
 | `permission_denied` | 403 | The backing object store rejected the deployment's storage credentials for this operation. Fix the storage credentials or bucket policy; retrying unchanged will not succeed. |
 | `content_too_large` | 413 | The request body exceeds the deployment's limit: `upload.max_content_bytes` for proxied uploads, `commit.max_body_bytes` for commit bodies. Served file content past `download.max_content_bytes` reports it too. For uploads, send a smaller payload or use `direct_put`; for commits, split the batch; for reads, the deployment limit must be raised. |
@@ -226,7 +228,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `upload_not_found` | 404 | No upload session with this id. |
 | `namespace_exists` | 409 | The create target already exists. |
 | `namespace_partial` | 409 | The namespace is partially initialized and unusable. |
-| `content_not_prepared` | 409 | A path put references external content without a matching admission. Prepare the content and retry with its proof. |
+| `content_not_prepared` | 409 | A path put or explicit create/replace operation references external content without a matching admission, or carries a rejected relevant token. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
 | `stale_head` | 409 | The write raced a head advance; retry against fresh state. |
@@ -480,12 +482,12 @@ clients.
 ```
 
 Path-oriented `put_file` operations then reference the completed `content_ref`.
-Publishing validates the durable content reference before metadata becomes
-visible. If the client has a matching `validated_content_token`, it may include
-that token in `content_tokens` so the server can skip repeated durable-content
-validation on the hot publish path. Missing, malformed, expired, or non-matching
-tokens are ignored and the server falls back to normal durable-content
-validation.
+The client includes the matching `validated_content_token` in `content_tokens`;
+the server verifies it before admission and publication checks only the
+resulting in-memory proof. A missing proof answers `content_not_prepared`
+without reading the content object. A malformed or expired token that names
+the put's ref also answers `content_not_prepared`; tokens naming other refs are
+ignored.
 
 ```json
 {
@@ -804,14 +806,14 @@ The semantic rule is:
 - `complete` finalizes the upload session only when the expected `content_ref`
   exactly matches the service-computed staged ref; and
 - the returned `content_ref` is then safe to reference from a commit. Remote
-  servers may also return an opaque `validated_content_token` for hot-path
-  admission; the token is an optimization hint, not a correctness requirement.
+  servers may also return an opaque `validated_content_token` that remote
+  create/replace mutations carry back as their content-preparation proof.
 
 Repeating `PUT /content` with the same bytes for the same upload id is
 idempotent. Repeating it with different bytes is a conflict. Completing an
 upload fails if no content was staged or if the expected `content_ref` differs
-from the staged one. Commits that reference arbitrary `content_ref`s still
-pass the write protocol's durable-content validation.
+from the staged one. Publication never downloads an arbitrary external ref to
+rescue a missing proof.
 
 Representative begin-upload response:
 
@@ -894,12 +896,37 @@ Representative request:
         "size_bytes": 20591
       }
     }
+  ],
+  "content_tokens": [
+    {
+      "content_ref": {
+        "kind": "whole_file_v0",
+        "digest": "sha256:7ab...",
+        "size_bytes": 20591
+      },
+      "token": "opaque-server-token"
+    }
   ]
 }
 ```
 
-A request may be rejected immediately. A successful response is returned only
-after the request is committed (section 5.1).
+`content_tokens` is an optional sibling of `commit_id`, `preconditions`, `ops`,
+and `message`; omitting it preserves the pre-token request shape. It is
+transport-only and is excluded from the semantic commit fingerprint. Each
+distinct external `content_ref` introduced by `create_file` or `replace_file`
+must have a verified proof; one token covers every operation using the same
+ref. `restore_revision` resolves retained namespace metadata and needs no
+proof. Tokens naming refs outside the commit are ignored. If coverage is
+incomplete, the first rejected relevant token is reported when present;
+otherwise `content_not_prepared` names the first uncovered digest. A retry of
+an already-landed semantic commit replays its durable receipt even when tokens
+are then absent, expired, or malformed.
+
+One submission accepts at most 4096 operations, 4096 `content_tokens` entries,
+and 4096 distinct new external refs. A violation answers `invalid_request`
+before publisher admission; the server never splits the commit. These bounds
+protect serialized publisher occupancy, not commit correctness. A successful
+response is returned only after the request is committed (section 5.1).
 
 Representative response:
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1061,7 +1061,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CommitRequest"
+                "$ref": "#/components/schemas/CommitSubmissionRequest"
               }
             }
           },
@@ -3447,6 +3447,27 @@
             "description": "Namespace that changed."
           }
         }
+      },
+      "CommitSubmissionRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommitRequest",
+            "description": "Semantic commit whose fields remain at the top level on the wire."
+          },
+          {
+            "type": "object",
+            "properties": {
+              "content_tokens": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ValidatedContentToken"
+                },
+                "description": "Proofs for new external content refs introduced by the commit."
+              }
+            }
+          }
+        ],
+        "description": "Transport wrapper for submitting an explicit semantic commit.\n\nThe flattened commit fields preserve the original bare request shape,\nwhile `content_tokens` carries transport-only preparation proofs that do\nnot participate in the semantic commit fingerprint."
       },
       "CommittedChange": {
         "type": "object",


### PR DESCRIPTION
Explicit commits were the last path that could make the serialized publisher download a file: the commit endpoint had no way to carry content proofs, so every `CreateFile`/`ReplaceFile` ref fell back to durable validation (HEAD, full GET, SHA-256) inside publication. The endpoint now accepts an optional `content_tokens` field as a sibling of the existing commit fields — the same shape `/filesystem/operations` uses — via a transport wrapper that flattens the semantic `CommitRequest`, so bare pre-existing bodies parse unchanged (proven by a serde test and an end-to-end mkdir test) and token bytes stay out of commit fingerprints. The handler mirrors #340's partitioning per ref: all refs covered by verified proofs publish `Ready`; any failed relevant token rides in as `Rejected` so a landed commit's retry replays byte-for-byte with an absent, expired, or garbage token; missing coverage is reported by the core check with the first uncovered digest.

With that in place the fallback is deleted. The coverage check is now one synchronous, storeless function over admissions for both mutation kinds; `ContentValidationTracker` is gone, and the publisher's view no longer even carries a content-store id. The last two #336 fallback tests flip to their end state (typed failure, zero content operations), and a new seam test publishes a multi-file commit with a repeated ref under zero content I/O. Embedded `FsWriter::commit_operations` stays bare this PR — seam callers use the new `commit_prepared` constructor, and the polished embedded prepare-and-commit API is the next PR.

First request limits land as core constants (4096 operations, token entries, and distinct external refs per commit — values easy to tune in review), enforced before queue admission on every path since identity computation validates them, rejected as `invalid_request`, and advertised as `commit.max_operations`. WAL-byte estimation is deliberately left out.
