### PR TITLE
feat(loonfs): add embedded prepared content APIs

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -9,6 +9,7 @@ use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::{bootstrap, delete, fork, BootstrapNamespaceError};
 use crate::options::{BootstrapOptions, DeleteNamespaceOptions};
 use crate::path::read::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
+use crate::storage::content_admission::PreparedContent;
 use loonfs_api::generated_id;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,
@@ -447,6 +448,19 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> CoreResult<CompleteUploadResponse> {
+        let (response, _) = self.complete_upload_prepared(upload_id, request).await?;
+        Ok(response)
+    }
+
+    /// Completes an upload session and returns proof for later publication.
+    ///
+    /// Service-proxied completion performs no content-blob I/O. Direct-put
+    /// completion performs one content-blob HEAD and no content-blob GET.
+    pub async fn complete_upload_prepared(
+        &self,
+        upload_id: &UploadId,
+        request: &CompleteUploadRequest,
+    ) -> CoreResult<(CompleteUploadResponse, PreparedContent)> {
         crate::protocol::complete_upload(
             &self.store,
             &self.namespace_id,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -245,7 +245,7 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     request: &CompleteUploadRequest,
     context: &MutationContext,
-) -> Result<CompleteUploadResponse> {
+) -> Result<(CompleteUploadResponse, PreparedContent)> {
     update_upload_session(
         store,
         namespace_id,
@@ -259,23 +259,32 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
             async move {
                 if let Some(completed) = &state.completed {
                     if completed.content_ref == request.content_ref {
-                        return Ok(UploadSessionUpdate::Noop(CompleteUploadResponse {
-                            namespace_id,
-                            upload_id,
-                            content_ref: completed.content_ref.clone(),
-                            validated_content_token: None,
-                        }));
+                        let prepared_content = prepare_completed_upload_content(
+                            namespace_id.clone(),
+                            completed.content_ref.clone(),
+                        );
+                        return Ok(UploadSessionUpdate::Noop((
+                            CompleteUploadResponse {
+                                namespace_id,
+                                upload_id,
+                                content_ref: completed.content_ref.clone(),
+                                validated_content_token: None,
+                            },
+                            prepared_content,
+                        )));
                     }
                     return Err(CoreError::UploadAlreadyCompleted { upload_id });
                 }
 
-                let staged_content_ref = match state.staged_content_ref.clone() {
-                    Some(content_ref) => content_ref,
-                    None => stage_direct_put_content_ref(store, &namespace_id, &state, &request)
-                        .await?
-                        .content_ref()
-                        .clone(),
+                let prepared_content = match state.staged_content_ref.clone() {
+                    Some(content_ref) => {
+                        prepare_completed_upload_content(namespace_id.clone(), content_ref)
+                    }
+                    None => {
+                        stage_direct_put_content_ref(store, &namespace_id, &state, &request).await?
+                    }
                 };
+                let staged_content_ref = prepared_content.content_ref().clone();
                 if staged_content_ref != request.content_ref {
                     return Err(CoreError::InvalidUploadContent(
                         "completed content ref does not match staged content".to_owned(),
@@ -291,17 +300,28 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
 
                 Ok(UploadSessionUpdate::Replace {
                     next: Box::new(state),
-                    outcome: CompleteUploadResponse {
-                        namespace_id,
-                        upload_id,
-                        content_ref: request.content_ref.clone(),
-                        validated_content_token: None,
-                    },
+                    outcome: (
+                        CompleteUploadResponse {
+                            namespace_id,
+                            upload_id,
+                            content_ref: request.content_ref.clone(),
+                            validated_content_token: None,
+                        },
+                        prepared_content,
+                    ),
                 })
             }
         },
     )
     .await
+}
+
+fn prepare_completed_upload_content(
+    namespace_id: NamespaceId,
+    content_ref: ContentRef,
+) -> PreparedContent {
+    let admission = ContentAdmission::for_durable_content_write(namespace_id, content_ref.clone());
+    PreparedContent::from_admission(content_ref, admission)
 }
 
 async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
@@ -338,8 +358,8 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     probe_durable_content_reference(store, &content_store_id, &request.content_ref)
         .await
         .map_err(|err| CoreError::InvalidUploadContent(err.to_string()))?;
-    let content_ref = request.content_ref.clone();
-    let admission =
-        ContentAdmission::for_durable_content_write(namespace_id.clone(), content_ref.clone());
-    Ok(PreparedContent::from_admission(content_ref, admission))
+    Ok(prepare_completed_upload_content(
+        namespace_id.clone(),
+        request.content_ref.clone(),
+    ))
 }

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -1,6 +1,7 @@
 //! Staged uploads and direct-put targets.
 
 use super::core::FsCore;
+use crate::publish::PreparedContent;
 use crate::uploads::BeginDirectPutUploadTargetResponse;
 use crate::Result;
 use crate::{
@@ -54,9 +55,25 @@ impl FsCore {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse> {
+        let (response, _) = self
+            .complete_upload_prepared(namespace_id, upload_id, request)
+            .await?;
+        Ok(response)
+    }
+
+    /// Completes an upload session and returns proof for later publication.
+    ///
+    /// Service-proxied completion performs no content-blob I/O. Direct-put
+    /// completion performs one content-blob HEAD and no content-blob GET.
+    pub(crate) async fn complete_upload_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteUploadRequest,
+    ) -> Result<(CompleteUploadResponse, PreparedContent)> {
         Ok(self
             .namespace_engine(namespace_id)
-            .complete_upload(upload_id, request)
+            .complete_upload_prepared(upload_id, request)
             .await?)
     }
 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -1,7 +1,7 @@
 //! Path mutations, commits, and the publication pipeline.
 
 use super::core::{BackgroundTickClaim, FsCore};
-use crate::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use crate::publish::{NamespaceMutationCandidate, PathMutationIntent, PreparedContent};
 use crate::{
     ChangeSeq, CommitId, CommitOp, CommitPrecondition, CommitRequest, CommitResponse, ContentRef,
     CopyOptions, CoreError, CreateDirectoryOptions, DeleteOptions, InodeId, MaintenanceTickOptions,
@@ -37,15 +37,36 @@ impl FsCore {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
-        // Parse the mutation path before staging content so an invalid or
-        // root path cannot orphan an already-written content blob; the
-        // intent carries the parsed path from here on.
-        let absolute_path = loonfs_core::path::parse_mutation_path(absolute_path)?;
-        // The bytes become durable content before the publish is submitted,
-        // so the publication queue never waits on a content upload and an
-        // upload failure surfaces here with nothing published. A publish
-        // that fails afterward leaves only a GC-covered orphan behind an
-        // unmoved head.
+        let prepared_content = self.prepare_file_bytes(namespace_id, bytes).await?;
+        self.put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .await
+    }
+
+    /// Stages file bytes as durable content for later publication.
+    ///
+    /// Preparation performs one content PUT and no content reads. A publish
+    /// that fails afterward leaves only a GC-covered orphan behind an
+    /// unmoved head.
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.prepare",
+        err,
+        skip_all,
+        fields(
+            operation = "prepare",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn prepare_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        bytes: &[u8],
+    ) -> Result<PreparedContent> {
+        let span = tracing::Span::current();
+        self.record_trace_context(&span);
+        span.record("payload_class", crate::trace::payload_class(bytes.len()));
         let cached_content_store_id = self
             .load_namespace_catalog_cached(namespace_id)
             .await?
@@ -64,17 +85,50 @@ impl FsCore {
                     .await?
             }
         };
-        // The acknowledged write is the authority for the prepared proof, so
-        // batch validation does not re-probe the blob this handle just stored.
-        let prepared_content =
-            loonfs_core::content::prepare_stored_content(namespace_id.clone(), stored);
+        Ok(loonfs_core::content::prepare_stored_content(
+            namespace_id.clone(),
+            stored,
+        ))
+    }
+
+    /// Publishes a file revision from already-prepared content.
+    ///
+    /// Submission and publication perform no content I/O. `options.behavior`
+    /// selects create-only or replace semantics.
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.put",
+        err,
+        skip_all,
+        fields(
+            operation = "put",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn put_file_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        prepared_content: PreparedContent,
+        options: PutFileOptions,
+    ) -> Result<CommitResponse> {
+        let span = tracing::Span::current();
+        self.record_trace_context(&span);
+        span.record(
+            "payload_class",
+            crate::trace::payload_class(
+                usize::try_from(prepared_content.content_ref().size_bytes).unwrap_or(usize::MAX),
+            ),
+        );
         let content_ref = prepared_content.content_ref().clone();
         self.publish_candidate(
             namespace_id,
             NamespaceMutationCandidate::path_prepared(
                 PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                    absolute_path,
+                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     content_ref,
                     behavior: options.behavior,
                 },
@@ -87,8 +141,8 @@ impl FsCore {
     /// Publishes a file revision that points at an already-durable content ref.
     ///
     /// This explicitly slow helper reads the full object to prove durability
-    /// before publication. Callers that already hold proof should prefer the
-    /// admitted path.
+    /// before publication. Callers that already hold proof should prefer
+    /// [`Self::put_file_prepared`].
     #[tracing::instrument(
         level = "info",
         name = "loon.put",
@@ -116,7 +170,41 @@ impl FsCore {
                 usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
             ),
         );
-        let absolute_path = loonfs_core::path::parse_mutation_path(absolute_path)?;
+        let prepared_content = self.prepare_content_ref(namespace_id, content_ref).await?;
+        self.put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .await
+    }
+
+    /// Fully validates an existing content ref for later publication.
+    ///
+    /// Preparation performs one content HEAD followed by one full content
+    /// GET and digest check. Later prepared publication performs no content
+    /// I/O.
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.prepare",
+        err,
+        skip_all,
+        fields(
+            operation = "prepare",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn prepare_content_ref(
+        &self,
+        namespace_id: &NamespaceId,
+        content_ref: ContentRef,
+    ) -> Result<PreparedContent> {
+        let span = tracing::Span::current();
+        self.record_trace_context(&span);
+        span.record(
+            "payload_class",
+            crate::trace::payload_class(
+                usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
+            ),
+        );
         let content_store_id = match self.load_namespace_catalog_cached(namespace_id).await? {
             Some(catalog) => catalog.content_store_id().clone(),
             None => {
@@ -127,28 +215,14 @@ impl FsCore {
                     .clone()
             }
         };
-        let prepared_content = loonfs_core::content::prepare_existing_content_ref(
+        Ok(loonfs_core::content::prepare_existing_content_ref(
             &self.inner.store,
             namespace_id,
             &content_store_id,
             content_ref,
         )
         .await
-        .map_err(CoreError::from)?;
-        let content_ref = prepared_content.content_ref().clone();
-        self.publish_candidate(
-            namespace_id,
-            NamespaceMutationCandidate::path_prepared(
-                PathMutationIntent::PutFile {
-                    commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
-                    absolute_path,
-                    content_ref,
-                    behavior: options.behavior,
-                },
-                vec![prepared_content],
-            ),
-        )
-        .await
+        .map_err(CoreError::from)?)
     }
 
     /// Creates a directory at an absolute path.
@@ -308,7 +382,8 @@ impl FsCore {
     /// Submits one explicit semantic commit request.
     ///
     /// This is the lower-level surface for clients that need their own commit
-    /// ids, preconditions, and operation lists.
+    /// ids, preconditions, and operation lists. Operations with external
+    /// content refs require [`Self::commit_operations_prepared`].
     pub(crate) async fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
@@ -316,6 +391,23 @@ impl FsCore {
     ) -> Result<CommitResponse> {
         self.publish_candidate(namespace_id, NamespaceMutationCandidate::commit(request))
             .await
+    }
+
+    /// Submits one semantic commit request with prepared content proofs.
+    ///
+    /// Submission and publication perform no content I/O. One prepared value
+    /// covers every operation that uses its content ref.
+    pub(crate) async fn commit_operations_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+        prepared_content: Vec<PreparedContent>,
+    ) -> Result<CommitResponse> {
+        self.publish_candidate(
+            namespace_id,
+            NamespaceMutationCandidate::commit_prepared(request, prepared_content),
+        )
+        .await
     }
 
     /// Submits explicit semantic commit requests, returning one result per

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -5,7 +5,7 @@ use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
 use crate::fs::FsCore;
 use crate::metrics::ObjectStoreMetricsRecorder;
-use crate::publish::NamespaceMutationCandidate;
+use crate::publish::{NamespaceMutationCandidate, PreparedContent};
 use crate::uploads::BeginDirectPutUploadTargetResponse;
 use crate::{
     BeginUploadRequest, BeginUploadResponse, CapabilityDocument, ChangeSeq, CommitRequest,
@@ -142,11 +142,39 @@ impl FsWriter {
             .await
     }
 
+    /// Stages file bytes as durable content for later publication.
+    ///
+    /// This performs one content PUT and no content reads. Preparations may
+    /// run concurrently on this writer; pass the result to
+    /// [`Self::put_file_prepared`] or [`Self::commit_operations_prepared`].
+    pub async fn prepare_file_bytes(
+        &self,
+        namespace_id: &NamespaceId,
+        bytes: &[u8],
+    ) -> Result<PreparedContent> {
+        self.core.prepare_file_bytes(namespace_id, bytes).await
+    }
+
+    /// Publishes a file revision from already-prepared content.
+    ///
+    /// Submission and publication perform no content I/O.
+    pub async fn put_file_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        prepared_content: PreparedContent,
+        options: PutFileOptions,
+    ) -> Result<CommitResponse> {
+        self.core
+            .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .await
+    }
+
     /// Publishes a file revision that points at an already-durable content ref.
     ///
     /// This explicitly slow helper reads the full object to prove durability
-    /// before publication. Callers that already hold proof should prefer the
-    /// admitted path.
+    /// before publication. Callers that already hold proof should prefer
+    /// [`Self::put_file_prepared`].
     pub async fn put_file_content_ref(
         &self,
         namespace_id: &NamespaceId,
@@ -156,6 +184,20 @@ impl FsWriter {
     ) -> Result<CommitResponse> {
         self.core
             .put_file_content_ref(namespace_id, absolute_path, content_ref, options)
+            .await
+    }
+
+    /// Fully validates an existing content ref for later publication.
+    ///
+    /// This performs one content HEAD followed by one full content GET and
+    /// digest check. Later prepared publication performs no content I/O.
+    pub async fn prepare_content_ref(
+        &self,
+        namespace_id: &NamespaceId,
+        content_ref: ContentRef,
+    ) -> Result<PreparedContent> {
+        self.core
+            .prepare_content_ref(namespace_id, content_ref)
             .await
     }
 
@@ -319,16 +361,49 @@ impl FsWriter {
             .await
     }
 
+    /// Completes an upload session and returns proof for later publication.
+    ///
+    /// Service-proxied completion performs no content-blob I/O. Direct-put
+    /// completion performs one content-blob HEAD and no content-blob GET.
+    /// Publishing the returned proof performs no content I/O.
+    pub async fn complete_upload_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteUploadRequest,
+    ) -> Result<(CompleteUploadResponse, PreparedContent)> {
+        self.core
+            .complete_upload_prepared(namespace_id, upload_id, request)
+            .await
+    }
+
     /// Submits one explicit semantic commit request.
     ///
     /// This is the lower-level surface for clients that need their own commit
-    /// ids, preconditions, and operation lists.
+    /// ids, preconditions, and operation lists. Operations with external
+    /// content refs fail with `content_not_prepared`; use
+    /// [`Self::commit_operations_prepared`] to attach proofs.
     pub async fn commit_operations(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
         self.core.commit_operations(namespace_id, request).await
+    }
+
+    /// Submits one semantic commit request with prepared content proofs.
+    ///
+    /// Submission and publication perform no content I/O. One prepared value
+    /// covers every operation that uses its content ref.
+    pub async fn commit_operations_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        request: CommitRequest,
+        prepared_content: Vec<PreparedContent>,
+    ) -> Result<CommitResponse> {
+        self.core
+            .commit_operations_prepared(namespace_id, request, prepared_content)
+            .await
     }
 
     /// Submits explicit semantic commit requests as one publication attempt,

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -9,9 +9,9 @@ use loonfs::publish::{
     PathMutationIntent, PreparedContent,
 };
 use loonfs::{
-    CommitId, CommitOp, CommitRequest, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
-    DestinationBehavior, ErrorCode, FsWriter, InodeId, NamespaceId, PutFileOptions, RevisionNo,
-    SharedObjectStore,
+    BeginUploadRequest, CommitId, CommitOp, CommitRequest, CompleteUploadRequest, CoreError,
+    CreateDirectoryOptions, CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter,
+    InodeId, NamespaceId, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore,
 };
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -503,6 +503,197 @@ async fn put_file_content_ref_validates_content_before_publication() {
 }
 
 #[tokio::test]
+async fn prepare_file_bytes_performs_one_content_put_and_no_reads() {
+    let harness = TestHarness::new("prepare-file-bytes").await;
+    let bytes = b"parallel preparation primitive";
+    harness.recording.reset();
+
+    let prepared = harness
+        .writer
+        .prepare_file_bytes(&harness.namespace_id, bytes)
+        .await
+        .expect("prepare file bytes");
+
+    assert_eq!(
+        prepared.content_ref(),
+        &loonfs::ContentRef::whole_file_v0(bytes)
+    );
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 1, 0);
+}
+
+#[tokio::test]
+async fn put_file_prepared_performs_no_content_io() {
+    let harness = TestHarness::new("put-file-prepared").await;
+    let prepared = harness
+        .writer
+        .prepare_file_bytes(&harness.namespace_id, b"already prepared")
+        .await
+        .expect("prepare file bytes");
+    harness.recording.reset();
+
+    harness
+        .writer
+        .put_file_prepared(
+            &harness.namespace_id,
+            "/file.txt",
+            prepared,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("publish prepared file");
+
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn prepare_content_ref_reads_once_and_prepared_publication_reads_nothing() {
+    let harness = TestHarness::new("prepare-content-ref").await;
+    let bytes = b"externally staged content";
+    let content_ref = harness.stage_content(bytes).await;
+    harness.recording.reset();
+
+    let prepared = harness
+        .writer
+        .prepare_content_ref(&harness.namespace_id, content_ref)
+        .await
+        .expect("prepare content ref");
+
+    assert_content_counts(harness.recording.snapshot(), 1, 1, 0, bytes.len());
+    harness.recording.reset();
+
+    harness
+        .writer
+        .put_file_prepared(
+            &harness.namespace_id,
+            "/file.txt",
+            prepared,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("publish prepared content ref");
+
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn proxied_upload_completion_proof_publishes_without_additional_content_io() {
+    let harness = TestHarness::new("proxied-completion-proof").await;
+    let bytes = b"service proxied upload";
+    let begin = harness
+        .writer
+        .begin_upload(&harness.namespace_id, BeginUploadRequest::default())
+        .await
+        .expect("begin upload");
+    harness.recording.reset();
+
+    let staged = harness
+        .writer
+        .upload_content(&harness.namespace_id, &begin.upload_id, bytes)
+        .await
+        .expect("upload content");
+    let upload_counts = harness.recording.snapshot();
+    assert_eq!(
+        upload_counts.operations(KeyClass::Content),
+        OperationCounts {
+            head: 0,
+            get: 1,
+            put: 1,
+        }
+    );
+    assert!(upload_counts.content_get_bytes > 0);
+    harness.recording.reset();
+
+    let (completed, prepared) = harness
+        .writer
+        .complete_upload_prepared(
+            &harness.namespace_id,
+            &begin.upload_id,
+            &CompleteUploadRequest {
+                content_ref: staged.content_ref,
+            },
+        )
+        .await
+        .expect("complete upload with proof");
+    assert_eq!(prepared.content_ref(), &completed.content_ref);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+    harness.recording.reset();
+
+    harness
+        .writer
+        .put_file_prepared(
+            &harness.namespace_id,
+            "/uploaded.txt",
+            prepared,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("publish uploaded content");
+
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_content_io() {
+    let harness = TestHarness::new("direct-completion-proof").await;
+    let bytes = b"direct provider upload";
+    let content_ref = loonfs::ContentRef::whole_file_v0(bytes);
+    let begin = harness
+        .writer
+        .begin_direct_put_upload_target(&harness.namespace_id, content_ref.clone())
+        .await
+        .expect("begin direct put");
+    harness.recording.reset();
+
+    harness
+        .store
+        .put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes))
+        .await
+        .expect("drive direct provider upload");
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 1, 0);
+    harness.recording.reset();
+
+    let (completed, prepared) = harness
+        .writer
+        .complete_upload_prepared(
+            &harness.namespace_id,
+            &begin.upload_id,
+            &CompleteUploadRequest {
+                content_ref: content_ref.clone(),
+            },
+        )
+        .await
+        .expect("complete direct put with proof");
+    assert_eq!(completed.content_ref, content_ref);
+    // Direct-put completion resolves the immutable content-store descriptor
+    // and proves the provider write with one object HEAD; it never reads the
+    // uploaded blob.
+    let completion_counts = harness.recording.snapshot();
+    assert_eq!(
+        completion_counts.operations(KeyClass::Content),
+        OperationCounts {
+            head: 1,
+            get: 1,
+            put: 0,
+        }
+    );
+    assert!(completion_counts.content_get_bytes > 0);
+    harness.recording.reset();
+
+    harness
+        .writer
+        .put_file_prepared(
+            &harness.namespace_id,
+            "/direct.txt",
+            prepared,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("publish direct uploaded content");
+
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
 async fn plain_path_put_fails_unprepared_without_content_io() {
     let harness = TestHarness::new("plain-path-unprepared").await;
     let content_ref = harness.stage_content(b"unprepared path content").await;
@@ -523,7 +714,7 @@ async fn plain_path_put_fails_unprepared_without_content_io() {
 }
 
 #[tokio::test]
-async fn explicit_create_file_fails_unprepared_without_content_io() {
+async fn commit_operations_with_external_ref_fails_typed_without_content_io() {
     let harness = TestHarness::new("create-unprepared").await;
     let content_ref = harness.stage_content(b"explicit create content").await;
     harness.recording.reset();
@@ -532,9 +723,8 @@ async fn explicit_create_file_fails_unprepared_without_content_io() {
     // publication never rescues an unprepared ref with content I/O.
     let error = harness
         .writer
-        .publisher()
-        .submit_commit(
-            harness.namespace_id.clone(),
+        .commit_operations(
+            &harness.namespace_id,
             CommitRequest {
                 commit_id: CommitId::parse("explicit-create").expect("valid commit id"),
                 preconditions: Vec::new(),
@@ -549,6 +739,13 @@ async fn explicit_create_file_fails_unprepared_without_content_io() {
         .await
         .expect_err("unprepared explicit create must fail");
 
+    assert!(
+        matches!(error, RuntimeError::Core(_)),
+        "expected typed core error, got {error:?}"
+    );
+    let RuntimeError::Core(error) = error else {
+        return;
+    };
     assert_content_not_prepared(error, &content_ref);
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
@@ -601,54 +798,67 @@ async fn explicit_replace_file_fails_unprepared_without_content_io() {
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
 }
 
-#[tokio::test]
-async fn explicit_commit_with_prepared_distinct_and_repeated_refs_uses_no_publication_content_io() {
+/// The spawned preparations exercise concurrent use of one cloned writer before one commit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn prepared_commit_after_concurrent_preparations_uses_no_publication_content_io() {
     let harness = TestHarness::new("prepared-explicit-many").await;
-    let first = harness.stage_content(b"first prepared content").await;
-    let second = harness.stage_content(b"second prepared content").await;
-    let third = harness.stage_content(b"third prepared content").await;
-    let prepared = vec![
-        prepare_content(&harness.store, &harness.namespace_id, &first).await,
-        prepare_content(&harness.store, &harness.namespace_id, &second).await,
-        prepare_content(&harness.store, &harness.namespace_id, &third).await,
-    ];
+    let preparations = [
+        b"first prepared content" as &'static [u8],
+        b"second prepared content",
+        b"third prepared content",
+    ]
+    .into_iter()
+    .map(|bytes| {
+        let writer = harness.writer.clone();
+        let namespace_id = harness.namespace_id.clone();
+        tokio::spawn(async move { writer.prepare_file_bytes(&namespace_id, bytes).await })
+    });
+    let mut prepared = Vec::new();
+    for preparation in preparations {
+        prepared.push(
+            preparation
+                .await
+                .expect("preparation task")
+                .expect("prepare file bytes"),
+        );
+    }
+    let first = prepared[0].content_ref().clone();
+    let second = prepared[1].content_ref().clone();
+    let third = prepared[2].content_ref().clone();
     harness.recording.reset();
 
     harness
         .writer
-        .publisher()
-        .submit_candidate(
-            harness.namespace_id.clone(),
-            NamespaceMutationCandidate::commit_prepared(
-                CommitRequest {
-                    commit_id: CommitId::parse("prepared-explicit-many").expect("valid commit id"),
-                    preconditions: Vec::new(),
-                    ops: vec![
-                        CommitOp::CreateFile {
-                            parent_inode_id: InodeId(1),
-                            display_name: "first.txt".to_owned(),
-                            content_ref: first.clone(),
-                        },
-                        CommitOp::CreateFile {
-                            parent_inode_id: InodeId(1),
-                            display_name: "first-copy.txt".to_owned(),
-                            content_ref: first,
-                        },
-                        CommitOp::CreateFile {
-                            parent_inode_id: InodeId(1),
-                            display_name: "second.txt".to_owned(),
-                            content_ref: second,
-                        },
-                        CommitOp::CreateFile {
-                            parent_inode_id: InodeId(1),
-                            display_name: "third.txt".to_owned(),
-                            content_ref: third,
-                        },
-                    ],
-                    message: None,
-                },
-                prepared,
-            ),
+        .commit_operations_prepared(
+            &harness.namespace_id,
+            CommitRequest {
+                commit_id: CommitId::parse("prepared-explicit-many").expect("valid commit id"),
+                preconditions: Vec::new(),
+                ops: vec![
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "first.txt".to_owned(),
+                        content_ref: first.clone(),
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "first-copy.txt".to_owned(),
+                        content_ref: first,
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "second.txt".to_owned(),
+                        content_ref: second,
+                    },
+                    CommitOp::CreateFile {
+                        parent_inode_id: InodeId(1),
+                        display_name: "third.txt".to_owned(),
+                        content_ref: third,
+                    },
+                ],
+                message: None,
+            },
+            prepared,
         )
         .await
         .expect("publish prepared explicit commit");

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -7,8 +7,8 @@
 //! the handles document.
 
 use loonfs::{
-    CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader, FsWriter,
-    MaintenanceTickOptions, ManifestId, NamespaceId, PutFileOptions, RuntimeCacheConfig,
+    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader,
+    FsWriter, MaintenanceTickOptions, ManifestId, NamespaceId, PutFileOptions, RuntimeCacheConfig,
     RuntimeError, StoreConfig,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
@@ -140,6 +140,70 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
             .shutdown_background()
             .await
             .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    block_on(async {
+        let writer = writer(temp_dir.path(), FsBackgroundWork::ManualOnly).await;
+        let simple_namespace = NamespaceId::parse("simple-put").expect("valid simple namespace id");
+        let prepared_namespace =
+            NamespaceId::parse("prepared-put").expect("valid prepared namespace id");
+        for namespace_id in [&simple_namespace, &prepared_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+        let bytes = b"equivalent content";
+        let commit_id = CommitId::parse("equivalent-put").expect("valid commit id");
+        let options = PutFileOptions {
+            commit_id: Some(commit_id.clone()),
+            ..PutFileOptions::default()
+        };
+
+        let simple = writer
+            .put_file_bytes(&simple_namespace, "/file.txt", bytes, options.clone())
+            .await
+            .expect("put file bytes");
+        let prepared = writer
+            .prepare_file_bytes(&prepared_namespace, bytes)
+            .await
+            .expect("prepare file bytes");
+        let composed = writer
+            .put_file_prepared(&prepared_namespace, "/file.txt", prepared, options)
+            .await
+            .expect("put prepared file");
+
+        assert_eq!(simple.commit_id, commit_id);
+        assert_eq!(composed.commit_id, commit_id);
+        assert_eq!(simple.committed_seq, composed.committed_seq);
+
+        let reader = writer.reader();
+        let simple_stat = reader
+            .stat_path(&simple_namespace, "/file.txt")
+            .await
+            .expect("stat simple put");
+        let prepared_stat = reader
+            .stat_path(&prepared_namespace, "/file.txt")
+            .await
+            .expect("stat prepared put");
+        assert_eq!(simple_stat.revision_no, prepared_stat.revision_no);
+        assert_eq!(simple_stat.size_bytes, prepared_stat.size_bytes);
+        assert_eq!(simple_stat.content_ref, prepared_stat.content_ref);
+
+        let simple_read = reader
+            .read_file_bytes(&simple_namespace, "/file.txt")
+            .await
+            .expect("read simple put");
+        let prepared_read = reader
+            .read_file_bytes(&prepared_namespace, "/file.txt")
+            .await
+            .expect("read prepared put");
+        assert_eq!(simple_read.bytes, bytes);
+        assert_eq!(prepared_read.bytes, bytes);
     });
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -293,6 +293,15 @@ This split is deliberate:
 A commit request may therefore be rejected immediately, or tentatively
 accepted into a WAL batch, without yet being a committed or successful change.
 
+The embedded `loonfs::FsWriter` makes the first two stages independently
+drivable. `prepare_file_bytes` stages bytes, while `prepare_content_ref`
+fully validates an existing reference; both return opaque prepared content.
+`put_file_prepared` and `commit_operations_prepared` consume that evidence
+without content-store I/O during publication. `complete_upload_prepared`
+returns the ordinary completion response together with the same evidence.
+These are embedded conveniences, not HTTP operations; hosted clients continue
+to carry validated content tokens on the existing wire requests.
+
 ### 5.1 Commit request envelope
 
 A commit request carries the following logical fields:


### PR DESCRIPTION
Stacked on #341.

The publisher no longer touches content, but an embedded caller who wanted many parallel preparations followed by one commit had to reach into core producers and the publisher seam directly, and `commit_operations` with external refs had no ergonomic way to attach proofs. This adds the prepared family to `FsWriter`, named inside the existing families: `prepare_file_bytes` (one PUT, concurrency-safe), `prepare_content_ref` (the explicitly slow HEAD + full GET validation, extracted from `put_file_content_ref`), `put_file_prepared`, `commit_operations_prepared` (one proof covers a ref used by several ops), and `complete_upload_prepared`, which returns the ordinary completion response together with a `PreparedContent` so an embedded caller can complete an upload and immediately publish it with no HMAC token round trip. `put_file_bytes` and `put_file_content_ref` are now literally preparation plus prepared put, with a differential test proving the two spellings commit identical state.

Completion proofs derive only from trusted state: the staged ref recorded by a proxied upload, the direct-put HEAD probe, or — for idempotent re-completion — the durable completed-session record, never from caller-supplied fields. Accounting tests pin every cost at its floor: prepared publication is zero content I/O in all modes, including three concurrent preparations feeding one multi-file commit with a repeated ref.

No wire changes; the server mints tokens exactly as before.
