### PR TITLE
fix(core): replay receipts before request limits

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -125,12 +125,12 @@ impl NamespaceMutationCandidate {
         }
     }
 
-    /// Computes semantic identity from the mutation alone.
+    /// Computes semantic identity from the mutation alone, without applying
+    /// current operational request limits.
     pub fn semantic_identity(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<SemanticMutationIdentity> {
-        self.validate_request_limits()?;
         match &self.mutation {
             NamespaceMutation::Commit(request) => {
                 core_commit_fingerprint_for_v0_request(namespace_id, request)
@@ -618,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn candidate_validation_rejects_commit_operation_and_prepared_proof_limits() {
+    fn semantic_identity_ignores_current_request_limits() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let oversized_ops = NamespaceMutationCandidate::commit(ApiCommitRequest {
             commit_id: CommitId::parse("too-many-ops").expect("valid commit id"),
@@ -631,10 +631,9 @@ mod tests {
                 .collect(),
             message: None,
         });
-        let operations_error = oversized_ops
+        oversized_ops
             .semantic_identity(&namespace_id)
-            .expect_err("operation limit must reject before admission");
-        assert_eq!(operations_error.code(), ErrorCode::InvalidRequest);
+            .expect("operation limits must not affect identity");
 
         let content_ref = ContentRef::whole_file_v0(b"proof");
         let admission = ContentAdmission::for_durable_content_write(
@@ -654,10 +653,9 @@ mod tests {
             },
             vec![prepared; crate::limits::MAX_COMMIT_CONTENT_TOKENS + 1],
         );
-        let proofs_error = oversized_proofs
+        oversized_proofs
             .semantic_identity(&namespace_id)
-            .expect_err("prepared proof limit must reject before admission");
-        assert_eq!(proofs_error.code(), ErrorCode::InvalidRequest);
+            .expect("prepared proof limits must not affect identity");
     }
 
     fn create_dir(commit_id: &str, display_name: &str) -> NamespaceMutationCandidate {

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -17,8 +17,9 @@ use loonfs_objectstore::{PROVIDER_ATTEMPT_TIMEOUT, PROVIDER_OP_DEADLINE};
 pub const MAX_COMMIT_OPERATIONS: usize = 4096;
 
 /// Maximum content-token or prepared-proof entries carried by one explicit
-/// commit, bounding its preparation work and retained publisher admission
-/// state.
+/// commit, bounding preparation work for a new primary. An oversized
+/// candidate may occupy a publisher queue slot until candidate preparation
+/// rejects it.
 pub const MAX_COMMIT_CONTENT_TOKENS: usize = 4096;
 
 /// Maximum distinct new external content refs in one explicit commit, bounding

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -129,7 +129,6 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     index: usize,
     dedup: &mut BatchDedup,
 ) -> Result<CandidateAdmission> {
-    candidate.validate_request_limits()?;
     let acquired_writer = view
         .acquired_writer
         .as_ref()
@@ -160,7 +159,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             {
                 return Ok(admission);
             }
-            reject_failed_content_preparation(candidate)?;
+            validate_new_primary(candidate)?;
             Ok(CandidateAdmission::Prepared(CandidateCoreRequest {
                 request,
                 identity_source: CommitIdentitySource::CoreCommitRequest,
@@ -184,7 +183,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             {
                 return Ok(admission);
             }
-            reject_failed_content_preparation(candidate)?;
+            validate_new_primary(candidate)?;
             let planned = session
                 .plan_path_mutation(namespace_id, intent, view.metadata_view())
                 .await?;
@@ -195,6 +194,12 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             }))
         }
     }
+}
+
+fn validate_new_primary(candidate: &NamespaceMutationCandidate) -> Result<()> {
+    // For new primaries, request limits precede rejected content preparation.
+    candidate.validate_request_limits()?;
+    reject_failed_content_preparation(candidate)
 }
 
 fn reject_failed_content_preparation(candidate: &NamespaceMutationCandidate) -> Result<()> {

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -3435,6 +3435,152 @@ async fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oversized_prepared_proof_candidate_replays_receipt_but_new_request_is_rejected() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let stored = store_bytes_as_content(&store, &namespace_id, b"proof replay")
+        .await
+        .expect("store content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref.clone())
+        .await
+        .expect("prepare content");
+    let request = ApiCommitRequest {
+        commit_id: CommitId::parse("over-proof-replay").expect("valid commit id"),
+        preconditions: Vec::new(),
+        ops: vec![ApiCommitOp::CreateFile {
+            parent_inode_id: InodeId(1),
+            display_name: "proof-replay.txt".to_owned(),
+            content_ref: stored.content_ref,
+        }],
+        message: None,
+    };
+
+    let original = publish_namespace_mutations_batch(
+        &store,
+        &namespace_id,
+        vec![NamespaceMutationCandidate::commit_prepared(
+            request.clone(),
+            vec![prepared.clone()],
+        )],
+        &context,
+    )
+    .remove(0)
+    .expect("land original commit");
+    let oversized_proofs = vec![prepared; loonfs_core::limits::MAX_COMMIT_CONTENT_TOKENS + 1];
+
+    let replay = publish_namespace_mutations_batch(
+        &store,
+        &namespace_id,
+        vec![NamespaceMutationCandidate::commit_prepared(
+            request.clone(),
+            oversized_proofs.clone(),
+        )],
+        &context,
+    )
+    .remove(0)
+    .expect("durable receipt must win over current proof limit");
+    assert_eq!(replay, original);
+
+    let mut new_request = request;
+    new_request.commit_id = CommitId::parse("over-proof-new").expect("valid commit id");
+    let error = publish_namespace_mutations_batch(
+        &store,
+        &namespace_id,
+        vec![NamespaceMutationCandidate::commit_prepared(
+            new_request,
+            oversized_proofs,
+        )],
+        &context,
+    )
+    .remove(0)
+    .expect_err("new over-proof request must be rejected after receipt miss");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_batch_over_limit_proof_duplicate_joins_its_primary() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let stored = store_bytes_as_content(&store, &namespace_id, b"batch proof")
+        .await
+        .expect("store content");
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref.clone())
+        .await
+        .expect("prepare content");
+    let request = ApiCommitRequest {
+        commit_id: CommitId::parse("over-proof-duplicate").expect("valid commit id"),
+        preconditions: Vec::new(),
+        ops: vec![ApiCommitOp::CreateFile {
+            parent_inode_id: InodeId(1),
+            display_name: "batch-proof.txt".to_owned(),
+            content_ref: stored.content_ref,
+        }],
+        message: None,
+    };
+
+    let responses = publish_namespace_mutations_batch(
+        &store,
+        &namespace_id,
+        vec![
+            NamespaceMutationCandidate::commit_prepared(request.clone(), vec![prepared.clone()]),
+            NamespaceMutationCandidate::commit_prepared(
+                request,
+                vec![prepared; loonfs_core::limits::MAX_COMMIT_CONTENT_TOKENS + 1],
+            ),
+        ],
+        &context,
+    );
+
+    let primary = responses[0].as_ref().expect("primary commit");
+    let duplicate = responses[1]
+        .as_ref()
+        .expect("over-limit duplicate must join primary");
+    assert_eq!(duplicate, primary);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_candidate_with_4097_operations_is_rejected_after_identity_computation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false).expect("bootstrap");
+    let candidate = NamespaceMutationCandidate::commit(ApiCommitRequest {
+        commit_id: CommitId::parse("over-operation-new").expect("valid commit id"),
+        preconditions: Vec::new(),
+        ops: (0..=loonfs_core::limits::MAX_COMMIT_OPERATIONS)
+            .map(|index| ApiCommitOp::CreateDirectory {
+                parent_inode_id: InodeId(1),
+                display_name: format!("over-operation-{index}"),
+            })
+            .collect(),
+        message: None,
+    });
+
+    // A later release may lower the operation limit below a durable request;
+    // identity must remain available so receipt resolution can win first.
+    candidate
+        .semantic_identity(&namespace_id)
+        .expect("current request limits must not affect identity");
+    let error = publish_namespace_mutations_batch(&store, &namespace_id, vec![candidate], &context)
+        .remove(0)
+        .expect_err("new over-operation request must be rejected");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn visible_commit_id_retry_aliases_across_writer_takeover() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -13,12 +13,10 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::publish::{
     parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
-    PathMutationIntent, PreparedContent, MAX_COMMIT_CONTENT_TOKENS,
-    MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_OPERATIONS,
+    PathMutationIntent, PreparedContent,
 };
 use loonfs::{
-    content_tokens::ContentTokenError, payload_class, CoreError, ErrorCode, ListChangesOptions,
-    TraceStoreKind,
+    content_tokens::ContentTokenError, payload_class, ErrorCode, ListChangesOptions, TraceStoreKind,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -645,10 +643,8 @@ pub(super) async fn commit_operations(
     let namespace_id = namespace.into_id()?;
     let commit_id = request.commit_id.clone();
     let external_content_refs = distinct_external_content_refs(&request);
-    validate_commit_submission_limits(&request, content_tokens.len(), external_content_refs.len())
-        .map_err(|error| {
-            ApiResponseError::core_for_namespace(&namespace_id, error).with_commit_id(&commit_id)
-        })?;
+    // The router's commit-body limit is the transport guard. Semantic limits
+    // stay in candidate preparation so durable replays reach receipt lookup.
     let content_preparation = prepare_commit_content(
         &state.writer,
         &state.config,
@@ -694,30 +690,6 @@ fn distinct_external_content_refs(request: &ApiCommitRequest) -> Vec<ContentRef>
         }
     }
     refs
-}
-
-fn validate_commit_submission_limits(
-    request: &ApiCommitRequest,
-    content_token_count: usize,
-    external_content_ref_count: usize,
-) -> Result<(), CoreError> {
-    if request.ops.len() > MAX_COMMIT_OPERATIONS {
-        return Err(CoreError::InvalidCommitRequest(format!(
-            "commit has {} operations; maximum is {MAX_COMMIT_OPERATIONS}",
-            request.ops.len()
-        )));
-    }
-    if content_token_count > MAX_COMMIT_CONTENT_TOKENS {
-        return Err(CoreError::InvalidCommitRequest(format!(
-            "commit has {content_token_count} content token entries; maximum is {MAX_COMMIT_CONTENT_TOKENS}"
-        )));
-    }
-    if external_content_ref_count > MAX_COMMIT_EXTERNAL_CONTENT_REFS {
-        return Err(CoreError::InvalidCommitRequest(format!(
-            "commit references {external_content_ref_count} distinct external content refs; maximum is {MAX_COMMIT_EXTERNAL_CONTENT_REFS}"
-        )));
-    }
-    Ok(())
 }
 
 async fn prepare_commit_content(

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use loonfs::content_tokens::mint_content_token;
+use loonfs::publish::MAX_COMMIT_CONTENT_TOKENS;
 use loonfs_api::{
     v0::{
         BeginUploadRequest, CommitDelta, CommitOp, CommitRequest as ApiCommitRequest,
@@ -1205,7 +1206,7 @@ async fn commit_with_invalid_relevant_token_reports_token_failure() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn landed_commit_replays_byte_for_byte_with_absent_expired_or_garbage_tokens() {
+async fn landed_commit_replays_byte_for_byte_with_over_limit_absent_expired_or_garbage_tokens() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -1222,6 +1223,7 @@ async fn landed_commit_replays_byte_for_byte_with_absent_expired_or_garbage_toke
             .expect("create namespace");
         let completed = stage_uploaded_content(&harness.client, &namespace, b"commit replay");
         let content_ref = completed.content_ref.clone();
+        let valid_token = validated_content_token(&completed);
         let mut request = CommitSubmissionRequest {
             commit: ApiCommitRequest {
                 commit_id: CommitId::parse("commit-token-replay").expect("valid commit id"),
@@ -1233,7 +1235,7 @@ async fn landed_commit_replays_byte_for_byte_with_absent_expired_or_garbage_toke
                 }],
                 message: None,
             },
-            content_tokens: vec![validated_content_token(&completed)],
+            content_tokens: vec![valid_token.clone()],
         };
         let send = |request: &CommitSubmissionRequest| {
             response_bytes(
@@ -1242,6 +1244,9 @@ async fn landed_commit_replays_byte_for_byte_with_absent_expired_or_garbage_toke
             )
         };
         let original = send(&request);
+
+        request.content_tokens = vec![valid_token; MAX_COMMIT_CONTENT_TOKENS + 1];
+        assert_eq!(send(&request), original);
 
         request.content_tokens.clear();
         assert_eq!(send(&request), original);
@@ -1309,7 +1314,7 @@ async fn bare_commit_body_without_content_tokens_still_parses_and_commits_mkdir(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn commit_operation_and_content_token_limits_reject_before_admission() {
+async fn commit_operation_and_prepared_proof_limits_reject_new_requests() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -1343,27 +1348,24 @@ async fn commit_operation_and_content_token_limits_reject_before_admission() {
             "4097 operations",
         );
 
-        let irrelevant_ref = ContentRef::whole_file_v0(b"irrelevant");
-        let oversized_tokens = CommitSubmissionRequest {
+        let completed = stage_uploaded_content(&harness.client, &namespace, b"proof limit");
+        let prepared_proof = validated_content_token(&completed);
+        let oversized_proofs = CommitSubmissionRequest {
             commit: ApiCommitRequest {
-                commit_id: CommitId::parse("commit-too-many-tokens").expect("valid commit id"),
+                commit_id: CommitId::parse("commit-too-many-proofs").expect("valid commit id"),
                 preconditions: Vec::new(),
-                ops: vec![CommitOp::CreateDirectory {
+                ops: vec![CommitOp::CreateFile {
                     parent_inode_id: InodeId(1),
-                    display_name: "never-admitted".to_owned(),
+                    display_name: "never-committed.txt".to_owned(),
+                    content_ref: completed.content_ref,
                 }],
                 message: None,
             },
-            content_tokens: (0..4097)
-                .map(|_| ValidatedContentToken {
-                    content_ref: irrelevant_ref.clone(),
-                    token: "irrelevant".to_owned(),
-                })
-                .collect(),
+            content_tokens: vec![prepared_proof; MAX_COMMIT_CONTENT_TOKENS + 1],
         };
         assert_invalid_commit_limit_response(
-            send_commit_submission(&harness.server_url, &namespace, &oversized_tokens),
-            "4097 content token entries",
+            send_commit_submission(&harness.server_url, &namespace, &oversized_proofs),
+            "4097 prepared content proofs",
         );
 
         let changes = harness

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -949,11 +949,13 @@ otherwise `content_not_prepared` names the first uncovered digest. A retry of
 an already-landed semantic commit replays its durable receipt even when tokens
 are then absent, expired, or malformed.
 
-One submission accepts at most 4096 operations, 4096 `content_tokens` entries,
-and 4096 distinct new external refs. A violation answers `invalid_request`
-before publisher admission; the server never splits the commit. These bounds
-protect serialized publisher occupancy, not commit correctness. A successful
-response is returned only after the request is committed (section 5.1).
+One new request accepts at most 4096 operations, 4096 prepared
+`content_tokens` proofs, and 4096 distinct new external refs. A violation
+answers `invalid_request`; the server never splits the commit. Current limits
+apply to new requests, while a committed request always replays from its
+receipt. These bounds protect serialized publisher occupancy, not commit
+correctness. A successful response is returned only after the request is
+committed (section 5.1).
 
 Representative response:
 


### PR DESCRIPTION
Request-limit validation ran before durable-receipt replay, breaking the system's own replay-wins principle — a placement chosen when the limits landed, for pre-admission enforcement, that was right for new requests and wrong for retries. Because content proofs are deliberately outside semantic identity, a retry of an already-landed commit carrying more proofs than the current limit has the identical fingerprint and must replay its receipt — but died at the limit check before the receipt was consulted. The same failure would hit every committed request if a later release lowered an operation or proof limit.

semantic_identity() now computes identity and nothing else, and candidate preparation orders itself the way the contract reads: identity, durable-receipt replay, same-batch dedup, and only then — for a new primary — current request limits, followed by the rejected-preparation check (limits first between the two, pinned by comment). The handler keeps only transport bounds early (the 8 MiB body cap); its semantic limit checks moved into core where replay can precede them. The accepted consequence, documented at each touched comment: an oversized new commit occupies one queue slot until preparation rejects it, instead of being refused at admission.

The flagship coverage is the ordering-visible contrast: the same over-proof-limit candidate replays byte-for-byte when its commit ID has a matching receipt — proven end to end over HTTP with 4097 attached valid proofs — and is rejected as invalid_request when it does not; a same-batch over-limit duplicate joins its primary; a 4097-operation new request still fails, now provably after identity computation. The spec states the rule in one sentence: current limits apply to new requests, and a committed request always replays from its receipt.