### PR TITLE
fix(core): require explicit partial namespace repair

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -144,8 +144,8 @@ pub enum CheckpointOwner {
     /// may carry the same name over different bases.
     User { name: String },
     /// A fork target keeping its source basis alive. Released only once the
-    /// target namespace is terminally deleted or its abandoned bootstrap is
-    /// proven dead.
+    /// target namespace is terminally deleted or its installation tree is
+    /// proven absent.
     Fork { target_namespace_id: NamespaceId },
 }
 

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -89,7 +89,8 @@ pub use v0::{
     ForkNamespaceRequest, GcRequest, GcResponse, GrepGcResponse, GrepMatch, GrepRequest,
     GrepResponse, ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceTickOutcome,
     MaintenanceTickRequest, MaintenanceTickResponse, NamespaceStatusResponse, NamespaceSummary,
-    ReleaseCheckpointResponse, RestoreFileRevisionRequest,
+    ReleaseCheckpointResponse, RepairNamespaceOutcome, RepairNamespaceResponse,
+    RestoreFileRevisionRequest,
 };
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -29,8 +29,8 @@ pub use operations::{
     ErrorDetails, FileRevision, FilesystemOperation, FilesystemOperationRequest, FlushWalOutcome,
     FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse, ListFileRevisionsResponse,
     MaintenanceTickOutcome, MaintenanceTickRequest, MaintenanceTickResponse,
-    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse,
-    RestoreFileRevisionRequest,
+    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RepairNamespaceOutcome,
+    RepairNamespaceResponse, RestoreFileRevisionRequest,
 };
 pub use reads::{AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse};
 pub use search::{

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -130,6 +130,31 @@ pub struct NamespaceStatusResponse {
     pub retention_floor_seq: ChangeSeq,
 }
 
+/// How an explicit namespace repair resolved the namespace's durable state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RepairNamespaceOutcome {
+    /// The namespace already carried its completion descriptor.
+    AlreadyComplete,
+    /// The missing completion descriptor was reconstructed and published.
+    Completed,
+    /// Aged, non-completable namespace debris was removed.
+    Reaped,
+    /// Non-completable debris is still inside the repair safety window.
+    InFlight,
+}
+
+/// Result of explicitly repairing one namespace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct RepairNamespaceResponse {
+    /// Namespace the repair inspected.
+    pub namespace_id: NamespaceId,
+    /// What the repair did, or why it left the namespace untouched.
+    pub outcome: RepairNamespaceOutcome,
+}
+
 /// Result of deleting a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -378,8 +403,8 @@ pub struct GcRequest {
     /// deadlines); a smaller value is rejected as `invalid_request`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grace_window_ms: Option<u64>,
-    /// Abandoned bootstrap trees older than this may be reaped. Must be at
-    /// least the grace window.
+    /// Old upload sessions and abandoned fork records older than this may be
+    /// reaped or released. Must be at least the grace window.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reap_window_ms: Option<u64>,
 }
@@ -401,8 +426,6 @@ pub struct GcResponse {
     /// Fork-owned checkpoint records released because their target namespace
     /// is provably gone.
     pub released_fork_checkpoints: u64,
-    /// Objects removed while reaping an abandoned bootstrap tree.
-    pub reaped_abandoned_objects: u64,
     /// Upload-session control objects deleted after the reap window.
     #[serde(default)]
     pub deleted_upload_sessions: u64,
@@ -415,6 +438,9 @@ pub struct GcResponse {
     pub retained_candidates: u64,
     /// True when ambiguous roots suppressed manifest/table deletion.
     pub degraded_retention: bool,
+    /// True when the namespace lacks a complete head-and-descriptor pair, so
+    /// the pass deliberately performed no listing or deletion.
+    pub incomplete_namespace_ignored: bool,
 }
 
 /// Result of advancing the retention floor.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -482,6 +482,8 @@ pub(crate) enum AdminCommand {
     Tick(AdminTickArgs),
     /// Run a mark-and-sweep garbage-collection pass.
     Gc(AdminGcArgs),
+    /// Repair one incomplete namespace installation explicitly.
+    Repair(AdminNamespaceArgs),
     /// Enable the gram content index and start its backfill.
     IndexEnable(AdminNamespaceArgs),
     /// Disable the gram content index.
@@ -536,8 +538,8 @@ pub(crate) struct AdminGcArgs {
     /// omitted).
     #[arg(long)]
     pub grace_window_ms: Option<u64>,
-    /// Abandoned bootstrap trees older than this may be reaped (server
-    /// default when omitted).
+    /// Old upload sessions and abandoned fork records wait at least this long
+    /// (server default when omitted).
     #[arg(long)]
     pub reap_window_ms: Option<u64>,
 }
@@ -605,6 +607,7 @@ pub(crate) enum CommandKind {
     AdminRetentionAdvance,
     AdminTick,
     AdminGc,
+    AdminRepair,
     AdminIndexEnable,
     AdminIndexDisable,
     ConfigPath,
@@ -647,6 +650,7 @@ impl CommandKind {
             CommandKind::AdminRetentionAdvance => "admin_retention_advance",
             CommandKind::AdminTick => "admin_tick",
             CommandKind::AdminGc => "admin_gc",
+            CommandKind::AdminRepair => "admin_repair",
             CommandKind::AdminIndexEnable => "admin_index_enable",
             CommandKind::AdminIndexDisable => "admin_index_disable",
             CommandKind::ConfigPath => "config_path",
@@ -700,6 +704,7 @@ impl Cli {
                 AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
                 AdminCommand::Tick(_) => CommandKind::AdminTick,
                 AdminCommand::Gc(_) => CommandKind::AdminGc,
+                AdminCommand::Repair(_) => CommandKind::AdminRepair,
                 AdminCommand::IndexEnable(_) => CommandKind::AdminIndexEnable,
                 AdminCommand::IndexDisable(_) => CommandKind::AdminIndexDisable,
             },

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -23,7 +23,7 @@ use loonfs_api::{
     FlushWalResponse, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
     ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, PaginationPolicy, ReleaseCheckpointResponse,
-    RevisionNo,
+    RepairNamespaceResponse, RevisionNo,
 };
 use loonfs_client::{Client, ClientConfig, NamespacePath};
 use std::sync::Arc;
@@ -476,6 +476,16 @@ impl Backend for EmbeddedBackend {
             .await
             .map(|report| gc_response_from_report(namespace_id.clone(), report))
             .map_err(map_runtime_error)
+    }
+
+    async fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<RepairNamespaceResponse, BackendError> {
+        self.admin
+            .repair_namespace(namespace_id)
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn list_changes_page(

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,5 +1,5 @@
-//! `loon admin` commands: status, checkpoints, retention, gc, indexes,
-//! and the change feed.
+//! `loon admin` commands: checkpoints, retention, GC, namespace repair,
+//! indexes, and the change feed.
 
 use super::context::resolve_command_context;
 use super::output::{CommandData, CommandFailure, CommandOutput};
@@ -22,9 +22,30 @@ pub(crate) async fn run_admin_command(
         AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
         AdminCommand::Tick(args) => run_admin_tick(kind, args).await,
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
+        AdminCommand::Repair(args) => run_admin_repair(kind, args).await,
         AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
         AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, args).await,
     }
+}
+
+async fn run_admin_repair(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let response = context
+        .target
+        .backend()
+        .repair_namespace(&context.namespace)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::NamespaceRepaired(response),
+    })
 }
 
 async fn run_admin_tick(

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -9,7 +9,7 @@ use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativePathEntry, CreateCheckpointResponse,
     DeleteNamespaceResponse, DisableGramsIndexResponse, EnableGramsIndexResponse, FileRevision,
     FlushWalResponse, GcResponse, GrepMatch, MaintenanceTickResponse, NamespaceSummary,
-    ReleaseCheckpointResponse,
+    ReleaseCheckpointResponse, RepairNamespaceResponse,
 };
 use serde::Serialize;
 
@@ -57,6 +57,7 @@ pub(crate) enum CommandData {
     RetentionAdvanced(AdvanceRetentionResponse),
     MaintenanceTicked(MaintenanceTickResponse),
     GarbageCollected(GcResponse),
+    NamespaceRepaired(RepairNamespaceResponse),
     GramsIndexEnabled(EnableGramsIndexResponse),
     GramsIndexDisabled(DisableGramsIndexResponse),
     Changes(ChangesResponse),

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -3,11 +3,14 @@
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput};
 use crate::error::CliError;
-use loonfs_api::{FlushWalOutcome, GcResponse, MaintenanceTickOutcome};
+use loonfs_api::{FlushWalOutcome, GcResponse, MaintenanceTickOutcome, RepairNamespaceOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
 
 fn gc_summary(report: &GcResponse) -> String {
+    if report.incomplete_namespace_ignored {
+        return "gc ignored incomplete namespace".to_owned();
+    }
     let mut summary = format!(
         "gc deleted {} wal segments, {} tables, {} manifests, {} checkpoint records ({} retained)",
         report.deleted_wal_segments,
@@ -242,6 +245,15 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         }
         CommandData::GarbageCollected(response) => {
             format!("gc for {}: {}", response.namespace_id, gc_summary(response))
+        }
+        CommandData::NamespaceRepaired(response) => {
+            let outcome = match response.outcome {
+                RepairNamespaceOutcome::AlreadyComplete => "already complete",
+                RepairNamespaceOutcome::Completed => "completed",
+                RepairNamespaceOutcome::Reaped => "reaped",
+                RepairNamespaceOutcome::InFlight => "in flight",
+            };
+            format!("repair for {}: {outcome}", response.namespace_id)
         }
         CommandData::Changes(response) => {
             let mut lines = vec![

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1179,6 +1179,7 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
                 &["admin", "retention-advance"],
                 &["admin", "tick"],
                 &["admin", "gc"],
+                &["admin", "repair"],
                 &["admin", "index-enable"],
                 &["admin", "index-disable"],
             ],
@@ -1399,6 +1400,14 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(gc_data["deleted_wal_segments"], 0);
         assert_eq!(gc_data["deleted_manifests"], 0);
         assert_eq!(gc_data["degraded_retention"], false);
+        assert_eq!(gc_data["incomplete_namespace_ignored"], false);
+
+        let repair = harness.run(&["--json", "admin", "repair", "--profile", profile]);
+        assert_success(&repair);
+        let repair_data = json_data(&repair);
+        assert_eq!(repair_data["kind"], "namespace_repaired");
+        assert_eq!(repair_data["namespace_id"], "demo");
+        assert_eq!(repair_data["outcome"], "already_complete");
 
         // Admin failures surface the registry code in both modes.
         let missing = harness.run(&[
@@ -1421,6 +1430,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             sorted_object_keys(&retention_data),
             sorted_object_keys(&tick_data),
             sorted_object_keys(&gc_data),
+            sorted_object_keys(&repair_data),
         ));
     }
 

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -24,7 +24,8 @@ use loonfs_api::{
     DestinationBehavior, DisableGramsIndexResponse, EnableGramsIndexResponse, ErrorCode,
     ErrorDetails, FlushWalResponse, GcRequest, GcResponse, GrepRequest, GrepResponse, InodeId,
     ListFileRevisionsResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
+    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RepairNamespaceResponse,
+    RevisionNo,
 };
 use thiserror::Error;
 
@@ -302,6 +303,11 @@ pub trait Backend {
         namespace_id: &NamespaceId,
         request: GcRequest,
     ) -> Result<GcResponse, BackendError>;
+    /// Explicitly repairs one incomplete namespace installation.
+    async fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<RepairNamespaceResponse, BackendError>;
     /// Reads the ordered change feed after the `after_seq` cursor.
     async fn list_changes_page(
         &self,
@@ -608,6 +614,15 @@ impl Backend for RemoteBackend {
     ) -> Result<GcResponse, BackendError> {
         let namespace_id = namespace_id.clone();
         self.wire(move |client| client.gc_namespace(&namespace_id, &request))
+            .await
+    }
+
+    async fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<RepairNamespaceResponse, BackendError> {
+        let namespace_id = namespace_id.clone();
+        self.wire(move |client| client.repair_namespace(&namespace_id))
             .await
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -27,7 +27,7 @@ use loonfs_api::{
     FilesystemOperationRequest, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
     GrepGcResponse, GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse,
     ListPathEntriesResponse, MaintenanceTickRequest, MaintenanceTickResponse, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse,
+    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RepairNamespaceResponse,
     RestoreFileRevisionRequest, RevisionNo,
 };
 use std::sync::{Arc, OnceLock};
@@ -539,6 +539,20 @@ impl Client {
     ) -> Result<GcResponse, ClientError> {
         let url = format!("{}/v0/admin/namespaces/{namespace_id}/gc", self.base_url);
         self.request_json(self.agent.post(&url), Some(request))
+    }
+
+    /// Explicitly repairs one incomplete namespace installation.
+    pub fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<RepairNamespaceResponse, ClientError> {
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace_id}/repair",
+            self.base_url
+        );
+        // Repair can reap a namespace, so a lost success cannot be replayed
+        // into the same outcome without a durable request identity.
+        self.request_json_once::<(), RepairNamespaceResponse>(self.agent.post(&url), None)
     }
 
     /// Content search over the namespace's gram index (query plane).
@@ -1076,6 +1090,7 @@ mod tests {
         assert_transport_failure_after_one_attempt(|client| {
             client.delete_namespace(&namespace_id, Some(ChangeSeq(7)))
         });
+        assert_transport_failure_after_one_attempt(|client| client.repair_namespace(&namespace_id));
     }
 
     #[test]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -175,7 +175,7 @@ pub enum CoreError {
     NamespaceAlreadyExists { namespace_id: NamespaceId },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
-    #[error("namespace `{namespace_id}` is partially initialized")]
+    #[error("namespace `{namespace_id}` is partially initialized; run admin repair explicitly")]
     NamespacePartiallyInitialized { namespace_id: NamespaceId },
 }
 

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -4,11 +4,10 @@ use crate::error::CoreError;
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use serde::{Deserialize, Serialize};
 
-/// Grace and reap windows for the sweep (format spec, "Garbage collection",
-/// rules 1 and 9). Both are wall-clock cleanup policy, never validity
-/// inputs. The defaults are conservative: every object gets one hour of
-/// unconditional protection, and an abandoned bootstrap tree must sit
-/// untouched for seven days before it may be reaped.
+/// Grace and reap windows for the sweep (format spec, "Garbage collection").
+/// Both are wall-clock cleanup policy, never validity inputs. The defaults
+/// are conservative: every object gets one hour of unconditional protection,
+/// while old upload sessions and abandoned fork records wait seven days.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GcConfig {
     pub grace_window_ms: u64,
@@ -52,11 +51,9 @@ pub struct GcReport {
     pub deleted_manifests: u64,
     pub deleted_checkpoint_records: u64,
     /// Fork-owned checkpoint records flipped to released because their
-    /// target namespace is provably gone (terminally deleted, or an
-    /// abandoned bootstrap past the reap window).
+    /// target namespace is provably gone (terminally deleted, or its
+    /// installation tree is absent past the reap window).
     pub released_fork_checkpoints: u64,
-    /// Objects removed while reaping an abandoned bootstrap tree (rule 9).
-    pub reaped_abandoned_objects: u64,
     /// Upload-session control objects deleted after the reap window.
     #[serde(default)]
     pub deleted_upload_sessions: u64,
@@ -72,4 +69,7 @@ pub struct GcReport {
     /// suppresses manifest and table deletion for the whole pass (rule 5:
     /// ambiguous roots cause retention).
     pub degraded_retention: bool,
+    /// The namespace lacked a complete head-and-descriptor pair, so GC
+    /// deliberately skipped it without listing or deleting any objects.
+    pub incomplete_namespace_ignored: bool,
 }

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -1,11 +1,12 @@
 //! Mark-and-sweep garbage collection (format spec, "Garbage collection").
 //!
-//! GC and floor advancement are the only code paths that list the store.
-//! Nothing sweeps by default: callers opt in through the admin endpoint or
-//! an explicit maintenance-tick option. Writers never coordinate with GC,
-//! so a sweep can race an in-flight publish or checkpoint creation. The
-//! grace window, delete-time re-verification, and retain-on-ambiguity
-//! defaults close those races. When in doubt, this module retains.
+//! GC, floor advancement, and explicit namespace repair are the only code
+//! paths that list the store. Nothing sweeps by default: callers opt in
+//! through the admin endpoint or an explicit maintenance-tick option.
+//! Writers never coordinate with GC, so a sweep can race an in-flight
+//! publish or checkpoint creation. The grace window, delete-time
+//! re-verification, and retain-on-ambiguity defaults close those races. When
+//! in doubt, this module retains.
 
 mod config;
 mod fork_checkpoints;
@@ -16,4 +17,5 @@ mod run;
 mod tests;
 
 pub use config::{GcConfig, GcReport};
+pub(crate) use reap::{reap_abandoned_bootstrap, AbandonedBootstrapReap};
 pub use run::gc_namespace;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -1,28 +1,34 @@
-//! Reaping: age-gated deletion of unreachable objects and abandoned
-//! bootstrap debris.
+//! Reaping: age-gated deletion of unreachable objects and the explicit
+//! namespace-repair reap for abandoned installation debris.
 
-use super::config::{GcConfig, GcReport};
+use super::config::GcReport;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError};
+use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use crate::namespace::control::ControlObjectLoadError;
 use loonfs_api::{ManifestObjectId, NamespaceId};
-use loonfs_objectstore::keys::namespace_config;
+use loonfs_objectstore::keys::{namespace_config, wal_head};
 use loonfs_objectstore::ObjectStore;
 
-/// Rule 9: a namespace tree with no `namespace.json` whose newest object is
-/// older than the reap window may be reaped, re-checking the completion
-/// marker's absence immediately before deleting.
-pub(super) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbandonedBootstrapReap {
+    Reaped,
+    InFlight,
+    AlreadyComplete,
+}
+
+/// Reaps a non-completable namespace tree for explicit admin repair once its
+/// newest object is older than [`GC_MIN_GRACE_WINDOW_MS`], re-checking the
+/// complete head-and-descriptor pair immediately before deletion.
+pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    config: &GcConfig,
     context: &MutationContext,
-) -> Result<GcReport, CoreError> {
+) -> Result<AbandonedBootstrapReap, CoreError> {
     let namespace_prefix = format!("namespaces/{}/", namespace_id.as_str());
     let keys = list_prefix(store, &namespace_prefix).await?;
-    let mut report = GcReport::default();
     if keys.is_empty() {
-        return Ok(report);
+        return Ok(AbandonedBootstrapReap::Reaped);
     }
 
     // The newest object bounds the tree's age; a missing timestamp reads as
@@ -36,34 +42,38 @@ pub(super) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
             continue;
         };
         let Some(last_modified_ms) = metadata.last_modified_ms else {
-            report.retained_candidates += u64::try_from(keys.len()).unwrap_or(u64::MAX);
-            return Ok(report);
+            return Ok(AbandonedBootstrapReap::InFlight);
         };
-        if context.now_ms.saturating_sub(last_modified_ms) < config.reap_window_ms {
-            report.retained_candidates += u64::try_from(keys.len()).unwrap_or(u64::MAX);
-            return Ok(report);
+        if context.now_ms.saturating_sub(last_modified_ms) < GC_MIN_GRACE_WINDOW_MS {
+            return Ok(AbandonedBootstrapReap::InFlight);
         }
     }
 
-    // Re-check the absence of the completion marker immediately before
-    // deleting (rule 9).
-    let complete_now = store
-        .head(&namespace_config(namespace_id.as_str()))
+    // Re-check the complete pair immediately before deleting. A descriptor
+    // without a head is itself non-completable debris; a real completed
+    // namespace always has both because the descriptor is written last.
+    let descriptor_key = namespace_config(namespace_id.as_str());
+    let head_key = wal_head(namespace_id.as_str());
+    let descriptor_exists = store
+        .head(&descriptor_key)
         .await
-        .map_err(|error| CoreError::store(namespace_config(namespace_id.as_str()), &error))?
+        .map_err(|error| CoreError::store(&descriptor_key, &error))?
         .is_some();
-    if complete_now {
-        report.retained_candidates = u64::try_from(keys.len()).unwrap_or(u64::MAX);
-        return Ok(report);
+    let head_exists = store
+        .head(&head_key)
+        .await
+        .map_err(|error| CoreError::store(&head_key, &error))?
+        .is_some();
+    if descriptor_exists && head_exists {
+        return Ok(AbandonedBootstrapReap::AlreadyComplete);
     }
     for key in keys {
         store
             .delete(&key)
             .await
             .map_err(|error| CoreError::store(&key, &error))?;
-        report.reaped_abandoned_objects += 1;
     }
-    Ok(report)
+    Ok(AbandonedBootstrapReap::Reaped)
 }
 
 pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -6,13 +6,17 @@ use super::fork_checkpoints::{
     maybe_release_fork_checkpoint, release_missing_basis_checkpoint, ForkCheckpointSweep,
 };
 use super::live_set::{collect_live_set, SweepVerifier};
-use super::reap::{delete_if_aged, list_prefix, manifest_object_id_of, reap_abandoned_bootstrap};
+use super::reap::{delete_if_aged, list_prefix, manifest_object_id_of};
 use crate::context::MutationContext;
 use crate::error::CoreError;
+use crate::namespace::catalog::{
+    map_namespace_initialization_error_to_core, namespace_initialization_state,
+    NamespaceInitializationState,
+};
 use loonfs_api::{ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, namespace_config,
-    upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix,
+    wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
@@ -57,14 +61,14 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     reverify_chunk: usize,
 ) -> Result<GcReport, CoreError> {
     config.validate()?;
-    let config_key = namespace_config(namespace_id.as_str());
-    let namespace_complete = store
-        .head(&config_key)
+    let initialization_state = namespace_initialization_state(store, namespace_id)
         .await
-        .map_err(|error| CoreError::store(&config_key, &error))?
-        .is_some();
-    if !namespace_complete {
-        return reap_abandoned_bootstrap(store, namespace_id, config, context).await;
+        .map_err(map_namespace_initialization_error_to_core)?;
+    if initialization_state != NamespaceInitializationState::Complete {
+        return Ok(GcReport {
+            incomplete_namespace_ignored: true,
+            ..GcReport::default()
+        });
     }
 
     // Mark: select sweep candidates against one live-set snapshot. The

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -15,7 +15,7 @@ use loonfs_api::wire::control::{
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_table_prefix,
-    namespace_config, wal_segment_prefix,
+    namespace_config, wal_head, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
 
@@ -50,6 +50,7 @@ use futures::stream::BoxStream;
 use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
 
 const GRACE_MS: u64 = 60 * 60 * 1000;
@@ -188,6 +189,54 @@ impl ObjectStore for TimestamplessStore {
     }
 }
 
+#[derive(Debug)]
+struct IncompleteGcAccountingStore {
+    inner: LocalFsStore,
+    deletes: AtomicUsize,
+    lists: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for IncompleteGcAccountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.deletes.fetch_add(1, Ordering::SeqCst);
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.lists.fetch_add(1, Ordering::SeqCst);
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
 /// The derived floor is enforced at validation: a pass configured below
 /// it is rejected as an invalid request before touching the store.
 #[tokio::test]
@@ -249,6 +298,7 @@ async fn gc_reaps_below_floor_segments_after_the_grace_window() {
     // The only segment sits at the floor with no replay gap above it.
     assert_eq!(report.deleted_wal_segments, 1);
     assert!(!report.degraded_retention);
+    assert!(!report.incomplete_namespace_ignored);
     stat_root(&store, &namespace_id).await;
 }
 
@@ -1456,37 +1506,36 @@ async fn gc_sweep_reverification_chunks_preserve_outcomes() {
 }
 
 #[tokio::test]
-async fn gc_reaps_an_abandoned_bootstrap_tree_after_the_reap_window() {
+async fn gc_ignores_incomplete_namespace_without_listing_or_deleting() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("orphan").expect("namespace id");
     // A partial tree: a head object but no namespace.json completion
     // marker.
-    store
+    inner
         .put_if_absent(
             &format!("namespaces/{}/wal/head.json", namespace_id.as_str()),
             bytes::Bytes::from_static(b"{}"),
         )
         .await
         .expect("write partial head");
+    let store = IncompleteGcAccountingStore {
+        inner,
+        deletes: AtomicUsize::new(0),
+        lists: AtomicUsize::new(0),
+    };
 
-    let young = context(now_after_newest_object(&store, &namespace_id, GRACE_MS).await);
-    let retained = gc_namespace(&store, &namespace_id, &config(), &young)
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(u64::MAX))
         .await
-        .expect("gc young tree");
-    assert_eq!(retained.reaped_abandoned_objects, 0);
-    assert!(retained.retained_candidates > 0);
-
-    let aged = context(now_after_newest_object(&store, &namespace_id, REAP_MS + 1).await);
-    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
-        .await
-        .expect("gc aged tree");
-    assert_eq!(report.reaped_abandoned_objects, 1);
+        .expect("gc incomplete tree");
+    assert!(report.incomplete_namespace_ignored);
+    assert_eq!(store.lists.load(Ordering::SeqCst), 0);
+    assert_eq!(store.deletes.load(Ordering::SeqCst), 0);
     assert!(store
-        .list_prefix(&format!("namespaces/{}/", namespace_id.as_str()))
+        .head(&wal_head(namespace_id.as_str()))
         .await
-        .expect("list")
-        .is_empty());
+        .expect("head partial object")
+        .is_some());
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -119,7 +119,7 @@ pub use error::{
     StoreFailureClass, WriterFence,
 };
 pub use gc::{gc_namespace, GcConfig, GcReport};
-pub use namespace::BootstrapNamespaceError;
+pub use namespace::{repair_namespace, BootstrapNamespaceError};
 pub use options::{BootstrapOptions, DeleteNamespaceOptions, WriteOptions};
 pub use timing::{MonotonicTimer, StdMonotonicTimer};
 

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -73,13 +73,15 @@ const fn max_u64(left: u64, right: u64) -> u64 {
     }
 }
 
-/// The derived minimum GC grace window (format spec, "Garbage collection",
-/// rule 1). Every acknowledged publication starts its final
-/// compare-and-swap within a publication budget measured from its first
-/// object write, and that compare-and-swap completes within one provider
-/// operation bound. So an object older than this window that is still
-/// unreachable at delete time cannot belong to a publication that might
-/// yet succeed. `GcConfig::validate` rejects smaller windows.
+/// The derived minimum GC grace window and explicit namespace-repair safety
+/// window (format spec, "Garbage collection", rule 1). Every acknowledged
+/// publication starts its final compare-and-swap within a publication budget
+/// measured from its first object write, and that compare-and-swap completes
+/// within one provider operation bound. So an object older than this window
+/// that is still unreachable at delete time cannot belong to a publication
+/// that might yet succeed. `GcConfig::validate` rejects smaller windows, and
+/// namespace repair uses the same bound before reaping non-completable install
+/// debris.
 pub const GC_MIN_GRACE_WINDOW_MS: u64 = max_u64(
     max_u64(WAL_PUBLISH_BUDGET_MS, CHECKPOINT_VERIFY_BUDGET_MS),
     METADATA_PUBLICATION_BUDGET_MS,

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -3,9 +3,10 @@
 
 use crate::checkpoint::{
     build_initial_namespace_manifest, load_namespace_manifest_envelope, write_namespace_manifest,
+    ManifestLoadFailureClass,
 };
 use crate::context::MutationContext;
-use crate::error::CoreError;
+use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use crate::metadata::{InodeRecord, MetadataState};
 use crate::namespace::catalog::{
@@ -39,7 +40,7 @@ pub enum BootstrapNamespaceError {
     EmptyWriterVersion,
     #[error("namespace `{namespace_id}` already exists")]
     NamespaceAlreadyExists { namespace_id: NamespaceId },
-    #[error("namespace `{namespace_id}` is partially initialized")]
+    #[error("namespace `{namespace_id}` is partially initialized; run admin repair explicitly")]
     NamespacePartiallyInitialized { namespace_id: NamespaceId },
     #[error("namespace `{namespace_id}` is deleted and its id is retired")]
     NamespaceDeleted { namespace_id: NamespaceId },
@@ -88,52 +89,34 @@ pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
         return Err(BootstrapNamespaceError::EmptyWriterVersion);
     }
 
-    let mut recovered_debris = false;
-    loop {
-        match namespace_initialization_state(store, namespace_id)
-            .await
-            .map_err(map_namespace_initialization_error_to_core)?
-        {
-            NamespaceInitializationState::Complete => {
-                let head = read_head_object(store, namespace_id).await?;
-                // A deleted namespace retires its id permanently; re-creation is
-                // refused as deleted, not as existing.
-                if head.envelope.state.state == NamespaceState::Deleted {
-                    return Err(BootstrapNamespaceError::NamespaceDeleted {
-                        namespace_id: namespace_id.clone(),
-                    });
-                }
-                if allow_existing {
-                    return Ok(NamespaceSummary {
-                        namespace_id: namespace_id.clone(),
-                    });
-                }
-                return Err(BootstrapNamespaceError::NamespaceAlreadyExists {
+    match namespace_initialization_state(store, namespace_id)
+        .await
+        .map_err(map_namespace_initialization_error_to_core)?
+    {
+        NamespaceInitializationState::Complete => {
+            let head = read_head_object(store, namespace_id).await?;
+            // A deleted namespace retires its id permanently; re-creation is
+            // refused as deleted, not as existing.
+            if head.envelope.state.state == NamespaceState::Deleted {
+                return Err(BootstrapNamespaceError::NamespaceDeleted {
                     namespace_id: namespace_id.clone(),
                 });
             }
-            NamespaceInitializationState::Partial => {
-                return complete_post_head_bootstrap(store, namespace_id, context).await;
+            if allow_existing {
+                return Ok(NamespaceSummary {
+                    namespace_id: namespace_id.clone(),
+                });
             }
-            NamespaceInitializationState::PreHeadDebris => {
-                // A crashed attempt's pre-head objects block a fresh
-                // create's put-if-absent writes. Aged debris is cleaned and
-                // the classification re-runs once; young debris may be a
-                // concurrent create mid-flight, so the honest answer is
-                // partial, not a race against it.
-                if recovered_debris
-                    || recover_pre_head_debris(store, namespace_id, context.now_ms).await?
-                        == PreHeadRecovery::InFlight
-                {
-                    return Err(BootstrapNamespaceError::NamespacePartiallyInitialized {
-                        namespace_id: namespace_id.clone(),
-                    });
-                }
-                recovered_debris = true;
-                continue;
-            }
-            NamespaceInitializationState::Absent => break,
+            return Err(BootstrapNamespaceError::NamespaceAlreadyExists {
+                namespace_id: namespace_id.clone(),
+            });
         }
+        NamespaceInitializationState::Partial | NamespaceInitializationState::PreHeadDebris => {
+            return Err(BootstrapNamespaceError::NamespacePartiallyInitialized {
+                namespace_id: namespace_id.clone(),
+            });
+        }
+        NamespaceInitializationState::Absent => {}
     }
 
     let mut initial_head = HeadState::initial(namespace_id.clone());
@@ -253,12 +236,10 @@ pub(super) enum PreHeadRecovery {
     InFlight,
 }
 
-/// Deletes a crashed attempt's pre-head objects once they are older than
-/// the derived grace floor — nothing published within the floor can still
-/// be mid-flight — re-checking head absence immediately before every
-/// delete, the same discipline the abandoned-bootstrap reap uses. Pre-head
-/// objects are unreachable until a head exists, so deletion can strand no
-/// reader.
+/// Deletes a crashed attempt's pre-head objects when explicit admin repair
+/// finds them older than the derived safety floor. Repair re-checks head
+/// absence immediately before every delete. Pre-head objects are unreachable
+/// until a head exists, so deletion can strand no reader.
 pub(super) async fn recover_pre_head_debris<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -307,29 +288,32 @@ pub(super) async fn recover_pre_head_debris<S: ObjectStore + ?Sized>(
     Ok(PreHeadRecovery::Cleaned)
 }
 
-/// Finishes a create that crashed after its head write: the head is the
-/// linearization point, so the retry writes the missing descriptor and
-/// reports success. Guarded to genesis trees only — the head must be the
+/// Finishes a create that crashed after its head write when explicit admin
+/// repair invokes it. Guarded to genesis trees only — the head must be the
 /// unmodified initial state and the root manifest must carry no fork block;
 /// anything else answers partial. The crashed attempt's content-store
 /// descriptor (written after the head, before the namespace descriptor)
 /// may remain as a tiny orphan; nothing references it.
-async fn complete_post_head_bootstrap<S: ObjectStore + ?Sized>(
+pub(super) async fn complete_post_head_bootstrap<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<NamespaceSummary, BootstrapNamespaceError> {
     // Completion is strictly best-effort: a tree whose head, root, or
     // manifest cannot be loaded and validated is not completable, and the
-    // honest answer stays `namespace_partial` — exactly what every partial
-    // tree answered before completion existed. A transient read failure
-    // answers partial and the next retry completes.
+    // honest answer stays `namespace_partial` so repair can apply the
+    // non-completable debris policy.
     let partial = || BootstrapNamespaceError::NamespacePartiallyInitialized {
         namespace_id: namespace_id.clone(),
     };
     let head = read_head_object(store, namespace_id)
         .await
-        .map_err(|_| partial())?
+        .map_err(|error| match error {
+            ControlObjectLoadError::Store { .. } => BootstrapNamespaceError::Core(
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error)),
+            ),
+            _ => partial(),
+        })?
         .envelope
         .state;
     let genesis = head.state == NamespaceState::Active
@@ -340,12 +324,22 @@ async fn complete_post_head_bootstrap<S: ObjectStore + ?Sized>(
     }
     let root = read_metadata_root_object(store, namespace_id)
         .await
-        .map_err(|_| partial())?
+        .map_err(|error| match error {
+            ControlObjectLoadError::Store { .. } => BootstrapNamespaceError::Core(
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error)),
+            ),
+            _ => partial(),
+        })?
         .envelope
         .state;
     let manifest = load_namespace_manifest_envelope(store, namespace_id, &root.manifest_object_id)
         .await
-        .map_err(|_| partial())?;
+        .map_err(|error| match error.failure_class() {
+            ManifestLoadFailureClass::Store => BootstrapNamespaceError::Core(
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error)),
+            ),
+            ManifestLoadFailureClass::Corrupt => partial(),
+        })?;
     if manifest.payload.fork.is_some() {
         // A crashed fork target must be completed by the fork path, which
         // knows the source; a create finishing it would bind the wrong
@@ -443,8 +437,10 @@ mod tests {
     use crate::commit_engine::{NamespaceCommitEngine, NamespaceMutationCandidate};
     use crate::namespace::catalog::load_namespace_descriptor;
     use crate::namespace::fork::fork_namespace;
+    use crate::namespace::repair::repair_namespace;
+    use crate::namespace::status::load_namespace_head_summary;
     use loonfs_api::v0::{CommitOp as ApiCommitOp, CommitRequest as ApiCommitRequest};
-    use loonfs_api::{CommitId, ManifestId, ManifestObjectId};
+    use loonfs_api::{CommitId, ManifestId, ManifestObjectId, RepairNamespaceOutcome};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
@@ -531,6 +527,13 @@ mod tests {
         newest + offset_ms
     }
 
+    async fn namespace_keys(store: &LocalFsStore, namespace_id: &NamespaceId) -> Vec<String> {
+        store
+            .list_prefix(&format!("namespaces/{}/", namespace_id.as_str()))
+            .await
+            .expect("list namespace")
+    }
+
     async fn commit_directory(store: &LocalFsStore, namespace_id: &NamespaceId, name: &str) {
         let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
         engine
@@ -555,7 +558,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_retry_cleans_aged_pre_head_debris_and_succeeds() {
+    async fn create_on_aged_pre_head_debris_stays_partial_until_repair_reaps() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -564,9 +567,20 @@ mod tests {
         let aged = context(
             now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
         );
+        let keys_before = namespace_keys(&store, &namespace_id).await;
+        let error = bootstrap_namespace(&store, &namespace_id, &aged, false)
+            .await
+            .expect_err("normal create never cleans aged debris");
+        assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        assert_eq!(namespace_keys(&store, &namespace_id).await, keys_before);
+
+        let report = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect("repair reaps aged debris");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Reaped);
         bootstrap_namespace(&store, &namespace_id, &aged, false)
             .await
-            .expect("retry past the grace floor cleans the debris and creates");
+            .expect("create succeeds after explicit reap");
         assert_eq!(
             namespace_initialization_state(&store, &namespace_id)
                 .await
@@ -576,7 +590,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_retry_inside_the_grace_floor_answers_namespace_partial() {
+    async fn young_debris_stays_partial_until_repair_safety_window_expires() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -587,7 +601,11 @@ mod tests {
             .await
             .expect_err("young debris may be a concurrent create");
         assert_eq!(error.code(), ErrorCode::NamespacePartial);
-        // The debris is untouched: recovery never races a live attempt.
+        let report = repair_namespace(&store, &namespace_id, &young)
+            .await
+            .expect("young repair is a typed refusal");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::InFlight);
+        // The debris is untouched: repair never races a live attempt.
         assert!(store
             .head(&metadata_root(namespace_id.as_str()))
             .await
@@ -598,10 +616,18 @@ mod tests {
             .await
             .expect("head floor")
             .is_some());
+
+        let aged = context(
+            now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
+        );
+        let report = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect("aged repair reaps");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Reaped);
     }
 
     #[tokio::test]
-    async fn create_finishes_a_headed_tree_missing_its_descriptor() {
+    async fn create_reports_partial_until_repair_completes_the_headed_tree() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -613,9 +639,16 @@ mod tests {
             .await
             .expect("simulate crash before the completion marker");
 
-        bootstrap_namespace(&store, &namespace_id, &context(2_000), false)
+        let keys_before = namespace_keys(&store, &namespace_id).await;
+        let error = bootstrap_namespace(&store, &namespace_id, &context(2_000), false)
             .await
-            .expect("retry finishes the genesis tree");
+            .expect_err("normal create leaves the partial tree untouched");
+        assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        assert_eq!(namespace_keys(&store, &namespace_id).await, keys_before);
+        let report = repair_namespace(&store, &namespace_id, &context(2_000))
+            .await
+            .expect("repair completes genesis tree");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Completed);
         assert_eq!(
             namespace_initialization_state(&store, &namespace_id)
                 .await
@@ -626,10 +659,15 @@ mod tests {
             .await
             .expect_err("the completed namespace exists");
         assert_eq!(error.code(), ErrorCode::NamespaceExists);
+        commit_directory(&store, &namespace_id, "docs").await;
+        let status = load_namespace_head_summary(&store, &namespace_id)
+            .await
+            .expect("repaired namespace remains readable");
+        assert_eq!(status.head_seq, ChangeSeq(1));
     }
 
     #[tokio::test]
-    async fn create_refuses_to_finish_a_tree_with_history() {
+    async fn non_completable_headed_tree_is_reaped_only_by_aged_repair() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -646,10 +684,26 @@ mod tests {
             .await
             .expect_err("a non-genesis tree is not a crashed create");
         assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        let young = context(now_after_newest_object(&store, &namespace_id, 1).await);
+        let report = repair_namespace(&store, &namespace_id, &young)
+            .await
+            .expect("young repair refuses to reap");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::InFlight);
+
+        let aged = context(
+            now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
+        );
+        let report = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect("aged repair reaps non-completable tree");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Reaped);
+        bootstrap_namespace(&store, &namespace_id, &aged, false)
+            .await
+            .expect("namespace is creatable after reap");
     }
 
     #[tokio::test]
-    async fn fork_finishes_its_headed_target_and_create_refuses_it() {
+    async fn fork_reports_partial_until_repair_completes_its_headed_target() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let source = NamespaceId::parse("source").expect("namespace id");
@@ -665,6 +719,7 @@ mod tests {
             .delete(&namespace_config(clone.as_str()))
             .await
             .expect("simulate crash before the completion marker");
+        let keys_before = namespace_keys(&store, &clone).await;
 
         // A create must not adopt a fork tree: it would bind the wrong
         // content store.
@@ -672,10 +727,21 @@ mod tests {
             .await
             .expect_err("create refuses the fork tree");
         assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        assert_eq!(namespace_keys(&store, &clone).await, keys_before);
 
-        fork_namespace(&store, &source, &clone, &context(3_000))
+        let error = fork_namespace(&store, &source, &clone, &context(3_000))
             .await
-            .expect("fork retry finishes its own tree");
+            .expect_err("normal fork leaves its partial target untouched");
+        assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        assert_eq!(namespace_keys(&store, &clone).await, keys_before);
+        let report = repair_namespace(&store, &clone, &context(3_000))
+            .await
+            .expect("repair completes fork target");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Completed);
+        let error = fork_namespace(&store, &source, &clone, &context(4_000))
+            .await
+            .expect_err("completed fork target exists");
+        assert_eq!(error.code(), ErrorCode::NamespaceExists);
         let source_config = load_namespace_descriptor(&store, &source)
             .await
             .expect("source descriptor");
@@ -689,7 +755,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fork_retry_cleans_aged_target_debris_and_succeeds() {
+    async fn fork_on_aged_target_debris_stays_partial_until_repair_reaps() {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let source = NamespaceId::parse("source").expect("namespace id");
@@ -702,14 +768,44 @@ mod tests {
 
         let aged =
             context(now_after_newest_object(&store, &clone, GC_MIN_GRACE_WINDOW_MS + 1).await);
+        let keys_before = namespace_keys(&store, &clone).await;
+        let error = fork_namespace(&store, &source, &clone, &aged)
+            .await
+            .expect_err("normal fork never cleans aged target debris");
+        assert_eq!(error.code(), ErrorCode::NamespacePartial);
+        assert_eq!(namespace_keys(&store, &clone).await, keys_before);
+        let report = repair_namespace(&store, &clone, &aged)
+            .await
+            .expect("repair reaps aged target debris");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::Reaped);
         fork_namespace(&store, &source, &clone, &aged)
             .await
-            .expect("fork retry cleans aged target debris");
+            .expect("fork succeeds after explicit reap");
         assert_eq!(
             namespace_initialization_state(&store, &clone)
                 .await
                 .expect("probe"),
             NamespaceInitializationState::Complete
         );
+    }
+
+    #[tokio::test]
+    async fn repair_reports_already_complete_and_absent_is_not_found() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let complete = NamespaceId::parse("complete").expect("namespace id");
+        let absent = NamespaceId::parse("absent").expect("namespace id");
+        bootstrap_namespace(&store, &complete, &context(1_000), false)
+            .await
+            .expect("bootstrap");
+
+        let report = repair_namespace(&store, &complete, &context(2_000))
+            .await
+            .expect("complete repair is a no-op");
+        assert_eq!(report.outcome, RepairNamespaceOutcome::AlreadyComplete);
+        let error = repair_namespace(&store, &absent, &context(2_000))
+            .await
+            .expect_err("absent namespace is not found");
+        assert_eq!(error.code(), ErrorCode::NamespaceNotFound);
     }
 }

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -44,11 +44,12 @@ pub(crate) enum NamespaceInitializationState {
     Absent,
     /// Head and descriptor are both absent but pre-head control objects
     /// (metadata root or WAL floor) exist: a create or fork crashed before
-    /// its head write, or one is in flight right now. Age decides which.
+    /// its head write, or one is in flight right now. Explicit repair uses
+    /// age to decide whether reaping is safe.
     PreHeadDebris,
     /// The head exists but the descriptor does not: a create or fork
-    /// crashed after its linearization point. Completable by a retry whose
-    /// derivable descriptor matches the tree.
+    /// crashed after its linearization point. Explicit repair can complete a
+    /// descriptor whose value is derivable from the tree.
     Partial,
     Complete,
 }

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -2,10 +2,10 @@
 //! source checkpoint, sharing content bytes and copying metadata
 //! references.
 
-use super::bootstrap::{recover_pre_head_debris, PreHeadRecovery};
 use crate::checkpoint::{
     create_checkpoint, freshen_fork_checkpoint, load_namespace_manifest_envelope,
     load_verified_manifest_tables, read_checkpoint_record, write_namespace_manifest,
+    ManifestLoadFailureClass,
 };
 use crate::context::MutationContext;
 use crate::error::MetadataProjectionLoadError;
@@ -34,56 +34,28 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     new_namespace_id: &NamespaceId,
     context: &MutationContext,
 ) -> Result<NamespaceSummary> {
-    let mut recovered_debris = false;
-    loop {
-        match namespace_initialization_state(store, new_namespace_id)
-            .await
-            .map_err(map_namespace_initialization_error_to_core)?
-        {
-            NamespaceInitializationState::Absent => break,
-            NamespaceInitializationState::Complete => {
-                let head = read_head_object(store, new_namespace_id)
-                    .await
-                    .map_err(|error| CoreError::MetadataProjection(error.into()))?;
-                if head.envelope.state.state == NamespaceState::Deleted {
-                    return Err(CoreError::NamespaceDeleted {
-                        namespace_id: new_namespace_id.clone(),
-                    });
-                }
-                return Err(CoreError::NamespaceAlreadyExists {
+    match namespace_initialization_state(store, new_namespace_id)
+        .await
+        .map_err(map_namespace_initialization_error_to_core)?
+    {
+        NamespaceInitializationState::Absent => {}
+        NamespaceInitializationState::Complete => {
+            let head = read_head_object(store, new_namespace_id)
+                .await
+                .map_err(|error| CoreError::MetadataProjection(error.into()))?;
+            if head.envelope.state.state == NamespaceState::Deleted {
+                return Err(CoreError::NamespaceDeleted {
                     namespace_id: new_namespace_id.clone(),
                 });
             }
-            NamespaceInitializationState::Partial => {
-                return complete_post_head_fork(
-                    store,
-                    source_namespace_id,
-                    new_namespace_id,
-                    context,
-                )
-                .await;
-            }
-            NamespaceInitializationState::PreHeadDebris => {
-                // A crashed fork's pre-head target objects block a fresh
-                // attempt. Aged debris is cleaned and classification
-                // re-runs once; young debris may be a concurrent attempt.
-                if recovered_debris {
-                    return Err(CoreError::NamespacePartiallyInitialized {
-                        namespace_id: new_namespace_id.clone(),
-                    });
-                }
-                match recover_pre_head_debris(store, new_namespace_id, context.now_ms).await? {
-                    PreHeadRecovery::Cleaned => {
-                        recovered_debris = true;
-                        continue;
-                    }
-                    PreHeadRecovery::InFlight => {
-                        return Err(CoreError::NamespacePartiallyInitialized {
-                            namespace_id: new_namespace_id.clone(),
-                        });
-                    }
-                }
-            }
+            return Err(CoreError::NamespaceAlreadyExists {
+                namespace_id: new_namespace_id.clone(),
+            });
+        }
+        NamespaceInitializationState::Partial | NamespaceInitializationState::PreHeadDebris => {
+            return Err(CoreError::NamespacePartiallyInitialized {
+                namespace_id: new_namespace_id.clone(),
+            });
         }
     }
 
@@ -255,14 +227,11 @@ pub(crate) async fn fork_namespace<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Finishes a fork that crashed after its target head write. The head is
-/// the linearization point and everything before it exists, so the retry
-/// only writes the missing descriptor — derived, exactly as the crashed
-/// attempt derived it, from the immutable parts of the source config. The
-/// guard is the target root manifest's fork block naming the same source;
-/// any other tree answers partial (a crashed plain create is completed by
-/// the create path, which binds a fresh content store).
-async fn complete_post_head_fork<S: ObjectStore + ?Sized>(
+/// Finishes a fork that crashed after its target head write when explicit
+/// admin repair invokes it. The missing descriptor is derived from the
+/// immutable parts of the source config. The guard is the target root
+/// manifest's fork block naming that source; any other tree answers partial.
+pub(super) async fn complete_post_head_fork<S: ObjectStore + ?Sized>(
     store: &S,
     source_namespace_id: &NamespaceId,
     new_namespace_id: &NamespaceId,
@@ -275,7 +244,12 @@ async fn complete_post_head_fork<S: ObjectStore + ?Sized>(
     };
     let head = read_head_object(store, new_namespace_id)
         .await
-        .map_err(|_| partial())?
+        .map_err(|error| match error {
+            crate::namespace::control::ControlObjectLoadError::Store { .. } => {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+            }
+            _ => partial(),
+        })?
         .envelope
         .state;
     if head.state == NamespaceState::Deleted {
@@ -285,13 +259,23 @@ async fn complete_post_head_fork<S: ObjectStore + ?Sized>(
     }
     let root = read_metadata_root_object(store, new_namespace_id)
         .await
-        .map_err(|_| partial())?
+        .map_err(|error| match error {
+            crate::namespace::control::ControlObjectLoadError::Store { .. } => {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+            }
+            _ => partial(),
+        })?
         .envelope
         .state;
     let manifest =
         load_namespace_manifest_envelope(store, new_namespace_id, &root.manifest_object_id)
             .await
-            .map_err(|_| partial())?;
+            .map_err(|error| match error.failure_class() {
+                ManifestLoadFailureClass::Store => {
+                    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+                }
+                ManifestLoadFailureClass::Corrupt => partial(),
+            })?;
     let names_this_source = manifest
         .payload
         .fork

--- a/crates/loonfs-core/src/namespace/mod.rs
+++ b/crates/loonfs-core/src/namespace/mod.rs
@@ -9,8 +9,10 @@ pub(crate) mod catalog;
 pub(crate) mod control;
 pub(crate) mod delete;
 pub(crate) mod fork;
+pub(crate) mod repair;
 pub(crate) mod status;
 pub(crate) mod writer_epoch;
 
 pub use bootstrap::BootstrapNamespaceError;
 pub use loonfs_api::wire::control::{HeadState, HeadStateEnvelope};
+pub use repair::repair_namespace;

--- a/crates/loonfs-core/src/namespace/repair.rs
+++ b/crates/loonfs-core/src/namespace/repair.rs
@@ -1,0 +1,111 @@
+//! Explicit per-namespace repair for incomplete namespace installations.
+
+use super::bootstrap::{
+    complete_post_head_bootstrap, recover_pre_head_debris, BootstrapNamespaceError, PreHeadRecovery,
+};
+use super::catalog::{
+    map_namespace_initialization_error_to_core, namespace_initialization_state,
+    NamespaceInitializationState,
+};
+use super::control::{read_metadata_root_object, ControlObjectLoadError};
+use super::fork::complete_post_head_fork;
+use crate::checkpoint::{load_namespace_manifest_envelope, ManifestLoadFailureClass};
+use crate::context::MutationContext;
+use crate::error::{CoreError, MetadataProjectionLoadError};
+use crate::gc::{reap_abandoned_bootstrap, AbandonedBootstrapReap};
+use loonfs_api::{NamespaceId, NamespaceSummary, RepairNamespaceOutcome, RepairNamespaceResponse};
+use loonfs_objectstore::keys::namespace_config;
+use loonfs_objectstore::ObjectStore;
+
+/// Explicitly completes or reaps one incomplete namespace installation.
+pub async fn repair_namespace<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<RepairNamespaceResponse, CoreError> {
+    let outcome = match namespace_initialization_state(store, namespace_id)
+        .await
+        .map_err(map_namespace_initialization_error_to_core)?
+    {
+        NamespaceInitializationState::Complete => RepairNamespaceOutcome::AlreadyComplete,
+        NamespaceInitializationState::Absent => return Err(namespace_not_found(namespace_id)),
+        NamespaceInitializationState::PreHeadDebris => {
+            match recover_pre_head_debris(store, namespace_id, context.now_ms).await? {
+                PreHeadRecovery::Cleaned => RepairNamespaceOutcome::Reaped,
+                PreHeadRecovery::InFlight => RepairNamespaceOutcome::InFlight,
+            }
+        }
+        NamespaceInitializationState::Partial => {
+            if try_complete_post_head_install(store, namespace_id, context).await? {
+                RepairNamespaceOutcome::Completed
+            } else {
+                match reap_abandoned_bootstrap(store, namespace_id, context).await? {
+                    AbandonedBootstrapReap::Reaped => RepairNamespaceOutcome::Reaped,
+                    AbandonedBootstrapReap::InFlight => RepairNamespaceOutcome::InFlight,
+                    AbandonedBootstrapReap::AlreadyComplete => {
+                        RepairNamespaceOutcome::AlreadyComplete
+                    }
+                }
+            }
+        }
+    };
+
+    Ok(RepairNamespaceResponse {
+        namespace_id: namespace_id.clone(),
+        outcome,
+    })
+}
+
+async fn try_complete_post_head_install<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> Result<bool, CoreError> {
+    match complete_post_head_bootstrap(store, namespace_id, context).await {
+        Ok(NamespaceSummary { .. }) => return Ok(true),
+        Err(BootstrapNamespaceError::NamespacePartiallyInitialized { .. }) => {}
+        Err(BootstrapNamespaceError::Core(error)) => return Err(error),
+        Err(error) => return Err(CoreError::Internal(error.to_string())),
+    }
+
+    let root = match read_metadata_root_object(store, namespace_id).await {
+        Ok(root) => root.envelope.state,
+        Err(error @ ControlObjectLoadError::Store { .. }) => {
+            return Err(CoreError::MetadataProjection(
+                MetadataProjectionLoadError::LoadHead(error),
+            ));
+        }
+        Err(_) => return Ok(false),
+    };
+    let manifest =
+        match load_namespace_manifest_envelope(store, namespace_id, &root.manifest_object_id).await
+        {
+            Ok(manifest) => manifest,
+            Err(error) if error.failure_class() == ManifestLoadFailureClass::Store => {
+                return Err(CoreError::MetadataProjection(
+                    MetadataProjectionLoadError::ManifestLoad(error),
+                ));
+            }
+            Err(_) => return Ok(false),
+        };
+    let Some(fork) = manifest.payload.fork else {
+        return Ok(false);
+    };
+
+    match complete_post_head_fork(store, &fork.source_namespace_id, namespace_id, context).await {
+        Ok(NamespaceSummary { .. }) => Ok(true),
+        Err(CoreError::NamespacePartiallyInitialized { .. }) => Ok(false),
+        Err(CoreError::MetadataProjection(
+            MetadataProjectionLoadError::LoadNamespaceDescriptor(error),
+        )) if !matches!(error, ControlObjectLoadError::Store { .. }) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn namespace_not_found(namespace_id: &NamespaceId) -> CoreError {
+    CoreError::MetadataProjection(MetadataProjectionLoadError::LoadNamespaceDescriptor(
+        ControlObjectLoadError::MissingObject {
+            object_key: namespace_config(namespace_id.as_str()),
+        },
+    ))
+}

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -25,7 +25,7 @@ use loonfs_api::{
     AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
     ContentStoreId, DeleteDirectoryBehavior, DestinationBehavior, DirectoryPageCursor,
     EffectiveLimit, InodeId, InodeKind, ManifestId, NameKey, NamespaceId, Page, PageRequest,
-    RevisionNo, UploadId, WriterEpoch,
+    RepairNamespaceOutcome, RevisionNo, UploadId, WriterEpoch,
 };
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
@@ -43,8 +43,8 @@ use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anch
 use loonfs_core::metadata::MetadataState;
 use loonfs_core::publish::{NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent};
 use loonfs_core::{
-    BeginDirectPutUploadTargetResponse, BootstrapOptions, Error as CoreError, ErrorCode,
-    MutationContext, NamespaceEngine, RuntimeReadContext,
+    repair_namespace, BeginDirectPutUploadTargetResponse, BootstrapOptions, Error as CoreError,
+    ErrorCode, MutationContext, NamespaceEngine, RuntimeReadContext,
 };
 use loonfs_objectstore::keys::{
     content_blob, content_store_descriptor, metadata_manifest_object, namespace_config,
@@ -1421,7 +1421,7 @@ async fn namespace_creation_writes_descriptors_and_rejects_partial_recreation() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
+async fn bootstrap_head_lost_ack_stays_partial_until_explicit_repair() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let context = mutation_context();
@@ -1451,11 +1451,14 @@ async fn bootstrap_head_reservation_failure_does_not_allocate_content_store() {
             .is_empty(),
         "content-store descriptor must not be allocated before namespace head reservation"
     );
-    // The injected failure wrote the head before reporting the lost ack —
-    // the crash window creation is now resumable from: a retry completes
-    // the genesis tree instead of wedging on namespace_partial.
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .expect("retry completes the ack-lost create");
+    // The injected failure wrote the head before reporting the lost ack.
+    // Normal create retries are classification-only and leave it untouched.
+    let retry = bootstrap_namespace(&store, &namespace_id, &context, false)
+        .expect_err("retry preserves the ack-lost partial tree");
+    assert_eq!(retry.code(), ErrorCode::NamespacePartial);
+    let report = block_on(repair_namespace(&store, &namespace_id, &context))
+        .expect("explicit repair completes the ack-lost create");
+    assert_eq!(report.outcome, RepairNamespaceOutcome::Completed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4306,6 +4309,12 @@ async fn fork_target_head_reservation_failure_keeps_descriptor_unpublished() {
         "descriptor must remain unpublished"
     );
     assert_namespace_partial(&store, &clone_namespace_id, &context);
+    let retry = fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
+        .expect_err("normal fork retry preserves the raced partial target");
+    assert_eq!(retry.code(), ErrorCode::NamespacePartial);
+    let report = block_on(repair_namespace(&store, &clone_namespace_id, &context))
+        .expect("explicit repair completes the raced fork target");
+    assert_eq!(report.outcome, RepairNamespaceOutcome::Completed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -14,10 +14,11 @@ use loonfs_api::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, ErrorCode, FlushWalResponse, ForkNamespaceRequest, GcRequest,
     GcResponse, MaintenanceTickRequest, MaintenanceTickResponse, ReleaseCheckpointResponse,
-    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_BODY_BYTES,
-    LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_QUERY_GREP_DEFAULT,
-    LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
-    LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
+    RepairNamespaceResponse, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT,
+    LIMIT_COMMIT_MAX_BODY_BYTES, LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
+    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, LIMIT_UPLOAD_MAX_CONCURRENT,
+    LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -236,6 +237,38 @@ pub(super) async fn fork_namespace(
     feature = "openapi",
     utoipa::path(
         post,
+        path = "/v0/admin/namespaces/{namespace}/repair",
+        tag = "admin",
+        summary = "Repair namespace",
+        description = "Explicitly completes a recoverable partial namespace, or reaps non-completable installation debris after the fixed safety window. Younger debris is left untouched and reported as in flight.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "Namespace repair inspected or changed the namespace", body = RepairNamespaceResponse),
+            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace not found", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn repair_namespace(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+) -> Result<Json<RepairNamespaceResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let response = state
+        .admin
+        .repair_namespace(&namespace_id)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
         path = "/v0/admin/namespaces/{namespace}/checkpoints",
         tag = "admin",
         summary = "Create checkpoint",
@@ -398,7 +431,7 @@ pub(super) async fn advance_retention(
         path = "/v0/admin/namespaces/{namespace}/gc",
         tag = "admin",
         summary = "Collect garbage",
-        description = "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
+        description = "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body(content = GcRequest, description = "Optional window overrides"),
         responses(

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -36,6 +36,7 @@ use self::handlers_filesystem::{
 use self::handlers_namespace::{
     advance_retention, create_checkpoint, create_namespace, delete_namespace, flush_wal,
     fork_namespace, gc_namespace, maintenance_tick, namespace_status, release_checkpoint,
+    repair_namespace,
 };
 use self::handlers_query::{
     disable_grams_index, enable_grams_index, gc_grams_index, grep, grep_not_supported,
@@ -375,6 +376,10 @@ fn router(state: AppState) -> Router {
             post(maintenance_tick),
         )
         .route("/v0/admin/namespaces/:namespace/gc", post(gc_namespace))
+        .route(
+            "/v0/admin/namespaces/:namespace/repair",
+            post(repair_namespace),
+        )
         // Unmatched paths and wrong methods answer inside the error
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -18,7 +18,8 @@ use loonfs_api::{
     CreateCheckpointResponse, CreateNamespaceRequest, FilesystemOperation,
     FilesystemOperationRequest, FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest,
     GcResponse, InodeId, ListFileRevisionsResponse, MaintenanceTickOutcome, MaintenanceTickRequest,
-    MaintenanceTickResponse, ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo,
+    MaintenanceTickResponse, ReleaseCheckpointResponse, RepairNamespaceOutcome,
+    RepairNamespaceResponse, RestoreFileRevisionRequest, RevisionNo,
 };
 
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
@@ -63,6 +64,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_namespace::advance_retention,
         crate::http::handlers_namespace::maintenance_tick,
         crate::http::handlers_namespace::gc_namespace,
+        crate::http::handlers_namespace::repair_namespace,
         crate::http::handlers_query::grep,
         crate::http::handlers_query::enable_grams_index,
         crate::http::handlers_query::disable_grams_index,
@@ -96,6 +98,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         MaintenanceTickResponse,
         GcRequest,
         GcResponse,
+        RepairNamespaceOutcome,
+        RepairNamespaceResponse,
         ContentRef,
         loonfs_api::NamespaceId,
         loonfs_api::ContentStoreId,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -76,11 +76,12 @@ use loonfs::{
 use loonfs_api::ErrorCode;
 use loonfs_api::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, GrepRequest, NamespaceId,
+    RepairNamespaceOutcome,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
 use loonfs_grep::keyspace::root_key as grep_root_key;
 use loonfs_grep::{GrepDriverParked, GrepWorker};
-use loonfs_objectstore::keys::wal_head;
+use loonfs_objectstore::keys::{metadata_root, namespace_config, wal_head};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -96,6 +97,56 @@ struct StaleHeadOnceStore {
     inner: LocalFsStore,
     head_key: String,
     armed: AtomicBool,
+}
+
+#[derive(Debug)]
+struct AgedMetadataStore(LocalFsStore);
+
+fn age_metadata(mut metadata: ObjectMetadata) -> ObjectMetadata {
+    metadata.last_modified_ms = Some(0);
+    metadata
+}
+
+#[async_trait]
+impl ObjectStore for AgedMetadataStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        Ok(self.0.head(key).await?.map(age_metadata))
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.0.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        Ok(self.0.get_with_metadata(key).await?.map(|mut body| {
+            body.metadata = age_metadata(body.metadata);
+            body
+        }))
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        Ok(age_metadata(self.0.put(key, bytes, mode).await?))
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.0.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.0.list_prefix_stream(prefix)
+    }
 }
 
 impl StaleHeadOnceStore {
@@ -555,6 +606,83 @@ async fn http_missing_namespace_reads_return_namespace_not_found() {
     .expect("join blocking task");
 
     harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_repair_reports_completed_already_complete_in_flight_and_not_found() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let shared = store.clone() as SharedObjectStore;
+    let partial = namespace_id("partial");
+    bootstrap_namespace(&shared, "seed-writer", &partial).await;
+    store
+        .delete(&namespace_config(partial.as_str()))
+        .await
+        .expect("remove completion descriptor");
+    let young = namespace_id("young");
+    store
+        .put_if_absent(
+            &metadata_root(young.as_str()),
+            Bytes::from_static(b"pre-head debris"),
+        )
+        .await
+        .expect("write young debris");
+    let harness = start_server(shared, temp_dir.path(), "server-writer").await;
+
+    tokio::task::spawn_blocking(move || {
+        let completed = harness
+            .client
+            .repair_namespace(&partial)
+            .expect("repair partial namespace");
+        assert_eq!(completed.outcome, RepairNamespaceOutcome::Completed);
+        let already = harness
+            .client
+            .repair_namespace(&partial)
+            .expect("repeat repair");
+        assert_eq!(already.outcome, RepairNamespaceOutcome::AlreadyComplete);
+        let in_flight = harness
+            .client
+            .repair_namespace(&young)
+            .expect("repair young debris");
+        assert_eq!(in_flight.outcome, RepairNamespaceOutcome::InFlight);
+        assert_api_error(
+            harness.client.repair_namespace(&namespace_id("absent")),
+            404,
+            "namespace_not_found",
+            Some("namespace `absent` does not exist"),
+        );
+        harness.server.abort();
+    })
+    .await
+    .expect("join blocking task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_repair_reports_reaped_for_aged_debris() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(AgedMetadataStore(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+    ));
+    let namespace_id = namespace_id("aged");
+    let root_key = metadata_root(namespace_id.as_str());
+    store
+        .put_if_absent(&root_key, Bytes::from_static(b"pre-head debris"))
+        .await
+        .expect("write aged debris");
+    let shared = store.clone() as SharedObjectStore;
+    let harness = start_server(shared, temp_dir.path(), "server-writer").await;
+
+    tokio::task::spawn_blocking(move || {
+        let reaped = harness
+            .client
+            .repair_namespace(&namespace_id)
+            .expect("repair aged debris");
+        assert_eq!(reaped.outcome, RepairNamespaceOutcome::Reaped);
+        harness.server.abort();
+    })
+    .await
+    .expect("join blocking task");
+    assert!(store.head(&root_key).await.expect("head debris").is_none());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/tests/openapi.rs
+++ b/crates/loonfs-server/tests/openapi.rs
@@ -69,6 +69,7 @@ fn openapi_documents_current_server_paths() {
         ("/v0/admin/namespaces/{namespace}/retention/advance", "post"),
         ("/v0/admin/namespaces/{namespace}/maintenance/tick", "post"),
         ("/v0/admin/namespaces/{namespace}/gc", "post"),
+        ("/v0/admin/namespaces/{namespace}/repair", "post"),
     ] {
         assert_path_method(paths, path, method);
     }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -264,6 +264,19 @@ impl FsCore {
         Ok(report)
     }
 
+    /// Explicitly completes or reaps one incomplete namespace installation.
+    pub(crate) async fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<crate::RepairNamespaceResponse> {
+        let response =
+            loonfs_core::repair_namespace(self.store(), namespace_id, &self.mutation_context()?)
+                .await
+                .map_err(RuntimeError::Core)?;
+        self.invalidate_namespace_read_cache(namespace_id);
+        Ok(response)
+    }
+
     /// Waits until every scheduled background maintenance tick has finished.
     ///
     /// Call this to quiesce before shutdown, or in tests that assert on

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -9,8 +9,8 @@ use crate::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
     DisableGramsIndexResponse, EnableGramsIndexResponse, FlushWalResponse, GcConfig, GcReport,
     MaintenanceTickOptions, MaintenanceTickResult, NamespaceId, NamespaceStatusResponse,
-    ReleaseCheckpointResponse, Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError,
-    SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    ReleaseCheckpointResponse, RepairNamespaceResponse, Result, RuntimeCacheConfig,
+    RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
 use std::sync::Arc;
 
@@ -18,8 +18,9 @@ use std::sync::Arc;
 ///
 /// `FsAdmin` owns the explicit maintenance surface: namespace status and
 /// inspection, checkpoint creation, retention advancement, garbage
-/// collection, and one-shot maintenance ticks. Every call runs in the
-/// caller's async task — the admin handle starts no workers of its own.
+/// collection, incomplete-installation repair, and one-shot maintenance
+/// ticks. Every call runs in the caller's async task — the admin handle starts
+/// no workers of its own.
 ///
 /// Admin operations that mutate durable control state carry the builder's
 /// `actor_id` for tracing, reports, and auditability.
@@ -156,6 +157,18 @@ impl FsAdmin {
         config: &GcConfig,
     ) -> Result<GcReport> {
         self.core.gc_namespace(namespace_id, config).await
+    }
+
+    /// Repairs one incomplete namespace installation explicitly.
+    ///
+    /// Completable post-head installs receive their missing completion
+    /// descriptor. Non-completable debris is reaped only after the fixed
+    /// repair safety window; younger debris is reported as in flight.
+    pub async fn repair_namespace(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<RepairNamespaceResponse> {
+        self.core.repair_namespace(namespace_id).await
     }
 
     /// Shuts down handle-owned background work. Admin calls are one-shot in

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -11,7 +11,7 @@
 //!   the writer schedules non-destructive maintenance after writes.
 //! - [`FsReader`] for read-only latest views.
 //! - [`FsAdmin`] for explicit maintenance: status, checkpoints, retention,
-//!   and garbage collection.
+//!   garbage collection, and incomplete-installation repair.
 //!
 //! ```no_run
 //! # async fn open(store_config: loonfs::StoreConfig) -> loonfs::Result<()> {
@@ -56,10 +56,10 @@ pub use loonfs_api::{
     FlushWalResponse, GrepMatch, GrepRequest, GrepResponse, InodeId, InodeKind,
     ListFileRevisionsResponse, ListPathEntriesResponse, ManifestId, NameKey, NamespaceId,
     NamespaceStatusResponse, NamespaceSummary, Page, PageRequest, PaginationPolicy,
-    ReleaseCheckpointResponse, RevisionNo, UploadId, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_QUERY_GREP,
-    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROFILE_QUERY_V0,
-    PROTOCOL_VERSION,
+    ReleaseCheckpointResponse, RepairNamespaceOutcome, RepairNamespaceResponse, RevisionNo,
+    UploadId, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROFILE_QUERY_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::{

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -64,11 +64,11 @@ pub fn gc_response_from_report(namespace_id: NamespaceId, report: GcReport) -> G
         deleted_manifests: report.deleted_manifests,
         deleted_checkpoint_records: report.deleted_checkpoint_records,
         released_fork_checkpoints: report.released_fork_checkpoints,
-        reaped_abandoned_objects: report.reaped_abandoned_objects,
         deleted_upload_sessions: report.deleted_upload_sessions,
         released_missing_basis_checkpoints: report.released_missing_basis_checkpoints,
         retained_candidates: report.retained_candidates,
         degraded_retention: report.degraded_retention,
+        incomplete_namespace_ignored: report.incomplete_namespace_ignored,
     }
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -227,7 +227,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `revision_not_found` | 404 | The file has no such revision. |
 | `upload_not_found` | 404 | No upload session with this id. |
 | `namespace_exists` | 409 | The create target already exists. |
-| `namespace_partial` | 409 | The namespace is partially initialized and unusable. |
+| `namespace_partial` | 409 | The namespace is partially initialized and unusable; run explicit admin repair. |
 | `content_not_prepared` | 409 | A path put or explicit create/replace operation references external content without a matching admission, or carries a rejected relevant token. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
@@ -430,6 +430,7 @@ A representative v0 binding is shown below.
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
 | Run a maintenance tick | `POST /v0/admin/namespaces/{ns}/maintenance/tick` (optional body overrides `max_wal_tail_segments` and opts into `gc`; an override above the write-rejection threshold is rejected as `invalid_request`; flush races surface as outcomes, not errors) |
 | Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; a grace window below the derived safety floor is rejected as `invalid_request`; nothing sweeps without an explicit call) |
+| Repair an incomplete namespace | `POST /v0/admin/namespaces/{ns}/repair` (no body or options; reports `already_complete`, `completed`, `reaped`, or `in_flight`; an absent namespace reports `namespace_not_found`) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized steady-state grep root) |
 | Enable the gram index | `POST /v0/admin/namespaces/{ns}/index/grams/enable` (CAS-publishes the independent grep root into checkpointed backfill; embedded mode starts that namespace's event-driven driver; idempotent) |
 | Disable the gram index | `POST /v0/admin/namespaces/{ns}/index/grams/disable` (CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
@@ -438,6 +439,13 @@ A representative v0 binding is shown below.
 Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
+
+Namespace repair is deterministic and takes no request body. Its response is
+`{"namespace_id":"...","outcome":"..."}`: `already_complete` is a no-op,
+`completed` published a derivable create/fork completion descriptor, `reaped`
+removed aged non-completable install debris, and `in_flight` left younger
+debris untouched. An absent namespace returns `namespace_not_found` instead
+of a report.
 
 For `direct_put`, the client requests a presigned upload capability:
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -124,17 +124,14 @@ The namespace tree's lifecycle can be read off its grammar:
 - **`namespace.json` is the existence marker**: written last at creation as
   the completion marker, kept forever after deletion as half of the
   tombstone pair that retires the namespace id.
-- **Creation and forking are crash-resumable.** The head write is the
-  linearization point. A retry that finds pre-head debris (a metadata root
-  or WAL floor with no head) cleans it once the debris is older than the
-  derived grace floor — nothing published within the floor can still be in
-  flight — re-checking head absence immediately before every delete;
-  younger debris answers `namespace_partial`, never a race. A retry that
-  finds a head without a descriptor finishes the create or fork by writing
-  the missing descriptor, guarded by the tree itself: a genesis head with a
-  fork-free root manifest completes as a create, a root manifest whose fork
-  block names the requested source completes as that fork, and anything
-  else answers `namespace_partial`.
+- **Creation and forking never repair partial namespace state.** The head
+  write remains the linearization point, but a normal create or fork that
+  finds any pre-head debris or a head without a descriptor answers
+  `namespace_partial` without writing or deleting anything, regardless of
+  age. Explicit per-namespace admin repair owns recovery: it completes a
+  genesis create or fork target whose immutable tree proves the missing
+  descriptor, reaps non-completable debris only after the derived safety
+  floor, and reports younger debris as `in_flight` without touching it.
 
 Names are never authority anywhere — recovery follows the head and its
 references.
@@ -148,9 +145,9 @@ The load-bearing invariants of this layout, in one place:
 > **Fencing authority is writer epoch plus CAS.** Wall-clock time never
 > gates commit validity, and fenced sessions never reacquire on their own.
 
-> **Nothing correct depends on listing.** GC and floor advancement alone
-> list — under a grace window, with delete-time re-verification, and with
-> retention winning every ambiguous race.
+> **Nothing correct depends on listing.** GC, floor advancement, and explicit
+> namespace repair alone list — under a safety window, with delete-time
+> re-verification, and with retention winning every ambiguous race.
 
 > **Throughput is group commit; deadlines are local monotonic budgets a
 > writer applies to itself.** No validator ever compares clocks, and
@@ -1490,9 +1487,10 @@ material to support readers from the new floor forward.
 
 Delete is tombstone-first. Garbage collection is the separate process that
 eventually reclaims content or metadata that is no longer reachable and no
-longer protected by retention policy. GC and floor advancement are the only
-consumers of listing, and nothing sweeps by default: a pass runs only through
-the admin endpoint or an explicit maintenance-tick opt-in.
+longer protected by retention policy. GC, floor advancement, and explicit
+namespace repair are the only consumers of listing, and nothing sweeps by
+default: a pass runs only through the admin endpoint or an explicit
+maintenance-tick opt-in.
 
 v1 GC is listing mark-and-sweep. Its inputs are `wal/head.json`,
 `wal/floor.json`, `metadata/root.json`, and the `metadata/manifests/`,
@@ -1562,12 +1560,17 @@ publishing CAS) — under these rules:
 8. **Retention wins residual races.** If the floor is ever observed ahead of
    an active checkpoint's basis, the checkpoint's objects remain protected;
    reconciling the floor is an explicit recovery action.
-9. **Abandoned bootstraps.** A namespace tree with no `namespace.json` whose
-   newest object is older than the reap window `R` (`R >= T`) may be reaped,
-   re-checking the marker's absence immediately before deleting. A fork-owned
-   checkpoint record whose target tree is completely gone is released under
-   the same window: the record must be older than `R`, since a live fork
-   retry freshens it before writing any target object.
+9. **Incomplete namespaces and abandoned forks.** Core GC ignores a namespace
+   without a complete head-and-descriptor pair: it performs no listing or
+   deletion and reports that the incomplete namespace was ignored. Explicit
+   per-namespace repair first attempts guarded create/fork completion, then
+   may reap a non-completable tree whose newest object is older than the
+   derived safety floor `T`, re-checking that the head-and-descriptor pair is
+   not complete before deletion; younger debris is reported as `in_flight`.
+   A fork-owned checkpoint record whose target tree is completely gone remains
+   GC-owned and is released under the reap window `R` (`R >= T`): the record
+   must be older than `R`, since a live fork retry freshens it before writing
+   any target object.
 
 Deletion proceeds data first, records last, so a crash mid-sweep leaves
 orphaned data for the next pass rather than a record whose data vanished.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -242,7 +242,7 @@
           "admin"
         ],
         "summary": "Collect garbage",
-        "description": "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
+        "description": "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-tick opt-in.",
         "operationId": "gc_namespace",
         "parameters": [
           {
@@ -582,6 +582,69 @@
           },
           "410": {
             "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/admin/namespaces/{namespace}/repair": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Repair namespace",
+        "description": "Explicitly completes a recoverable partial namespace, or reaps non-completable installation debris after the fixed safety window. Younger debris is left untouched and reported as in flight.",
+        "operationId": "repair_namespace",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Namespace repair inspected or changed the namespace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepairNamespaceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid namespace id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4274,7 +4337,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Abandoned bootstrap trees older than this may be reaped. Must be at\nleast the grace window.",
+            "description": "Old upload sessions and abandoned fork records older than this may be\nreaped or released. Must be at least the grace window.",
             "minimum": 0
           }
         }
@@ -4289,9 +4352,9 @@
           "deleted_manifests",
           "deleted_checkpoint_records",
           "released_fork_checkpoints",
-          "reaped_abandoned_objects",
           "retained_candidates",
-          "degraded_retention"
+          "degraded_retention",
+          "incomplete_namespace_ignored"
         ],
         "properties": {
           "degraded_retention": {
@@ -4328,15 +4391,13 @@
             "description": "Unreferenced WAL segments deleted.",
             "minimum": 0
           },
+          "incomplete_namespace_ignored": {
+            "type": "boolean",
+            "description": "True when the namespace lacks a complete head-and-descriptor pair, so\nthe pass deliberately performed no listing or deletion."
+          },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace the pass ran against."
-          },
-          "reaped_abandoned_objects": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Objects removed while reaping an abandoned bootstrap tree.",
-            "minimum": 0
           },
           "released_fork_checkpoints": {
             "type": "integer",
@@ -4910,6 +4971,34 @@
           "was_active": {
             "type": "boolean",
             "description": "True when this call flipped an active record to released; false when\nthe record was already released or no longer exists. Release is\nidempotent — the end state is the same either way."
+          }
+        }
+      },
+      "RepairNamespaceOutcome": {
+        "type": "string",
+        "description": "How an explicit namespace repair resolved the namespace's durable state.",
+        "enum": [
+          "already_complete",
+          "completed",
+          "reaped",
+          "in_flight"
+        ]
+      },
+      "RepairNamespaceResponse": {
+        "type": "object",
+        "description": "Result of explicitly repairing one namespace.",
+        "required": [
+          "namespace_id",
+          "outcome"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the repair inspected."
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/RepairNamespaceOutcome",
+            "description": "What the repair did, or why it left the namespace untouched."
           }
         }
       },


### PR DESCRIPTION
The normal create, fork, and GC paths self-healed partial namespace state: a crashed create resumed on the next attempt, aged pre-head debris was deleted on the way through, and GC reaped abandoned bootstraps. That self-healing is deliberately removed — auto-repair on the main path is a classic source of destructive bugs — and replaced with a contract that normal paths only classify: absent creates, complete is used or reports `namespace_exists`, and partial or debris state of any age reports `namespace_partial` while touching nothing. GC on an incomplete namespace performs no listing or deletion and says so in its report.

The tradeoff is not left dangling: the explicit repair operation ships in this same PR. `POST /v0/admin/namespaces/{ns}/repair` (with `FsAdmin::repair_namespace`, the client method, and `loon admin repair`) applies one deterministic policy and reports which arm ran: `already_complete`; `completed` when the install is completable (the existing completion machinery, now reachable only from here); `reaped` when non-completable debris is older than the existing 20.5-minute grace floor — the same constant, its documentation extended — making the namespace absent and creatable again; and `in_flight` for debris younger than the window or with no usable timestamp, changing nothing. Two safety properties are pinned: a transient store failure during completion is never treated as permission to reap, and the reap rechecks the head-and-descriptor state immediately before deleting so it cannot race a concurrent completion.

The lost-ack and reservation-failure pins flip from "resumes" to "partial until explicit repair completes it," with new coverage walking every outcome across core, the wire, and the CLI. Crash debris now requires an operator action.
