### PR TITLE
fix(content): bind prepared admissions to stores

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -577,13 +577,11 @@ pub(crate) async fn publish_namespace_mutations_batch<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::content::{mint_content_token, verify_content_token};
     use crate::error::ErrorCode;
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::namespace::control::read_head_object;
     use futures::StreamExt;
-    use loonfs_api::v0::ValidatedContentToken;
-    use loonfs_api::{ChangeSeq, ContentRef, InodeId, WriterEpoch};
+    use loonfs_api::{ChangeSeq, ContentRef, ContentStoreId, InodeId, WriterEpoch};
     use loonfs_objectstore::keys::wal_segment_prefix;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
@@ -639,15 +637,11 @@ mod tests {
         assert_eq!(operations_error.code(), ErrorCode::InvalidRequest);
 
         let content_ref = ContentRef::whole_file_v0(b"proof");
-        let token =
-            mint_content_token("secret", &namespace_id, &content_ref, 1_000).expect("mint token");
-        let prepared = verify_content_token(
-            "secret",
-            &namespace_id,
-            &ValidatedContentToken { content_ref, token },
-            1_000,
-        )
-        .expect("verify token");
+        let admission = ContentAdmission::for_durable_content_write(
+            ContentStoreId::parse("cs_00000000000000000000000000000001").expect("content store id"),
+            content_ref,
+        );
+        let prepared = PreparedContent::from_admission(admission);
         let oversized_proofs = NamespaceMutationCandidate::commit_prepared(
             ApiCommitRequest {
                 commit_id: CommitId::parse("too-many-proofs").expect("valid commit id"),

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -459,9 +459,35 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> CoreResult<(CompleteUploadResponse, PreparedContent)> {
+        let catalog = crate::namespace::catalog::load_namespace_catalog_entry(
+            &self.store,
+            &self.namespace_id,
+        )
+        .await?;
+        self.complete_upload_prepared_with_catalog(&catalog, upload_id, request)
+            .await
+    }
+
+    /// Completes an upload with a namespace catalog binding already resolved
+    /// by the runtime.
+    pub async fn complete_upload_prepared_with_catalog(
+        &self,
+        catalog: &VerifiedNamespaceCatalogEntry,
+        upload_id: &UploadId,
+        request: &CompleteUploadRequest,
+    ) -> CoreResult<(CompleteUploadResponse, PreparedContent)> {
+        if catalog.namespace_id() != &self.namespace_id {
+            return Err(
+                crate::commit_engine::ContentPreparationError::ContentNotPrepared {
+                    content_ref_digest: request.content_ref.digest.clone(),
+                }
+                .into(),
+            );
+        }
         crate::protocol::complete_upload(
             &self.store,
             &self.namespace_id,
+            catalog.content_store_id(),
             upload_id,
             request,
             &self.mutation_context()?,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -577,9 +577,8 @@ fn classify_durable_content_error(error: &DurableContentValidationError) -> Erro
         | DurableContentValidationError::InvalidDigest { .. }
         | DurableContentValidationError::MissingContentObject { .. }
         | DurableContentValidationError::ContentLengthMismatch { .. }
-        | DurableContentValidationError::ContentDigestMismatch { .. } => {
-            ErrorCode::NamespaceCorrupt
-        }
+        | DurableContentValidationError::ContentDigestMismatch { .. }
+        | DurableContentValidationError::ContentStoreMismatch { .. } => ErrorCode::NamespaceCorrupt,
         DurableContentValidationError::Store { .. } => ErrorCode::ServerError,
     }
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -106,7 +106,10 @@ async fn write_file<S: ObjectStore>(
         .await
         .expect("store content");
     let content_ref = stored.content_ref.clone();
-    let prepared = prepare_stored_content(namespace_id.clone(), stored);
+    let catalog = crate::namespace::catalog::load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(
             store,

--- a/crates/loonfs-core/src/namespace/catalog.rs
+++ b/crates/loonfs-core/src/namespace/catalog.rs
@@ -34,6 +34,11 @@ pub struct VerifiedNamespaceCatalogEntry {
 }
 
 impl VerifiedNamespaceCatalogEntry {
+    /// Returns the namespace whose immutable catalog binding was verified.
+    pub fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_config.namespace_id
+    }
+
     pub fn content_store_id(&self) -> &ContentStoreId {
         &self.content_store_id
     }

--- a/crates/loonfs-core/src/path/write/content_write.rs
+++ b/crates/loonfs-core/src/path/write/content_write.rs
@@ -1,8 +1,9 @@
 //! Stages file bytes as durable content before a metadata publish.
 
 use crate::error::Result;
+use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::path::helpers::validate_path_for_mutation;
-use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
+use crate::storage::content::{prepare_stored_content, store_bytes_as_content_with_store_id};
 use crate::storage::content_admission::PreparedContent;
 use loonfs_api::NamespaceId;
 use loonfs_objectstore::ObjectStore;
@@ -14,6 +15,9 @@ pub(super) async fn store_file_bytes_before_metadata_publish<S: ObjectStore + ?S
     bytes: &[u8],
 ) -> Result<PreparedContent> {
     validate_path_for_mutation(absolute_path)?;
-    let stored = store_bytes_as_content(store, namespace_id, bytes).await?;
-    Ok(prepare_stored_content(namespace_id.clone(), stored))
+    let catalog = load_namespace_catalog_entry(store, namespace_id).await?;
+    let stored =
+        store_bytes_as_content_with_store_id(store, catalog.content_store_id().clone(), bytes)
+            .await?;
+    Ok(prepare_stored_content(&catalog, stored)?)
 }

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -112,10 +112,11 @@ mod tests {
     fn put_file_candidate(
         commit_id: &str,
         absolute_path: &str,
+        content_store_id: &loonfs_api::ContentStoreId,
         content_ref: loonfs_api::ContentRef,
     ) -> NamespaceMutationCandidate {
         let admission = ContentAdmission::for_durable_content_write(
-            NamespaceId::parse("demo").expect("valid namespace id"),
+            content_store_id.clone(),
             content_ref.clone(),
         );
         NamespaceMutationCandidate::path_prepared(
@@ -125,7 +126,7 @@ mod tests {
                 content_ref: content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
             },
-            vec![PreparedContent::from_admission(content_ref, admission)],
+            vec![PreparedContent::from_admission(admission)],
         )
     }
 
@@ -145,6 +146,7 @@ mod tests {
             vec![put_file_candidate(
                 "seed-docs",
                 "/docs/seed.txt",
+                &staged.content_store_id,
                 staged.content_ref.clone(),
             )],
             &context,
@@ -214,8 +216,18 @@ mod tests {
             &store,
             &namespace_id,
             vec![
-                put_file_candidate("create-wide-a", "/wide/a.txt", staged.content_ref.clone()),
-                put_file_candidate("create-wide-b", "/wide/b.txt", staged.content_ref.clone()),
+                put_file_candidate(
+                    "create-wide-a",
+                    "/wide/a.txt",
+                    &staged.content_store_id,
+                    staged.content_ref.clone(),
+                ),
+                put_file_candidate(
+                    "create-wide-b",
+                    "/wide/b.txt",
+                    &staged.content_store_id,
+                    staged.content_ref.clone(),
+                ),
             ],
             &context,
         )
@@ -250,8 +262,18 @@ mod tests {
             &store,
             &namespace_id,
             vec![
-                put_file_candidate("create-a-first", "/docs/a.txt", staged.content_ref.clone()),
-                put_file_candidate("create-a-second", "/docs/a.txt", staged.content_ref.clone()),
+                put_file_candidate(
+                    "create-a-first",
+                    "/docs/a.txt",
+                    &staged.content_store_id,
+                    staged.content_ref.clone(),
+                ),
+                put_file_candidate(
+                    "create-a-second",
+                    "/docs/a.txt",
+                    &staged.content_store_id,
+                    staged.content_ref.clone(),
+                ),
             ],
             &context,
         )
@@ -277,6 +299,7 @@ mod tests {
                 put_file_candidate(
                     "create-doomed",
                     "/docs/doomed.txt",
+                    &staged.content_store_id,
                     staged.content_ref.clone(),
                 ),
                 NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -142,7 +142,9 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 accepted_rows: session.accepted_rows(),
             };
             let request = candidate_request.request;
-            if let Err(error) = validate_commit_content_references(&request, candidate) {
+            if let Err(error) =
+                validate_commit_content_references(&request, candidate, view.content_store_id())
+            {
                 outcomes[index] = Some(Err(error));
                 continue;
             }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -15,7 +15,7 @@ use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{path_intent_fingerprint_for_path_intent, PublishPlanningSession};
 use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::{CommitOp, CommitResponse as ApiCommitResponse};
-use loonfs_api::{CommitId, ContentRef, NamespaceId};
+use loonfs_api::{CommitId, ContentRef, ContentStoreId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
@@ -248,7 +248,7 @@ fn commit_response_from_commit_receipt(
 }
 
 struct CommitContentAdmissions<'a> {
-    namespace_id: &'a NamespaceId,
+    content_store_id: &'a ContentStoreId,
     admissions: &'a [ContentAdmission],
 }
 
@@ -256,7 +256,7 @@ impl CommitContentAdmissions<'_> {
     fn admits(&self, content_ref: &ContentRef) -> bool {
         self.admissions
             .iter()
-            .any(|admission| admission.admits(self.namespace_id, content_ref))
+            .any(|admission| admission.admits(self.content_store_id, content_ref))
     }
 }
 
@@ -264,9 +264,10 @@ impl CommitContentAdmissions<'_> {
 pub(super) fn validate_commit_content_references(
     request: &CoreCommitRequest,
     candidate: &NamespaceMutationCandidate,
+    content_store_id: &ContentStoreId,
 ) -> Result<()> {
     let admissions = CommitContentAdmissions {
-        namespace_id: &request.namespace_id,
+        content_store_id,
         admissions: match candidate.content_preparation() {
             ContentPreparation::Ready(admissions) => admissions,
             ContentPreparation::Rejected(_) => {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -13,12 +13,15 @@ use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceC
 use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
-use loonfs_api::{ChangeSeq, CommitId, ManifestId, ManifestObjectId, NamePolicy, NamespaceId};
+use loonfs_api::{
+    ChangeSeq, CommitId, ContentStoreId, ManifestId, ManifestObjectId, NamePolicy, NamespaceId,
+};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     name_policy: NamePolicy,
+    content_store_id: ContentStoreId,
     pub(super) head: HeadState,
     pub(super) head_etag: String,
     pub(super) acquired_writer: Option<AcquiredWriter>,
@@ -39,6 +42,10 @@ impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
             &self.manifest_tables,
             &self.tail_state,
         )
+    }
+
+    pub(crate) fn content_store_id(&self) -> &ContentStoreId {
+        &self.content_store_id
     }
 
     pub(super) async fn find_commit_receipt(
@@ -195,6 +202,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     Ok((
         PublishMetadataView {
             name_policy: catalog_entry.namespace_config.name_policy,
+            content_store_id: catalog_entry.content_store_id,
             head,
             head_etag,
             acquired_writer,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -25,7 +25,7 @@ use loonfs_api::wire::control::{
     encode_control_object, CompletedUpload, ControlObjectKind, UploadSessionEnvelope,
     UploadSessionState,
 };
-use loonfs_api::{ContentRef, ContentRefKind, NamespaceId, UploadId};
+use loonfs_api::{ContentRef, ContentRefKind, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::keys::{content_blob, namespace_config, upload_session};
 use loonfs_objectstore::ObjectStore;
 
@@ -242,6 +242,7 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
 pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
     upload_id: &UploadId,
     request: &CompleteUploadRequest,
     context: &MutationContext,
@@ -254,13 +255,14 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
         UPLOAD_SESSION_RETRY_LIMIT,
         |mut state| {
             let namespace_id = namespace_id.clone();
+            let content_store_id = content_store_id.clone();
             let upload_id = upload_id.to_owned();
             let request = request.clone();
             async move {
                 if let Some(completed) = &state.completed {
                     if completed.content_ref == request.content_ref {
                         let prepared_content = prepare_completed_upload_content(
-                            namespace_id.clone(),
+                            content_store_id.clone(),
                             completed.content_ref.clone(),
                         );
                         return Ok(UploadSessionUpdate::Noop((
@@ -278,10 +280,11 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
 
                 let prepared_content = match state.staged_content_ref.clone() {
                     Some(content_ref) => {
-                        prepare_completed_upload_content(namespace_id.clone(), content_ref)
+                        prepare_completed_upload_content(content_store_id.clone(), content_ref)
                     }
                     None => {
-                        stage_direct_put_content_ref(store, &namespace_id, &state, &request).await?
+                        stage_direct_put_content_ref(store, &content_store_id, &state, &request)
+                            .await?
                     }
                 };
                 let staged_content_ref = prepared_content.content_ref().clone();
@@ -317,16 +320,16 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
 }
 
 fn prepare_completed_upload_content(
-    namespace_id: NamespaceId,
+    content_store_id: ContentStoreId,
     content_ref: ContentRef,
 ) -> PreparedContent {
-    let admission = ContentAdmission::for_durable_content_write(namespace_id, content_ref.clone());
-    PreparedContent::from_admission(content_ref, admission)
+    let admission = ContentAdmission::for_durable_content_write(content_store_id, content_ref);
+    PreparedContent::from_admission(admission)
 }
 
 async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
     state: &UploadSessionState,
     request: &CompleteUploadRequest,
 ) -> Result<PreparedContent> {
@@ -354,12 +357,11 @@ async fn stage_direct_put_content_ref<S: ObjectStore + ?Sized>(
     // object can exist at this key with bytes that do not hash to the
     // content ref. One HEAD proves existence and the declared size without
     // pulling the payload back through the server.
-    let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
-    probe_durable_content_reference(store, &content_store_id, &request.content_ref)
+    probe_durable_content_reference(store, content_store_id, &request.content_ref)
         .await
         .map_err(|err| CoreError::InvalidUploadContent(err.to_string()))?;
     Ok(prepare_completed_upload_content(
-        namespace_id.clone(),
+        content_store_id.clone(),
         request.content_ref.clone(),
     ))
 }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{CoreError, StoreFailureClass};
 use crate::invariants::InvariantId;
-use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId, NamespaceId};
@@ -63,6 +63,13 @@ pub enum DurableContentValidationError {
         expected: String,
         actual: String,
     },
+    #[error(
+        "stored content belongs to content store `{actual}`, not namespace-bound store `{expected}`"
+    )]
+    ContentStoreMismatch {
+        expected: ContentStoreId,
+        actual: ContentStoreId,
+    },
     #[error("object store error for `{object_key}`: {message}")]
     Store { object_key: String, message: String },
 }
@@ -92,29 +99,39 @@ pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
 /// Prepares content from an acknowledged LoonFS-managed durable write.
 ///
 /// Consuming [`StoredContent`] ties the proof to the successful return from
-/// [`store_bytes_as_content`] or [`store_bytes_as_content_with_store_id`].
+/// [`store_bytes_as_content`] or [`store_bytes_as_content_with_store_id`]. The
+/// verified catalog prevents pairing that acknowledgement with an unrelated
+/// namespace binding.
 pub fn prepare_stored_content(
-    namespace_id: NamespaceId,
+    catalog: &VerifiedNamespaceCatalogEntry,
     stored_content: StoredContent,
-) -> PreparedContent {
+) -> Result<PreparedContent, DurableContentValidationError> {
+    if stored_content.content_store_id != *catalog.content_store_id() {
+        return Err(DurableContentValidationError::ContentStoreMismatch {
+            expected: catalog.content_store_id().clone(),
+            actual: stored_content.content_store_id,
+        });
+    }
+    let content_store_id = stored_content.content_store_id;
     let content_ref = stored_content.content_ref;
-    let admission = ContentAdmission::for_durable_content_write(namespace_id, content_ref.clone());
-    PreparedContent::from_admission(content_ref, admission)
+    let admission = ContentAdmission::for_durable_content_write(content_store_id, content_ref);
+    Ok(PreparedContent::from_admission(admission))
 }
 
 /// Fully validates an existing durable content reference for publication.
 ///
-/// This performs one object HEAD followed by one full GET and digest check.
+/// The verified catalog selects the store to validate. This performs one
+/// object HEAD followed by one full GET and digest check.
 pub async fn prepare_existing_content_ref<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
+    catalog: &VerifiedNamespaceCatalogEntry,
     content_ref: ContentRef,
 ) -> Result<PreparedContent, DurableContentValidationError> {
+    let content_store_id = catalog.content_store_id();
     validate_durable_content_reference(store, content_store_id, &content_ref).await?;
     let admission =
-        ContentAdmission::for_durable_content_write(namespace_id.clone(), content_ref.clone());
-    Ok(PreparedContent::from_admission(content_ref, admission))
+        ContentAdmission::for_durable_content_write(content_store_id.clone(), content_ref);
+    Ok(PreparedContent::from_admission(admission))
 }
 
 /// Proves a content reference is durable — the object exists and carries the

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -6,9 +6,10 @@
 //! evidence that the identified content is durable, rather than carrying
 //! another clock.
 
+use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use base64::Engine as _;
 use loonfs_api::v0::ValidatedContentToken;
-use loonfs_api::{ContentRef, NamespaceId};
+use loonfs_api::{ContentRef, ContentStoreId, NamespaceId};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use thiserror::Error;
@@ -18,44 +19,44 @@ const DEFAULT_TOKEN_TTL_MS: u64 = 60 * 60 * 1000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentAdmission {
-    namespace_id: NamespaceId,
+    content_store_id: ContentStoreId,
     content_ref: ContentRef,
 }
 
 impl ContentAdmission {
     pub(crate) fn for_durable_content_write(
-        namespace_id: NamespaceId,
+        content_store_id: ContentStoreId,
         content_ref: ContentRef,
     ) -> Self {
         Self {
-            namespace_id,
+            content_store_id,
             content_ref,
         }
     }
 
-    pub(crate) fn admits(&self, namespace_id: &NamespaceId, content_ref: &ContentRef) -> bool {
-        self.namespace_id == *namespace_id && self.content_ref == *content_ref
+    pub(crate) fn admits(
+        &self,
+        content_store_id: &ContentStoreId,
+        content_ref: &ContentRef,
+    ) -> bool {
+        self.content_store_id == *content_store_id && self.content_ref == *content_ref
     }
 }
 
 /// Opaque evidence that a content reference was prepared for publication.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreparedContent {
-    content_ref: ContentRef,
     admission: ContentAdmission,
 }
 
 impl PreparedContent {
-    pub(crate) fn from_admission(content_ref: ContentRef, admission: ContentAdmission) -> Self {
-        Self {
-            content_ref,
-            admission,
-        }
+    pub(crate) fn from_admission(admission: ContentAdmission) -> Self {
+        Self { admission }
     }
 
     /// Returns the prepared content reference.
     pub fn content_ref(&self) -> &ContentRef {
-        &self.content_ref
+        &self.admission.content_ref
     }
 
     pub(crate) fn into_admission(self) -> ContentAdmission {
@@ -113,7 +114,7 @@ pub fn mint_content_token(
 
 pub fn verify_content_token(
     secret: &str,
-    namespace_id: &NamespaceId,
+    catalog: &VerifiedNamespaceCatalogEntry,
     token: &ValidatedContentToken,
     now_ms: u64,
 ) -> Result<PreparedContent, ContentTokenError> {
@@ -137,7 +138,7 @@ pub fn verify_content_token(
     if payload.version != TOKEN_VERSION {
         return Err(ContentTokenError::Malformed);
     }
-    if payload.namespace_id != *namespace_id {
+    if payload.namespace_id != *catalog.namespace_id() {
         return Err(ContentTokenError::NamespaceMismatch);
     }
     if payload.content_ref != token.content_ref {
@@ -148,9 +149,11 @@ pub fn verify_content_token(
     }
 
     let content_ref = payload.content_ref;
-    let admission =
-        ContentAdmission::for_durable_content_write(payload.namespace_id, content_ref.clone());
-    Ok(PreparedContent::from_admission(content_ref, admission))
+    let admission = ContentAdmission::for_durable_content_write(
+        catalog.content_store_id().clone(),
+        content_ref,
+    );
+    Ok(PreparedContent::from_admission(admission))
 }
 
 fn base64_url(bytes: &[u8]) -> String {
@@ -195,8 +198,25 @@ mod tests {
         );
     }
     use super::{mint_content_token, verify_content_token};
+    use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
     use loonfs_api::v0::ValidatedContentToken;
-    use loonfs_api::{ContentRef, NamespaceId};
+    use loonfs_api::wire::control::NamespaceConfigState;
+    use loonfs_api::{ContentRef, ContentStoreId, NamePolicy, NamespaceId};
+
+    fn catalog_entry(
+        namespace_id: NamespaceId,
+        content_store: &str,
+    ) -> VerifiedNamespaceCatalogEntry {
+        let content_store_id = ContentStoreId::parse(content_store).expect("content store id");
+        VerifiedNamespaceCatalogEntry {
+            namespace_config: NamespaceConfigState {
+                namespace_id,
+                content_store_id: content_store_id.clone(),
+                name_policy: NamePolicy::default(),
+            },
+            content_store_id,
+        }
+    }
 
     #[test]
     fn token_round_trips_and_admits_matching_content() {
@@ -207,12 +227,15 @@ mod tests {
             content_ref: content.clone(),
             token,
         };
+        let catalog = catalog_entry(namespace, "cs_00000000000000000000000000000001");
 
         let prepared =
-            verify_content_token("secret", &namespace, &token, 1_000).expect("verify token");
+            verify_content_token("secret", &catalog, &token, 1_000).expect("verify token");
 
         assert_eq!(prepared.content_ref(), &content);
-        assert!(prepared.into_admission().admits(&namespace, &content));
+        assert!(prepared
+            .into_admission()
+            .admits(catalog.content_store_id(), &content));
     }
 
     #[test]
@@ -225,9 +248,10 @@ mod tests {
             content_ref: content.clone(),
             token,
         };
+        let catalog = catalog_entry(namespace, "cs_00000000000000000000000000000001");
         let prepared = verify_content_token(
             "secret",
-            &namespace,
+            &catalog,
             &token,
             issued_at_ms + DEFAULT_TOKEN_TTL_MS,
         )
@@ -235,7 +259,9 @@ mod tests {
 
         // The prepared proof carries no clock: expiry was the token's
         // concern, checked exactly once by the verification above.
-        assert!(prepared.into_admission().admits(&namespace, &content));
+        assert!(prepared
+            .into_admission()
+            .admits(catalog.content_store_id(), &content));
     }
 
     #[test]
@@ -249,12 +275,18 @@ mod tests {
             content_ref: content.clone(),
             token,
         };
+        let catalog = catalog_entry(namespace, "cs_00000000000000000000000000000001");
+        let other_catalog = catalog_entry(other_namespace, "cs_00000000000000000000000000000001");
 
-        assert!(verify_content_token("other", &namespace, &token, 1_000).is_err());
-        assert!(verify_content_token("secret", &other_namespace, &token, 1_000).is_err());
+        assert!(verify_content_token("other", &catalog, &token, 1_000).is_err());
+        assert_eq!(
+            verify_content_token("secret", &other_catalog, &token, 1_000),
+            Err(ContentTokenError::NamespaceMismatch),
+            "sharing a content store must not share token authorization"
+        );
         assert!(verify_content_token(
             "secret",
-            &namespace,
+            &catalog,
             &ValidatedContentToken {
                 content_ref: other_content,
                 token: token.token.clone(),
@@ -263,7 +295,7 @@ mod tests {
         )
         .is_err());
         assert!(
-            verify_content_token("secret", &namespace, &token, 1_000 + 60 * 60 * 1000 + 1).is_err()
+            verify_content_token("secret", &catalog, &token, 1_000 + 60 * 60 * 1000 + 1).is_err()
         );
     }
 }

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -38,14 +38,12 @@ async fn put_file<S: ObjectStore + ?Sized>(
     let content = store_bytes_as_content(store, namespace_id, bytes)
         .await
         .expect("stage content");
-    let prepared = prepare_existing_content_ref(
-        store,
-        namespace_id,
-        &content.content_store_id,
-        content.content_ref,
-    )
-    .await
-    .expect("prepare existing content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_existing_content_ref(store, &catalog, content.content_ref)
+        .await
+        .expect("prepare existing content");
     let content_ref = prepared.content_ref().clone();
     NamespaceCommitEngine::new(namespace_id.clone())
         .publish_batch(

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -159,19 +159,25 @@ fn prepared_commit_candidate<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     request: ApiCommitRequest,
 ) -> Result<NamespaceMutationCandidate, CoreError> {
-    let content_store_id = load_namespace_descriptor_state(store, namespace_id).content_store_id;
     let mut seen = HashSet::new();
     let mut prepared = Vec::new();
+    let mut catalog = None;
     for content_ref in request.ops.iter().filter_map(|op| match op {
         ApiCommitOp::CreateFile { content_ref, .. }
         | ApiCommitOp::ReplaceFile { content_ref, .. } => Some(content_ref),
         _ => None,
     }) {
         if seen.insert(content_ref.clone()) {
+            if catalog.is_none() {
+                catalog = Some(block_on(
+                    loonfs_core::control::load_namespace_catalog_entry(store, namespace_id),
+                )?);
+            }
             prepared.push(block_on(prepare_existing_content_ref(
                 store,
-                namespace_id,
-                &content_store_id,
+                catalog
+                    .as_ref()
+                    .expect("external content should load the namespace catalog"),
                 content_ref.clone(),
             ))?);
         }
@@ -293,12 +299,14 @@ fn admitted_candidate<S: ObjectStore + ?Sized>(
 ) -> NamespaceMutationCandidate {
     match &intent {
         PathMutationIntent::PutFile { content_ref, .. } => {
-            let content_store_id =
-                load_namespace_descriptor_state(store, namespace_id).content_store_id;
-            let prepared = block_on(prepare_existing_content_ref(
+            let catalog = block_on(loonfs_core::control::load_namespace_catalog_entry(
                 store,
                 namespace_id,
-                &content_store_id,
+            ))
+            .expect("load namespace catalog");
+            let prepared = block_on(prepare_existing_content_ref(
+                store,
+                &catalog,
                 content_ref.clone(),
             ))
             .expect("prepare existing content");
@@ -1814,9 +1822,12 @@ async fn valid_content_admission_skips_durable_content_validation() {
         )
         .expect("mint token"),
     };
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     let prepared = verify_content_token(
         "test-content-token-secret",
-        &namespace_id,
+        &catalog,
         &token,
         context.now_ms,
     )

--- a/crates/loonfs-core/tests/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/visibility_equivalence.rs
@@ -92,7 +92,11 @@ impl VisibilityHarness {
             .await
             .expect("stage content");
         let content_ref = stored.content_ref.clone();
-        let prepared = prepare_stored_content(self.namespace_id().clone(), stored);
+        let catalog =
+            loonfs_core::control::load_namespace_catalog_entry(&self.store, self.namespace_id())
+                .await
+                .expect("load namespace catalog");
+        let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
         self.publish(NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::generate(),

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -136,7 +136,10 @@ async fn put_file(
         .await
         .expect("store content");
     let content_ref = stored.content_ref.clone();
-    let prepared = prepare_stored_content(namespace_id.clone(), stored);
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
     engine
         .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -226,7 +226,10 @@ async fn put_file_at(
         .await
         .expect("store content");
     let content_ref = stored.content_ref.clone();
-    let prepared = prepare_stored_content(namespace_id.clone(), stored);
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
     let result = engine
         .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -17,8 +17,8 @@ use loonfs::publish::{
     MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_OPERATIONS,
 };
 use loonfs::{
-    content_tokens::{verify_content_token, ContentTokenError},
-    payload_class, CoreError, ErrorCode, ListChangesOptions, TraceStoreKind,
+    content_tokens::ContentTokenError, payload_class, CoreError, ErrorCode, ListChangesOptions,
+    TraceStoreKind,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -484,13 +484,17 @@ pub(super) async fn filesystem_operation(
         _ => None,
     };
     let put_content_preparation = match &operation {
-        FilesystemOperation::PutFile { content_ref, .. } => Some(content_preparation_for_put(
-            &state.config,
-            &namespace_id,
-            content_ref,
-            &content_tokens,
-            current_unix_ms()?,
-        )),
+        FilesystemOperation::PutFile { content_ref, .. } => Some(
+            content_preparation_for_put(
+                &state.writer,
+                &state.config,
+                &namespace_id,
+                content_ref,
+                &content_tokens,
+                current_unix_ms()?,
+            )
+            .await?,
+        ),
         _ => None,
     };
     // Wire paths are raw strings; the intent carries validated paths, so
@@ -646,11 +650,13 @@ pub(super) async fn commit_operations(
             ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
         })?;
     let content_preparation = prepare_commit_content(
+        &state.writer,
         &state.config,
         &namespace_id,
         &external_content_refs,
         &content_tokens,
-    )?;
+    )
+    .await?;
     let candidate = match content_preparation {
         CommitContentPreparation::Ready(content) => {
             NamespaceMutationCandidate::commit_prepared(request, content)
@@ -714,7 +720,8 @@ fn validate_commit_submission_limits(
     Ok(())
 }
 
-fn prepare_commit_content(
+async fn prepare_commit_content(
+    writer: &loonfs::FsWriter,
     config: &crate::config::ServerConfig,
     namespace_id: &loonfs_api::NamespaceId,
     external_content_refs: &[ContentRef],
@@ -726,9 +733,10 @@ fn prepare_commit_content(
         .collect::<HashSet<_>>();
     let relevant_tokens = content_tokens
         .iter()
-        .filter(|token| relevant_refs.contains(&token.content_ref));
-    let mut relevant_tokens = relevant_tokens.peekable();
-    if relevant_tokens.peek().is_none() {
+        .filter(|token| relevant_refs.contains(&token.content_ref))
+        .cloned()
+        .collect::<Vec<_>>();
+    if relevant_tokens.is_empty() {
         return Ok(CommitContentPreparation::Ready(Vec::new()));
     }
 
@@ -736,8 +744,12 @@ fn prepare_commit_content(
     let mut prepared = Vec::new();
     let mut prepared_refs = HashSet::new();
     let mut first_error = None;
-    for token in relevant_tokens {
-        match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
+    for token in &relevant_tokens {
+        match writer
+            .prepare_content_token(namespace_id, config.content_token_secret(), token, now_ms)
+            .await
+            .map_err(|error| ApiResponseError::runtime_for_namespace(namespace_id, error))?
+        {
             Ok(content) => {
                 prepared_refs.insert(content.content_ref().clone());
                 prepared.push(content);

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -9,8 +9,9 @@ use crate::config::ServerConfig;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use loonfs::content_tokens::{mint_content_token, verify_content_token, ContentTokenError};
+use loonfs::content_tokens::{mint_content_token, ContentTokenError};
 use loonfs::publish::PreparedContent;
+use loonfs::FsWriter;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::ErrorCode;
@@ -150,20 +151,27 @@ fn direct_put_presign_time() -> SystemTime {
     SystemTime::now()
 }
 
-pub(super) fn content_preparation_for_put(
+pub(super) async fn content_preparation_for_put(
+    writer: &FsWriter,
     config: &ServerConfig,
     namespace_id: &NamespaceId,
     content_ref: &ContentRef,
     tokens: &[ValidatedContentToken],
     now_ms: u64,
-) -> PutContentPreparation {
+) -> Result<PutContentPreparation, ApiResponseError> {
     let mut prepared_content = Vec::new();
     let mut first_error = None;
-    for token in tokens
+    let matching_tokens = tokens
         .iter()
         .filter(|token| token.content_ref == *content_ref)
-    {
-        match verify_content_token(config.content_token_secret(), namespace_id, token, now_ms) {
+        .cloned()
+        .collect::<Vec<_>>();
+    for token in &matching_tokens {
+        match writer
+            .prepare_content_token(namespace_id, config.content_token_secret(), token, now_ms)
+            .await
+            .map_err(|error| ApiResponseError::runtime_for_namespace(namespace_id, error))?
+        {
             Ok(prepared) => prepared_content.push(prepared),
             Err(error) => {
                 tracing::debug!(
@@ -178,11 +186,11 @@ pub(super) fn content_preparation_for_put(
     }
 
     if !prepared_content.is_empty() {
-        PutContentPreparation::Ready(prepared_content)
+        Ok(PutContentPreparation::Ready(prepared_content))
     } else if let Some(error) = first_error {
-        PutContentPreparation::Rejected(error)
+        Ok(PutContentPreparation::Rejected(error))
     } else {
-        PutContentPreparation::Absent
+        Ok(PutContentPreparation::Absent)
     }
 }
 

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -71,9 +71,12 @@ impl FsCore {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> Result<(CompleteUploadResponse, PreparedContent)> {
+        let catalog = self
+            .load_namespace_catalog_for_content_preparation(namespace_id)
+            .await?;
         Ok(self
             .namespace_engine(namespace_id)
-            .complete_upload_prepared(upload_id, request)
+            .complete_upload_prepared_with_catalog(&catalog, upload_id, request)
             .await?)
     }
 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -67,28 +67,19 @@ impl FsCore {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
-        let cached_content_store_id = self
-            .load_namespace_catalog_cached(namespace_id)
-            .await?
-            .map(|catalog| catalog.content_store_id().clone());
-        let stored = match cached_content_store_id {
-            Some(content_store_id) => {
-                loonfs_core::content::store_bytes_as_content_with_store_id(
-                    &self.inner.store,
-                    content_store_id,
-                    bytes,
-                )
-                .await?
-            }
-            None => {
-                loonfs_core::content::store_bytes_as_content(&self.inner.store, namespace_id, bytes)
-                    .await?
-            }
-        };
-        Ok(loonfs_core::content::prepare_stored_content(
-            namespace_id.clone(),
-            stored,
-        ))
+        let catalog = self
+            .load_namespace_catalog_for_content_preparation(namespace_id)
+            .await?;
+        let stored = loonfs_core::content::store_bytes_as_content_with_store_id(
+            &self.inner.store,
+            catalog.content_store_id().clone(),
+            bytes,
+        )
+        .await?;
+        Ok(
+            loonfs_core::content::prepare_stored_content(&catalog, stored)
+                .map_err(CoreError::from)?,
+        )
     }
 
     /// Publishes a file revision from already-prepared content.
@@ -205,24 +196,46 @@ impl FsCore {
                 usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
             ),
         );
-        let content_store_id = match self.load_namespace_catalog_cached(namespace_id).await? {
-            Some(catalog) => catalog.content_store_id().clone(),
-            None => {
-                loonfs_core::control::load_namespace_catalog_entry(&self.inner.store, namespace_id)
-                    .await
-                    .map_err(CoreError::from)?
-                    .content_store_id()
-                    .clone()
-            }
-        };
+        let catalog = self
+            .load_namespace_catalog_for_content_preparation(namespace_id)
+            .await?;
         Ok(loonfs_core::content::prepare_existing_content_ref(
             &self.inner.store,
-            namespace_id,
-            &content_store_id,
+            &catalog,
             content_ref,
         )
         .await
         .map_err(CoreError::from)?)
+    }
+
+    pub(crate) async fn prepare_content_token(
+        &self,
+        namespace_id: &NamespaceId,
+        secret: &str,
+        token: &loonfs_api::v0::ValidatedContentToken,
+        now_ms: u64,
+    ) -> Result<std::result::Result<PreparedContent, loonfs_core::content::ContentTokenError>> {
+        let catalog = self
+            .load_namespace_catalog_for_content_preparation(namespace_id)
+            .await?;
+        Ok(loonfs_core::content::verify_content_token(
+            secret, &catalog, token, now_ms,
+        ))
+    }
+
+    pub(crate) async fn load_namespace_catalog_for_content_preparation(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<loonfs_core::control::VerifiedNamespaceCatalogEntry> {
+        match self.load_namespace_catalog_cached(namespace_id).await? {
+            Some(catalog) => Ok(catalog),
+            None => {
+                loonfs_core::control::load_namespace_catalog_entry(&self.inner.store, namespace_id)
+                    .await
+                    .map_err(CoreError::from)
+                    .map_err(RuntimeError::from)
+            }
+        }
     }
 
     /// Creates a directory at an absolute path.

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -201,6 +201,20 @@ impl FsWriter {
             .await
     }
 
+    /// Verifies a namespace-authorized wire token and binds its proof to the
+    /// namespace's verified content store.
+    pub async fn prepare_content_token(
+        &self,
+        namespace_id: &NamespaceId,
+        secret: &str,
+        token: &loonfs_api::v0::ValidatedContentToken,
+        now_ms: u64,
+    ) -> Result<std::result::Result<PreparedContent, loonfs_core::content::ContentTokenError>> {
+        self.core
+            .prepare_content_token(namespace_id, secret, token, now_ms)
+            .await
+    }
+
     /// Creates a directory at an absolute path.
     pub async fn create_directory(
         &self,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -87,12 +87,12 @@ pub mod publish {
 
 /// Server-integration seam for producer-only content preparation proofs.
 ///
-/// A serving session mints short-lived wire tokens after durable preparation
-/// and verifies expiry once before yielding opaque prepared content. Its
-/// internal admission records accepted durability evidence and does not expire.
-/// Most embedded users never need this module.
+/// A serving session mints short-lived wire tokens after durable preparation;
+/// [`FsWriter::prepare_content_token`] verifies them against the namespace's
+/// catalog binding. The resulting admission records accepted durability
+/// evidence and does not expire. Most embedded users never need this module.
 pub mod content_tokens {
-    pub use loonfs_core::content::{mint_content_token, verify_content_token, ContentTokenError};
+    pub use loonfs_core::content::{mint_content_token, ContentTokenError};
 }
 
 /// Server-integration seam: the resolved direct-put upload target a serving

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -2187,8 +2187,7 @@ mod tests {
             .expect("load namespace catalog");
         let prepared_content = loonfs_core::content::prepare_existing_content_ref(
             &store,
-            &namespace_id,
-            catalog.content_store_id(),
+            &catalog,
             staged.content_ref,
         )
         .await

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -125,6 +125,9 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
 
     // Three commit batches, checkpointed one L0 run each, with names
     // interleaved by stride so every run's direntry key range straddles the
@@ -145,8 +148,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             .expect("stage content");
             let prepared = loonfs_core::content::prepare_existing_content_ref(
                 &store,
-                &namespace_id,
-                &stored.content_store_id,
+                &catalog,
                 stored.content_ref,
             )
             .await

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -13,7 +13,11 @@ use loonfs::{
     CreateDirectoryOptions, CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter,
     InodeId, NamespaceId, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore,
 };
-use loonfs_objectstore::keys::wal_head;
+use loonfs_api::wire::control::{
+    encode_control_object, ControlObjectKind, NamespaceConfigEnvelope, NamespaceConfigState,
+};
+use loonfs_api::{ContentStoreId, NamePolicy};
+use loonfs_objectstore::keys::{namespace_config, wal_head};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -422,6 +426,30 @@ async fn build_initialized_writer(
     writer
 }
 
+async fn bind_namespace_to_content_store(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+    content_store_id: ContentStoreId,
+) {
+    let descriptor = NamespaceConfigEnvelope::from_state(
+        ControlObjectKind::NamespaceConfig,
+        "content-request-accounting/0.1",
+        NamespaceConfigState {
+            namespace_id: namespace_id.clone(),
+            content_store_id,
+            name_policy: NamePolicy::default(),
+        },
+    )
+    .expect("build namespace descriptor");
+    store
+        .put_overwrite(
+            &namespace_config(namespace_id.as_str()),
+            Bytes::from(encode_control_object(&descriptor).expect("encode namespace descriptor")),
+        )
+        .await
+        .expect("replace namespace descriptor");
+}
+
 /// Full external preparation performs one content HEAD and one full GET.
 async fn prepare_content(
     store: &SharedObjectStore,
@@ -431,14 +459,9 @@ async fn prepare_content(
     let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");
-    loonfs_core::content::prepare_existing_content_ref(
-        store,
-        namespace_id,
-        catalog.content_store_id(),
-        content_ref.clone(),
-    )
-    .await
-    .expect("prepare existing content")
+    loonfs_core::content::prepare_existing_content_ref(store, &catalog, content_ref.clone())
+        .await
+        .expect("prepare existing content")
 }
 
 fn put_intent(commit_id: &str, path: &str, content_ref: loonfs::ContentRef) -> PathMutationIntent {
@@ -543,6 +566,142 @@ async fn put_file_prepared_performs_no_content_io() {
         .expect("publish prepared file");
 
     assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn prepared_content_for_another_store_is_rejected_without_content_io() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let source = NamespaceId::parse("source-store").expect("source namespace id");
+    let target = NamespaceId::parse("target-store").expect("target namespace id");
+    let writer = build_initialized_writer(store.clone(), &source, "cross-store-writer").await;
+    writer
+        .create_namespace(&target, CreateNamespaceOptions::default())
+        .await
+        .expect("create target namespace");
+    writer
+        .create_directory(
+            &target,
+            "/catalog-warmup",
+            CreateDirectoryOptions::default(),
+        )
+        .await
+        .expect("warm target catalog");
+    let prepared = writer
+        .prepare_file_bytes(&source, b"source-store-only")
+        .await
+        .expect("prepare source content");
+    let content_ref = prepared.content_ref().clone();
+    recording.reset();
+
+    let error = writer
+        .put_file_prepared(&target, "/file.txt", prepared, PutFileOptions::default())
+        .await
+        .expect_err("another store must reject the admission");
+    assert!(
+        matches!(error, RuntimeError::Core(_)),
+        "expected core content-preparation error"
+    );
+    let RuntimeError::Core(error) = error else {
+        return;
+    };
+
+    assert_content_not_prepared(error, &content_ref);
+    assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn independent_namespaces_sharing_a_store_share_prepared_content() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let source = NamespaceId::parse("shared-source").expect("source namespace id");
+    let target = NamespaceId::parse("shared-target").expect("target namespace id");
+    let writer = build_initialized_writer(store.clone(), &source, "shared-store-writer").await;
+    writer
+        .create_namespace(&target, CreateNamespaceOptions::default())
+        .await
+        .expect("create independent target namespace");
+    let source_catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &source)
+        .await
+        .expect("load source catalog");
+    bind_namespace_to_content_store(&store, &target, source_catalog.content_store_id().clone())
+        .await;
+    writer
+        .create_directory(
+            &target,
+            "/catalog-warmup",
+            CreateDirectoryOptions::default(),
+        )
+        .await
+        .expect("warm shared target catalog");
+    let prepared = writer
+        .prepare_file_bytes(&source, b"independently shared")
+        .await
+        .expect("prepare through source namespace");
+    recording.reset();
+
+    writer
+        .put_file_prepared(&target, "/shared.txt", prepared, PutFileOptions::default())
+        .await
+        .expect("shared-store target accepts source proof");
+
+    assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
+}
+
+#[tokio::test]
+async fn fork_and_source_share_prepared_content_in_both_directions() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
+    let store: SharedObjectStore = recording.clone();
+    let source = NamespaceId::parse("fork-source").expect("source namespace id");
+    let fork = NamespaceId::parse("fork-target").expect("fork namespace id");
+    let writer = build_initialized_writer(store, &source, "fork-sharing-writer").await;
+    let prepared_for_fork = writer
+        .prepare_file_bytes(&source, b"prepared before fork")
+        .await
+        .expect("prepare through source namespace");
+    writer
+        .fork_namespace(&source, &fork)
+        .await
+        .expect("fork namespace");
+    writer
+        .create_directory(
+            &fork,
+            "/fork-catalog-warmup",
+            CreateDirectoryOptions::default(),
+        )
+        .await
+        .expect("warm fork catalog");
+    recording.reset();
+
+    writer
+        .put_file_prepared(
+            &fork,
+            "/from-source.txt",
+            prepared_for_fork,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("fork accepts source proof");
+    assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
+
+    let prepared_for_source = writer
+        .prepare_file_bytes(&fork, b"prepared through fork")
+        .await
+        .expect("prepare through fork namespace");
+    recording.reset();
+    writer
+        .put_file_prepared(
+            &source,
+            "/from-fork.txt",
+            prepared_for_source,
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("source accepts fork proof");
+    assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
 #[tokio::test]
@@ -664,19 +823,19 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
         .await
         .expect("complete direct put with proof");
     assert_eq!(completed.content_ref, content_ref);
-    // Direct-put completion resolves the immutable content-store descriptor
+    // The session path reuses the runtime-resolved immutable store binding
     // and proves the provider write with one object HEAD; it never reads the
-    // uploaded blob.
+    // uploaded blob or reloads the content-store descriptor.
     let completion_counts = harness.recording.snapshot();
     assert_eq!(
         completion_counts.operations(KeyClass::Content),
         OperationCounts {
             head: 1,
-            get: 1,
+            get: 0,
             put: 0,
         }
     );
-    assert!(completion_counts.content_get_bytes > 0);
+    assert_eq!(completion_counts.content_get_bytes, 0);
     harness.recording.reset();
 
     harness

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -184,14 +184,10 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
         .await
         .expect("load namespace catalog");
-    let prepared = loonfs_core::content::prepare_existing_content_ref(
-        &store,
-        &namespace_id,
-        catalog.content_store_id(),
-        staged.content_ref,
-    )
-    .await
-    .expect("prepare second put content");
+    let prepared =
+        loonfs_core::content::prepare_existing_content_ref(&store, &catalog, staged.content_ref)
+            .await
+            .expect("prepare second put content");
     let prepared_content_ref = prepared.content_ref().clone();
 
     store_impl.arm();

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -207,6 +207,9 @@ async fn warm_phase_request_accounting() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
     // The bench publishes 100-mutation batches (one WAL segment each) and
     // ticks a few times across the build; mirror that shape.
     let mut index = 0usize;
@@ -225,8 +228,7 @@ async fn warm_phase_request_accounting() {
             // content HEAD and one full GET by design.
             let prepared = loonfs_core::content::prepare_existing_content_ref(
                 &store,
-                &namespace_id,
-                &stored.content_store_id,
+                &catalog,
                 stored.content_ref,
             )
             .await

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2514,8 +2514,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
             prepared_contents.push(
                 loonfs_core::content::prepare_existing_content_ref(
                     &object_store,
-                    &namespace_id,
-                    catalog.content_store_id(),
+                    &catalog,
                     completed.content_ref,
                 )
                 .await


### PR DESCRIPTION
A prepared-content proof was scoped to the wrong authority: admissions bound a caller-supplied namespace to a content ref, and the low-level producers let any embedder pair a namespace with a store it never verified — write bytes into store A, mint a proof for a namespace whose catalog binds store B, publish, and the committed metadata points at content that does not exist where that namespace reads. The real authority is the store where the bytes were proven durable, so the admission now binds ContentStoreId plus ContentRef and the namespace leaves the proof entirely. Every producer derives its store from what it actually proved — the staging ack's recorded store (now also cross-checked against the catalog), validation's verified store, the direct-put session's resolved store (which incidentally drops a catalog GET from completion), and token verification through the new engine-owned FsWriter::prepare_content_token. The free preparation functions stop accepting loose ids: their signatures now require a VerifiedNamespaceCatalogEntry, so the type system forces catalog verification instead of visibility hiding it.

Publication coverage compares proofs against the publishing namespace's binding — the publish view carries the ContentStoreId again, as data moved from the catalog already loaded at view setup, with the accounting suite pinning zero added I/O. A wrong-store proof fails as content_not_prepared with zero content reads. The deliberate semantic change: same-store sharing now works — a proof minted against one namespace publishes into any namespace bound to the same store, pinned for independent namespaces and for forks in both directions — while wire tokens keep their namespace check untouched, because that is authorization, not durability, and the distinction now has its own test.