### PR TITLE
fix(core): include delete guard in path identity

### DIFF
--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -52,6 +52,7 @@ enum PathFingerprintInput {
         namespace_id: NamespaceId,
         absolute_path: String,
         behavior: DeleteDirectoryBehavior,
+        expected_inode_id: Option<InodeId>,
     },
     MovePath {
         namespace_id: NamespaceId,
@@ -120,18 +121,21 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             behavior: *behavior,
             content_ref: content_ref.clone(),
         },
-        // `expected_inode_id` is deliberately outside the preimage: it is
-        // a precondition on current state, not part of the mutation's
-        // semantic identity (same stance as explicit commit preconditions
-        // vs the path-op vocabulary).
+        // Path-intent identity covers the complete caller-visible logical
+        // request. A changed delete guard must conflict instead of replaying
+        // the old receipt without checking the new guard, and including it
+        // matches explicit-commit identity, which already covers request
+        // preconditions.
         PathMutationIntent::DeletePath {
             absolute_path,
             behavior,
+            expected_inode_id,
             ..
         } => PathFingerprintInput::DeletePath {
             namespace_id: namespace_id.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
+            expected_inode_id: *expected_inode_id,
         },
         PathMutationIntent::MovePath {
             from_path,
@@ -966,6 +970,28 @@ mod tests {
             // value); post-release this literal only moves with a scheme
             // tag bump.
             "v0:sha256:06414b716b076c98e7a61e465ae729b2340045c133437a557c76902d73a5f33b"
+        );
+    }
+
+    /// Pins the exact stored fingerprint encoding for a guarded delete.
+    #[test]
+    fn guarded_delete_path_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let intent = PathMutationIntent::DeletePath {
+            commit_id: CommitId::parse("c_00000000000000000000000000000043").expect("commit id"),
+            absolute_path: AbsolutePath::parse("/docs").expect("path"),
+            behavior: DeleteDirectoryBehavior::NonRecursive,
+            expected_inode_id: Some(InodeId(42)),
+        };
+
+        let fingerprint =
+            path_intent_fingerprint_for_path_intent(&namespace_id, &intent).expect("fingerprint");
+
+        assert_eq!(
+            fingerprint.as_str(),
+            // Added pre-release when the delete guard became semantic
+            // request content; no deployed receipts use the prior preimage.
+            "v0:sha256:6b233b1fa124c36c09104446f8a1de60b6bec76fccf6fc41e72e064c60f47715"
         );
     }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -433,6 +433,27 @@ fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     )
 }
 
+fn delete_path_non_recursive_expecting<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    expected_inode_id: Option<InodeId>,
+    context: &MutationContext,
+    commit_id: &str,
+) -> Result<loonfs_api::CommitResponse, CoreError> {
+    submit_intent(
+        store,
+        namespace_id,
+        PathMutationIntent::DeletePath {
+            commit_id: CommitId::parse(commit_id).expect("valid test commit id"),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            behavior: DeleteDirectoryBehavior::NonRecursive,
+            expected_inode_id,
+        },
+        context,
+    )
+}
+
 fn move_path<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -3635,6 +3656,186 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         .await
         .expect("list wal");
     assert_eq!(wal_keys.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_path_commit_id_reuse_includes_expected_inode_id() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let seeded_paths = [
+        ("/same-guard.txt", "seed-same-guard"),
+        ("/changed-guard.txt", "seed-changed-guard"),
+        ("/removed-guard.txt", "seed-removed-guard"),
+        ("/added-guard.txt", "seed-added-guard"),
+    ];
+    for (path, commit_id) in seeded_paths {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            path,
+            b"hello",
+            &context,
+            Some(commit_id),
+        )
+        .expect("seed guarded delete target");
+    }
+
+    let same_inode = resolve_path(&store, &namespace_id, "/same-guard.txt")
+        .expect("resolve same-guard target")
+        .inode_id;
+    let first = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/same-guard.txt",
+        Some(same_inode),
+        &context,
+        "delete-same-guard",
+    )
+    .expect("first guarded delete");
+    let retry = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/same-guard.txt",
+        Some(same_inode),
+        &context,
+        "delete-same-guard",
+    )
+    .expect("identical guarded delete retry");
+    assert_eq!(retry, first);
+
+    let changed_inode = resolve_path(&store, &namespace_id, "/changed-guard.txt")
+        .expect("resolve changed-guard target")
+        .inode_id;
+    let removed_inode = resolve_path(&store, &namespace_id, "/removed-guard.txt")
+        .expect("resolve removed-guard target")
+        .inode_id;
+    let added_inode = resolve_path(&store, &namespace_id, "/added-guard.txt")
+        .expect("resolve added-guard target")
+        .inode_id;
+    let conflicts = [
+        (
+            "delete-changed-guard",
+            "/changed-guard.txt",
+            Some(changed_inode),
+            Some(InodeId(1)),
+        ),
+        (
+            "delete-removed-guard",
+            "/removed-guard.txt",
+            Some(removed_inode),
+            None,
+        ),
+        (
+            "delete-added-guard",
+            "/added-guard.txt",
+            None,
+            Some(added_inode),
+        ),
+    ];
+    for (commit_id, path, first_guard, retry_guard) in conflicts {
+        delete_path_non_recursive_expecting(
+            &store,
+            &namespace_id,
+            path,
+            first_guard,
+            &context,
+            commit_id,
+        )
+        .expect("first delete");
+
+        let error = delete_path_non_recursive_expecting(
+            &store,
+            &namespace_id,
+            path,
+            retry_guard,
+            &context,
+            commit_id,
+        )
+        .expect_err("changed guard must conflict");
+        assert!(matches!(
+            error,
+            CoreError::CommitIdReuseConflict(reused) if reused == commit_id
+        ));
+    }
+
+    let head = load_namespace_head_control(&store, &namespace_id)
+        .await
+        .expect("load head");
+    assert_eq!(head.state.seq, ChangeSeq(8));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fresh_delete_path_expected_inode_guard_still_matches_or_rejects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/matching-guard.txt",
+        b"matching",
+        &context,
+        Some("seed-matching-guard"),
+    )
+    .expect("seed matching target");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/mismatching-guard.txt",
+        b"mismatching",
+        &context,
+        Some("seed-mismatching-guard"),
+    )
+    .expect("seed mismatching target");
+    let matching_inode = resolve_path(&store, &namespace_id, "/matching-guard.txt")
+        .expect("resolve matching target")
+        .inode_id;
+    let mismatching_inode = resolve_path(&store, &namespace_id, "/mismatching-guard.txt")
+        .expect("resolve mismatching target")
+        .inode_id;
+
+    delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/matching-guard.txt",
+        Some(matching_inode),
+        &context,
+        "delete-matching-guard",
+    )
+    .expect("matching guard deletes");
+    let missing = resolve_path(&store, &namespace_id, "/matching-guard.txt")
+        .expect_err("matching target is deleted");
+    assert_eq!(missing.code(), ErrorCode::PathNotFound);
+
+    let error = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/mismatching-guard.txt",
+        Some(InodeId(1)),
+        &context,
+        "delete-mismatching-guard",
+    )
+    .expect_err("mismatching guard must fail planning");
+    assert!(matches!(
+        error,
+        CoreError::CommitValidation(CommitValidationError::BindingPreconditionMismatch {
+            expected_child_inode_id: InodeId(1),
+            actual_child_inode_id: Some(actual),
+            ..
+        }) if actual == mismatching_inode
+    ));
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/mismatching-guard.txt")
+            .expect("mismatching target remains")
+            .inode_id,
+        mismatching_inode
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -357,6 +357,10 @@ The retry rule has three cases:
   `commit_id_reuse_conflict`.
 - Retrying with a new `commit_id` is a new logical mutation.
 
+For a path-oriented delete, `expected_inode_id` is part of the mutation's
+semantic identity, so changing, adding, or removing the guard while reusing a
+`commit_id` fails with `commit_id_reuse_conflict`.
+
 Identical resubmission is the reconciliation mechanism. There is no separate
 commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
 a process restart, resubmit the same request with the same `commit_id` and


### PR DESCRIPTION
A delete's `expected_inode_id` guard was deliberately excluded from the path-intent fingerprint as "a precondition on current state, not part of semantic identity" — but that stance had a surprising consequence and a false premise. The consequence: a retry of a landed commit ID with a *changed* guard silently replayed the original receipt without the new guard ever being evaluated. The premise: the old comment claimed consistency with explicit commits, whose fingerprint in fact already folds preconditions into identity. The adopted rule is that a commit ID identifies the complete caller-visible logical request (temporary content proofs stay excluded — they are transport), so the guard joins the preimage, the rationale comment now states the real rule, and same-commit-ID retries with a differing guard — in all four present/absent directions — conflict instead of replaying. Identical retries replay unchanged, and fresh-request guard behavior is untouched.

An audit of every other fingerprint variant found no further caller-visible gaps: everything else excluded is derived planning state or the commit ID itself (the lookup key). The exact guarded-delete fingerprint is pinned byte-for-byte; pre-release, the preimage change ships without compatibility handling.