### PR TITLE
fix(grep): bound indexing steps across commits and namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
 name = "loonfs-grep"
 version = "0.1.1"
 dependencies = [
+ "async-trait",
  "bytes",
  "ciborium",
  "clap",

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -54,7 +54,9 @@ writer_version = "loonfs-server/0.1.0"
 # an external `loonfs-grep` process.
 #[grep]
 #mode = "embedded"
-# Bounded build/fold budgets; every value must be greater than zero.
+# Shared expensive-step cap and bounded build/fold budgets; every value must
+# be greater than zero.
+#max_concurrent_steps = 2
 #max_files_per_step = 256
 #max_content_bytes_per_step = 67108864
 #max_rows_per_segment = 65536

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 ciborium.workspace = true
 tempfile.workspace = true
 

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -20,7 +20,7 @@ explicitly collects each named namespace's grep-owned keyspace once before
 maintenance starts, including reaping aged extension state for an absent or tombstoned namespace.
 
 The strict config keeps the provider under `[store]`, puts the one detached-deployment timer at the
-top level, and uses `[grep]` only for bounded step budgets:
+top level, and uses `[grep]` for bounded step budgets and the deployment-wide step cap:
 
 ```toml
 poll_interval_ms = 1000
@@ -30,6 +30,7 @@ kind = "local-fs"
 root = "./.loonfs-store"
 
 [grep]
+max_concurrent_steps = 2
 max_files_per_step = 256
 max_content_bytes_per_step = 67108864
 max_rows_per_segment = 65536
@@ -38,5 +39,5 @@ max_mid_runs = 8
 max_fold_rows_per_step = 131072
 ```
 
-`poll_interval_ms` defaults to 1000 and must be greater than zero. Every step budget must also be
-greater than zero.
+`poll_interval_ms` defaults to 1000 and must be greater than zero. Every step budget and
+`max_concurrent_steps` must also be greater than zero.

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -4,10 +4,18 @@ use crate::GramIndexBuildPolicy;
 use serde::Deserialize;
 use thiserror::Error;
 
+/// Default cap on concurrently executing grep build or fold steps.
+///
+/// Mirrors `loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE`; both background
+/// maintenance families default to two expensive namespace steps at once.
+pub const DEFAULT_MAX_CONCURRENT_STEPS: usize = 2;
+
 /// Bounded-work policy shared by embedded and standalone drivers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GrepWorkerConfig {
+    /// Build or fold steps allowed to execute concurrently across namespaces.
+    pub max_concurrent_steps: usize,
     /// Revisions examined per build step.
     pub max_files_per_step: usize,
     /// Content bytes read per build step.
@@ -37,6 +45,12 @@ impl GrepWorkerConfig {
 
     /// Rejects zero step budgets.
     pub fn validate(self) -> Result<(), GrepWorkerConfigError> {
+        if self.max_concurrent_steps == 0 {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field: "max_concurrent_steps",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
         if let Some(field) = self.build_policy().zero_budget_field() {
             return Err(GrepWorkerConfigError::InvalidField {
                 field,
@@ -51,6 +65,7 @@ impl Default for GrepWorkerConfig {
     fn default() -> Self {
         let policy = GramIndexBuildPolicy::default();
         Self {
+            max_concurrent_steps: DEFAULT_MAX_CONCURRENT_STEPS,
             max_files_per_step: policy.max_files_per_step,
             max_content_bytes_per_step: policy.max_content_bytes_per_step,
             max_rows_per_segment: policy.max_rows_per_segment,
@@ -90,6 +105,13 @@ mod tests {
     #[test]
     fn zero_policy_fields_are_rejected() {
         for (field, config) in [
+            (
+                "max_concurrent_steps",
+                GrepWorkerConfig {
+                    max_concurrent_steps: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
             (
                 "max_files_per_step",
                 GrepWorkerConfig {

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -6,11 +6,38 @@ use loonfs_objectstore::ObjectStore;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, watch, Notify};
+use tokio::sync::{mpsc, watch, Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinError, JoinHandle};
 
 const ERROR_BACKOFF_BASE_MS: u64 = 10;
 const ERROR_BACKOFF_CAP_MS: u64 = 1_000;
+
+/// Shared cap on concurrently executing grep build or fold steps.
+///
+/// Tokio's semaphore admits queued drivers in FIFO order, so a namespace
+/// waiting behind busy siblings cannot be starved by later arrivals.
+#[derive(Debug, Clone)]
+pub struct GrepStepLimiter {
+    permits: Arc<Semaphore>,
+}
+
+impl GrepStepLimiter {
+    /// Creates a shared limiter. Direct callers receive the same safe
+    /// normalization as directly supplied build policies; config rejects zero.
+    pub fn new(max_concurrent_steps: usize) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(max_concurrent_steps.max(1))),
+        }
+    }
+
+    async fn acquire(&self) -> OwnedSemaphorePermit {
+        self.permits
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("grep step semaphore is never closed")
+    }
+}
 
 /// Why a per-namespace driver has no immediate work.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,6 +159,7 @@ pub struct GrepDriver<S> {
     worker: GrepWorker<S>,
     namespace_id: NamespaceId,
     policy: GramIndexBuildPolicy,
+    step_limiter: GrepStepLimiter,
     handle: GrepDriverHandle,
     work: mpsc::Receiver<()>,
 }
@@ -142,6 +170,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
         worker: GrepWorker<S>,
         namespace_id: NamespaceId,
         policy: GramIndexBuildPolicy,
+        step_limiter: GrepStepLimiter,
     ) -> Self {
         let (state, _) = watch::channel(GrepDriverState::Active);
         let (work_send, work) = mpsc::channel(1);
@@ -152,6 +181,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
             worker,
             namespace_id,
             policy,
+            step_limiter,
             handle: GrepDriverHandle {
                 control: Arc::new(DriverControl {
                     stopping: AtomicBool::new(false),
@@ -205,11 +235,13 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
             if self.stopping() {
                 return None;
             }
-            let build = match self
+            let step_permit = self.acquire_step_permit().await?;
+            let build_result = self
                 .worker
                 .build_step(&self.namespace_id, self.policy)
-                .await
-            {
+                .await;
+            drop(step_permit);
+            let build = match build_result {
                 Ok(report) => report.outcome,
                 Err(error)
                     if matches!(
@@ -234,7 +266,10 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
                 return Some(GrepDriverParked::NotEnabled);
             }
 
-            let fold = match self.worker.fold_step(&self.namespace_id, self.policy).await {
+            let step_permit = self.acquire_step_permit().await?;
+            let fold_result = self.worker.fold_step(&self.namespace_id, self.policy).await;
+            drop(step_permit);
+            let fold = match fold_result {
                 Ok(report) => report.outcome,
                 Err(error) => {
                     consecutive_failures = consecutive_failures.saturating_add(1);
@@ -299,6 +334,16 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
 
     fn stopping(&self) -> bool {
         self.handle.control.stopping.load(Ordering::Acquire)
+    }
+
+    async fn acquire_step_permit(&self) -> Option<OwnedSemaphorePermit> {
+        if self.stopping() {
+            return None;
+        }
+        tokio::select! {
+            permit = self.step_limiter.acquire() => Some(permit),
+            () = self.handle.control.stop_notify.notified() => None,
+        }
     }
 
     fn set_state(&self, state: GrepDriverState) {

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -19,8 +19,11 @@ pub mod root;
 mod service;
 mod worker;
 
-pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
-pub use driver::{GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask};
+pub use config::{GrepWorkerConfig, GrepWorkerConfigError, DEFAULT_MAX_CONCURRENT_STEPS};
+pub use driver::{
+    GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask,
+    GrepStepLimiter,
+};
 pub use error::GrepError as Error;
 pub use error::{GrepError, Result};
 pub use service::{

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -5,7 +5,8 @@ use loonfs_api::NamespaceId;
 use loonfs_core::control::load_namespace_head_control;
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
-    GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask, GrepWorker, GrepWorkerConfig,
+    GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask, GrepStepLimiter, GrepWorker,
+    GrepWorkerConfig,
 };
 use loonfs_objectstore::{SharedObjectStore, StoreConfig};
 use serde::Deserialize;
@@ -138,12 +139,14 @@ async fn run() -> Result<(), StandaloneError> {
     }
 
     let runtime = tokio::runtime::Handle::current();
+    let step_limiter = GrepStepLimiter::new(config.grep.max_concurrent_steps);
     let mut drivers = Vec::with_capacity(namespace_ids.len());
     for namespace_id in &namespace_ids {
         let task = GrepDriver::new(
             worker.clone(),
             namespace_id.clone(),
             config.grep.build_policy(),
+            step_limiter.clone(),
         )
         .spawn_on(&runtime);
         drivers.push((namespace_id.clone(), task));

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -17,7 +17,7 @@ use loonfs_core::{BootstrapOptions, NamespaceEngine, RuntimeReadContext};
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask,
-    GrepIndexSnapshot, GrepService, GrepWorker,
+    GrepIndexSnapshot, GrepService, GrepStepLimiter, GrepWorker,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
@@ -213,8 +213,13 @@ fn spawn_driver(
     worker: GrepWorker<SharedObjectStore>,
     namespace_id: NamespaceId,
 ) -> GrepDriverTask {
-    GrepDriver::new(worker, namespace_id, GramIndexBuildPolicy::default())
-        .spawn_on(&tokio::runtime::Handle::current())
+    GrepDriver::new(
+        worker,
+        namespace_id,
+        GramIndexBuildPolicy::default(),
+        GrepStepLimiter::new(1),
+    )
+    .spawn_on(&tokio::runtime::Handle::current())
 }
 
 fn spawn_poll(

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -1,10 +1,11 @@
 //! The atomic grep root pointer, immutable manifests, and publication boundary.
 //!
 //! One immutable manifest pairs the query-visible segment set with its
-//! `built_through_seq` watermark, lifecycle, in-progress fold, and run
-//! ordinal allocation. Publication writes that manifest create-if-absent,
-//! then installs a tiny pointer in one object-store compare-and-swap, so a
-//! reader never observes a watermark without the segments that implement it.
+//! `(built_through_seq, next_delta_index)` cursor, lifecycle, in-progress
+//! fold, and run ordinal allocation. Publication writes that manifest
+//! create-if-absent, then installs a tiny pointer in one object-store
+//! compare-and-swap, so a reader never observes a cursor without the segments
+//! that implement it.
 //!
 //! Segment and manifest objects are immutable derived data written before
 //! the pointer CAS. A CAS loser therefore leaks only unreachable derived

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -183,8 +183,15 @@ pub struct GrepFoldState {
 pub struct GrepIndexState {
     /// Version of this nested index-state schema.
     pub format_version: u32,
-    /// Changes at or below this sequence are represented by `segments`.
+    /// Sequence of the commit at the index cursor.
     pub built_through_seq: ChangeSeq,
+    /// Offset of the next delta within `built_through_seq`, or zero when the
+    /// cursor is at the commit boundary and the whole commit is represented.
+    ///
+    /// WAL commit deltas retain their durable vector order; incremental
+    /// indexing relies on that stable order when it resumes within a commit.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub next_delta_index: u32,
     /// One in-progress partitioned fold, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fold: Option<GrepFoldState>,
@@ -196,16 +203,22 @@ impl GrepIndexState {
     /// Creates index bookkeeping in the current grep-owned format.
     pub fn new(
         built_through_seq: ChangeSeq,
+        next_delta_index: u32,
         fold: Option<GrepFoldState>,
         next_run_ordinal: u64,
     ) -> Self {
         Self {
             format_version: GREP_INDEX_FORMAT_VERSION,
             built_through_seq,
+            next_delta_index,
             fold,
             next_run_ordinal,
         }
     }
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 /// Query-visible descriptor for one immutable grep segment.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -79,6 +79,7 @@ pub struct GrepIndexSnapshot {
 #[derive(Debug, Clone)]
 struct MaterializedGrepIndexSnapshot {
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     segments: Vec<GrepQuerySegment>,
 }
 
@@ -194,6 +195,7 @@ impl GrepIndexSnapshot {
         Self {
             state: Ok(MaterializedGrepIndexSnapshot {
                 built_through_seq: root.index().built_through_seq,
+                next_delta_index: root.index().next_delta_index,
                 segments,
             }),
         }
@@ -464,19 +466,39 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     Ok(postings)
 }
 
-/// The file revisions committed after the index watermark, newest revision
-/// per inode, from WAL replay — the exhaustive-scan tail.
+/// The file revisions after the index cursor, newest revision per inode, from
+/// WAL replay — the exhaustive-scan tail. A cursor within its watermark
+/// commit includes only that commit's remaining delta-vector suffix.
 async fn tail_revisions<S: ObjectStore + ?Sized>(
     store: &S,
     view: &LoadedMetadataView<'_, S>,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
 ) -> Result<BTreeSet<InodeId>> {
     let mut tail = BTreeMap::new();
-    for record in view
-        .grep_wal_records_after(store, built_through_seq)
-        .await?
-    {
-        for delta in &record.deltas {
+    let after_seq = if next_delta_index == 0 {
+        built_through_seq
+    } else {
+        ChangeSeq(built_through_seq.0.saturating_sub(1))
+    };
+    for record in view.grep_wal_records_after(store, after_seq).await? {
+        let start_delta_index = if record.seq == built_through_seq {
+            usize::try_from(next_delta_index).map_err(|_| {
+                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+            })?
+        } else {
+            0
+        };
+        if start_delta_index > record.deltas.len() {
+            return Err(GrepError::CorruptIndex {
+                message: format!(
+                    "grep delta cursor `{next_delta_index}` exceeds commit `{}` length `{}`",
+                    record.seq,
+                    record.deltas.len()
+                ),
+            });
+        }
+        for delta in record.deltas.iter().skip(start_delta_index) {
             if let WalDelta::AppendFileRevision { inode_id, .. } = &delta.delta {
                 tail.insert(*inode_id, ());
             }
@@ -748,7 +770,13 @@ impl GrepService {
             }
         }
 
-        let tail = tail_revisions(store, view, snapshot.built_through_seq).await?;
+        let tail = tail_revisions(
+            store,
+            view,
+            snapshot.built_through_seq,
+            snapshot.next_delta_index,
+        )
+        .await?;
         let mut tail_scanned = true;
         if tail.len() > MAX_GREP_TAIL_FILES {
             if request.allow_stale {
@@ -764,7 +792,7 @@ impl GrepService {
                 .into());
             }
         } else {
-            candidates.unfiltered.extend(tail);
+            candidates.unfiltered.extend(tail.iter().copied());
         }
 
         let mut matches: Vec<GrepMatch> = Vec::new();
@@ -833,7 +861,7 @@ impl GrepService {
                 // unindexed revision while tail-only files stay invisible
                 // — a mix of two snapshots rather than a stale-but-
                 // consistent one.
-                if !tail_scanned && revision.committed_seq > snapshot.built_through_seq {
+                if !tail_scanned && tail.contains(&inode_id) {
                     rejected_frontier = Some(inode_id);
                     continue;
                 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -311,6 +311,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepLifecycle::Disabled,
             GrepIndexState::new(
                 current.state().index().built_through_seq,
+                0,
                 None,
                 current.state().index().next_run_ordinal,
             ),
@@ -392,6 +393,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     namespace_id,
                     &content_store_id,
                     current.state().index().built_through_seq,
+                    current.state().index().next_delta_index,
                     policy,
                 )
                 .await?
@@ -562,6 +564,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             lifecycle,
             GrepIndexState::new(
                 unit.built_through_seq,
+                unit.next_delta_index,
                 current.state().index().fold.clone(),
                 next_run_ordinal,
             ),
@@ -614,7 +617,7 @@ fn backfilling_root(
             backfill_cursor: String::new(),
             checkpoint_id: Some(checkpoint_id),
         },
-        GrepIndexState::new(target_seq, None, next_run_ordinal),
+        GrepIndexState::new(target_seq, 0, None, next_run_ordinal),
         Vec::new(),
     )
     .map_err(core_state_error)
@@ -636,6 +639,7 @@ struct CollectedIndexUnit {
     skipped_revisions: u64,
     run_seq: ChangeSeq,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     backfill_cursor: Option<String>,
 }
 
@@ -659,6 +663,7 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
         skipped_revisions: 0,
         run_seq: target_seq,
         built_through_seq: target_seq,
+        next_delta_index: 0,
         backfill_cursor: Some(cursor.to_owned()),
     };
     let mut pending = Vec::new();
@@ -695,9 +700,15 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     policy: GramIndexBuildPolicy,
 ) -> Result<IncrementalCollection> {
-    let feed = load_grep_change_feed(store, namespace_id, built_through_seq).await?;
+    let after_seq = if next_delta_index == 0 {
+        built_through_seq
+    } else {
+        ChangeSeq(built_through_seq.0.saturating_sub(1))
+    };
+    let feed = load_grep_change_feed(store, namespace_id, after_seq).await?;
     let GrepChangeFeed::Records { records, .. } = feed else {
         return Ok(IncrementalCollection::RebootstrapRequired);
     };
@@ -710,18 +721,24 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
         skipped_revisions: 0,
         run_seq: built_through_seq,
         built_through_seq,
+        next_delta_index,
         backfill_cursor: None,
     };
     let mut pending = Vec::new();
     let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
-    for record in records {
-        if examined_files >= policy.max_files_per_step
-            || planned_content_bytes >= policy.max_content_bytes_per_step
-        {
-            break;
+    'records: for record in records {
+        let start_delta_index = if record.seq == built_through_seq {
+            usize::try_from(next_delta_index).map_err(|_| {
+                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+            })?
+        } else {
+            0
+        };
+        if start_delta_index > record.deltas.len() {
+            return Ok(IncrementalCollection::RebootstrapRequired);
         }
-        for delta in &record.deltas {
+        for (delta_index, delta) in record.deltas.iter().enumerate().skip(start_delta_index) {
             if let WalDelta::AppendFileRevision {
                 inode_id,
                 revision_no,
@@ -729,6 +746,19 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                 ..
             } = &delta.delta
             {
+                let would_exceed_content_budget = planned_content_bytes > 0
+                    && planned_content_bytes.saturating_add(content_ref.size_bytes)
+                        > policy.max_content_bytes_per_step;
+                if examined_files >= policy.max_files_per_step || would_exceed_content_budget {
+                    if delta_index > 0 {
+                        unit.built_through_seq = record.seq;
+                        unit.run_seq = record.seq;
+                        unit.next_delta_index = u32::try_from(delta_index).map_err(|_| {
+                            CoreError::Internal("grep delta cursor overflow".to_owned())
+                        })?;
+                    }
+                    break 'records;
+                }
                 examined_files += 1;
                 if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
                     unit.skipped_revisions += 1;
@@ -740,12 +770,30 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                         content_ref: content_ref.clone(),
                     });
                 }
+                if examined_files >= policy.max_files_per_step
+                    || planned_content_bytes >= policy.max_content_bytes_per_step
+                {
+                    unit.built_through_seq = record.seq;
+                    unit.run_seq = record.seq;
+                    let next_delta_index = delta_index.checked_add(1).ok_or_else(|| {
+                        CoreError::Internal("grep delta cursor overflow".to_owned())
+                    })?;
+                    if next_delta_index < record.deltas.len() {
+                        unit.next_delta_index = u32::try_from(next_delta_index).map_err(|_| {
+                            CoreError::Internal("grep delta cursor overflow".to_owned())
+                        })?;
+                    } else {
+                        unit.next_delta_index = 0;
+                    }
+                    break 'records;
+                }
             }
         }
         unit.built_through_seq = record.seq;
         unit.run_seq = record.seq;
+        unit.next_delta_index = 0;
     }
-    if unit.built_through_seq == built_through_seq {
+    if unit.built_through_seq == built_through_seq && unit.next_delta_index == next_delta_index {
         return Ok(IncrementalCollection::UpToDate);
     }
     load_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
@@ -1029,6 +1077,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             current.state().lifecycle().clone(),
             GrepIndexState::new(
                 current.state().index().built_through_seq,
+                current.state().index().next_delta_index,
                 fold,
                 next_run_ordinal,
             ),

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -1,19 +1,29 @@
 #![allow(clippy::panic)]
 //! Per-namespace driver isolation, backoff, and explicit-GC boundaries.
 
+use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
 use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, IndexSegmentId, NamespaceId};
 use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
 use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use loonfs_core::{BootstrapOptions, DeleteNamespaceOptions, NamespaceEngine};
 use loonfs_grep::keyspace::{root_key, segment_key};
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepWorker,
+    GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepStepLimiter,
+    GrepWorker,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::ObjectStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::future::Future;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
+use tokio::sync::Notify;
 
 #[tokio::test]
 async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explicit() {
@@ -45,10 +55,21 @@ async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explici
         .expect("poison root");
 
     let runtime = tokio::runtime::Handle::current();
-    let poisoned_task = GrepDriver::new(worker.clone(), poisoned, GramIndexBuildPolicy::default())
-        .spawn_on(&runtime);
-    let healthy_task =
-        GrepDriver::new(worker, healthy, GramIndexBuildPolicy::default()).spawn_on(&runtime);
+    let step_limiter = GrepStepLimiter::new(2);
+    let poisoned_task = GrepDriver::new(
+        worker.clone(),
+        poisoned,
+        GramIndexBuildPolicy::default(),
+        step_limiter.clone(),
+    )
+    .spawn_on(&runtime);
+    let healthy_task = GrepDriver::new(
+        worker,
+        healthy,
+        GramIndexBuildPolicy::default(),
+        step_limiter,
+    )
+    .spawn_on(&runtime);
     assert_eq!(
         healthy_task.handle().wait_for_quiescence().await,
         Some(GrepDriverParked::CaughtUp {
@@ -99,8 +120,13 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
         .await
         .expect("delete namespace");
 
-    let task = GrepDriver::new(worker, namespace_id, GramIndexBuildPolicy::default())
-        .spawn_on(&tokio::runtime::Handle::current());
+    let task = GrepDriver::new(
+        worker,
+        namespace_id,
+        GramIndexBuildPolicy::default(),
+        GrepStepLimiter::new(1),
+    )
+    .spawn_on(&tokio::runtime::Handle::current());
     assert_eq!(
         task.handle().wait_for_quiescence().await,
         Some(GrepDriverParked::NotEnabled)
@@ -108,10 +134,201 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
     task.shutdown().await.expect("stop deleted driver");
 }
 
-async fn bootstrap(
-    store: Arc<LocalFsStore>,
+/// Namespace drivers keep their singleflight ownership but share one FIFO
+/// expensive-step cap. Blocking each namespace's sole backfill content read
+/// makes the number of simultaneously entered build steps directly visible.
+#[tokio::test]
+async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
+    const NAMESPACES: usize = 8;
+    const MAX_CONCURRENT_STEPS: usize = 2;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(StepConcurrencyStore::new(temp_dir.path()));
+    let worker = GrepWorker::new(
+        store.clone(),
+        "concurrency-driver-worker",
+        "concurrency-driver-session",
+        "concurrency-driver/0.1",
+    );
+    let mut namespace_ids = Vec::new();
+    for index in 0..NAMESPACES {
+        let namespace_id =
+            NamespaceId::parse(format!("concurrency-{index}")).expect("namespace id");
+        let engine = bootstrap(store.clone(), &namespace_id).await;
+        put_file(
+            &store,
+            &engine,
+            &namespace_id,
+            &format!("concurrency-put-{index}"),
+        )
+        .await;
+        worker.enable(&namespace_id).await.expect("enable grep");
+        namespace_ids.push(namespace_id);
+    }
+
+    store.pause_content_reads();
+    let limiter = GrepStepLimiter::new(MAX_CONCURRENT_STEPS);
+    let runtime = tokio::runtime::Handle::current();
+    let mut tasks = Vec::new();
+    for namespace_id in namespace_ids {
+        tasks.push(
+            GrepDriver::new(
+                worker.clone(),
+                namespace_id,
+                GramIndexBuildPolicy::default(),
+                limiter.clone(),
+            )
+            .spawn_on(&runtime),
+        );
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        store.wait_for_started(MAX_CONCURRENT_STEPS),
+    )
+    .await
+    .expect("the permitted drivers must enter their build steps");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), store.wait_for_started(3))
+            .await
+            .is_err(),
+        "a third namespace must remain queued while both permits are held"
+    );
+    assert_eq!(store.peak_in_flight(), MAX_CONCURRENT_STEPS);
+
+    store.resume_content_reads();
+    for task in &tasks {
+        assert_eq!(
+            task.handle().wait_for_quiescence().await,
+            Some(GrepDriverParked::CaughtUp {
+                built_through_seq: loonfs_api::ChangeSeq(1),
+            })
+        );
+    }
+    assert!(
+        store.peak_in_flight() <= MAX_CONCURRENT_STEPS,
+        "executing grep steps exceeded the shared cap"
+    );
+    for task in tasks {
+        task.shutdown().await.expect("stop concurrency driver");
+    }
+}
+
+#[derive(Debug)]
+struct StepConcurrencyStore {
+    inner: LocalFsStore,
+    pause_content_reads: AtomicBool,
+    started: AtomicUsize,
+    in_flight: AtomicUsize,
+    peak: AtomicUsize,
+    started_notify: Notify,
+    resume_notify: Notify,
+}
+
+impl StepConcurrencyStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("store"),
+            pause_content_reads: AtomicBool::new(false),
+            started: AtomicUsize::new(0),
+            in_flight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+            started_notify: Notify::new(),
+            resume_notify: Notify::new(),
+        }
+    }
+
+    fn pause_content_reads(&self) {
+        self.pause_content_reads.store(true, Ordering::Release);
+    }
+
+    fn resume_content_reads(&self) {
+        self.pause_content_reads.store(false, Ordering::Release);
+        self.resume_notify.notify_waiters();
+    }
+
+    fn peak_in_flight(&self) -> usize {
+        self.peak.load(Ordering::Acquire)
+    }
+
+    async fn wait_for_started(&self, target: usize) {
+        loop {
+            let notified = self.started_notify.notified();
+            if self.started.load(Ordering::Acquire) >= target {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn observe_content_read<T>(&self, key: &str, read: impl Future<Output = T>) -> T {
+        if !key.contains("/blobs/sha256/") {
+            return read.await;
+        }
+        let in_flight = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak.fetch_max(in_flight, Ordering::AcqRel);
+        self.started.fetch_add(1, Ordering::AcqRel);
+        self.started_notify.notify_waiters();
+        if self.pause_content_reads.load(Ordering::Acquire) {
+            loop {
+                let notified = self.resume_notify.notified();
+                if !self.pause_content_reads.load(Ordering::Acquire) {
+                    break;
+                }
+                notified.await;
+            }
+        }
+        let result = read.await;
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        result
+    }
+}
+
+#[async_trait]
+impl ObjectStore for StepConcurrencyStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.observe_content_read(key, self.inner.get_with_metadata(key))
+            .await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.observe_content_read(key, self.inner.get(key, range))
+            .await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+async fn bootstrap<S: ObjectStore + Clone>(
+    store: S,
     namespace_id: &NamespaceId,
-) -> NamespaceEngine<Arc<LocalFsStore>> {
+) -> NamespaceEngine<S> {
     let engine = NamespaceEngine::builder(store)
         .namespace_id(namespace_id.clone())
         .writer_id(format!("seed-{namespace_id}"))
@@ -126,17 +343,17 @@ async fn bootstrap(
     engine
 }
 
-async fn put_file(
-    store: &Arc<LocalFsStore>,
-    engine: &NamespaceEngine<Arc<LocalFsStore>>,
+async fn put_file<S: ObjectStore + Clone>(
+    store: &S,
+    engine: &NamespaceEngine<S>,
     namespace_id: &NamespaceId,
     commit_id: &str,
 ) {
-    let stored = store_bytes_as_content(&**store, namespace_id, b"driver needle\n")
+    let stored = store_bytes_as_content(store, namespace_id, b"driver needle\n")
         .await
         .expect("store content");
     let content_ref = stored.content_ref.clone();
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");
     let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -12,12 +12,12 @@ use loonfs_grep::root::{
 // fixtures: changing field names, ordering, enum tags, or omission rules must
 // change them deliberately. Together they represent every lifecycle state.
 const BACKFILLING_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:15277f5e958c561781b58ca8faff30a9284ef154e184bd662d76d1b7d34c6824","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":"revision-00000000000000000007","checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"fold":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:ed1974bcc4b70b0d2df55ca19c9aa1f6080abdebdbbaa873e963af80b32e9124","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_delta_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
 const DISABLED_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
 const ADDITIVE_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"future-writer/9.0","payload_checksum":"sha256:2582065ee15d356cbaf1b40d245207ab8e2b61e3ae2a86a108957baf41336be9","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":1,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
 
 const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:05115c1932ff163b89f566ff9b04601120830830898ec57129e781f19490c30f","payload":{"namespace_id":"docs","manifest_id":"15277f5e958c561781b58ca8faff30a9284ef154e184bd662d76d1b7d34c6824"}}"#;
-const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:f73e1fd3c768a4fd87544c4280554dc445ade14202104c3434b268115650d06d","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad"}}"#;
+const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:073ed9d53d4b99a865e05d0874580488d99f5ff1ff1635e50693958517c0d2e3","payload":{"namespace_id":"docs","manifest_id":"ed1974bcc4b70b0d2df55ca19c9aa1f6080abdebdbbaa873e963af80b32e9124"}}"#;
 const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:e5c0fbe19e4bee1cfb5ddf3a99f7c4439a83e4c323b1a6054bfa62e16a9c1d73","payload":{"namespace_id":"docs","manifest_id":"70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c"}}"#;
 const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"future-writer/9.0","payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","future_pointer":true},"future_envelope":{"retained":true}}"#;
 
@@ -25,7 +25,7 @@ const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","
 fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
     let cases = [
         (sample_backfilling_root(), BACKFILLING_V1),
-        (sample_steady_root(ChangeSeq(11)), STEADY_V1),
+        (sample_steady_root(ChangeSeq(11), 5), STEADY_V1),
         (sample_disabled_root(), DISABLED_V1),
     ];
 
@@ -58,7 +58,7 @@ fn decoders_read_frozen_v1_bytes_with_additive_fields() {
     let decoded =
         decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
 
-    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11)));
+    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
     let pointer =
         decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()).expect("decode additive pointer fixture");
     assert_eq!(
@@ -107,7 +107,7 @@ fn decoder_rejects_truncated_payload() {
 
 #[test]
 fn constructor_rejects_fold_segment_mismatch() {
-    let mut index = GrepIndexState::new(ChangeSeq(7), None, 2);
+    let mut index = GrepIndexState::new(ChangeSeq(7), 0, None, 2);
     index.fold = Some(GrepFoldState {
         snapshot_segment_ids: vec![segment_id(9)],
         output_segment_ids: Vec::new(),
@@ -144,7 +144,7 @@ fn sample_backfilling_root() -> GrepRootState {
                     .expect("valid checkpoint id"),
             ),
         },
-        GrepIndexState::new(ChangeSeq(7), Some(fold), 4),
+        GrepIndexState::new(ChangeSeq(7), 0, Some(fold), 4),
         vec![
             segment_ref(1, 1, 0, 0),
             segment_ref(2, 2, 0, 0),
@@ -154,11 +154,11 @@ fn sample_backfilling_root() -> GrepRootState {
     .expect("valid backfilling root")
 }
 
-fn sample_steady_root(built_through_seq: ChangeSeq) -> GrepRootState {
+fn sample_steady_root(built_through_seq: ChangeSeq, next_delta_index: u32) -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, None, 2),
+        GrepIndexState::new(built_through_seq, next_delta_index, None, 2),
         vec![segment_ref(1, 1, 0, 0)],
     )
     .expect("valid steady root")
@@ -168,7 +168,7 @@ fn sample_disabled_root() -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Disabled,
-        GrepIndexState::new(ChangeSeq(15), None, 4),
+        GrepIndexState::new(ChangeSeq(15), 0, None, 4),
         Vec::new(),
     )
     .expect("valid disabled root")

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -137,7 +137,7 @@ fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootStat
     GrepRootState::new(
         namespace_id,
         GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, None, 0),
+        GrepIndexState::new(built_through_seq, 0, None, 0),
         Vec::new(),
     )
     .expect("valid root")

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -124,6 +124,19 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
     assert!(stderr.contains("poll_interval_ms"), "{stderr}");
     assert!(stderr.contains("greater than zero"), "{stderr}");
 
+    let bad_grep_config_path = temp_dir.path().join("bad-grep-worker.toml");
+    write_config(
+        &bad_grep_config_path,
+        &store_root,
+        "",
+        "max_concurrent_steps = 0\n",
+    );
+    let bad = run_once(&bad_grep_config_path, &[&namespace_id]);
+    assert!(!bad.status.success(), "zero step cap must exit nonzero");
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    assert!(stderr.contains("max_concurrent_steps"), "{stderr}");
+    assert!(stderr.contains("greater than zero"), "{stderr}");
+
     let missing_namespace = Command::new(env!("CARGO_BIN_EXE_loonfs-grep"))
         .arg("--config")
         .arg(&config_path)

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -179,6 +179,8 @@ impl GrepMode {
 #[serde(default, deny_unknown_fields)]
 pub struct GrepConfig {
     pub mode: GrepMode,
+    /// Build or fold steps allowed to execute concurrently across namespaces.
+    pub max_concurrent_steps: usize,
     pub max_files_per_step: usize,
     pub max_content_bytes_per_step: u64,
     pub max_rows_per_segment: usize,
@@ -191,6 +193,7 @@ impl GrepConfig {
     /// Returns the shared bounded-step configuration represented by this table.
     pub fn worker_config(self) -> GrepWorkerConfig {
         GrepWorkerConfig {
+            max_concurrent_steps: self.max_concurrent_steps,
             max_files_per_step: self.max_files_per_step,
             max_content_bytes_per_step: self.max_content_bytes_per_step,
             max_rows_per_segment: self.max_rows_per_segment,
@@ -206,6 +209,7 @@ impl Default for GrepConfig {
         let worker = GrepWorkerConfig::default();
         Self {
             mode: GrepMode::Embedded,
+            max_concurrent_steps: worker.max_concurrent_steps,
             max_files_per_step: worker.max_files_per_step,
             max_content_bytes_per_step: worker.max_content_bytes_per_step,
             max_rows_per_segment: worker.max_rows_per_segment,
@@ -857,6 +861,7 @@ writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
 [grep]
+max_concurrent_steps = 0
 max_fold_rows_per_step = 0
 
 [store]
@@ -864,7 +869,7 @@ kind = "local-fs"
 root = "/tmp/loonfs-server"
 "#,
         );
-        let error = load_server_config(&path).expect_err("zero gram budget must be rejected");
+        let error = load_server_config(&path).expect_err("zero grep bound must be rejected");
         assert_invalid_field(error, "grep");
     }
 
@@ -1170,6 +1175,7 @@ writer_version = "loonfs-server/0.1.0"
 
 [grep]
 mode = "serve_only"
+max_concurrent_steps = 7
 max_files_per_step = 4096
 max_content_bytes_per_step = 536870912
 max_rows_per_segment = 131072
@@ -1185,6 +1191,7 @@ root = "/tmp/loonfs-server"
 
         let grep = load_server_config(&path).expect("load config").grep;
         assert_eq!(grep.mode, super::GrepMode::ServeOnly);
+        assert_eq!(grep.max_concurrent_steps, 7);
         let policy = grep.worker_config().build_policy();
         assert_eq!(policy.max_files_per_step, 4096);
         assert_eq!(policy.max_content_bytes_per_step, 536_870_912);

--- a/crates/loonfs-server/src/grep_drivers.rs
+++ b/crates/loonfs-server/src/grep_drivers.rs
@@ -3,7 +3,7 @@
 use loonfs::{NamespaceId, RuntimeError, SharedObjectStore};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverTask,
-    GrepWorker,
+    GrepStepLimiter, GrepWorker,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -16,6 +16,7 @@ pub(crate) struct GrepDrivers {
 struct GrepDriversInner {
     worker: GrepWorker<SharedObjectStore>,
     policy: GramIndexBuildPolicy,
+    step_limiter: GrepStepLimiter,
     runtime: tokio::runtime::Handle,
     tasks: Mutex<HashMap<NamespaceId, GrepDriverTask>>,
     finished: Mutex<Vec<GrepDriverTask>>,
@@ -25,6 +26,7 @@ impl GrepDrivers {
     pub(crate) fn new(
         worker: GrepWorker<SharedObjectStore>,
         policy: GramIndexBuildPolicy,
+        max_concurrent_steps: usize,
     ) -> Result<Self, crate::ServerConfigError> {
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
             crate::ServerConfigError::InvalidField {
@@ -36,6 +38,7 @@ impl GrepDrivers {
             inner: Arc::new(GrepDriversInner {
                 worker,
                 policy,
+                step_limiter: GrepStepLimiter::new(max_concurrent_steps),
                 runtime,
                 tasks: Mutex::new(HashMap::new()),
                 finished: Mutex::new(Vec::new()),
@@ -63,6 +66,7 @@ impl GrepDrivers {
             self.inner.worker.clone(),
             namespace_id.clone(),
             self.inner.policy,
+            self.inner.step_limiter.clone(),
         )
         .spawn_on(&self.inner.runtime);
         let handle = task.handle();

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -284,11 +284,16 @@ async fn start_driver_for_query_if_needed(
     };
     let needs_catch_up = match root.state().lifecycle() {
         GrepLifecycle::Backfilling { .. } => true,
-        GrepLifecycle::Steady => state
-            .admin
-            .namespace_status(namespace_id)
-            .await
-            .is_ok_and(|status| root.state().index().built_through_seq < status.head_seq),
+        GrepLifecycle::Steady => {
+            state
+                .admin
+                .namespace_status(namespace_id)
+                .await
+                .is_ok_and(|status| {
+                    root.state().index().next_delta_index != 0
+                        || root.state().index().built_through_seq < status.head_seq
+                })
+        }
         GrepLifecycle::Disabled => false,
     };
     if needs_catch_up {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -230,6 +230,7 @@ async fn app_with_store_and_transfer_issuer(
                 .expect("driver-running grep mode should serve grep")
                 .clone(),
             config.grep.worker_config().build_policy(),
+            config.grep.max_concurrent_steps,
         )?)
     } else {
         None

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -7,12 +7,12 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs::{
-    ChangeSeq, CreateNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter, GrepRequest,
-    NamespaceId, PutFileOptions,
+    ChangeSeq, CommitId, CommitOp, CommitRequest, CreateNamespaceOptions, ErrorCode, FsAdmin,
+    FsReader, FsWriter, GrepRequest, InodeId, NamespaceId, PutFileOptions,
 };
 use loonfs_api::decode_grep_cursor;
 use loonfs_grep::codec::INDEX_GRAMS_MAX_FILE_BYTES;
-use loonfs_grep::{GramIndexBuildPolicy, GrepWorker};
+use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -380,6 +380,254 @@ async fn a_worker_policy_bounds_each_build_step() {
     writer.shutdown_background().await.expect("writer shutdown");
 }
 
+/// A single legal commit can carry thousands of file revisions. The content
+/// budget must split that one WAL record at a durable delta cursor, queries
+/// must combine the indexed prefix with only its unindexed suffix, and a new
+/// worker must resume without reading the prefix again.
+#[tokio::test]
+async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumable() {
+    const FILES: usize = 1_000;
+    const FILES_PER_STEP: usize = 500;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(BuildContentAccountingStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-thousand-atomic").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-thousand-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-thousand-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    let first_worker = grep_worker(&store);
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    first_worker
+        .build_step(&namespace_id, GramIndexBuildPolicy::default())
+        .await
+        .expect("materialize empty backfill");
+
+    let content_bytes = format!("bounded needle file {:04}\n", 0).len();
+    let max_content_bytes_per_step = (content_bytes * FILES_PER_STEP) as u64;
+    let policy = GramIndexBuildPolicy {
+        max_files_per_step: FILES,
+        max_content_bytes_per_step,
+        max_l0_runs: usize::MAX,
+        ..GramIndexBuildPolicy::default()
+    };
+    let mut ops = Vec::with_capacity(FILES);
+    let mut prepared = Vec::with_capacity(FILES);
+    for index in 0..FILES {
+        let bytes = format!("bounded needle file {index:04}\n");
+        assert_eq!(bytes.len(), content_bytes);
+        let content = writer
+            .prepare_file_bytes(&namespace_id, bytes.as_bytes())
+            .await
+            .expect("prepare atomic-commit content");
+        ops.push(CommitOp::CreateFile {
+            parent_inode_id: InodeId(1),
+            display_name: format!("bounded-{index:04}.txt"),
+            content_ref: content.content_ref().clone(),
+        });
+        prepared.push(content);
+    }
+    let commit = writer
+        .commit_operations_prepared(
+            &namespace_id,
+            CommitRequest {
+                commit_id: CommitId::parse("thousand-file-atomic").expect("commit id"),
+                preconditions: Vec::new(),
+                ops,
+                message: None,
+            },
+            prepared,
+        )
+        .await
+        .expect("publish thousand-file commit");
+
+    raw_store.reset_content_reads();
+    let first = first_worker
+        .build_step(&namespace_id, policy)
+        .await
+        .expect("first bounded build");
+    assert!(matches!(
+        first.outcome,
+        GrepBuildOutcome::Published {
+            indexed_revisions,
+            ..
+        } if indexed_revisions == FILES_PER_STEP as u64
+    ));
+    let first_reads = raw_store.take_content_reads();
+    assert_eq!(first_reads.len(), FILES_PER_STEP);
+    assert!(
+        content_read_bytes(&first_reads) <= max_content_bytes_per_step,
+        "first step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
+        content_read_bytes(&first_reads)
+    );
+
+    let partial = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load partial grep root")
+        .expect("partial grep root");
+    assert_eq!(
+        partial.state().index().built_through_seq,
+        commit.committed_seq
+    );
+    assert!(
+        partial.state().index().next_delta_index > 0,
+        "the first step must stop within the atomic commit"
+    );
+    let prefix_segment_ids: BTreeSet<_> = partial
+        .state()
+        .segments()
+        .iter()
+        .map(|segment| segment.segment_id.clone())
+        .collect();
+
+    assert_grep_paths(
+        &reader,
+        &namespace_id,
+        "file 0000",
+        BTreeSet::from(["/bounded-0000.txt".to_owned()]),
+    )
+    .await;
+    assert_grep_paths(
+        &reader,
+        &namespace_id,
+        "file 0999",
+        BTreeSet::from(["/bounded-0999.txt".to_owned()]),
+    )
+    .await;
+    assert_eq!(
+        collect_grep_paths(&reader, &namespace_id, "bounded needle")
+            .await
+            .len(),
+        FILES,
+        "the indexed prefix and unindexed suffix must produce every file exactly once"
+    );
+
+    // Simulate a crash: the fresh worker has no in-memory collection state and
+    // can resume only from the published manifest cursor.
+    let resumed_worker = GrepWorker::new(
+        store.clone(),
+        "grams-resumed-worker",
+        "grams-resumed-session",
+        "grams-test/0.1",
+    );
+    raw_store.reset_content_reads();
+    let second = resumed_worker
+        .build_step(&namespace_id, policy)
+        .await
+        .expect("resumed bounded build");
+    assert!(matches!(
+        second.outcome,
+        GrepBuildOutcome::Published {
+            indexed_revisions,
+            ..
+        } if indexed_revisions == FILES_PER_STEP as u64
+    ));
+    let second_reads = raw_store.take_content_reads();
+    assert_eq!(second_reads.len(), FILES_PER_STEP);
+    assert!(
+        content_read_bytes(&second_reads) <= max_content_bytes_per_step,
+        "resumed step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
+        content_read_bytes(&second_reads)
+    );
+    let first_keys: BTreeSet<_> = first_reads.iter().map(|(key, _)| key).collect();
+    let second_keys: BTreeSet<_> = second_reads.iter().map(|(key, _)| key).collect();
+    assert!(
+        first_keys.is_disjoint(&second_keys),
+        "the fresh worker must not re-read any indexed-prefix content"
+    );
+    assert_eq!(first_keys.len() + second_keys.len(), FILES);
+
+    let complete = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load complete grep root")
+        .expect("complete grep root");
+    assert_eq!(
+        complete.state().index().built_through_seq,
+        commit.committed_seq
+    );
+    assert_eq!(complete.state().index().next_delta_index, 0);
+    let complete_segment_ids: BTreeSet<_> = complete
+        .state()
+        .segments()
+        .iter()
+        .map(|segment| segment.segment_id.clone())
+        .collect();
+    assert!(
+        prefix_segment_ids.is_subset(&complete_segment_ids),
+        "resume must retain the prefix segments instead of replacing them"
+    );
+    assert_eq!(
+        collect_grep_paths(&reader, &namespace_id, "bounded needle")
+            .await
+            .len(),
+        FILES
+    );
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+async fn assert_grep_paths(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    pattern: &str,
+    expected: BTreeSet<String>,
+) {
+    assert_eq!(
+        collect_grep_paths(reader, namespace_id, pattern).await,
+        expected
+    );
+}
+
+async fn collect_grep_paths(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    pattern: &str,
+) -> BTreeSet<String> {
+    let mut request = grep_request(pattern);
+    request.limit = Some(1_000);
+    let mut paths = BTreeSet::new();
+    loop {
+        let response = reader
+            .grep(namespace_id, &request)
+            .await
+            .expect("grep bounded atomic commit");
+        paths.extend(
+            response
+                .matches
+                .into_iter()
+                .map(|found| found.absolute_path),
+        );
+        let Some(cursor) = response.next_cursor else {
+            return paths;
+        };
+        request.cursor = Some(cursor);
+    }
+}
+
+fn content_read_bytes(reads: &[(String, usize)]) -> u64 {
+    reads.iter().map(|(_, bytes)| *bytes as u64).sum::<u64>()
+}
+
 /// Ten one-file rounds cross the default delta-fold threshold, so the
 /// worker steps tier the index (delta segments fold into a mid run)
 /// while the rounds run. Grep must answer identically before, across, and
@@ -466,6 +714,94 @@ async fn grep_answers_identically_across_tiered_folds() {
     );
 
     writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Accounts full content-blob GETs issued by one explicit worker step.
+#[derive(Debug)]
+struct BuildContentAccountingStore {
+    inner: LocalFsStore,
+    content_reads: Mutex<Vec<(String, usize)>>,
+}
+
+impl BuildContentAccountingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            content_reads: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn reset_content_reads(&self) {
+        self.content_reads
+            .lock()
+            .expect("content read accounting lock")
+            .clear();
+    }
+
+    fn take_content_reads(&self) -> Vec<(String, usize)> {
+        std::mem::take(
+            &mut *self
+                .content_reads
+                .lock()
+                .expect("content read accounting lock"),
+        )
+    }
+
+    fn record_content_read(&self, key: &str, bytes: usize) {
+        if key.contains("/blobs/sha256/") {
+            self.content_reads
+                .lock()
+                .expect("content read accounting lock")
+                .push((key.to_owned(), bytes));
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for BuildContentAccountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let body = self.inner.get_with_metadata(key).await?;
+        if let Some(body) = &body {
+            self.record_content_read(key, body.bytes.len());
+        }
+        Ok(body)
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let bytes = self.inner.get(key, range).await?;
+        if let Some(bytes) = &bytes {
+            self.record_content_read(key, bytes.len());
+        }
+        Ok(bytes)
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 /// Counts store GETs against gram index segment objects, so tests can

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -913,6 +913,7 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         current_state.lifecycle().clone(),
         GrepIndexState::new(
             current_state.index().built_through_seq,
+            current_state.index().next_delta_index,
             current_state.index().fold.clone(),
             current_state.index().next_run_ordinal + 1,
         ),

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -113,8 +113,11 @@ Segments live under
 `namespaces/{namespace}/extensions/grep/segments/`. The small mutable
 `extensions/grep/root.json` pointer names an immutable, content-derived
 manifest under `extensions/grep/manifests/`; that manifest records the
-query-visible segments, `built_through_seq`, lifecycle, run-ordinal
-allocation, and any in-progress fold snapshot, outputs, and cursor. The
+query-visible segments, the incremental
+`(built_through_seq, next_delta_index)` cursor, lifecycle, run-ordinal
+allocation, and any in-progress fold snapshot, outputs, and cursor. A zero
+or absent `next_delta_index` is the commit boundary; a nonzero value resumes
+at that offset in the watermark commit's durably ordered delta vector. The
 pointer and manifests are independent of the namespace manifest, so core
 never has to understand grep state to read the filesystem.
 
@@ -143,11 +146,14 @@ releases the checkpoint.
 
 One per-namespace driver owns those steps. Starting a driver immediately
 runs backfill and incremental catch-up continuously, yielding between bounded
-steps. Once the root is steady and its watermark reaches the namespace head,
-the driver parks without a timer. A nudge received while active coalesces into
-one more catch-up run; a nudge received while parked wakes it. Step failures
-back off exponentially inside only that namespace's driver, capped at one
-second, so a poisoned root cannot delay a sibling namespace.
+steps. Drivers share one FIFO semaphore, configured by
+`max_concurrent_steps` (default 2), and acquire it only while a build or fold
+step executes; parked drivers hold no permit. Once the root is steady and its
+watermark reaches the namespace head, the driver parks without a timer. A
+nudge received while active coalesces into one more catch-up run; a nudge
+received while parked wakes it. Step failures back off exponentially inside
+only that namespace's driver, capped at one second, so a poisoned root cannot
+delay a sibling namespace.
 
 In server `embedded` mode, enable and re-enable start the namespace driver,
 disable stops it, and successful runtime publications send a non-blocking


### PR DESCRIPTION
Two advertised bounds were not real. The step budget was evaluated at the commit boundary — once a commit's record was entered, every delta processed regardless — so a single legal 4,096-operation commit could make a step advertised as 64 MiB read gigabytes, in every deployment mode. And nothing capped how many namespace drivers executed expensive steps concurrently, so a busy multi-namespace server fanned out unbounded object reads while core maintenance next door already had the right idiom.

The budget becomes real through an intra-commit cursor: the manifest's index state gains next_delta_index alongside the watermark — omitted when zero, so the schema change is additive within version one and zero-valued fixtures stay byte-identical — and budgets are enforced per delta, publishing the exact resume position mid-commit when they trip. The correctness crux is the tail: a query now scans the watermark commit's remaining delta suffix plus everything after, preserving exact semantics on both sides of the cursor — a mid-commit freeze test greps 1,000 files and finds each exactly once, indexed prefix and unindexed remainder alike — and an out-of-range cursor reports index_corrupt rather than clamping. The 1,000-file atomic commit now indexes in exactly two steps of 500 objects each, and crash-resume proves disjoint reads with unchanged prefix segments.

Concurrency follows core's max_concurrent idiom: one shared FIFO permit owned by the driver machinery and cloned across both hosts, held only during build/fold execution — parked drivers hold nothing, ownership and wakeups stay per-namespace. One new zero-rejected [grep] knob, max_concurrent_steps, defaulting to core maintenance's value; eight namespaces under a cap of two peaked at exactly two while all converged. No LSM, posting, or result-semantics changes anywhere.