### PR TITLE
refactor(grep): move durable layout under namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo build -p loonfs-server
 ./target/debug/loonfs-server --config configs/loonfs-server.local-fs.example.toml
 ```
 
-Commented example configs for every supported store live in [configs/](configs) (`local-fs`, `aws-s3`, `gcp-gcs`, `cloudflare-r2`, `azure-abs`). The required fields are `bind`, `writer_id`, `writer_version`, and a `[store]` block; everything else defaults. The optional `[grep]` table selects `mode = "disabled" | "embedded" | "serve_only"` (default `embedded`), worker intervals (`step_interval_ms = 1000`, `gc_interval_ms = 60000`), and the bounded build/fold policy shown in the local-fs example. Connect a client:
+Commented example configs for every supported store live in [configs/](configs) (`local-fs`, `aws-s3`, `gcp-gcs`, `cloudflare-r2`, `azure-abs`). The required fields are `bind`, `writer_id`, `writer_version`, and a `[store]` block; everything else defaults. The optional `[grep]` table selects `mode = "disabled" | "embedded" | "serve_only"` (default `embedded`), worker intervals (`step_interval_ms = 1000`, `gc_interval_ms = 60000`, `rescan_interval_ms = 300000`), and the bounded build/fold policy shown in the local-fs example. Grep rediscovery scans the whole `namespaces/` keyspace and is proportional to total store keys until a namespace catalog exists, so the default keeps it rare. Connect a client:
 
 ```bash
 export LOONFS_AUTH_TOKEN={auth_token}

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -56,6 +56,8 @@ writer_version = "loonfs-server/0.1.0"
 #mode = "embedded"
 #step_interval_ms = 1000
 #gc_interval_ms = 60000
+# Whole-store `namespaces/` scan; proportional to total key count until a namespace catalog exists.
+#rescan_interval_ms = 300000
 # Bounded build/fold budgets; every value must be greater than zero.
 #max_files_per_step = 256
 #max_content_bytes_per_step = 67108864

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -1,8 +1,8 @@
 # loonfs-grep
 
 `loonfs-grep` contains LoonFS's optional full-text grep subsystem. It owns the gram codec, the
-independent durable root and keyspace, and the explicitly driven `GrepWorker`; a standalone worker
-process and server-embedded mode share one fair all-namespaces `GrepWorkerLoop`.
+namespace-scoped `extensions/grep/` pointer, manifests, and segments, plus the explicitly driven
+`GrepWorker`; a standalone process and server-embedded mode share one fair worker loop.
 
 Run the standalone worker with a strict TOML config containing `[store]` (the same provider shape
 as `loonfs-server`) and an optional `[grep]` pacing/budget table:
@@ -12,4 +12,14 @@ loonfs-grep --config loonfs-grep.toml
 loonfs-grep --config loonfs-grep.toml --once
 ```
 
-`--once` performs one complete build/fold sweep plus grep garbage collection and exits.
+```toml
+[grep]
+step_interval_ms = 1000
+gc_interval_ms = 60000
+rescan_interval_ms = 300000
+```
+
+`--once` performs startup rediscovery, one complete build/fold sweep, and grep garbage collection,
+then exits. Rediscovery lists the entire `namespaces/` prefix and is proportional to the store's
+total key count. It is required for standalone and serve-only deployments until LoonFS has a
+namespace catalog; the five-minute default keeps periodic scans rare.

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -1,15 +1,17 @@
-//! Grep-private cache for decoded immutable index-segment blocks.
+//! Grep-private cache for immutable manifests and decoded segment blocks.
 
 use crate::codec::IndexRow;
+use crate::root::GrepRootState;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
-/// Maximum decoded segment sections retained by one grep service.
+/// Maximum decoded manifests and segment sections retained by one grep service.
 pub(crate) const MAX_CACHED_GREP_BLOCKS: usize = 4_096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum GrepBlockKind {
+    Manifest,
     Filter,
     Index,
     Data,
@@ -24,6 +26,7 @@ pub(crate) struct GrepBlockCacheKey {
 
 #[derive(Debug, Clone)]
 pub(crate) enum DecodedGrepBlock {
+    Manifest(Arc<GrepRootState>),
     Filter(Arc<SegmentFilter>),
     Index(Arc<Vec<SegmentIndexEntry>>),
     Data(Arc<DecodedDataBlock<IndexRow>>),

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 pub const DEFAULT_GREP_STEP_INTERVAL_MS: u64 = 1_000;
 /// Default delay between grep-owned garbage-collection passes.
 pub const DEFAULT_GREP_GC_INTERVAL_MS: u64 = 60_000;
+/// Default delay between whole-store namespace-extension rediscovery scans.
+pub const DEFAULT_GREP_RESCAN_INTERVAL_MS: u64 = 300_000;
 
 /// Pacing and bounded-work policy shared by embedded and standalone workers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -17,6 +19,14 @@ pub struct GrepWorkerConfig {
     pub step_interval_ms: u64,
     /// Delay between grep-owned garbage-collection passes.
     pub gc_interval_ms: u64,
+    /// Delay between grep root rediscovery scans.
+    ///
+    /// Each scan lists the whole `namespaces/` keyspace and is therefore
+    /// proportional to the store's total key count. This is the cost of the
+    /// namespace-scoped extension layout until a namespace catalog exists;
+    /// the default keeps the scan rare. Standalone workers and serve-only
+    /// deployments rely on it to observe enablements from another process.
+    pub rescan_interval_ms: u64,
     /// Revisions examined per build step.
     pub max_files_per_step: usize,
     /// Content bytes read per build step.
@@ -58,6 +68,12 @@ impl GrepWorkerConfig {
                 reason: "must be greater than zero".to_owned(),
             });
         }
+        if self.rescan_interval_ms == 0 {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field: "rescan_interval_ms",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
         if let Some(field) = self.build_policy().zero_budget_field() {
             return Err(GrepWorkerConfigError::InvalidField {
                 field,
@@ -74,6 +90,7 @@ impl Default for GrepWorkerConfig {
         Self {
             step_interval_ms: DEFAULT_GREP_STEP_INTERVAL_MS,
             gc_interval_ms: DEFAULT_GREP_GC_INTERVAL_MS,
+            rescan_interval_ms: DEFAULT_GREP_RESCAN_INTERVAL_MS,
             max_files_per_step: policy.max_files_per_step,
             max_content_bytes_per_step: policy.max_content_bytes_per_step,
             max_rows_per_segment: policy.max_rows_per_segment,
@@ -108,6 +125,7 @@ mod tests {
 
         assert_eq!(config.step_interval_ms, 1_000);
         assert_eq!(config.gc_interval_ms, 60_000);
+        assert_eq!(config.rescan_interval_ms, 300_000);
         assert_eq!(config.build_policy(), GramIndexBuildPolicy::default());
         assert_eq!(config.validate(), Ok(()));
     }
@@ -126,6 +144,13 @@ mod tests {
                 "gc_interval_ms",
                 GrepWorkerConfig {
                     gc_interval_ms: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "rescan_interval_ms",
+                GrepWorkerConfig {
+                    rescan_interval_ms: 0,
                     ..GrepWorkerConfig::default()
                 },
             ),

--- a/crates/loonfs-grep/src/keyspace.rs
+++ b/crates/loonfs-grep/src/keyspace.rs
@@ -1,13 +1,16 @@
 //! Grep-owned durable object keys and their strict parser.
 
+use crate::root::GrepManifestId;
 use loonfs_api::{IndexSegmentId, NamespaceId};
 
-const ALL_NAMESPACES_PREFIX: &str = "grep/v0/namespaces/";
+const ALL_NAMESPACES_PREFIX: &str = "namespaces/";
+const GREP_EXTENSION_SUFFIX: &str = "/extensions/grep/";
 
 /// The grep-owned object kind named by a parsed key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GrepKeyKind {
     Root,
+    Manifest { manifest_id: GrepManifestId },
     Segment { segment_id: IndexSegmentId },
 }
 
@@ -18,22 +21,35 @@ pub struct ParsedGrepKey {
     pub kind: GrepKeyKind,
 }
 
-/// Prefix containing grep state for every namespace.
+/// Prefix containing all namespace-scoped objects.
 ///
-/// Grep-owned garbage collection uses this prefix to find state belonging
-/// to namespaces that core has deleted.
+/// Grep discovery must scan this whole prefix until a namespace catalog
+/// exists; callers filter the stream through [`parse_key`].
 pub const fn all_namespaces_prefix() -> &'static str {
     ALL_NAMESPACES_PREFIX
 }
 
 /// Prefix containing every grep object for one namespace.
 pub fn namespace_prefix(namespace_id: &NamespaceId) -> String {
-    format!("{ALL_NAMESPACES_PREFIX}{namespace_id}/")
+    format!("{ALL_NAMESPACES_PREFIX}{namespace_id}{GREP_EXTENSION_SUFFIX}")
 }
 
-/// Key of one namespace's atomic grep root.
+/// Key of one namespace's atomic grep root pointer.
 pub fn root_key(namespace_id: &NamespaceId) -> String {
     format!("{}root.json", namespace_prefix(namespace_id))
+}
+
+/// Prefix containing one namespace's immutable grep manifests.
+pub fn manifests_prefix(namespace_id: &NamespaceId) -> String {
+    format!("{}manifests/", namespace_prefix(namespace_id))
+}
+
+/// Key of one immutable, content-derived grep manifest.
+pub fn manifest_key(namespace_id: &NamespaceId, manifest_id: &GrepManifestId) -> String {
+    format!(
+        "{}{manifest_id}.manifest.json",
+        manifests_prefix(namespace_id)
+    )
 }
 
 /// Prefix containing one namespace's immutable grep segments.
@@ -43,21 +59,30 @@ pub fn segments_prefix(namespace_id: &NamespaceId) -> String {
 
 /// Key of one immutable grep segment.
 pub fn segment_key(namespace_id: &NamespaceId, segment_id: &IndexSegmentId) -> String {
-    format!("{}{segment_id}.sst", segments_prefix(namespace_id))
+    format!("{}{segment_id}.sst.zst", segments_prefix(namespace_id))
 }
 
-/// Parses exactly the grep root and segment key grammar.
+/// Parses exactly the grep root, manifest, and segment key grammar.
 ///
 /// Prefixes, malformed ids, unknown object families, temporary suffixes,
 /// and keys with trailing path components are rejected.
 pub fn parse_key(key: &str) -> Option<ParsedGrepKey> {
     let suffix = key.strip_prefix(ALL_NAMESPACES_PREFIX)?;
-    let (namespace, object) = suffix.split_once('/')?;
+    let (namespace, suffix) = suffix.split_once('/')?;
     let namespace_id = NamespaceId::parse(namespace).ok()?;
+    let object = suffix.strip_prefix("extensions/grep/")?;
     let kind = if object == "root.json" {
         GrepKeyKind::Root
+    } else if let Some(manifest) = object.strip_prefix("manifests/") {
+        let manifest = manifest.strip_suffix(".manifest.json")?;
+        if manifest.contains('/') {
+            return None;
+        }
+        GrepKeyKind::Manifest {
+            manifest_id: GrepManifestId::parse(manifest).ok()?,
+        }
     } else {
-        let segment = object.strip_prefix("segments/")?.strip_suffix(".sst")?;
+        let segment = object.strip_prefix("segments/")?.strip_suffix(".sst.zst")?;
         if segment.contains('/') {
             return None;
         }
@@ -81,20 +106,39 @@ mod tests {
     }
 
     #[test]
-    fn key_builders_pin_the_v0_grammar() {
+    fn key_builders_pin_the_extension_grammar() {
         let namespace_id = namespace_id();
         let segment_id = segment_id();
 
-        assert_eq!(all_namespaces_prefix(), "grep/v0/namespaces/");
-        assert_eq!(namespace_prefix(&namespace_id), "grep/v0/namespaces/docs/");
-        assert_eq!(root_key(&namespace_id), "grep/v0/namespaces/docs/root.json");
+        let manifest_id = GrepManifestId::parse(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .expect("valid manifest id");
+
+        assert_eq!(all_namespaces_prefix(), "namespaces/");
+        assert_eq!(
+            namespace_prefix(&namespace_id),
+            "namespaces/docs/extensions/grep/"
+        );
+        assert_eq!(
+            root_key(&namespace_id),
+            "namespaces/docs/extensions/grep/root.json"
+        );
+        assert_eq!(
+            manifests_prefix(&namespace_id),
+            "namespaces/docs/extensions/grep/manifests/"
+        );
+        assert_eq!(
+            manifest_key(&namespace_id, &manifest_id),
+            "namespaces/docs/extensions/grep/manifests/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.manifest.json"
+        );
         assert_eq!(
             segments_prefix(&namespace_id),
-            "grep/v0/namespaces/docs/segments/"
+            "namespaces/docs/extensions/grep/segments/"
         );
         assert_eq!(
             segment_key(&namespace_id, &segment_id),
-            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst"
+            "namespaces/docs/extensions/grep/segments/idx_00000000000000000000000000000001.sst.zst"
         );
     }
 
@@ -102,12 +146,23 @@ mod tests {
     fn built_keys_round_trip_through_the_parser() {
         let namespace_id = namespace_id();
         let segment_id = segment_id();
+        let manifest_id = GrepManifestId::parse(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .expect("valid manifest id");
 
         assert_eq!(
             parse_key(&root_key(&namespace_id)),
             Some(ParsedGrepKey {
                 namespace_id: namespace_id.clone(),
                 kind: GrepKeyKind::Root,
+            })
+        );
+        assert_eq!(
+            parse_key(&manifest_key(&namespace_id, &manifest_id)),
+            Some(ParsedGrepKey {
+                namespace_id: namespace_id.clone(),
+                kind: GrepKeyKind::Manifest { manifest_id },
             })
         );
         assert_eq!(
@@ -123,21 +178,45 @@ mod tests {
     fn parser_rejects_non_keys_and_malformed_keys() {
         let rejected = [
             "",
-            "grep/v0/namespaces/",
-            "grep/v0/namespaces/docs/",
-            "grep/v0/namespaces/docs/root.json/extra",
-            "grep/v0/namespaces/docs/root.json.tmp",
-            "grep/v0/namespaces/docs/segments/",
-            "grep/v0/namespaces/docs/segments/not-an-index-id.sst",
-            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst.tmp",
-            "grep/v0/namespaces/docs/segments/idx_00000000000000000000000000000001.sst/extra",
-            "grep/v0/namespaces/docs/other/object",
+            "namespaces/",
+            "namespaces/docs/extensions/grep/",
+            "namespaces/docs/extensions/grep/root.json/extra",
+            "namespaces/docs/extensions/grep/root.json.tmp",
+            "namespaces/docs/extensions/grep/manifests/",
+            "namespaces/docs/extensions/grep/manifests/not-a-digest.manifest.json",
+            "namespaces/docs/extensions/grep/segments/",
+            "namespaces/docs/extensions/grep/segments/idx_00000000000000000000000000000001.sst",
+            "namespaces/docs/extensions/grep/segments/not-an-index-id.sst.zst",
+            "namespaces/docs/extensions/grep/segments/idx_00000000000000000000000000000001.sst.zst.tmp",
+            "namespaces/docs/extensions/grep/segments/idx_00000000000000000000000000000001.sst.zst/extra",
+            "namespaces/docs/extensions/grep/other/object",
             "grep/v1/namespaces/docs/root.json",
             "namespaces/docs/metadata/root.json",
         ];
 
         for key in rejected {
             assert_eq!(parse_key(key), None, "parser accepted `{key}`");
+        }
+    }
+
+    #[test]
+    fn core_key_parser_ignores_grep_extension_objects() {
+        let namespace_id = namespace_id();
+        let segment_id = segment_id();
+        let manifest_id = GrepManifestId::parse(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .expect("valid manifest id");
+
+        for key in [
+            root_key(&namespace_id),
+            manifest_key(&namespace_id, &manifest_id),
+            segment_key(&namespace_id, &segment_id),
+        ] {
+            assert!(
+                loonfs_objectstore::layout::parse_object_key(&key).is_none(),
+                "core key parser accepted grep extension key `{key}`"
+            );
         }
     }
 }

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -1,12 +1,14 @@
 //! LoonFS full-text grep subsystem.
 //!
-//! Grep durable state lives under a grep-owned keyspace and is independent
-//! of the namespace manifest. A missing or corrupt grep root disables grep
-//! work for that namespace; it must never affect core filesystem operation.
-//! Query execution reads a caller-provided core snapshot. [`GrepWorker`]
-//! owns explicitly driven storage maintenance, while [`GrepWorkerLoop`]
-//! supplies the shared all-namespaces driving loop used by server-embedded
-//! and standalone hosts.
+//! Grep durable state lives under each namespace's `extensions/grep/`
+//! prefix and is independent of the namespace manifest. A missing or corrupt
+//! grep root disables grep work for that namespace; it never affects core
+//! filesystem operation. [`GrepWorker`] registers in-process enablements
+//! directly with its loop. Startup and periodic rediscovery must list the
+//! whole `namespaces/` keyspace and are proportional to the store's total key
+//! count—the price of the namespace-scoped layout until a namespace catalog
+//! exists. [`GrepWorkerLoop`] keeps that scan rare and drives the same bounded
+//! work for server-embedded and standalone hosts.
 
 mod cache;
 pub mod codec;
@@ -21,7 +23,7 @@ mod worker_loop;
 
 pub use config::{
     GrepWorkerConfig, GrepWorkerConfigError, DEFAULT_GREP_GC_INTERVAL_MS,
-    DEFAULT_GREP_STEP_INTERVAL_MS,
+    DEFAULT_GREP_RESCAN_INTERVAL_MS, DEFAULT_GREP_STEP_INTERVAL_MS,
 };
 pub use service::{
     GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
     /// TOML file containing `[store]` and optional `[grep]` tables.
     #[arg(long)]
     config: PathBuf,
-    /// Run exactly one all-namespaces build/fold/GC sweep and exit.
+    /// Rediscover grep roots, run one build/fold/GC sweep, and exit.
     #[arg(long)]
     once: bool,
 }

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -1,40 +1,86 @@
-//! Versioned JSON envelope codec for the grep root.
+//! Versioned JSON envelope codecs for grep root pointers and manifests.
 
 use super::error::GrepRootCodecError;
-use super::state::GrepRootState;
+use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
 use loonfs_api::sha256_digest;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
-/// Durable kind string for a grep root envelope.
+/// Durable kind string for a grep root-pointer envelope.
 pub const GREP_ROOT_KIND: &str = "grep_root";
-/// Durable v0 format string. Unknown strings are rejected without fallback.
+/// Durable kind string for a grep manifest envelope.
+pub const GREP_MANIFEST_KIND: &str = "grep_manifest";
+/// Durable v0 root-pointer format string. Unknown strings are rejected.
 pub const GREP_ROOT_FORMAT_VERSION: &str = "v0";
+/// Durable v0 manifest format string. Unknown strings are rejected.
+pub const GREP_MANIFEST_FORMAT_VERSION: &str = "v0";
 
-/// Verified in-memory representation of one grep root envelope.
+/// Verified in-memory representation of one grep root-pointer envelope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrepRootEnvelope {
     format_version: String,
     writer_version: String,
     payload_checksum: String,
-    state: GrepRootState,
+    pointer: GrepRootPointer,
 }
 
 impl GrepRootEnvelope {
-    /// Builds a fresh envelope and checksums the canonical payload bytes.
+    /// Builds a fresh root-pointer envelope over its canonical payload bytes.
+    pub fn from_pointer(
+        writer_version: impl Into<String>,
+        pointer: GrepRootPointer,
+    ) -> Result<Self, GrepRootCodecError> {
+        let payload = payload_bytes(&pointer)?;
+        Ok(Self {
+            format_version: GREP_ROOT_FORMAT_VERSION.to_owned(),
+            writer_version: writer_version.into(),
+            payload_checksum: sha256_digest(&payload),
+            pointer,
+        })
+    }
+
+    pub fn format_version(&self) -> &str {
+        &self.format_version
+    }
+
+    pub fn writer_version(&self) -> &str {
+        &self.writer_version
+    }
+
+    pub fn payload_checksum(&self) -> &str {
+        &self.payload_checksum
+    }
+
+    pub fn pointer(&self) -> &GrepRootPointer {
+        &self.pointer
+    }
+}
+
+/// Verified in-memory representation of one immutable grep manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrepManifestEnvelope {
+    format_version: String,
+    writer_version: String,
+    payload_checksum: String,
+    manifest_id: GrepManifestId,
+    state: GrepRootState,
+}
+
+impl GrepManifestEnvelope {
+    /// Builds a manifest whose id is the SHA-256 of its canonical payload.
     pub fn from_state(
         writer_version: impl Into<String>,
         state: GrepRootState,
     ) -> Result<Self, GrepRootCodecError> {
         state.validate()?;
-        let payload =
-            serde_json::to_vec(&state).map_err(|error| GrepRootCodecError::PayloadEncode {
-                message: error.to_string(),
-            })?;
+        let payload = payload_bytes(&state)?;
+        let manifest_id = GrepManifestId::for_payload(&payload);
         Ok(Self {
-            format_version: GREP_ROOT_FORMAT_VERSION.to_owned(),
+            format_version: GREP_MANIFEST_FORMAT_VERSION.to_owned(),
             writer_version: writer_version.into(),
-            payload_checksum: sha256_digest(&payload),
+            payload_checksum: manifest_id.payload_checksum(),
+            manifest_id,
             state,
         })
     }
@@ -49,6 +95,10 @@ impl GrepRootEnvelope {
 
     pub fn payload_checksum(&self) -> &str {
         &self.payload_checksum
+    }
+
+    pub fn manifest_id(&self) -> &GrepManifestId {
+        &self.manifest_id
     }
 
     pub fn state(&self) -> &GrepRootState {
@@ -71,27 +121,100 @@ struct EnvelopeDocument {
     payload: Box<RawValue>,
 }
 
-/// Encodes an envelope after rechecking its version, state, and checksum.
+/// Encodes a root pointer after rechecking its version and checksum.
 pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRootCodecError> {
-    verify_version(&envelope.format_version)?;
+    encode_envelope(
+        GREP_ROOT_KIND,
+        GREP_ROOT_FORMAT_VERSION,
+        &envelope.format_version,
+        &envelope.writer_version,
+        &envelope.payload_checksum,
+        &envelope.pointer,
+    )
+}
+
+/// Decodes only the current root-pointer format and verifies exact payload bytes.
+pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
+    let document = decode_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
+    let pointer: GrepRootPointer = decode_payload(&document)?;
+    Ok(GrepRootEnvelope {
+        format_version: document.format_version,
+        writer_version: document.writer_version,
+        payload_checksum: document.payload_checksum,
+        pointer,
+    })
+}
+
+/// Encodes an immutable manifest after rechecking every boundary invariant.
+pub fn encode_grep_manifest(
+    envelope: &GrepManifestEnvelope,
+) -> Result<Vec<u8>, GrepRootCodecError> {
     envelope.state.validate()?;
-    let payload = serde_json::to_string(&envelope.state).map_err(|error| {
-        GrepRootCodecError::PayloadEncode {
-            message: error.to_string(),
-        }
-    })?;
-    let actual = sha256_digest(payload.as_bytes());
-    if actual != envelope.payload_checksum {
+    let bytes = encode_envelope(
+        GREP_MANIFEST_KIND,
+        GREP_MANIFEST_FORMAT_VERSION,
+        &envelope.format_version,
+        &envelope.writer_version,
+        &envelope.payload_checksum,
+        &envelope.state,
+    )?;
+    let payload = payload_bytes(&envelope.state)?;
+    let actual_id = GrepManifestId::for_payload(&payload);
+    if actual_id != envelope.manifest_id {
         return Err(GrepRootCodecError::StalePayloadChecksum {
-            checksum: envelope.payload_checksum.clone(),
+            checksum: envelope.manifest_id.payload_checksum(),
+            actual: actual_id.payload_checksum(),
+        });
+    }
+    Ok(bytes)
+}
+
+/// Decodes only the current manifest format, verifies it, and derives its id.
+pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepRootCodecError> {
+    let document = decode_document(bytes, GREP_MANIFEST_KIND, GREP_MANIFEST_FORMAT_VERSION)?;
+    let state: GrepRootState = decode_payload(&document)?;
+    state.validate()?;
+    let manifest_id = GrepManifestId::for_payload(document.payload.get().as_bytes());
+    if manifest_id.payload_checksum() != document.payload_checksum {
+        return Err(GrepRootCodecError::ChecksumMismatch {
+            expected: document.payload_checksum,
+            actual: manifest_id.payload_checksum(),
+        });
+    }
+    Ok(GrepManifestEnvelope {
+        format_version: document.format_version,
+        writer_version: document.writer_version,
+        payload_checksum: manifest_id.payload_checksum(),
+        manifest_id,
+        state,
+    })
+}
+
+fn encode_envelope<T: Serialize>(
+    kind: &str,
+    supported_version: &str,
+    format_version: &str,
+    writer_version: &str,
+    payload_checksum: &str,
+    payload: &T,
+) -> Result<Vec<u8>, GrepRootCodecError> {
+    verify_version(format_version, supported_version)?;
+    let payload =
+        serde_json::to_string(payload).map_err(|error| GrepRootCodecError::PayloadEncode {
+            message: error.to_string(),
+        })?;
+    let actual = sha256_digest(payload.as_bytes());
+    if actual != payload_checksum {
+        return Err(GrepRootCodecError::StalePayloadChecksum {
+            checksum: payload_checksum.to_owned(),
             actual,
         });
     }
     let document = EnvelopeDocument {
-        kind: GREP_ROOT_KIND.to_owned(),
-        format_version: envelope.format_version.clone(),
-        writer_version: envelope.writer_version.clone(),
-        payload_checksum: envelope.payload_checksum.clone(),
+        kind: kind.to_owned(),
+        format_version: format_version.to_owned(),
+        writer_version: writer_version.to_owned(),
+        payload_checksum: payload_checksum.to_owned(),
         payload: RawValue::from_string(payload).map_err(|error| {
             GrepRootCodecError::PayloadEncode {
                 message: error.to_string(),
@@ -103,20 +226,22 @@ pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRoot
     })
 }
 
-/// Decodes only v0, verifies the exact stored payload bytes, and validates
-/// the decoded root's cross-field invariants.
-pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
+fn decode_document(
+    bytes: &[u8],
+    expected_kind: &str,
+    supported_version: &str,
+) -> Result<EnvelopeDocument, GrepRootCodecError> {
     let probe: EnvelopeProbe =
         serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
             message: error.to_string(),
         })?;
-    if probe.kind != GREP_ROOT_KIND {
+    if probe.kind != expected_kind {
         return Err(GrepRootCodecError::KindMismatch {
-            expected: GREP_ROOT_KIND.to_owned(),
+            expected: expected_kind.to_owned(),
             found: probe.kind,
         });
     }
-    verify_version(&probe.format_version)?;
+    verify_version(&probe.format_version, supported_version)?;
 
     let document: EnvelopeDocument =
         serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
@@ -129,25 +254,30 @@ pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecE
             actual,
         });
     }
-    let state: GrepRootState = serde_json::from_str(document.payload.get()).map_err(|error| {
+    Ok(document)
+}
+
+fn decode_payload<T: DeserializeOwned>(
+    document: &EnvelopeDocument,
+) -> Result<T, GrepRootCodecError> {
+    serde_json::from_str(document.payload.get()).map_err(|error| {
         GrepRootCodecError::PayloadDecode {
             message: error.to_string(),
         }
-    })?;
-    state.validate()?;
-    Ok(GrepRootEnvelope {
-        format_version: document.format_version,
-        writer_version: document.writer_version,
-        payload_checksum: document.payload_checksum,
-        state,
     })
 }
 
-fn verify_version(found: &str) -> Result<(), GrepRootCodecError> {
-    if found != GREP_ROOT_FORMAT_VERSION {
+fn payload_bytes<T: Serialize>(payload: &T) -> Result<Vec<u8>, GrepRootCodecError> {
+    serde_json::to_vec(payload).map_err(|error| GrepRootCodecError::PayloadEncode {
+        message: error.to_string(),
+    })
+}
+
+fn verify_version(found: &str, supported: &str) -> Result<(), GrepRootCodecError> {
+    if found != supported {
         return Err(GrepRootCodecError::UnsupportedFormatVersion {
             found: found.to_owned(),
-            supported: GREP_ROOT_FORMAT_VERSION.to_owned(),
+            supported: supported.to_owned(),
         });
     }
     Ok(())

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -4,6 +4,13 @@ use loonfs_api::{IndexSegmentId, NamespaceId};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid grep manifest id {value:?}: {reason}")]
+pub struct GrepManifestIdError {
+    pub(crate) value: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum GrepRootStateError {
     #[error("unsupported grep index format version `{found}`: this build supports `{supported}`")]
@@ -63,6 +70,8 @@ pub enum GrepRootCodecError {
     StalePayloadChecksum { checksum: String, actual: String },
     #[error("invalid grep root state: {0}")]
     InvalidState(#[from] GrepRootStateError),
+    #[error("invalid grep manifest id: {0}")]
+    InvalidManifestId(#[from] GrepManifestIdError),
 }
 
 /// Failure to load or publish a grep root.
@@ -73,6 +82,11 @@ pub enum GrepRootError {
     Store { object_key: String, message: String },
     #[error("grep root `{object_key}` is corrupt: {message}")]
     Corrupt { object_key: String, message: String },
+    #[error("grep root `{root_key}` names missing manifest `{manifest_key}`")]
+    MissingManifest {
+        root_key: String,
+        manifest_key: String,
+    },
     #[error(
         "grep root `{object_key}` names namespace `{actual}` instead of requested namespace \
          `{expected}`"

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -1,15 +1,15 @@
-//! The atomic grep root and its durable publication boundary.
+//! The atomic grep root pointer, immutable manifests, and publication boundary.
 //!
-//! One root pairs the query-visible segment set with its
+//! One immutable manifest pairs the query-visible segment set with its
 //! `built_through_seq` watermark, lifecycle, in-progress fold, and run
-//! ordinal allocation. Publication replaces that whole set in one object
-//! store compare-and-swap, so a reader never observes a watermark without
-//! the segments that implement it.
+//! ordinal allocation. Publication writes that manifest create-if-absent,
+//! then installs a tiny pointer in one object-store compare-and-swap, so a
+//! reader never observes a watermark without the segments that implement it.
 //!
-//! Segment objects are immutable derived data written before the root CAS.
-//! A CAS loser therefore leaks only unreachable derived objects; it never
-//! changes visible grep state. [`crate::GrepWorker`] garbage collection
-//! reclaims those unreachable objects after its grace window.
+//! Segment and manifest objects are immutable derived data written before
+//! the pointer CAS. A CAS loser therefore leaks only unreachable derived
+//! objects; it never changes visible grep state. [`crate::GrepWorker`]
+//! garbage collection reclaims those objects after its grace window.
 
 mod codec;
 mod error;
@@ -17,11 +17,18 @@ mod state;
 mod store;
 
 pub use codec::{
-    decode_grep_root, encode_grep_root, GrepRootEnvelope, GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
+    decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root,
+    GrepManifestEnvelope, GrepRootEnvelope, GREP_MANIFEST_FORMAT_VERSION, GREP_MANIFEST_KIND,
+    GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
 };
-pub use error::{GrepRootCodecError, GrepRootError, GrepRootStateError, Result};
+pub use error::{
+    GrepManifestIdError, GrepRootCodecError, GrepRootError, GrepRootStateError, Result,
+};
 pub use state::{
-    GrepFoldState, GrepIndexState, GrepLifecycle, GrepRootState, GrepSegmentRef,
-    GREP_INDEX_FORMAT_VERSION,
+    GrepFoldState, GrepIndexState, GrepLifecycle, GrepManifestId, GrepRootPointer, GrepRootState,
+    GrepSegmentRef, GREP_INDEX_FORMAT_VERSION,
 };
-pub use store::{advance_grep_root, load_grep_root, seed_grep_root, LoadedGrepRoot};
+pub use store::{
+    advance_grep_root, load_grep_manifest, load_grep_root, load_grep_root_pointer, seed_grep_root,
+    LoadedGrepRoot, LoadedGrepRootPointer,
+};

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -1,13 +1,149 @@
-//! Constructor-validated state carried by the grep root payload.
+//! Constructor-validated grep manifest payload and its root pointer.
 
-use super::error::GrepRootStateError;
+use super::error::{GrepManifestIdError, GrepRootStateError};
+use loonfs_api::sha256_digest;
 use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, NamespaceId};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::str::FromStr;
 
-/// Version of the grep index state nested inside a v0 root.
+const SHA256_PREFIX: &str = "sha256:";
+const SHA256_HEX_LEN: usize = 64;
+
+/// Version of the grep index state nested inside a v0 manifest.
 pub const GREP_INDEX_FORMAT_VERSION: u32 = 0;
+
+/// Content-derived identity of one immutable grep manifest payload.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GrepManifestId(String);
+
+impl GrepManifestId {
+    /// Parses the manifest id's 64-character lowercase SHA-256 hex form.
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, GrepManifestIdError> {
+        let value = value.as_ref();
+        if value.len() != SHA256_HEX_LEN {
+            return Err(GrepManifestIdError {
+                value: value.to_owned(),
+                reason: format!("must contain exactly {SHA256_HEX_LEN} lowercase hex characters"),
+            });
+        }
+        if !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(GrepManifestIdError {
+                value: value.to_owned(),
+                reason: "must contain only lowercase hex characters".to_owned(),
+            });
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn for_payload(payload: &[u8]) -> Self {
+        let digest = sha256_digest(payload);
+        Self(
+            digest
+                .strip_prefix(SHA256_PREFIX)
+                .expect("sha256_digest should carry the sha256 prefix")
+                .to_owned(),
+        )
+    }
+
+    pub(crate) fn payload_checksum(&self) -> String {
+        format!("{SHA256_PREFIX}{}", self.0)
+    }
+}
+
+impl AsRef<str> for GrepManifestId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::borrow::Borrow<str> for GrepManifestId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for GrepManifestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for GrepManifestId {
+    type Err = GrepManifestIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<&str> for GrepManifestId {
+    type Error = GrepManifestIdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for GrepManifestId {
+    type Error = GrepManifestIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for GrepManifestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for GrepManifestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Small mutable control payload installed at `extensions/grep/root.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepRootPointer {
+    namespace_id: NamespaceId,
+    manifest_id: GrepManifestId,
+}
+
+impl GrepRootPointer {
+    pub fn new(namespace_id: NamespaceId, manifest_id: GrepManifestId) -> Self {
+        Self {
+            namespace_id,
+            manifest_id,
+        }
+    }
+
+    pub fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    pub fn manifest_id(&self) -> &GrepManifestId {
+        &self.manifest_id
+    }
+}
 
 /// Durable lifecycle of grep indexing for one namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -93,9 +229,9 @@ pub struct GrepSegmentRef {
     pub payload_checksum: String,
 }
 
-/// One namespace's complete grep control state.
+/// One namespace's complete immutable grep manifest state.
 ///
-/// Fields stay private so every constructed or decoded root passes the
+/// Fields stay private so every constructed or decoded manifest passes the
 /// inexpensive fold/segment and run-allocation checks in [`Self::new`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GrepRootState {

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -1,27 +1,30 @@
-//! Loading and single-attempt CAS publication for grep roots.
+//! Two-step grep root loading and manifest-first pointer publication.
 //!
-//! Publication intentionally does not retry: a compare-and-swap loser gets
-//! [`GrepRootError::Conflict`](super::GrepRootError), reloads the now-current
-//! root, and rebuilds its candidate. Any immutable segments written for the
-//! losing candidate remain unreachable garbage for grep-owned collection.
+//! Publication intentionally does not retry: a pointer compare-and-swap
+//! loser gets [`GrepRootError::Conflict`](super::GrepRootError), reloads the
+//! current root, and rebuilds its candidate. The losing immutable manifest
+//! remains unreachable derived garbage for grep-owned collection.
 
-use super::codec::{decode_grep_root, encode_grep_root, GrepRootEnvelope};
+use super::codec::{
+    decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root,
+    GrepManifestEnvelope, GrepRootEnvelope,
+};
 use super::error::{GrepRootError, Result};
-use super::state::GrepRootState;
-use crate::keyspace::root_key;
+use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
+use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 
-/// A verified grep root and the metadata from the same object-store read.
+/// A verified grep root pointer and metadata from the same store read.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LoadedGrepRoot {
+pub struct LoadedGrepRootPointer {
     object_key: String,
     envelope: GrepRootEnvelope,
     metadata: ObjectMetadata,
 }
 
-impl LoadedGrepRoot {
+impl LoadedGrepRootPointer {
     pub fn object_key(&self) -> &str {
         &self.object_key
     }
@@ -30,8 +33,8 @@ impl LoadedGrepRoot {
         &self.envelope
     }
 
-    pub fn state(&self) -> &GrepRootState {
-        self.envelope.state()
+    pub fn pointer(&self) -> &GrepRootPointer {
+        self.envelope.pointer()
     }
 
     pub fn metadata(&self) -> &ObjectMetadata {
@@ -39,12 +42,40 @@ impl LoadedGrepRoot {
     }
 }
 
-/// Loads and verifies one namespace's grep root, returning `None` when the
-/// independent grep subsystem has not seeded it.
-pub async fn load_grep_root<S: ObjectStore + ?Sized>(
+/// A verified pointer and the immutable manifest it names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedGrepRoot {
+    pointer: LoadedGrepRootPointer,
+    manifest: GrepManifestEnvelope,
+}
+
+impl LoadedGrepRoot {
+    pub fn object_key(&self) -> &str {
+        self.pointer.object_key()
+    }
+
+    pub fn envelope(&self) -> &GrepRootEnvelope {
+        self.pointer.envelope()
+    }
+
+    pub fn manifest_envelope(&self) -> &GrepManifestEnvelope {
+        &self.manifest
+    }
+
+    pub fn state(&self) -> &GrepRootState {
+        self.manifest.state()
+    }
+
+    pub fn metadata(&self) -> &ObjectMetadata {
+        self.pointer.metadata()
+    }
+}
+
+/// Loads and verifies one namespace's mutable grep root pointer.
+pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<Option<LoadedGrepRoot>> {
+) -> Result<Option<LoadedGrepRootPointer>> {
     let object_key = root_key(namespace_id);
     let Some(body) = store
         .get_with_metadata(&object_key)
@@ -57,6 +88,47 @@ pub async fn load_grep_root<S: ObjectStore + ?Sized>(
         object_key: object_key.clone(),
         message: error.to_string(),
     })?;
+    if envelope.pointer().namespace_id() != namespace_id {
+        return Err(GrepRootError::IdentityMismatch {
+            object_key,
+            expected: namespace_id.clone(),
+            actual: envelope.pointer().namespace_id().clone(),
+        });
+    }
+    Ok(Some(LoadedGrepRootPointer {
+        object_key,
+        envelope,
+        metadata: body.metadata,
+    }))
+}
+
+/// Loads and verifies one immutable manifest when it is present.
+pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    manifest_id: &GrepManifestId,
+) -> Result<Option<GrepManifestEnvelope>> {
+    let object_key = manifest_key(namespace_id, manifest_id);
+    let Some(bytes) = store
+        .get(&object_key, None)
+        .await
+        .map_err(|error| store_error(&object_key, &error))?
+    else {
+        return Ok(None);
+    };
+    let envelope = decode_grep_manifest(&bytes).map_err(|error| GrepRootError::Corrupt {
+        object_key: object_key.clone(),
+        message: error.to_string(),
+    })?;
+    if envelope.manifest_id() != manifest_id {
+        return Err(GrepRootError::Corrupt {
+            object_key,
+            message: format!(
+                "manifest id mismatch: key names `{manifest_id}`, payload derives `{}`",
+                envelope.manifest_id()
+            ),
+        });
+    }
     if envelope.state().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
@@ -64,34 +136,44 @@ pub async fn load_grep_root<S: ObjectStore + ?Sized>(
             actual: envelope.state().namespace_id().clone(),
         });
     }
-    Ok(Some(LoadedGrepRoot {
-        object_key,
-        envelope,
-        metadata: body.metadata,
-    }))
+    Ok(Some(envelope))
 }
 
-/// Seeds a grep root with create-if-absent semantics.
+/// Loads a fresh pointer and then its immutable manifest.
+pub async fn load_grep_root<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Result<Option<LoadedGrepRoot>> {
+    let Some(pointer) = load_grep_root_pointer(store, namespace_id).await? else {
+        return Ok(None);
+    };
+    let manifest_id = pointer.pointer().manifest_id();
+    let Some(manifest) = load_grep_manifest(store, namespace_id, manifest_id).await? else {
+        return Err(GrepRootError::MissingManifest {
+            root_key: pointer.object_key.clone(),
+            manifest_key: manifest_key(namespace_id, manifest_id),
+        });
+    };
+    Ok(Some(LoadedGrepRoot { pointer, manifest }))
+}
+
+/// Seeds grep by writing an immutable manifest, then creating its pointer.
 ///
-/// An existing root is a typed conflict, even when it carries identical
-/// bytes; callers seed exactly once and load thereafter.
+/// An existing pointer is a typed conflict even when it carries identical
+/// bytes. Its candidate manifest remains valid derived garbage for GC.
 pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
     store: &S,
     state: &GrepRootState,
     writer_version: &str,
 ) -> Result<LoadedGrepRoot> {
+    let manifest = write_grep_manifest(store, state, writer_version).await?;
     let object_key = root_key(state.namespace_id());
-    let envelope =
-        GrepRootEnvelope::from_state(writer_version, state.clone()).map_err(|error| {
-            GrepRootError::Corrupt {
-                object_key: object_key.clone(),
-                message: error.to_string(),
-            }
-        })?;
-    let bytes = encode_grep_root(&envelope).map_err(|error| GrepRootError::Corrupt {
-        object_key: object_key.clone(),
-        message: error.to_string(),
-    })?;
+    let envelope = GrepRootEnvelope::from_pointer(
+        writer_version,
+        GrepRootPointer::new(state.namespace_id().clone(), manifest.manifest_id().clone()),
+    )
+    .map_err(|error| corrupt(&object_key, error))?;
+    let bytes = encode_grep_root(&envelope).map_err(|error| corrupt(&object_key, error))?;
     let metadata = match store
         .put(&object_key, Bytes::from(bytes), PutMode::CreateIfAbsent)
         .await
@@ -103,23 +185,26 @@ pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
         Err(error) => return Err(store_error(&object_key, &error)),
     };
     Ok(LoadedGrepRoot {
-        object_key,
-        envelope,
-        metadata,
+        pointer: LoadedGrepRootPointer {
+            object_key,
+            envelope,
+            metadata,
+        },
+        manifest,
     })
 }
 
-/// Advances a loaded grep root in one etag compare-and-swap attempt.
+/// Writes a successor manifest, then advances the pointer in one etag CAS.
 ///
 /// A conflict is never retried against the stale candidate: the caller must
-/// reload and recompute the whole atomic root state.
+/// reload and recompute the whole atomic manifest state.
 pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
     store: &S,
     current: &LoadedGrepRoot,
     next: &GrepRootState,
     writer_version: &str,
 ) -> Result<LoadedGrepRoot> {
-    let expected_namespace_id = current.envelope.state().namespace_id();
+    let expected_namespace_id = current.pointer.pointer().namespace_id();
     if next.namespace_id() != expected_namespace_id {
         return Err(GrepRootError::AdvanceIdentityMismatch {
             expected: expected_namespace_id.clone(),
@@ -127,33 +212,33 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         });
     }
     let expected_key = root_key(expected_namespace_id);
-    if current.object_key != expected_key {
+    if current.pointer.object_key != expected_key {
         return Err(GrepRootError::Corrupt {
-            object_key: current.object_key.clone(),
+            object_key: current.pointer.object_key.clone(),
             message: format!("loaded root key does not match `{expected_key}`"),
         });
     }
     let expected_etag =
         current
+            .pointer
             .metadata
             .etag
             .as_deref()
             .ok_or_else(|| GrepRootError::MissingEtag {
-                object_key: current.object_key.clone(),
+                object_key: current.pointer.object_key.clone(),
             })?;
-    let envelope = GrepRootEnvelope::from_state(writer_version, next.clone()).map_err(|error| {
-        GrepRootError::Corrupt {
-            object_key: current.object_key.clone(),
-            message: error.to_string(),
-        }
-    })?;
-    let bytes = encode_grep_root(&envelope).map_err(|error| GrepRootError::Corrupt {
-        object_key: current.object_key.clone(),
-        message: error.to_string(),
-    })?;
+
+    let manifest = write_grep_manifest(store, next, writer_version).await?;
+    let envelope = GrepRootEnvelope::from_pointer(
+        writer_version,
+        GrepRootPointer::new(next.namespace_id().clone(), manifest.manifest_id().clone()),
+    )
+    .map_err(|error| corrupt(&current.pointer.object_key, error))?;
+    let bytes =
+        encode_grep_root(&envelope).map_err(|error| corrupt(&current.pointer.object_key, error))?;
     let metadata = match store
         .put(
-            &current.object_key,
+            &current.pointer.object_key,
             Bytes::from(bytes),
             PutMode::CompareAndSwap {
                 expected_etag: expected_etag.to_owned(),
@@ -164,16 +249,61 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         Ok(metadata) => metadata,
         Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
             return Err(GrepRootError::Conflict {
-                object_key: current.object_key.clone(),
+                object_key: current.pointer.object_key.clone(),
             });
         }
-        Err(error) => return Err(store_error(&current.object_key, &error)),
+        Err(error) => return Err(store_error(&current.pointer.object_key, &error)),
     };
     Ok(LoadedGrepRoot {
-        object_key: current.object_key.clone(),
-        envelope,
-        metadata,
+        pointer: LoadedGrepRootPointer {
+            object_key: current.pointer.object_key.clone(),
+            envelope,
+            metadata,
+        },
+        manifest,
     })
+}
+
+async fn write_grep_manifest<S: ObjectStore + ?Sized>(
+    store: &S,
+    state: &GrepRootState,
+    writer_version: &str,
+) -> Result<GrepManifestEnvelope> {
+    let envelope = GrepManifestEnvelope::from_state(writer_version, state.clone())
+        .map_err(|error| corrupt(&root_key(state.namespace_id()), error))?;
+    let object_key = manifest_key(state.namespace_id(), envelope.manifest_id());
+    let bytes = encode_grep_manifest(&envelope).map_err(|error| corrupt(&object_key, error))?;
+    match store.put_if_absent(&object_key, Bytes::from(bytes)).await {
+        Ok(_) => Ok(envelope),
+        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
+            let existing = load_grep_manifest(store, state.namespace_id(), envelope.manifest_id())
+                .await?
+                .ok_or_else(|| GrepRootError::MissingManifest {
+                    root_key: root_key(state.namespace_id()),
+                    manifest_key: object_key.clone(),
+                })?;
+            if existing.payload_checksum() == envelope.payload_checksum() {
+                Ok(existing)
+            } else {
+                Err(GrepRootError::Corrupt {
+                    object_key,
+                    message: format!(
+                        "manifest conflict: expected payload checksum {}, actual {}",
+                        envelope.payload_checksum(),
+                        existing.payload_checksum()
+                    ),
+                })
+            }
+        }
+        Err(error) => Err(store_error(&object_key, &error)),
+    }
+}
+
+fn corrupt(object_key: &str, error: impl ToString) -> GrepRootError {
+    GrepRootError::Corrupt {
+        object_key: object_key.to_owned(),
+        message: error.to_string(),
+    }
 }
 
 fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -1,20 +1,22 @@
 //! [`GrepService`]: query planning and execution over a core read view.
 
-use crate::cache::{GrepBlockCache, MAX_CACHED_GREP_BLOCKS};
+use crate::cache::{
+    DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind, MAX_CACHED_GREP_BLOCKS,
+};
 use crate::codec::{lookup, Gram, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES};
 use crate::index_read::{
     index_segment_corrupt, load_data_block, load_filter_block, load_index_block,
 };
 use crate::keyspace::segment_key;
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
-use crate::root::{GrepLifecycle, GrepRootState};
+use crate::root::{load_grep_manifest, load_grep_root_pointer, GrepLifecycle, GrepRootState};
 use futures::future::{join_all, try_join_all};
 use loonfs_api::wire::manifest::hex_decode_bytes;
 use loonfs_api::wire::sst_blocks::{decode_filter_block, index_blocks_for_key_range};
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     decode_grep_cursor, encode_grep_cursor, AbsolutePath, ChangeSeq, GrepMatch, GrepPageCursor,
-    GrepRequest, GrepResponse, InodeId, RevisionNo,
+    GrepRequest, GrepResponse, InodeId, NamespaceId, RevisionNo,
 };
 use loonfs_core::content::read_durable_content_bytes;
 use loonfs_core::grep::{LoadedMetadataView, MetadataViewSession};
@@ -91,16 +93,57 @@ struct GrepQuerySegment {
 }
 
 impl GrepIndexSnapshot {
-    /// Captures an unreadable grep root while preserving request-error precedence.
+    /// Captures unreadable grep extension state while preserving error precedence.
     pub fn from_error(error: CoreError) -> Self {
         Self { state: Err(error) }
     }
 
-    /// Builds a query snapshot from one verified grep-owned root.
+    /// Freshly loads the grep pointer, then loads or reuses its immutable manifest.
     ///
-    /// A missing, disabled, or still-backfilling root has the same
-    /// `index.grams` not-materialized surface as the former manifest feature.
-    pub fn from_grep_root(root: Option<&GrepRootState>) -> Self {
+    /// Missing or corrupt pointers/manifests and disabled or backfilling
+    /// lifecycles all collapse to the same `index.grams` not-materialized
+    /// surface. Grep-private corruption never changes core read behavior.
+    pub async fn from_grep_root<S: ObjectStore + ?Sized>(
+        store: &S,
+        namespace_id: &NamespaceId,
+        service: &GrepService,
+    ) -> Self {
+        let pointer = match load_grep_root_pointer(store, namespace_id).await {
+            Ok(Some(pointer)) => pointer,
+            Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+        };
+        let manifest_id = pointer.pointer().manifest_id();
+        let cache_key = GrepBlockCacheKey {
+            payload_checksum: manifest_id.payload_checksum(),
+            block_kind: GrepBlockKind::Manifest,
+            block_offset: 0,
+        };
+        let state = match service.block_cache.get(&cache_key) {
+            Some(DecodedGrepBlock::Manifest(state)) => state,
+            Some(
+                DecodedGrepBlock::Filter(_)
+                | DecodedGrepBlock::Index(_)
+                | DecodedGrepBlock::Data(_),
+            ) => return Self::from_error(feature_not_materialized()),
+            None => {
+                let manifest = match load_grep_manifest(store, namespace_id, manifest_id).await {
+                    Ok(Some(manifest)) => manifest,
+                    Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+                };
+                let state = std::sync::Arc::new(manifest.state().clone());
+                service
+                    .block_cache
+                    .insert(cache_key, DecodedGrepBlock::Manifest(state.clone()));
+                state
+            }
+        };
+        if state.namespace_id() != namespace_id {
+            return Self::from_error(feature_not_materialized());
+        }
+        Self::from_state(Some(&state))
+    }
+
+    fn from_state(root: Option<&GrepRootState>) -> Self {
         let Some(root) = root else {
             return Self::from_error(feature_not_materialized());
         };

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -3,7 +3,7 @@
 use crate::cache::{GrepBlockCache, MAX_CACHED_GREP_BLOCKS};
 use crate::codec::{extract_grams, Gram, GramPosting, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES};
 use crate::index_read::{load_data_block, load_index_block};
-use crate::keyspace::{all_namespaces_prefix, root_key, segment_key};
+use crate::keyspace::{all_namespaces_prefix, manifest_key, root_key, segment_key};
 use crate::root::{
     advance_grep_root, load_grep_root, seed_grep_root, GrepFoldState, GrepIndexState,
     GrepLifecycle, GrepRootError, GrepRootState, GrepSegmentRef, LoadedGrepRoot,
@@ -35,6 +35,7 @@ use loonfs_objectstore::{
     ObjectStore, ObjectStoreError, PutMode, PROVIDER_MULTIPART_THRESHOLD_BYTES,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// User-checkpoint lifetime used by one backfill attempt. An expired attempt
@@ -194,13 +195,25 @@ pub struct GrepGcReport {
 ///
 /// Calls are explicit and bounded. A later standalone process or server mode
 /// can drive the same methods without changing the durable protocol.
-#[derive(Debug)]
+#[derive(Debug, Default)]
+struct GrepNamespaceRegistry {
+    state: Mutex<GrepNamespaceRegistryState>,
+}
+
+#[derive(Debug, Default)]
+struct GrepNamespaceRegistryState {
+    namespace_generations: BTreeMap<NamespaceId, u64>,
+    generation: u64,
+}
+
+#[derive(Debug, Clone)]
 pub struct GrepWorker<S> {
     store: S,
     writer_id: String,
     writer_session_id: String,
     writer_version: String,
-    block_cache: GrepBlockCache,
+    block_cache: Arc<GrepBlockCache>,
+    namespace_registry: Arc<GrepNamespaceRegistry>,
 }
 
 impl<S: ObjectStore + Clone> GrepWorker<S> {
@@ -216,8 +229,64 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             writer_id: writer_id.into(),
             writer_session_id: writer_session_id.into(),
             writer_version: writer_version.into(),
-            block_cache: GrepBlockCache::new(MAX_CACHED_GREP_BLOCKS),
+            block_cache: Arc::new(GrepBlockCache::new(MAX_CACHED_GREP_BLOCKS)),
+            namespace_registry: Arc::new(GrepNamespaceRegistry::default()),
         }
+    }
+
+    pub(crate) fn registered_namespace_ids(&self) -> Vec<NamespaceId> {
+        self.namespace_registry
+            .state
+            .lock()
+            .expect("grep namespace registry lock poisoned")
+            .namespace_generations
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn namespace_registration_generation(&self) -> u64 {
+        self.namespace_registry
+            .state
+            .lock()
+            .expect("grep namespace registry lock poisoned")
+            .generation
+    }
+
+    pub(crate) fn reconcile_namespaces(
+        &self,
+        discovered: BTreeSet<NamespaceId>,
+        scan_started_at_generation: u64,
+    ) {
+        let mut registry = self
+            .namespace_registry
+            .state
+            .lock()
+            .expect("grep namespace registry lock poisoned");
+        registry
+            .namespace_generations
+            .retain(|namespace_id, generation| {
+                discovered.contains(namespace_id) || *generation > scan_started_at_generation
+            });
+        for namespace_id in discovered {
+            registry
+                .namespace_generations
+                .entry(namespace_id)
+                .or_default();
+        }
+    }
+
+    fn register_namespace(&self, namespace_id: &NamespaceId) {
+        let mut registry = self
+            .namespace_registry
+            .state
+            .lock()
+            .expect("grep namespace registry lock poisoned");
+        registry.generation = registry.generation.saturating_add(1);
+        let generation = registry.generation;
+        registry
+            .namespace_generations
+            .insert(namespace_id.clone(), generation);
     }
 
     /// Enables grep by pinning a checkpoint and CAS-publishing a fresh
@@ -228,6 +297,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .map_err(core_root_error)?
         {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+                self.register_namespace(namespace_id);
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
                     built_through_seq: current.state().index().built_through_seq,
                 });
@@ -246,6 +316,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     current.state(),
                 )
                 .await?;
+                self.register_namespace(namespace_id);
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
                     built_through_seq: current.state().index().built_through_seq,
                 });
@@ -261,10 +332,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             next_run_ordinal,
         )?;
         let published = match current {
-            Some(current) => {
-                advance_grep_root(&self.store, &current, &next, &self.writer_version).await
-            }
-            None => seed_grep_root(&self.store, &next, &self.writer_version).await,
+            Some(current) => self.advance_root(&current, &next).await,
+            None => self.seed_root(&next).await,
         };
         match published {
             Ok(_) => Ok(GrepEnableOutcome::Enabled {
@@ -315,7 +384,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Vec::new(),
         )
         .map_err(core_state_error)?;
-        match advance_grep_root(&self.store, &current, &next, &self.writer_version).await {
+        match self.advance_root(&current, &next).await {
             Ok(_) => {
                 if let Some(checkpoint_id) = checkpoint_id {
                     self.engine(namespace_id)?
@@ -426,6 +495,22 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             })
     }
 
+    async fn seed_root(&self, state: &GrepRootState) -> crate::root::Result<LoadedGrepRoot> {
+        let loaded = seed_grep_root(&self.store, state, &self.writer_version).await?;
+        self.register_namespace(state.namespace_id());
+        Ok(loaded)
+    }
+
+    async fn advance_root(
+        &self,
+        current: &LoadedGrepRoot,
+        next: &GrepRootState,
+    ) -> crate::root::Result<LoadedGrepRoot> {
+        let loaded = advance_grep_root(&self.store, current, next, &self.writer_version).await?;
+        self.register_namespace(next.namespace_id());
+        Ok(loaded)
+    }
+
     async fn create_backfill_checkpoint(
         &self,
         namespace_id: &NamespaceId,
@@ -468,7 +553,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             checkpoint.checkpoint_id.clone(),
             current.state().index().next_run_ordinal,
         )?;
-        match advance_grep_root(&self.store, current, &next, &self.writer_version).await {
+        match self.advance_root(current, &next).await {
             Ok(_) => {
                 if let Some(previous_checkpoint_id) = previous_checkpoint_id {
                     if previous_checkpoint_id != checkpoint.checkpoint_id {
@@ -553,7 +638,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         )
         .map_err(core_state_error)?;
         ensure_publication_budget(&timer, publication_started_ms)?;
-        match advance_grep_root(&self.store, &current, &next, &self.writer_version).await {
+        match self.advance_root(&current, &next).await {
             Ok(_) => {
                 if let Some(checkpoint_id) = completed_checkpoint_id {
                     self.engine(namespace_id)?
@@ -1019,7 +1104,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         )
         .map_err(core_state_error)?;
         ensure_publication_budget(&timer, publication_started_ms)?;
-        match advance_grep_root(&self.store, &current, &next, &self.writer_version).await {
+        match self.advance_root(&current, &next).await {
             Ok(_) => Ok(fold_report(
                 namespace_id,
                 GrepFoldOutcome::StepPublished {
@@ -1368,13 +1453,18 @@ async fn ensure_live_namespace<S: ObjectStore + ?Sized>(
 
 fn namespace_id_from_grep_key(key: &str) -> Option<NamespaceId> {
     let suffix = key.strip_prefix(all_namespaces_prefix())?;
-    let (namespace, _) = suffix.split_once('/')?;
-    NamespaceId::parse(namespace).ok()
+    let (namespace, object) = suffix.split_once('/')?;
+    object
+        .starts_with("extensions/grep/")
+        .then(|| NamespaceId::parse(namespace).ok())?
 }
 
 fn live_grep_keys(root: &LoadedGrepRoot) -> BTreeSet<String> {
     let namespace_id = root.state().namespace_id();
-    let mut live = BTreeSet::from([root_key(namespace_id)]);
+    let mut live = BTreeSet::from([
+        root_key(namespace_id),
+        manifest_key(namespace_id, root.manifest_envelope().manifest_id()),
+    ]);
     live.extend(
         root.state()
             .segments()

--- a/crates/loonfs-grep/src/worker_loop.rs
+++ b/crates/loonfs-grep/src/worker_loop.rs
@@ -1,4 +1,4 @@
-//! Fair all-namespaces scheduling for [`crate::GrepWorker`] steps and GC.
+//! Registered scheduling plus rare whole-store grep-root rediscovery and GC.
 
 use crate::keyspace::{all_namespaces_prefix, parse_key, GrepKeyKind};
 use crate::{GrepGcReport, GrepWorker, GrepWorkerConfig};
@@ -17,7 +17,7 @@ const MAX_NAMESPACE_BACKOFF_SWEEPS: u64 = 64;
 /// Counts from one complete build/fold sweep and optional GC pass.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GrepSweepReport {
-    /// Exact grep roots discovered under the all-namespaces prefix.
+    /// Registered namespaces considered by this sweep.
     pub namespaces_seen: u64,
     /// Namespaces whose build and fold steps both completed.
     pub namespaces_completed: u64,
@@ -120,6 +120,9 @@ impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
     pub async fn run_once(
         &mut self,
     ) -> std::result::Result<GrepSweepReport, GrepWorkerRunOnceError> {
+        self.rediscover_namespaces()
+            .await
+            .map_err(GrepWorkerRunOnceError::Sweep)?;
         let mut report = self
             .sweep(false)
             .await
@@ -146,14 +149,28 @@ impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
     pub async fn run(mut self) {
         let step_interval = Duration::from_millis(self.config.step_interval_ms);
         let gc_interval = Duration::from_millis(self.config.gc_interval_ms);
+        let rescan_interval = Duration::from_millis(self.config.rescan_interval_ms);
         let mut next_gc = tokio::time::Instant::now();
+        let mut next_rescan = tokio::time::Instant::now();
         while !self.shutdown.requested() {
+            let now = tokio::time::Instant::now();
+            if now >= next_rescan {
+                if let Err(error) = self.rediscover_namespaces().await {
+                    tracing::warn!(
+                        phase = "grep_worker_rediscovery",
+                        result = "error",
+                        error = %error,
+                        "grep worker could not rediscover roots; retaining registrations"
+                    );
+                }
+                next_rescan = tokio::time::Instant::now() + rescan_interval;
+            }
             if let Err(error) = self.sweep(true).await {
                 tracing::warn!(
                     phase = "grep_worker_sweep",
                     result = "error",
                     error = %error,
-                    "grep worker could not enumerate namespaces; retrying"
+                    "grep worker sweep failed; retrying"
                 );
             }
             if self.shutdown.requested() {
@@ -189,7 +206,7 @@ impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
 
     async fn sweep(&mut self, honor_shutdown: bool) -> Result<GrepSweepReport> {
         self.sweep_number = self.sweep_number.saturating_add(1);
-        let namespace_ids = self.namespace_ids().await?;
+        let namespace_ids = self.worker.registered_namespace_ids();
         let discovered: BTreeSet<NamespaceId> = namespace_ids.iter().cloned().collect();
         self.namespace_failures
             .retain(|namespace_id, _| discovered.contains(namespace_id));
@@ -232,7 +249,8 @@ impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
         Ok(report)
     }
 
-    async fn namespace_ids(&self) -> Result<Vec<NamespaceId>> {
+    async fn rediscover_namespaces(&self) -> Result<()> {
+        let scan_started_at_generation = self.worker.namespace_registration_generation();
         let keys = self
             .store
             .list_prefix(all_namespaces_prefix())
@@ -242,15 +260,16 @@ impl<S: ObjectStore + Clone> GrepWorkerLoop<S> {
                 message: error.message(),
                 class: StoreFailureClass::of(&error),
             })?;
-        Ok(keys
+        let namespace_ids = keys
             .into_iter()
             .filter_map(|key| {
                 let parsed = parse_key(&key)?;
                 matches!(parsed.kind, GrepKeyKind::Root).then_some(parsed.namespace_id)
             })
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect())
+            .collect::<BTreeSet<_>>();
+        self.worker
+            .reconcile_namespaces(namespace_ids, scan_started_at_generation);
+        Ok(())
     }
 
     fn namespace_is_backed_off(&self, namespace_id: &NamespaceId) -> bool {

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -3,20 +3,26 @@
 use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, NamespaceId};
 use loonfs_grep::root::{
-    decode_grep_root, encode_grep_root, GrepFoldState, GrepIndexState, GrepLifecycle,
-    GrepRootCodecError, GrepRootEnvelope, GrepRootState, GrepRootStateError, GrepSegmentRef,
+    decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepFoldState,
+    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepRootCodecError,
+    GrepRootEnvelope, GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
 };
 
 // Frozen v0 format pins. These byte strings are the durable compatibility
 // fixtures: changing field names, ordering, enum tags, or omission rules must
 // change them deliberately. Together they represent every lifecycle state.
-const BACKFILLING_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:85e924a85e511959db7c82e342f7c2f6417fae1b8a57038ffa913084873e3f5e","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":"revision-00000000000000000007","checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":0,"built_through_seq":7,"fold":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:4711db321ec737abf7334d89865e3488d1d79c4d567823402f25bb971b989eee","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":0,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
-const ADDITIVE_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"future-writer/9.0","payload_checksum":"sha256:2d8afef7322d76189d288b50b3b02e8f475a6249b6d6f89659d6561d0f193870","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+const BACKFILLING_V0: &str = r#"{"kind":"grep_manifest","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:85e924a85e511959db7c82e342f7c2f6417fae1b8a57038ffa913084873e3f5e","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":"revision-00000000000000000007","checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":0,"built_through_seq":7,"fold":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V0: &str = r#"{"kind":"grep_manifest","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_V0: &str = r#"{"kind":"grep_manifest","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:4711db321ec737abf7334d89865e3488d1d79c4d567823402f25bb971b989eee","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":0,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
+const ADDITIVE_V0: &str = r#"{"kind":"grep_manifest","format_version":"v0","writer_version":"future-writer/9.0","payload_checksum":"sha256:2d8afef7322d76189d288b50b3b02e8f475a6249b6d6f89659d6561d0f193870","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":0,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+
+const BACKFILLING_POINTER_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:cb37939961048d1e11ad75ed9ee12048289c64e7b658183e37ee54d3dd4775bc","payload":{"namespace_id":"docs","manifest_id":"85e924a85e511959db7c82e342f7c2f6417fae1b8a57038ffa913084873e3f5e"}}"#;
+const STEADY_POINTER_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:7f8626871c6be491b412bd6f51ca6ea801bfc7bea4f963da81ab1f4666b39f3a","payload":{"namespace_id":"docs","manifest_id":"f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09"}}"#;
+const DISABLED_POINTER_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:aa4229c568fce32c8130970b4ca439cc73766739f444bdac5005ef68426a2123","payload":{"namespace_id":"docs","manifest_id":"4711db321ec737abf7334d89865e3488d1d79c4d567823402f25bb971b989eee"}}"#;
+const ADDITIVE_POINTER_V0: &str = r#"{"kind":"grep_root","format_version":"v0","writer_version":"future-writer/9.0","payload_checksum":"sha256:eedcda6d70834cf888191e747ea90ea440a41f9cf1f1189e49f803af38f5797e","payload":{"namespace_id":"docs","manifest_id":"f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09","future_pointer":true},"future_envelope":{"retained":true}}"#;
 
 #[test]
-fn encoded_roots_match_frozen_v0_bytes() {
+fn encoded_manifests_and_pointers_match_frozen_v0_bytes() {
     let cases = [
         (sample_backfilling_root(), BACKFILLING_V0),
         (sample_steady_root(ChangeSeq(11)), STEADY_V0),
@@ -24,19 +30,47 @@ fn encoded_roots_match_frozen_v0_bytes() {
     ];
 
     for (state, expected) in cases {
-        let envelope =
-            GrepRootEnvelope::from_state("loonfs-grep-tests/0.1.1", state).expect("build envelope");
-        let actual = String::from_utf8(encode_grep_root(&envelope).expect("encode root"))
-            .expect("root JSON is UTF-8");
+        let manifest = GrepManifestEnvelope::from_state("loonfs-grep-tests/0.1.1", state)
+            .expect("build manifest envelope");
+        let actual =
+            String::from_utf8(encode_grep_manifest(&manifest).expect("encode grep manifest"))
+                .expect("manifest JSON is UTF-8");
+        assert_eq!(actual, expected);
+
+        let pointer = GrepRootEnvelope::from_pointer(
+            "loonfs-grep-tests/0.1.1",
+            GrepRootPointer::new(namespace_id("docs"), manifest.manifest_id().clone()),
+        )
+        .expect("build pointer envelope");
+        let actual = String::from_utf8(encode_grep_root(&pointer).expect("encode grep pointer"))
+            .expect("pointer JSON is UTF-8");
+        let expected = match manifest.state().lifecycle() {
+            GrepLifecycle::Backfilling { .. } => BACKFILLING_POINTER_V0,
+            GrepLifecycle::Steady => STEADY_POINTER_V0,
+            GrepLifecycle::Disabled => DISABLED_POINTER_V0,
+        };
         assert_eq!(actual, expected);
     }
 }
 
 #[test]
-fn decoder_reads_frozen_v0_bytes_with_additive_fields() {
-    let decoded = decode_grep_root(ADDITIVE_V0.as_bytes()).expect("decode additive v0 fixture");
+fn decoders_read_frozen_v0_bytes_with_additive_fields() {
+    let decoded =
+        decode_grep_manifest(ADDITIVE_V0.as_bytes()).expect("decode additive manifest fixture");
 
     assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11)));
+    let pointer =
+        decode_grep_root(ADDITIVE_POINTER_V0.as_bytes()).expect("decode additive pointer fixture");
+    assert_eq!(
+        pointer.pointer(),
+        &GrepRootPointer::new(
+            namespace_id("docs"),
+            GrepManifestId::parse(
+                "f49e60b4af9f8e074e7c31107e5a7260698c791cfa3d2b9319d65b993a26ec09"
+            )
+            .expect("valid manifest id")
+        )
+    );
 }
 
 #[test]
@@ -44,7 +78,7 @@ fn decoder_rejects_unknown_version_without_fallback() {
     let future = STEADY_V0.replacen("\"format_version\":\"v0\"", "\"format_version\":\"v1\"", 1);
 
     assert!(matches!(
-        decode_grep_root(future.as_bytes()),
+        decode_grep_manifest(future.as_bytes()),
         Err(GrepRootCodecError::UnsupportedFormatVersion { found, supported })
             if found == "v1" && supported == "v0"
     ));
@@ -55,7 +89,7 @@ fn decoder_rejects_corrupted_checksum() {
     let corrupted = STEADY_V0.replacen("\"steady\"", "\"disabled\"", 1);
 
     assert!(matches!(
-        decode_grep_root(corrupted.as_bytes()),
+        decode_grep_manifest(corrupted.as_bytes()),
         Err(GrepRootCodecError::ChecksumMismatch { .. })
     ));
 }
@@ -65,7 +99,7 @@ fn decoder_rejects_truncated_payload() {
     let truncated = &STEADY_V0.as_bytes()[..STEADY_V0.len() - 8];
 
     assert!(matches!(
-        decode_grep_root(truncated),
+        decode_grep_manifest(truncated),
         Err(GrepRootCodecError::EnvelopeDecode { .. })
     ));
 }

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -2,10 +2,11 @@
 
 use bytes::Bytes;
 use loonfs_api::{ChangeSeq, NamespaceId};
-use loonfs_grep::keyspace::root_key;
+use loonfs_grep::keyspace::{manifest_key, manifests_prefix, root_key};
 use loonfs_grep::root::{
-    advance_grep_root, encode_grep_root, load_grep_root, seed_grep_root, GrepIndexState,
-    GrepLifecycle, GrepRootEnvelope, GrepRootError, GrepRootState,
+    advance_grep_root, encode_grep_manifest, encode_grep_root, load_grep_root, seed_grep_root,
+    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepRootEnvelope, GrepRootError,
+    GrepRootPointer, GrepRootState,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
@@ -16,8 +17,22 @@ async fn load_rejects_namespace_identity_mismatch() {
     let store = LocalFsStore::new(temp_dir.path()).expect("local store");
     let requested = namespace_id("requested");
     let wrong = root(namespace_id("other"), ChangeSeq(0));
-    let envelope = GrepRootEnvelope::from_state("test", wrong).expect("envelope");
-    let bytes = encode_grep_root(&envelope).expect("encode");
+    let manifest = GrepManifestEnvelope::from_state("test", wrong).expect("manifest envelope");
+    let manifest_bytes = encode_grep_manifest(&manifest).expect("encode manifest");
+    store
+        .put(
+            &manifest_key(&requested, manifest.manifest_id()),
+            Bytes::from(manifest_bytes),
+            PutMode::CreateIfAbsent,
+        )
+        .await
+        .expect("write mismatched manifest");
+    let envelope = GrepRootEnvelope::from_pointer(
+        "test",
+        GrepRootPointer::new(requested.clone(), manifest.manifest_id().clone()),
+    )
+    .expect("pointer envelope");
+    let bytes = encode_grep_root(&envelope).expect("encode pointer");
     let key = root_key(&requested);
     store
         .put(&key, Bytes::from(bytes), PutMode::CreateIfAbsent)
@@ -69,6 +84,15 @@ async fn racing_advancers_have_one_winner_and_loser_can_reload_and_retry() {
             .filter(|result| matches!(result, Err(GrepRootError::Conflict { .. })))
             .count(),
         1
+    );
+    assert_eq!(
+        store
+            .list_prefix(&manifests_prefix(&namespace_id))
+            .await
+            .expect("list candidate manifests")
+            .len(),
+        3,
+        "the seed, winner, and CAS loser's immutable manifests remain durable"
     );
 
     let reloaded = load_grep_root(&store, &namespace_id)

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -103,6 +103,22 @@ async fn standalone_once_advances_the_index_is_idempotent_and_rejects_bad_config
     assert!(stderr.contains("invalid grep config"), "{stderr}");
     assert!(stderr.contains("step_interval_ms"), "{stderr}");
     assert!(stderr.contains("greater than zero"), "{stderr}");
+
+    let bad_rescan_config_path = temp_dir.path().join("bad-rescan-worker.toml");
+    write_config(
+        &bad_rescan_config_path,
+        &store_root,
+        "rescan_interval_ms = 0\n",
+    );
+    let bad_rescan = run_once(&bad_rescan_config_path);
+    assert!(
+        !bad_rescan.status.success(),
+        "zero rescan interval must exit nonzero"
+    );
+    let stderr = String::from_utf8_lossy(&bad_rescan.stderr);
+    assert!(stderr.contains("invalid grep config"), "{stderr}");
+    assert!(stderr.contains("rescan_interval_ms"), "{stderr}");
+    assert!(stderr.contains("greater than zero"), "{stderr}");
 }
 
 async fn put_file(

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -181,6 +181,9 @@ pub struct GrepConfig {
     pub mode: GrepMode,
     pub step_interval_ms: u64,
     pub gc_interval_ms: u64,
+    /// Whole-store grep rediscovery interval. Each scan is proportional to
+    /// all keys below `namespaces/` until a namespace catalog exists.
+    pub rescan_interval_ms: u64,
     pub max_files_per_step: usize,
     pub max_content_bytes_per_step: u64,
     pub max_rows_per_segment: usize,
@@ -195,6 +198,7 @@ impl GrepConfig {
         GrepWorkerConfig {
             step_interval_ms: self.step_interval_ms,
             gc_interval_ms: self.gc_interval_ms,
+            rescan_interval_ms: self.rescan_interval_ms,
             max_files_per_step: self.max_files_per_step,
             max_content_bytes_per_step: self.max_content_bytes_per_step,
             max_rows_per_segment: self.max_rows_per_segment,
@@ -212,6 +216,7 @@ impl Default for GrepConfig {
             mode: GrepMode::Embedded,
             step_interval_ms: worker.step_interval_ms,
             gc_interval_ms: worker.gc_interval_ms,
+            rescan_interval_ms: worker.rescan_interval_ms,
             max_files_per_step: worker.max_files_per_step,
             max_content_bytes_per_step: worker.max_content_bytes_per_step,
             max_rows_per_segment: worker.max_rows_per_segment,
@@ -1178,6 +1183,7 @@ writer_version = "loonfs-server/0.1.0"
 mode = "serve_only"
 step_interval_ms = 25
 gc_interval_ms = 500
+rescan_interval_ms = 750
 max_files_per_step = 4096
 max_content_bytes_per_step = 536870912
 max_rows_per_segment = 131072
@@ -1195,6 +1201,7 @@ root = "/tmp/loonfs-server"
         assert_eq!(grep.mode, super::GrepMode::ServeOnly);
         assert_eq!(grep.step_interval_ms, 25);
         assert_eq!(grep.gc_interval_ms, 500);
+        assert_eq!(grep.rescan_interval_ms, 750);
         let policy = grep.worker_config().build_policy();
         assert_eq!(policy.max_files_per_step, 4096);
         assert_eq!(policy.max_content_bytes_per_step, 536_870_912);

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -11,6 +11,7 @@ use loonfs_api::v0::{
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::FEATURE_QUERY_GREP;
+use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome};
 
 #[cfg_attr(
     feature = "openapi",
@@ -75,7 +76,7 @@ pub(super) async fn grep_not_supported(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
+            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
         )
     )
 )]
@@ -86,11 +87,38 @@ pub(super) async fn enable_grams_index(
 ) -> Result<Json<EnableGramsIndexResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
-    let response = state
-        .admin
-        .enable_grams_index(&namespace_id)
+    let outcome = state
+        .grep_worker
+        .as_ref()
+        .expect("grep routes should carry a grep worker")
+        .enable(&namespace_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(
+                &namespace_id,
+                loonfs::RuntimeError::Core(error),
+            )
+        })?;
+    let response = match outcome {
+        GrepEnableOutcome::Enabled { target_seq } => EnableGramsIndexResponse {
+            namespace_id: namespace_id.clone(),
+            built_through_seq: target_seq,
+            already_enabled: false,
+        },
+        GrepEnableOutcome::AlreadyEnabled { built_through_seq } => EnableGramsIndexResponse {
+            namespace_id: namespace_id.clone(),
+            built_through_seq,
+            already_enabled: true,
+        },
+        GrepEnableOutcome::Superseded => {
+            return Err(ApiResponseError::runtime_for_namespace(
+                &namespace_id,
+                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
+                    "enabling grep lost a root publication race; retry".to_owned(),
+                )),
+            ));
+        }
+    };
     Ok(Json(response))
 }
 
@@ -108,7 +136,7 @@ pub(super) async fn enable_grams_index(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a manifest publication race; retry", body = ApiError)
+            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
         )
     )
 )]
@@ -119,10 +147,35 @@ pub(super) async fn disable_grams_index(
 ) -> Result<Json<DisableGramsIndexResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
-    let response = state
-        .admin
-        .disable_grams_index(&namespace_id)
+    let outcome = state
+        .grep_worker
+        .as_ref()
+        .expect("grep routes should carry a grep worker")
+        .disable(&namespace_id)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(
+                &namespace_id,
+                loonfs::RuntimeError::Core(error),
+            )
+        })?;
+    let response = match outcome {
+        GrepDisableOutcome::Disabled => DisableGramsIndexResponse {
+            namespace_id: namespace_id.clone(),
+            was_enabled: true,
+        },
+        GrepDisableOutcome::NotEnabled => DisableGramsIndexResponse {
+            namespace_id: namespace_id.clone(),
+            was_enabled: false,
+        },
+        GrepDisableOutcome::Superseded => {
+            return Err(ApiResponseError::runtime_for_namespace(
+                &namespace_id,
+                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
+                    "disabling grep lost a root publication race; retry".to_owned(),
+                )),
+            ));
+        }
+    };
     Ok(Json(response))
 }

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -107,6 +107,7 @@ struct AppState {
     admin: FsAdmin,
     publisher: PublisherRegistry,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
+    grep_worker: Option<GrepWorker<SharedObjectStore>>,
     /// Bounds concurrently buffered proxied-upload bodies; with the
     /// per-request body limit this makes worst-case upload memory
     /// `max_concurrent_uploads * max_upload_bytes`. Requests past the cap
@@ -153,13 +154,11 @@ struct GrepBackgroundWork {
 }
 
 impl GrepBackgroundWork {
-    fn spawn(config: &ServerConfig, store: SharedObjectStore) -> Result<Self, ServerConfigError> {
-        let worker = GrepWorker::new(
-            store.clone(),
-            format!("{}-grep", config.writer_id),
-            loonfs_api::generated_id("wrs"),
-            config.writer_version.clone(),
-        );
+    fn spawn(
+        config: &ServerConfig,
+        worker: GrepWorker<SharedObjectStore>,
+        store: SharedObjectStore,
+    ) -> Result<Self, ServerConfigError> {
         let worker_loop = GrepWorkerLoop::new(worker, store, config.grep.worker_config());
         let shutdown = worker_loop.shutdown_handle();
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
@@ -223,8 +222,23 @@ async fn app_with_store_and_transfer_issuer(
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<(Router, ServerLifecycle, AppState), ServerConfigError> {
     let (writer, reader, admin) = build_handles(&config, store.clone()).await?;
+    let grep_worker = config.grep.mode.serves_grep().then(|| {
+        GrepWorker::new(
+            store.clone(),
+            format!("{}-grep", config.writer_id),
+            loonfs_api::generated_id("wrs"),
+            config.writer_version.clone(),
+        )
+    });
     let grep = if config.grep.mode.runs_worker() {
-        Some(GrepBackgroundWork::spawn(&config, store)?)
+        Some(GrepBackgroundWork::spawn(
+            &config,
+            grep_worker
+                .as_ref()
+                .expect("worker-running grep mode should serve grep")
+                .clone(),
+            store,
+        )?)
     } else {
         None
     };
@@ -248,6 +262,7 @@ async fn app_with_store_and_transfer_issuer(
         admin,
         publisher,
         transfer_issuer,
+        grep_worker,
     };
     Ok((router(state.clone()), lifecycle, state))
 }

--- a/crates/loonfs-server/tests/grep_modes.rs
+++ b/crates/loonfs-server/tests/grep_modes.rs
@@ -11,7 +11,9 @@ use loonfs_api::{
     LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
 };
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
-use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker};
+use loonfs_grep::{
+    GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker, GrepWorkerConfig, GrepWorkerLoop,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
 use loonfs_server::{
@@ -53,12 +55,13 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
 }
 
 #[tokio::test]
-async fn embedded_mode_indexes_written_files_without_manual_ticks() {
+async fn embedded_mode_registers_fresh_enablement_without_waiting_for_rescan() {
     let temp_dir = tempdir().expect("store tempdir");
     let (_store, writer, namespace_id) = seed_namespace(temp_dir.path(), "embedded").await;
     let (router, lifecycle) = app(test_config(temp_dir.path(), GrepMode::Embedded))
         .await
         .expect("build app");
+    wait_for_worker_opportunity().await;
     assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
     writer
         .put_file_bytes(
@@ -81,6 +84,54 @@ async fn embedded_mode_indexes_written_files_without_manual_ticks() {
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.matches[0].absolute_path, "/note.txt");
     assert_eq!(response.built_through_seq, response.head_seq);
+    lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+#[tokio::test]
+async fn standalone_worker_rediscovers_server_enablement_within_one_rescan() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "rediscovered").await;
+    let (router, lifecycle) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
+        .await
+        .expect("build app");
+
+    let external_worker = GrepWorker::new(
+        store.clone(),
+        "standalone-rediscovery-worker",
+        "standalone-rediscovery-session",
+        "standalone-rediscovery/0.1",
+    );
+    let worker_loop = GrepWorkerLoop::new(
+        external_worker,
+        store,
+        GrepWorkerConfig {
+            step_interval_ms: 5,
+            gc_interval_ms: 60_000,
+            rescan_interval_ms: 10,
+            ..GrepWorkerConfig::default()
+        },
+    );
+    let shutdown = worker_loop.shutdown_handle();
+    let worker_task = tokio::spawn(worker_loop.run());
+    wait_for_worker_opportunity().await;
+
+    assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/note.txt",
+            b"rediscovered needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write file");
+
+    let response = wait_for_grep(&router, &namespace_id, "rediscovered needle").await;
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/note.txt");
+
+    shutdown.request_shutdown();
+    worker_task.await.expect("standalone worker loop joins");
     lifecycle.shutdown().await.expect("drain lifecycle");
 }
 
@@ -173,6 +224,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
             mode,
             step_interval_ms: 5,
             gc_interval_ms: 25,
+            rescan_interval_ms: 60_000,
             ..GrepConfig::default()
         },
         background_maintenance: true,
@@ -299,6 +351,7 @@ async fn wait_for_grep(router: &Router, namespace_id: &NamespaceId, pattern: &st
 
 #[allow(clippy::disallowed_methods)]
 async fn wait_for_worker_opportunity() {
-    // Five server step intervals are long enough to prove serve_only did not spawn the loop.
+    // Five step intervals let an embedded/standalone loop finish startup work,
+    // and are long enough to prove serve_only did not spawn a loop.
     tokio::time::sleep(std::time::Duration::from_millis(25)).await;
 }

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -161,13 +161,9 @@ impl FsCore {
         let view = engine
             .load_grep_view_with_runtime_context(&read_context)
             .await?;
-        let root = loonfs_grep::root::load_grep_root(self.store(), namespace_id).await;
-        let snapshot = match root {
-            Ok(root) => GrepIndexSnapshot::from_grep_root(root.as_ref().map(|root| root.state())),
-            Err(error) => GrepIndexSnapshot::from_error(CoreError::NamespaceCorrupt(format!(
-                "grep state for `{namespace_id}` is unreadable: {error}"
-            ))),
-        };
+        let snapshot =
+            GrepIndexSnapshot::from_grep_root(self.store(), namespace_id, &self.inner.grep_service)
+                .await;
         let response = self
             .inner
             .grep_service

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -486,7 +486,7 @@ impl IndexSegmentGetCountingStore {
     }
 
     fn record_if_index_segment(&self, key: &str) {
-        if key.starts_with("grep/v0/") && key.contains("/segments/") {
+        if key.contains("/extensions/grep/segments/") && key.ends_with(".sst.zst") {
             self.index_segment_gets.fetch_add(1, Ordering::SeqCst);
         }
     }
@@ -1108,7 +1108,7 @@ impl InFlightIndexGetProbeStore {
     where
         F: std::future::Future<Output = T>,
     {
-        if !key.starts_with("grep/v0/") || !key.contains("/segments/") {
+        if !key.contains("/extensions/grep/segments/") || !key.ends_with(".sst.zst") {
             return read.await;
         }
         let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -83,10 +83,9 @@ impl ServiceHarness {
             .engine
             .load_grep_view_with_runtime_context(&context)
             .await?;
-        let root = load_grep_root(&*self.store, &self.namespace_id)
-            .await
-            .map_err(|error| CoreError::NamespaceCorrupt(error.to_string()))?;
-        let snapshot = GrepIndexSnapshot::from_grep_root(root.as_ref().map(|root| root.state()));
+        let snapshot =
+            GrepIndexSnapshot::from_grep_root(&*self.store, &self.namespace_id, &self.service)
+                .await;
         self.service
             .query(grep_request, &snapshot, &view, &self.store)
             .await

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -20,8 +20,13 @@ use loonfs_core::cache::{
 };
 use loonfs_core::control::{load_namespace_checkpoint_record_control, load_namespace_read_anchor};
 use loonfs_core::{NamespaceEngine, RuntimeReadContext};
-use loonfs_grep::keyspace::{namespace_prefix, segment_key};
-use loonfs_grep::root::{load_grep_root, GrepLifecycle};
+use loonfs_grep::keyspace::{
+    manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
+};
+use loonfs_grep::root::{
+    encode_grep_root, load_grep_root, GrepLifecycle, GrepManifestId, GrepRootEnvelope,
+    GrepRootPointer,
+};
 use loonfs_grep::{
     GrepBuildOutcome, GrepFoldOutcome, GrepIndexSnapshot, GrepService, GrepWorker,
     GREP_GC_GRACE_WINDOW_MS,
@@ -114,13 +119,9 @@ async fn new_query(
         .expect("new query engine");
     let context = read_context(store, namespace_id).await;
     let view = engine.load_grep_view_with_runtime_context(&context).await?;
-    let root = load_grep_root(&**store, namespace_id)
-        .await
-        .map_err(|error| loonfs_core::Error::NamespaceCorrupt(error.to_string()))?;
-    let snapshot = GrepIndexSnapshot::from_grep_root(root.as_ref().map(|root| root.state()));
-    GrepService::new()
-        .query(grep_request, &snapshot, &view, store)
-        .await
+    let service = GrepService::new();
+    let snapshot = GrepIndexSnapshot::from_grep_root(&**store, namespace_id, &service).await;
+    service.query(grep_request, &snapshot, &view, store).await
 }
 
 fn normalize_namespace(mut response: GrepResponse, namespace_id: &NamespaceId) -> GrepResponse {
@@ -386,7 +387,63 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         "disabled",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
+
+    let missing_manifest_id =
+        GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
+            .expect("valid manifest id");
+    write_pointer(&*store, &namespace_id, missing_manifest_id).await;
+    assert_not_materialized_error(
+        "missing manifest",
+        new_reader.grep(&namespace_id, &request("needle")).await,
+    );
+
+    let corrupt_manifest_id =
+        GrepManifestId::parse("2222222222222222222222222222222222222222222222222222222222222222")
+            .expect("valid manifest id");
+    store
+        .put_overwrite(
+            &manifest_key(&namespace_id, &corrupt_manifest_id),
+            Bytes::from_static(b"corrupt manifest"),
+        )
+        .await
+        .expect("write corrupt manifest");
+    write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
+    assert_not_materialized_error(
+        "corrupt manifest",
+        new_reader.grep(&namespace_id, &request("needle")).await,
+    );
+
+    store
+        .put_overwrite(
+            &root_key(&namespace_id),
+            Bytes::from_static(b"corrupt pointer"),
+        )
+        .await
+        .expect("write corrupt pointer");
+    assert_not_materialized_error(
+        "corrupt pointer",
+        new_reader.grep(&namespace_id, &request("needle")).await,
+    );
     writer.shutdown_background().await.expect("shutdown");
+}
+
+async fn write_pointer(
+    store: &dyn ObjectStore,
+    namespace_id: &NamespaceId,
+    manifest_id: GrepManifestId,
+) {
+    let envelope = GrepRootEnvelope::from_pointer(
+        "grep-error-surface-test/0.1",
+        GrepRootPointer::new(namespace_id.clone(), manifest_id),
+    )
+    .expect("build pointer");
+    store
+        .put_overwrite(
+            &root_key(namespace_id),
+            Bytes::from(encode_grep_root(&envelope).expect("encode pointer")),
+        )
+        .await
+        .expect("write pointer");
 }
 
 fn assert_not_materialized_error(case: &str, result: loonfs::Result<GrepResponse>) {
@@ -783,6 +840,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
     let store: SharedObjectStore = aged_store.clone();
     let live_namespace = NamespaceId::parse("gc-live").expect("namespace id");
     let deleted_namespace = NamespaceId::parse("gc-deleted").expect("namespace id");
+    let corrupt_namespace = NamespaceId::parse("gc-corrupt").expect("namespace id");
     let absent_namespace = NamespaceId::parse("gc-absent").expect("namespace id");
     let writer = FsWriter::builder_with_store(store.clone())
         .writer_id("gc-writer")
@@ -795,7 +853,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .build()
         .await
         .expect("admin");
-    for namespace_id in [&live_namespace, &deleted_namespace] {
+    for namespace_id in [&live_namespace, &deleted_namespace, &corrupt_namespace] {
         writer
             .create_namespace(namespace_id, CreateNamespaceOptions::default())
             .await
@@ -811,7 +869,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
             .expect("write file");
     }
     let worker = worker(&store);
-    for namespace_id in [&live_namespace, &deleted_namespace] {
+    for namespace_id in [&live_namespace, &deleted_namespace, &corrupt_namespace] {
         worker.enable(namespace_id).await.expect("enable");
         drive_worker_to_current(&worker, namespace_id, GramIndexBuildPolicy::default()).await;
     }
@@ -821,6 +879,8 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .expect("root exists");
     let live_segment_key =
         segment_key(&live_namespace, &live_root.state().segments()[0].segment_id);
+    let live_manifest_key =
+        manifest_key(&live_namespace, live_root.manifest_envelope().manifest_id());
     let orphan_key = segment_key(&live_namespace, &IndexSegmentId::generate());
     store
         .put(
@@ -849,6 +909,17 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         )
         .await
         .expect("write absent namespace grep state");
+    let corrupt_keys = store
+        .list_prefix(&namespace_prefix(&corrupt_namespace))
+        .await
+        .expect("list corrupt namespace grep state");
+    store
+        .put_overwrite(
+            &root_key(&corrupt_namespace),
+            Bytes::from_static(b"corrupt root pointer"),
+        )
+        .await
+        .expect("corrupt root pointer");
 
     writer
         .delete_namespace(&deleted_namespace, DeleteNamespaceOptions::default())
@@ -859,11 +930,25 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .await
         .expect("grep gc");
     assert!(report.deleted_segments >= 1);
+    assert!(report.degraded_namespaces >= 1);
     assert!(store
         .head(&live_segment_key)
         .await
         .expect("head live")
         .is_some());
+    assert!(store
+        .head(&live_manifest_key)
+        .await
+        .expect("head live manifest")
+        .is_some());
+    assert_eq!(
+        store
+            .list_prefix(&manifests_prefix(&live_namespace))
+            .await
+            .expect("list retained live manifests"),
+        vec![live_manifest_key],
+        "only the root-referenced manifest remains live"
+    );
     assert!(store
         .head(&orphan_key)
         .await
@@ -879,6 +964,16 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .await
         .expect("list absent grep prefix")
         .is_empty());
+    for key in corrupt_keys {
+        assert!(
+            store
+                .head(&key)
+                .await
+                .expect("head degraded-retained key")
+                .is_some(),
+            "corrupt live grep state must degrade to retention for `{key}`"
+        );
+    }
     assert!(store
         .head(&non_grep_key)
         .await

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -98,7 +98,7 @@ one gram sort together, and batches from different runs for the
 same gram are unioned by readers, so merges never need to combine
 payloads to stay correct.
 
-## Segments and the grep root
+## Segments, manifests, and the grep root pointer
 
 Index segments reuse the metadata segment layout described in
 `metadata-block-storage.md` — prefix-compressed keys,
@@ -110,16 +110,24 @@ for this gram", which is exactly the pruning a query wants. The
 block builder is generalized over the row payload to make this
 possible; metadata families keep byte-identical output.
 
-Segments live under the grep-owned
-`grep/v0/namespaces/{namespace}/segments/` family. One atomic
-`grep/v0/namespaces/{namespace}/root.json` names the query-visible
-segments and records `built_through_seq`, lifecycle, run-ordinal
-allocation, and any in-progress fold snapshot, outputs, and cursor.
-The root is independent of the namespace manifest, so an older core
-reader never has to understand grep state to read the filesystem.
+Segments live under
+`namespaces/{namespace}/extensions/grep/segments/`. The small mutable
+`extensions/grep/root.json` pointer names an immutable, content-derived
+manifest under `extensions/grep/manifests/`; that manifest records the
+query-visible segments, `built_through_seq`, lifecycle, run-ordinal
+allocation, and any in-progress fold snapshot, outputs, and cursor. The
+pointer and manifests are independent of the namespace manifest, so core
+never has to understand grep state to read the filesystem.
 
-Disabling CAS-publishes a root with lifecycle `disabled` and no segment
-references. The objects become candidates for grep-owned collection;
+Publication writes the immutable manifest first and installs the pointer by
+one etag CAS. A CAS loser's manifest and segments are unreachable derived
+garbage for grep GC. Embedded enablement registers directly with the worker
+loop. Standalone rediscovery lists the whole `namespaces/` prefix at startup
+and on a rare interval; this is proportional to total store keys until a
+namespace catalog exists.
+
+Disabling writes a manifest with lifecycle `disabled` and no segment
+references, then CAS-publishes its pointer. The old objects become candidates for grep-owned collection;
 the disable call never deletes them synchronously. Grep GC retains every
 object named by a verified live root and deletes unreferenced grep objects
 only after its grace window. A fork does not copy a grep root, so it begins
@@ -176,7 +184,7 @@ Fold triggers count logical runs, never physical segments. Every
 publish that creates gram segments — a WAL or backfill build
 unit, a delta fold's outputs, a base fold's outputs — stamps one
 run ordinal on the whole batch, allocated from a counter in the
-grep root and incremented in the same root publication,
+grep manifest and incremented in the same pointer publication,
 so allocation is atomic with the root swap. The per-segment row
 cap can therefore split a run into any number of segments without
 changing fold cadence, and backfill units — which all carry the
@@ -195,7 +203,7 @@ readers that union them see duplicates, never gaps — and segments
 that arrive during the fold stay out of the snapshot and survive
 it. The completing step swaps the snapshot out for the outputs; a
 fold interrupted anywhere resumes from the cursor the last
-published root carries. The step's row budget is soft: rows
+published manifest carries. The step's row budget is soft: rows
 with equal keys are consumed as one atomic group, because the
 resume cursor is the last merged key plus a terminator and
 splitting the group would strand its tail behind the cursor.
@@ -203,7 +211,7 @@ splitting the group would strand its tail behind the cursor.
 The tiering and run identity are durable writer-side bookkeeping,
 invisible to reads:
 
-- Descriptor `level` in the grep root's segment list: `0` for the
+- Descriptor `level` in the grep manifest's segment list: `0` for the
   delta segments build units write, `1` for a delta fold's mid
   runs, and `2` for the base.
 - Descriptor `run_ordinal`: the batch-wide run identity described
@@ -333,7 +341,7 @@ Following the segment-format convention, two different contracts:
 - **Format constants.** The tokenizer (ASCII-case-folded byte
   trigrams), the eligibility rule (the 8 MiB cap and the text
   sniff), the posting row key shape, and the batch encoding are
-  pinned by the grep root/index and segment codec versions. Changing any
+  pinned by the grep pointer/manifest and segment codec versions. Changing any
   of them is a format-version bump and a rebuild — cheap by
   construction, since the index is derived work.
 - **Writer-side defaults.** The per-step build budgets (256
@@ -341,7 +349,7 @@ Following the segment-format convention, two different contracts:
   eight mid runs), the fold step's row budget, the posting
   batch target (about 256), page limits, the verified-candidate
   budget, and the query tail budget are writer- or server-side
-  tunables; readers take what the grep root and descriptors
+  tunables; readers take what the grep manifest and descriptors
   describe.
 
 ## Deferred, with intent

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -98,8 +98,9 @@ recovery authority. `wal/head.json` and `wal/floor.json` live outside the
 only segment keys.
 
 WAL and metadata-table deletion is reachability-driven from the live
-manifest, checkpoint records, and the retention floor. Grep objects live in
-the independent `grep/v0` keyspace and are never core-GC candidates.
+manifest, checkpoint records, and the retention floor. Extension-owned
+objects below `namespaces/{namespace_id}/extensions/` are foreign to the core
+key parser and are never core-GC candidates.
 
 ### 1.3 Durable naming conventions
 
@@ -1228,8 +1229,9 @@ Two rules make these envelopes evolvable:
 | --- | --- | --- | --- |
 | WAL segment | `namespace_wal_segment` | CBOR envelope, zstd-compressed; CBOR payload | 1 |
 | Metadata segment | none (section 4.2.1) | block sections, per-block zstd + CRC32C | 1 (via manifest) |
-| Grep root | `grep_root` | JSON, uncompressed | `v0` |
-| Grep segment | none (section 4.2.2) | block sections, per-block zstd + CRC32C | `v0` (via the grep root) |
+| Grep root pointer | `grep_root` | JSON, uncompressed | `v0` |
+| Grep manifest | `grep_manifest` | JSON, uncompressed | `v0` |
+| Grep segment | none (section 4.2.2) | block sections, per-block zstd + CRC32C | `v0` (via the grep manifest) |
 | Namespace manifest | `namespace_manifest` | JSON, uncompressed | 1 |
 | Control objects (head, descriptors, upload session) | per-kind snake_case names | JSON, uncompressed | 1 (tracked per kind) |
 
@@ -1268,17 +1270,40 @@ out-of-order index entries, and checksum failures as malformed. The segment
 format is versioned by the manifest that references it (`namespace_manifest`
 `format_version`), since a segment is unreachable except through a manifest.
 
-#### 4.2.2 Grep roots and gram-index segments
+#### 4.2.2 Grep roots, manifests, and gram-index segments
 
-`loonfs-grep` owns all grep durability under
-`grep/v0/namespaces/{namespace_id}/`: one atomic `root.json` and immutable
-segments under `segments/{segment_id}.sst`. Namespace manifests carry no
-grep root, watermark, lifecycle, or segment references. A fork consequently
+`loonfs-grep` owns all grep durability under the namespace extension prefix:
+
+```text
+namespaces/{namespace_id}/extensions/grep/
+├── root.json
+├── manifests/{manifest_id}.manifest.json
+└── segments/{segment_id}.sst.zst
+```
+
+`manifest_id` is the 64-character lowercase hex portion of the SHA-256 digest
+of the exact manifest payload fragment. The manifest envelope's
+`payload_checksum` is `sha256:{manifest_id}`. Namespace manifests carry no
+grep pointer, watermark, lifecycle, or segment references. A fork therefore
 starts without grep state until grep is enabled for the target.
+
+`root.json` is a small mutable pointer envelope with these fields, in order:
+
+- envelope: `kind = "grep_root"`, `format_version = "v0"`, informational
+  `writer_version`, `payload_checksum`, and raw JSON `payload`;
+- payload: `namespace_id` and `manifest_id`.
+
+Each immutable manifest has the same envelope grammar with
+`kind = "grep_manifest"` and `format_version = "v0"`. Its payload is the full
+grep state: `namespace_id`, `lifecycle`, nested `index` bookkeeping, and the
+`segments` descriptors. Both decoders verify the checksum over the exact
+stored payload fragment before decoding, reject unknown versions and kind
+mismatches without fallback, and validate namespace, manifest-id, lifecycle,
+fold, run-allocation, and segment invariants at every boundary.
 
 A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,
-handles and checksums in the grep-root descriptor — with a grep-owned row
+handles and checksums in the grep-manifest descriptor — with a grep-owned row
 payload instead of metadata rows. The tokenizer, row shapes, and posting
 encoding below are frozen by grep format `v0`; changing them requires a new
 grep format and a rebuild, which is always legal for derived work
@@ -1301,10 +1326,27 @@ grep format and a rebuild, which is always legal for derived work
 - Several rows may carry the same gram (within a segment and across
   segments); readers union their batches.
 
-The grep root carries the query-visible watermark, lifecycle, fold state,
-and segment descriptors. Grep's worker alone publishes and collects that
-state. Core maintenance does not list `grep/v0`, and grep maintenance does
-not list or sweep core-owned collections.
+Publication writes segments first, writes the content-derived manifest with
+create-if-absent semantics, and finally installs `root.json` with one etag
+compare-and-swap (or create-if-absent for the first pointer). A pointer-CAS
+loser's manifest and segments remain unreachable derived garbage; grep GC
+reclaims them after its grace window. Query readers load the pointer afresh,
+then load the immutable manifest it names; decoded manifests may be cached by
+manifest id.
+
+The namespace-scoped layout has no cheap all-grep listing. At worker startup
+and periodically, grep discovery lists the whole `namespaces/` prefix and
+filters exact `namespaces/{namespace_id}/extensions/grep/root.json` keys.
+That scan is proportional to the store's total key count and is the price of
+the layout until a namespace catalog exists, so the default interval is five
+minutes. In-process enablement also registers its namespace directly with the
+embedded loop and does not wait for rediscovery. Grep GC performs the same
+whole-namespace-prefix discovery on its own interval, retains the verified
+pointer, referenced manifest, and referenced segments, degrades to retention
+on corruption or ambiguity, and reaps the whole `extensions/grep/` prefix for
+a tombstoned or absent namespace. Core maintenance does not recognize or
+sweep `extensions/` keys, and grep maintenance does not sweep core-owned
+collections.
 
 ### 4.3 Evolution rules
 
@@ -1462,8 +1504,8 @@ manifest roots every object key its `metadata_files` list names. The pass also s
 session whose provider age exceeds the reap window is deleted whatever its
 state — the abort-incomplete-upload convention. A `complete` after the
 window answers session-not-found.
-Core GC never lists or deletes any object below `grep/v0`; grep collection is
-owned by `loonfs-grep`.
+Core GC never recognizes, lists specifically, or deletes any object below a
+namespace's `extensions/` prefix; grep collection is owned by `loonfs-grep`.
 Because floor, root, and checkpoint publication no longer serialize through
 one head CAS, two cross-object races must be closed explicitly —
 create-vs-collect (a record written while GC concludes its basis is


### PR DESCRIPTION
Per review, the grep keyspace moves under the namespace prefix and the top-level `grep/v0` dies: everything now lives at `namespaces/{id}/extensions/grep/` with `root.json`, `manifests/`, and `segments/`, versioned inside the objects like every other durable format rather than in the path. The root also restructures to the `metadata/` idiom: `root.json` is a tiny pointer naming the current grep manifest, the full state (lifecycle, watermark, fold state, segment refs) lives in immutable content-addressed manifests written create-if-absent, and one expected-etag CAS of the pointer installs an advance — a loser's manifest and segments are unreachable derived garbage for grep GC, the model the crate already documented. Both envelopes keep the established conventions (kind string, explicit internal version, checksum over the exact stored payload fragment, hard rejection, validation at every boundary), with frozen fixtures regenerated for both kinds across all lifecycle states. Segments pick up core's `.sst.zst` naming; encoding is unchanged. Hard cutover, no migration or dual-layout reading anywhere.

The one real cost of the namespace-scoped layout is discovery: there is no longer a single prefix enumerating all grep state. The worker registers namespaces in-process the moment an enable installs a pointer (an embedded server indexes fresh enablements with no scan), and rediscovers by scanning the `namespaces/` prefix at startup and every `rescan_interval_ms` (default five minutes, zero-rejected) — a scan proportional to the whole store's key count, documented as the price of this layout until a namespace catalog exists. A registration racing a scan is preserved by generation-based reconciliation: the scan only evicts entries older than its own start. Standalone and serve-only deployments pick up server-side enablements within one rescan, pinned by tests in both directions. Grep GC discovers the same way and keeps all its rules, including reaping the whole extension prefix of tombstoned or absent namespaces; core's key parser ignoring the extension shape is pinned from the grep side without touching core.

Queries load the pointer fresh each time, then the named manifest through the existing grep-private cache (immutable, cached by id, identity revalidated on hits). Missing or corrupt pointers and manifests all map to the same not-materialized surface as before — a broken grep extension still cannot affect core reads.
