### PR TITLE
feat(grep): add deployment modes and standalone worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "ciborium",
+ "clap",
  "futures",
  "loonfs-api",
  "loonfs-core",
@@ -1196,7 +1197,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1245,6 +1248,7 @@ dependencies = [
  "loonfs-api",
  "loonfs-client",
  "loonfs-core",
+ "loonfs-grep",
  "loonfs-objectstore",
  "serde",
  "serde_json",
@@ -1252,6 +1256,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "ureq",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo build -p loonfs-server
 ./target/debug/loonfs-server --config configs/loonfs-server.local-fs.example.toml
 ```
 
-Commented example configs for every supported store live in [configs/](configs) (`local-fs`, `aws-s3`, `gcp-gcs`, `cloudflare-r2`, `azure-abs`). The required fields are `bind`, `writer_id`, `writer_version`, and a `[store]` block; everything else defaults. Connect a client:
+Commented example configs for every supported store live in [configs/](configs) (`local-fs`, `aws-s3`, `gcp-gcs`, `cloudflare-r2`, `azure-abs`). The required fields are `bind`, `writer_id`, `writer_version`, and a `[store]` block; everything else defaults. The optional `[grep]` table selects `mode = "disabled" | "embedded" | "serve_only"` (default `embedded`), worker intervals (`step_interval_ms = 1000`, `gc_interval_ms = 60000`), and the bounded build/fold policy shown in the local-fs example. Connect a client:
 
 ```bash
 export LOONFS_AUTH_TOKEN={auth_token}

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -48,11 +48,15 @@ writer_version = "loonfs-server/0.1.0"
 # Decoded-byte budget for the metadata table cache; unlimited by default.
 #metadata_table_cache_max_decoded_bytes = 268435456
 
-# Optional gram index build budgets; omitted fields keep the runtime
-# defaults. Each maintenance tick runs one build step and one fold step
-# under these budgets — bulk backfills raise the per-step budgets so a
-# tick indexes more files per manifest publish.
-#[gram_index_build]
+# Grep defaults to embedded: this server serves queries and owns background
+# indexing. `disabled` serves uniform `not_supported` responses and advertises
+# no `query.grep` feature or limits; `serve_only` serves an index maintained by
+# an external `loonfs-grep` process.
+#[grep]
+#mode = "embedded"
+#step_interval_ms = 1000
+#gc_interval_ms = 60000
+# Bounded build/fold budgets; every value must be greater than zero.
 #max_files_per_step = 256
 #max_content_bytes_per_step = 67108864
 #max_rows_per_segment = 65536

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -550,7 +550,7 @@ impl Client {
     }
 
     /// Publishes the `index.grams` feature entry (admin plane); backfill
-    /// runs through maintenance ticks. Idempotent.
+    /// runs through grep worker sweeps. Idempotent.
     pub fn enable_grams_index(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 bytes.workspace = true
+clap.workspace = true
 futures.workspace = true
 loonfs-api = { path = "../loonfs-api" }
 loonfs-core = { path = "../loonfs-core" }
@@ -24,12 +25,14 @@ serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 ciborium.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -2,4 +2,14 @@
 
 `loonfs-grep` contains LoonFS's optional full-text grep subsystem. It owns the gram codec, the
 independent durable root and keyspace, and the explicitly driven `GrepWorker`; a standalone worker
-process arrives in a later change.
+process and server-embedded mode share one fair all-namespaces `GrepWorkerLoop`.
+
+Run the standalone worker with a strict TOML config containing `[store]` (the same provider shape
+as `loonfs-server`) and an optional `[grep]` pacing/budget table:
+
+```console
+loonfs-grep --config loonfs-grep.toml
+loonfs-grep --config loonfs-grep.toml --once
+```
+
+`--once` performs one complete build/fold sweep plus grep garbage collection and exits.

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -1,0 +1,149 @@
+//! Shared pacing and step-budget configuration for grep worker hosts.
+
+use crate::GramIndexBuildPolicy;
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Default delay between all-namespace build/fold sweeps.
+pub const DEFAULT_GREP_STEP_INTERVAL_MS: u64 = 1_000;
+/// Default delay between grep-owned garbage-collection passes.
+pub const DEFAULT_GREP_GC_INTERVAL_MS: u64 = 60_000;
+
+/// Pacing and bounded-work policy shared by embedded and standalone workers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct GrepWorkerConfig {
+    /// Delay between all-namespace build/fold sweeps.
+    pub step_interval_ms: u64,
+    /// Delay between grep-owned garbage-collection passes.
+    pub gc_interval_ms: u64,
+    /// Revisions examined per build step.
+    pub max_files_per_step: usize,
+    /// Content bytes read per build step.
+    pub max_content_bytes_per_step: u64,
+    /// Rows per written grep segment.
+    pub max_rows_per_segment: usize,
+    /// Delta-level runs that trigger a fold.
+    pub max_l0_runs: usize,
+    /// Mid-level runs that trigger a base fold.
+    pub max_mid_runs: usize,
+    /// Rows merged by one fold step.
+    pub max_fold_rows_per_step: usize,
+}
+
+impl GrepWorkerConfig {
+    /// Returns the bounded build/fold policy represented by this config.
+    pub fn build_policy(self) -> GramIndexBuildPolicy {
+        GramIndexBuildPolicy {
+            max_files_per_step: self.max_files_per_step,
+            max_content_bytes_per_step: self.max_content_bytes_per_step,
+            max_rows_per_segment: self.max_rows_per_segment,
+            max_l0_runs: self.max_l0_runs,
+            max_mid_runs: self.max_mid_runs,
+            max_fold_rows_per_step: self.max_fold_rows_per_step,
+        }
+    }
+
+    /// Rejects zero pacing intervals and zero step budgets.
+    pub fn validate(self) -> Result<(), GrepWorkerConfigError> {
+        if self.step_interval_ms == 0 {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field: "step_interval_ms",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
+        if self.gc_interval_ms == 0 {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field: "gc_interval_ms",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
+        if let Some(field) = self.build_policy().zero_budget_field() {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field,
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Default for GrepWorkerConfig {
+    fn default() -> Self {
+        let policy = GramIndexBuildPolicy::default();
+        Self {
+            step_interval_ms: DEFAULT_GREP_STEP_INTERVAL_MS,
+            gc_interval_ms: DEFAULT_GREP_GC_INTERVAL_MS,
+            max_files_per_step: policy.max_files_per_step,
+            max_content_bytes_per_step: policy.max_content_bytes_per_step,
+            max_rows_per_segment: policy.max_rows_per_segment,
+            max_l0_runs: policy.max_l0_runs,
+            max_mid_runs: policy.max_mid_runs,
+            max_fold_rows_per_step: policy.max_fold_rows_per_step,
+        }
+    }
+}
+
+/// Invalid grep worker configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum GrepWorkerConfigError {
+    /// One field cannot safely drive the worker.
+    #[error("invalid `{field}`: {reason}")]
+    InvalidField {
+        /// Field within the `[grep]` table.
+        field: &'static str,
+        /// Human-readable rejection reason.
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_the_build_policy_and_worker_pacing() {
+        let config = GrepWorkerConfig::default();
+
+        assert_eq!(config.step_interval_ms, 1_000);
+        assert_eq!(config.gc_interval_ms, 60_000);
+        assert_eq!(config.build_policy(), GramIndexBuildPolicy::default());
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    #[test]
+    fn zero_pacing_and_policy_fields_are_rejected() {
+        for (field, config) in [
+            (
+                "step_interval_ms",
+                GrepWorkerConfig {
+                    step_interval_ms: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "gc_interval_ms",
+                GrepWorkerConfig {
+                    gc_interval_ms: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_files_per_step",
+                GrepWorkerConfig {
+                    max_files_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+        ] {
+            assert_eq!(
+                config.validate(),
+                Err(GrepWorkerConfigError::InvalidField {
+                    field,
+                    reason: "must be greater than zero".to_owned(),
+                })
+            );
+        }
+    }
+}

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -4,18 +4,25 @@
 //! of the namespace manifest. A missing or corrupt grep root disables grep
 //! work for that namespace; it must never affect core filesystem operation.
 //! Query execution reads a caller-provided core snapshot. [`GrepWorker`]
-//! owns explicitly driven storage maintenance; its standalone process arrives
-//! in a later change.
+//! owns explicitly driven storage maintenance, while [`GrepWorkerLoop`]
+//! supplies the shared all-namespaces driving loop used by server-embedded
+//! and standalone hosts.
 
 mod cache;
 pub mod codec;
+mod config;
 mod index_read;
 pub mod keyspace;
 mod query;
 pub mod root;
 mod service;
 mod worker;
+mod worker_loop;
 
+pub use config::{
+    GrepWorkerConfig, GrepWorkerConfigError, DEFAULT_GREP_GC_INTERVAL_MS,
+    DEFAULT_GREP_STEP_INTERVAL_MS,
+};
 pub use service::{
     GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,
     MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,
@@ -25,15 +32,6 @@ pub use worker::{
     GrepFoldOutcome, GrepFoldReport, GrepGcReport, GrepWorker, GREP_BACKFILL_CHECKPOINT_TTL_MS,
     GREP_GC_GRACE_WINDOW_MS,
 };
-
-use std::io::Write as _;
-use std::process::ExitCode;
-
-/// Entry point for the standalone `loonfs-grep` binary.
-pub fn main() -> ExitCode {
-    let _ = writeln!(
-        std::io::stderr().lock(),
-        "usage: loonfs-grep (the standalone worker arrives in a later change)"
-    );
-    ExitCode::FAILURE
-}
+pub use worker_loop::{
+    GrepSweepReport, GrepWorkerLoop, GrepWorkerLoopShutdown, GrepWorkerRunOnceError,
+};

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -1,7 +1,150 @@
 //! The `loonfs-grep` standalone worker binary.
 
+use clap::Parser;
+use loonfs_grep::{GrepWorker, GrepWorkerConfig, GrepWorkerLoop};
+use loonfs_objectstore::{SharedObjectStore, StoreConfig};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
+use thiserror::Error;
+use tracing_subscriber::EnvFilter;
 
-fn main() -> ExitCode {
-    loonfs_grep::main()
+#[derive(Debug, Parser)]
+#[command(about = "Drive LoonFS grep indexing and garbage collection")]
+struct Args {
+    /// TOML file containing `[store]` and optional `[grep]` tables.
+    #[arg(long)]
+    config: PathBuf,
+    /// Run exactly one all-namespaces build/fold/GC sweep and exit.
+    #[arg(long)]
+    once: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StandaloneConfig {
+    store: StoreConfig,
+    #[serde(default)]
+    grep: GrepWorkerConfig,
+}
+
+#[derive(Debug, Error)]
+enum StandaloneError {
+    #[error("failed to read config `{path}`: {source}")]
+    ReadConfig {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to decode config `{path}`: {source}")]
+    DecodeConfig {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("invalid grep config: {0}")]
+    GrepConfig(#[from] loonfs_grep::GrepWorkerConfigError),
+    #[error("invalid store config: {0}")]
+    StoreConfig(#[from] loonfs_objectstore::StoreConfigError),
+    #[error("failed to open configured store: {0}")]
+    OpenStore(#[from] loonfs_objectstore::ObjectStoreError),
+    #[error(transparent)]
+    RunOnce(#[from] loonfs_grep::GrepWorkerRunOnceError),
+    #[error("failed to initialize tracing: {0}")]
+    Tracing(String),
+    #[error("standalone signal task failed: {0}")]
+    SignalTask(String),
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(error = %error, "loonfs-grep failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<(), StandaloneError> {
+    init_tracing()?;
+    let args = Args::parse();
+    let config = load_config(&args.config)?;
+    let store = Arc::new(config.store.configured_object_store()?) as SharedObjectStore;
+    let worker = GrepWorker::new(
+        store.clone(),
+        "loonfs-grep",
+        loonfs_api::generated_id("wrs"),
+        format!("loonfs-grep/{}", env!("CARGO_PKG_VERSION")),
+    );
+    let mut worker_loop = GrepWorkerLoop::new(worker, store, config.grep);
+
+    if args.once {
+        let report = worker_loop.run_once().await?;
+        tracing::info!(
+            namespaces_seen = report.namespaces_seen,
+            namespaces_completed = report.namespaces_completed,
+            "grep worker one-shot sweep completed"
+        );
+        return Ok(());
+    }
+
+    let shutdown = worker_loop.shutdown_handle();
+    let signal_task = tokio::runtime::Handle::current().spawn(async move {
+        shutdown_signal().await;
+        shutdown.request_shutdown();
+    });
+    worker_loop.run().await;
+    signal_task
+        .await
+        .map_err(|error| StandaloneError::SignalTask(error.to_string()))?;
+    Ok(())
+}
+
+fn load_config(path: &Path) -> Result<StandaloneConfig, StandaloneError> {
+    let source = std::fs::read_to_string(path).map_err(|source| StandaloneError::ReadConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let config: StandaloneConfig =
+        toml::from_str(&source).map_err(|source| StandaloneError::DecodeConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    config.grep.validate()?;
+    config.store.validate()?;
+    Ok(config)
+}
+
+fn init_tracing() -> Result<(), StandaloneError> {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("loonfs_grep=info,loonfs_core=info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init()
+        .map_err(|error| StandaloneError::Tracing(error.to_string()))
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("install ctrl-c handler");
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        () = ctrl_c => {}
+        _ = terminate => {}
+    }
 }

--- a/crates/loonfs-grep/src/worker_loop.rs
+++ b/crates/loonfs-grep/src/worker_loop.rs
@@ -1,0 +1,409 @@
+//! Fair all-namespaces scheduling for [`crate::GrepWorker`] steps and GC.
+
+use crate::keyspace::{all_namespaces_prefix, parse_key, GrepKeyKind};
+use crate::{GrepGcReport, GrepWorker, GrepWorkerConfig};
+use loonfs_api::NamespaceId;
+use loonfs_core::{Error as CoreError, Result, StoreFailureClass};
+use loonfs_objectstore::ObjectStore;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use tokio::sync::Notify;
+
+const MAX_NAMESPACE_BACKOFF_SWEEPS: u64 = 64;
+
+/// Counts from one complete build/fold sweep and optional GC pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GrepSweepReport {
+    /// Exact grep roots discovered under the all-namespaces prefix.
+    pub namespaces_seen: u64,
+    /// Namespaces whose build and fold steps both completed.
+    pub namespaces_completed: u64,
+    /// Namespaces whose build or fold step failed.
+    pub namespace_failures: u64,
+    /// Persistently failing namespaces skipped until their retry sweep.
+    pub namespaces_backed_off: u64,
+    /// Grep garbage-collection counts when this sweep included GC.
+    pub garbage_collection: Option<GrepGcReport>,
+}
+
+/// Failure that prevents a standalone one-shot from completing its sweep.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum GrepWorkerRunOnceError {
+    /// The worker could not enumerate grep roots or run grep GC.
+    #[error("grep worker sweep failed: {0}")]
+    Sweep(#[source] CoreError),
+    /// Individual namespaces failed, after the sweep still serviced peers.
+    #[error("grep worker sweep completed with {failures} namespace failure(s)")]
+    NamespaceFailures { failures: u64 },
+}
+
+#[derive(Debug)]
+struct ShutdownState {
+    requested: AtomicBool,
+    notify: Notify,
+}
+
+/// Cloneable stop handle for a running [`GrepWorkerLoop`].
+#[derive(Debug, Clone)]
+pub struct GrepWorkerLoopShutdown {
+    state: Arc<ShutdownState>,
+}
+
+impl GrepWorkerLoopShutdown {
+    /// Requests a clean stop between bounded worker steps.
+    pub fn request_shutdown(&self) {
+        self.state.requested.store(true, Ordering::Release);
+        self.state.notify.notify_waiters();
+    }
+
+    fn requested(&self) -> bool {
+        self.state.requested.load(Ordering::Acquire)
+    }
+
+    async fn wait_or_timeout(&self, deadline: tokio::time::Instant) {
+        let notified = self.state.notify.notified();
+        if self.requested() {
+            return;
+        }
+        tokio::select! {
+            () = notified => {}
+            () = tokio::time::sleep_until(deadline) => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NamespaceFailure {
+    consecutive_failures: u32,
+    retry_at_sweep: u64,
+}
+
+/// Shared grep worker driving loop used by embedded and standalone hosts.
+#[derive(Debug)]
+pub struct GrepWorkerLoop<S> {
+    worker: GrepWorker<S>,
+    store: S,
+    config: GrepWorkerConfig,
+    shutdown: GrepWorkerLoopShutdown,
+    sweep_number: u64,
+    namespace_failures: BTreeMap<NamespaceId, NamespaceFailure>,
+}
+
+impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
+    /// Builds a loop around one worker and the same store it operates on.
+    pub fn new(worker: GrepWorker<S>, store: S, config: GrepWorkerConfig) -> Self {
+        Self {
+            worker,
+            store,
+            config,
+            shutdown: GrepWorkerLoopShutdown {
+                state: Arc::new(ShutdownState {
+                    requested: AtomicBool::new(false),
+                    notify: Notify::new(),
+                }),
+            },
+            sweep_number: 0,
+            namespace_failures: BTreeMap::new(),
+        }
+    }
+
+    /// Returns a handle that cleanly stops [`Self::run`] between steps.
+    pub fn shutdown_handle(&self) -> GrepWorkerLoopShutdown {
+        self.shutdown.clone()
+    }
+
+    /// Runs exactly one full build/fold sweep and one grep GC pass.
+    pub async fn run_once(
+        &mut self,
+    ) -> std::result::Result<GrepSweepReport, GrepWorkerRunOnceError> {
+        let mut report = self
+            .sweep(false)
+            .await
+            .map_err(GrepWorkerRunOnceError::Sweep)?;
+        report.garbage_collection = Some(
+            self.worker
+                .garbage_collect(current_time_ms().map_err(GrepWorkerRunOnceError::Sweep)?)
+                .await
+                .map_err(GrepWorkerRunOnceError::Sweep)?,
+        );
+        if report.namespace_failures > 0 {
+            return Err(GrepWorkerRunOnceError::NamespaceFailures {
+                failures: report.namespace_failures,
+            });
+        }
+        Ok(report)
+    }
+
+    /// Runs periodic sweeps until the matching shutdown handle is signaled.
+    ///
+    /// Namespace and store errors are logged and retried; only a task panic
+    /// can escape to the host's task join. A shutdown requested during IO is
+    /// observed after that bounded build, fold, or GC step finishes.
+    pub async fn run(mut self) {
+        let step_interval = Duration::from_millis(self.config.step_interval_ms);
+        let gc_interval = Duration::from_millis(self.config.gc_interval_ms);
+        let mut next_gc = tokio::time::Instant::now();
+        while !self.shutdown.requested() {
+            if let Err(error) = self.sweep(true).await {
+                tracing::warn!(
+                    phase = "grep_worker_sweep",
+                    result = "error",
+                    error = %error,
+                    "grep worker could not enumerate namespaces; retrying"
+                );
+            }
+            if self.shutdown.requested() {
+                break;
+            }
+            let now = tokio::time::Instant::now();
+            if now >= next_gc {
+                match current_time_ms() {
+                    Ok(now_ms) => {
+                        if let Err(error) = self.worker.garbage_collect(now_ms).await {
+                            tracing::warn!(
+                                phase = "grep_gc",
+                                result = "error",
+                                error = %error,
+                                "grep garbage collection failed; retrying"
+                            );
+                        }
+                    }
+                    Err(error) => tracing::warn!(
+                        phase = "grep_gc",
+                        result = "error",
+                        error = %error,
+                        "grep garbage collection clock failed; retrying"
+                    ),
+                }
+                next_gc = tokio::time::Instant::now() + gc_interval;
+            }
+            self.shutdown
+                .wait_or_timeout(tokio::time::Instant::now() + step_interval)
+                .await;
+        }
+    }
+
+    async fn sweep(&mut self, honor_shutdown: bool) -> Result<GrepSweepReport> {
+        self.sweep_number = self.sweep_number.saturating_add(1);
+        let namespace_ids = self.namespace_ids().await?;
+        let discovered: BTreeSet<NamespaceId> = namespace_ids.iter().cloned().collect();
+        self.namespace_failures
+            .retain(|namespace_id, _| discovered.contains(namespace_id));
+        let mut report = GrepSweepReport {
+            namespaces_seen: namespace_ids.len() as u64,
+            ..GrepSweepReport::default()
+        };
+        for namespace_id in namespace_ids {
+            if honor_shutdown && self.shutdown.requested() {
+                break;
+            }
+            if self.namespace_is_backed_off(&namespace_id) {
+                report.namespaces_backed_off += 1;
+                continue;
+            }
+            if let Err(error) = self
+                .worker
+                .build_step(&namespace_id, self.config.build_policy())
+                .await
+            {
+                report.namespace_failures += 1;
+                self.record_namespace_failure(&namespace_id, "grep_build", &error);
+                continue;
+            }
+            if honor_shutdown && self.shutdown.requested() {
+                break;
+            }
+            if let Err(error) = self
+                .worker
+                .fold_step(&namespace_id, self.config.build_policy())
+                .await
+            {
+                report.namespace_failures += 1;
+                self.record_namespace_failure(&namespace_id, "grep_fold", &error);
+                continue;
+            }
+            self.namespace_failures.remove(&namespace_id);
+            report.namespaces_completed += 1;
+        }
+        Ok(report)
+    }
+
+    async fn namespace_ids(&self) -> Result<Vec<NamespaceId>> {
+        let keys = self
+            .store
+            .list_prefix(all_namespaces_prefix())
+            .await
+            .map_err(|error| CoreError::Store {
+                object_key: all_namespaces_prefix().to_owned(),
+                message: error.message(),
+                class: StoreFailureClass::of(&error),
+            })?;
+        Ok(keys
+            .into_iter()
+            .filter_map(|key| {
+                let parsed = parse_key(&key)?;
+                matches!(parsed.kind, GrepKeyKind::Root).then_some(parsed.namespace_id)
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect())
+    }
+
+    fn namespace_is_backed_off(&self, namespace_id: &NamespaceId) -> bool {
+        self.namespace_failures
+            .get(namespace_id)
+            .is_some_and(|failure| self.sweep_number < failure.retry_at_sweep)
+    }
+
+    fn record_namespace_failure(
+        &mut self,
+        namespace_id: &NamespaceId,
+        phase: &'static str,
+        error: &CoreError,
+    ) {
+        let consecutive_failures = self
+            .namespace_failures
+            .get(namespace_id)
+            .map_or(1, |failure| failure.consecutive_failures.saturating_add(1));
+        let backoff_sweeps =
+            (1u64 << consecutive_failures.min(6)).min(MAX_NAMESPACE_BACKOFF_SWEEPS);
+        self.namespace_failures.insert(
+            namespace_id.clone(),
+            NamespaceFailure {
+                consecutive_failures,
+                retry_at_sweep: self.sweep_number.saturating_add(backoff_sweeps),
+            },
+        );
+        tracing::warn!(
+            namespace_id = %namespace_id,
+            phase,
+            result = "error",
+            error = %error,
+            consecutive_failures,
+            backoff_sweeps,
+            "grep worker namespace step failed; continuing the sweep"
+        );
+    }
+}
+
+#[allow(clippy::disallowed_methods)]
+fn current_time_ms() -> Result<u64> {
+    // Grep GC age checks enter wall time at the worker-loop boundary; durable replay stays deterministic.
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .map_err(|error| CoreError::Internal(format!("system clock before unix epoch: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior};
+    use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
+    use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+    use loonfs_core::{BootstrapOptions, NamespaceEngine};
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::ObjectStore;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn poisoned_namespace_backs_off_while_later_namespaces_keep_indexing() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let poisoned = NamespaceId::parse("a-poisoned").expect("namespace id");
+        let healthy = NamespaceId::parse("z-healthy").expect("namespace id");
+        let _poisoned_engine = bootstrap(store.clone(), &poisoned).await;
+        let healthy_engine = bootstrap(store.clone(), &healthy).await;
+        put_file(&store, &healthy_engine, &healthy, b"healthy needle").await;
+
+        let worker = GrepWorker::new(
+            store.clone(),
+            "loop-test-worker",
+            "loop-test-session",
+            "loop-test/0.1",
+        );
+        worker.enable(&poisoned).await.expect("enable poisoned");
+        worker.enable(&healthy).await.expect("enable healthy");
+        store
+            .put_overwrite(
+                &crate::keyspace::root_key(&poisoned),
+                Bytes::from_static(b"poison"),
+            )
+            .await
+            .expect("poison root");
+
+        let mut worker_loop =
+            GrepWorkerLoop::new(worker, store.clone(), GrepWorkerConfig::default());
+        assert!(matches!(
+            worker_loop.run_once().await,
+            Err(GrepWorkerRunOnceError::NamespaceFailures { failures: 1 })
+        ));
+        let healthy_root = crate::root::load_grep_root(&*store, &healthy)
+            .await
+            .expect("load healthy root")
+            .expect("healthy root exists");
+        assert_eq!(healthy_root.state().index().built_through_seq.0, 1);
+        assert!(matches!(
+            healthy_root.state().lifecycle(),
+            crate::root::GrepLifecycle::Steady
+        ));
+        assert!(!healthy_root.state().segments().is_empty());
+
+        let report = worker_loop
+            .run_once()
+            .await
+            .expect("backed-off poison does not fail the next sweep");
+        assert_eq!(report.namespaces_backed_off, 1);
+        assert_eq!(report.namespaces_completed, 1);
+    }
+
+    async fn bootstrap(
+        store: Arc<LocalFsStore>,
+        namespace_id: &NamespaceId,
+    ) -> NamespaceEngine<Arc<LocalFsStore>> {
+        let engine = NamespaceEngine::builder(store)
+            .namespace_id(namespace_id.clone())
+            .writer_id(format!("seed-{namespace_id}"))
+            .writer_session_id(format!("seed-{namespace_id}-session"))
+            .writer_version("worker-loop-test/0.1")
+            .build()
+            .expect("engine");
+        engine
+            .bootstrap_namespace(BootstrapOptions::default())
+            .await
+            .expect("bootstrap namespace");
+        engine
+    }
+
+    async fn put_file(
+        store: &Arc<LocalFsStore>,
+        engine: &NamespaceEngine<Arc<LocalFsStore>>,
+        namespace_id: &NamespaceId,
+        bytes: &[u8],
+    ) {
+        let stored = store_bytes_as_content(&**store, namespace_id, bytes)
+            .await
+            .expect("store content");
+        let content_ref = stored.content_ref.clone();
+        let prepared = prepare_stored_content(namespace_id.clone(), stored);
+        let result = engine
+            .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse("worker-loop-put").expect("commit id"),
+                    absolute_path: AbsolutePath::parse("/healthy.txt").expect("path"),
+                    content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                vec![prepared],
+            )])
+            .await
+            .pop()
+            .expect("one result");
+        result.expect("publish file");
+    }
+}

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -1,0 +1,159 @@
+#![allow(clippy::panic)]
+//! Standalone worker one-shot and configuration smoke coverage.
+
+use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, NamespaceId};
+use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
+use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use loonfs_core::{BootstrapOptions, NamespaceEngine};
+use loonfs_grep::keyspace::{root_key, segments_prefix};
+use loonfs_grep::root::{load_grep_root, GrepLifecycle};
+use loonfs_grep::GrepWorker;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::ObjectStore;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn standalone_once_advances_the_index_is_idempotent_and_rejects_bad_config() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store_root = temp_dir.path().join("store");
+    let store = Arc::new(LocalFsStore::new(&store_root).expect("store"));
+    let namespace_id = NamespaceId::parse("standalone").expect("namespace id");
+    let engine = NamespaceEngine::builder(store.clone())
+        .namespace_id(namespace_id.clone())
+        .writer_id("standalone-seed")
+        .writer_session_id("standalone-seed-session")
+        .writer_version("standalone-test/0.1")
+        .build()
+        .expect("engine");
+    engine
+        .bootstrap_namespace(BootstrapOptions::default())
+        .await
+        .expect("bootstrap namespace");
+    put_file(&store, &engine, &namespace_id).await;
+    GrepWorker::new(
+        store.clone(),
+        "standalone-enable",
+        "standalone-enable-session",
+        "standalone-enable/0.1",
+    )
+    .enable(&namespace_id)
+    .await
+    .expect("enable grep");
+
+    let config_path = temp_dir.path().join("worker.toml");
+    write_config(&config_path, &store_root, "");
+    let first = run_once(&config_path);
+    assert!(
+        first.status.success(),
+        "first one-shot failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_root = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load root")
+        .expect("root exists");
+    assert_eq!(first_root.state().index().built_through_seq.0, 1);
+    assert!(matches!(
+        first_root.state().lifecycle(),
+        GrepLifecycle::Steady
+    ));
+    assert!(!first_root.state().segments().is_empty());
+    let first_root_bytes = store
+        .get(&root_key(&namespace_id), None)
+        .await
+        .expect("read root")
+        .expect("root bytes");
+    let first_segments = store
+        .list_prefix(&segments_prefix(&namespace_id))
+        .await
+        .expect("list segments");
+
+    let second = run_once(&config_path);
+    assert!(
+        second.status.success(),
+        "second one-shot failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(
+        store
+            .get(&root_key(&namespace_id), None)
+            .await
+            .expect("read root again")
+            .expect("root bytes again"),
+        first_root_bytes,
+        "an up-to-date one-shot must not republish the root"
+    );
+    assert_eq!(
+        store
+            .list_prefix(&segments_prefix(&namespace_id))
+            .await
+            .expect("list segments again"),
+        first_segments,
+        "an up-to-date one-shot must not write segments"
+    );
+
+    let bad_config_path = temp_dir.path().join("bad-worker.toml");
+    write_config(&bad_config_path, &store_root, "step_interval_ms = 0\n");
+    let bad = run_once(&bad_config_path);
+    assert!(!bad.status.success(), "bad config must exit nonzero");
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    assert!(stderr.contains("invalid grep config"), "{stderr}");
+    assert!(stderr.contains("step_interval_ms"), "{stderr}");
+    assert!(stderr.contains("greater than zero"), "{stderr}");
+}
+
+async fn put_file(
+    store: &Arc<LocalFsStore>,
+    engine: &NamespaceEngine<Arc<LocalFsStore>>,
+    namespace_id: &NamespaceId,
+) {
+    let stored = store_bytes_as_content(&**store, namespace_id, b"standalone needle\n")
+        .await
+        .expect("store content");
+    let content_ref = stored.content_ref.clone();
+    let prepared = prepare_stored_content(namespace_id.clone(), stored);
+    let result = engine
+        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
+            PathMutationIntent::PutFile {
+                commit_id: CommitId::parse("standalone-put").expect("commit id"),
+                absolute_path: AbsolutePath::parse("/note.txt").expect("path"),
+                content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+            vec![prepared],
+        )])
+        .await
+        .pop()
+        .expect("one result");
+    result.expect("publish file");
+}
+
+fn write_config(path: &Path, store_root: &Path, grep_fields: &str) {
+    std::fs::write(
+        path,
+        format!(
+            r#"
+[store]
+kind = "local-fs"
+root = "{}"
+
+[grep]
+{}"#,
+            store_root.display(),
+            grep_fields
+        ),
+    )
+    .expect("write config");
+}
+
+fn run_once(config_path: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_loonfs-grep"))
+        .arg("--config")
+        .arg(config_path)
+        .arg("--once")
+        .output()
+        .expect("run loonfs-grep")
+}

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -23,6 +23,7 @@ clap.workspace = true
 http.workspace = true
 loonfs-api = { path = "../loonfs-api" }
 loonfs = { path = "../loonfs" }
+loonfs-grep = { path = "../loonfs-grep" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
 serde.workspace = true
 serde_json.workspace = true
@@ -41,6 +42,7 @@ loonfs-client = { path = "../loonfs-client" }
 # (`load_namespace_head_control`); production code depends on `loonfs` alone.
 loonfs-core = { path = "../loonfs-core" }
 tempfile.workspace = true
+tower = { version = "0.5", features = ["util"] }
 ureq.workspace = true
 
 [features]

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1,7 +1,8 @@
 //! Server configuration: strict TOML decoding of the listen address,
 //! store, and runtime cache overrides.
 
-use loonfs::{GramIndexBuildPolicy, RuntimeCacheConfig};
+use loonfs::RuntimeCacheConfig;
+use loonfs_grep::GrepWorkerConfig;
 use loonfs_objectstore::{ConfiguredObjectStore, SecretString, StoreConfigError};
 use serde::Deserialize;
 use std::env;
@@ -39,13 +40,9 @@ pub struct ServerConfig {
     pub writer_version: String,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
-    /// Budgets for the gram index build and fold steps run by this
-    /// server's maintenance (background catch-up after writes and explicit
-    /// ticks). Omitted fields keep the runtime defaults; bulk backfills
-    /// typically raise the per-step budgets so each tick indexes more
-    /// files per manifest publish. Zero budgets are rejected at startup.
+    /// Grep serving mode plus worker pacing and bounded-step budgets.
     #[serde(default)]
-    pub gram_index_build: GramIndexBuildPolicyOverrides,
+    pub grep: GrepConfig,
     /// Whether the server writer schedules maintenance (checkpoints and
     /// reorganization folds) after writes that cross the WAL-tail
     /// threshold. On by default; set `false` on write-serving nodes when a
@@ -152,17 +149,77 @@ pub struct RuntimeCacheConfigOverrides {
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
 }
 
-/// Optional `[gram_index_build]` overrides, field-for-field the budgets of
-/// [`GramIndexBuildPolicy`]; omitted fields keep that policy's defaults.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct GramIndexBuildPolicyOverrides {
-    pub max_files_per_step: Option<usize>,
-    pub max_content_bytes_per_step: Option<u64>,
-    pub max_rows_per_segment: Option<usize>,
-    pub max_l0_runs: Option<usize>,
-    pub max_mid_runs: Option<usize>,
-    pub max_fold_rows_per_step: Option<usize>,
+/// Whether this server serves grep and owns grep background maintenance.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrepMode {
+    /// Neither serve grep nor run its worker.
+    Disabled,
+    /// Serve grep and run the shared worker loop in this server process.
+    #[default]
+    Embedded,
+    /// Serve grep while an external process owns worker maintenance.
+    ServeOnly,
+}
+
+impl GrepMode {
+    /// Whether grep query and index-administration endpoints are supported.
+    pub fn serves_grep(self) -> bool {
+        self != Self::Disabled
+    }
+
+    /// Whether this server process owns the grep worker loop.
+    pub fn runs_worker(self) -> bool {
+        self == Self::Embedded
+    }
+}
+
+/// The server's `[grep]` table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct GrepConfig {
+    pub mode: GrepMode,
+    pub step_interval_ms: u64,
+    pub gc_interval_ms: u64,
+    pub max_files_per_step: usize,
+    pub max_content_bytes_per_step: u64,
+    pub max_rows_per_segment: usize,
+    pub max_l0_runs: usize,
+    pub max_mid_runs: usize,
+    pub max_fold_rows_per_step: usize,
+}
+
+impl GrepConfig {
+    /// Returns the shared worker-loop configuration represented by this table.
+    pub fn worker_config(self) -> GrepWorkerConfig {
+        GrepWorkerConfig {
+            step_interval_ms: self.step_interval_ms,
+            gc_interval_ms: self.gc_interval_ms,
+            max_files_per_step: self.max_files_per_step,
+            max_content_bytes_per_step: self.max_content_bytes_per_step,
+            max_rows_per_segment: self.max_rows_per_segment,
+            max_l0_runs: self.max_l0_runs,
+            max_mid_runs: self.max_mid_runs,
+            max_fold_rows_per_step: self.max_fold_rows_per_step,
+        }
+    }
+}
+
+impl Default for GrepConfig {
+    fn default() -> Self {
+        let worker = GrepWorkerConfig::default();
+        Self {
+            mode: GrepMode::Embedded,
+            step_interval_ms: worker.step_interval_ms,
+            gc_interval_ms: worker.gc_interval_ms,
+            max_files_per_step: worker.max_files_per_step,
+            max_content_bytes_per_step: worker.max_content_bytes_per_step,
+            max_rows_per_segment: worker.max_rows_per_segment,
+            max_l0_runs: worker.max_l0_runs,
+            max_mid_runs: worker.max_mid_runs,
+            max_fold_rows_per_step: worker.max_fold_rows_per_step,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -220,29 +277,6 @@ impl ServerConfig {
             config.metadata_table_cache.max_decoded_bytes = value;
         }
         config
-    }
-
-    pub fn gram_index_build_policy(&self) -> GramIndexBuildPolicy {
-        let mut policy = GramIndexBuildPolicy::default();
-        if let Some(value) = self.gram_index_build.max_files_per_step {
-            policy.max_files_per_step = value;
-        }
-        if let Some(value) = self.gram_index_build.max_content_bytes_per_step {
-            policy.max_content_bytes_per_step = value;
-        }
-        if let Some(value) = self.gram_index_build.max_rows_per_segment {
-            policy.max_rows_per_segment = value;
-        }
-        if let Some(value) = self.gram_index_build.max_l0_runs {
-            policy.max_l0_runs = value;
-        }
-        if let Some(value) = self.gram_index_build.max_mid_runs {
-            policy.max_mid_runs = value;
-        }
-        if let Some(value) = self.gram_index_build.max_fold_rows_per_step {
-            policy.max_fold_rows_per_step = value;
-        }
-        policy
     }
 
     pub fn object_store(&self) -> Result<ConfiguredObjectStore, ServerConfigError> {
@@ -321,10 +355,10 @@ impl ServerConfig {
                     .to_owned(),
             });
         }
-        if let Some(budget) = self.gram_index_build_policy().zero_budget_field() {
+        if let Err(error) = self.grep.worker_config().validate() {
             return Err(ServerConfigError::InvalidField {
-                field: "gram_index_build",
-                reason: format!("`{budget}` must be greater than zero"),
+                field: "grep",
+                reason: error.to_string(),
             });
         }
         require_non_empty("content_token_secret", self.content_token_secret.expose())?;
@@ -347,10 +381,17 @@ impl From<StoreConfigError> for ServerConfigError {
 
 pub fn load_server_config(path: impl AsRef<Path>) -> Result<ServerConfig, ServerConfigError> {
     let bytes = fs::read(path.as_ref()).map_err(|err| ServerConfigError::Io(err.to_string()))?;
-    let mut config: ServerConfig = toml::from_str(
-        std::str::from_utf8(&bytes).map_err(|err| ServerConfigError::Decode(err.to_string()))?,
-    )
-    .map_err(|err| ServerConfigError::Decode(err.to_string()))?;
+    let source =
+        std::str::from_utf8(&bytes).map_err(|err| ServerConfigError::Decode(err.to_string()))?;
+    let table: toml::Table =
+        toml::from_str(source).map_err(|err| ServerConfigError::Decode(err.to_string()))?;
+    if table.contains_key("gram_index_build") {
+        return Err(ServerConfigError::Decode(
+            "removed `[gram_index_build]` table; move these fields under `[grep]`".to_owned(),
+        ));
+    }
+    let mut config: ServerConfig =
+        toml::from_str(source).map_err(|err| ServerConfigError::Decode(err.to_string()))?;
     config.apply_env_fallbacks(
         env::var(AUTH_TOKEN_ENV).ok(),
         env::var(CONTENT_TOKEN_SECRET_ENV).ok(),
@@ -828,7 +869,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
-[gram_index_build]
+[grep]
 max_fold_rows_per_step = 0
 
 [store]
@@ -837,7 +878,7 @@ root = "/tmp/loonfs-server"
 "#,
         );
         let error = load_server_config(&path).expect_err("zero gram budget must be rejected");
-        assert_invalid_field(error, "gram_index_build");
+        assert_invalid_field(error, "grep");
     }
 
     #[test]
@@ -963,14 +1004,14 @@ kind = "local-fs"
 root = "/tmp/loonfs-server"
 "#,
         );
-        let gram_index_build_level = write_config(
+        let grep_level = write_config(
             r#"
 bind = "127.0.0.1:9400"
 auth_token = "dev-token"
 writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
-[gram_index_build]
+[grep]
 max_files_per_stepp = 3
 
 [store]
@@ -983,7 +1024,7 @@ root = "/tmp/loonfs-server"
             (top_level, "lease_duration"),
             (store_level, "key_prefiks"),
             (runtime_cache_level, "max_cached_namespacs"),
-            (gram_index_build_level, "max_files_per_stepp"),
+            (grep_level, "max_files_per_stepp"),
         ] {
             let error = load_server_config(&path).expect_err("typo'd key must be rejected");
             match error {
@@ -1108,7 +1149,7 @@ root = "/tmp/loonfs-server"
     }
 
     #[test]
-    fn load_uses_default_gram_index_build_policy_when_omitted() {
+    fn load_uses_embedded_grep_defaults_when_table_is_omitted() {
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -1123,14 +1164,16 @@ root = "/tmp/loonfs-server"
         );
 
         let config = load_server_config(&path).expect("load config");
+        assert_eq!(config.grep, super::GrepConfig::default());
+        assert_eq!(config.grep.mode, super::GrepMode::Embedded);
         assert_eq!(
-            config.gram_index_build_policy(),
+            config.grep.worker_config().build_policy(),
             loonfs::GramIndexBuildPolicy::default()
         );
     }
 
     #[test]
-    fn load_applies_gram_index_build_overrides() {
+    fn load_applies_grep_mode_pacing_and_policy() {
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -1138,7 +1181,10 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
-[gram_index_build]
+[grep]
+mode = "serve_only"
+step_interval_ms = 25
+gc_interval_ms = 500
 max_files_per_step = 4096
 max_content_bytes_per_step = 536870912
 max_rows_per_segment = 131072
@@ -1152,9 +1198,11 @@ root = "/tmp/loonfs-server"
 "#,
         );
 
-        let policy = load_server_config(&path)
-            .expect("load config")
-            .gram_index_build_policy();
+        let grep = load_server_config(&path).expect("load config").grep;
+        assert_eq!(grep.mode, super::GrepMode::ServeOnly);
+        assert_eq!(grep.step_interval_ms, 25);
+        assert_eq!(grep.gc_interval_ms, 500);
+        let policy = grep.worker_config().build_policy();
         assert_eq!(policy.max_files_per_step, 4096);
         assert_eq!(policy.max_content_bytes_per_step, 536_870_912);
         assert_eq!(policy.max_rows_per_segment, 131_072);
@@ -1164,8 +1212,8 @@ root = "/tmp/loonfs-server"
     }
 
     #[test]
-    fn gram_index_build_overrides_apply_verbatim() {
-        // The policy handed to the runtime is exactly the configured one:
+    fn grep_policy_overrides_apply_verbatim() {
+        // The policy handed to the worker is exactly the configured one:
         // zero budgets are rejected by validation, never rewritten.
         let path = write_config(
             r#"
@@ -1174,7 +1222,7 @@ auth_token = "dev-token"
 writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
-[gram_index_build]
+[grep]
 max_files_per_step = 1024
 max_l0_runs = 3
 
@@ -1186,7 +1234,9 @@ root = "/tmp/loonfs-server"
 
         let policy = load_server_config(&path)
             .expect("load config")
-            .gram_index_build_policy();
+            .grep
+            .worker_config()
+            .build_policy();
         assert_eq!(policy.max_files_per_step, 1024);
         assert_eq!(policy.max_l0_runs, 3);
         assert_eq!(
@@ -1194,6 +1244,34 @@ root = "/tmp/loonfs-server"
             loonfs::GramIndexBuildPolicy::default().max_mid_runs,
             "untouched budgets keep their defaults"
         );
+    }
+
+    #[test]
+    fn removed_gram_index_build_table_names_grep_replacement() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+writer_version = "loonfs-server/0.1.0"
+
+[gram_index_build]
+max_files_per_step = 4
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let error = load_server_config(&path).expect_err("removed table must fail");
+        match error {
+            ServerConfigError::Decode(message) => {
+                assert!(message.contains("[gram_index_build]"), "{message}");
+                assert!(message.contains("[grep]"), "{message}");
+            }
+            other => panic!("expected decode error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -14,8 +14,10 @@ use loonfs_api::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, ErrorCode, FlushWalResponse, ForkNamespaceRequest, GcRequest,
     GcResponse, MaintenanceTickRequest, MaintenanceTickResponse, ReleaseCheckpointResponse,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_BODY_BYTES, LIMIT_DOWNLOAD_MAX_CONCURRENT,
-    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
+    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_BODY_BYTES,
+    LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_QUERY_GREP_DEFAULT,
+    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
+    LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -73,6 +75,17 @@ pub(super) async fn config(
         LIMIT_COMMIT_MAX_BODY_BYTES.to_owned(),
         state.config.max_commit_body_bytes,
     );
+    if !state.config.grep.mode.serves_grep() {
+        capabilities.features.remove(FEATURE_QUERY_GREP);
+        for limit in [
+            LIMIT_QUERY_GREP_DEFAULT,
+            LIMIT_QUERY_GREP_MAX,
+            LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+            LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
+        ] {
+            capabilities.limits.remove(limit);
+        }
+    }
     Ok(Json(capabilities))
 }
 

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -10,6 +10,7 @@ use loonfs_api::v0::{
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
+use loonfs_api::FEATURE_QUERY_GREP;
 
 #[cfg_attr(
     feature = "openapi",
@@ -18,7 +19,7 @@ use loonfs_api::ApiError;
         path = "/v0/namespaces/{namespace}/query/grep",
         tag = "query",
         summary = "Content search",
-        description = "Searches file content with a regular expression, accelerated by the namespace's gram index (`index.grams`). Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires the index to be materialized on the namespace.",
+        description = "Searches file content with a regular expression, accelerated by the namespace's gram index (`index.grams`). Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires this deployment to serve grep and the index to be materialized on the namespace.",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = GrepRequest,
         responses(
@@ -27,7 +28,7 @@ use loonfs_api::ApiError;
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 501, description = "The gram index is not materialized on this namespace", body = ApiError),
+            (status = 501, description = "Grep serving is disabled or the gram index is not materialized on this namespace", body = ApiError),
             (status = 503, description = "The index trails the head past the scan budget", body = ApiError)
         )
     )
@@ -48,6 +49,18 @@ pub(super) async fn grep(
     Ok(Json(response))
 }
 
+/// Uniform absent-capability response for every grep-owned HTTP operation.
+pub(super) async fn grep_not_supported(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    Err(ApiResponseError::not_supported(
+        FEATURE_QUERY_GREP,
+        "grep is disabled for this deployment; set `[grep].mode` to `embedded` or `serve_only`",
+    ))
+}
+
 #[cfg_attr(
     feature = "openapi",
     utoipa::path(
@@ -55,12 +68,13 @@ pub(super) async fn grep(
         path = "/v0/admin/namespaces/{namespace}/index/grams/enable",
         tag = "admin",
         summary = "Enable the gram index",
-        description = "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next maintenance tick and the index stays current from then on. Idempotent.",
+        description = "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next grep worker sweep and the index stays current from then on. Idempotent.",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Feature entry published or already present", body = EnableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
             (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
         )
     )
@@ -93,6 +107,7 @@ pub(super) async fn enable_grams_index(
             (status = 200, description = "Feature entry removed or already absent", body = DisableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
             (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
         )
     )

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -37,7 +37,7 @@ use self::handlers_namespace::{
     advance_retention, create_checkpoint, create_namespace, delete_namespace, flush_wal,
     fork_namespace, gc_namespace, maintenance_tick, namespace_status, release_checkpoint,
 };
-use self::handlers_query::{disable_grams_index, enable_grams_index, grep};
+use self::handlers_query::{disable_grams_index, enable_grams_index, grep, grep_not_supported};
 use self::handlers_uploads::{begin_upload, complete_upload, upload_content};
 use crate::config::{ServerConfig, ServerConfigError};
 use axum::async_trait;
@@ -59,6 +59,7 @@ use loonfs::{
     TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
+use loonfs_grep::{GrepWorker, GrepWorkerLoop, GrepWorkerLoopShutdown};
 use loonfs_objectstore::presign::ObjectTransferIssuer;
 use std::convert::Infallible;
 use std::ffi::OsString;
@@ -117,9 +118,8 @@ struct AppState {
     download_permits: Arc<Semaphore>,
 }
 
-/// Everything the app spawns that must settle at shutdown: the publisher
-/// registry's in-flight publications and the writer's scheduled background
-/// maintenance.
+/// Everything the app spawns that must settle at shutdown: the optional
+/// embedded grep loop, publisher publications, and writer maintenance.
 ///
 /// [`serve`] drives this itself. A host embedding the [`Router`] on its own
 /// HTTP server must call [`ServerLifecycle::shutdown`] after its listener
@@ -128,17 +128,55 @@ struct AppState {
 pub struct ServerLifecycle {
     writer: FsWriter,
     publisher: PublisherRegistry,
+    grep: Option<GrepBackgroundWork>,
 }
 
 impl ServerLifecycle {
-    /// Settles the app's spawned work, in dependency order: publisher
-    /// admission closes (later submissions fail with `shutting_down`),
-    /// admitted publications finish, then writer-scheduled maintenance
-    /// settles. Panicked tasks surface as the returned error.
+    /// Settles the app's spawned work in dependency order: the grep loop
+    /// stops between bounded steps, publisher admission closes, admitted
+    /// publications finish, then writer-scheduled maintenance settles.
+    /// Panicked tasks surface as the returned error.
     pub async fn shutdown(self) -> Result<(), loonfs::RuntimeError> {
+        if let Some(grep) = self.grep {
+            grep.shutdown().await?;
+        }
         self.publisher.close_admission();
         self.publisher.drain().await?;
         self.writer.shutdown_background().await
+    }
+}
+
+/// One server-owned grep loop and the stop handle that lets shutdown join it.
+struct GrepBackgroundWork {
+    shutdown: GrepWorkerLoopShutdown,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl GrepBackgroundWork {
+    fn spawn(config: &ServerConfig, store: SharedObjectStore) -> Result<Self, ServerConfigError> {
+        let worker = GrepWorker::new(
+            store.clone(),
+            format!("{}-grep", config.writer_id),
+            loonfs_api::generated_id("wrs"),
+            config.writer_version.clone(),
+        );
+        let worker_loop = GrepWorkerLoop::new(worker, store, config.grep.worker_config());
+        let shutdown = worker_loop.shutdown_handle();
+        let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+            ServerConfigError::InvalidField {
+                field: "runtime",
+                reason: format!("server app must be built inside a Tokio runtime: {error}"),
+            }
+        })?;
+        let task = runtime.spawn(worker_loop.run());
+        Ok(Self { shutdown, task })
+    }
+
+    async fn shutdown(self) -> Result<(), loonfs::RuntimeError> {
+        self.shutdown.request_shutdown();
+        self.task.await.map_err(|error| {
+            loonfs::RuntimeError::RuntimeTask(format!("grep worker task failed: {error}"))
+        })
     }
 }
 
@@ -184,12 +222,18 @@ async fn app_with_store_and_transfer_issuer(
     store: SharedObjectStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<(Router, ServerLifecycle, AppState), ServerConfigError> {
-    let (writer, reader, admin) = build_handles(&config, store).await?;
+    let (writer, reader, admin) = build_handles(&config, store.clone()).await?;
+    let grep = if config.grep.mode.runs_worker() {
+        Some(GrepBackgroundWork::spawn(&config, store)?)
+    } else {
+        None
+    };
     let config = Arc::new(config);
     let publisher = writer.publisher();
     let lifecycle = ServerLifecycle {
         writer: writer.clone(),
         publisher: publisher.clone(),
+        grep,
     };
     let state = AppState {
         upload_permits: Arc::new(Semaphore::new(
@@ -215,6 +259,21 @@ fn router(state: AppState) -> Router {
     let max_upload_bytes = usize::try_from(state.config.max_upload_bytes).unwrap_or(usize::MAX);
     let max_commit_body_bytes =
         usize::try_from(state.config.max_commit_body_bytes).unwrap_or(usize::MAX);
+    let grep_route = if state.config.grep.mode.serves_grep() {
+        post(grep)
+    } else {
+        post(grep_not_supported)
+    };
+    let enable_grep_route = if state.config.grep.mode.serves_grep() {
+        post(enable_grams_index)
+    } else {
+        post(grep_not_supported)
+    };
+    let disable_grep_route = if state.config.grep.mode.serves_grep() {
+        post(disable_grams_index)
+    } else {
+        post(grep_not_supported)
+    };
     Router::new()
         .route("/health", get(health))
         .route("/health/ready", get(health_ready))
@@ -236,14 +295,14 @@ fn router(state: AppState) -> Router {
             "/v0/namespaces/:namespace/filesystem/content",
             get(get_content),
         )
-        .route("/v0/namespaces/:namespace/query/grep", post(grep))
+        .route("/v0/namespaces/:namespace/query/grep", grep_route)
         .route(
             "/v0/admin/namespaces/:namespace/index/grams/enable",
-            post(enable_grams_index),
+            enable_grep_route,
         )
         .route(
             "/v0/admin/namespaces/:namespace/index/grams/disable",
-            post(disable_grams_index),
+            disable_grep_route,
         )
         .route(
             "/v0/namespaces/:namespace/filesystem/revisions",
@@ -371,7 +430,6 @@ async fn build_handles_with_metrics_jsonl_path(
         .max_read_content_bytes(config.max_download_bytes)
         .max_concurrent_maintenance(config.max_concurrent_maintenance)
         .runtime_cache(config.runtime_cache_config())
-        .gram_index_build(config.gram_index_build_policy())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
     if let Some(recorder) = metrics_recorder.clone() {
@@ -388,7 +446,6 @@ async fn build_handles_with_metrics_jsonl_path(
         // reuses blocks reader traffic already decoded instead of
         // populating a second, default-sized cache.
         .runtime_cache(config.runtime_cache_config())
-        .gram_index_build(config.gram_index_build_policy())
         .shared_metadata_table_cache(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
@@ -436,9 +493,9 @@ pub enum ServeError {
 }
 
 /// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
-/// stops accepting, in-flight requests drain, publisher admission closes
-/// and admitted publications finish, and the writer's scheduled background
-/// maintenance settles before this returns.
+/// stops accepting, in-flight requests drain, the embedded grep loop stops,
+/// publisher work finishes, and writer maintenance settles before this
+/// returns.
 pub async fn serve(config: ServerConfig) -> Result<(), ServeError> {
     serve_with_shutdown(config, shutdown_signal()).await
 }
@@ -466,10 +523,10 @@ async fn serve_on(
         .with_graceful_shutdown(shutdown)
         .await
         .map_err(ServeError::Serve)?;
-    // The listener has drained; close publisher admission, finish admitted
-    // publications, then settle writer-owned maintenance so neither a
-    // publication nor a checkpoint tick is torn down mid-write. Panicked
-    // tasks surface here rather than disappearing with the process.
+    // The listener has drained; stop grep between bounded steps, close
+    // publisher admission, finish admitted publications, then settle
+    // writer-owned maintenance. Panicked tasks surface here rather than
+    // disappearing with the process.
     lifecycle.shutdown().await.map_err(ServeError::Shutdown)
 }
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -76,6 +76,8 @@ use loonfs::{
 use loonfs_api::ErrorCode;
 use loonfs_api::{ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, NamespaceId};
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
+use loonfs_grep::keyspace::root_key as grep_root_key;
+use loonfs_grep::GrepWorker;
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -85,6 +87,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
+use tokio::sync::Notify;
 
 #[derive(Debug)]
 struct StaleHeadOnceStore {
@@ -135,6 +138,74 @@ impl ObjectStore for StaleHeadOnceStore {
                 let _ = self.inner.put_overwrite(key, existing).await?;
             }
         }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+#[derive(Debug)]
+struct BlockGrepRootOnceStore {
+    inner: LocalFsStore,
+    root_key: String,
+    armed: AtomicBool,
+    entered: Notify,
+    release: Notify,
+}
+
+impl BlockGrepRootOnceStore {
+    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
+            root_key: grep_root_key(namespace_id),
+            armed: AtomicBool::new(false),
+            entered: Notify::new(),
+            release: Notify::new(),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ObjectStore for BlockGrepRootOnceStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        if key == self.root_key && self.armed.swap(false, Ordering::SeqCst) {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
         self.inner.put(key, bytes, mode).await
     }
 
@@ -231,6 +302,49 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
         std::net::TcpStream::connect(addr).is_err(),
         "listener should refuse connections after shutdown"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embedded_shutdown_drains_an_active_grep_step() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("grep-shutdown");
+    let blocking_store = Arc::new(BlockGrepRootOnceStore::new(temp_dir.path(), &namespace_id));
+    let store = blocking_store.clone() as SharedObjectStore;
+    let writer = test_runtime(store.clone(), "grep-shutdown-seed").await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    GrepWorker::new(
+        store.clone(),
+        "grep-shutdown-enable",
+        "grep-shutdown-enable-session",
+        "grep-shutdown-enable/0.1",
+    )
+    .enable(&namespace_id)
+    .await
+    .expect("enable grep");
+
+    blocking_store.arm();
+    let mut config = test_config(temp_dir.path(), "grep-shutdown-server");
+    config.grep.step_interval_ms = 1;
+    let (_router, lifecycle, _state) =
+        super::app_with_store_and_transfer_issuer(config, store, None)
+            .await
+            .expect("build app");
+    blocking_store.entered.notified().await;
+
+    let shutdown = tokio::runtime::Handle::current().spawn(lifecycle.shutdown());
+    tokio::task::yield_now().await;
+    assert!(
+        !shutdown.is_finished(),
+        "shutdown must wait for the active bounded grep step"
+    );
+    blocking_store.release.notify_one();
+    shutdown
+        .await
+        .expect("join shutdown")
+        .expect("drain grep step");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1303,7 +1417,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
-        gram_index_build: crate::config::GramIndexBuildPolicyOverrides::default(),
+        grep: crate::config::GrepConfig::default(),
         background_maintenance: true,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -10,7 +10,7 @@ mod http;
 mod trace;
 
 pub use config::{
-    load_server_config, GramIndexBuildPolicyOverrides, RuntimeCacheConfigOverrides, ServerConfig,
+    load_server_config, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig,
     ServerConfigError, StoreConfig,
 };
 pub use http::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle};

--- a/crates/loonfs-server/src/trace.rs
+++ b/crates/loonfs-server/src/trace.rs
@@ -8,7 +8,8 @@ use tracing_subscriber::EnvFilter;
 
 const TRACE_ENV: &str = "LOONFS_TRACE";
 const RUST_LOG_ENV: &str = "RUST_LOG";
-const DEFAULT_TRACE_FILTER: &str = "loonfs_server=info,loonfs=info,loonfs_core=info";
+const DEFAULT_TRACE_FILTER: &str =
+    "loonfs_server=info,loonfs_grep=info,loonfs=info,loonfs_core=info";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TraceConfig {

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -6,9 +6,7 @@ use loonfs_api::{
     FilesystemOperationRequest, NamespaceId,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loonfs_server::{
-    app, GramIndexBuildPolicyOverrides, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
-};
+use loonfs_server::{app, GrepConfig, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -27,7 +25,7 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-aws-s3".to_owned(),
         writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
-        gram_index_build: GramIndexBuildPolicyOverrides::default(),
+        grep: GrepConfig::default(),
         background_maintenance: true,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,
@@ -63,7 +61,7 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
         writer_id: "direct-put-r2".to_owned(),
         writer_version: "direct-put-r2/0.1.0".to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
-        gram_index_build: GramIndexBuildPolicyOverrides::default(),
+        grep: GrepConfig::default(),
         background_maintenance: true,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,

--- a/crates/loonfs-server/tests/grep_modes.rs
+++ b/crates/loonfs-server/tests/grep_modes.rs
@@ -1,0 +1,304 @@
+#![allow(clippy::panic)]
+//! In-process HTTP mode matrix for grep serving and worker ownership.
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions};
+use loonfs_api::{
+    ApiError, CapabilityDocument, GrepRequest, GrepResponse, NamespaceId, FEATURE_QUERY_GREP,
+    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
+};
+use loonfs_grep::root::{load_grep_root, GrepLifecycle};
+use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::SharedObjectStore;
+use loonfs_server::{
+    app, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+};
+use serde::de::DeserializeOwned;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (_store, _writer, namespace_id) = seed_namespace(temp_dir.path(), "disabled").await;
+    let (router, lifecycle) = app(test_config(temp_dir.path(), GrepMode::Disabled))
+        .await
+        .expect("build app");
+
+    let capabilities: CapabilityDocument =
+        response_json(send(&router, Method::GET, "/v0/config", None).await).await;
+    assert!(!capabilities.features.contains_key(FEATURE_QUERY_GREP));
+    for limit in grep_limits() {
+        assert!(!capabilities.limits.contains_key(limit));
+    }
+
+    for path in [
+        format!("/v0/namespaces/{namespace_id}/query/grep"),
+        format!("/v0/admin/namespaces/{namespace_id}/index/grams/enable"),
+        format!("/v0/admin/namespaces/{namespace_id}/index/grams/disable"),
+    ] {
+        let response = send(&router, Method::POST, &path, None).await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        let error: ApiError = response_json(response).await;
+        assert_eq!(error.code, "not_supported");
+        assert_eq!(error.feature.as_deref(), Some(FEATURE_QUERY_GREP));
+    }
+    lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+#[tokio::test]
+async fn embedded_mode_indexes_written_files_without_manual_ticks() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (_store, writer, namespace_id) = seed_namespace(temp_dir.path(), "embedded").await;
+    let (router, lifecycle) = app(test_config(temp_dir.path(), GrepMode::Embedded))
+        .await
+        .expect("build app");
+    assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/note.txt",
+            b"automatic needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write file");
+
+    let capabilities: CapabilityDocument =
+        response_json(send(&router, Method::GET, "/v0/config", None).await).await;
+    assert!(capabilities.supports(FEATURE_QUERY_GREP));
+    for limit in grep_limits() {
+        assert!(capabilities.limits.contains_key(limit));
+    }
+
+    let response = wait_for_grep(&router, &namespace_id, "automatic needle").await;
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/note.txt");
+    assert_eq!(response.built_through_seq, response.head_seq);
+    lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+#[tokio::test]
+async fn serve_only_mode_requires_an_external_worker_to_advance_the_watermark() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "serve-only").await;
+    let (router, lifecycle) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
+        .await
+        .expect("build app");
+    assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/note.txt",
+            b"external needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write file");
+
+    wait_for_worker_opportunity().await;
+    let before = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load grep root")
+        .expect("enabled grep root");
+    assert_eq!(before.state().index().built_through_seq.0, 0);
+    assert!(matches!(
+        before.state().lifecycle(),
+        GrepLifecycle::Backfilling { .. }
+    ));
+
+    let worker = GrepWorker::new(
+        store,
+        "external-grep-worker",
+        "external-grep-worker-session",
+        "external-grep-worker/0.1",
+    );
+    for _ in 0..8 {
+        let build = worker
+            .build_step(&namespace_id, GramIndexBuildPolicy::default())
+            .await
+            .expect("external build step");
+        worker
+            .fold_step(&namespace_id, GramIndexBuildPolicy::default())
+            .await
+            .expect("external fold step");
+        if matches!(
+            build.outcome,
+            GrepBuildOutcome::UpToDate {
+                built_through_seq: loonfs_api::ChangeSeq(1)
+            }
+        ) {
+            break;
+        }
+    }
+
+    let response = grep(&router, &namespace_id, "external needle").await;
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.built_through_seq.0, 1);
+    lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+async fn seed_namespace(root: &Path, name: &str) -> (SharedObjectStore, FsWriter, NamespaceId) {
+    let store = Arc::new(LocalFsStore::new(root).expect("store")) as SharedObjectStore;
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id(format!("grep-mode-seed-{name}"))
+        .writer_version("grep-mode-tests/0.1")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    let namespace_id = NamespaceId::parse(name).expect("namespace id");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    (store, writer, namespace_id)
+}
+
+fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
+    ServerConfig {
+        bind: "127.0.0.1:0".to_owned(),
+        auth_token: Some("test-token".into()),
+        content_token_secret: "test-content-token-secret".into(),
+        writer_id: format!("grep-mode-{mode:?}"),
+        writer_version: "grep-mode-tests/0.1".to_owned(),
+        runtime_cache: RuntimeCacheConfigOverrides::default(),
+        grep: GrepConfig {
+            mode,
+            step_interval_ms: 5,
+            gc_interval_ms: 25,
+            ..GrepConfig::default()
+        },
+        background_maintenance: true,
+        min_publish_interval_ms: 0,
+        max_upload_bytes: 1024 * 1024,
+        max_download_bytes: 1024 * 1024,
+        max_commit_body_bytes: 1024 * 1024,
+        max_concurrent_uploads: 2,
+        max_concurrent_downloads: 2,
+        max_concurrent_maintenance: 2,
+        allow_unauthenticated_remote: false,
+        store: StoreConfig::LocalFs {
+            root: store_root.display().to_string(),
+            key_prefix: None,
+        },
+    }
+}
+
+async fn enable_grep(router: &Router, namespace_id: &NamespaceId) -> StatusCode {
+    send(
+        router,
+        Method::POST,
+        &format!("/v0/admin/namespaces/{namespace_id}/index/grams/enable"),
+        None,
+    )
+    .await
+    .status()
+}
+
+async fn grep(router: &Router, namespace_id: &NamespaceId, pattern: &str) -> GrepResponse {
+    let request = GrepRequest {
+        pattern: pattern.to_owned(),
+        case_insensitive: false,
+        path_prefix: None,
+        cursor: None,
+        limit: None,
+        allow_stale: false,
+        allow_scan: false,
+    };
+    response_json(
+        send(
+            router,
+            Method::POST,
+            &format!("/v0/namespaces/{namespace_id}/query/grep"),
+            Some(serde_json::to_vec(&request).expect("serialize grep request")),
+        )
+        .await,
+    )
+    .await
+}
+
+async fn send(
+    router: &Router,
+    method: Method,
+    uri: &str,
+    body: Option<Vec<u8>>,
+) -> axum::response::Response {
+    let mut request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", "Bearer test-token");
+    if body.is_some() {
+        request = request.header("content-type", "application/json");
+    }
+    router
+        .clone()
+        .oneshot(
+            request
+                .body(body.map_or_else(Body::empty, Body::from))
+                .expect("request"),
+        )
+        .await
+        .expect("route request")
+}
+
+async fn response_json<T: DeserializeOwned>(response: axum::response::Response) -> T {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&bytes).expect("decode response JSON")
+}
+
+fn grep_limits() -> [&'static str; 4] {
+    [
+        LIMIT_QUERY_GREP_DEFAULT,
+        LIMIT_QUERY_GREP_MAX,
+        LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+        LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
+    ]
+}
+
+#[allow(clippy::disallowed_methods)]
+async fn wait_for_grep(router: &Router, namespace_id: &NamespaceId, pattern: &str) -> GrepResponse {
+    // The real background timer is the behavior under test; the bounded poll only observes it.
+    for _ in 0..200 {
+        let response = send(
+            router,
+            Method::POST,
+            &format!("/v0/namespaces/{namespace_id}/query/grep"),
+            Some(
+                serde_json::to_vec(&GrepRequest {
+                    pattern: pattern.to_owned(),
+                    case_insensitive: false,
+                    path_prefix: None,
+                    cursor: None,
+                    limit: None,
+                    allow_stale: false,
+                    allow_scan: false,
+                })
+                .expect("serialize grep request"),
+            ),
+        )
+        .await;
+        if response.status() == StatusCode::OK {
+            let response: GrepResponse = response_json(response).await;
+            if !response.matches.is_empty() && response.built_through_seq == response.head_seq {
+                return response;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("grep worker did not make the file searchable");
+}
+
+#[allow(clippy::disallowed_methods)]
+async fn wait_for_worker_opportunity() {
+    // Five server step intervals are long enough to prove serve_only did not spawn the loop.
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+}

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -2600,7 +2600,7 @@ fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str
         writer_id: writer_id.to_owned(),
         writer_version: format!("{writer_id}/0.1.0"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
-        gram_index_build: loonfs_server::GramIndexBuildPolicyOverrides::default(),
+        grep: loonfs_server::GrepConfig::default(),
         background_maintenance: true,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -360,6 +360,16 @@
               }
             }
           },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "503": {
             "description": "Lost a manifest publication race; retry",
             "content": {
@@ -379,7 +389,7 @@
           "admin"
         ],
         "summary": "Enable the gram index",
-        "description": "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next maintenance tick and the index stays current from then on. Idempotent.",
+        "description": "Publishes the namespace's index.grams feature entry. Backfill over existing revisions starts on the next grep worker sweep and the index stays current from then on. Idempotent.",
         "operationId": "enable_grams_index",
         "parameters": [
           {
@@ -415,6 +425,16 @@
           },
           "404": {
             "description": "Namespace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
             "content": {
               "application/json": {
                 "schema": {
@@ -2078,7 +2098,7 @@
           "query"
         ],
         "summary": "Content search",
-        "description": "Searches file content with a regular expression, accelerated by the namespace's gram index (`index.grams`). Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires the index to be materialized on the namespace.",
+        "description": "Searches file content with a regular expression, accelerated by the namespace's gram index (`index.grams`). Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires this deployment to serve grep and the index to be materialized on the namespace.",
         "operationId": "grep",
         "parameters": [
           {
@@ -2153,7 +2173,7 @@
             }
           },
           "501": {
-            "description": "The gram index is not materialized on this namespace",
+            "description": "Grep serving is disabled or the gram index is not materialized on this namespace",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Grep becomes a deployment decision. The server grows a `[grep]` table (replacing `[gram_index_build]`, whose old name now fails validation with a message naming the replacement) with three modes. `embedded` — the default, preserving today's behavior for existing configs — serves grep and runs the worker loop on the server's runtime: a background sweep of the `grep/v0` prefix that steps build and fold for enabled roots, runs grep GC on its own interval, backs off exponentially on a failing namespace without starving its peers, and drains between bounded steps at shutdown through the existing lifecycle machinery. `serve_only` serves queries and expects an external process to own maintenance (pinned: the watermark does not advance on its own). `disabled` routes the grep and enable/disable endpoints to the standard `not_supported` response at router construction time and omits `query.grep` and the grep limits from the capability document, which is now composed from configuration by a server-side overlay — the narrowest seam, since deployment mode is server configuration; plain embedded library use is untouched, and nothing ever starts a worker implicitly.

The `loonfs-grep` binary gains its real main: a TOML config with a `[store]` section reusing the objectstore's `StoreConfig` and the same pacing fields, driving the identical shared sweep loop until SIGINT/SIGTERM, with `--once` performing exactly one sweep for tests and operational one-shots. One loop implementation, two hosts; the binary has no HTTP surface — serving stays in the server.

The mode matrix, shutdown drain, poisoned-namespace resilience, standalone smoke (advance, idempotent re-run, bad-config rejection), and config-cutover tests pin all of it; an embedded server indexes a freshly written file with no manual tick, which is the first time the system has done that without core maintenance involvement.
