### PR TITLE
refactor(grep): move query execution into service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "futures",
  "loonfs-api",
  "loonfs-core",
+ "loonfs-grep",
  "loonfs-objectstore",
  "serde_json",
  "tempfile",
@@ -1185,14 +1186,19 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "ciborium",
+ "futures",
  "loonfs-api",
+ "loonfs-core",
  "loonfs-objectstore",
+ "regex",
+ "regex-syntax",
  "serde",
  "serde_bytes",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/loonfs-core/src/checkpoint/index_build.rs
+++ b/crates/loonfs-core/src/checkpoint/index_build.rs
@@ -256,7 +256,10 @@ pub enum GramIndexFoldOutcome {
 /// leading sample; a sample that ends inside a multi-byte character still
 /// counts as valid). The query path applies the same rule to unindexed
 /// data, so eligibility is uniform whether or not a revision was indexed.
-pub(crate) fn is_indexable_text_content(content: &[u8]) -> bool {
+/// This is part of the read surface consumed by `loonfs-grep`; the build
+/// and query copies are kept public together until their equality test can
+/// be retired with the old core grep implementation.
+pub fn is_indexable_text_content(content: &[u8]) -> bool {
     if content.len() as u64 > INDEX_GRAMS_MAX_FILE_BYTES {
         return false;
     }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -62,9 +62,9 @@ pub(crate) use self::runs::MetadataLsmPolicy;
 pub(crate) use self::cache::CacheAdmission;
 pub(crate) use self::create::{build_initial_namespace_manifest, create_checkpoint};
 pub(crate) use self::flush::flush_wal;
+pub use self::index_build::is_indexable_text_content;
 pub(crate) use self::index_build::{
     build_grams_index_step, disable_grams_index, enable_grams_index, fold_grams_index_step,
-    is_indexable_text_content,
 };
 pub(crate) use self::index_read::{
     index_segment_corrupt, load_index_segment_data_block, load_index_segment_filter_block,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -206,7 +206,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Runs one content-search page against the pinned runtime read context.
+    /// Runs one content-search page through core's reference executor.
+    ///
+    /// Retained for differential testing until the final core-deletion PR;
+    /// the production runtime delegates content search to `loonfs-grep`.
     pub async fn grep_with_runtime_context(
         &self,
         request: &GrepRequest,
@@ -216,6 +219,19 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .load_read_view(runtime_read_load_context(options))
             .await?;
         view.grep(&self.store, request).await
+    }
+
+    /// Loads the coherent read view passed to `loonfs-grep`.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`. The old
+    /// [`Self::grep_with_runtime_context`] remains callable only as the
+    /// differential-test reference until the final core-deletion change.
+    pub async fn load_grep_view_with_runtime_context<'a>(
+        &'a self,
+        options: &'a RuntimeReadContext,
+    ) -> CoreResult<LoadedMetadataView<'a, S>> {
+        self.load_read_view(runtime_read_load_context(options))
+            .await
     }
 
     /// Lists one revision page for a path against the pinned runtime read context.

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -111,9 +111,9 @@ pub mod publish {
 }
 
 pub use checkpoint::{
-    GramIndexBuildOutcome, GramIndexBuildPolicy, GramIndexBuildReport, GramIndexDisableOutcome,
-    GramIndexEnableOutcome, GramIndexFoldOutcome, GramIndexFoldReport, MetadataReorganizeOutcome,
-    MetadataReorganizeReport,
+    is_indexable_text_content, GramIndexBuildOutcome, GramIndexBuildPolicy, GramIndexBuildReport,
+    GramIndexDisableOutcome, GramIndexEnableOutcome, GramIndexFoldOutcome, GramIndexFoldReport,
+    MetadataReorganizeOutcome, MetadataReorganizeReport,
 };
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;
@@ -133,4 +133,10 @@ pub mod grep_limits {
     pub use crate::path::read::{
         DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,
     };
+}
+
+/// Concrete read-view types consumed by `loonfs-grep`.
+pub mod grep {
+    pub use crate::metadata::MetadataViewSession;
+    pub use crate::path::read::LoadedMetadataView;
 }

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -43,7 +43,8 @@ pub use self::rows::{
 
 pub(crate) use self::durable_cache::DurableVisibilityCache;
 pub(crate) use self::view::{InMemoryMetadataView, MetadataView};
-pub(crate) use self::view_session::{MetadataViewSession, VisibleChildEntry};
+pub use self::view_session::MetadataViewSession;
+pub(crate) use self::view_session::VisibleChildEntry;
 pub(crate) use self::visibility::{unbind_matches_binding, BindingIdentity};
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -73,7 +73,11 @@ pub(crate) struct MetadataViewSessionCounters {
     pub(crate) list_preload_child_lookups: u64,
 }
 
-pub(crate) struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
+/// One loaded-view session with memoized visibility reads.
+///
+/// This is part of the read surface consumed by `loonfs-grep`; construction
+/// stays on the loaded view so callers cannot assemble incoherent sessions.
+pub struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
     base: MetadataView<'a, 'store, S>,
     inode_at_seq_cache: HashMap<InodeId, Option<InodeRecord>>,
     visible_inode_cache: HashMap<InodeId, Option<InodeRecord>>,
@@ -393,7 +397,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     /// have fetched. The canonical rules then decide over cache hits, so a
     /// cold resolution costs one round-trip wave per path component instead
     /// of five-plus sequential lookups each.
-    pub(crate) async fn resolve_visible_path(
+    /// Resolves a path under the loaded view's visibility rules.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub async fn resolve_visible_path(
         &mut self,
         absolute_path: &AbsolutePath,
         prefetch_leaf_revision: bool,
@@ -596,7 +603,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         visibility::visible_child(self, parent_inode_id, name_key).await
     }
 
-    pub(crate) async fn visible_inode(
+    /// Returns the inode when it is visible in this session's snapshot.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub async fn visible_inode(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
@@ -629,7 +639,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     /// child-binds scan and tombstone probe per entry on a wide listing,
     /// and it can never disagree with the enumeration that just admitted
     /// the entry at the same seq.
-    pub(crate) async fn latest_revision_head_of_visible(
+    /// Returns the latest revision for an inode already proven visible.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub async fn latest_revision_head_of_visible(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<RevisionRecord>, CoreError> {
@@ -655,7 +668,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             .await
     }
 
-    pub(crate) async fn current_parent_binding_for_child(
+    /// Returns the child's active parent binding at the visible sequence.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub async fn current_parent_binding_for_child(
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -20,9 +20,14 @@ use crate::path::helpers::{map_path_error_to_core, parse_absolute_path_for_core}
 use crate::storage::content::read_durable_content_bytes;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceState};
+use loonfs_api::wire::index_grams::{
+    IndexGramsCodecError, IndexGramsFeature, INDEX_FAMILY_GRAMS, INDEX_GRAMS_FEATURE_KEY,
+};
+use loonfs_api::wire::manifest::{IndexFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::ManifestObjectId;
 use loonfs_api::{
-    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ContentStoreId,
+    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentStoreId,
     DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind,
     ManifestId, NamePolicy, NamespaceId, Page, PageRequest, RevisionNo,
 };
@@ -132,7 +137,11 @@ pub(crate) async fn load_metadata_view<'a, S: ObjectStore + ?Sized>(
     }
 }
 
-pub(crate) struct LoadedMetadataView<'a, S: ObjectStore + ?Sized> {
+/// A coherent, seq-pinned namespace read view.
+///
+/// This is part of the read surface consumed by `loonfs-grep`; applications
+/// should continue to use the runtime handles.
+pub struct LoadedMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) namespace_id: NamespaceId,
     pub(super) content_store_id: ContentStoreId,
     name_policy: NamePolicy,
@@ -142,6 +151,144 @@ pub(crate) struct LoadedMetadataView<'a, S: ObjectStore + ?Sized> {
 }
 
 impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
+    /// Returns the namespace bound to this loaded view.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    /// Returns the coherent head bound to this loaded view.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub fn head(&self) -> &HeadState {
+        &self.head
+    }
+
+    /// Returns the durable content-store identity for this namespace.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub fn content_store_id(&self) -> &ContentStoreId {
+        &self.content_store_id
+    }
+
+    /// Opens the memoized visibility session used by one grep page.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`.
+    pub fn grep_session(&self) -> MetadataViewSession<'_, '_, S> {
+        self.metadata_view().session()
+    }
+
+    /// Returns the materialized gram-index watermark and segment descriptors.
+    ///
+    /// This is part of the read surface consumed by `loonfs-grep`. The tuple
+    /// deliberately contains API vocabulary rather than a grep-owned type so
+    /// `loonfs-core` remains independent of `loonfs-grep`.
+    pub fn grep_index_snapshot_parts(&self) -> Result<(ChangeSeq, Vec<IndexFileRef>), CoreError> {
+        let manifest = self.tables.manifest();
+        let Some(value) = manifest.payload.features.get(INDEX_GRAMS_FEATURE_KEY) else {
+            return Err(CoreError::FeatureNotMaterialized {
+                feature: INDEX_GRAMS_FEATURE_KEY.to_owned(),
+            });
+        };
+        let feature = IndexGramsFeature::from_value(value).map_err(|error| match error {
+            IndexGramsCodecError::UnsupportedFeatureVersion { .. } => {
+                CoreError::FeatureNotMaterialized {
+                    feature: INDEX_GRAMS_FEATURE_KEY.to_owned(),
+                }
+            }
+            error => CoreError::NamespaceCorrupt(format!(
+                "namespace `{}` carries an unreadable index.grams feature value: {error}",
+                self.namespace_id.as_str()
+            )),
+        })?;
+        if !feature.is_materialized() {
+            return Err(CoreError::FeatureNotMaterialized {
+                feature: INDEX_GRAMS_FEATURE_KEY.to_owned(),
+            });
+        }
+        Ok((
+            feature.built_through_seq,
+            manifest
+                .payload
+                .index_files
+                .iter()
+                .filter(|segment| segment.family == INDEX_FAMILY_GRAMS)
+                .cloned()
+                .collect(),
+        ))
+    }
+
+    /// Loads one ordered page of revision-family row keys and inode ids.
+    ///
+    /// This is the narrow revision scan surface consumed by `loonfs-grep` for
+    /// plan-less queries; no other metadata family or table primitive is
+    /// exposed.
+    pub async fn grep_revision_inode_page(
+        &self,
+        lower_bound: &str,
+        upper_bound: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(String, InodeId)>, CoreError> {
+        let page = self
+            .tables
+            .scan_range_page_with_keys(
+                MetadataTableFamily::Revisions,
+                lower_bound,
+                upper_bound,
+                limit,
+            )
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
+        Ok(page
+            .into_iter()
+            .filter_map(|(row_key, row)| match row {
+                MetadataRow::Revision { inode_id, .. } => Some((row_key, inode_id)),
+                _ => None,
+            })
+            .collect())
+    }
+
+    /// Loads the validated WAL commit records after an index watermark.
+    ///
+    /// This is the narrow WAL-tail read surface consumed by `loonfs-grep`;
+    /// the service owns revision selection and all query policy while core
+    /// keeps WAL framing and validation private.
+    pub async fn grep_wal_records_after(
+        &self,
+        store: &S,
+        built_through_seq: ChangeSeq,
+    ) -> Result<Vec<WalCommitPayload>, CoreError> {
+        if built_through_seq >= self.head.seq {
+            return Ok(Vec::new());
+        }
+        let manifest = self.tables.manifest();
+        let wal_chain = load_validated_wal_chain(
+            store,
+            WalChainLoadRequest {
+                namespace_id: &self.namespace_id,
+                chain_base_seq: manifest.payload.retention_floor_seq,
+                head_seq: self.head.seq,
+                visible_tip: self.head.visible_wal_tip.clone(),
+                stop_after_seq: Some(built_through_seq),
+                recent_segments: &self.head.recent_segments,
+            },
+        )
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+        })?;
+        Ok(wal_chain
+            .segments()
+            .iter()
+            .flat_map(|segment| segment.records())
+            .filter(|record| record.seq > built_through_seq)
+            .cloned()
+            .collect())
+    }
+
     async fn load_at_head(
         store: &'a S,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -5,7 +5,8 @@ mod grep;
 mod listing;
 mod materialized_view;
 
-pub(crate) use materialized_view::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
+pub use materialized_view::LoadedMetadataView;
+pub(crate) use materialized_view::{load_metadata_view, ReadLoadContext};
 
 pub use grep::{
     DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -14,12 +14,17 @@ path = "src/main.rs"
 
 [dependencies]
 bytes.workspace = true
+futures.workspace = true
 loonfs-api = { path = "../loonfs-api" }
+loonfs-core = { path = "../loonfs-core" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
+regex.workspace = true
+regex-syntax.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 ciborium.workspace = true

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -1,0 +1,132 @@
+//! Grep-private cache for decoded immutable index-segment blocks.
+
+use loonfs_api::wire::index_grams::IndexRow;
+use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+/// Maximum decoded segment sections retained by one grep service.
+pub(crate) const MAX_CACHED_GREP_BLOCKS: usize = 4_096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum GrepBlockKind {
+    Filter,
+    Index,
+    Data,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct GrepBlockCacheKey {
+    pub(crate) payload_checksum: String,
+    pub(crate) block_kind: GrepBlockKind,
+    pub(crate) block_offset: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DecodedGrepBlock {
+    Filter(Arc<SegmentFilter>),
+    Index(Arc<Vec<SegmentIndexEntry>>),
+    Data(Arc<DecodedDataBlock<IndexRow>>),
+}
+
+#[derive(Debug)]
+pub(crate) struct GrepBlockCache {
+    max_blocks: usize,
+    inner: Mutex<GrepBlockCacheInner>,
+}
+
+#[derive(Debug, Default)]
+struct GrepBlockCacheInner {
+    entries: HashMap<GrepBlockCacheKey, CacheSlot>,
+    order: VecDeque<(GrepBlockCacheKey, u64)>,
+    touch_counter: u64,
+}
+
+#[derive(Debug)]
+struct CacheSlot {
+    block: DecodedGrepBlock,
+    last_touch: u64,
+}
+
+impl GrepBlockCache {
+    pub(crate) fn new(max_blocks: usize) -> Self {
+        Self {
+            max_blocks,
+            inner: Mutex::new(GrepBlockCacheInner::default()),
+        }
+    }
+
+    pub(crate) fn get(&self, key: &GrepBlockCacheKey) -> Option<DecodedGrepBlock> {
+        if self.max_blocks == 0 {
+            return None;
+        }
+        let mut inner = self.inner.lock().expect("grep block cache lock poisoned");
+        let block = inner.entries.get(key)?.block.clone();
+        inner.touch(key);
+        inner.compact_if_needed(self.max_blocks);
+        Some(block)
+    }
+
+    pub(crate) fn insert(&self, key: GrepBlockCacheKey, block: DecodedGrepBlock) {
+        if self.max_blocks == 0 {
+            return;
+        }
+        let mut inner = self.inner.lock().expect("grep block cache lock poisoned");
+        let stamp = inner.next_stamp();
+        inner.entries.insert(
+            key.clone(),
+            CacheSlot {
+                block,
+                last_touch: stamp,
+            },
+        );
+        inner.order.push_back((key, stamp));
+        while inner.entries.len() > self.max_blocks {
+            inner.evict_oldest();
+        }
+        inner.compact_if_needed(self.max_blocks);
+    }
+}
+
+impl GrepBlockCacheInner {
+    fn next_stamp(&mut self) -> u64 {
+        self.touch_counter = self.touch_counter.saturating_add(1);
+        self.touch_counter
+    }
+
+    fn touch(&mut self, key: &GrepBlockCacheKey) {
+        let stamp = self.next_stamp();
+        let Some(slot) = self.entries.get_mut(key) else {
+            return;
+        };
+        slot.last_touch = stamp;
+        self.order.push_back((key.clone(), stamp));
+    }
+
+    fn evict_oldest(&mut self) {
+        while let Some((key, stamp)) = self.order.pop_front() {
+            if self
+                .entries
+                .get(&key)
+                .is_some_and(|slot| slot.last_touch == stamp)
+            {
+                self.entries.remove(&key);
+                return;
+            }
+        }
+    }
+
+    fn compact_if_needed(&mut self, max_blocks: usize) {
+        let queue_limit = max_blocks.saturating_mul(4).max(1);
+        if self.order.len() <= queue_limit {
+            return;
+        }
+        let mut live = self
+            .entries
+            .iter()
+            .map(|(key, slot)| (key.clone(), slot.last_touch))
+            .collect::<Vec<_>>();
+        live.sort_by_key(|(_, stamp)| *stamp);
+        self.order = live.into();
+    }
+}

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -1,0 +1,128 @@
+//! Cached reads of gram-index segment filter, index, and data blocks.
+
+use crate::cache::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
+use loonfs_api::wire::index_grams::IndexRow;
+use loonfs_api::wire::sst_blocks::{
+    decode_data_block_rows, decode_filter_block, decode_index_block, BlockHandle, DecodedDataBlock,
+    SegmentFilter, SegmentIndexEntry,
+};
+use loonfs_core::{Error as CoreError, Result, StoreFailureClass};
+use loonfs_objectstore::{ByteRange, ObjectStore};
+use std::sync::Arc;
+
+pub(crate) fn index_segment_corrupt(
+    object_key: &str,
+    what: &str,
+    error: &dyn std::fmt::Display,
+) -> CoreError {
+    CoreError::NamespaceCorrupt(format!(
+        "index segment `{object_key}` carries an unreadable {what}: {error}"
+    ))
+}
+
+fn cache_key(
+    payload_checksum: &str,
+    block_kind: GrepBlockKind,
+    handle: &BlockHandle,
+) -> GrepBlockCacheKey {
+    GrepBlockCacheKey {
+        payload_checksum: payload_checksum.to_owned(),
+        block_kind,
+        block_offset: handle.offset,
+    }
+}
+
+async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
+    store: &S,
+    object_key: &str,
+    handle: &BlockHandle,
+) -> Result<Vec<u8>> {
+    let end_exclusive = handle
+        .offset
+        .checked_add(u64::from(handle.stored_len))
+        .ok_or_else(|| {
+            CoreError::NamespaceCorrupt(format!(
+                "index segment `{object_key}` descriptor names bytes past the address space"
+            ))
+        })?;
+    let bytes = store
+        .get(
+            object_key,
+            Some(ByteRange {
+                start_inclusive: handle.offset,
+                end_exclusive,
+            }),
+        )
+        .await
+        .map_err(|error| CoreError::Store {
+            object_key: object_key.to_owned(),
+            message: error.message(),
+            class: StoreFailureClass::of(&error),
+        })?
+        .ok_or_else(|| {
+            CoreError::NamespaceCorrupt(format!(
+                "manifest references missing index segment `{object_key}`"
+            ))
+        })?;
+    Ok(bytes.to_vec())
+}
+
+pub(crate) async fn load_filter_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    cache: &GrepBlockCache,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<SegmentFilter>> {
+    let key = cache_key(payload_checksum, GrepBlockKind::Filter, handle);
+    if let Some(DecodedGrepBlock::Filter(filter)) = cache.get(&key) {
+        return Ok(filter);
+    }
+    let bytes = load_index_section_bytes(store, object_key, handle).await?;
+    let filter = Arc::new(
+        decode_filter_block(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?,
+    );
+    cache.insert(key, DecodedGrepBlock::Filter(Arc::clone(&filter)));
+    Ok(filter)
+}
+
+pub(crate) async fn load_index_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    cache: &GrepBlockCache,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<Vec<SegmentIndexEntry>>> {
+    let key = cache_key(payload_checksum, GrepBlockKind::Index, handle);
+    if let Some(DecodedGrepBlock::Index(entries)) = cache.get(&key) {
+        return Ok(entries);
+    }
+    let bytes = load_index_section_bytes(store, object_key, handle).await?;
+    let entries = Arc::new(
+        decode_index_block(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?,
+    );
+    cache.insert(key, DecodedGrepBlock::Index(Arc::clone(&entries)));
+    Ok(entries)
+}
+
+pub(crate) async fn load_data_block<S: ObjectStore + ?Sized>(
+    store: &S,
+    cache: &GrepBlockCache,
+    object_key: &str,
+    payload_checksum: &str,
+    handle: &BlockHandle,
+) -> Result<Arc<DecodedDataBlock<IndexRow>>> {
+    let key = cache_key(payload_checksum, GrepBlockKind::Data, handle);
+    if let Some(DecodedGrepBlock::Data(block)) = cache.get(&key) {
+        return Ok(block);
+    }
+    let bytes = load_index_section_bytes(store, object_key, handle).await?;
+    let block = Arc::new(
+        decode_data_block_rows::<IndexRow>(&bytes, handle)
+            .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?,
+    );
+    cache.insert(key, DecodedGrepBlock::Data(Arc::clone(&block)));
+    Ok(block)
+}

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -3,12 +3,21 @@
 //! Grep durable state lives under a grep-owned keyspace and is independent
 //! of the namespace manifest. A missing or corrupt grep root disables grep
 //! work for that namespace; it must never affect core filesystem operation.
-//! Query execution, storage maintenance, and the standalone worker arrive
-//! in later changes.
+//! Query execution reads a caller-provided core snapshot; storage maintenance
+//! and the standalone worker arrive in later changes.
 
+mod cache;
 pub mod codec;
+mod index_read;
 pub mod keyspace;
+mod query;
 pub mod root;
+mod service;
+
+pub use service::{
+    is_indexable_text_content, GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT,
+    MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,
+};
 
 use std::io::Write as _;
 use std::process::ExitCode;

--- a/crates/loonfs-grep/src/query.rs
+++ b/crates/loonfs-grep/src/query.rs
@@ -1,0 +1,386 @@
+//! Gram query planning: turns a pattern into the grams any match must
+//! contain — the classic code-search transformation, conservatively.
+//!
+//! The plan is an AND of OR-sets over case-folded grams. Soundness is the
+//! only obligation: every true match satisfies the plan, so dropping a
+//! constraint (a complex subexpression, a wide alternation, a non-ASCII
+//! case pair) costs candidates, never correctness — verification runs the
+//! real pattern over every candidate. A pattern that yields no constraint
+//! at all is unindexable and the caller decides between rejection and a
+//! capped scan.
+//!
+//! The analysis walks the parsed pattern tracking runs of fixed bytes.
+//! Case-insensitive patterns parse into character classes; a class whose
+//! members fold to one ASCII byte extends the run (matching the index's
+//! ASCII-folded tokenizer), anything wider breaks it. Zero-width
+//! constructs (anchors, look-around the dialect permits) pass through;
+//! optional or repeated subexpressions contribute their inner constraints
+//! only when they must occur.
+
+use loonfs_api::wire::index_grams::{extract_grams, Gram, GRAM_LEN};
+use regex_syntax::hir::{Class, Hir, HirKind, Look, Repetition};
+use std::collections::BTreeSet;
+
+/// AND of OR-sets: a candidate must contain, for every set, at least one
+/// of the set's grams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GramQueryPlan {
+    pub(crate) required: Vec<BTreeSet<Gram>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GramPlanOutcome {
+    Indexable(GramQueryPlan),
+    /// No construct requires any literal bytes; the index cannot narrow
+    /// candidates.
+    Unindexable,
+}
+
+/// AND-sets kept per plan; extra constraints are dropped (sound: fewer
+/// constraints only widen the candidate set).
+const MAX_REQUIRED_SETS: usize = 16;
+/// Branches an alternation may contribute to one OR-set before the set is
+/// dropped as unselective.
+const MAX_OR_SET_GRAMS: usize = 64;
+
+/// Plans a pattern. `Err` is a pattern-syntax problem; `Unindexable` is a
+/// valid pattern with no required bytes.
+pub(crate) fn plan_pattern(
+    pattern: &str,
+    case_insensitive: bool,
+) -> Result<GramPlanOutcome, String> {
+    let hir = regex_syntax::ParserBuilder::new()
+        .utf8(false)
+        .case_insensitive(case_insensitive)
+        // Matches the executor's line-anchored compilation; the analysis
+        // must see the same pattern the verifier runs.
+        .multi_line(true)
+        .build()
+        .parse(pattern)
+        .map_err(|error| error.to_string())?;
+    let analysis = analyze(&hir);
+    let mut required = analysis.sets;
+    if let Some(run) = analysis.run {
+        push_run_grams(&mut required, &run);
+    }
+    required.retain(|set| !set.is_empty() && set.len() <= MAX_OR_SET_GRAMS);
+    required.sort();
+    required.dedup();
+    required.truncate(MAX_REQUIRED_SETS);
+    if required.is_empty() {
+        Ok(GramPlanOutcome::Unindexable)
+    } else {
+        Ok(GramPlanOutcome::Indexable(GramQueryPlan { required }))
+    }
+}
+
+/// What one subexpression guarantees about any text it matches.
+struct Analysis {
+    /// Gram constraints every match of this subexpression satisfies.
+    sets: Vec<BTreeSet<Gram>>,
+    /// When the subexpression matches exactly one folded byte string, that
+    /// string — so concatenation can join runs across children before
+    /// extracting grams.
+    run: Option<Vec<u8>>,
+}
+
+impl Analysis {
+    fn unconstrained() -> Self {
+        Self {
+            sets: Vec::new(),
+            run: None,
+        }
+    }
+
+    fn empty_match() -> Self {
+        Self {
+            sets: Vec::new(),
+            run: Some(Vec::new()),
+        }
+    }
+
+    /// True when a match implies at least one gram.
+    fn constrains(&self) -> bool {
+        !self.sets.is_empty() || self.run.as_ref().is_some_and(|run| run.len() >= GRAM_LEN)
+    }
+
+    /// Every gram some match of this subexpression must contain.
+    fn all_grams(&self) -> BTreeSet<Gram> {
+        let mut grams: BTreeSet<Gram> = self.sets.iter().flatten().copied().collect();
+        if let Some(run) = &self.run {
+            grams.extend(extract_grams(run));
+        }
+        grams
+    }
+}
+
+fn analyze(hir: &Hir) -> Analysis {
+    match hir.kind() {
+        HirKind::Empty => Analysis::empty_match(),
+        HirKind::Literal(literal) => Analysis {
+            sets: Vec::new(),
+            run: Some(fold_bytes(&literal.0)),
+        },
+        HirKind::Class(class) => match single_folded_byte(class) {
+            Some(byte) => Analysis {
+                sets: Vec::new(),
+                run: Some(vec![byte]),
+            },
+            None => Analysis::unconstrained(),
+        },
+        // Zero-width assertions match the empty string between bytes; they
+        // neither add constraints nor break a byte run.
+        HirKind::Look(look) => match look {
+            Look::Start
+            | Look::End
+            | Look::StartLF
+            | Look::EndLF
+            | Look::StartCRLF
+            | Look::EndCRLF
+            | Look::WordAscii
+            | Look::WordAsciiNegate
+            | Look::WordUnicode
+            | Look::WordUnicodeNegate
+            | Look::WordStartAscii
+            | Look::WordEndAscii
+            | Look::WordStartUnicode
+            | Look::WordEndUnicode
+            | Look::WordStartHalfAscii
+            | Look::WordEndHalfAscii
+            | Look::WordStartHalfUnicode
+            | Look::WordEndHalfUnicode => Analysis::empty_match(),
+        },
+        HirKind::Repetition(Repetition { min, max, sub, .. }) => {
+            if *min == 0 {
+                return Analysis::unconstrained();
+            }
+            let inner = analyze(sub);
+            if *min == 1 && *max == Some(1) {
+                return inner;
+            }
+            // The subexpression occurs at least once, so its constraints
+            // hold; its bytes are not a fixed run at this position.
+            let mut sets = inner.sets;
+            if let Some(run) = inner.run {
+                push_run_grams(&mut sets, &run);
+            }
+            Analysis { sets, run: None }
+        }
+        HirKind::Capture(capture) => analyze(&capture.sub),
+        HirKind::Concat(children) => {
+            let mut sets = Vec::new();
+            let mut pending_run: Option<Vec<u8>> = Some(Vec::new());
+            for child in children {
+                let child_analysis = analyze(child);
+                sets.extend(child_analysis.sets);
+                match (pending_run.as_mut(), child_analysis.run) {
+                    (Some(run), Some(child_run)) => run.extend_from_slice(&child_run),
+                    (run_slot, child_run) => {
+                        // The fixed run ends here (or the child restarts
+                        // one): bank the accumulated bytes as grams.
+                        if let Some(run) = run_slot.map(std::mem::take) {
+                            push_run_grams(&mut sets, &run);
+                        }
+                        pending_run = child_run;
+                    }
+                }
+            }
+            match pending_run {
+                // Every child was a fixed run: the whole concat is one.
+                Some(run) if sets.is_empty() => Analysis {
+                    sets,
+                    run: Some(run),
+                },
+                Some(run) => {
+                    push_run_grams(&mut sets, &run);
+                    Analysis { sets, run: None }
+                }
+                None => Analysis { sets, run: None },
+            }
+        }
+        HirKind::Alternation(branches) => {
+            // Any match satisfies one branch, so one sound constraint is
+            // "some gram from each branch's guarantees": the union over
+            // branches, provided every branch guarantees something.
+            let mut or_set = BTreeSet::new();
+            for branch in branches {
+                let branch_analysis = analyze(branch);
+                if !branch_analysis.constrains() {
+                    return Analysis::unconstrained();
+                }
+                or_set.extend(branch_analysis.all_grams());
+            }
+            Analysis {
+                sets: vec![or_set],
+                run: None,
+            }
+        }
+    }
+}
+
+/// Adds each gram of a completed fixed-byte run as its own AND constraint.
+fn push_run_grams(sets: &mut Vec<BTreeSet<Gram>>, run: &[u8]) {
+    for gram in extract_grams(run) {
+        sets.push(BTreeSet::from([gram]));
+    }
+}
+
+fn fold_bytes(bytes: &[u8]) -> Vec<u8> {
+    bytes.iter().map(|byte| byte.to_ascii_lowercase()).collect()
+}
+
+/// The one ASCII-folded byte every member of the class becomes, if the
+/// class is that narrow. `[Aa]` folds to `a`; anything wider (real
+/// character choices, non-ASCII case pairs) returns `None`.
+fn single_folded_byte(class: &Class) -> Option<u8> {
+    let mut folded: Option<u8> = None;
+    let mut fold_into = |byte: u8| -> bool {
+        let byte = byte.to_ascii_lowercase();
+        match folded {
+            None => {
+                folded = Some(byte);
+                true
+            }
+            Some(existing) => existing == byte,
+        }
+    };
+    match class {
+        Class::Bytes(class) => {
+            for range in class.ranges() {
+                for byte in range.start()..=range.end() {
+                    if !fold_into(byte) {
+                        return None;
+                    }
+                }
+            }
+        }
+        Class::Unicode(class) => {
+            for range in class.ranges() {
+                for character in range.start()..=range.end() {
+                    let mut buffer = [0u8; 4];
+                    let encoded = character.encode_utf8(&mut buffer).as_bytes();
+                    if encoded.len() != 1 || !fold_into(encoded[0]) {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+    folded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grams(plan: &GramPlanOutcome) -> Vec<Vec<String>> {
+        let GramPlanOutcome::Indexable(plan) = plan else {
+            unreachable!("expected an indexable plan");
+        };
+        plan.required
+            .iter()
+            .map(|set| set.iter().map(Gram::as_hex).collect())
+            .collect()
+    }
+
+    fn gram(text: &[u8; 3]) -> String {
+        Gram(*text).as_hex()
+    }
+
+    #[test]
+    fn literals_require_their_grams() {
+        let plan = plan_pattern("needle", false).expect("plan");
+        let sets = grams(&plan);
+        assert!(sets.contains(&vec![gram(b"nee")]));
+        assert!(sets.contains(&vec![gram(b"dle")]));
+    }
+
+    #[test]
+    fn case_insensitive_ascii_folds_into_the_same_grams() {
+        let plan = plan_pattern("NeEdLe", true).expect("plan");
+        let sets = grams(&plan);
+        assert!(sets.contains(&vec![gram(b"nee")]));
+    }
+
+    #[test]
+    fn concatenation_joins_runs_across_groups_and_anchors() {
+        let plan = plan_pattern("^(ab)(cd)$", false).expect("plan");
+        let sets = grams(&plan);
+        assert!(sets.contains(&vec![gram(b"abc")]));
+        assert!(sets.contains(&vec![gram(b"bcd")]));
+    }
+
+    #[test]
+    fn alternation_requires_a_gram_from_some_branch() {
+        let plan = plan_pattern("needle|haystack", false).expect("plan");
+        let sets = grams(&plan);
+        assert_eq!(sets.len(), 1);
+        assert!(sets[0].contains(&gram(b"nee")));
+        assert!(sets[0].contains(&gram(b"hay")));
+    }
+
+    #[test]
+    fn optional_and_star_contribute_nothing() {
+        assert_eq!(
+            plan_pattern("(needle)?", false).expect("plan"),
+            GramPlanOutcome::Unindexable
+        );
+        assert_eq!(
+            plan_pattern(".*", false).expect("plan"),
+            GramPlanOutcome::Unindexable
+        );
+        assert_eq!(
+            plan_pattern("ab", false).expect("plan"),
+            GramPlanOutcome::Unindexable,
+            "two bytes cannot form a gram"
+        );
+    }
+
+    #[test]
+    fn plus_requires_its_inner_grams() {
+        let plan = plan_pattern("(needle)+", false).expect("plan");
+        let sets = grams(&plan);
+        assert!(sets.contains(&vec![gram(b"nee")]));
+    }
+
+    #[test]
+    fn unconstrained_alternation_branches_disable_the_set() {
+        assert_eq!(
+            plan_pattern("needle|n.", false).expect("plan"),
+            GramPlanOutcome::Unindexable
+        );
+    }
+
+    #[test]
+    fn wildcards_break_runs_but_keep_both_sides() {
+        let plan = plan_pattern("foo.+bar", false).expect("plan");
+        let sets = grams(&plan);
+        assert!(sets.contains(&vec![gram(b"foo")]));
+        assert!(sets.contains(&vec![gram(b"bar")]));
+    }
+
+    #[test]
+    fn non_ascii_case_pairs_stay_conservative() {
+        // The folded index cannot answer for ß/SS pairs; the planner must
+        // not require grams it will never find.
+        let plan = plan_pattern("straße", true).expect("plan");
+        match plan {
+            GramPlanOutcome::Indexable(plan) => {
+                for set in &plan.required {
+                    for gram in set {
+                        assert!(
+                            gram.0.iter().all(|byte| byte.is_ascii()),
+                            "non-ASCII grams must not be required under (?i)"
+                        );
+                    }
+                }
+            }
+            GramPlanOutcome::Unindexable => {}
+        }
+    }
+
+    #[test]
+    fn invalid_patterns_error() {
+        assert!(plan_pattern("(unclosed", false).is_err());
+    }
+}

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -1,0 +1,974 @@
+//! [`GrepService`]: query planning and execution over a core read view.
+
+use crate::cache::{GrepBlockCache, MAX_CACHED_GREP_BLOCKS};
+use crate::index_read::{
+    index_segment_corrupt, load_data_block, load_filter_block, load_index_block,
+};
+use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
+use futures::future::{join_all, try_join_all};
+use loonfs_api::wire::index_grams::{
+    lookup, Gram, IndexRow, INDEX_FAMILY_GRAMS, INDEX_GRAMS_MAX_FILE_BYTES,
+};
+use loonfs_api::wire::manifest::{hex_decode_bytes, IndexFileRef};
+use loonfs_api::wire::sst_blocks::{decode_filter_block, index_blocks_for_key_range};
+use loonfs_api::wire::wal::WalDelta;
+use loonfs_api::{
+    decode_grep_cursor, encode_grep_cursor, AbsolutePath, ChangeSeq, GrepMatch, GrepPageCursor,
+    GrepRequest, GrepResponse, InodeId, RevisionNo,
+};
+use loonfs_core::content::read_durable_content_bytes;
+use loonfs_core::grep::{LoadedMetadataView, MetadataViewSession};
+use loonfs_core::metadata::RevisionRecord;
+use loonfs_core::{Error as CoreError, MetadataViewError, Result};
+use loonfs_objectstore::ObjectStore;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Matches returned per page when the request names no limit.
+pub const DEFAULT_GREP_PAGE_LIMIT: usize = 100;
+/// Largest per-page match limit a request may name.
+pub const MAX_GREP_PAGE_LIMIT: usize = 1000;
+/// Unindexed-tail revisions one query will scan exhaustively before
+/// failing with `index_lagging` (or skipping the tail under `allow_stale`).
+/// Advertised as the `query.grep.tail_budget_files` capability limit.
+pub const MAX_GREP_TAIL_FILES: usize = 512;
+/// Files a plan-less `allow_scan` query will scan before refusing.
+/// Advertised as the `query.grep.scan_budget_files` capability limit.
+pub const MAX_GREP_SCAN_FILES: usize = 4096;
+/// Longest match line returned, in bytes; longer lines are truncated.
+pub(crate) const GREP_LINE_CAP_BYTES: usize = 512;
+/// Candidate files one page will read and verify before returning with a
+/// resume cursor, so a page's cost is bounded by its own budget rather
+/// than by how many false-positive candidates the plan admits.
+pub(crate) const MAX_GREP_VERIFIED_FILES_PER_PAGE: usize = 256;
+/// Candidates one page will examine — visibility, latest revision, path
+/// derivation, scope — before returning with a resume cursor: the metadata
+/// twin of [`MAX_GREP_VERIFIED_FILES_PER_PAGE`], for pages where a scope
+/// filter rejects nearly every candidate. Rejected candidates move the
+/// cursor with them (see `fold_rejected_frontier`), so the next page
+/// continues past them instead of re-examining the same run.
+pub(crate) const MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE: usize = 4096;
+/// Concurrent gram posting probes one grep query issues at a time: the
+/// (gram, segment) probes of an OR-set fan out in chunks of this size,
+/// each probe a handful of small ranged GETs (filter, index, and posting
+/// blocks). Deliberately below [`MAX_GREP_CONTENT_IO`]: probes multiply
+/// into many small requests per chunk, where a content read is one whole
+/// object. The read-side sibling of the maintenance path's
+/// `MAX_MAINTENANCE_TABLE_IO` (`checkpoint/runs.rs`), which stays at its
+/// own value.
+pub(crate) const MAX_GREP_READ_IO: usize = 16;
+/// Concurrent candidate content reads one grep query issues at a time.
+/// Content verification is a whole-object GET of a small file (index
+/// eligibility caps candidates at `INDEX_GRAMS_MAX_FILE_BYTES`), so it
+/// tolerates a wider fan-out than the posting probes: 32 matches the
+/// content-object concurrency the ecosystem already runs against these
+/// stores (bulk content uploads fan out 32 wide). Each batch is
+/// additionally bounded by the remaining
+/// [`MAX_GREP_VERIFIED_FILES_PER_PAGE`] budget, so a page issues at most
+/// that many content reads however wide the batches are.
+pub(crate) const MAX_GREP_CONTENT_IO: usize = 32;
+
+/// The immutable gram-index state one query reads.
+#[derive(Debug, Clone)]
+pub struct GrepIndexSnapshot {
+    state: Result<MaterializedGrepIndexSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+struct MaterializedGrepIndexSnapshot {
+    built_through_seq: ChangeSeq,
+    segments: Vec<IndexFileRef>,
+}
+
+impl GrepIndexSnapshot {
+    /// Builds a materialized snapshot from its watermark and gram segments.
+    pub fn new(built_through_seq: ChangeSeq, segments: Vec<IndexFileRef>) -> Self {
+        Self {
+            state: Ok(MaterializedGrepIndexSnapshot {
+                built_through_seq,
+                segments,
+            }),
+        }
+    }
+
+    /// Captures core's snapshot load result without changing request-error
+    /// precedence; [`GrepService::query`] resolves it after limit and cursor
+    /// validation at the same point the reference executor loaded the feature.
+    pub fn from_core_parts(parts: Result<(ChangeSeq, Vec<IndexFileRef>)>) -> Self {
+        match parts {
+            Ok((built_through_seq, segments)) => Self::new(built_through_seq, segments),
+            Err(error) => Self { state: Err(error) },
+        }
+    }
+
+    fn materialized(&self) -> Result<&MaterializedGrepIndexSnapshot> {
+        self.state.as_ref().map_err(Clone::clone)
+    }
+}
+
+/// Namespace-independent grep execution with its own decoded-block cache.
+#[derive(Debug)]
+pub struct GrepService {
+    block_cache: GrepBlockCache,
+}
+
+impl GrepService {
+    /// Creates a service with the fixed grep-private block-cache bound.
+    pub fn new() -> Self {
+        Self {
+            block_cache: GrepBlockCache::new(MAX_CACHED_GREP_BLOCKS),
+        }
+    }
+}
+
+impl Default for GrepService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The revisions a query must examine, keyed by durable inode identity.
+#[derive(Debug, Default)]
+struct GrepCandidates {
+    /// Index-supplied candidates: the revisions whose content contained
+    /// every required gram. A candidate survives only if the inode's
+    /// newest visible revision is in its set.
+    indexed: BTreeMap<InodeId, BTreeSet<RevisionNo>>,
+    /// Tail- or scan-supplied candidates: examined whatever their newest
+    /// visible revision is, because no gram filter applies to them.
+    unfiltered: BTreeSet<InodeId>,
+}
+
+impl GrepCandidates {
+    fn inodes(&self) -> impl Iterator<Item = InodeId> + '_ {
+        let mut merged: BTreeSet<InodeId> = self.indexed.keys().copied().collect();
+        merged.extend(self.unfiltered.iter().copied());
+        merged.into_iter()
+    }
+
+    /// Whether the inode's newest visible revision should be verified.
+    fn admits(&self, inode_id: InodeId, revision_no: RevisionNo) -> bool {
+        if self.unfiltered.contains(&inode_id) {
+            return true;
+        }
+        self.indexed
+            .get(&inode_id)
+            .is_some_and(|revisions| revisions.contains(&revision_no))
+    }
+}
+
+/// Evaluates the plan against every gram index segment: for each AND set,
+/// the union of its grams' postings; the candidates are the intersection.
+/// The probes of one AND set — one per surviving (gram, segment) pair —
+/// are independent, so they run concurrently in chunks of
+/// [`MAX_GREP_READ_IO`]; the sets union order-independently, so the
+/// result is identical to a serial evaluation, and an AND set whose
+/// running intersection empties still short-circuits the sets after it.
+///
+/// Probing also stops once the running intersection fits the page's
+/// verification budget ([`MAX_GREP_VERIFIED_FILES_PER_PAGE`]): further AND
+/// sets could only shrink a candidate set the page can already afford to
+/// verify whole. The invariant that makes this sound: dropping AND
+/// constraints only WIDENS the candidate set, and verification runs the
+/// real pattern over every candidate, so grep results are byte-identical
+/// — the only effect is fewer cold posting reads (a rare literal's 16
+/// single-gram sets typically stop after the first few). The stop rule is
+/// deliberately this simple; a refinement that also stops when an AND set
+/// fails to shrink the intersection materially (common terms whose grams
+/// match nearly everything) is left out until evidence demands a
+/// heuristic.
+async fn indexed_candidates<S: ObjectStore + ?Sized>(
+    store: &S,
+    block_cache: &GrepBlockCache,
+    segments: &[IndexFileRef],
+    plan: &GramQueryPlan,
+) -> Result<BTreeMap<InodeId, BTreeSet<RevisionNo>>> {
+    let mut intersection: Option<BTreeSet<(InodeId, RevisionNo)>> = None;
+    for or_set in &plan.required {
+        // Lookup keys derive once per gram; the key-range prune is free
+        // (already in the descriptor), so only surviving probes fan out.
+        let lookups: Vec<GramLookup> = or_set.iter().map(|gram| GramLookup::new(*gram)).collect();
+        let mut probes: Vec<(&GramLookup, &IndexFileRef)> = Vec::new();
+        for gram_lookup in &lookups {
+            for descriptor in segments {
+                if descriptor.family != INDEX_FAMILY_GRAMS {
+                    continue;
+                }
+                if descriptor.max_key.as_str() < gram_lookup.probe.as_str()
+                    || gram_lookup
+                        .upper
+                        .as_deref()
+                        .is_some_and(|upper| descriptor.min_key.as_str() >= upper)
+                {
+                    continue;
+                }
+                probes.push((gram_lookup, descriptor));
+            }
+        }
+        // This union is the query's peak memory: worst case one
+        // (inode, revision) pair per indexed revision when a gram is
+        // common to every file — 16 bytes a pair, on the order of 16 MiB
+        // per million indexed revisions. A streamed merge-intersection
+        // would trade that ceiling for probe-ordering complexity; not
+        // taken until a profile shows these unions dominating.
+        let mut set_postings = BTreeSet::new();
+        for chunk in probes.chunks(MAX_GREP_READ_IO) {
+            let batches = try_join_all(chunk.iter().map(|(gram_lookup, descriptor)| {
+                segment_postings_for_gram(store, block_cache, descriptor, gram_lookup)
+            }))
+            .await?;
+            for batch in batches {
+                set_postings.extend(batch);
+            }
+        }
+        intersection = Some(match intersection {
+            None => set_postings,
+            Some(current) => current.intersection(&set_postings).copied().collect(),
+        });
+        if intersection.as_ref().is_some_and(BTreeSet::is_empty) {
+            break;
+        }
+        // The budget stop: the intersection holds (inode, revision) pairs,
+        // an upper bound on the files a page could ever verify from it, so
+        // once it fits the per-page verification budget the remaining AND
+        // sets are constraints the page cannot use.
+        if intersection
+            .as_ref()
+            .is_some_and(|candidates| candidates.len() <= MAX_GREP_VERIFIED_FILES_PER_PAGE)
+        {
+            break;
+        }
+    }
+    let mut candidates: BTreeMap<InodeId, BTreeSet<RevisionNo>> = BTreeMap::new();
+    for (inode_id, revision_no) in intersection.unwrap_or_default() {
+        candidates.entry(inode_id).or_default().insert(revision_no);
+    }
+    Ok(candidates)
+}
+
+/// One gram's derived lookup keys: the exact filter probe, the row-key
+/// prefix its postings share, and that prefix's exclusive upper bound.
+struct GramLookup {
+    gram: Gram,
+    probe: String,
+    prefix: String,
+    upper: Option<String>,
+}
+
+impl GramLookup {
+    fn new(gram: Gram) -> Self {
+        let probe = lookup::gram_probe(gram);
+        let prefix = lookup::gram_prefix(gram);
+        let upper = string_prefix_upper_bound(&prefix);
+        Self {
+            gram,
+            probe,
+            prefix,
+            upper,
+        }
+    }
+}
+
+fn string_prefix_upper_bound(prefix: &str) -> Option<String> {
+    let mut bytes = prefix.as_bytes().to_vec();
+    for index in (0..bytes.len()).rev() {
+        if bytes[index] != u8::MAX {
+            bytes[index] += 1;
+            bytes.truncate(index + 1);
+            return String::from_utf8(bytes).ok();
+        }
+    }
+    None
+}
+
+/// One gram's postings from one segment: bloom filter first (the inline
+/// copy when the descriptor carries one — no fetch at all — otherwise the
+/// cached filter block), then only the data blocks the segment index
+/// names for the gram's key range, loaded concurrently in chunks of
+/// [`MAX_GREP_READ_IO`] (the cap applies per probe). Every fetched
+/// section resolves through the grep-private decoded-block cache.
+async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
+    store: &S,
+    block_cache: &GrepBlockCache,
+    descriptor: &IndexFileRef,
+    gram_lookup: &GramLookup,
+) -> Result<BTreeSet<(InodeId, RevisionNo)>> {
+    let mut postings = BTreeSet::new();
+    let admitted = match &descriptor.filter_inline {
+        Some(inline) => {
+            let filter_bytes = hex_decode_bytes(inline).map_err(|error| {
+                CoreError::NamespaceCorrupt(format!(
+                    "index segment `{}` carries undecodable inline filter hex: {error}",
+                    descriptor.object_key
+                ))
+            })?;
+            let filter =
+                decode_filter_block(&filter_bytes, &descriptor.filter_block).map_err(|error| {
+                    index_segment_corrupt(&descriptor.object_key, "filter block", &error)
+                })?;
+            filter.may_contain(&gram_lookup.probe)
+        }
+        None => {
+            let filter = load_filter_block(
+                store,
+                block_cache,
+                &descriptor.object_key,
+                &descriptor.payload_checksum,
+                &descriptor.filter_block,
+            )
+            .await?;
+            filter.may_contain(&gram_lookup.probe)
+        }
+    };
+    if !admitted {
+        return Ok(postings);
+    }
+    let entries = load_index_block(
+        store,
+        block_cache,
+        &descriptor.object_key,
+        &descriptor.payload_checksum,
+        &descriptor.index_block,
+    )
+    .await?;
+    let range =
+        index_blocks_for_key_range(&entries, &gram_lookup.prefix, gram_lookup.upper.as_deref());
+    // The range's blocks are independent ranged GETs, so they fan out
+    // instead of paying one round trip each; `try_join_all` returns them
+    // in entry order and rows fold in that order, so assembly stays
+    // deterministic even though the posting union is order-independent.
+    for chunk in entries[range].chunks(MAX_GREP_READ_IO) {
+        let blocks = try_join_all(chunk.iter().map(|entry| {
+            load_data_block(
+                store,
+                block_cache,
+                &descriptor.object_key,
+                &descriptor.payload_checksum,
+                &entry.block,
+            )
+        }))
+        .await?;
+        for block in blocks {
+            for row in &block.rows {
+                let IndexRow::GramPostings { gram: row_gram, .. } = row;
+                if *row_gram != gram_lookup.gram {
+                    continue;
+                }
+                let batch = row.postings().map_err(|error| {
+                    index_segment_corrupt(&descriptor.object_key, "posting batch", &error)
+                })?;
+                postings.extend(
+                    batch
+                        .into_iter()
+                        .map(|posting| (posting.inode_id, posting.revision_no)),
+                );
+            }
+        }
+    }
+    Ok(postings)
+}
+
+/// The file revisions committed after the index watermark, newest revision
+/// per inode, from WAL replay — the exhaustive-scan tail.
+async fn tail_revisions<S: ObjectStore + ?Sized>(
+    store: &S,
+    view: &LoadedMetadataView<'_, S>,
+    built_through_seq: ChangeSeq,
+) -> Result<BTreeSet<InodeId>> {
+    let mut tail = BTreeMap::new();
+    for record in view
+        .grep_wal_records_after(store, built_through_seq)
+        .await?
+    {
+        for delta in &record.deltas {
+            if let WalDelta::AppendFileRevision { inode_id, .. } = &delta.delta {
+                tail.insert(*inode_id, ());
+            }
+        }
+    }
+    Ok(tail.into_keys().collect())
+}
+
+/// One verified line match inside a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LineMatch {
+    line_number: u64,
+    byte_offset: u64,
+    line: String,
+    line_truncated: bool,
+}
+
+/// Runs the pattern over content, one match per line, in offset order.
+/// One forward pass: matches arrive in offset order, so the current line's
+/// bounds and number advance monotonically — a file full of matches costs
+/// one scan of its bytes, never a rescan per match.
+fn line_matches(content: &[u8], pattern: &regex::bytes::Regex) -> Vec<LineMatch> {
+    let mut matches = Vec::new();
+    let mut line_start = 0usize;
+    let mut line_number = 1u64;
+    let mut emitted_line_start = usize::MAX;
+    for found in pattern.find_iter(content) {
+        // Advance the line window forward to the one holding this match.
+        while let Some(newline) = content[line_start..found.start()]
+            .iter()
+            .position(|byte| *byte == b'\n')
+        {
+            line_start += newline + 1;
+            line_number += 1;
+        }
+        if line_start == emitted_line_start {
+            continue;
+        }
+        emitted_line_start = line_start;
+        let line_end = content[found.start()..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(content.len(), |newline| found.start() + newline);
+        let line_bytes = &content[line_start..line_end];
+        let line_truncated = line_bytes.len() > GREP_LINE_CAP_BYTES;
+        let line_bytes = &line_bytes[..line_bytes.len().min(GREP_LINE_CAP_BYTES)];
+        matches.push(LineMatch {
+            line_number,
+            byte_offset: found.start() as u64,
+            line: String::from_utf8_lossy(line_bytes).into_owned(),
+            line_truncated,
+        });
+    }
+    matches
+}
+
+/// Derives the inode's visible absolute path by walking active parent
+/// bindings to the root, then verifies the derived path forward under the
+/// full visibility rules — tombstones, unbinds, kinds — by resolving it
+/// back to the same inode. `None` means the inode is not visible at the
+/// view's sequence. Runs over the page's session so candidates under the
+/// same directories share the ancestor lookups.
+async fn derive_visible_path<S: ObjectStore + ?Sized>(
+    session: &mut MetadataViewSession<'_, '_, S>,
+    inode_id: InodeId,
+) -> Result<Option<VisiblePathChain>> {
+    const MAX_PATH_DEPTH: usize = 4096;
+    let mut segments = Vec::new();
+    // The chain includes the inode itself and every ancestor up to the
+    // root, so scope filters test durable identity instead of comparing
+    // path strings (which would bypass name-policy folding and slash
+    // normalization).
+    let mut ancestors = vec![inode_id];
+    let mut current = inode_id;
+    while current != InodeId(1) {
+        if segments.len() >= MAX_PATH_DEPTH {
+            return Ok(None);
+        }
+        let Some(binding) = session.current_parent_binding_for_child(current).await? else {
+            return Ok(None);
+        };
+        segments.push(binding.display_name.clone());
+        current = binding.parent_inode_id;
+        ancestors.push(current);
+    }
+    segments.reverse();
+    let path = format!("/{}", segments.join("/"));
+    let parsed = match AbsolutePath::parse(&path) {
+        Ok(parsed) => parsed,
+        // A display name the path grammar rejects cannot be served as a
+        // path result; the file is unreachable by path and skipped.
+        Err(_) => return Ok(None),
+    };
+    match session.resolve_visible_path(&parsed, false).await {
+        Ok(resolved) if resolved.inode_id == inode_id => {
+            Ok(Some(VisiblePathChain { path, ancestors }))
+        }
+        Ok(_) => Ok(None),
+        Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Folds the page's highest examined-and-rejected candidate into the resume
+/// cursor on a budget exit. Sound only when every examined candidate is
+/// resolved — rejected, or scanned by a fully-walked batch — which the
+/// budget exits guarantee. Never sound on a mid-file page fill: there,
+/// later batch members were examined but their fetched contents discarded,
+/// and the cursor must stay at the last emitted match.
+fn fold_rejected_frontier(
+    resume_cursor: &mut Option<(InodeId, u64)>,
+    rejected_frontier: Option<InodeId>,
+) {
+    let Some(frontier) = rejected_frontier else {
+        return;
+    };
+    let folded = (frontier, u64::MAX);
+    if resume_cursor.is_none_or(|cursor| cursor < folded) {
+        *resume_cursor = Some(folded);
+    }
+}
+
+/// A derived visible path plus the inode chain that produced it, root
+/// included.
+struct VisiblePathChain {
+    path: String,
+    ancestors: Vec<InodeId>,
+}
+
+/// One grep candidate that survived the cheap visibility checks and awaits
+/// its content read, carrying everything match emission needs so the
+/// fetched batch is processed without further metadata lookups.
+struct GrepContentCandidate {
+    inode_id: InodeId,
+    revision: RevisionRecord,
+    path: String,
+    /// The declared content size exceeds the index eligibility cap, so no
+    /// read is scheduled: the file could never pass the post-read text
+    /// check, and the walk skips it as fully scanned.
+    oversized: bool,
+}
+
+impl GrepService {
+    /// Content search over the view: index-accelerated candidates through
+    /// the `index.grams` watermark, an exhaustive scan of the unindexed
+    /// tail, and real-pattern verification of every candidate. Matches
+    /// order by `(inode_id, byte_offset)`. Two budgets bound a page — the
+    /// match limit and a verified-candidate budget — and the cursor
+    /// resumes strictly after the last candidate the page finished
+    /// scanning, bound to the request that issued it. Each page is
+    /// evaluated against the view it runs on and reports that head in
+    /// `head_seq`.
+    #[tracing::instrument(
+        level = "info",
+        name = "loon.phase",
+        err,
+        skip_all,
+        fields(phase = "grep")
+    )]
+    pub async fn query<S: ObjectStore + ?Sized>(
+        &self,
+        request: &GrepRequest,
+        snapshot: &GrepIndexSnapshot,
+        view: &LoadedMetadataView<'_, S>,
+        store: &S,
+    ) -> Result<GrepResponse> {
+        let limit = match request.limit {
+            None => DEFAULT_GREP_PAGE_LIMIT,
+            Some(0) => {
+                return Err(CoreError::InvalidQuery(
+                    "limit must be greater than zero".to_owned(),
+                ));
+            }
+            Some(limit) if limit as usize > MAX_GREP_PAGE_LIMIT => {
+                return Err(CoreError::InvalidQuery(format!(
+                    "limit {limit} exceeds the maximum of {MAX_GREP_PAGE_LIMIT}"
+                )));
+            }
+            Some(limit) => limit as usize,
+        };
+        let fingerprint = request.fingerprint();
+        let resume = match &request.cursor {
+            Some(cursor) => {
+                let cursor = decode_grep_cursor(cursor)
+                    .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+                if cursor.fingerprint != fingerprint {
+                    return Err(CoreError::InvalidCursor(
+                        "the cursor was issued by a different request; replaying it \
+                         under new criteria would silently skip results"
+                            .to_owned(),
+                    ));
+                }
+                if cursor.head_seq > view.head().seq {
+                    return Err(MetadataViewError::SnapshotUnavailable {
+                        requested_seq: cursor.head_seq,
+                        head_seq: view.head().seq,
+                    }
+                    .into());
+                }
+                Some((cursor.last_inode_id, cursor.last_byte_offset))
+            }
+            None => None,
+        };
+
+        let snapshot = snapshot.materialized()?;
+
+        // Line-anchored semantics: `^` and `$` match line boundaries, the
+        // grep-family contract. The planner parses with the same flags so
+        // its gram analysis sees the pattern the verifier runs.
+        let pattern = regex::bytes::RegexBuilder::new(&request.pattern)
+            .case_insensitive(request.case_insensitive)
+            .multi_line(true)
+            .build()
+            .map_err(|error| CoreError::InvalidQuery(error.to_string()))?;
+
+        // One view session serves the whole page: candidates in the same
+        // directory tree share ancestor bindings, tombstone checks, and
+        // path verifications, so the per-candidate metadata walks below hit
+        // the session caches instead of re-fetching per candidate.
+        let mut session = view.grep_session();
+        // The scope filter tests durable identity: resolve the prefix to
+        // its inode once, then require it among each candidate's ancestors,
+        // so name-policy folding and path normalization apply exactly as
+        // they do to every other read. A prefix that resolves to nothing
+        // has no matches.
+        let scope_root = match &request.path_prefix {
+            Some(prefix) => {
+                let parsed = AbsolutePath::parse(prefix).map_err(|error| {
+                    CoreError::InvalidPath(error.invalid_path_input().to_owned())
+                })?;
+                match session.resolve_visible_path(&parsed, false).await {
+                    Ok(resolved) => Some(resolved.inode_id),
+                    Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => {
+                        return Ok(GrepResponse {
+                            namespace_id: view.namespace_id().clone(),
+                            head_seq: view.head().seq,
+                            built_through_seq: snapshot.built_through_seq,
+                            tail_scanned: true,
+                            matches: Vec::new(),
+                            next_cursor: None,
+                        });
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            None => None,
+        };
+
+        let mut candidates = GrepCandidates::default();
+        match plan_pattern(&request.pattern, request.case_insensitive)
+            .map_err(CoreError::InvalidQuery)?
+        {
+            GramPlanOutcome::Indexable(plan) => {
+                candidates.indexed =
+                    indexed_candidates(store, &self.block_cache, &snapshot.segments, &plan).await?;
+            }
+            GramPlanOutcome::Unindexable => {
+                if !request.allow_scan {
+                    return Err(CoreError::QueryUnindexable(
+                        "the pattern has no run of at least 3 literal bytes for the \
+                         trigram index; set allow_scan to search without it"
+                            .to_owned(),
+                    ));
+                }
+                candidates.unfiltered = scan_candidate_inodes(view).await?;
+            }
+        }
+
+        let tail = tail_revisions(store, view, snapshot.built_through_seq).await?;
+        let mut tail_scanned = true;
+        if tail.len() > MAX_GREP_TAIL_FILES {
+            if request.allow_stale {
+                tail_scanned = false;
+            } else {
+                return Err(CoreError::IndexLagging {
+                    behind_commits: view
+                        .head()
+                        .seq
+                        .0
+                        .saturating_sub(snapshot.built_through_seq.0),
+                });
+            }
+        } else {
+            candidates.unfiltered.extend(tail);
+        }
+
+        let mut matches: Vec<GrepMatch> = Vec::new();
+        let mut verified_files = 0usize;
+        let mut examined_candidates = 0usize;
+        let mut has_more = false;
+        // Where the next page resumes when this one stops early: the last
+        // candidate this page finished scanning (offset MAX), or the last
+        // emitted match when the page filled mid-file.
+        let mut resume_cursor: Option<(InodeId, u64)> = None;
+        // Highest candidate this page examined and rejected (invisible,
+        // superseded, or out of scope). A rejection is final for the page,
+        // so budget exits fold this into the cursor — without it, a run of
+        // rejections longer than a page budget would resume at the same
+        // cursor and re-reject the same candidates forever.
+        let mut rejected_frontier: Option<InodeId> = None;
+        let ordered_candidates = candidates.inodes().collect::<Vec<_>>();
+        let mut next_candidate = 0usize;
+        'page: loop {
+            // Select the next fan-out batch: walk candidates in inode
+            // order through the cheap checks (metadata lookups served by
+            // the loaded view) until enough survivors need content, the
+            // verified-file budget fills, or the candidates run out. The
+            // content read is the only per-candidate store fetch, so it is
+            // the only stage that fans out — the design doc's "small fixed
+            // fan-out" for candidate reads.
+            let mut batch: Vec<GrepContentCandidate> = Vec::new();
+            let mut budget_exhausted = false;
+            while next_candidate < ordered_candidates.len() {
+                let inode_id = ordered_candidates[next_candidate];
+                if let Some((last_inode, last_offset)) = resume {
+                    if inode_id < last_inode || (inode_id == last_inode && last_offset == u64::MAX)
+                    {
+                        next_candidate += 1;
+                        continue;
+                    }
+                }
+                // The examination budget bounds a page's metadata work the
+                // way the verified budget bounds its content work: a scope
+                // filter that rejects nearly every candidate would
+                // otherwise walk metadata for the entire candidate set in
+                // one page. The candidate at the boundary is left for the
+                // next page.
+                if examined_candidates == MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE {
+                    budget_exhausted = true;
+                    break;
+                }
+                next_candidate += 1;
+                examined_candidates += 1;
+                if session.visible_inode(inode_id).await?.is_none() {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                }
+                let Some(revision) = session.latest_revision_head_of_visible(inode_id).await?
+                else {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                };
+                if !candidates.admits(inode_id, revision.revision_no) {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                }
+                // With the tail skipped (`allow_stale`), serve the index's
+                // cut and nothing newer: a candidate whose newest revision
+                // is past the watermark would otherwise be verified at an
+                // unindexed revision while tail-only files stay invisible
+                // — a mix of two snapshots rather than a stale-but-
+                // consistent one.
+                if !tail_scanned && revision.committed_seq > snapshot.built_through_seq {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                }
+                let Some(chain) = derive_visible_path(&mut session, inode_id).await? else {
+                    rejected_frontier = Some(inode_id);
+                    continue;
+                };
+                if let Some(scope_root) = scope_root {
+                    if !chain.ancestors.contains(&scope_root) {
+                        rejected_frontier = Some(inode_id);
+                        continue;
+                    }
+                }
+                if verified_files == MAX_GREP_VERIFIED_FILES_PER_PAGE {
+                    budget_exhausted = true;
+                    break;
+                }
+                verified_files += 1;
+                // Content past the index eligibility cap can never be
+                // indexable text, so tail and scan candidates skip their
+                // doomed reads on the declared size alone — the same
+                // pre-fetch check the index builder applies
+                // (`checkpoint/index_build.rs`); index-supplied candidates
+                // are under the cap by construction. The candidate still
+                // rides the batch in inode order, so the budget and the
+                // resume cursor advance exactly as if its bytes had been
+                // fetched and refused.
+                let oversized = revision.content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES;
+                batch.push(GrepContentCandidate {
+                    inode_id,
+                    revision,
+                    path: chain.path,
+                    oversized,
+                });
+                if batch.len() == MAX_GREP_CONTENT_IO {
+                    break;
+                }
+            }
+            if batch.is_empty() {
+                if budget_exhausted {
+                    has_more = true;
+                    fold_rejected_frontier(&mut resume_cursor, rejected_frontier);
+                }
+                break 'page;
+            }
+            // The reads fan out, but their errors do not short-circuit:
+            // each result rides with its candidate into the ordered walk
+            // below, which surfaces a failure only when it reaches that
+            // candidate — the position the serial loop surfaced it. A
+            // failure the walk never reaches (the page filled first) is
+            // discarded with the rest of the speculative batch; the next
+            // page re-issues that read and reports it then. An oversized
+            // candidate carries no read at all (`None`).
+            let contents = join_all(batch.iter().map(|candidate| async move {
+                if candidate.oversized {
+                    return None;
+                }
+                Some(
+                    read_durable_content_bytes(
+                        store,
+                        view.content_store_id(),
+                        &candidate.revision.content_ref,
+                    )
+                    .await,
+                )
+            }))
+            .await;
+            // Emission stays strictly in candidate (inode) order: the batch
+            // was selected in order and its results are consumed in order,
+            // so matches, limits, errors, and the resume cursor advance
+            // exactly as the serial walk advanced them.
+            for (candidate, content) in batch.iter().zip(contents) {
+                let inode_id = candidate.inode_id;
+                let Some(content) = content else {
+                    // Skipped as oversized: scanned-and-refused without the
+                    // fetch, so the cursor moves past it like any other
+                    // ineligible file.
+                    resume_cursor = Some((inode_id, u64::MAX));
+                    continue;
+                };
+                let content = content?;
+                if !is_indexable_text_content(&content.bytes) {
+                    resume_cursor = Some((inode_id, u64::MAX));
+                    continue;
+                }
+                for found in line_matches(&content.bytes, &pattern) {
+                    if let Some((last_inode, last_offset)) = resume {
+                        if inode_id == last_inode && found.byte_offset <= last_offset {
+                            continue;
+                        }
+                    }
+                    if matches.len() == limit {
+                        // The page filled mid-batch: contents already
+                        // fetched for the batch's later candidates are
+                        // discarded, and the cursor resumes from the last
+                        // processed candidate, never a discarded one.
+                        has_more = true;
+                        break 'page;
+                    }
+                    resume_cursor = Some((inode_id, found.byte_offset));
+                    matches.push(GrepMatch {
+                        absolute_path: candidate.path.clone(),
+                        inode_id,
+                        revision_no: candidate.revision.revision_no,
+                        line_number: found.line_number,
+                        byte_offset: found.byte_offset,
+                        line: found.line,
+                        line_truncated: found.line_truncated,
+                    });
+                }
+                // The file was fully scanned; a later stop resumes past it.
+                resume_cursor = Some((inode_id, u64::MAX));
+            }
+            if budget_exhausted {
+                has_more = true;
+                // The whole final batch was scanned, so every examined
+                // candidate is resolved; rejections past the last scanned
+                // file move the cursor with them.
+                fold_rejected_frontier(&mut resume_cursor, rejected_frontier);
+                break 'page;
+            }
+        }
+
+        let next_cursor = if has_more {
+            let (last_inode_id, last_byte_offset) = resume_cursor.or(resume).ok_or_else(|| {
+                CoreError::Internal(
+                    "a truncated page must have scanned at least one candidate".to_owned(),
+                )
+            })?;
+            Some(
+                encode_grep_cursor(&GrepPageCursor {
+                    head_seq: view.head().seq,
+                    last_inode_id,
+                    last_byte_offset,
+                    fingerprint,
+                })
+                .map_err(|error| CoreError::Internal(error.to_string()))?,
+            )
+        } else {
+            None
+        };
+        Ok(GrepResponse {
+            namespace_id: view.namespace_id().clone(),
+            head_seq: view.head().seq,
+            built_through_seq: snapshot.built_through_seq,
+            tail_scanned,
+            matches,
+            next_cursor,
+        })
+    }
+}
+
+/// Every inode holding any revision in the manifest tables, for plan-less
+/// scans; the WAL tail is collected separately. Refuses past the scan budget.
+async fn scan_candidate_inodes<S: ObjectStore + ?Sized>(
+    view: &LoadedMetadataView<'_, S>,
+) -> Result<BTreeSet<InodeId>> {
+    let mut inodes = BTreeSet::new();
+    let mut lower = "revision-".to_owned();
+    let upper = string_prefix_upper_bound("revision-");
+    loop {
+        let page = view
+            .grep_revision_inode_page(
+                &lower,
+                upper.as_deref(),
+                MAX_GREP_SCAN_FILES.saturating_add(1),
+            )
+            .await?;
+        let Some((last_key, _)) = page.last() else {
+            break;
+        };
+        let last_key = last_key.clone();
+        let exhausted = page.len() <= MAX_GREP_SCAN_FILES;
+        inodes.extend(page.into_iter().map(|(_, inode_id)| inode_id));
+        if inodes.len() > MAX_GREP_SCAN_FILES {
+            return Err(CoreError::QueryUnindexable(format!(
+                "the namespace exceeds the {MAX_GREP_SCAN_FILES}-file scan budget; \
+                 give the pattern a run of at least 3 literal bytes so the \
+                 trigram index can narrow candidates"
+            )));
+        }
+        if exhausted {
+            break;
+        }
+        lower = format!("{last_key}\0");
+    }
+    Ok(inodes)
+}
+
+/// True when content participates in the gram index: within the size cap
+/// and text by the grep-family sniff (no NUL byte and valid UTF-8 in the
+/// leading sample; a sample that ends inside a multi-byte character still
+/// counts as valid).
+pub fn is_indexable_text_content(content: &[u8]) -> bool {
+    const ELIGIBILITY_SAMPLE_BYTES: usize = 8 * 1024;
+
+    if content.len() as u64 > INDEX_GRAMS_MAX_FILE_BYTES {
+        return false;
+    }
+    let sample = &content[..content.len().min(ELIGIBILITY_SAMPLE_BYTES)];
+    if sample.contains(&0) {
+        return false;
+    }
+    match std::str::from_utf8(sample) {
+        Ok(_) => true,
+        Err(error) => error.error_len().is_none() && error.valid_up_to() > 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pattern(text: &str) -> regex::bytes::Regex {
+        regex::bytes::Regex::new(text).expect("pattern")
+    }
+
+    #[test]
+    fn line_matches_report_positions_once_per_line() {
+        let content = b"alpha\nneedle one needle\nomega needle\n";
+        let matches = line_matches(content, &pattern("needle"));
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].line_number, 2);
+        assert_eq!(matches[0].byte_offset, 6);
+        assert_eq!(matches[0].line, "needle one needle");
+        assert_eq!(matches[1].line_number, 3);
+        assert_eq!(matches[1].line, "omega needle");
+    }
+
+    #[test]
+    fn rejected_frontier_folds_forward_only() {
+        let mut cursor = None;
+        fold_rejected_frontier(&mut cursor, Some(InodeId(9)));
+        assert_eq!(cursor, Some((InodeId(9), u64::MAX)));
+        cursor = Some((InodeId(12), 40));
+        fold_rejected_frontier(&mut cursor, Some(InodeId(9)));
+        assert_eq!(cursor, Some((InodeId(12), 40)));
+    }
+}

--- a/crates/loonfs-grep/tests/text_eligibility.rs
+++ b/crates/loonfs-grep/tests/text_eligibility.rs
@@ -1,0 +1,42 @@
+//! Equality lock between the core build-side and grep query-side text sniff.
+
+use loonfs_api::wire::index_grams::INDEX_GRAMS_MAX_FILE_BYTES;
+
+fn assert_same(label: &str, content: &[u8]) {
+    assert_eq!(
+        loonfs_grep::is_indexable_text_content(content),
+        loonfs_core::is_indexable_text_content(content),
+        "eligibility diverged for {label}"
+    );
+}
+
+#[test]
+fn query_text_eligibility_matches_core_across_content_boundaries() {
+    const SAMPLE_BYTES: usize = 8 * 1024;
+
+    assert_same("empty", b"");
+    assert_same("ascii text", b"plain text\n");
+    assert_same("utf-8 text", "snowman: ☃\n".as_bytes());
+    assert_same("leading nul", b"\0binary");
+
+    let mut nul_at_sample_end = vec![b'a'; SAMPLE_BYTES];
+    nul_at_sample_end[SAMPLE_BYTES - 1] = 0;
+    assert_same("nul at sample end", &nul_at_sample_end);
+
+    let mut invalid_utf8 = vec![b'a'; SAMPLE_BYTES];
+    invalid_utf8[SAMPLE_BYTES / 2] = 0xff;
+    assert_same("invalid utf-8 inside sample", &invalid_utf8);
+
+    let mut split_character = vec![b'a'; SAMPLE_BYTES - 1];
+    split_character.extend_from_slice(&[0xc3, 0xa9]);
+    assert_same("sample ending inside utf-8 character", &split_character);
+
+    let mut invalid_after_sample = vec![b'a'; SAMPLE_BYTES + 1];
+    invalid_after_sample[SAMPLE_BYTES] = 0xff;
+    assert_same("invalid byte after sample", &invalid_after_sample);
+
+    let at_cap = vec![b'a'; INDEX_GRAMS_MAX_FILE_BYTES as usize];
+    assert_same("exact size cap", &at_cap);
+    let over_cap = vec![b'a'; INDEX_GRAMS_MAX_FILE_BYTES as usize + 1];
+    assert_same("one byte over size cap", &over_cap);
+}

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -13,6 +13,7 @@ bytes.workspace = true
 futures.workspace = true
 loonfs-api = { path = "../loonfs-api" }
 loonfs-core = { path = "../loonfs-core" }
+loonfs-grep = { path = "../loonfs-grep" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -25,6 +25,7 @@ use loonfs_core::cache::{
     MetadataTableCache, WalTailProjectionCache, WalTailProjectionCacheConfig,
 };
 use loonfs_core::{MutationContext, NamespaceEngine};
+use loonfs_grep::GrepService;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -45,6 +46,7 @@ pub(crate) struct FsInner {
     pub(crate) control_cache: Mutex<RuntimeControlCache>,
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
+    pub(crate) grep_service: GrepService,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
     pub(crate) background: BackgroundWork,
     /// The core's publication service: every mutation — direct handle
@@ -116,6 +118,7 @@ impl FsCore {
                 control_cache: Mutex::new(RuntimeControlCache::default()),
                 metadata_table_cache,
                 wal_tail_projection_cache,
+                grep_service: GrepService::new(),
                 cache_stats: RuntimeCacheStatsInner::default(),
                 background,
                 publisher: PublisherRegistry::from_core(
@@ -172,19 +175,19 @@ impl FsCore {
                 let mut limits = PaginationPolicy::default().capability_limits();
                 limits.insert(
                     LIMIT_QUERY_GREP_DEFAULT.to_owned(),
-                    loonfs_core::grep_limits::DEFAULT_GREP_PAGE_LIMIT as u64,
+                    loonfs_grep::DEFAULT_GREP_PAGE_LIMIT as u64,
                 );
                 limits.insert(
                     LIMIT_QUERY_GREP_MAX.to_owned(),
-                    loonfs_core::grep_limits::MAX_GREP_PAGE_LIMIT as u64,
+                    loonfs_grep::MAX_GREP_PAGE_LIMIT as u64,
                 );
                 limits.insert(
                     LIMIT_QUERY_GREP_SCAN_BUDGET_FILES.to_owned(),
-                    loonfs_core::grep_limits::MAX_GREP_SCAN_FILES as u64,
+                    loonfs_grep::MAX_GREP_SCAN_FILES as u64,
                 );
                 limits.insert(
                     LIMIT_QUERY_GREP_TAIL_BUDGET_FILES.to_owned(),
-                    loonfs_core::grep_limits::MAX_GREP_TAIL_FILES as u64,
+                    loonfs_grep::MAX_GREP_TAIL_FILES as u64,
                 );
                 limits.insert(
                     LIMIT_GC_MIN_GRACE_WINDOW_MS.to_owned(),

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -10,6 +10,7 @@ use loonfs_api::{
     encode_directory_cursor, AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor,
     GrepRequest, GrepResponse, PageRequest,
 };
+use loonfs_grep::GrepIndexSnapshot;
 
 impl FsCore {
     /// Resolves an absolute path to its authoritative entry at the current
@@ -176,8 +177,14 @@ impl FsCore {
             } else {
                 (engine, read_context)
             };
-        let response = engine
-            .grep_with_runtime_context(request, &read_context)
+        let view = engine
+            .load_grep_view_with_runtime_context(&read_context)
+            .await?;
+        let snapshot = GrepIndexSnapshot::from_core_parts(view.grep_index_snapshot_parts());
+        let response = self
+            .inner
+            .grep_service
+            .query(request, &snapshot, &view, &self.inner.store)
             .await?;
         self.inner.cache_stats.record_latest_metadata_view_read();
         Ok(response)

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -123,6 +123,20 @@ async fn maintenance_ticks_build_the_gram_index_once_enabled() {
         .await
         .expect("write bravo");
 
+    // Request validation precedes feature materialization in the reference
+    // executor; snapshot construction in the delegated path must preserve
+    // that error ordering.
+    let mut invalid_limit = grep_request("needle");
+    invalid_limit.limit = Some(0);
+    let error = reader
+        .grep(&namespace_id, &invalid_limit)
+        .await
+        .expect_err("invalid limit must win before the missing feature");
+    let loonfs::Error::Core(core) = &error else {
+        panic!("expected a core error, got {error:?}");
+    };
+    assert_eq!(core.code(), ErrorCode::InvalidRequest);
+
     // Before enablement, grep names the missing data half.
     let error = reader
         .grep(&namespace_id, &grep_request("needle"))
@@ -526,11 +540,11 @@ impl ObjectStore for IndexSegmentGetCountingStore {
     }
 }
 
-/// Index segment blocks are immutable and keyed by payload checksum, so a
-/// reader's decoded-block cache must serve a repeated query's posting
+/// Index segment blocks are immutable and keyed by payload checksum, so the
+/// grep-private decoded-block cache must serve a repeated query's posting
 /// probes without re-fetching the segments it already decoded.
 #[tokio::test]
-async fn repeated_grep_serves_posting_blocks_from_the_table_cache() {
+async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
     let store: loonfs::SharedObjectStore = raw_store.clone();
@@ -954,22 +968,16 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     writer.shutdown_background().await.expect("writer shutdown");
 }
 
-/// Fold steps resolve their merge reads through the same decoded-block
-/// cache queries fill: a reader derived from the writer shares its
-/// runtime core, so a grep that decoded the delta segments must spare the
-/// next fold those segments' store reads.
+/// Fold steps and grep queries deliberately use separate decoded-block
+/// caches: warming grep must not warm core's maintenance cache.
 ///
 /// Two identically shaped delta folds run through one runtime — eight
 /// one-file rounds each, background ticks folding on the eighth. The
-/// first fold runs cold (nothing read those segments before) and is the
-/// in-test control; before the second, a grep warms seven of its eight
-/// inputs. Only the tick that triggers a fold can write its eighth delta,
-/// so that segment is always cold and a zero-read fold is unreachable
-/// through the runtime; strictly fewer reads than the identically shaped
-/// cold fold is the deterministic form of "already-warm blocks are not
-/// re-fetched", and it stays true if segment block layout changes.
+/// first fold runs cold and is the in-test control; before the second, a
+/// grep warms seven of its eight inputs in the grep-private cache. The two
+/// identically shaped folds must therefore issue the same core-cache reads.
 #[tokio::test]
-async fn a_fold_reuses_the_index_blocks_a_grep_already_decoded() {
+async fn a_fold_does_not_reuse_grep_private_index_blocks() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
     let store: loonfs::SharedObjectStore = raw_store.clone();
@@ -1052,11 +1060,11 @@ async fn a_fold_reuses_the_index_blocks_a_grep_already_decoded() {
         warm_fold_gets > 0,
         "the sixteenth round's fold must still read the delta its own tick wrote"
     );
-    assert!(
-        warm_fold_gets < cold_fold_gets,
-        "a fold whose snapshot a grep already decoded must serve those \
-         blocks from the table cache: cold fold read {cold_fold_gets} \
-         sections, query-warmed fold read {warm_fold_gets}"
+    assert_eq!(
+        warm_fold_gets, cold_fold_gets,
+        "grep-private cache entries must not alter core fold reads: cold \
+         fold read {cold_fold_gets} sections, query-warmed fold read \
+         {warm_fold_gets}"
     );
 
     // The premise of the comparison: both rounds really did fold, leaving

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -1,0 +1,442 @@
+#![allow(clippy::panic)]
+// Lifecycle assertions use panic for precise differential diagnostics.
+
+//! Full-pipeline differential lock between core's reference grep and GrepService.
+
+use loonfs::{
+    CommitId, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, DestinationBehavior,
+    ErrorCode, FsAdmin, FsReader, FsWriter, GramIndexBuildPolicy, GrepRequest, GrepResponse,
+    MaintenanceTickOptions, MoveOptions, NamespaceId, PutFileOptions, SharedObjectStore,
+};
+use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_api::AbsolutePath;
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
+    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+};
+use loonfs_core::control::load_namespace_read_anchor;
+use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use loonfs_core::{NamespaceEngine, RuntimeReadContext};
+use loonfs_grep::{GrepIndexSnapshot, GrepService};
+use loonfs_objectstore::keys::metadata_manifest_object;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn request(pattern: &str) -> GrepRequest {
+    GrepRequest {
+        pattern: pattern.to_owned(),
+        case_insensitive: false,
+        path_prefix: None,
+        cursor: None,
+        limit: None,
+        allow_stale: false,
+        allow_scan: false,
+    }
+}
+
+async fn read_context(store: &SharedObjectStore, namespace_id: &NamespaceId) -> RuntimeReadContext {
+    let (head, root) = load_namespace_read_anchor(&**store, namespace_id)
+        .await
+        .expect("load read anchor");
+    RuntimeReadContext {
+        head: head.state,
+        head_etag: head.identity.etag,
+        manifest_id: root.state.manifest_id,
+        manifest_object_id: root.state.manifest_object_id,
+        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
+        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+            max_entries: 4,
+            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        })),
+        catalog: None,
+    }
+}
+
+struct DifferentialHarness {
+    store: SharedObjectStore,
+    namespace_id: NamespaceId,
+    engine: NamespaceEngine<SharedObjectStore>,
+    service: GrepService,
+}
+
+impl DifferentialHarness {
+    fn new(store: SharedObjectStore, namespace_id: NamespaceId) -> Self {
+        let engine = NamespaceEngine::builder(store.clone())
+            .namespace_id(namespace_id.clone())
+            .writer_id("grep-differential-reference")
+            .build()
+            .expect("build reference engine");
+        Self {
+            store,
+            namespace_id,
+            engine,
+            service: GrepService::new(),
+        }
+    }
+
+    async fn results(
+        &self,
+        grep_request: &GrepRequest,
+    ) -> (
+        loonfs_core::Result<GrepResponse>,
+        loonfs_core::Result<GrepResponse>,
+    ) {
+        let context = read_context(&self.store, &self.namespace_id).await;
+        // This old core entry point intentionally survives only as the
+        // differential oracle until the final deletion PR.
+        let core = self
+            .engine
+            .grep_with_runtime_context(grep_request, &context)
+            .await;
+        let service = async {
+            let view = self
+                .engine
+                .load_grep_view_with_runtime_context(&context)
+                .await?;
+            let snapshot = GrepIndexSnapshot::from_core_parts(view.grep_index_snapshot_parts());
+            self.service
+                .query(grep_request, &snapshot, &view, &self.store)
+                .await
+        }
+        .await;
+        (core, service)
+    }
+
+    async fn success(&self, case: &str, grep_request: &GrepRequest) -> GrepResponse {
+        let (core, service) = self.results(grep_request).await;
+        match (core, service) {
+            (Ok(core), Ok(service)) => {
+                assert_eq!(service, core, "full response diverged for {case}");
+                service
+            }
+            (core, service) => {
+                panic!("expected success for {case}, got core={core:?}, service={service:?}")
+            }
+        }
+    }
+
+    async fn error(&self, case: &str, grep_request: &GrepRequest, code: ErrorCode) {
+        let (core, service) = self.results(grep_request).await;
+        match (core, service) {
+            (Err(core), Err(service)) => {
+                assert_eq!(core.code(), code, "unexpected core code for {case}");
+                assert_eq!(service.code(), code, "unexpected service code for {case}");
+                assert_eq!(
+                    service.to_string(),
+                    core.to_string(),
+                    "error text for {case}"
+                );
+            }
+            (core, service) => {
+                panic!("expected error for {case}, got core={core:?}, service={service:?}")
+            }
+        }
+    }
+}
+
+async fn publish_same_content_files(
+    writer: &FsWriter,
+    namespace_id: &NamespaceId,
+    prefix: &str,
+    count: usize,
+    content: &[u8],
+) {
+    let prepared = writer
+        .prepare_file_bytes(namespace_id, content)
+        .await
+        .expect("prepare shared content");
+    let content_ref = prepared.content_ref().clone();
+    let candidates = (0..count)
+        .map(|index| {
+            NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::generate(),
+                    absolute_path: AbsolutePath::parse(format!("/{prefix}-{index:04}.txt"))
+                        .expect("batch path"),
+                    content_ref: content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                vec![prepared.clone()],
+            )
+        })
+        .collect();
+    let results = writer
+        .publish_namespace_mutations_batch(namespace_id, candidates)
+        .await;
+    for result in results {
+        result.expect("publish batch file");
+    }
+}
+
+async fn gram_segment_levels(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> BTreeSet<u32> {
+    let (_, root) = load_namespace_read_anchor(&**store, namespace_id)
+        .await
+        .expect("load root");
+    let key = metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let bytes = store
+        .get(&key, None)
+        .await
+        .expect("read manifest")
+        .expect("manifest exists");
+    decode_namespace_manifest_json(&bytes)
+        .expect("decode manifest")
+        .payload
+        .index_files
+        .into_iter()
+        .filter(|segment| segment.family == "grams")
+        .map(|segment| segment.level)
+        .collect()
+}
+
+#[tokio::test]
+async fn grep_service_matches_core_across_query_semantics_and_budgets() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("grep-service-differential").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grep-differential-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grep-differential-admin")
+        .gram_index_build(GramIndexBuildPolicy {
+            max_l0_runs: 2,
+            max_mid_runs: 2,
+            ..GramIndexBuildPolicy::default()
+        })
+        .build()
+        .await
+        .expect("build admin");
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable index");
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("materialize empty backfill");
+
+    let folded_corpus: [(&str, &[u8]); 10] = [
+        ("/docs/indexed.txt", b"indexed-needle\n"),
+        ("/docs/deleted.txt", b"visibility-token deleted\n"),
+        ("/docs/moved-source.txt", b"visibility-token moved\n"),
+        ("/docs/case.txt", b"MiXeD CaSe ToKeN\n"),
+        ("/docs/binary.bin", b"binary-token\0payload"),
+        ("/docs/short.txt", b"ab short token\n"),
+        ("/docs/empty.txt", b""),
+        ("/docs/pages.txt", b"page-token one\npage-token two\n"),
+        ("/fold/filler-08.txt", b"fold filler eight\n"),
+        ("/fold/filler-09.txt", b"fold filler nine\n"),
+    ];
+    for (path, content) in folded_corpus {
+        writer
+            .put_file_bytes(&namespace_id, path, content, PutFileOptions::default())
+            .await
+            .expect("write folded corpus file");
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("build and fold corpus round");
+    }
+
+    // The ten rounds above finish a base fold. Two more one-file rounds
+    // fold into a fresh mid run, then the large batch below remains delta.
+    for round in 10..12u32 {
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/fold/filler-{round:02}.txt"),
+                format!("fold filler {round}\n").as_bytes(),
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("write mid-run filler");
+        admin
+            .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+            .await
+            .expect("build mid-run filler");
+    }
+
+    // One final indexed delta supplies enough false-positive candidates to
+    // force the 256-file verification budget while preserving delta, mid,
+    // and base levels in the same caller-provided snapshot.
+    publish_same_content_files(
+        &writer,
+        &namespace_id,
+        "budget/candidate",
+        270,
+        b"budget-needle without the final letter\n",
+    )
+    .await;
+    admin
+        .maintenance_tick_namespace(&namespace_id, MaintenanceTickOptions::default())
+        .await
+        .expect("index budget corpus");
+    assert_eq!(
+        gram_segment_levels(&store, &namespace_id).await,
+        BTreeSet::from([0, 1, 2]),
+        "the differential snapshot must exercise delta, mid, and base segments"
+    );
+
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/tail/tail-hit.txt",
+            b"ab tail-only-token\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write unindexed tail hit");
+    writer
+        .delete_path(&namespace_id, "/docs/deleted.txt", DeleteOptions::default())
+        .await
+        .expect("delete indexed file");
+    writer
+        .create_directory(&namespace_id, "/archive", CreateDirectoryOptions::default())
+        .await
+        .expect("create move destination");
+    writer
+        .move_path(
+            &namespace_id,
+            "/docs/moved-source.txt",
+            "/archive/moved.txt",
+            MoveOptions::default(),
+        )
+        .await
+        .expect("move indexed file");
+
+    let harness = DifferentialHarness::new(store.clone(), namespace_id.clone());
+
+    let indexed = harness
+        .success("indexed hits", &request("indexed-needle"))
+        .await;
+    assert_eq!(indexed.matches.len(), 1);
+
+    let runtime = reader
+        .grep(&namespace_id, &request("indexed-needle"))
+        .await
+        .expect("runtime delegated grep");
+    assert_eq!(
+        runtime, indexed,
+        "runtime must delegate to the service result"
+    );
+
+    let tail = harness
+        .success("unindexed-tail hits", &request("tail-only-token"))
+        .await;
+    assert_eq!(tail.matches.len(), 1);
+    assert!(tail.tail_scanned);
+
+    let mut scan_off = request("ab");
+    harness
+        .error("allow_scan off", &scan_off, ErrorCode::QueryUnindexable)
+        .await;
+    scan_off.allow_scan = true;
+    let scanned = harness
+        .success("allow_scan on and short pattern", &scan_off)
+        .await;
+    assert_eq!(scanned.matches.len(), 1);
+    assert_eq!(scanned.matches[0].absolute_path, "/tail/tail-hit.txt");
+
+    let mut case_folded = request("mixed case token");
+    case_folded.case_insensitive = true;
+    let case_folded = harness.success("case folding", &case_folded).await;
+    assert_eq!(case_folded.matches.len(), 1);
+
+    let visible = harness
+        .success("deleted and moved visibility", &request("visibility-token"))
+        .await;
+    assert_eq!(visible.matches.len(), 1);
+    assert_eq!(visible.matches[0].absolute_path, "/archive/moved.txt");
+
+    let mut binary = request("bi");
+    binary.allow_scan = true;
+    let binary = harness.success("binary eligibility", &binary).await;
+    assert!(binary.matches.is_empty());
+
+    let empty = harness
+        .success("empty result", &request("definitely-absent-token"))
+        .await;
+    assert!(empty.matches.is_empty());
+
+    let mut paged_request = request("budget-needle");
+    paged_request.limit = Some(17);
+    let mut pages = 0usize;
+    let mut matches = 0usize;
+    loop {
+        let page = harness
+            .success("multi-page cursor walk", &paged_request)
+            .await;
+        pages += 1;
+        matches += page.matches.len();
+        let Some(cursor) = page.next_cursor else {
+            break;
+        };
+        paged_request.cursor = Some(cursor);
+    }
+    assert!(pages > 1);
+    assert_eq!(matches, 270);
+
+    let budget_page = harness
+        .success("verified-file budget page", &request("budget-needle.*z"))
+        .await;
+    assert!(budget_page.matches.is_empty());
+    let mut budget_resume = request("budget-needle.*z");
+    budget_resume.cursor = budget_page.next_cursor.clone();
+    assert!(
+        budget_resume.cursor.is_some(),
+        "budget exit must return a cursor"
+    );
+    let budget_end = harness
+        .success("verified-file budget resume", &budget_resume)
+        .await;
+    assert!(budget_end.next_cursor.is_none());
+
+    // Raise the unindexed revision tail to 513 files without advancing the
+    // index, one over the exact tail budget.
+    publish_same_content_files(
+        &writer,
+        &namespace_id,
+        "tail/lagging",
+        512,
+        b"tail-only-token bulk\n",
+    )
+    .await;
+    let stale_request = request("indexed-needle");
+    harness
+        .error(
+            "allow_stale off over tail budget",
+            &stale_request,
+            ErrorCode::IndexLagging,
+        )
+        .await;
+    let mut stale_request = stale_request;
+    stale_request.allow_stale = true;
+    let stale = harness
+        .success("allow_stale on over tail budget", &stale_request)
+        .await;
+    assert!(!stale.tail_scanned);
+    assert_eq!(stale.matches.len(), 1);
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}


### PR DESCRIPTION
Query ownership moves out of core: planning, execution, and segment reading now live in `loonfs-grep` as `GrepService`, and the runtime's grep delegates to it. This is an extraction, not a rewrite — the differential suite builds real indexes through the existing pipeline (delta, mid, and base levels via maintenance and folds) and asserts the old core path and the service return identical full responses across indexed hits, tail hits, `allow_scan` and `allow_stale` in both positions, multi-page cursor walks to exhaustion, budget exhaustion and resumption, case folding, deleted and moved files, binary content, empty results, and sub-gram patterns. The old path has no production call sites but stays callable as the differential reference until the final deletion PR.

The service reads the index through a caller-built snapshot (watermark plus segment refs), so the worker PR re-points it at the durable grep root without touching query code. Core's new public surface is deliberately small and named for its purpose: a `grep` seam module re-exporting the view/session types, four promoted visibility primitives, read-only view accessors, a snapshot-parts accessor, and a validated-WAL-records accessor that keeps WAL framing core-private. Path derivation was copied rather than exposed — it only orchestrates the promoted primitives and re-verifies every derived path back through core's visibility resolution, so drift is self-detecting. Grep gets its own bounded decoded-block cache; fold and query no longer share warm blocks, and the grams tests repin that split as deliberate.

Fixed-seed sim (seed 42, 800 steps, same machine, uncontended): main baseline 47.6s/50.0s wall (22.5s/22.9s user); this branch 46.4s/46.8s (22.3s/22.1s user). No regression; the cache split is free at this workload.

One pre-existing behavior was found and preserved identically on both sides: a plan-less scan reads manifest revision rows plus WAL revisions after the index watermark, so an older revision at or below the watermark that is not yet folded into manifest tables can be missed. Filed for separate investigation rather than fixed here, since both implementations must stay equal.
