### PR TITLE
feat(grep): add independent durable root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,11 +1183,16 @@ dependencies = [
 name = "loonfs-grep"
 version = "0.1.1"
 dependencies = [
+ "bytes",
  "ciborium",
  "loonfs-api",
+ "loonfs-objectstore",
  "serde",
  "serde_bytes",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -13,13 +13,18 @@ name = "loonfs-grep"
 path = "src/main.rs"
 
 [dependencies]
+bytes.workspace = true
 loonfs-api = { path = "../loonfs-api" }
+loonfs-objectstore = { path = "../loonfs-objectstore" }
 serde.workspace = true
 serde_bytes.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
 ciborium.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -1,4 +1,4 @@
 # loonfs-grep
 
-`loonfs-grep` contains LoonFS's optional full-text grep subsystem. This first package version
-provides the gram codec; the standalone worker arrives in a later change.
+`loonfs-grep` contains LoonFS's optional full-text grep subsystem. It owns the gram codec and an
+independent durable root and keyspace; the standalone worker arrives in a later change.

--- a/crates/loonfs-grep/src/keyspace.rs
+++ b/crates/loonfs-grep/src/keyspace.rs
@@ -1,0 +1,143 @@
+//! Grep-owned durable object keys and their strict parser.
+
+use loonfs_api::{IndexSegmentId, NamespaceId};
+
+const ALL_NAMESPACES_PREFIX: &str = "grep/v0/namespaces/";
+
+/// The grep-owned object kind named by a parsed key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrepKeyKind {
+    Root,
+    Segment { segment_id: IndexSegmentId },
+}
+
+/// A recognized grep key split into its namespace and object kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedGrepKey {
+    pub namespace_id: NamespaceId,
+    pub kind: GrepKeyKind,
+}
+
+/// Prefix containing grep state for every namespace.
+///
+/// Grep-owned garbage collection uses this prefix to find state belonging
+/// to namespaces that core has deleted.
+pub const fn all_namespaces_prefix() -> &'static str {
+    ALL_NAMESPACES_PREFIX
+}
+
+/// Prefix containing every grep object for one namespace.
+pub fn namespace_prefix(namespace_id: &NamespaceId) -> String {
+    format!("{ALL_NAMESPACES_PREFIX}{namespace_id}/")
+}
+
+/// Key of one namespace's atomic grep root.
+pub fn root_key(namespace_id: &NamespaceId) -> String {
+    format!("{}root.json", namespace_prefix(namespace_id))
+}
+
+/// Prefix containing one namespace's immutable grep segments.
+pub fn segments_prefix(namespace_id: &NamespaceId) -> String {
+    format!("{}segments/", namespace_prefix(namespace_id))
+}
+
+/// Key of one immutable grep segment.
+pub fn segment_key(namespace_id: &NamespaceId, segment_id: &IndexSegmentId) -> String {
+    format!("{}{segment_id}.sst", segments_prefix(namespace_id))
+}
+
+/// Parses exactly the grep root and segment key grammar.
+///
+/// Prefixes, malformed ids, unknown object families, temporary suffixes,
+/// and keys with trailing path components are rejected.
+pub fn parse_key(key: &str) -> Option<ParsedGrepKey> {
+    let suffix = key.strip_prefix(ALL_NAMESPACES_PREFIX)?;
+    let (namespace, object) = suffix.split_once('/')?;
+    let namespace_id = NamespaceId::parse(namespace).ok()?;
+    let kind = if object == "root.json" {
+        GrepKeyKind::Root
+    } else {
+        let segment = object.strip_prefix("segments/")?.strip_suffix(".sst")?;
+        if segment.contains('/') {
+            return None;
+        }
+        GrepKeyKind::Segment {
+            segment_id: IndexSegmentId::parse(segment).ok()?,
+        }
+    };
+    Some(ParsedGrepKey { namespace_id, kind })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn namespace_id() -> NamespaceId {
+        NamespaceId::parse("docs").expect("valid namespace id")
+    }
+
+    fn segment_id() -> IndexSegmentId {
+        IndexSegmentId::parse("idx_00000000000000000000000000000001").expect("valid segment id")
+    }
+
+    #[test]
+    fn key_builders_pin_the_v0_grammar() {
+        let namespace_id = namespace_id();
+        let segment_id = segment_id();
+
+        assert_eq!(all_namespaces_prefix(), "grep/v0/namespaces/");
+        assert_eq!(namespace_prefix(&namespace_id), "grep/v0/namespaces/docs/");
+        assert_eq!(root_key(&namespace_id), "grep/v0/namespaces/docs/root.json");
+        assert_eq!(
+            segments_prefix(&namespace_id),
+            "grep/v0/namespaces/docs/segments/"
+        );
+        assert_eq!(
+            segment_key(&namespace_id, &segment_id),
+            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst"
+        );
+    }
+
+    #[test]
+    fn built_keys_round_trip_through_the_parser() {
+        let namespace_id = namespace_id();
+        let segment_id = segment_id();
+
+        assert_eq!(
+            parse_key(&root_key(&namespace_id)),
+            Some(ParsedGrepKey {
+                namespace_id: namespace_id.clone(),
+                kind: GrepKeyKind::Root,
+            })
+        );
+        assert_eq!(
+            parse_key(&segment_key(&namespace_id, &segment_id)),
+            Some(ParsedGrepKey {
+                namespace_id,
+                kind: GrepKeyKind::Segment { segment_id },
+            })
+        );
+    }
+
+    #[test]
+    fn parser_rejects_non_keys_and_malformed_keys() {
+        let rejected = [
+            "",
+            "grep/v0/namespaces/",
+            "grep/v0/namespaces/docs/",
+            "grep/v0/namespaces/docs/root.json/extra",
+            "grep/v0/namespaces/docs/root.json.tmp",
+            "grep/v0/namespaces/docs/segments/",
+            "grep/v0/namespaces/docs/segments/not-an-index-id.sst",
+            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst.tmp",
+            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst/extra",
+            "grep/v0/namespaces/docs/other/object",
+            "grep/v1/namespaces/docs/root.json",
+            "namespaces/docs/metadata/root.json",
+        ];
+
+        for key in rejected {
+            assert_eq!(parse_key(key), None, "parser accepted `{key}`");
+        }
+    }
+}

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -1,10 +1,14 @@
 //! LoonFS full-text grep subsystem.
 //!
-//! This first extraction step owns a byte-compatible copy of the gram
-//! codec. Query execution, storage maintenance, and the standalone worker
-//! arrive in later changes.
+//! Grep durable state lives under a grep-owned keyspace and is independent
+//! of the namespace manifest. A missing or corrupt grep root disables grep
+//! work for that namespace; it must never affect core filesystem operation.
+//! Query execution, storage maintenance, and the standalone worker arrive
+//! in later changes.
 
 pub mod codec;
+pub mod keyspace;
+pub mod root;
 
 use std::io::Write as _;
 use std::process::ExitCode;

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -1,0 +1,154 @@
+//! Versioned JSON envelope codec for the grep root.
+
+use super::error::GrepRootCodecError;
+use super::state::GrepRootState;
+use loonfs_api::sha256_digest;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+/// Durable kind string for a grep root envelope.
+pub const GREP_ROOT_KIND: &str = "grep_root";
+/// Durable v0 format string. Unknown strings are rejected without fallback.
+pub const GREP_ROOT_FORMAT_VERSION: &str = "v0";
+
+/// Verified in-memory representation of one grep root envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrepRootEnvelope {
+    format_version: String,
+    writer_version: String,
+    payload_checksum: String,
+    state: GrepRootState,
+}
+
+impl GrepRootEnvelope {
+    /// Builds a fresh envelope and checksums the canonical payload bytes.
+    pub fn from_state(
+        writer_version: impl Into<String>,
+        state: GrepRootState,
+    ) -> Result<Self, GrepRootCodecError> {
+        state.validate()?;
+        let payload =
+            serde_json::to_vec(&state).map_err(|error| GrepRootCodecError::PayloadEncode {
+                message: error.to_string(),
+            })?;
+        Ok(Self {
+            format_version: GREP_ROOT_FORMAT_VERSION.to_owned(),
+            writer_version: writer_version.into(),
+            payload_checksum: sha256_digest(&payload),
+            state,
+        })
+    }
+
+    pub fn format_version(&self) -> &str {
+        &self.format_version
+    }
+
+    pub fn writer_version(&self) -> &str {
+        &self.writer_version
+    }
+
+    pub fn payload_checksum(&self) -> &str {
+        &self.payload_checksum
+    }
+
+    pub fn state(&self) -> &GrepRootState {
+        &self.state
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvelopeProbe {
+    kind: String,
+    format_version: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct EnvelopeDocument {
+    kind: String,
+    format_version: String,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+/// Encodes an envelope after rechecking its version, state, and checksum.
+pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRootCodecError> {
+    verify_version(&envelope.format_version)?;
+    envelope.state.validate()?;
+    let payload = serde_json::to_string(&envelope.state).map_err(|error| {
+        GrepRootCodecError::PayloadEncode {
+            message: error.to_string(),
+        }
+    })?;
+    let actual = sha256_digest(payload.as_bytes());
+    if actual != envelope.payload_checksum {
+        return Err(GrepRootCodecError::StalePayloadChecksum {
+            checksum: envelope.payload_checksum.clone(),
+            actual,
+        });
+    }
+    let document = EnvelopeDocument {
+        kind: GREP_ROOT_KIND.to_owned(),
+        format_version: envelope.format_version.clone(),
+        writer_version: envelope.writer_version.clone(),
+        payload_checksum: envelope.payload_checksum.clone(),
+        payload: RawValue::from_string(payload).map_err(|error| {
+            GrepRootCodecError::PayloadEncode {
+                message: error.to_string(),
+            }
+        })?,
+    };
+    serde_json::to_vec(&document).map_err(|error| GrepRootCodecError::EnvelopeEncode {
+        message: error.to_string(),
+    })
+}
+
+/// Decodes only v0, verifies the exact stored payload bytes, and validates
+/// the decoded root's cross-field invariants.
+pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
+    let probe: EnvelopeProbe =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    if probe.kind != GREP_ROOT_KIND {
+        return Err(GrepRootCodecError::KindMismatch {
+            expected: GREP_ROOT_KIND.to_owned(),
+            found: probe.kind,
+        });
+    }
+    verify_version(&probe.format_version)?;
+
+    let document: EnvelopeDocument =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    let actual = sha256_digest(document.payload.get().as_bytes());
+    if actual != document.payload_checksum {
+        return Err(GrepRootCodecError::ChecksumMismatch {
+            expected: document.payload_checksum,
+            actual,
+        });
+    }
+    let state: GrepRootState = serde_json::from_str(document.payload.get()).map_err(|error| {
+        GrepRootCodecError::PayloadDecode {
+            message: error.to_string(),
+        }
+    })?;
+    state.validate()?;
+    Ok(GrepRootEnvelope {
+        format_version: document.format_version,
+        writer_version: document.writer_version,
+        payload_checksum: document.payload_checksum,
+        state,
+    })
+}
+
+fn verify_version(found: &str) -> Result<(), GrepRootCodecError> {
+    if found != GREP_ROOT_FORMAT_VERSION {
+        return Err(GrepRootCodecError::UnsupportedFormatVersion {
+            found: found.to_owned(),
+            supported: GREP_ROOT_FORMAT_VERSION.to_owned(),
+        });
+    }
+    Ok(())
+}

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -1,0 +1,96 @@
+//! Typed failures for grep root state, encoding, loading, and publication.
+
+use loonfs_api::{IndexSegmentId, NamespaceId};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum GrepRootStateError {
+    #[error("unsupported grep index format version `{found}`: this build supports `{supported}`")]
+    UnsupportedIndexFormatVersion { found: u32, supported: u32 },
+    #[error("disabled grep root carries query-visible segments")]
+    DisabledHasSegments,
+    #[error("disabled grep root carries an in-progress fold")]
+    DisabledHasFold,
+    #[error("duplicate grep segment id `{segment_id}`")]
+    DuplicateSegmentId { segment_id: IndexSegmentId },
+    #[error("grep segment `{segment_id}` has a minimum row key after its maximum")]
+    InvalidSegmentRange { segment_id: IndexSegmentId },
+    #[error(
+        "grep segment `{segment_id}` uses run ordinal `{run_ordinal}` but the next ordinal is \
+         `{next_run_ordinal}`"
+    )]
+    UnallocatedSegmentRunOrdinal {
+        segment_id: IndexSegmentId,
+        run_ordinal: u64,
+        next_run_ordinal: u64,
+    },
+    #[error(
+        "grep fold uses run ordinal `{run_ordinal}` but the next ordinal is `{next_run_ordinal}`"
+    )]
+    UnallocatedFoldRunOrdinal {
+        run_ordinal: u64,
+        next_run_ordinal: u64,
+    },
+    #[error("grep fold repeats segment id `{segment_id}`")]
+    DuplicateFoldSegmentId { segment_id: IndexSegmentId },
+    #[error("grep fold snapshot references missing segment `{segment_id}`")]
+    MissingFoldSnapshotSegment { segment_id: IndexSegmentId },
+    #[error("grep fold output references missing segment `{segment_id}`")]
+    MissingFoldOutputSegment { segment_id: IndexSegmentId },
+    #[error("grep fold output `{segment_id}` does not carry the fold's level and run ordinal")]
+    FoldOutputDescriptorMismatch { segment_id: IndexSegmentId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum GrepRootCodecError {
+    #[error("failed to encode grep root payload: {message}")]
+    PayloadEncode { message: String },
+    #[error("failed to encode grep root envelope: {message}")]
+    EnvelopeEncode { message: String },
+    #[error("failed to decode grep root envelope: {message}")]
+    EnvelopeDecode { message: String },
+    #[error("failed to decode grep root payload: {message}")]
+    PayloadDecode { message: String },
+    #[error("grep root kind mismatch: expected `{expected}`, found `{found}`")]
+    KindMismatch { expected: String, found: String },
+    #[error("unsupported grep root format version `{found}`: this build supports `{supported}`")]
+    UnsupportedFormatVersion { found: String, supported: String },
+    #[error("grep root payload checksum mismatch: expected {expected}, actual {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+    #[error("grep root checksum `{checksum}` is stale for payload `{actual}`")]
+    StalePayloadChecksum { checksum: String, actual: String },
+    #[error("invalid grep root state: {0}")]
+    InvalidState(#[from] GrepRootStateError),
+}
+
+/// Failure to load or publish a grep root.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum GrepRootError {
+    #[error("object-store operation failed for grep root `{object_key}`: {message}")]
+    Store { object_key: String, message: String },
+    #[error("grep root `{object_key}` is corrupt: {message}")]
+    Corrupt { object_key: String, message: String },
+    #[error(
+        "grep root `{object_key}` names namespace `{actual}` instead of requested namespace \
+         `{expected}`"
+    )]
+    IdentityMismatch {
+        object_key: String,
+        expected: NamespaceId,
+        actual: NamespaceId,
+    },
+    #[error("grep root `{object_key}` has no etag for compare-and-swap")]
+    MissingEtag { object_key: String },
+    #[error("grep root publication conflict for `{object_key}`")]
+    Conflict { object_key: String },
+    #[error("grep root advance changes namespace from `{expected}` to `{actual}`")]
+    AdvanceIdentityMismatch {
+        expected: NamespaceId,
+        actual: NamespaceId,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, GrepRootError>;

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -1,0 +1,27 @@
+//! The atomic grep root and its durable publication boundary.
+//!
+//! One root pairs the query-visible segment set with its
+//! `built_through_seq` watermark, lifecycle, in-progress fold, and run
+//! ordinal allocation. Publication replaces that whole set in one object
+//! store compare-and-swap, so a reader never observes a watermark without
+//! the segments that implement it.
+//!
+//! Segment objects are immutable derived data written before the root CAS.
+//! A CAS loser therefore leaks only unreachable derived objects; it never
+//! changes visible grep state. Grep-owned garbage collection will reclaim
+//! those objects in a later change.
+
+mod codec;
+mod error;
+mod state;
+mod store;
+
+pub use codec::{
+    decode_grep_root, encode_grep_root, GrepRootEnvelope, GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
+};
+pub use error::{GrepRootCodecError, GrepRootError, GrepRootStateError, Result};
+pub use state::{
+    GrepFoldState, GrepIndexState, GrepLifecycle, GrepRootState, GrepSegmentRef,
+    GREP_INDEX_FORMAT_VERSION,
+};
+pub use store::{advance_grep_root, load_grep_root, seed_grep_root, LoadedGrepRoot};

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -1,0 +1,231 @@
+//! Constructor-validated state carried by the grep root payload.
+
+use super::error::GrepRootStateError;
+use loonfs_api::wire::sst_blocks::BlockHandle;
+use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, NamespaceId};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Version of the grep index state nested inside a v0 root.
+pub const GREP_INDEX_FORMAT_VERSION: u32 = 0;
+
+/// Durable lifecycle of grep indexing for one namespace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GrepLifecycle {
+    /// Initial materialization is walking existing revisions.
+    Backfilling {
+        /// Resume key for the next backfill step; empty means the start.
+        backfill_cursor: String,
+        /// Reserved pin for a later checkpoint-backed backfill protocol.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        checkpoint_id: Option<CheckpointId>,
+    },
+    /// Backfill is complete and changes are consumed incrementally.
+    Steady,
+    /// Grep indexing and queries are disabled for this namespace.
+    Disabled,
+}
+
+/// Resumable state for one partitioned segment fold.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepFoldState {
+    /// Fixed input snapshot retained until the completing root swap.
+    pub snapshot_segment_ids: Vec<IndexSegmentId>,
+    /// Outputs written by completed fold steps and retained until the swap.
+    pub output_segment_ids: Vec<IndexSegmentId>,
+    /// Inclusive row key at which the next fold step resumes.
+    pub row_key_cursor: String,
+    /// Level stamped on every output segment of this fold.
+    pub output_level: u32,
+    /// Logical run identity stamped on every output segment of this fold.
+    pub run_ordinal: u64,
+}
+
+/// Durable index bookkeeping paired with the visible segment set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepIndexState {
+    /// Version of this nested index-state schema.
+    pub format_version: u32,
+    /// Changes at or below this sequence are represented by `segments`.
+    pub built_through_seq: ChangeSeq,
+    /// One in-progress partitioned fold, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fold: Option<GrepFoldState>,
+    /// Next logical run ordinal to allocate atomically with a root update.
+    pub next_run_ordinal: u64,
+}
+
+impl GrepIndexState {
+    /// Creates index bookkeeping in the current grep-owned format.
+    pub fn new(
+        built_through_seq: ChangeSeq,
+        fold: Option<GrepFoldState>,
+        next_run_ordinal: u64,
+    ) -> Self {
+        Self {
+            format_version: GREP_INDEX_FORMAT_VERSION,
+            built_through_seq,
+            fold,
+            next_run_ordinal,
+        }
+    }
+}
+
+/// Query-visible descriptor for one immutable grep segment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepSegmentRef {
+    pub segment_id: IndexSegmentId,
+    pub run_seq: ChangeSeq,
+    pub run_ordinal: u64,
+    pub level: u32,
+    pub segment_index: u32,
+    pub min_row_key: String,
+    pub max_row_key: String,
+    /// Entry point for the segment's data-block index and its CRC.
+    pub index_block: BlockHandle,
+    /// Bloom-filter layout and CRC for query probes.
+    pub filter_block: BlockHandle,
+    /// Small filters may be inlined while retaining the same block handle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter_inline: Option<String>,
+    /// SHA-256 identity of the full immutable segment payload.
+    pub payload_checksum: String,
+}
+
+/// One namespace's complete grep control state.
+///
+/// Fields stay private so every constructed or decoded root passes the
+/// inexpensive fold/segment and run-allocation checks in [`Self::new`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepRootState {
+    namespace_id: NamespaceId,
+    lifecycle: GrepLifecycle,
+    index: GrepIndexState,
+    segments: Vec<GrepSegmentRef>,
+}
+
+impl GrepRootState {
+    /// Creates a root after validating its cross-field invariants.
+    pub fn new(
+        namespace_id: NamespaceId,
+        lifecycle: GrepLifecycle,
+        index: GrepIndexState,
+        segments: Vec<GrepSegmentRef>,
+    ) -> Result<Self, GrepRootStateError> {
+        let state = Self {
+            namespace_id,
+            lifecycle,
+            index,
+            segments,
+        };
+        state.validate()?;
+        Ok(state)
+    }
+
+    pub fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    pub fn lifecycle(&self) -> &GrepLifecycle {
+        &self.lifecycle
+    }
+
+    pub fn index(&self) -> &GrepIndexState {
+        &self.index
+    }
+
+    pub fn segments(&self) -> &[GrepSegmentRef] {
+        &self.segments
+    }
+
+    pub(super) fn validate(&self) -> Result<(), GrepRootStateError> {
+        if self.index.format_version != GREP_INDEX_FORMAT_VERSION {
+            return Err(GrepRootStateError::UnsupportedIndexFormatVersion {
+                found: self.index.format_version,
+                supported: GREP_INDEX_FORMAT_VERSION,
+            });
+        }
+        if matches!(self.lifecycle, GrepLifecycle::Disabled) {
+            if !self.segments.is_empty() {
+                return Err(GrepRootStateError::DisabledHasSegments);
+            }
+            if self.index.fold.is_some() {
+                return Err(GrepRootStateError::DisabledHasFold);
+            }
+        }
+
+        let mut by_id = BTreeMap::new();
+        for segment in &self.segments {
+            if segment.min_row_key > segment.max_row_key {
+                return Err(GrepRootStateError::InvalidSegmentRange {
+                    segment_id: segment.segment_id.clone(),
+                });
+            }
+            if segment.run_ordinal >= self.index.next_run_ordinal {
+                return Err(GrepRootStateError::UnallocatedSegmentRunOrdinal {
+                    segment_id: segment.segment_id.clone(),
+                    run_ordinal: segment.run_ordinal,
+                    next_run_ordinal: self.index.next_run_ordinal,
+                });
+            }
+            if by_id.insert(&segment.segment_id, segment).is_some() {
+                return Err(GrepRootStateError::DuplicateSegmentId {
+                    segment_id: segment.segment_id.clone(),
+                });
+            }
+        }
+
+        if let Some(fold) = &self.index.fold {
+            validate_fold(fold, self.index.next_run_ordinal, &by_id)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_fold(
+    fold: &GrepFoldState,
+    next_run_ordinal: u64,
+    segments: &BTreeMap<&IndexSegmentId, &GrepSegmentRef>,
+) -> Result<(), GrepRootStateError> {
+    if fold.run_ordinal >= next_run_ordinal {
+        return Err(GrepRootStateError::UnallocatedFoldRunOrdinal {
+            run_ordinal: fold.run_ordinal,
+            next_run_ordinal,
+        });
+    }
+
+    let mut snapshot_ids = BTreeSet::new();
+    for segment_id in &fold.snapshot_segment_ids {
+        if !snapshot_ids.insert(segment_id) {
+            return Err(GrepRootStateError::DuplicateFoldSegmentId {
+                segment_id: segment_id.clone(),
+            });
+        }
+        if !segments.contains_key(segment_id) {
+            return Err(GrepRootStateError::MissingFoldSnapshotSegment {
+                segment_id: segment_id.clone(),
+            });
+        }
+    }
+
+    let mut output_ids = BTreeSet::new();
+    for segment_id in &fold.output_segment_ids {
+        if snapshot_ids.contains(segment_id) || !output_ids.insert(segment_id) {
+            return Err(GrepRootStateError::DuplicateFoldSegmentId {
+                segment_id: segment_id.clone(),
+            });
+        }
+        let Some(segment) = segments.get(segment_id) else {
+            return Err(GrepRootStateError::MissingFoldOutputSegment {
+                segment_id: segment_id.clone(),
+            });
+        };
+        if segment.level != fold.output_level || segment.run_ordinal != fold.run_ordinal {
+            return Err(GrepRootStateError::FoldOutputDescriptorMismatch {
+                segment_id: segment_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -1,0 +1,184 @@
+//! Loading and single-attempt CAS publication for grep roots.
+//!
+//! Publication intentionally does not retry: a compare-and-swap loser gets
+//! [`GrepRootError::Conflict`](super::GrepRootError), reloads the now-current
+//! root, and rebuilds its candidate. Any immutable segments written for the
+//! losing candidate remain unreachable garbage for grep-owned collection.
+
+use super::codec::{decode_grep_root, encode_grep_root, GrepRootEnvelope};
+use super::error::{GrepRootError, Result};
+use super::state::GrepRootState;
+use crate::keyspace::root_key;
+use bytes::Bytes;
+use loonfs_api::NamespaceId;
+use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
+
+/// A verified grep root and the metadata from the same object-store read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedGrepRoot {
+    object_key: String,
+    envelope: GrepRootEnvelope,
+    metadata: ObjectMetadata,
+}
+
+impl LoadedGrepRoot {
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub fn envelope(&self) -> &GrepRootEnvelope {
+        &self.envelope
+    }
+
+    pub fn state(&self) -> &GrepRootState {
+        self.envelope.state()
+    }
+
+    pub fn metadata(&self) -> &ObjectMetadata {
+        &self.metadata
+    }
+}
+
+/// Loads and verifies one namespace's grep root, returning `None` when the
+/// independent grep subsystem has not seeded it.
+pub async fn load_grep_root<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<Option<LoadedGrepRoot>> {
+    let object_key = root_key(namespace_id);
+    let Some(body) = store
+        .get_with_metadata(&object_key)
+        .await
+        .map_err(|error| store_error(&object_key, &error))?
+    else {
+        return Ok(None);
+    };
+    let envelope = decode_grep_root(&body.bytes).map_err(|error| GrepRootError::Corrupt {
+        object_key: object_key.clone(),
+        message: error.to_string(),
+    })?;
+    if envelope.state().namespace_id() != namespace_id {
+        return Err(GrepRootError::IdentityMismatch {
+            object_key,
+            expected: namespace_id.clone(),
+            actual: envelope.state().namespace_id().clone(),
+        });
+    }
+    Ok(Some(LoadedGrepRoot {
+        object_key,
+        envelope,
+        metadata: body.metadata,
+    }))
+}
+
+/// Seeds a grep root with create-if-absent semantics.
+///
+/// An existing root is a typed conflict, even when it carries identical
+/// bytes; callers seed exactly once and load thereafter.
+pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
+    store: &S,
+    state: &GrepRootState,
+    writer_version: &str,
+) -> Result<LoadedGrepRoot> {
+    let object_key = root_key(state.namespace_id());
+    let envelope =
+        GrepRootEnvelope::from_state(writer_version, state.clone()).map_err(|error| {
+            GrepRootError::Corrupt {
+                object_key: object_key.clone(),
+                message: error.to_string(),
+            }
+        })?;
+    let bytes = encode_grep_root(&envelope).map_err(|error| GrepRootError::Corrupt {
+        object_key: object_key.clone(),
+        message: error.to_string(),
+    })?;
+    let metadata = match store
+        .put(&object_key, Bytes::from(bytes), PutMode::CreateIfAbsent)
+        .await
+    {
+        Ok(metadata) => metadata,
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
+            return Err(GrepRootError::Conflict { object_key });
+        }
+        Err(error) => return Err(store_error(&object_key, &error)),
+    };
+    Ok(LoadedGrepRoot {
+        object_key,
+        envelope,
+        metadata,
+    })
+}
+
+/// Advances a loaded grep root in one etag compare-and-swap attempt.
+///
+/// A conflict is never retried against the stale candidate: the caller must
+/// reload and recompute the whole atomic root state.
+pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
+    store: &S,
+    current: &LoadedGrepRoot,
+    next: &GrepRootState,
+    writer_version: &str,
+) -> Result<LoadedGrepRoot> {
+    let expected_namespace_id = current.envelope.state().namespace_id();
+    if next.namespace_id() != expected_namespace_id {
+        return Err(GrepRootError::AdvanceIdentityMismatch {
+            expected: expected_namespace_id.clone(),
+            actual: next.namespace_id().clone(),
+        });
+    }
+    let expected_key = root_key(expected_namespace_id);
+    if current.object_key != expected_key {
+        return Err(GrepRootError::Corrupt {
+            object_key: current.object_key.clone(),
+            message: format!("loaded root key does not match `{expected_key}`"),
+        });
+    }
+    let expected_etag =
+        current
+            .metadata
+            .etag
+            .as_deref()
+            .ok_or_else(|| GrepRootError::MissingEtag {
+                object_key: current.object_key.clone(),
+            })?;
+    let envelope = GrepRootEnvelope::from_state(writer_version, next.clone()).map_err(|error| {
+        GrepRootError::Corrupt {
+            object_key: current.object_key.clone(),
+            message: error.to_string(),
+        }
+    })?;
+    let bytes = encode_grep_root(&envelope).map_err(|error| GrepRootError::Corrupt {
+        object_key: current.object_key.clone(),
+        message: error.to_string(),
+    })?;
+    let metadata = match store
+        .put(
+            &current.object_key,
+            Bytes::from(bytes),
+            PutMode::CompareAndSwap {
+                expected_etag: expected_etag.to_owned(),
+            },
+        )
+        .await
+    {
+        Ok(metadata) => metadata,
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
+            return Err(GrepRootError::Conflict {
+                object_key: current.object_key.clone(),
+            });
+        }
+        Err(error) => return Err(store_error(&current.object_key, &error)),
+    };
+    Ok(LoadedGrepRoot {
+        object_key: current.object_key.clone(),
+        envelope,
+        metadata,
+    })
+}
+
+fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
+    GrepRootError::Store {
+        object_key: object_key.to_owned(),
+        message: error.message(),
+    }
+}

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -1,0 +1,175 @@
+#![allow(clippy::panic)]
+
+use loonfs_api::wire::sst_blocks::BlockHandle;
+use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, NamespaceId};
+use loonfs_grep::root::{
+    decode_grep_root, encode_grep_root, GrepFoldState, GrepIndexState, GrepLifecycle,
+    GrepRootCodecError, GrepRootEnvelope, GrepRootState, GrepRootStateError, GrepSegmentRef,
+};
+
+// Frozen v0 format pins. These byte strings are the durable compatibility
+// fixtures: changing field names, ordering, enum tags, or omission rules must
+// change them deliberately. Together they represent every lifecycle state.
+const BACKFILLING_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:85e924a85e511959db7c82e342f7c2f6417fae1b8a57038ffa913084873e3f5e","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":"revision-00000000000000000007","checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":0,"built_through_seq":7,"fold":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:4711db321ec737abf7334d89865e3488d1d79c4d567823402f25bb971b989eee","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":0,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
+const ADDITIVE_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"future-writer/9.0","payload_checksum":"sha256:2d8afef7322d76189d288b50b3b02e8f475a6249b6d6f89659d6561d0f193870","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+
+#[test]
+fn encoded_roots_match_frozen_v0_bytes() {
+    let cases = [
+        (sample_backfilling_root(), BACKFILLING_V0),
+        (sample_steady_root(ChangeSeq(11)), STEADY_V0),
+        (sample_disabled_root(), DISABLED_V0),
+    ];
+
+    for (state, expected) in cases {
+        let envelope =
+            GrepRootEnvelope::from_state("loonfs-grep-tests/0.1.1", state).expect("build envelope");
+        let actual = String::from_utf8(encode_grep_root(&envelope).expect("encode root"))
+            .expect("root JSON is UTF-8");
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn decoder_reads_frozen_v0_bytes_with_additive_fields() {
+    let decoded = decode_grep_root(ADDITIVE_V0.as_bytes()).expect("decode additive v0 fixture");
+
+    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11)));
+}
+
+#[test]
+fn decoder_rejects_unknown_version_without_fallback() {
+    let future = STEADY_V0.replacen("\"format_version\":\"v0\"", "\"format_version\":\"v1\"", 1);
+
+    assert!(matches!(
+        decode_grep_root(future.as_bytes()),
+        Err(GrepRootCodecError::UnsupportedFormatVersion { found, supported })
+            if found == "v1" && supported == "v0"
+    ));
+}
+
+#[test]
+fn decoder_rejects_corrupted_checksum() {
+    let corrupted = STEADY_V0.replacen("\"steady\"", "\"disabled\"", 1);
+
+    assert!(matches!(
+        decode_grep_root(corrupted.as_bytes()),
+        Err(GrepRootCodecError::ChecksumMismatch { .. })
+    ));
+}
+
+#[test]
+fn decoder_rejects_truncated_payload() {
+    let truncated = &STEADY_V0.as_bytes()[..STEADY_V0.len() - 8];
+
+    assert!(matches!(
+        decode_grep_root(truncated),
+        Err(GrepRootCodecError::EnvelopeDecode { .. })
+    ));
+}
+
+#[test]
+fn constructor_rejects_fold_segment_mismatch() {
+    let mut index = GrepIndexState::new(ChangeSeq(7), None, 2);
+    index.fold = Some(GrepFoldState {
+        snapshot_segment_ids: vec![segment_id(9)],
+        output_segment_ids: Vec::new(),
+        row_key_cursor: String::new(),
+        output_level: 1,
+        run_ordinal: 1,
+    });
+
+    assert!(matches!(
+        GrepRootState::new(
+            namespace_id("docs"),
+            GrepLifecycle::Steady,
+            index,
+            vec![segment_ref(1, 1, 0, 0)]
+        ),
+        Err(GrepRootStateError::MissingFoldSnapshotSegment { .. })
+    ));
+}
+
+fn sample_backfilling_root() -> GrepRootState {
+    let fold = GrepFoldState {
+        snapshot_segment_ids: vec![segment_id(1), segment_id(2)],
+        output_segment_ids: vec![segment_id(3)],
+        row_key_cursor: "gram-6d6e6f-00000000000000000042".to_owned(),
+        output_level: 1,
+        run_ordinal: 3,
+    };
+    GrepRootState::new(
+        namespace_id("docs"),
+        GrepLifecycle::Backfilling {
+            backfill_cursor: "revision-00000000000000000007".to_owned(),
+            checkpoint_id: Some(
+                CheckpointId::parse("chk_00000000000000000000000000000009")
+                    .expect("valid checkpoint id"),
+            ),
+        },
+        GrepIndexState::new(ChangeSeq(7), Some(fold), 4),
+        vec![
+            segment_ref(1, 1, 0, 0),
+            segment_ref(2, 2, 0, 0),
+            segment_ref(3, 3, 1, 0),
+        ],
+    )
+    .expect("valid backfilling root")
+}
+
+fn sample_steady_root(built_through_seq: ChangeSeq) -> GrepRootState {
+    GrepRootState::new(
+        namespace_id("docs"),
+        GrepLifecycle::Steady,
+        GrepIndexState::new(built_through_seq, None, 2),
+        vec![segment_ref(1, 1, 0, 0)],
+    )
+    .expect("valid steady root")
+}
+
+fn sample_disabled_root() -> GrepRootState {
+    GrepRootState::new(
+        namespace_id("docs"),
+        GrepLifecycle::Disabled,
+        GrepIndexState::new(ChangeSeq(15), None, 4),
+        Vec::new(),
+    )
+    .expect("valid disabled root")
+}
+
+fn segment_ref(number: u8, run_ordinal: u64, level: u32, segment_index: u32) -> GrepSegmentRef {
+    GrepSegmentRef {
+        segment_id: segment_id(number),
+        run_seq: ChangeSeq(7 + u64::from(number)),
+        run_ordinal,
+        level,
+        segment_index,
+        min_row_key: "gram-616263-00000000000000000001".to_owned(),
+        max_row_key: "gram-7a7a7a-00000000000000000099".to_owned(),
+        index_block: BlockHandle {
+            offset: 128,
+            stored_len: 48,
+            decoded_len: 96,
+            crc32c: 305_419_896,
+        },
+        filter_block: BlockHandle {
+            offset: 176,
+            stored_len: 16,
+            decoded_len: 16,
+            crc32c: 2_591_069_104,
+        },
+        filter_inline: (number == 1).then(|| "00112233445566778899aabbccddeeff".to_owned()),
+        payload_checksum: "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            .to_owned(),
+    }
+}
+
+fn namespace_id(value: &str) -> NamespaceId {
+    NamespaceId::parse(value).expect("valid namespace id")
+}
+
+fn segment_id(number: u8) -> IndexSegmentId {
+    IndexSegmentId::parse(format!("idx_{number:032x}")).expect("valid segment id")
+}

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -1,0 +1,124 @@
+#![allow(clippy::panic)]
+
+use bytes::Bytes;
+use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_grep::keyspace::root_key;
+use loonfs_grep::root::{
+    advance_grep_root, encode_grep_root, load_grep_root, seed_grep_root, GrepIndexState,
+    GrepLifecycle, GrepRootEnvelope, GrepRootError, GrepRootState,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::{ObjectStore, PutMode};
+
+#[tokio::test]
+async fn load_rejects_namespace_identity_mismatch() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let requested = namespace_id("requested");
+    let wrong = root(namespace_id("other"), ChangeSeq(0));
+    let envelope = GrepRootEnvelope::from_state("test", wrong).expect("envelope");
+    let bytes = encode_grep_root(&envelope).expect("encode");
+    let key = root_key(&requested);
+    store
+        .put(&key, Bytes::from(bytes), PutMode::CreateIfAbsent)
+        .await
+        .expect("write mismatched root");
+
+    assert!(matches!(
+        load_grep_root(&store, &requested).await,
+        Err(GrepRootError::IdentityMismatch { expected, actual, .. })
+            if expected.as_str() == "requested" && actual.as_str() == "other"
+    ));
+}
+
+#[tokio::test]
+async fn seed_succeeds_once_and_second_seed_conflicts() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let state = root(namespace_id("docs"), ChangeSeq(0));
+
+    seed_grep_root(&store, &state, "seed-one")
+        .await
+        .expect("first seed succeeds");
+    assert!(matches!(
+        seed_grep_root(&store, &state, "seed-two").await,
+        Err(GrepRootError::Conflict { .. })
+    ));
+}
+
+#[tokio::test]
+async fn racing_advancers_have_one_winner_and_loser_can_reload_and_retry() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = namespace_id("docs");
+    let seeded = seed_grep_root(&store, &root(namespace_id.clone(), ChangeSeq(0)), "seed")
+        .await
+        .expect("seed root");
+    let first = root(namespace_id.clone(), ChangeSeq(1));
+    let second = root(namespace_id.clone(), ChangeSeq(2));
+
+    let (first_result, second_result) = tokio::join!(
+        advance_grep_root(&store, &seeded, &first, "racer-one"),
+        advance_grep_root(&store, &seeded, &second, "racer-two")
+    );
+    let outcomes = [first_result, second_result];
+    assert_eq!(outcomes.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(GrepRootError::Conflict { .. })))
+            .count(),
+        1
+    );
+
+    let reloaded = load_grep_root(&store, &namespace_id)
+        .await
+        .expect("reload succeeds")
+        .expect("root exists");
+    let retry = root(namespace_id.clone(), ChangeSeq(3));
+    advance_grep_root(&store, &reloaded, &retry, "retry")
+        .await
+        .expect("reload-and-retry succeeds");
+    let final_root = load_grep_root(&store, &namespace_id)
+        .await
+        .expect("final load succeeds")
+        .expect("root exists");
+    assert_eq!(final_root.state().index().built_through_seq, ChangeSeq(3));
+}
+
+#[tokio::test]
+async fn stale_etag_advance_fails_after_concurrent_advance() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = namespace_id("docs");
+    let stale = seed_grep_root(&store, &root(namespace_id.clone(), ChangeSeq(0)), "seed")
+        .await
+        .expect("seed root");
+    advance_grep_root(
+        &store,
+        &stale,
+        &root(namespace_id.clone(), ChangeSeq(1)),
+        "winner",
+    )
+    .await
+    .expect("concurrent advance succeeds");
+
+    assert!(matches!(
+        advance_grep_root(&store, &stale, &root(namespace_id, ChangeSeq(2)), "stale").await,
+        Err(GrepRootError::Conflict { .. })
+    ));
+}
+
+fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootState {
+    GrepRootState::new(
+        namespace_id,
+        GrepLifecycle::Steady,
+        GrepIndexState::new(built_through_seq, None, 0),
+        Vec::new(),
+    )
+    .expect("valid root")
+}
+
+fn namespace_id(value: &str) -> NamespaceId {
+    NamespaceId::parse(value).expect("valid namespace id")
+}


### PR DESCRIPTION
The grep subsystem gets its own durable home: a `grep/v0/namespaces/{ns}/` keyspace and a CAS-published root, owned entirely by `loonfs-grep`, with core learning nothing. The root preserves every durable meaning the namespace manifest carries for the index today — the `built_through_seq` watermark, backfill cursor, partitioned fold state (snapshots, outputs, row-key cursor, output level, run ordinal), run-ordinal allocation, and the query-visible segment set — atomically paired in one object so a single compare-and-swap advances all of them together. Lifecycle is explicit (backfilling with a reserved slot for the checkpoint pin the backfill PR will use, steady, disabled), and the constructor rejects inconsistent pairings such as a disabled root carrying segments or a fold naming unknown segment ids. Four old `IndexFileRef` fields are deliberately dropped: the owner namespace (the root is identity-validated), the object key (derived from ids), the family tag (this keyspace holds only grep segments), and the manifest-side row count.

The encoding follows the control-object conventions: a JSON envelope with a kind string, an explicit `v0` version probed before any shape assumptions, and a SHA-256 over the exact stored payload fragment — verified against the raw bytes on load, so re-serialization can never drift the checksum. Unknown versions, wrong kinds, corrupt checksums, truncation, and identity mismatches are hard failures with no fallback decoding. Publication seeds with create-if-absent and advances by etag compare-and-swap; a loser gets a typed conflict and reloads, leaving at most unreachable derived objects for grep-owned GC to collect later. Frozen byte fixtures pin all three lifecycle states, and the CAS race tests prove exactly-one-winner with a working reload-and-retry path.

Everything is inside `crates/loonfs-grep`; the keyspace module also ships the all-namespaces prefix and a strict key parser, which the later grep-GC work uses to reap state for deleted namespaces.
