### PR TITLE
feat(grep): add byte-identical gram codec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loonfs-grep"
+version = "0.1.1"
+dependencies = [
+ "ciborium",
+ "loonfs-api",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "loonfs-model"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/loonfs-api",
+  "crates/loonfs-grep",
   "crates/loonfs-objectstore",
   "crates/loonfs-core",
   "crates/loonfs",

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "loonfs-grep"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "The standalone LoonFS full-text grep subsystem."
+repository.workspace = true
+readme = "README.md"
+
+[[bin]]
+name = "loonfs-grep"
+path = "src/main.rs"
+
+[dependencies]
+loonfs-api = { path = "../loonfs-api" }
+serde.workspace = true
+serde_bytes.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+ciborium.workspace = true
+
+[lints]
+workspace = true

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -1,0 +1,4 @@
+# loonfs-grep
+
+`loonfs-grep` contains LoonFS's optional full-text grep subsystem. This first package version
+provides the gram codec; the standalone worker arrives in a later change.

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -1,0 +1,478 @@
+//! Gram tokenizer and durable segment codecs for LoonFS grep.
+//!
+//! The gram index accelerates content grep: every eligible file revision
+//! contributes its three-byte substrings (grams, ASCII-case-folded), and
+//! each gram maps to the `(inode_id, revision_no)` pairs whose content
+//! contains it. Queries intersect posting lists to find candidates and
+//! verify every candidate against the real pattern, so the index can only
+//! make a grep slower, never wrong.
+//!
+//! Durable layout, copied byte-for-byte from the original API codec:
+//!
+//! - The **tokenizer** is every overlapping three-byte window of the
+//!   content after folding ASCII letters to lower case. Grams are bytes,
+//!   not characters.
+//! - A **posting batch** is a varint-packed run of postings sorted
+//!   strictly ascending by `(inode_id, revision_no)`: the posting count,
+//!   the first posting's inode id and revision number, then for each
+//!   subsequent posting its inode delta and absolute revision number. All
+//!   integers are LEB128 varints, the same encoding data blocks use.
+//! - An **index row** ([`IndexRow::GramPostings`]) carries one gram, the
+//!   batch's first inode id (repeated from the batch so row keys derive
+//!   without decoding it), and the packed batch. Its row key is
+//!   `gram-{gram hex}-{first inode id:020}`; its filter key is the
+//!   `gram-{gram hex}` prefix, so a segment's bloom filter answers "no
+//!   postings for this gram here". Rows use the shared `loonfs-api`
+//!   segment-block grammar.
+
+use loonfs_api::{InodeId, RevisionNo};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+/// Bytes per gram. Fixed by the copied durable format.
+pub const GRAM_LEN: usize = 3;
+
+/// One tokenizer gram: three content bytes, ASCII-case-folded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Gram(pub [u8; GRAM_LEN]);
+
+impl Gram {
+    /// The gram as the six lowercase hex characters row keys embed.
+    pub fn as_hex(&self) -> String {
+        loonfs_api::wire::manifest::hex_encode_bytes(&self.0)
+    }
+
+    /// Parses the row-key hex form back into a gram.
+    pub fn from_hex(hex: &str) -> Result<Self, IndexGramsCodecError> {
+        let bytes = loonfs_api::wire::manifest::hex_decode_bytes(hex)
+            .map_err(|reason| IndexGramsCodecError::InvalidGram { reason })?;
+        let bytes: [u8; GRAM_LEN] =
+            bytes
+                .try_into()
+                .map_err(|bytes: Vec<u8>| IndexGramsCodecError::InvalidGram {
+                    reason: format!("expected {GRAM_LEN} bytes, got {}", bytes.len()),
+                })?;
+        Ok(Self(bytes))
+    }
+}
+
+impl Serialize for Gram {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Gram {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let hex = String::deserialize(deserializer)?;
+        Self::from_hex(&hex).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Extracts the distinct grams of one content buffer, in gram order.
+/// Content shorter than one gram contributes nothing.
+pub fn extract_grams(content: &[u8]) -> BTreeSet<Gram> {
+    content
+        .windows(GRAM_LEN)
+        .map(|window| {
+            let mut gram = [0u8; GRAM_LEN];
+            for (folded, byte) in gram.iter_mut().zip(window) {
+                *folded = byte.to_ascii_lowercase();
+            }
+            Gram(gram)
+        })
+        .collect()
+}
+
+/// One posting: a file revision whose content contains the gram.
+///
+/// Postings name durable `(inode_id, revision_no)` identity, never paths:
+/// inode identity survives renames and forks, and paths are derived at
+/// query time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GramPosting {
+    pub inode_id: InodeId,
+    pub revision_no: RevisionNo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IndexGramsCodecError {
+    #[error("a posting batch must contain at least one posting")]
+    EmptyPostings,
+    #[error(
+        "posting inode {inode}/revision {revision} is not in strictly ascending \
+         order after inode {previous_inode}/revision {previous_revision}"
+    )]
+    PostingsOutOfOrder {
+        previous_inode: u64,
+        previous_revision: u64,
+        inode: u64,
+        revision: u64,
+    },
+    #[error("malformed posting batch: {0}")]
+    Malformed(String),
+    #[error("invalid gram hex: {reason}")]
+    InvalidGram { reason: String },
+    #[error("gram postings row first inode {declared} does not match its batch's {actual}")]
+    FirstInodeMismatch { declared: u64, actual: u64 },
+}
+
+/// Packs postings into the frozen batch layout. The slice must be
+/// non-empty and strictly ascending by `(inode_id, revision_no)`.
+pub fn encode_gram_postings(postings: &[GramPosting]) -> Result<Vec<u8>, IndexGramsCodecError> {
+    let first = postings
+        .first()
+        .ok_or(IndexGramsCodecError::EmptyPostings)?;
+    let mut bytes = Vec::with_capacity(postings.len() * 3);
+    write_varint(&mut bytes, postings.len() as u64);
+    write_varint(&mut bytes, first.inode_id.0);
+    write_varint(&mut bytes, first.revision_no.0);
+    let mut previous = *first;
+    for posting in &postings[1..] {
+        if *posting <= previous {
+            return Err(IndexGramsCodecError::PostingsOutOfOrder {
+                previous_inode: previous.inode_id.0,
+                previous_revision: previous.revision_no.0,
+                inode: posting.inode_id.0,
+                revision: posting.revision_no.0,
+            });
+        }
+        write_varint(&mut bytes, posting.inode_id.0 - previous.inode_id.0);
+        write_varint(&mut bytes, posting.revision_no.0);
+        previous = *posting;
+    }
+    Ok(bytes)
+}
+
+/// Unpacks a posting batch, validating the count, strict ascending order,
+/// and that the batch ends exactly where its bytes do.
+pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGramsCodecError> {
+    let mut cursor = 0usize;
+    let count = batch_varint(bytes, &mut cursor)?;
+    if count == 0 {
+        return Err(IndexGramsCodecError::EmptyPostings);
+    }
+    let count = usize::try_from(count)
+        .map_err(|_| IndexGramsCodecError::Malformed("posting count exceeds usize".to_owned()))?;
+    if count > bytes.len() {
+        // Every posting costs at least two bytes past the count varint; a
+        // count beyond the byte length is corrupt, not just implausible.
+        return Err(IndexGramsCodecError::Malformed(format!(
+            "posting count {count} exceeds batch bytes {}",
+            bytes.len()
+        )));
+    }
+    let mut postings = Vec::with_capacity(count);
+    let mut previous = GramPosting {
+        inode_id: InodeId(batch_varint(bytes, &mut cursor)?),
+        revision_no: RevisionNo(batch_varint(bytes, &mut cursor)?),
+    };
+    postings.push(previous);
+    for _ in 1..count {
+        let inode_delta = batch_varint(bytes, &mut cursor)?;
+        let inode_id = previous
+            .inode_id
+            .0
+            .checked_add(inode_delta)
+            .ok_or_else(|| {
+                IndexGramsCodecError::Malformed("posting inode delta overflows".to_owned())
+            })?;
+        let posting = GramPosting {
+            inode_id: InodeId(inode_id),
+            revision_no: RevisionNo(batch_varint(bytes, &mut cursor)?),
+        };
+        if posting <= previous {
+            return Err(IndexGramsCodecError::PostingsOutOfOrder {
+                previous_inode: previous.inode_id.0,
+                previous_revision: previous.revision_no.0,
+                inode: posting.inode_id.0,
+                revision: posting.revision_no.0,
+            });
+        }
+        postings.push(posting);
+        previous = posting;
+    }
+    if cursor != bytes.len() {
+        return Err(IndexGramsCodecError::Malformed(format!(
+            "{} trailing bytes after the last posting",
+            bytes.len() - cursor
+        )));
+    }
+    Ok(postings)
+}
+
+fn batch_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64, IndexGramsCodecError> {
+    read_varint(bytes, cursor)
+}
+
+fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            bytes.push(byte);
+            return;
+        }
+        bytes.push(byte | 0x80);
+    }
+}
+
+fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64, IndexGramsCodecError> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *bytes.get(*cursor).ok_or_else(|| {
+            IndexGramsCodecError::Malformed("varint runs past the block".to_owned())
+        })?;
+        *cursor += 1;
+        if shift >= 64 {
+            return Err(IndexGramsCodecError::Malformed(
+                "varint exceeds 64 bits".to_owned(),
+            ));
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+    }
+}
+
+/// One row of a gram index segment. Kind-tagged so the family can grow
+/// additional row kinds under future format versions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IndexRow {
+    GramPostings {
+        gram: Gram,
+        /// The batch's first inode id, repeated from the packed postings so
+        /// row keys derive without decoding the batch. [`Self::postings`]
+        /// validates the pairing.
+        first_inode_id: InodeId,
+        postings: serde_bytes::ByteBuf,
+    },
+}
+
+impl IndexRow {
+    /// Packs postings into a row for `gram`. The postings must be
+    /// non-empty and strictly ascending, as for [`encode_gram_postings`].
+    pub fn gram_postings(
+        gram: Gram,
+        postings: &[GramPosting],
+    ) -> Result<Self, IndexGramsCodecError> {
+        let first = postings
+            .first()
+            .ok_or(IndexGramsCodecError::EmptyPostings)?;
+        let first_inode_id = first.inode_id;
+        let bytes = encode_gram_postings(postings)?;
+        Ok(Self::GramPostings {
+            gram,
+            first_inode_id,
+            postings: serde_bytes::ByteBuf::from(bytes),
+        })
+    }
+
+    pub fn row_key(&self) -> String {
+        match self {
+            Self::GramPostings {
+                gram,
+                first_inode_id,
+                ..
+            } => format!("gram-{}-{:020}", gram.as_hex(), first_inode_id.0),
+        }
+    }
+
+    /// The lookup prefix a query probes for this row, and therefore the key
+    /// inserted into the segment's bloom filter.
+    pub fn filter_key(&self) -> String {
+        match self {
+            Self::GramPostings { gram, .. } => lookup::gram_probe(*gram),
+        }
+    }
+
+    /// Unpacks and validates this row's posting batch, including that the
+    /// declared first inode matches the batch.
+    pub fn postings(&self) -> Result<Vec<GramPosting>, IndexGramsCodecError> {
+        match self {
+            Self::GramPostings {
+                first_inode_id,
+                postings,
+                ..
+            } => {
+                let decoded = decode_gram_postings(postings)?;
+                let actual = decoded
+                    .first()
+                    .expect("decode_gram_postings rejects empty batches")
+                    .inode_id;
+                if actual != *first_inode_id {
+                    return Err(IndexGramsCodecError::FirstInodeMismatch {
+                        declared: first_inode_id.0,
+                        actual: actual.0,
+                    });
+                }
+                Ok(decoded)
+            }
+        }
+    }
+}
+
+/// Reader-side lookup grammar for gram index rows, defined beside the row
+/// keys they select: a probe must equal the filter key the writer stored,
+/// and a prefix must be a prefix of the row keys it selects.
+pub mod lookup {
+    use super::Gram;
+
+    pub fn gram_probe(gram: Gram) -> String {
+        format!("gram-{}", gram.as_hex())
+    }
+
+    pub fn gram_prefix(gram: Gram) -> String {
+        format!("{}-", gram_probe(gram))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn posting(inode: u64, revision: u64) -> GramPosting {
+        GramPosting {
+            inode_id: InodeId(inode),
+            revision_no: RevisionNo(revision),
+        }
+    }
+
+    #[test]
+    fn extraction_case_folds_ascii_and_dedups() {
+        let grams = extract_grams(b"AbaBA");
+        let expected: BTreeSet<Gram> = [Gram(*b"aba"), Gram(*b"bab")].into_iter().collect();
+        assert_eq!(grams, expected);
+    }
+
+    #[test]
+    fn extraction_keeps_non_ascii_bytes_verbatim() {
+        // UTF-8 continuation bytes are above the ASCII range; folding must
+        // not touch them, so the grams of multi-byte text stay exact.
+        let content = "Grüße".as_bytes();
+        let grams = extract_grams(content);
+        assert!(grams.contains(&Gram([b'g', b'r', 0xc3])));
+        assert!(grams.contains(&Gram([0xc3, 0xbc, 0xc3])));
+    }
+
+    #[test]
+    fn extraction_of_short_content_is_empty() {
+        assert!(extract_grams(b"").is_empty());
+        assert!(extract_grams(b"ab").is_empty());
+        assert_eq!(extract_grams(b"abc").len(), 1);
+    }
+
+    #[test]
+    fn posting_batches_round_trip() {
+        let postings = vec![
+            posting(1, 1),
+            posting(1, 4),
+            posting(7, 2),
+            posting(900, 1),
+            posting(900, 2),
+        ];
+        let bytes = encode_gram_postings(&postings).expect("encode");
+        assert_eq!(decode_gram_postings(&bytes).expect("decode"), postings);
+    }
+
+    #[test]
+    fn posting_batches_reject_disorder_duplicates_and_empties() {
+        assert!(matches!(
+            encode_gram_postings(&[]),
+            Err(IndexGramsCodecError::EmptyPostings)
+        ));
+        assert!(matches!(
+            encode_gram_postings(&[posting(2, 1), posting(1, 1)]),
+            Err(IndexGramsCodecError::PostingsOutOfOrder { .. })
+        ));
+        assert!(matches!(
+            encode_gram_postings(&[posting(1, 1), posting(1, 1)]),
+            Err(IndexGramsCodecError::PostingsOutOfOrder { .. })
+        ));
+    }
+
+    #[test]
+    fn posting_batch_decode_rejects_trailing_and_truncated_bytes() {
+        let bytes = encode_gram_postings(&[posting(1, 1), posting(2, 1)]).expect("encode");
+
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert!(matches!(
+            decode_gram_postings(&trailing),
+            Err(IndexGramsCodecError::Malformed(_))
+        ));
+
+        let truncated = &bytes[..bytes.len() - 1];
+        assert!(matches!(
+            decode_gram_postings(truncated),
+            Err(IndexGramsCodecError::Malformed(_))
+        ));
+
+        assert!(matches!(
+            decode_gram_postings(&[]),
+            Err(IndexGramsCodecError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn posting_batch_decode_rejects_reordered_bytes() {
+        // A hand-built batch whose second posting repeats the first: valid
+        // varints, invalid order.
+        let mut bytes = Vec::new();
+        write_varint(&mut bytes, 2);
+        write_varint(&mut bytes, 5);
+        write_varint(&mut bytes, 3);
+        write_varint(&mut bytes, 0);
+        write_varint(&mut bytes, 3);
+        assert!(matches!(
+            decode_gram_postings(&bytes),
+            Err(IndexGramsCodecError::PostingsOutOfOrder { .. })
+        ));
+    }
+
+    #[test]
+    fn row_keys_and_filter_keys_pin_their_shapes() {
+        let row =
+            IndexRow::gram_postings(Gram(*b"fox"), &[posting(42, 7), posting(43, 1)]).expect("row");
+        assert_eq!(row.row_key(), "gram-666f78-00000000000000000042");
+        assert_eq!(row.filter_key(), "gram-666f78");
+        assert_eq!(lookup::gram_prefix(Gram(*b"fox")), "gram-666f78-");
+        assert_eq!(
+            row.postings().expect("postings"),
+            vec![posting(42, 7), posting(43, 1)]
+        );
+    }
+
+    #[test]
+    fn rows_reject_first_inode_mismatch() {
+        let row = IndexRow::GramPostings {
+            gram: Gram(*b"fox"),
+            first_inode_id: InodeId(9),
+            postings: serde_bytes::ByteBuf::from(
+                encode_gram_postings(&[posting(42, 7)]).expect("encode"),
+            ),
+        };
+        assert!(matches!(
+            row.postings(),
+            Err(IndexGramsCodecError::FirstInodeMismatch {
+                declared: 9,
+                actual: 42
+            })
+        ));
+    }
+
+    #[test]
+    fn gram_hex_round_trips_and_rejects_bad_input() {
+        let gram = Gram([0x00, 0xab, 0xff]);
+        assert_eq!(gram.as_hex(), "00abff");
+        assert_eq!(Gram::from_hex("00abff").expect("parse"), gram);
+        assert!(Gram::from_hex("00ab").is_err());
+        assert!(Gram::from_hex("00abff00").is_err());
+        assert!(Gram::from_hex("00abzz").is_err());
+    }
+}

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -1,0 +1,19 @@
+//! LoonFS full-text grep subsystem.
+//!
+//! This first extraction step owns a byte-compatible copy of the gram
+//! codec. Query execution, storage maintenance, and the standalone worker
+//! arrive in later changes.
+
+pub mod codec;
+
+use std::io::Write as _;
+use std::process::ExitCode;
+
+/// Entry point for the standalone `loonfs-grep` binary.
+pub fn main() -> ExitCode {
+    let _ = writeln!(
+        std::io::stderr().lock(),
+        "usage: loonfs-grep (the standalone worker arrives in a later change)"
+    );
+    ExitCode::FAILURE
+}

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -1,0 +1,7 @@
+//! The `loonfs-grep` standalone worker binary.
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    loonfs_grep::main()
+}

--- a/crates/loonfs-grep/tests/codec_identity.rs
+++ b/crates/loonfs-grep/tests/codec_identity.rs
@@ -1,0 +1,281 @@
+//! Byte-identity tests between the extracted grep codec and its API source.
+
+use loonfs_api::wire::index_grams as api_codec;
+use loonfs_api::wire::sst_blocks::{
+    decode_data_block_rows, decode_index_block, BlockHandle, BuiltSegmentBlocks,
+    SegmentBlocksBuilder,
+};
+use loonfs_api::{InodeId, RevisionNo};
+use loonfs_grep::codec as grep_codec;
+
+const GOLDEN_POSTING_BATCH: &[u8] = &[0x04, 0x02, 0x01, 0x00, 0x03, 0x03, 0x01, 0xff, 0x06, 0x07];
+const GOLDEN_POSTING_ROW: &[u8] = &[
+    0xa4, 0x64, 0x6b, 0x69, 0x6e, 0x64, 0x6d, 0x67, 0x72, 0x61, 0x6d, 0x5f, 0x70, 0x6f, 0x73, 0x74,
+    0x69, 0x6e, 0x67, 0x73, 0x64, 0x67, 0x72, 0x61, 0x6d, 0x66, 0x36, 0x36, 0x36, 0x66, 0x37, 0x38,
+    0x6e, 0x66, 0x69, 0x72, 0x73, 0x74, 0x5f, 0x69, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x69, 0x64, 0x02,
+    0x68, 0x70, 0x6f, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x73, 0x4a, 0x04, 0x02, 0x01, 0x00, 0x03, 0x03,
+    0x01, 0xff, 0x06, 0x07,
+];
+
+fn posting_values(size: usize) -> Vec<(u64, u64)> {
+    (0..size)
+        .map(|index| ((index / 4) as u64 + 1, (index % 4) as u64 + 1))
+        .collect()
+}
+
+fn grep_postings(values: &[(u64, u64)]) -> Vec<grep_codec::GramPosting> {
+    values
+        .iter()
+        .map(|&(inode, revision)| grep_codec::GramPosting {
+            inode_id: InodeId(inode),
+            revision_no: RevisionNo(revision),
+        })
+        .collect()
+}
+
+fn api_postings(values: &[(u64, u64)]) -> Vec<api_codec::GramPosting> {
+    values
+        .iter()
+        .map(|&(inode, revision)| api_codec::GramPosting {
+            inode_id: InodeId(inode),
+            revision_no: RevisionNo(revision),
+        })
+        .collect()
+}
+
+fn grep_values(postings: &[grep_codec::GramPosting]) -> Vec<(u64, u64)> {
+    postings
+        .iter()
+        .map(|posting| (posting.inode_id.0, posting.revision_no.0))
+        .collect()
+}
+
+fn api_values(postings: &[api_codec::GramPosting]) -> Vec<(u64, u64)> {
+    postings
+        .iter()
+        .map(|posting| (posting.inode_id.0, posting.revision_no.0))
+        .collect()
+}
+
+#[test]
+fn tokenizer_is_identical_for_the_format_corpus() {
+    let corpus: &[&[u8]] = &[
+        b"The quick brown fox",
+        b"AbCdEf",
+        b"aBcDeF",
+        "Grüße".as_bytes(),
+        &[0xff, b'A', 0x80, b'Z'],
+        b"",
+        b"a",
+        b"ab",
+        b"abc",
+        b"aaaaaa",
+        b"abcabcabc",
+    ];
+
+    for content in corpus {
+        let grep: Vec<[u8; 3]> = grep_codec::extract_grams(content)
+            .into_iter()
+            .map(|gram| gram.0)
+            .collect();
+        let api: Vec<[u8; 3]> = api_codec::extract_grams(content)
+            .into_iter()
+            .map(|gram| gram.0)
+            .collect();
+        assert_eq!(grep, api, "tokenizer diverged for {content:?}");
+    }
+
+    assert_eq!(
+        grep_codec::extract_grams(b"AbCdEf"),
+        grep_codec::extract_grams(b"aBcDeF")
+    );
+}
+
+#[test]
+fn posting_batches_are_byte_identical_and_cross_decode() {
+    assert!(matches!(
+        grep_codec::encode_gram_postings(&[]),
+        Err(grep_codec::IndexGramsCodecError::EmptyPostings)
+    ));
+    assert!(matches!(
+        api_codec::encode_gram_postings(&[]),
+        Err(api_codec::IndexGramsCodecError::EmptyPostings)
+    ));
+
+    let cases = [
+        vec![(42, 7)],
+        vec![(2, 1), (2, 3), (5, 1), (900, 7)],
+        posting_values(255),
+        posting_values(256),
+        posting_values(257),
+    ];
+    for values in cases {
+        let grep_bytes =
+            grep_codec::encode_gram_postings(&grep_postings(&values)).expect("grep encode");
+        let api_bytes =
+            api_codec::encode_gram_postings(&api_postings(&values)).expect("api encode");
+        assert_eq!(
+            grep_bytes,
+            api_bytes,
+            "encoding diverged for {} postings",
+            values.len()
+        );
+        assert_eq!(
+            grep_values(&grep_codec::decode_gram_postings(&api_bytes).expect("grep decode API")),
+            values
+        );
+        assert_eq!(
+            api_values(&api_codec::decode_gram_postings(&grep_bytes).expect("API decode grep")),
+            values
+        );
+    }
+
+    let fixture_values = [(2, 1), (2, 3), (5, 1), (900, 7)];
+    let encoded = grep_codec::encode_gram_postings(&grep_postings(&fixture_values))
+        .expect("encode golden posting batch");
+    assert_eq!(encoded, GOLDEN_POSTING_BATCH);
+}
+
+#[test]
+fn row_cbor_is_golden_and_cross_decodes() {
+    let values = [(2, 1), (2, 3), (5, 1), (900, 7)];
+    let grep_row =
+        grep_codec::IndexRow::gram_postings(grep_codec::Gram(*b"fox"), &grep_postings(&values))
+            .expect("grep row");
+    let api_row =
+        api_codec::IndexRow::gram_postings(api_codec::Gram(*b"fox"), &api_postings(&values))
+            .expect("api row");
+
+    let mut grep_bytes = Vec::new();
+    ciborium::ser::into_writer(&grep_row, &mut grep_bytes).expect("encode grep row");
+    let mut api_bytes = Vec::new();
+    ciborium::ser::into_writer(&api_row, &mut api_bytes).expect("encode API row");
+    assert_eq!(grep_bytes, api_bytes);
+    assert_eq!(grep_bytes, GOLDEN_POSTING_ROW);
+
+    let decoded_grep: grep_codec::IndexRow =
+        ciborium::de::from_reader(api_bytes.as_slice()).expect("grep decodes API row");
+    let decoded_api: api_codec::IndexRow =
+        ciborium::de::from_reader(grep_bytes.as_slice()).expect("API decodes grep row");
+    assert_eq!(decoded_grep.row_key(), api_row.row_key());
+    assert_eq!(decoded_grep.filter_key(), api_row.filter_key());
+    assert_eq!(
+        grep_values(&decoded_grep.postings().expect("grep postings")),
+        values
+    );
+    assert_eq!(
+        api_values(&decoded_api.postings().expect("API postings")),
+        values
+    );
+}
+
+#[test]
+fn row_keys_and_lookup_grammar_are_identical() {
+    let cases = [(*b"fox", 42), ([0x00, 0xab, 0xff], 0), (*b"ABC", u64::MAX)];
+    for (gram, inode) in cases {
+        let values = [(inode, 7)];
+        let grep_gram = grep_codec::Gram(gram);
+        let api_gram = api_codec::Gram(gram);
+        let grep_row = grep_codec::IndexRow::gram_postings(grep_gram, &grep_postings(&values))
+            .expect("grep row");
+        let api_row =
+            api_codec::IndexRow::gram_postings(api_gram, &api_postings(&values)).expect("api row");
+
+        assert_eq!(grep_row.row_key(), api_row.row_key());
+        assert_eq!(grep_row.filter_key(), api_row.filter_key());
+        assert_eq!(
+            grep_codec::lookup::gram_probe(grep_gram),
+            api_codec::lookup::gram_probe(api_gram)
+        );
+        assert_eq!(
+            grep_codec::lookup::gram_prefix(grep_gram),
+            api_codec::lookup::gram_prefix(api_gram)
+        );
+    }
+}
+
+fn grep_rows() -> Vec<grep_codec::IndexRow> {
+    [b"box", b"fox", b"the"]
+        .into_iter()
+        .map(|gram| {
+            let values = if gram == b"fox" {
+                vec![(2, 1), (2, 3), (5, 1), (900, 7)]
+            } else {
+                vec![(2, 1)]
+            };
+            grep_codec::IndexRow::gram_postings(grep_codec::Gram(*gram), &grep_postings(&values))
+                .expect("grep row")
+        })
+        .collect()
+}
+
+fn api_rows() -> Vec<api_codec::IndexRow> {
+    [b"box", b"fox", b"the"]
+        .into_iter()
+        .map(|gram| {
+            let values = if gram == b"fox" {
+                vec![(2, 1), (2, 3), (5, 1), (900, 7)]
+            } else {
+                vec![(2, 1)]
+            };
+            api_codec::IndexRow::gram_postings(api_codec::Gram(*gram), &api_postings(&values))
+                .expect("api row")
+        })
+        .collect()
+}
+
+fn build_grep_segment() -> BuiltSegmentBlocks {
+    let mut builder = SegmentBlocksBuilder::new(256);
+    for row in grep_rows() {
+        builder
+            .push(&row.row_key(), &row.filter_key(), &row)
+            .expect("push grep row");
+    }
+    builder.finish().expect("finish grep segment")
+}
+
+fn build_api_segment() -> BuiltSegmentBlocks {
+    let mut builder = SegmentBlocksBuilder::new(256);
+    for row in api_rows() {
+        builder
+            .push(&row.row_key(), &row.filter_key(), &row)
+            .expect("push API row");
+    }
+    builder.finish().expect("finish API segment")
+}
+
+fn section<'a>(bytes: &'a [u8], handle: &BlockHandle) -> &'a [u8] {
+    &bytes[handle.offset as usize..handle.offset as usize + handle.stored_len as usize]
+}
+
+#[test]
+fn shared_segment_block_encoding_is_identical_and_cross_decodes() {
+    let grep = build_grep_segment();
+    let api = build_api_segment();
+    assert_eq!(grep, api);
+
+    let grep_index = decode_index_block(section(&grep.bytes, &grep.index), &grep.index)
+        .expect("decode grep index");
+    let api_index =
+        decode_index_block(section(&api.bytes, &api.index), &api.index).expect("decode API index");
+    assert_eq!(grep_index, api_index);
+
+    let mut grep_from_api = Vec::new();
+    let mut api_from_grep = Vec::new();
+    for (grep_entry, api_entry) in grep_index.iter().zip(&api_index) {
+        let grep_block = decode_data_block_rows::<grep_codec::IndexRow>(
+            section(&api.bytes, &api_entry.block),
+            &api_entry.block,
+        )
+        .expect("grep decodes API block");
+        let api_block = decode_data_block_rows::<api_codec::IndexRow>(
+            section(&grep.bytes, &grep_entry.block),
+            &grep_entry.block,
+        )
+        .expect("API decodes grep block");
+        grep_from_api.extend(grep_block.rows.into_iter().map(|row| row.row_key()));
+        api_from_grep.extend(api_block.rows.into_iter().map(|row| row.row_key()));
+    }
+    assert_eq!(grep_from_api, api_from_grep);
+    assert_eq!(grep_from_api.len(), 3);
+}


### PR DESCRIPTION
First PR of the grep extraction. The gram subsystem is moving out of the core crates into an optional package over several PRs; this one creates `loonfs-grep` (a `loonfs_grep` library plus a thin `loonfs-grep` binary, the same shape as `loonfs-cli`) and gives it a byte-compatible copy of the pure codec layer: the three-byte ASCII-folded tokenizer, the gram row-key grammar, the posting batch codec, the gram segment row, and the probe/prefix lookup primitives. Copying instead of moving keeps the dependency direction one-way for the whole migration — core never depends on the new crate, both implementations stay live until the final deletion PR, and the differential tests the later query move needs require both alive anyway.

The proofs the cross-crate identity suite: tokenizer equality over a folding/Unicode/boundary corpus; posting batches byte-identical and cross-decodable in both directions, including 255/256/257-entry boundaries; the existing 68-byte CBOR row fixture pinned from both crates; row-key, filter-key, probe, and prefix equality; and full shared-segment-block encodings that each crate's decoder reads from the other's bytes. The old manifest-feature types (`IndexGramsFeature`, `GramIndexFoldState`, `IndexFileRef`) are deliberately not copied — they belong to the old durable format and die with it; the new crate gets its own root in the next PR.

No existing crate changed; the binary prints a usage note and exits until the worker arrives.
