### PR TITLE
fix(grep): surface truthful index errors

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -153,6 +153,7 @@ error_codes! {
     RebootstrapRequired => "rebootstrap_required",
     QueryUnindexable => "query_unindexable",
     IndexLagging => "index_lagging",
+    IndexCorrupt => "index_corrupt",
     NamespaceCorrupt => "namespace_corrupt",
     ServerError => "server_error",
 }
@@ -192,7 +193,7 @@ impl ErrorCode {
             | ErrorCode::IndexLagging
             | ErrorCode::MaintenanceRequired => ErrorKind::Unavailable,
             ErrorCode::CommitOutcomeUnknown => ErrorKind::OutcomeUnknown,
-            ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
+            ErrorCode::IndexCorrupt | ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
             ErrorCode::ServerError => ErrorKind::Internal,
             // The spec deliberately surfaces precondition failures
             // (`stale_revision`, `stale_head`, `commit_id_reuse_conflict`) as

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -12,7 +12,7 @@ use loonfs::{
     gc_config_from_request, gc_response_from_report, BootstrapNamespaceError, ChangesResponse,
     CopyOptions, CoreError, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, ListChangesOptions,
+    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepError, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickResult, MoveOptions, PutFileOptions,
     RestoreRevisionOptions, RuntimeError, SharedObjectStore, TraceStoreKind, UndeleteOptions,
 };
@@ -518,6 +518,7 @@ fn map_runtime_error(error: RuntimeError) -> BackendError {
     match error {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
+        RuntimeError::Grep(error) => map_grep_error(error),
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
         other => BackendError::runtime_error(other.to_string()),
@@ -531,6 +532,7 @@ fn map_namespace_scoped_runtime_error(
     match error {
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace_id, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
+        RuntimeError::Grep(error) => map_namespace_scoped_grep_error(namespace_id, error),
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
         other => BackendError::runtime_error(other.to_string()),
@@ -545,6 +547,13 @@ fn map_core_error(error: CoreError) -> BackendError {
     BackendError::new(error.code().as_str(), error.to_string())
 }
 
+fn map_grep_error(error: GrepError) -> BackendError {
+    match error {
+        GrepError::Core(error) => map_core_error(error),
+        error => BackendError::new(error.code().as_str(), error.to_string()),
+    }
+}
+
 fn map_namespace_scoped_core_error(namespace_id: &NamespaceId, error: CoreError) -> BackendError {
     if matches!(error.code(), ErrorCode::NamespaceNotFound) {
         return BackendError::new(
@@ -554,6 +563,13 @@ fn map_namespace_scoped_core_error(namespace_id: &NamespaceId, error: CoreError)
     }
 
     map_core_error(error)
+}
+
+fn map_namespace_scoped_grep_error(namespace_id: &NamespaceId, error: GrepError) -> BackendError {
+    match error {
+        GrepError::Core(error) => map_namespace_scoped_core_error(namespace_id, error),
+        error => BackendError::new(error.code().as_str(), error.to_string()),
+    }
 }
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> BackendError {
@@ -701,12 +717,13 @@ impl RemoteTarget {
 #[allow(clippy::panic)]
 mod tests {
     use super::{
-        map_bootstrap_error, map_core_error, resolve_cli_page_limit, Backend, EmbeddedTarget,
+        map_bootstrap_error, map_core_error, map_grep_error, resolve_cli_page_limit, Backend,
+        EmbeddedTarget,
     };
     use crate::config::StoreConfig;
     use loonfs::{
         BootstrapNamespaceError, CoreError, CreateNamespaceOptions, ErrorCode, FsBackgroundWork,
-        FsWriter, PutFileOptions, RuntimeError, SharedObjectStore,
+        FsWriter, GrepError, PutFileOptions, RuntimeError, SharedObjectStore,
     };
     use loonfs_api::{
         ChangeSeq, CreateCheckpointRequest, DestinationBehavior, InodeId, NamespaceId, RevisionNo,
@@ -735,6 +752,27 @@ mod tests {
         ));
         assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
         assert!(error.message.contains("abc123"));
+    }
+
+    #[test]
+    fn map_grep_error_preserves_embedded_remote_code_parity() {
+        for (error, expected) in [
+            (GrepError::NotEnabled, ErrorCode::NotSupported),
+            (
+                GrepError::CorruptIndex {
+                    message: "bad pointer".to_owned(),
+                },
+                ErrorCode::IndexCorrupt,
+            ),
+            (
+                GrepError::PublicationConflict {
+                    object_key: "namespaces/demo/extensions/grep/root.json".to_owned(),
+                },
+                ErrorCode::StaleHead,
+            ),
+        ] {
+            assert_eq!(map_grep_error(error).code, expected.as_str());
+        }
     }
 
     #[test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1271,6 +1271,10 @@ mod tests {
         let error = api_error(503, "commit_outcome_unknown");
         assert_eq!(error.error_code(), Some(ErrorCode::CommitOutcomeUnknown));
         assert_eq!(error.kind(), Some(ErrorKind::OutcomeUnknown));
+
+        let error = api_error(500, "index_corrupt");
+        assert_eq!(error.error_code(), Some(ErrorCode::IndexCorrupt));
+        assert_eq!(error.kind(), Some(ErrorKind::DataCorruption));
     }
 
     #[test]

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -1,8 +1,7 @@
 //! Event-driven maintenance for one grep-enabled namespace.
 
-use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepFoldOutcome, GrepWorker};
+use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepFoldOutcome, GrepWorker};
 use loonfs_api::{ChangeSeq, ErrorCode, NamespaceId};
-use loonfs_core::Error as CoreError;
 use loonfs_objectstore::ObjectStore;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -266,7 +265,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
         &self,
         consecutive_failures: u32,
         phase: &'static str,
-        error: &CoreError,
+        error: &GrepError,
     ) -> bool {
         let shift = consecutive_failures.saturating_sub(1).min(16);
         let delay_ms = ERROR_BACKOFF_BASE_MS

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -1,0 +1,122 @@
+//! Public grep failures and their wire-code classification.
+
+use crate::root::GrepRootError;
+use loonfs_api::{ErrorCode, ErrorKind};
+use loonfs_core::{Error as CoreError, StoreFailureClass};
+use thiserror::Error;
+
+/// Failure returned by grep queries or maintenance.
+///
+/// The variants preserve only distinctions that change caller or operator
+/// action. Detailed root loading and publication failures remain available
+/// internally as [`GrepRootError`].
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum GrepError {
+    /// The namespace has no active grep root.
+    #[error("feature `index.grams` is not materialized on this namespace")]
+    NotEnabled,
+    /// The namespace's grep backfill has not completed.
+    #[error("feature `index.grams` is not materialized on this namespace")]
+    Backfilling,
+    /// The backing provider could not serve grep-owned state.
+    #[error("object-store operation failed for grep state `{object_key}`: {message}")]
+    StoreUnavailable {
+        /// Grep-owned object or prefix the provider operation targeted.
+        object_key: String,
+        /// Provider failure text without a repeated object key.
+        message: String,
+        /// Classification retained from the provider boundary.
+        class: StoreFailureClass,
+    },
+    /// Grep's rebuildable derived state failed validation.
+    #[error("grep index is corrupt: {message}; disable and re-enable grep to rebuild it")]
+    CorruptIndex {
+        /// Root, manifest, or segment validation failure.
+        message: String,
+    },
+    /// A grep root compare-and-swap lost to another publisher.
+    #[error("grep root publication conflict for `{object_key}`; retry")]
+    PublicationConflict {
+        /// Mutable grep root whose publication raced.
+        object_key: String,
+    },
+    /// A genuine core namespace failure encountered while grep read core state.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+}
+
+impl GrepError {
+    /// Returns the caller-action category for this failure.
+    pub fn kind(&self) -> ErrorKind {
+        self.code().kind()
+    }
+
+    /// Returns the stable wire code for this failure.
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
+            Self::StoreUnavailable { class, .. } => match class {
+                StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+                StoreFailureClass::Other => ErrorCode::ServerError,
+            },
+            Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
+            Self::PublicationConflict { .. } => ErrorCode::StaleHead,
+            Self::Core(error) => error.code(),
+        }
+    }
+}
+
+impl From<GrepRootError> for GrepError {
+    fn from(error: GrepRootError) -> Self {
+        match error {
+            GrepRootError::Store {
+                object_key,
+                message,
+                class,
+            } => Self::StoreUnavailable {
+                object_key,
+                message,
+                class,
+            },
+            GrepRootError::MissingEtag { object_key } => Self::StoreUnavailable {
+                object_key,
+                message: "grep root has no etag for compare-and-swap".to_owned(),
+                class: StoreFailureClass::Other,
+            },
+            GrepRootError::Conflict { object_key } => Self::PublicationConflict { object_key },
+            error @ (GrepRootError::Corrupt { .. }
+            | GrepRootError::MissingManifest { .. }
+            | GrepRootError::IdentityMismatch { .. }
+            | GrepRootError::AdvanceIdentityMismatch { .. }) => Self::CorruptIndex {
+                message: error.to_string(),
+            },
+        }
+    }
+}
+
+/// Result type used by grep query and maintenance entrypoints.
+pub type Result<T> = std::result::Result<T, GrepError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ErrorCode, GrepError, StoreFailureClass};
+
+    #[test]
+    fn store_failure_class_survives_the_grep_boundary() {
+        for (class, expected) in [
+            (
+                StoreFailureClass::PermissionDenied,
+                ErrorCode::PermissionDenied,
+            ),
+            (StoreFailureClass::Other, ErrorCode::ServerError),
+        ] {
+            let error = GrepError::StoreUnavailable {
+                object_key: "namespaces/demo/extensions/grep/root.json".to_owned(),
+                message: "provider failure".to_owned(),
+                class,
+            };
+            assert_eq!(error.code(), expected);
+        }
+    }
+}

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -2,11 +2,12 @@
 
 use crate::cache::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
 use crate::codec::IndexRow;
+use crate::{GrepError, Result};
 use loonfs_api::wire::sst_blocks::{
     decode_data_block_rows, decode_filter_block, decode_index_block, BlockHandle, DecodedDataBlock,
     SegmentFilter, SegmentIndexEntry,
 };
-use loonfs_core::{Error as CoreError, Result, StoreFailureClass};
+use loonfs_core::StoreFailureClass;
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::sync::Arc;
 
@@ -14,10 +15,10 @@ pub(crate) fn index_segment_corrupt(
     object_key: &str,
     what: &str,
     error: &dyn std::fmt::Display,
-) -> CoreError {
-    CoreError::NamespaceCorrupt(format!(
-        "index segment `{object_key}` carries an unreadable {what}: {error}"
-    ))
+) -> GrepError {
+    GrepError::CorruptIndex {
+        message: format!("index segment `{object_key}` carries an unreadable {what}: {error}"),
+    }
 }
 
 fn cache_key(
@@ -40,10 +41,10 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
     let end_exclusive = handle
         .offset
         .checked_add(u64::from(handle.stored_len))
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
+        .ok_or_else(|| GrepError::CorruptIndex {
+            message: format!(
                 "index segment `{object_key}` descriptor names bytes past the address space"
-            ))
+            ),
         })?;
     let bytes = store
         .get(
@@ -54,15 +55,13 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
             }),
         )
         .await
-        .map_err(|error| CoreError::Store {
+        .map_err(|error| GrepError::StoreUnavailable {
             object_key: object_key.to_owned(),
             message: error.message(),
             class: StoreFailureClass::of(&error),
         })?
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
-                "manifest references missing index segment `{object_key}`"
-            ))
+        .ok_or_else(|| GrepError::CorruptIndex {
+            message: format!("manifest references missing index segment `{object_key}`"),
         })?;
     Ok(bytes.to_vec())
 }

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -11,6 +11,7 @@ mod cache;
 pub mod codec;
 mod config;
 mod driver;
+mod error;
 mod index_read;
 pub mod keyspace;
 mod query;
@@ -20,6 +21,8 @@ mod worker;
 
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
 pub use driver::{GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask};
+pub use error::GrepError as Error;
+pub use error::{GrepError, Result};
 pub use service::{
     GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,
     MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -71,6 +71,8 @@ enum StandaloneError {
     OpenStore(#[from] loonfs_objectstore::ObjectStoreError),
     #[error("grep maintenance failed: {0}")]
     Maintenance(#[from] loonfs_core::Error),
+    #[error("grep operation failed: {0}")]
+    Grep(#[from] loonfs_grep::GrepError),
     #[error("grep driver for namespace `{namespace_id}` stopped before parking")]
     DriverStopped { namespace_id: NamespaceId },
     #[error("grep driver task failed: {0}")]

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -1,6 +1,7 @@
 //! Typed failures for grep root state, encoding, loading, and publication.
 
 use loonfs_api::{IndexSegmentId, NamespaceId};
+use loonfs_core::StoreFailureClass;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -79,7 +80,11 @@ pub enum GrepRootCodecError {
 #[non_exhaustive]
 pub enum GrepRootError {
     #[error("object-store operation failed for grep root `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("grep root `{object_key}` is corrupt: {message}")]
     Corrupt { object_key: String, message: String },
     #[error("grep root `{root_key}` names missing manifest `{manifest_key}`")]

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -14,6 +14,7 @@ use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
 use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs_api::NamespaceId;
+use loonfs_core::StoreFailureClass;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 
 /// A verified grep root pointer and metadata from the same store read.
@@ -371,5 +372,6 @@ fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
     GrepRootError::Store {
         object_key: object_key.to_owned(),
         message: error.message(),
+        class: StoreFailureClass::of(error),
     }
 }

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -7,9 +7,10 @@ use crate::codec::{lookup, Gram, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES};
 use crate::index_read::{
     index_segment_corrupt, load_data_block, load_filter_block, load_index_block,
 };
-use crate::keyspace::segment_key;
+use crate::keyspace::{manifest_key, segment_key};
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
 use crate::root::{load_grep_manifest, load_grep_root_pointer, GrepLifecycle, GrepRootState};
+use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
 use loonfs_api::wire::manifest::hex_decode_bytes;
 use loonfs_api::wire::sst_blocks::{decode_filter_block, index_blocks_for_key_range};
@@ -21,7 +22,7 @@ use loonfs_api::{
 use loonfs_core::content::read_durable_content_bytes;
 use loonfs_core::grep::{LoadedMetadataView, MetadataViewSession};
 use loonfs_core::metadata::RevisionRecord;
-use loonfs_core::{Error as CoreError, MetadataViewError, Result};
+use loonfs_core::{Error as CoreError, MetadataViewError};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -94,15 +95,15 @@ struct GrepQuerySegment {
 
 impl GrepIndexSnapshot {
     /// Captures unreadable grep extension state while preserving error precedence.
-    pub fn from_error(error: CoreError) -> Self {
+    pub fn from_error(error: GrepError) -> Self {
         Self { state: Err(error) }
     }
 
     /// Freshly loads the grep pointer, then loads or reuses its immutable manifest.
     ///
-    /// Missing or corrupt pointers/manifests and disabled or backfilling
-    /// lifecycles all collapse to the same `index.grams` not-materialized
-    /// surface. Grep-private corruption never changes core read behavior.
+    /// Missing or disabled roots and incomplete backfills remain
+    /// not-materialized. Unreadable derived state retains its actionable
+    /// grep-specific failure without changing core read behavior.
     pub async fn from_grep_root<S: ObjectStore + ?Sized>(
         store: &S,
         namespace_id: &NamespaceId,
@@ -110,7 +111,8 @@ impl GrepIndexSnapshot {
     ) -> Self {
         let pointer = match load_grep_root_pointer(store, namespace_id).await {
             Ok(Some(pointer)) => pointer,
-            Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+            Ok(None) => return Self::from_error(GrepError::NotEnabled),
+            Err(error) => return Self::from_error(error.into()),
         };
         let manifest_id = pointer.pointer().manifest_id();
         let cache_key = GrepBlockCacheKey {
@@ -124,11 +126,27 @@ impl GrepIndexSnapshot {
                 DecodedGrepBlock::Filter(_)
                 | DecodedGrepBlock::Index(_)
                 | DecodedGrepBlock::Data(_),
-            ) => return Self::from_error(feature_not_materialized()),
+            ) => {
+                return Self::from_error(GrepError::CorruptIndex {
+                    message: format!(
+                        "grep manifest `{}` resolved to a non-manifest cache entry",
+                        manifest_key(namespace_id, manifest_id)
+                    ),
+                });
+            }
             None => {
                 let manifest = match load_grep_manifest(store, namespace_id, manifest_id).await {
                     Ok(Some(manifest)) => manifest,
-                    Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+                    Ok(None) => {
+                        return Self::from_error(GrepError::CorruptIndex {
+                            message: format!(
+                                "grep root `{}` names missing manifest `{}`",
+                                pointer.object_key(),
+                                manifest_key(namespace_id, manifest_id)
+                            ),
+                        });
+                    }
+                    Err(error) => return Self::from_error(error.into()),
                 };
                 let state = std::sync::Arc::new(manifest.state().clone());
                 service
@@ -138,17 +156,27 @@ impl GrepIndexSnapshot {
             }
         };
         if state.namespace_id() != namespace_id {
-            return Self::from_error(feature_not_materialized());
+            return Self::from_error(GrepError::CorruptIndex {
+                message: format!(
+                    "grep manifest `{}` names namespace `{}` instead of requested namespace `{namespace_id}`",
+                    manifest_key(namespace_id, manifest_id),
+                    state.namespace_id()
+                ),
+            });
         }
         Self::from_state(Some(&state))
     }
 
     fn from_state(root: Option<&GrepRootState>) -> Self {
         let Some(root) = root else {
-            return Self::from_error(feature_not_materialized());
+            return Self::from_error(GrepError::NotEnabled);
         };
-        if !matches!(root.lifecycle(), GrepLifecycle::Steady) {
-            return Self::from_error(feature_not_materialized());
+        match root.lifecycle() {
+            GrepLifecycle::Disabled => return Self::from_error(GrepError::NotEnabled),
+            GrepLifecycle::Backfilling { .. } => {
+                return Self::from_error(GrepError::Backfilling);
+            }
+            GrepLifecycle::Steady => {}
         }
         let segments = root
             .segments()
@@ -173,12 +201,6 @@ impl GrepIndexSnapshot {
 
     fn materialized(&self) -> Result<&MaterializedGrepIndexSnapshot> {
         self.state.as_ref().map_err(Clone::clone)
-    }
-}
-
-fn feature_not_materialized() -> CoreError {
-    CoreError::FeatureNotMaterialized {
-        feature: "index.grams".to_owned(),
     }
 }
 
@@ -369,12 +391,13 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     let mut postings = BTreeSet::new();
     let admitted = match &descriptor.filter_inline {
         Some(inline) => {
-            let filter_bytes = hex_decode_bytes(inline).map_err(|error| {
-                CoreError::NamespaceCorrupt(format!(
-                    "index segment `{}` carries undecodable inline filter hex: {error}",
-                    descriptor.object_key
-                ))
-            })?;
+            let filter_bytes =
+                hex_decode_bytes(inline).map_err(|error| GrepError::CorruptIndex {
+                    message: format!(
+                        "index segment `{}` carries undecodable inline filter hex: {error}",
+                        descriptor.object_key
+                    ),
+                })?;
             let filter =
                 decode_filter_block(&filter_bytes, &descriptor.filter_block).map_err(|error| {
                     index_segment_corrupt(&descriptor.object_key, "filter block", &error)
@@ -553,7 +576,7 @@ async fn derive_visible_path<S: ObjectStore + ?Sized>(
         }
         Ok(_) => Ok(None),
         Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => Ok(None),
-        Err(error) => Err(error),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -623,14 +646,15 @@ impl GrepService {
         let limit = match request.limit {
             None => DEFAULT_GREP_PAGE_LIMIT,
             Some(0) => {
-                return Err(CoreError::InvalidQuery(
-                    "limit must be greater than zero".to_owned(),
-                ));
+                return Err(
+                    CoreError::InvalidQuery("limit must be greater than zero".to_owned()).into(),
+                );
             }
             Some(limit) if limit as usize > MAX_GREP_PAGE_LIMIT => {
                 return Err(CoreError::InvalidQuery(format!(
                     "limit {limit} exceeds the maximum of {MAX_GREP_PAGE_LIMIT}"
-                )));
+                ))
+                .into());
             }
             Some(limit) => limit as usize,
         };
@@ -644,13 +668,14 @@ impl GrepService {
                         "the cursor was issued by a different request; replaying it \
                          under new criteria would silently skip results"
                             .to_owned(),
-                    ));
+                    )
+                    .into());
                 }
                 if cursor.head_seq > view.head().seq {
-                    return Err(MetadataViewError::SnapshotUnavailable {
+                    return Err(CoreError::from(MetadataViewError::SnapshotUnavailable {
                         requested_seq: cursor.head_seq,
                         head_seq: view.head().seq,
-                    }
+                    })
                     .into());
                 }
                 Some((cursor.last_inode_id, cursor.last_byte_offset))
@@ -696,7 +721,7 @@ impl GrepService {
                             next_cursor: None,
                         });
                     }
-                    Err(error) => return Err(error),
+                    Err(error) => return Err(error.into()),
                 }
             }
             None => None,
@@ -716,7 +741,8 @@ impl GrepService {
                         "the pattern has no run of at least 3 literal bytes for the \
                          trigram index; set allow_scan to search without it"
                             .to_owned(),
-                    ));
+                    )
+                    .into());
                 }
                 candidates.unfiltered = scan_candidate_inodes(view).await?;
             }
@@ -734,7 +760,8 @@ impl GrepService {
                         .seq
                         .0
                         .saturating_sub(snapshot.built_through_seq.0),
-                });
+                }
+                .into());
             }
         } else {
             candidates.unfiltered.extend(tail);
@@ -887,7 +914,7 @@ impl GrepService {
                     resume_cursor = Some((inode_id, u64::MAX));
                     continue;
                 };
-                let content = content?;
+                let content = content.map_err(CoreError::from)?;
                 if !is_indexable_text_content(&content.bytes) {
                     resume_cursor = Some((inode_id, u64::MAX));
                     continue;
@@ -986,7 +1013,8 @@ async fn scan_candidate_inodes<S: ObjectStore + ?Sized>(
                 "the namespace exceeds the {MAX_GREP_SCAN_FILES}-file scan budget; \
                  give the pattern a run of at least 3 literal bytes so the \
                  trigram index can narrow candidates"
-            )));
+            ))
+            .into());
         }
         if exhausted {
             break;

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -11,6 +11,7 @@ use crate::root::{
     GrepLifecycle, GrepRootError, GrepRootState, GrepSegmentRef, LoadedGrepRoot,
 };
 use crate::service::is_indexable_text_content;
+use crate::{GrepError, Result};
 use bytes::Bytes;
 use futures::future::try_join_all;
 use loonfs_api::wire::control::NamespaceState;
@@ -30,7 +31,7 @@ use loonfs_core::grep::{
 };
 use loonfs_core::limits::METADATA_PUBLICATION_BUDGET_MS;
 use loonfs_core::{
-    Error as CoreError, MetadataProjectionLoadError, MonotonicTimer, NamespaceEngine, Result,
+    Error as CoreError, MetadataProjectionLoadError, MonotonicTimer, NamespaceEngine,
     StdMonotonicTimer, StoreFailureClass,
 };
 use loonfs_objectstore::{
@@ -228,7 +229,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     pub async fn enable(&self, namespace_id: &NamespaceId) -> Result<GrepEnableOutcome> {
         if let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
@@ -240,7 +241,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
         let current = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?;
+            .map_err(GrepError::from)?;
         if let Some(current) = &current {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
                 self.release_checkpoint_if_unreferenced(
@@ -274,7 +275,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 let winner = load_grep_root(&self.store, namespace_id)
                     .await
-                    .map_err(core_root_error)?;
+                    .map_err(GrepError::from)?;
                 if winner.as_ref().is_none_or(|root| {
                     !root_names_checkpoint(root.state(), &checkpoint.checkpoint_id)
                 }) {
@@ -284,7 +285,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 }
                 Ok(GrepEnableOutcome::Superseded)
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -294,7 +295,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         ensure_live_namespace(&self.store, namespace_id).await?;
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(GrepDisableOutcome::NotEnabled);
         };
@@ -326,7 +327,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 Ok(GrepDisableOutcome::Disabled)
             }
             Err(GrepRootError::Conflict { .. }) => Ok(GrepDisableOutcome::Superseded),
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -339,7 +340,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         };
@@ -347,7 +348,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         }
         let content_store_id = load_namespace_catalog_entry(&self.store, namespace_id)
-            .await?
+            .await
+            .map_err(CoreError::from)?
             .content_store_id()
             .clone();
 
@@ -416,7 +418,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     }
 
     fn engine(&self, namespace_id: &NamespaceId) -> Result<NamespaceEngine<S>> {
-        NamespaceEngine::builder(self.store.clone())
+        Ok(NamespaceEngine::builder(self.store.clone())
             .namespace_id(namespace_id.clone())
             .writer_id(self.writer_id.clone())
             .writer_session_id(self.writer_session_id.clone())
@@ -424,7 +426,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .build()
             .map_err(|error| {
                 CoreError::Internal(format!("failed to build grep worker engine: {error}"))
-            })
+            })?)
     }
 
     async fn seed_root(&self, state: &GrepRootState) -> crate::root::Result<LoadedGrepRoot> {
@@ -443,12 +445,13 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_api::CreateCheckpointResponse> {
-        self.engine(namespace_id)?
+        Ok(self
+            .engine(namespace_id)?
             .create_checkpoint(
                 GREP_BACKFILL_CHECKPOINT_NAME.to_owned(),
                 Some(GREP_BACKFILL_CHECKPOINT_TTL_MS),
             )
-            .await
+            .await?)
     }
 
     async fn release_checkpoint_if_unreferenced(
@@ -500,7 +503,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 let winner = load_grep_root(&self.store, namespace_id)
                     .await
-                    .map_err(core_root_error)?;
+                    .map_err(GrepError::from)?;
                 if winner.as_ref().is_none_or(|root| {
                     !root_names_checkpoint(root.state(), &checkpoint.checkpoint_id)
                 }) {
@@ -510,7 +513,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 }
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -587,7 +590,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 }
@@ -765,7 +768,8 @@ async fn load_and_fold_revision_contents<S: ObjectStore + ?Sized>(
         let contents = try_join_all(chunk.iter().map(|revision| {
             read_durable_content_bytes(store, content_store_id, &revision.content_ref)
         }))
-        .await?;
+        .await
+        .map_err(CoreError::from)?;
         for (revision, content) in chunk.iter().zip(contents) {
             if !is_indexable_text_content(&content.bytes) {
                 unit.skipped_revisions += 1;
@@ -900,7 +904,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(fold_report(namespace_id, GrepFoldOutcome::NotEnabled));
         };
@@ -967,10 +971,10 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     .segments()
                     .iter()
                     .find(|segment| &segment.segment_id == segment_id)
-                    .ok_or_else(|| {
-                        CoreError::NamespaceCorrupt(format!(
+                    .ok_or_else(|| GrepError::CorruptIndex {
+                        message: format!(
                             "grep fold snapshot segment `{segment_id}` is missing from the root"
-                        ))
+                        ),
                     })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1044,7 +1048,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 Ok(fold_report(namespace_id, GrepFoldOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -1245,10 +1249,10 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
 fn fold_snapshot_row(merged: &mut MergedRange, row: IndexRow, object_key: &str) -> Result<()> {
     let IndexRow::GramPostings { gram, .. } = &row;
     let gram = *gram;
-    let batch = row.postings().map_err(|error| {
-        CoreError::NamespaceCorrupt(format!(
+    let batch = row.postings().map_err(|error| GrepError::CorruptIndex {
+        message: format!(
             "index segment `{object_key}` carries an unreadable posting batch: {error}"
-        ))
+        ),
     })?;
     merged.postings.entry(gram).or_default().extend(batch);
     merged.rows += 1;
@@ -1381,12 +1385,14 @@ async fn ensure_live_namespace<S: ObjectStore + ?Sized>(
     if head.state.state == NamespaceState::Deleted {
         return Err(CoreError::NamespaceDeleted {
             namespace_id: namespace_id.clone(),
-        });
+        }
+        .into());
     }
     if head.state.state != NamespaceState::Active {
         return Err(CoreError::NamespacePartiallyInitialized {
             namespace_id: namespace_id.clone(),
-        });
+        }
+        .into());
     }
     Ok(())
 }
@@ -1474,7 +1480,7 @@ async fn write_immutable_object<S: ObjectStore + ?Sized>(
             if existing_object_matches(store, object_key, expected_bytes).await? {
                 Ok(())
             } else {
-                Err(CoreError::Store {
+                Err(GrepError::StoreUnavailable {
                     object_key: object_key.to_owned(),
                     message: "object already exists with different bytes".to_owned(),
                     class: StoreFailureClass::Other,
@@ -1485,20 +1491,14 @@ async fn write_immutable_object<S: ObjectStore + ?Sized>(
             let message = error.message();
             match existing_object_matches(store, object_key, expected_bytes).await {
                 Ok(true) => Ok(()),
-                Ok(false) => Err(CoreError::Store {
+                Ok(false) => Err(GrepError::StoreUnavailable {
                     object_key: object_key.to_owned(),
                     message: format!(
                         "{message}; immutable object exists with different bytes after transport error"
                     ),
                     class: StoreFailureClass::Other,
                 }),
-                Err(verify_error) => Err(CoreError::Store {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "{message}; failed to verify immutable write after transport error: {verify_error}"
-                    ),
-                    class: StoreFailureClass::Other,
-                }),
+                Err(verify_error) => Err(verify_error),
             }
         }
         Err(error) => Err(core_store_error(object_key, &error)),
@@ -1523,7 +1523,7 @@ async fn existing_object_matches<S: ObjectStore + ?Sized>(
         .get(object_key, None)
         .await
         .map_err(|error| core_store_error(object_key, &error))?
-        .ok_or_else(|| CoreError::Store {
+        .ok_or_else(|| GrepError::StoreUnavailable {
             object_key: object_key.to_owned(),
             message: "object is missing while verifying immutable write".to_owned(),
             class: StoreFailureClass::Other,
@@ -1539,32 +1539,16 @@ fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Re
     Err(CoreError::MetadataPublicationBudgetExceeded {
         elapsed_ms,
         budget_ms: METADATA_PUBLICATION_BUDGET_MS,
-    })
-}
-
-fn core_root_error(error: GrepRootError) -> CoreError {
-    match error {
-        GrepRootError::Store {
-            object_key,
-            message,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class: StoreFailureClass::Other,
-        },
-        GrepRootError::Conflict { object_key } => CoreError::CheckpointUnavailable(format!(
-            "grep root publication conflict for `{object_key}`; retry"
-        )),
-        error => CoreError::NamespaceCorrupt(error.to_string()),
     }
+    .into())
 }
 
-fn core_state_error(error: crate::root::GrepRootStateError) -> CoreError {
-    CoreError::Internal(format!("failed to build grep root state: {error}"))
+fn core_state_error(error: crate::root::GrepRootStateError) -> GrepError {
+    CoreError::Internal(format!("failed to build grep root state: {error}")).into()
 }
 
-fn core_store_error(object_key: &str, error: &ObjectStoreError) -> CoreError {
-    CoreError::Store {
+fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {
+    GrepError::StoreUnavailable {
         object_key: object_key.to_owned(),
         message: error.message(),
         class: StoreFailureClass::of(error),
@@ -1577,5 +1561,7 @@ fn current_time_ms() -> Result<u64> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_millis() as u64)
-        .map_err(|error| CoreError::Internal(format!("system clock before unix epoch: {error}")))
+        .map_err(|error| {
+            CoreError::Internal(format!("system clock before unix epoch: {error}")).into()
+        })
 }

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -1,7 +1,7 @@
 //! The `query/v0` plane: derived-index reads.
 
 use super::{authorize, AppJson, AppState, NamespaceIdPath};
-use crate::http::error::ApiResponseError;
+use crate::http::error::{status_for_core_error_code, ApiResponseError};
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
@@ -12,8 +12,10 @@ use loonfs_api::v0::{
 use loonfs_api::ApiError;
 use loonfs_api::FEATURE_QUERY_GREP;
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
-use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome};
+use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const GREP_INDEX_FEATURE: &str = "index.grams";
 
 #[cfg_attr(
     feature = "openapi",
@@ -29,10 +31,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
             (status = 200, description = "One page of matches", body = GrepResponse),
             (status = 400, description = "Invalid pattern, cursor, or an unindexable pattern without allow_scan", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "Grep serving is disabled or the gram index is not materialized on this namespace", body = ApiError),
-            (status = 503, description = "The index trails the head past the scan budget", body = ApiError)
+            (status = 503, description = "The index trails the head past the scan budget", body = ApiError),
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -49,7 +53,7 @@ pub(super) async fn grep(
         .reader
         .grep(&namespace_id, &request)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| map_runtime_grep_error(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -77,9 +81,11 @@ pub(super) async fn grep_not_supported(
         responses(
             (status = 200, description = "Grep root enabled or already enabled", body = EnableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -96,12 +102,7 @@ pub(super) async fn enable_grams_index(
         .expect("grep routes should carry a grep worker")
         .enable(&namespace_id)
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     let response = match outcome {
         GrepEnableOutcome::Enabled { target_seq } => EnableGramsIndexResponse {
             namespace_id: namespace_id.clone(),
@@ -114,11 +115,11 @@ pub(super) async fn enable_grams_index(
             already_enabled: true,
         },
         GrepEnableOutcome::Superseded => {
-            return Err(ApiResponseError::runtime_for_namespace(
+            return Err(map_grep_error(
                 &namespace_id,
-                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
-                    "enabling grep lost a root publication race; retry".to_owned(),
-                )),
+                GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
+                },
             ));
         }
     };
@@ -140,9 +141,11 @@ pub(super) async fn enable_grams_index(
         responses(
             (status = 200, description = "Grep root disabled or already disabled", body = DisableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -165,12 +168,7 @@ pub(super) async fn disable_grams_index(
         .expect("grep routes should carry a grep worker")
         .disable(&namespace_id)
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     let response = match outcome {
         GrepDisableOutcome::Disabled => DisableGramsIndexResponse {
             namespace_id: namespace_id.clone(),
@@ -181,11 +179,11 @@ pub(super) async fn disable_grams_index(
             was_enabled: false,
         },
         GrepDisableOutcome::Superseded => {
-            return Err(ApiResponseError::runtime_for_namespace(
+            return Err(map_grep_error(
                 &namespace_id,
-                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
-                    "disabling grep lost a root publication race; retry".to_owned(),
-                )),
+                GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
+                },
             ));
         }
     };
@@ -204,7 +202,9 @@ pub(super) async fn disable_grams_index(
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError)
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
+            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -229,12 +229,7 @@ pub(super) async fn gc_grams_index(
             })?,
         )
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(GrepGcResponse {
         namespace_id,
         deleted_segments: report.deleted_segments,
@@ -243,6 +238,38 @@ pub(super) async fn gc_grams_index(
         retained_candidates: report.retained_candidates,
         namespace_degraded: report.namespace_degraded,
     }))
+}
+
+fn map_runtime_grep_error(
+    namespace_id: &loonfs_api::NamespaceId,
+    error: loonfs::RuntimeError,
+) -> ApiResponseError {
+    match error {
+        loonfs::RuntimeError::Grep(error) => map_grep_error(namespace_id, error),
+        error => ApiResponseError::runtime_for_namespace(namespace_id, error),
+    }
+}
+
+fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> ApiResponseError {
+    match error {
+        error @ (GrepError::NotEnabled | GrepError::Backfilling) => {
+            ApiResponseError::not_supported(GREP_INDEX_FEATURE, &error.to_string())
+        }
+        error @ (GrepError::StoreUnavailable { .. }
+        | GrepError::CorruptIndex { .. }
+        | GrepError::PublicationConflict { .. }) => {
+            let code = error.code();
+            ApiResponseError::new(status_for_core_error_code(code), code, &error.to_string())
+        }
+        GrepError::Core(error) => {
+            ApiResponseError::runtime_for_namespace(namespace_id, loonfs::RuntimeError::Core(error))
+        }
+        error => ApiResponseError::new(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            loonfs_api::ErrorCode::ServerError,
+            &error.to_string(),
+        ),
+    }
 }
 
 async fn start_driver_for_query_if_needed(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -79,7 +79,8 @@ use loonfs_api::{
     RepairNamespaceOutcome,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
-use loonfs_grep::keyspace::root_key as grep_root_key;
+use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
+use loonfs_grep::root::{encode_grep_root, GrepManifestId, GrepRootEnvelope, GrepRootPointer};
 use loonfs_grep::{GrepDriverParked, GrepWorker};
 use loonfs_objectstore::keys::{metadata_root, namespace_config, wal_head};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -213,6 +214,92 @@ struct BlockGrepRootOnceStore {
     armed: AtomicBool,
     entered: Notify,
     release: Notify,
+}
+
+#[derive(Debug)]
+struct FaultGrepRootStore {
+    inner: LocalFsStore,
+    root_key: String,
+    fail_next_root_read: AtomicBool,
+    conflict_next_root_publication: AtomicBool,
+}
+
+impl FaultGrepRootStore {
+    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
+            root_key: grep_root_key(namespace_id),
+            fail_next_root_read: AtomicBool::new(false),
+            conflict_next_root_publication: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_next_root_read(&self) {
+        self.fail_next_root_read.store(true, Ordering::SeqCst);
+    }
+
+    fn conflict_next_root_publication(&self) {
+        self.conflict_next_root_publication
+            .store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FaultGrepRootStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        if key == self.root_key && self.fail_next_root_read.swap(false, Ordering::SeqCst) {
+            return Err(ObjectStoreError::transport(
+                key,
+                "injected grep-root outage",
+            ));
+        }
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key == self.root_key
+            && matches!(
+                &mode,
+                PutMode::CreateIfAbsent | PutMode::CompareAndSwap { .. }
+            )
+            && self
+                .conflict_next_root_publication
+                .swap(false, Ordering::SeqCst)
+        {
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 impl BlockGrepRootOnceStore {
@@ -472,6 +559,213 @@ async fn embedded_publish_observer_nudges_only_the_enabled_namespace_driver() {
         .expect("grep caught-up index");
     assert_eq!(response.matches.len(), 1);
     lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_disabled_root_is_not_materialized_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-disabled");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let worker = grep_error_worker(&store);
+    worker.enable(&namespace_id).await.expect("enable grep");
+    worker.disable(&namespace_id).await.expect("disable grep");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "disabled-server").await;
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                501,
+                ErrorCode::NotSupported,
+                "not materialized",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_mid_backfill_is_not_materialized_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-backfill");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    grep_error_worker(&store)
+        .enable(&namespace_id)
+        .await
+        .expect("leave grep backfilling");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "backfill-server").await;
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                501,
+                ErrorCode::NotSupported,
+                "not materialized",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("grep-error-store");
+    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let store = fault_store.clone() as SharedObjectStore;
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "store-server").await;
+    fault_store.fail_next_root_read();
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                500,
+                ErrorCode::ServerError,
+                "injected grep-root outage",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_corrupt_pointer_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-pointer");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    store
+        .put_overwrite(
+            &grep_root_key(&namespace_id),
+            Bytes::from_static(b"corrupt grep pointer"),
+        )
+        .await
+        .expect("write corrupt grep pointer");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "pointer-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_missing_manifest_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-missing-manifest");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
+            .expect("manifest id");
+    write_grep_pointer(&*store, &namespace_id, namespace_id.clone(), manifest_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "missing-manifest-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_corrupt_manifest_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-manifest");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("2222222222222222222222222222222222222222222222222222222222222222")
+            .expect("manifest id");
+    store
+        .put_overwrite(
+            &grep_manifest_key(&namespace_id, &manifest_id),
+            Bytes::from_static(b"corrupt grep manifest"),
+        )
+        .await
+        .expect("write corrupt grep manifest");
+    write_grep_pointer(&*store, &namespace_id, namespace_id.clone(), manifest_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "manifest-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_identity_mismatch_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-identity");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("3333333333333333333333333333333333333333333333333333333333333333")
+            .expect("manifest id");
+    write_grep_pointer(
+        &*store,
+        &namespace_id,
+        NamespaceId::parse("different-grep-identity").expect("different namespace id"),
+        manifest_id,
+    )
+    .await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "identity-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_publication_conflict_is_stale_head_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("grep-error-conflict");
+    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let store = fault_store.clone() as SharedObjectStore;
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "conflict-server").await;
+    fault_store.conflict_next_root_publication();
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.enable_grams_index(&namespace_id);
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                409,
+                ErrorCode::StaleHead,
+                "publication conflict",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1579,8 +1873,144 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
     server.abort();
 }
 
+async fn seed_grep_error_namespace(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> FsWriter {
+    let writer = test_runtime(store.clone(), "grep-error-seed").await;
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create grep-error namespace");
+    writer
+        .put_file_bytes(
+            namespace_id,
+            "/core.txt",
+            b"core remains readable",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write core isolation sentinel");
+    writer
+}
+
+fn grep_error_worker(store: &SharedObjectStore) -> GrepWorker<SharedObjectStore> {
+    GrepWorker::new(
+        store.clone(),
+        "grep-error-worker",
+        "grep-error-worker-session",
+        "grep-error-worker/0.1",
+    )
+}
+
+fn grep_error_request() -> GrepRequest {
+    GrepRequest {
+        pattern: "needle".to_owned(),
+        case_insensitive: false,
+        path_prefix: None,
+        cursor: None,
+        limit: None,
+        allow_stale: false,
+        allow_scan: false,
+    }
+}
+
+async fn write_grep_pointer(
+    store: &dyn ObjectStore,
+    stored_namespace_id: &NamespaceId,
+    pointer_namespace_id: NamespaceId,
+    manifest_id: GrepManifestId,
+) {
+    let envelope = GrepRootEnvelope::from_pointer(
+        "grep-error-api-test/0.1",
+        GrepRootPointer::new(pointer_namespace_id, manifest_id),
+    )
+    .expect("build grep pointer");
+    store
+        .put_overwrite(
+            &grep_root_key(stored_namespace_id),
+            Bytes::from(encode_grep_root(&envelope).expect("encode grep pointer")),
+        )
+        .await
+        .expect("write grep pointer");
+}
+
+async fn start_grep_error_server(
+    store: SharedObjectStore,
+    root: &Path,
+    writer_id: &str,
+) -> TestHarness {
+    let mut config = test_config(root, writer_id);
+    config.grep.mode = crate::config::GrepMode::ServeOnly;
+    start_server_with_config(store, config).await
+}
+
+async fn assert_index_corrupt_and_core_read(harness: TestHarness, namespace_id: NamespaceId) {
+    tokio::task::spawn_blocking({
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                500,
+                ErrorCode::IndexCorrupt,
+                "disable and re-enable grep to rebuild it",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+fn assert_grep_api_error_and_core_read<T: std::fmt::Debug>(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    result: Result<T, ClientError>,
+    status: u16,
+    code: ErrorCode,
+    message_fragment: &str,
+) {
+    match result {
+        Err(ClientError::Api {
+            status: actual_status,
+            code: actual_code,
+            feature,
+            message,
+            ..
+        }) => {
+            assert_eq!(actual_status, status);
+            assert_eq!(actual_code, code.as_str());
+            assert!(
+                message.contains(message_fragment),
+                "expected `{message_fragment}` in `{message}`"
+            );
+            if code == ErrorCode::NotSupported {
+                assert_eq!(feature.as_deref(), Some("index.grams"));
+            } else {
+                assert_eq!(feature, None);
+            }
+        }
+        other => panic!(
+            "expected grep api error {status} {}, got {other:?}",
+            code.as_str()
+        ),
+    }
+
+    let target = NamespacePath::parse(namespace_id.as_str(), "/core.txt").expect("core target");
+    let bytes = client
+        .read_file_bytes(&target)
+        .expect("grep failure must not affect core reads");
+    assert_eq!(bytes, b"core remains readable");
+}
+
 async fn start_server(store: SharedObjectStore, root: &Path, writer_id: &str) -> TestHarness {
-    let config = test_config(root, writer_id);
+    start_server_with_config(store, test_config(root, writer_id)).await
+}
+
+async fn start_server_with_config(store: SharedObjectStore, config: ServerConfig) -> TestHarness {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -3,9 +3,9 @@
 
 use super::core::FsCore;
 use crate::{
-    AdvanceRetentionResponse, CheckpointId, CoreError, CreateCheckpointOptions,
-    CreateCheckpointResponse, ErrorCode, FlushWalOutcome, FlushWalResponse, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, NamespaceId, ReleaseCheckpointResponse,
+    AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
+    ErrorCode, FlushWalOutcome, FlushWalResponse, MaintenanceTickOptions, MaintenanceTickOutcome,
+    MaintenanceTickResult, NamespaceId, ReleaseCheckpointResponse,
 };
 use crate::{Result, RuntimeError};
 use loonfs_api::{DisableGramsIndexResponse, EnableGramsIndexResponse};
@@ -180,7 +180,7 @@ impl FsCore {
             .grep_worker()
             .enable(namespace_id)
             .await
-            .map_err(RuntimeError::Core)?;
+            .map_err(RuntimeError::Grep)?;
         match outcome {
             loonfs_grep::GrepEnableOutcome::Enabled { target_seq } => {
                 Ok(EnableGramsIndexResponse {
@@ -196,11 +196,11 @@ impl FsCore {
                     already_enabled: true,
                 })
             }
-            loonfs_grep::GrepEnableOutcome::Superseded => {
-                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
-                    "enabling grep lost a root publication race; retry".to_owned(),
-                )))
-            }
+            loonfs_grep::GrepEnableOutcome::Superseded => Err(RuntimeError::Grep(
+                loonfs_grep::GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(namespace_id),
+                },
+            )),
         }
     }
 
@@ -214,7 +214,7 @@ impl FsCore {
             .grep_worker()
             .disable(namespace_id)
             .await
-            .map_err(RuntimeError::Core)?;
+            .map_err(RuntimeError::Grep)?;
         match outcome {
             loonfs_grep::GrepDisableOutcome::Disabled => Ok(DisableGramsIndexResponse {
                 namespace_id: namespace_id.clone(),
@@ -224,11 +224,11 @@ impl FsCore {
                 namespace_id: namespace_id.clone(),
                 was_enabled: false,
             }),
-            loonfs_grep::GrepDisableOutcome::Superseded => {
-                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
-                    "disabling grep lost a root publication race; retry".to_owned(),
-                )))
-            }
+            loonfs_grep::GrepDisableOutcome::Superseded => Err(RuntimeError::Grep(
+                loonfs_grep::GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(namespace_id),
+                },
+            )),
         }
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -66,6 +66,7 @@ pub use loonfs_core::{
     BootstrapNamespaceError, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind,
     GcConfig, GcReport, WriterFence,
 };
+pub use loonfs_grep::GrepError;
 pub use publisher::PublishObserver;
 
 /// Integration seam: the vocabulary for handing classified mutation work to
@@ -132,6 +133,9 @@ pub enum RuntimeError {
     /// Bootstrapping a namespace failed.
     #[error(transparent)]
     Bootstrap(#[from] BootstrapNamespaceError),
+    /// A grep query or grep-owned maintenance operation failed.
+    #[error(transparent)]
+    Grep(#[from] GrepError),
     /// The runtime configuration is invalid.
     #[error("invalid runtime config: {0}")]
     Config(String),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1016,6 +1016,7 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
     match error {
         RuntimeError::Core(error) => error,
         RuntimeError::Bootstrap(error) => CoreError::Internal(error.to_string()),
+        RuntimeError::Grep(error) => CoreError::Internal(error.to_string()),
         RuntimeError::Config(message) => CoreError::Internal(message),
         RuntimeError::RuntimeTask(message) => CoreError::Internal(message),
     }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -140,8 +140,8 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &invalid_limit)
         .await
         .expect_err("invalid limit must win before the missing feature");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::InvalidRequest);
 
@@ -150,10 +150,11 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("grep without the feature must be refused");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = &error else {
+        panic!("expected a grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::NotEnabled));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     let enabled = admin
         .enable_grams_index(&namespace_id)
@@ -211,10 +212,11 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("grep after disable must be refused");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = &error else {
+        panic!("expected a grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::NotEnabled));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     writer.shutdown_background().await.expect("writer shutdown");
 }
@@ -280,10 +282,11 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("background metadata work must not materialize grep");
-    let loonfs::Error::Core(core) = error else {
-        panic!("expected core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = error else {
+        panic!("expected grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::Backfilling));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     drive_worker_step(&grep_worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     drive_worker_step(&grep_worker, &namespace_id, GramIndexBuildPolicy::default()).await;
@@ -705,8 +708,8 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("a reached candidate's failed read must fail its page");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
 
@@ -735,8 +738,8 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .grep(&namespace_id, &second_page)
         .await
         .expect_err("the deferred read error must surface on the next page");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
 

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -78,7 +78,7 @@ impl ServiceHarness {
         }
     }
 
-    async fn result(&self, grep_request: &GrepRequest) -> loonfs_core::Result<GrepResponse> {
+    async fn result(&self, grep_request: &GrepRequest) -> loonfs_grep::Result<GrepResponse> {
         let context = read_context(&self.store, &self.namespace_id).await;
         let view = self
             .engine

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -113,7 +113,7 @@ async fn new_query(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
     grep_request: &GrepRequest,
-) -> loonfs_core::Result<GrepResponse> {
+) -> loonfs_grep::Result<GrepResponse> {
     let engine = NamespaceEngine::builder(store.clone())
         .namespace_id(namespace_id.clone())
         .writer_id("new-query")
@@ -458,17 +458,17 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         .expect("create namespace");
     let worker = worker(&store);
 
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "never enabled",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
     worker.enable(&namespace_id).await.expect("enable");
-    assert_not_materialized_error(
+    assert_backfilling_error(
         "backfilling",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
     worker.disable(&namespace_id).await.expect("disable");
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "disabled",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -477,7 +477,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
             .expect("valid manifest id");
     write_pointer(&*store, &namespace_id, missing_manifest_id).await;
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "missing manifest",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -493,7 +493,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         .await
         .expect("write corrupt manifest");
     write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "corrupt manifest",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -505,7 +505,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         )
         .await
         .expect("write corrupt pointer");
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "corrupt pointer",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -531,9 +531,9 @@ async fn write_pointer(
         .expect("write pointer");
 }
 
-fn assert_not_materialized_error(case: &str, result: loonfs::Result<GrepResponse>) {
+fn assert_not_enabled_error(case: &str, result: loonfs::Result<GrepResponse>) {
     match result {
-        Err(loonfs::Error::Core(error)) => {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::NotEnabled)) => {
             assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
             assert_eq!(
                 error.to_string(),
@@ -542,6 +542,35 @@ fn assert_not_materialized_error(case: &str, result: loonfs::Result<GrepResponse
             );
         }
         outcome => panic!("expected not-materialized error for {case}, got {outcome:?}"),
+    }
+}
+
+fn assert_backfilling_error(case: &str, result: loonfs::Result<GrepResponse>) {
+    match result {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::Backfilling)) => {
+            assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
+            assert_eq!(
+                error.to_string(),
+                "feature `index.grams` is not materialized on this namespace",
+                "error text for {case}"
+            );
+        }
+        outcome => panic!("expected backfilling error for {case}, got {outcome:?}"),
+    }
+}
+
+fn assert_corrupt_index_error(case: &str, result: loonfs::Result<GrepResponse>) {
+    match result {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::CorruptIndex { .. })) => {
+            assert_eq!(error.code(), ErrorCode::IndexCorrupt, "code for {case}");
+            assert!(
+                error
+                    .to_string()
+                    .contains("disable and re-enable grep to rebuild it"),
+                "error text for {case}: {error}"
+            );
+        }
+        outcome => panic!("expected corrupt-index error for {case}, got {outcome:?}"),
     }
 }
 
@@ -724,7 +753,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         "fork target must have no grep root until explicitly enabled"
     );
     let target_reader = writer.reader();
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "fork target",
         target_reader.grep(&target, &request("needle")).await,
     );

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -250,6 +250,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, changed during the operation, condemned pending GC deletion, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `index_lagging` | 503 | The gram index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |
+| `index_corrupt` | 500 | The grep index's derived state failed validation. Disable and re-enable grep on the namespace to rebuild it; core filesystem state remains available. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -350,6 +350,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -360,8 +370,8 @@
               }
             }
           },
-          "501": {
-            "description": "Grep serving is disabled for this deployment",
+          "409": {
+            "description": "Lost a grep root-pointer publication race; retry",
             "content": {
               "application/json": {
                 "schema": {
@@ -370,8 +380,18 @@
               }
             }
           },
-          "503": {
-            "description": "Lost a grep root-pointer publication race; retry",
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
             "content": {
               "application/json": {
                 "schema": {
@@ -423,6 +443,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -433,8 +463,8 @@
               }
             }
           },
-          "501": {
-            "description": "Grep serving is disabled for this deployment",
+          "409": {
+            "description": "Lost a grep root-pointer publication race; retry",
             "content": {
               "application/json": {
                 "schema": {
@@ -443,8 +473,18 @@
               }
             }
           },
-          "503": {
-            "description": "Lost a grep root-pointer publication race; retry",
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
             "content": {
               "application/json": {
                 "schema": {
@@ -488,6 +528,26 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -2268,6 +2328,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -2280,6 +2350,16 @@
           },
           "410": {
             "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Grep's error surface collapsed everything into lies: the query loader mapped provider outages, corrupt roots, and missing manifests to the same not-materialized response as a namespace where grep was simply never enabled, and the worker called grep-root corruption namespace corruption and CAS conflicts checkpoint unavailability. The collapse was deliberate migration-era conservatism — a byte-identical surface for differential testing — but the migration is over, and everywhere else this codebase makes errors tell the truth.

One GrepError now carries exactly the distinctions that change what an operator does: NotEnabled and Backfilling (the only two states allowed to claim the existing not-materialized surface, preserved byte-for-byte), StoreUnavailable (retaining the provider failure class), CorruptIndex (corrupt pointer, missing or corrupt manifest, identity mismatch — the remedy is a disable/re-enable rebuild, and the message says so), PublicationConflict, and a core passthrough. The wire mapping is one table used by query, enable, disable, and GC alike, with exactly one new code: index_corrupt (500). Everything else reuses honestly — outages flow through the existing provider codes, CAS losses join stale_head's retry vocabulary, and core namespace failures keep their own identities. The worker's namespace-corrupt and checkpoint-unavailable mislabels are gone.