### PR TITLE
fix(client): scope retries by operation

### DIFF
--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -29,11 +29,10 @@ pub struct ClientConfig {
     /// failures: the retryable-unavailability codes (`server_busy`,
     /// `commit_queue_full`, `shutting_down` — a draining process telling the
     /// caller to retry against the next one) and network-level transport
-    /// errors (connect failures, timeouts, resets). Off by default — the
-    /// retry runs — because every request the client sends is idempotent to
-    /// resend: mutations carry their commit id in the body and staging
-    /// repeats are recognized, so resending after an ambiguous transport
-    /// failure is safe by construction.
+    /// errors (connect failures, timeouts, resets). Off by default. The retry
+    /// applies only to reads, mutations with durable replay identity, and
+    /// operations whose repeat semantics are idempotent; lifecycle mutations
+    /// and upload-session creation are always single-attempt.
     #[serde(default)]
     pub disable_transient_retry: bool,
 }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -140,7 +140,8 @@ impl Client {
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceSummary, ClientError> {
         let url = format!("{}/v0/namespaces", self.base_url);
-        self.request_json::<_, NamespaceSummary>(
+        // Namespace creation has no durable request identity to reconcile an ambiguous success.
+        self.request_json_once::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&CreateNamespaceRequest {
                 namespace_id: namespace_id.clone(),
@@ -172,7 +173,8 @@ impl Client {
         if let Some(expected) = expected_head_seq {
             url.push_str(&format!("?expected_head_seq={}", expected.0));
         }
-        self.request_json::<(), DeleteNamespaceResponse>(self.agent.delete(&url), None)
+        // The expected head is a precondition, not an idempotency key for an ambiguous delete.
+        self.request_json_once::<(), DeleteNamespaceResponse>(self.agent.delete(&url), None)
     }
 
     pub fn fork_namespace(
@@ -184,7 +186,8 @@ impl Client {
             "{}/v0/namespaces/{source_namespace_id}/forks",
             self.base_url
         );
-        self.request_json::<_, NamespaceSummary>(
+        // Namespace forks have no durable request identity to replay after an ambiguous success.
+        self.request_json_once::<_, NamespaceSummary>(
             self.agent.post(&url),
             Some(&ForkNamespaceRequest {
                 new_namespace_id: new_namespace_id.clone(),
@@ -341,7 +344,7 @@ impl Client {
     pub fn health(&self) -> Result<(), ClientError> {
         let url = format!("{}/health", self.base_url);
         let request = self.authenticated(self.agent.get(&url));
-        request.call().map_err(|err| self.map_error(err))?;
+        self.call_with_transient_retry(&request, None)?;
         Ok(())
     }
 
@@ -351,7 +354,8 @@ impl Client {
         request: &BeginUploadRequest,
     ) -> Result<BeginUploadResponse, ClientError> {
         let url = format!("{}/v0/namespaces/{namespace_id}/uploads", self.base_url);
-        self.request_json::<_, BeginUploadResponse>(self.agent.post(&url), Some(request))
+        // Beginning an upload mints a new session id, so a resend could create a second session.
+        self.request_json_once::<_, BeginUploadResponse>(self.agent.post(&url), Some(request))
     }
 
     pub fn begin_direct_put(
@@ -390,10 +394,8 @@ impl Client {
         for (name, value) in headers {
             request = request.set(name, value);
         }
-        request
-            .send_bytes(bytes)
-            .map(|_| ())
-            .map_err(|err| self.map_error(err))
+        // A successful create-only PUT may replay as a provider precondition error, not success.
+        self.call_once(&request, Some(bytes)).map(|_| ())
     }
 
     pub fn upload_content(
@@ -426,6 +428,7 @@ impl Client {
             "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
             self.base_url
         );
+        // The durable completed-session record replays an identical completion without new effect.
         self.request_json::<_, CompleteUploadResponse>(self.agent.post(&url), Some(request))
     }
 
@@ -435,6 +438,7 @@ impl Client {
         request: &CommitSubmissionRequest,
     ) -> Result<ApiCommitResponse, ClientError> {
         let url = format!("{}/v0/namespaces/{namespace_id}/commits", self.base_url);
+        // The request's commit id resolves an ambiguous resend through a durable receipt.
         self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
@@ -597,6 +601,7 @@ impl Client {
             "{}/v0/namespaces/{namespace_id}/filesystem/operations",
             self.base_url
         );
+        // The request's commit id resolves an ambiguous resend through a durable receipt.
         self.request_json::<_, ApiCommitResponse>(self.agent.post(&url), Some(request))
     }
 
@@ -1001,37 +1006,14 @@ mod tests {
         ));
     }
 
-    /// A connection the server drops before answering is a transport
-    /// failure: with the retry enabled the client resends up to the attempt
-    /// cap; with it disabled the first failure surfaces.
+    /// A network-level transport failure resends up to the attempt cap when
+    /// retry is enabled; with it disabled the first failure surfaces.
     #[test]
     fn transport_failures_resend_up_to_the_attempt_cap() {
-        use std::io::Read;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind listener");
-        let addr = listener.local_addr().expect("listener addr");
-        let accepted = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&accepted);
-        let total_expected = MAX_TRANSIENT_ATTEMPTS as usize + 1;
-        let server = std::thread::spawn(move || {
-            for stream in listener.incoming() {
-                let Ok(mut stream) = stream else { break };
-                let seen = counter.fetch_add(1, Ordering::SeqCst) + 1;
-                // Read a little so the request bytes are on the wire, then
-                // drop the connection without answering.
-                let mut buf = [0u8; 256];
-                let _ = stream.read(&mut buf);
-                drop(stream);
-                if seen >= total_expected {
-                    break;
-                }
-            }
-        });
-
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let transport = crate::transport::test_transport::failures(MAX_TRANSIENT_ATTEMPTS as usize);
         let retrying = Client::new(ClientConfig {
-            server_url: format!("http://{addr}"),
+            server_url: "http://example.invalid".to_owned(),
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: false,
@@ -1041,13 +1023,12 @@ mod tests {
             .namespace_status(&namespace_id)
             .expect_err("dropped connections must fail");
         assert!(matches!(error, ClientError::Http(_)), "{error:?}");
-        assert_eq!(
-            accepted.load(Ordering::SeqCst),
-            MAX_TRANSIENT_ATTEMPTS as usize
-        );
+        assert_eq!(transport.attempts(), MAX_TRANSIENT_ATTEMPTS as usize);
+        drop(transport);
 
+        let transport = crate::transport::test_transport::failures(1);
         let single_shot = Client::new(ClientConfig {
-            server_url: format!("http://{addr}"),
+            server_url: "http://example.invalid".to_owned(),
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: true,
@@ -1056,11 +1037,168 @@ mod tests {
         single_shot
             .namespace_status(&namespace_id)
             .expect_err("dropped connection must fail without retry");
-        assert_eq!(
-            accepted.load(Ordering::SeqCst),
-            MAX_TRANSIENT_ATTEMPTS as usize + 1
+        assert_eq!(transport.attempts(), 1);
+    }
+
+    fn retry_policy_client() -> Client {
+        Client::new(ClientConfig {
+            server_url: "http://example.invalid".to_owned(),
+            auth_token: None,
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+        })
+        .expect("valid client config")
+    }
+
+    fn assert_transport_failure_after_one_attempt<T>(
+        call: impl FnOnce(&Client) -> Result<T, ClientError>,
+    ) {
+        let transport = crate::transport::test_transport::failure_then_success(b"{}".to_vec());
+        let client = retry_policy_client();
+        let result = call(&client);
+        assert!(
+            matches!(result, Err(ClientError::Http(_))),
+            "expected the first transport failure to surface"
         );
-        server.join().expect("server thread");
+        assert_eq!(transport.attempts(), 1);
+    }
+
+    #[test]
+    fn retry_policy_lifecycle_mutations_are_single_attempt() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        assert_transport_failure_after_one_attempt(|client| client.create_namespace(&namespace_id));
+        assert_transport_failure_after_one_attempt(|client| {
+            client.fork_namespace(
+                &namespace_id,
+                &NamespaceId::parse("fork").expect("valid id"),
+            )
+        });
+        assert_transport_failure_after_one_attempt(|client| {
+            client.delete_namespace(&namespace_id, Some(ChangeSeq(7)))
+        });
+    }
+
+    #[test]
+    fn retry_policy_commit_id_filesystem_mutation_retries() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let commit_id =
+            CommitId::parse("c_00000000000000000000000000000001").expect("valid commit id");
+        let response = ApiCommitResponse {
+            namespace_id: namespace_id.clone(),
+            commit_id: commit_id.clone(),
+            committed_seq: ChangeSeq(1),
+        };
+        let transport = crate::transport::test_transport::failure_then_success(
+            serde_json::to_vec(&response).expect("serialize response"),
+        );
+        let client = retry_policy_client();
+        let spec = NamespacePath::parse("demo", "/docs").expect("valid namespace path");
+
+        let actual = client
+            .create_directory(&spec, false, &MutationOptions::with_commit_id(commit_id))
+            .expect("commit-id mutation should retry");
+        assert_eq!(actual, response);
+        assert_eq!(transport.attempts(), 2);
+    }
+
+    #[test]
+    fn retry_policy_read_retries() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let response = NamespaceStatusResponse {
+            namespace_id: namespace_id.clone(),
+            head_seq: ChangeSeq(0),
+            current_manifest_id: None,
+            wal_tail_segments: 0,
+            retention_floor_seq: ChangeSeq(0),
+        };
+        let transport = crate::transport::test_transport::failure_then_success(
+            serde_json::to_vec(&response).expect("serialize response"),
+        );
+        let client = retry_policy_client();
+
+        let actual = client
+            .namespace_status(&namespace_id)
+            .expect("read should retry");
+        assert_eq!(actual, response);
+        assert_eq!(transport.attempts(), 2);
+    }
+
+    #[test]
+    fn retry_policy_upload_begins_are_single_attempt() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        assert_transport_failure_after_one_attempt(|client| {
+            client.begin_upload(&namespace_id, &BeginUploadRequest::default())
+        });
+        assert_transport_failure_after_one_attempt(|client| {
+            client.begin_direct_put(&namespace_id, ContentRef::whole_file_v0(b"direct"))
+        });
+    }
+
+    #[test]
+    fn retry_policy_presigned_upload_is_single_attempt() {
+        let transport = crate::transport::test_transport::failure_then_success(Vec::new());
+        let client = retry_policy_client();
+        let access = ObjectTransferAccess::PresignedUrl {
+            method: "PUT".to_owned(),
+            url: "http://example.invalid/upload".to_owned(),
+            headers: std::collections::BTreeMap::new(),
+            expires_at_ms: 1,
+        };
+
+        let result = client.upload_via_presigned_url(&access, b"direct");
+
+        assert!(matches!(result, Err(ClientError::Http(_))), "{result:?}");
+        assert_eq!(transport.attempts(), 1);
+    }
+
+    #[test]
+    fn retry_policy_proxied_upload_content_retries() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let upload_id = loonfs_api::UploadId::parse("upl_00000000000000000000000000000001")
+            .expect("valid upload id");
+        let response = UploadContentResponse {
+            namespace_id: namespace_id.clone(),
+            upload_id: upload_id.clone(),
+            content_ref: ContentRef::whole_file_v0(b"content"),
+        };
+        let transport = crate::transport::test_transport::failure_then_success(
+            serde_json::to_vec(&response).expect("serialize response"),
+        );
+        let client = retry_policy_client();
+
+        let actual = client
+            .upload_content(&namespace_id, upload_id.as_str(), b"content")
+            .expect("identical content staging should retry");
+        assert_eq!(actual, response);
+        assert_eq!(transport.attempts(), 2);
+    }
+
+    #[test]
+    fn retry_policy_upload_completion_retries() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let upload_id = loonfs_api::UploadId::parse("upl_00000000000000000000000000000001")
+            .expect("valid upload id");
+        let content_ref = ContentRef::whole_file_v0(b"content");
+        let response = CompleteUploadResponse {
+            namespace_id: namespace_id.clone(),
+            upload_id: upload_id.clone(),
+            content_ref: content_ref.clone(),
+            validated_content_token: None,
+        };
+        let transport = crate::transport::test_transport::failure_then_success(
+            serde_json::to_vec(&response).expect("serialize response"),
+        );
+        let client = retry_policy_client();
+
+        let actual = client
+            .complete_upload(
+                &namespace_id,
+                upload_id.as_str(),
+                &CompleteUploadRequest { content_ref },
+            )
+            .expect("completed-session replay should retry");
+        assert_eq!(actual, response);
+        assert_eq!(transport.attempts(), 2);
     }
 
     /// An intermediary answering with a non-envelope body (a load balancer's

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -61,17 +61,49 @@ impl Client {
         Req: serde::Serialize,
         Resp: serde::de::DeserializeOwned,
     {
+        self.request_json_inner(request, body, true)
+    }
+
+    pub(crate) fn request_json_once<Req, Resp>(
+        &self,
+        request: ureq::Request,
+        body: Option<&Req>,
+    ) -> Result<Resp, ClientError>
+    where
+        Req: serde::Serialize,
+        Resp: serde::de::DeserializeOwned,
+    {
+        self.request_json_inner(request, body, false)
+    }
+
+    fn request_json_inner<Req, Resp>(
+        &self,
+        request: ureq::Request,
+        body: Option<&Req>,
+        retry: bool,
+    ) -> Result<Resp, ClientError>
+    where
+        Req: serde::Serialize,
+        Resp: serde::de::DeserializeOwned,
+    {
         let request = self.authenticated(request);
-        let response = match body {
+        let body = match body {
             Some(body) => {
                 // Serialized once: every retry attempt resends identical
-                // bytes under the same commit id.
-                let bytes =
-                    serde_json::to_vec(body).map_err(|err| ClientError::Json(err.to_string()))?;
-                let request = request.set("content-type", "application/json");
-                self.call_with_transient_retry(&request, Some(&bytes))?
+                // bytes when this call site permits a resend.
+                Some(serde_json::to_vec(body).map_err(|err| ClientError::Json(err.to_string()))?)
             }
-            None => self.call_with_transient_retry(&request, None)?,
+            None => None,
+        };
+        let request = if body.is_some() {
+            request.set("content-type", "application/json")
+        } else {
+            request
+        };
+        let response = if retry {
+            self.call_with_transient_retry(&request, body.as_deref())?
+        } else {
+            self.call_once(&request, body.as_deref())?
         };
         serde_json::from_reader(response.into_reader())
             .map_err(|err| ClientError::Json(err.to_string()))
@@ -87,19 +119,29 @@ impl Client {
         Ok(bytes)
     }
 
+    /// Sends one request without retrying. Callers use this path when an
+    /// ambiguous success cannot be reconciled through durable replay state.
+    pub(crate) fn call_once(
+        &self,
+        request: &ureq::Request,
+        body: Option<&[u8]>,
+    ) -> Result<ureq::Response, ClientError> {
+        send_request(request, body).map_err(|error| self.map_error(*error))
+    }
+
     /// Sends one request, resending on quick-clearing transient failures —
     /// the retryable-unavailability codes (`server_busy`,
     /// `commit_queue_full`, `shutting_down`) and network-level transport
     /// errors — with doubling backoff, bounded by
-    /// [`MAX_TRANSIENT_ATTEMPTS`]. Resending is safe for every request this
-    /// client issues: mutation bodies carry their commit id (replayed,
-    /// never double-committed) and staging repeats are recognized by the
-    /// server, which is exactly what makes an ambiguous transport failure —
-    /// the request may or may not have been served — safe to resend. Other
-    /// unavailability codes are excluded on purpose — `maintenance_required`
-    /// and `index_lagging` clear on a maintenance tick, not on a resend —
-    /// and a served status with a non-envelope body is not retried: only
-    /// failures the network layer itself reported count as transport.
+    /// [`MAX_TRANSIENT_ATTEMPTS`]. Call sites opt into this path only for
+    /// reads, mutations with durable replay identity, and operations whose
+    /// repeat semantics are idempotent. Lifecycle mutations and upload
+    /// session creation use [`Self::call_once`] so ambiguous success remains
+    /// visible to the caller. Other unavailability codes are excluded on
+    /// purpose — `maintenance_required` and `index_lagging` clear on a
+    /// maintenance tick, not on a resend — and a served status with a
+    /// non-envelope body is not retried: only failures the network layer
+    /// itself reported count as transport.
     pub(crate) fn call_with_transient_retry(
         &self,
         request: &ureq::Request,
@@ -107,10 +149,7 @@ impl Client {
     ) -> Result<ureq::Response, ClientError> {
         let mut attempts = 0;
         loop {
-            let outcome = match body {
-                Some(bytes) => request.clone().send_bytes(bytes),
-                None => request.clone().call(),
-            };
+            let outcome = send_request(request, body);
             let error = match outcome {
                 Ok(response) => return Ok(response),
                 Err(error) => error,
@@ -118,8 +157,8 @@ impl Client {
             // Classified before `map_error` flattens it: only a true
             // network-level failure retries — a served status with a
             // non-envelope body (a load balancer's HTML 502) does not.
-            let transport = matches!(&error, ureq::Error::Transport(_));
-            let error = self.map_error(error);
+            let transport = matches!(error.as_ref(), ureq::Error::Transport(_));
+            let error = self.map_error(*error);
             attempts += 1;
             let transient = transient_failure(transport, &error);
             if !self.transient_retry || !transient || attempts >= MAX_TRANSIENT_ATTEMPTS {
@@ -160,5 +199,101 @@ impl Client {
             }
             ureq::Error::Transport(err) => ClientError::Http(err.to_string()),
         }
+    }
+}
+
+fn send_request(
+    request: &ureq::Request,
+    body: Option<&[u8]>,
+) -> Result<ureq::Response, Box<ureq::Error>> {
+    #[cfg(test)]
+    if let Some(outcome) = test_transport::next() {
+        return outcome;
+    }
+    match body {
+        Some(bytes) => request.clone().send_bytes(bytes).map_err(Box::new),
+        None => request.clone().call().map_err(Box::new),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_transport {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    enum Outcome {
+        TransportFailure,
+        Success(Vec<u8>),
+    }
+
+    struct State {
+        outcomes: VecDeque<Outcome>,
+        attempts: usize,
+    }
+
+    thread_local! {
+        static STATE: RefCell<Option<State>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) struct Guard;
+
+    impl Guard {
+        pub(crate) fn attempts(&self) -> usize {
+            STATE.with(|state| {
+                state
+                    .borrow()
+                    .as_ref()
+                    .expect("test transport should be installed")
+                    .attempts
+            })
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            STATE.with(|state| *state.borrow_mut() = None);
+        }
+    }
+
+    pub(crate) fn failures(count: usize) -> Guard {
+        install(std::iter::repeat_with(|| Outcome::TransportFailure).take(count))
+    }
+
+    pub(crate) fn failure_then_success(body: Vec<u8>) -> Guard {
+        install([Outcome::TransportFailure, Outcome::Success(body)])
+    }
+
+    fn install(outcomes: impl IntoIterator<Item = Outcome>) -> Guard {
+        STATE.with(|state| {
+            let replaced = state.borrow_mut().replace(State {
+                outcomes: outcomes.into_iter().collect(),
+                attempts: 0,
+            });
+            assert!(replaced.is_none(), "test transport already installed");
+        });
+        Guard
+    }
+
+    pub(super) fn next() -> Option<Result<ureq::Response, Box<ureq::Error>>> {
+        STATE.with(|state| {
+            let mut state = state.borrow_mut();
+            let state = state.as_mut()?;
+            state.attempts += 1;
+            let outcome = state
+                .outcomes
+                .pop_front()
+                .expect("test transport exhausted before client stopped sending");
+            Some(match outcome {
+                Outcome::TransportFailure => {
+                    Err(Box::new(ureq::get("broken/url").call().expect_err(
+                        "relative URL should produce a transport error",
+                    )))
+                }
+                Outcome::Success(body) => {
+                    let body = String::from_utf8(body).expect("test response should be UTF-8");
+                    ureq::Response::new(200, "OK", &body).map_err(Box::new)
+                }
+            })
+        })
     }
 }

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -52,6 +52,7 @@ enum PathFingerprintInput {
         namespace_id: NamespaceId,
         absolute_path: String,
         behavior: DeleteDirectoryBehavior,
+        expected_inode_id: Option<InodeId>,
     },
     MovePath {
         namespace_id: NamespaceId,
@@ -120,18 +121,21 @@ pub(crate) fn path_intent_fingerprint_for_path_intent(
             behavior: *behavior,
             content_ref: content_ref.clone(),
         },
-        // `expected_inode_id` is deliberately outside the preimage: it is
-        // a precondition on current state, not part of the mutation's
-        // semantic identity (same stance as explicit commit preconditions
-        // vs the path-op vocabulary).
+        // Path-intent identity covers the complete caller-visible logical
+        // request. A changed delete guard must conflict instead of replaying
+        // the old receipt without checking the new guard, and including it
+        // matches explicit-commit identity, which already covers request
+        // preconditions.
         PathMutationIntent::DeletePath {
             absolute_path,
             behavior,
+            expected_inode_id,
             ..
         } => PathFingerprintInput::DeletePath {
             namespace_id: namespace_id.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
+            expected_inode_id: *expected_inode_id,
         },
         PathMutationIntent::MovePath {
             from_path,
@@ -966,6 +970,28 @@ mod tests {
             // value); post-release this literal only moves with a scheme
             // tag bump.
             "v0:sha256:06414b716b076c98e7a61e465ae729b2340045c133437a557c76902d73a5f33b"
+        );
+    }
+
+    /// Pins the exact stored fingerprint encoding for a guarded delete.
+    #[test]
+    fn guarded_delete_path_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let intent = PathMutationIntent::DeletePath {
+            commit_id: CommitId::parse("c_00000000000000000000000000000043").expect("commit id"),
+            absolute_path: AbsolutePath::parse("/docs").expect("path"),
+            behavior: DeleteDirectoryBehavior::NonRecursive,
+            expected_inode_id: Some(InodeId(42)),
+        };
+
+        let fingerprint =
+            path_intent_fingerprint_for_path_intent(&namespace_id, &intent).expect("fingerprint");
+
+        assert_eq!(
+            fingerprint.as_str(),
+            // Added pre-release when the delete guard became semantic
+            // request content; no deployed receipts use the prior preimage.
+            "v0:sha256:6b233b1fa124c36c09104446f8a1de60b6bec76fccf6fc41e72e064c60f47715"
         );
     }
 

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -433,6 +433,27 @@ fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
     )
 }
 
+fn delete_path_non_recursive_expecting<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+    expected_inode_id: Option<InodeId>,
+    context: &MutationContext,
+    commit_id: &str,
+) -> Result<loonfs_api::CommitResponse, CoreError> {
+    submit_intent(
+        store,
+        namespace_id,
+        PathMutationIntent::DeletePath {
+            commit_id: CommitId::parse(commit_id).expect("valid test commit id"),
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            behavior: DeleteDirectoryBehavior::NonRecursive,
+            expected_inode_id,
+        },
+        context,
+    )
+}
+
 fn move_path<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -3635,6 +3656,186 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         .await
         .expect("list wal");
     assert_eq!(wal_keys.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_path_commit_id_reuse_includes_expected_inode_id() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+
+    let seeded_paths = [
+        ("/same-guard.txt", "seed-same-guard"),
+        ("/changed-guard.txt", "seed-changed-guard"),
+        ("/removed-guard.txt", "seed-removed-guard"),
+        ("/added-guard.txt", "seed-added-guard"),
+    ];
+    for (path, commit_id) in seeded_paths {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            path,
+            b"hello",
+            &context,
+            Some(commit_id),
+        )
+        .expect("seed guarded delete target");
+    }
+
+    let same_inode = resolve_path(&store, &namespace_id, "/same-guard.txt")
+        .expect("resolve same-guard target")
+        .inode_id;
+    let first = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/same-guard.txt",
+        Some(same_inode),
+        &context,
+        "delete-same-guard",
+    )
+    .expect("first guarded delete");
+    let retry = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/same-guard.txt",
+        Some(same_inode),
+        &context,
+        "delete-same-guard",
+    )
+    .expect("identical guarded delete retry");
+    assert_eq!(retry, first);
+
+    let changed_inode = resolve_path(&store, &namespace_id, "/changed-guard.txt")
+        .expect("resolve changed-guard target")
+        .inode_id;
+    let removed_inode = resolve_path(&store, &namespace_id, "/removed-guard.txt")
+        .expect("resolve removed-guard target")
+        .inode_id;
+    let added_inode = resolve_path(&store, &namespace_id, "/added-guard.txt")
+        .expect("resolve added-guard target")
+        .inode_id;
+    let conflicts = [
+        (
+            "delete-changed-guard",
+            "/changed-guard.txt",
+            Some(changed_inode),
+            Some(InodeId(1)),
+        ),
+        (
+            "delete-removed-guard",
+            "/removed-guard.txt",
+            Some(removed_inode),
+            None,
+        ),
+        (
+            "delete-added-guard",
+            "/added-guard.txt",
+            None,
+            Some(added_inode),
+        ),
+    ];
+    for (commit_id, path, first_guard, retry_guard) in conflicts {
+        delete_path_non_recursive_expecting(
+            &store,
+            &namespace_id,
+            path,
+            first_guard,
+            &context,
+            commit_id,
+        )
+        .expect("first delete");
+
+        let error = delete_path_non_recursive_expecting(
+            &store,
+            &namespace_id,
+            path,
+            retry_guard,
+            &context,
+            commit_id,
+        )
+        .expect_err("changed guard must conflict");
+        assert!(matches!(
+            error,
+            CoreError::CommitIdReuseConflict(reused) if reused == commit_id
+        ));
+    }
+
+    let head = load_namespace_head_control(&store, &namespace_id)
+        .await
+        .expect("load head");
+    assert_eq!(head.state.seq, ChangeSeq(8));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fresh_delete_path_expected_inode_guard_still_matches_or_rejects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/matching-guard.txt",
+        b"matching",
+        &context,
+        Some("seed-matching-guard"),
+    )
+    .expect("seed matching target");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/mismatching-guard.txt",
+        b"mismatching",
+        &context,
+        Some("seed-mismatching-guard"),
+    )
+    .expect("seed mismatching target");
+    let matching_inode = resolve_path(&store, &namespace_id, "/matching-guard.txt")
+        .expect("resolve matching target")
+        .inode_id;
+    let mismatching_inode = resolve_path(&store, &namespace_id, "/mismatching-guard.txt")
+        .expect("resolve mismatching target")
+        .inode_id;
+
+    delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/matching-guard.txt",
+        Some(matching_inode),
+        &context,
+        "delete-matching-guard",
+    )
+    .expect("matching guard deletes");
+    let missing = resolve_path(&store, &namespace_id, "/matching-guard.txt")
+        .expect_err("matching target is deleted");
+    assert_eq!(missing.code(), ErrorCode::PathNotFound);
+
+    let error = delete_path_non_recursive_expecting(
+        &store,
+        &namespace_id,
+        "/mismatching-guard.txt",
+        Some(InodeId(1)),
+        &context,
+        "delete-mismatching-guard",
+    )
+    .expect_err("mismatching guard must fail planning");
+    assert!(matches!(
+        error,
+        CoreError::CommitValidation(CommitValidationError::BindingPreconditionMismatch {
+            expected_child_inode_id: InodeId(1),
+            actual_child_inode_id: Some(actual),
+            ..
+        }) if actual == mismatching_inode
+    ));
+    assert_eq!(
+        resolve_path(&store, &namespace_id, "/mismatching-guard.txt")
+            .expect("mismatching target remains")
+            .inode_id,
+        mismatching_inode
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -357,6 +357,10 @@ The retry rule has three cases:
   `commit_id_reuse_conflict`.
 - Retrying with a new `commit_id` is a new logical mutation.
 
+For a path-oriented delete, `expected_inode_id` is part of the mutation's
+semantic identity, so changing, adding, or removing the guard while reusing a
+`commit_id` fails with `commit_id_reuse_conflict`.
+
 Identical resubmission is the reconciliation mechanism. There is no separate
 commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
 a process restart, resubmit the same request with the same `commit_id` and

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -366,6 +366,11 @@ commit-status lookup: after `commit_outcome_unknown`, a transport failure, or
 a process restart, resubmit the same request with the same `commit_id` and
 read the definitive answer from the response.
 
+The blocking Rust client automatically retries reads, commit-id mutations,
+replay-safe upload stages, and idempotent maintenance calls, but makes one
+attempt for namespace create, fork, and delete, upload-session begin, and
+presigned direct PUT.
+
 Committed mutations record a durable receipt binding the `commit_id` to its
 `committed_seq`; replay reads that receipt. Receipts are currently retained
 for the life of the namespace. When receipt retention becomes bounded, this


### PR DESCRIPTION
The client retried every request through one blanket transient path, with a comment asserting "resending is safe for every request this client issues." It is not: namespace create and fork carry no durable idempotency, so a lost response followed by a transient-classified retry resends a succeeded operation and surfaces a spurious `namespace_exists` or `namespace_partial`; namespace delete's `expected_head_seq` is a precondition, not a replay key. The transient error classes stay exactly as they are — what narrows is which operations use them. Reads retry. Commit-ID mutations retry, because durable receipts make a resend land as a replay or a typed conflict (the guarded-delete row of that argument holds because #353 put the guard into identity). Lifecycle mutations without durable idempotency make one attempt and surface the error — the accepted tradeoff. The false comment now states the real policy.

The upload calls were audited individually rather than assumed: content staging keeps its retry (identical bytes under one upload ID are documented byte-idempotent), completion keeps its retry (the durable completed-session record replays the identical completion), and two previously retrying calls lose theirs with cause — a resent begin can mint a second session, and a resent presigned create-only PUT can answer a precondition conflict after an ambiguous success (completion's probe owns that recovery). `put_file_bytes` is therefore deliberately a mixed pipeline: single-attempt begin, retrying content, completion, and publication.

The transport grows a single-attempt sibling (`request_json_once`/`call_once`) rather than a flag or policy machinery, and the PR body's justification per method lives in the report table; the policy tests inject outcomes at the send boundary and assert exact attempt counts for a lifecycle mutation, a commit-ID mutation, a read, and all four upload decisions. The old localhost-socket attempt-cap test moved onto the same deterministic injector.
