### PR TITLE
test(server): bound raw http requests with socket timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
 name = "loonfs-grep"
 version = "0.1.1"
 dependencies = [
+ "async-trait",
  "bytes",
  "ciborium",
  "clap",

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -54,7 +54,9 @@ writer_version = "loonfs-server/0.1.0"
 # an external `loonfs-grep` process.
 #[grep]
 #mode = "embedded"
-# Bounded build/fold budgets; every value must be greater than zero.
+# Shared expensive-step cap and bounded build/fold budgets; every value must
+# be greater than zero.
+#max_concurrent_steps = 2
 #max_files_per_step = 256
 #max_content_bytes_per_step = 67108864
 #max_rows_per_segment = 65536

--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -153,6 +153,7 @@ error_codes! {
     RebootstrapRequired => "rebootstrap_required",
     QueryUnindexable => "query_unindexable",
     IndexLagging => "index_lagging",
+    IndexCorrupt => "index_corrupt",
     NamespaceCorrupt => "namespace_corrupt",
     ServerError => "server_error",
 }
@@ -192,7 +193,7 @@ impl ErrorCode {
             | ErrorCode::IndexLagging
             | ErrorCode::MaintenanceRequired => ErrorKind::Unavailable,
             ErrorCode::CommitOutcomeUnknown => ErrorKind::OutcomeUnknown,
-            ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
+            ErrorCode::IndexCorrupt | ErrorCode::NamespaceCorrupt => ErrorKind::DataCorruption,
             ErrorCode::ServerError => ErrorKind::Internal,
             // The spec deliberately surfaces precondition failures
             // (`stale_revision`, `stale_head`, `commit_id_reuse_conflict`) as

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -12,7 +12,7 @@ use loonfs::{
     gc_config_from_request, gc_response_from_report, BootstrapNamespaceError, ChangesResponse,
     CopyOptions, CoreError, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, ListChangesOptions,
+    ErrorCode, FsAdmin, FsBackgroundWork, FsReader, FsWriter, GrepError, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickResult, MoveOptions, PutFileOptions,
     RestoreRevisionOptions, RuntimeError, SharedObjectStore, TraceStoreKind, UndeleteOptions,
 };
@@ -518,6 +518,7 @@ fn map_runtime_error(error: RuntimeError) -> BackendError {
     match error {
         RuntimeError::Core(error) => map_core_error(error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
+        RuntimeError::Grep(error) => map_grep_error(error),
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
         other => BackendError::runtime_error(other.to_string()),
@@ -531,6 +532,7 @@ fn map_namespace_scoped_runtime_error(
     match error {
         RuntimeError::Core(error) => map_namespace_scoped_core_error(namespace_id, error),
         RuntimeError::Bootstrap(error) => map_bootstrap_error(error),
+        RuntimeError::Grep(error) => map_namespace_scoped_grep_error(namespace_id, error),
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
         other => BackendError::runtime_error(other.to_string()),
@@ -545,6 +547,13 @@ fn map_core_error(error: CoreError) -> BackendError {
     BackendError::new(error.code().as_str(), error.to_string())
 }
 
+fn map_grep_error(error: GrepError) -> BackendError {
+    match error {
+        GrepError::Core(error) => map_core_error(error),
+        error => BackendError::new(error.code().as_str(), error.to_string()),
+    }
+}
+
 fn map_namespace_scoped_core_error(namespace_id: &NamespaceId, error: CoreError) -> BackendError {
     if matches!(error.code(), ErrorCode::NamespaceNotFound) {
         return BackendError::new(
@@ -554,6 +563,13 @@ fn map_namespace_scoped_core_error(namespace_id: &NamespaceId, error: CoreError)
     }
 
     map_core_error(error)
+}
+
+fn map_namespace_scoped_grep_error(namespace_id: &NamespaceId, error: GrepError) -> BackendError {
+    match error {
+        GrepError::Core(error) => map_namespace_scoped_core_error(namespace_id, error),
+        error => BackendError::new(error.code().as_str(), error.to_string()),
+    }
 }
 
 fn map_bootstrap_error(error: BootstrapNamespaceError) -> BackendError {
@@ -701,12 +717,13 @@ impl RemoteTarget {
 #[allow(clippy::panic)]
 mod tests {
     use super::{
-        map_bootstrap_error, map_core_error, resolve_cli_page_limit, Backend, EmbeddedTarget,
+        map_bootstrap_error, map_core_error, map_grep_error, resolve_cli_page_limit, Backend,
+        EmbeddedTarget,
     };
     use crate::config::StoreConfig;
     use loonfs::{
         BootstrapNamespaceError, CoreError, CreateNamespaceOptions, ErrorCode, FsBackgroundWork,
-        FsWriter, PutFileOptions, RuntimeError, SharedObjectStore,
+        FsWriter, GrepError, PutFileOptions, RuntimeError, SharedObjectStore,
     };
     use loonfs_api::{
         ChangeSeq, CreateCheckpointRequest, DestinationBehavior, InodeId, NamespaceId, RevisionNo,
@@ -735,6 +752,27 @@ mod tests {
         ));
         assert_eq!(error.code, ErrorCode::ContentNotPrepared.as_str());
         assert!(error.message.contains("abc123"));
+    }
+
+    #[test]
+    fn map_grep_error_preserves_embedded_remote_code_parity() {
+        for (error, expected) in [
+            (GrepError::NotEnabled, ErrorCode::NotSupported),
+            (
+                GrepError::CorruptIndex {
+                    message: "bad pointer".to_owned(),
+                },
+                ErrorCode::IndexCorrupt,
+            ),
+            (
+                GrepError::PublicationConflict {
+                    object_key: "namespaces/demo/extensions/grep/root.json".to_owned(),
+                },
+                ErrorCode::StaleHead,
+            ),
+        ] {
+            assert_eq!(map_grep_error(error).code, expected.as_str());
+        }
     }
 
     #[test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1271,6 +1271,10 @@ mod tests {
         let error = api_error(503, "commit_outcome_unknown");
         assert_eq!(error.error_code(), Some(ErrorCode::CommitOutcomeUnknown));
         assert_eq!(error.kind(), Some(ErrorKind::OutcomeUnknown));
+
+        let error = api_error(500, "index_corrupt");
+        assert_eq!(error.error_code(), Some(ErrorCode::IndexCorrupt));
+        assert_eq!(error.kind(), Some(ErrorKind::DataCorruption));
     }
 
     #[test]

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 ciborium.workspace = true
 tempfile.workspace = true
 

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -20,7 +20,7 @@ explicitly collects each named namespace's grep-owned keyspace once before
 maintenance starts, including reaping aged extension state for an absent or tombstoned namespace.
 
 The strict config keeps the provider under `[store]`, puts the one detached-deployment timer at the
-top level, and uses `[grep]` only for bounded step budgets:
+top level, and uses `[grep]` for bounded step budgets and the deployment-wide step cap:
 
 ```toml
 poll_interval_ms = 1000
@@ -30,6 +30,7 @@ kind = "local-fs"
 root = "./.loonfs-store"
 
 [grep]
+max_concurrent_steps = 2
 max_files_per_step = 256
 max_content_bytes_per_step = 67108864
 max_rows_per_segment = 65536
@@ -38,5 +39,5 @@ max_mid_runs = 8
 max_fold_rows_per_step = 131072
 ```
 
-`poll_interval_ms` defaults to 1000 and must be greater than zero. Every step budget must also be
-greater than zero.
+`poll_interval_ms` defaults to 1000 and must be greater than zero. Every step budget and
+`max_concurrent_steps` must also be greater than zero.

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -4,10 +4,18 @@ use crate::GramIndexBuildPolicy;
 use serde::Deserialize;
 use thiserror::Error;
 
+/// Default cap on concurrently executing grep build or fold steps.
+///
+/// Mirrors `loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE`; both background
+/// maintenance families default to two expensive namespace steps at once.
+pub const DEFAULT_MAX_CONCURRENT_STEPS: usize = 2;
+
 /// Bounded-work policy shared by embedded and standalone drivers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GrepWorkerConfig {
+    /// Build or fold steps allowed to execute concurrently across namespaces.
+    pub max_concurrent_steps: usize,
     /// Revisions examined per build step.
     pub max_files_per_step: usize,
     /// Content bytes read per build step.
@@ -37,6 +45,12 @@ impl GrepWorkerConfig {
 
     /// Rejects zero step budgets.
     pub fn validate(self) -> Result<(), GrepWorkerConfigError> {
+        if self.max_concurrent_steps == 0 {
+            return Err(GrepWorkerConfigError::InvalidField {
+                field: "max_concurrent_steps",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
         if let Some(field) = self.build_policy().zero_budget_field() {
             return Err(GrepWorkerConfigError::InvalidField {
                 field,
@@ -51,6 +65,7 @@ impl Default for GrepWorkerConfig {
     fn default() -> Self {
         let policy = GramIndexBuildPolicy::default();
         Self {
+            max_concurrent_steps: DEFAULT_MAX_CONCURRENT_STEPS,
             max_files_per_step: policy.max_files_per_step,
             max_content_bytes_per_step: policy.max_content_bytes_per_step,
             max_rows_per_segment: policy.max_rows_per_segment,
@@ -90,6 +105,13 @@ mod tests {
     #[test]
     fn zero_policy_fields_are_rejected() {
         for (field, config) in [
+            (
+                "max_concurrent_steps",
+                GrepWorkerConfig {
+                    max_concurrent_steps: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
             (
                 "max_files_per_step",
                 GrepWorkerConfig {

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -1,8 +1,7 @@
 //! Event-driven maintenance for one grep-enabled namespace.
 
-use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepFoldOutcome, GrepWorker};
+use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepFoldOutcome, GrepWorker};
 use loonfs_api::{ChangeSeq, ErrorCode, NamespaceId};
-use loonfs_core::Error as CoreError;
 use loonfs_objectstore::ObjectStore;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -266,7 +265,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
         &self,
         consecutive_failures: u32,
         phase: &'static str,
-        error: &CoreError,
+        error: &GrepError,
     ) -> bool {
         let shift = consecutive_failures.saturating_sub(1).min(16);
         let delay_ms = ERROR_BACKOFF_BASE_MS

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -6,11 +6,38 @@ use loonfs_objectstore::ObjectStore;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, watch, Notify};
+use tokio::sync::{mpsc, watch, Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinError, JoinHandle};
 
 const ERROR_BACKOFF_BASE_MS: u64 = 10;
 const ERROR_BACKOFF_CAP_MS: u64 = 1_000;
+
+/// Shared cap on concurrently executing grep build or fold steps.
+///
+/// Tokio's semaphore admits queued drivers in FIFO order, so a namespace
+/// waiting behind busy siblings cannot be starved by later arrivals.
+#[derive(Debug, Clone)]
+pub struct GrepStepLimiter {
+    permits: Arc<Semaphore>,
+}
+
+impl GrepStepLimiter {
+    /// Creates a shared limiter. Direct callers receive the same safe
+    /// normalization as directly supplied build policies; config rejects zero.
+    pub fn new(max_concurrent_steps: usize) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(max_concurrent_steps.max(1))),
+        }
+    }
+
+    async fn acquire(&self) -> OwnedSemaphorePermit {
+        self.permits
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("grep step semaphore is never closed")
+    }
+}
 
 /// Why a per-namespace driver has no immediate work.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,6 +159,7 @@ pub struct GrepDriver<S> {
     worker: GrepWorker<S>,
     namespace_id: NamespaceId,
     policy: GramIndexBuildPolicy,
+    step_limiter: GrepStepLimiter,
     handle: GrepDriverHandle,
     work: mpsc::Receiver<()>,
 }
@@ -142,6 +170,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
         worker: GrepWorker<S>,
         namespace_id: NamespaceId,
         policy: GramIndexBuildPolicy,
+        step_limiter: GrepStepLimiter,
     ) -> Self {
         let (state, _) = watch::channel(GrepDriverState::Active);
         let (work_send, work) = mpsc::channel(1);
@@ -152,6 +181,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
             worker,
             namespace_id,
             policy,
+            step_limiter,
             handle: GrepDriverHandle {
                 control: Arc::new(DriverControl {
                     stopping: AtomicBool::new(false),
@@ -205,11 +235,13 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
             if self.stopping() {
                 return None;
             }
-            let build = match self
+            let step_permit = self.acquire_step_permit().await?;
+            let build_result = self
                 .worker
                 .build_step(&self.namespace_id, self.policy)
-                .await
-            {
+                .await;
+            drop(step_permit);
+            let build = match build_result {
                 Ok(report) => report.outcome,
                 Err(error)
                     if matches!(
@@ -234,7 +266,10 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
                 return Some(GrepDriverParked::NotEnabled);
             }
 
-            let fold = match self.worker.fold_step(&self.namespace_id, self.policy).await {
+            let step_permit = self.acquire_step_permit().await?;
+            let fold_result = self.worker.fold_step(&self.namespace_id, self.policy).await;
+            drop(step_permit);
+            let fold = match fold_result {
                 Ok(report) => report.outcome,
                 Err(error) => {
                     consecutive_failures = consecutive_failures.saturating_add(1);
@@ -299,6 +334,16 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> GrepDriver<S> {
 
     fn stopping(&self) -> bool {
         self.handle.control.stopping.load(Ordering::Acquire)
+    }
+
+    async fn acquire_step_permit(&self) -> Option<OwnedSemaphorePermit> {
+        if self.stopping() {
+            return None;
+        }
+        tokio::select! {
+            permit = self.step_limiter.acquire() => Some(permit),
+            () = self.handle.control.stop_notify.notified() => None,
+        }
     }
 
     fn set_state(&self, state: GrepDriverState) {

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -1,0 +1,122 @@
+//! Public grep failures and their wire-code classification.
+
+use crate::root::GrepRootError;
+use loonfs_api::{ErrorCode, ErrorKind};
+use loonfs_core::{Error as CoreError, StoreFailureClass};
+use thiserror::Error;
+
+/// Failure returned by grep queries or maintenance.
+///
+/// The variants preserve only distinctions that change caller or operator
+/// action. Detailed root loading and publication failures remain available
+/// internally as [`GrepRootError`].
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum GrepError {
+    /// The namespace has no active grep root.
+    #[error("feature `index.grams` is not materialized on this namespace")]
+    NotEnabled,
+    /// The namespace's grep backfill has not completed.
+    #[error("feature `index.grams` is not materialized on this namespace")]
+    Backfilling,
+    /// The backing provider could not serve grep-owned state.
+    #[error("object-store operation failed for grep state `{object_key}`: {message}")]
+    StoreUnavailable {
+        /// Grep-owned object or prefix the provider operation targeted.
+        object_key: String,
+        /// Provider failure text without a repeated object key.
+        message: String,
+        /// Classification retained from the provider boundary.
+        class: StoreFailureClass,
+    },
+    /// Grep's rebuildable derived state failed validation.
+    #[error("grep index is corrupt: {message}; disable and re-enable grep to rebuild it")]
+    CorruptIndex {
+        /// Root, manifest, or segment validation failure.
+        message: String,
+    },
+    /// A grep root compare-and-swap lost to another publisher.
+    #[error("grep root publication conflict for `{object_key}`; retry")]
+    PublicationConflict {
+        /// Mutable grep root whose publication raced.
+        object_key: String,
+    },
+    /// A genuine core namespace failure encountered while grep read core state.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+}
+
+impl GrepError {
+    /// Returns the caller-action category for this failure.
+    pub fn kind(&self) -> ErrorKind {
+        self.code().kind()
+    }
+
+    /// Returns the stable wire code for this failure.
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            Self::NotEnabled | Self::Backfilling => ErrorCode::NotSupported,
+            Self::StoreUnavailable { class, .. } => match class {
+                StoreFailureClass::PermissionDenied => ErrorCode::PermissionDenied,
+                StoreFailureClass::Other => ErrorCode::ServerError,
+            },
+            Self::CorruptIndex { .. } => ErrorCode::IndexCorrupt,
+            Self::PublicationConflict { .. } => ErrorCode::StaleHead,
+            Self::Core(error) => error.code(),
+        }
+    }
+}
+
+impl From<GrepRootError> for GrepError {
+    fn from(error: GrepRootError) -> Self {
+        match error {
+            GrepRootError::Store {
+                object_key,
+                message,
+                class,
+            } => Self::StoreUnavailable {
+                object_key,
+                message,
+                class,
+            },
+            GrepRootError::MissingEtag { object_key } => Self::StoreUnavailable {
+                object_key,
+                message: "grep root has no etag for compare-and-swap".to_owned(),
+                class: StoreFailureClass::Other,
+            },
+            GrepRootError::Conflict { object_key } => Self::PublicationConflict { object_key },
+            error @ (GrepRootError::Corrupt { .. }
+            | GrepRootError::MissingManifest { .. }
+            | GrepRootError::IdentityMismatch { .. }
+            | GrepRootError::AdvanceIdentityMismatch { .. }) => Self::CorruptIndex {
+                message: error.to_string(),
+            },
+        }
+    }
+}
+
+/// Result type used by grep query and maintenance entrypoints.
+pub type Result<T> = std::result::Result<T, GrepError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{ErrorCode, GrepError, StoreFailureClass};
+
+    #[test]
+    fn store_failure_class_survives_the_grep_boundary() {
+        for (class, expected) in [
+            (
+                StoreFailureClass::PermissionDenied,
+                ErrorCode::PermissionDenied,
+            ),
+            (StoreFailureClass::Other, ErrorCode::ServerError),
+        ] {
+            let error = GrepError::StoreUnavailable {
+                object_key: "namespaces/demo/extensions/grep/root.json".to_owned(),
+                message: "provider failure".to_owned(),
+                class,
+            };
+            assert_eq!(error.code(), expected);
+        }
+    }
+}

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -2,11 +2,12 @@
 
 use crate::cache::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
 use crate::codec::IndexRow;
+use crate::{GrepError, Result};
 use loonfs_api::wire::sst_blocks::{
     decode_data_block_rows, decode_filter_block, decode_index_block, BlockHandle, DecodedDataBlock,
     SegmentFilter, SegmentIndexEntry,
 };
-use loonfs_core::{Error as CoreError, Result, StoreFailureClass};
+use loonfs_core::StoreFailureClass;
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::sync::Arc;
 
@@ -14,10 +15,10 @@ pub(crate) fn index_segment_corrupt(
     object_key: &str,
     what: &str,
     error: &dyn std::fmt::Display,
-) -> CoreError {
-    CoreError::NamespaceCorrupt(format!(
-        "index segment `{object_key}` carries an unreadable {what}: {error}"
-    ))
+) -> GrepError {
+    GrepError::CorruptIndex {
+        message: format!("index segment `{object_key}` carries an unreadable {what}: {error}"),
+    }
 }
 
 fn cache_key(
@@ -40,10 +41,10 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
     let end_exclusive = handle
         .offset
         .checked_add(u64::from(handle.stored_len))
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
+        .ok_or_else(|| GrepError::CorruptIndex {
+            message: format!(
                 "index segment `{object_key}` descriptor names bytes past the address space"
-            ))
+            ),
         })?;
     let bytes = store
         .get(
@@ -54,15 +55,13 @@ async fn load_index_section_bytes<S: ObjectStore + ?Sized>(
             }),
         )
         .await
-        .map_err(|error| CoreError::Store {
+        .map_err(|error| GrepError::StoreUnavailable {
             object_key: object_key.to_owned(),
             message: error.message(),
             class: StoreFailureClass::of(&error),
         })?
-        .ok_or_else(|| {
-            CoreError::NamespaceCorrupt(format!(
-                "manifest references missing index segment `{object_key}`"
-            ))
+        .ok_or_else(|| GrepError::CorruptIndex {
+            message: format!("manifest references missing index segment `{object_key}`"),
         })?;
     Ok(bytes.to_vec())
 }

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -11,6 +11,7 @@ mod cache;
 pub mod codec;
 mod config;
 mod driver;
+mod error;
 mod index_read;
 pub mod keyspace;
 mod query;
@@ -20,6 +21,8 @@ mod worker;
 
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
 pub use driver::{GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask};
+pub use error::GrepError as Error;
+pub use error::{GrepError, Result};
 pub use service::{
     GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,
     MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -19,8 +19,11 @@ pub mod root;
 mod service;
 mod worker;
 
-pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
-pub use driver::{GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask};
+pub use config::{GrepWorkerConfig, GrepWorkerConfigError, DEFAULT_MAX_CONCURRENT_STEPS};
+pub use driver::{
+    GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverState, GrepDriverTask,
+    GrepStepLimiter,
+};
 pub use error::GrepError as Error;
 pub use error::{GrepError, Result};
 pub use service::{

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -71,6 +71,8 @@ enum StandaloneError {
     OpenStore(#[from] loonfs_objectstore::ObjectStoreError),
     #[error("grep maintenance failed: {0}")]
     Maintenance(#[from] loonfs_core::Error),
+    #[error("grep operation failed: {0}")]
+    Grep(#[from] loonfs_grep::GrepError),
     #[error("grep driver for namespace `{namespace_id}` stopped before parking")]
     DriverStopped { namespace_id: NamespaceId },
     #[error("grep driver task failed: {0}")]

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 use loonfs_api::NamespaceId;
 use loonfs_core::control::load_namespace_head_control;
+use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
     GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask, GrepWorker, GrepWorkerConfig,
 };
@@ -238,13 +239,37 @@ async fn poll_namespace(
             _ = interval.tick() => {
                 match load_namespace_head_control(&*store, &namespace_id).await {
                     Ok(head) => {
-                        let behind = matches!(
-                            driver.state(),
+                        let should_nudge = match driver.state() {
                             GrepDriverState::Parked(GrepDriverParked::CaughtUp {
                                 built_through_seq,
-                            }) if built_through_seq < head.state.seq
-                        );
-                        if behind {
+                            }) => built_through_seq < head.state.seq,
+                            GrepDriverState::Parked(GrepDriverParked::NotEnabled) => {
+                                // Assigned namespaces are an explicit, small operator-chosen set,
+                                // so one small conditional read per existing poll interval is
+                                // cheaper than introducing a second cadence concept.
+                                match load_grep_root(&*store, &namespace_id).await {
+                                    Ok(Some(root)) => matches!(
+                                        root.state().lifecycle(),
+                                        GrepLifecycle::Backfilling { .. } | GrepLifecycle::Steady
+                                    ),
+                                    Ok(None) => false,
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            namespace_id = %namespace_id,
+                                            phase = "grep_root_poll",
+                                            result = "error",
+                                            error = %error,
+                                            "grep namespace root poll failed"
+                                        );
+                                        false
+                                    }
+                                }
+                            }
+                            GrepDriverState::Active
+                            | GrepDriverState::BackingOff { .. }
+                            | GrepDriverState::Stopped => false,
+                        };
+                        if should_nudge {
                             driver.nudge();
                         }
                     }
@@ -325,3 +350,7 @@ fn current_time_ms() -> Result<u64, loonfs_core::Error> {
             loonfs_core::Error::Internal(format!("system clock before unix epoch: {error}"))
         })
 }
+
+#[cfg(test)]
+#[path = "main_tests.rs"]
+mod tests;

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -5,7 +5,8 @@ use loonfs_api::NamespaceId;
 use loonfs_core::control::load_namespace_head_control;
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
-    GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask, GrepWorker, GrepWorkerConfig,
+    GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask, GrepStepLimiter, GrepWorker,
+    GrepWorkerConfig,
 };
 use loonfs_objectstore::{SharedObjectStore, StoreConfig};
 use serde::Deserialize;
@@ -138,12 +139,14 @@ async fn run() -> Result<(), StandaloneError> {
     }
 
     let runtime = tokio::runtime::Handle::current();
+    let step_limiter = GrepStepLimiter::new(config.grep.max_concurrent_steps);
     let mut drivers = Vec::with_capacity(namespace_ids.len());
     for namespace_id in &namespace_ids {
         let task = GrepDriver::new(
             worker.clone(),
             namespace_id.clone(),
             config.grep.build_policy(),
+            step_limiter.clone(),
         )
         .spawn_on(&runtime);
         drivers.push((namespace_id.clone(), task));

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -1,0 +1,317 @@
+#![allow(clippy::panic)]
+//! Standalone poller wakeup coverage with in-process driver observation.
+
+use super::{poll_namespace, PollShutdown};
+use loonfs_api::{
+    AbsolutePath, ChangeSeq, CommitId, DestinationBehavior, GrepRequest, NamespaceId,
+};
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
+    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+};
+use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
+use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anchor};
+use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use loonfs_core::{BootstrapOptions, NamespaceEngine, RuntimeReadContext};
+use loonfs_grep::root::{load_grep_root, GrepLifecycle};
+use loonfs_grep::{
+    GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask,
+    GrepIndexSnapshot, GrepService, GrepWorker,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::SharedObjectStore;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+const TEST_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::test]
+async fn standalone_starts_before_enable_and_wakes_within_poll() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("poll-enable");
+    let engine = bootstrap(store.clone(), &namespace_id).await;
+    put_file(&store, &engine, &namespace_id, "poll-enable-put").await;
+    let worker = worker(&store, "poll-enable");
+    let driver = spawn_driver(worker.clone(), namespace_id.clone());
+    let handle = driver.handle();
+    wait_for_parked(&handle, GrepDriverParked::NotEnabled).await;
+    let (poll, shutdown) = spawn_poll(store.clone(), namespace_id.clone(), handle.clone());
+
+    worker
+        .enable(&namespace_id)
+        .await
+        .expect("externally enable grep");
+    wait_for_parked(
+        &handle,
+        GrepDriverParked::CaughtUp {
+            built_through_seq: ChangeSeq(1),
+        },
+    )
+    .await;
+    assert_searchable(&store, &namespace_id).await;
+
+    stop_poll_and_driver(poll, shutdown, driver).await;
+}
+
+#[tokio::test]
+async fn standalone_wakes_after_disable_then_reenable_and_backfills_fresh() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("poll-reenable");
+    let engine = bootstrap(store.clone(), &namespace_id).await;
+    let worker = worker(&store, "poll-reenable");
+    worker.enable(&namespace_id).await.expect("enable grep");
+    let driver = spawn_driver(worker.clone(), namespace_id.clone());
+    let handle = driver.handle();
+    wait_for_parked(
+        &handle,
+        GrepDriverParked::CaughtUp {
+            built_through_seq: ChangeSeq(0),
+        },
+    )
+    .await;
+    let (poll, shutdown) = spawn_poll(store.clone(), namespace_id.clone(), handle.clone());
+
+    worker.disable(&namespace_id).await.expect("disable grep");
+    put_file(&store, &engine, &namespace_id, "poll-reenable-put").await;
+    wait_for_parked(&handle, GrepDriverParked::NotEnabled).await;
+    worker.enable(&namespace_id).await.expect("re-enable grep");
+    let backfill = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load re-enabled root")
+        .expect("re-enabled root");
+    assert!(matches!(
+        backfill.state().lifecycle(),
+        GrepLifecycle::Backfilling { .. }
+    ));
+    assert!(
+        backfill.state().segments().is_empty(),
+        "re-enable must begin a fresh backfill"
+    );
+
+    wait_for_parked(
+        &handle,
+        GrepDriverParked::CaughtUp {
+            built_through_seq: ChangeSeq(1),
+        },
+    )
+    .await;
+    assert_searchable(&store, &namespace_id).await;
+
+    stop_poll_and_driver(poll, shutdown, driver).await;
+}
+
+#[tokio::test]
+async fn standalone_enable_without_head_change_wakes_empty_backfill() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("poll-empty");
+    bootstrap(store.clone(), &namespace_id).await;
+    let worker = worker(&store, "poll-empty");
+    let driver = spawn_driver(worker.clone(), namespace_id.clone());
+    let handle = driver.handle();
+    wait_for_parked(&handle, GrepDriverParked::NotEnabled).await;
+    let (poll, shutdown) = spawn_poll(store.clone(), namespace_id.clone(), handle.clone());
+    let head_before = load_namespace_head_control(&*store, &namespace_id)
+        .await
+        .expect("load head before enable");
+
+    worker
+        .enable(&namespace_id)
+        .await
+        .expect("externally enable empty namespace");
+    wait_for_parked(
+        &handle,
+        GrepDriverParked::CaughtUp {
+            built_through_seq: ChangeSeq(0),
+        },
+    )
+    .await;
+
+    let head_after = load_namespace_head_control(&*store, &namespace_id)
+        .await
+        .expect("load head after enable");
+    assert_eq!(head_after.state.seq, head_before.state.seq);
+    let root = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load empty root")
+        .expect("empty root");
+    assert!(matches!(root.state().lifecycle(), GrepLifecycle::Steady));
+    assert!(root.state().segments().is_empty());
+
+    stop_poll_and_driver(poll, shutdown, driver).await;
+}
+
+fn namespace_id(value: &str) -> NamespaceId {
+    NamespaceId::parse(value).expect("namespace id")
+}
+
+fn worker(store: &SharedObjectStore, actor: &str) -> GrepWorker<SharedObjectStore> {
+    GrepWorker::new(
+        store.clone(),
+        format!("{actor}-worker"),
+        format!("{actor}-session"),
+        "standalone-poll-test/0.1",
+    )
+}
+
+async fn bootstrap(
+    store: SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> NamespaceEngine<SharedObjectStore> {
+    let engine = NamespaceEngine::builder(store)
+        .namespace_id(namespace_id.clone())
+        .writer_id(format!("{}-seed", namespace_id.as_str()))
+        .writer_session_id(format!("{}-seed-session", namespace_id.as_str()))
+        .writer_version("standalone-poll-test/0.1")
+        .build()
+        .expect("engine");
+    engine
+        .bootstrap_namespace(BootstrapOptions::default())
+        .await
+        .expect("bootstrap namespace");
+    engine
+}
+
+async fn put_file(
+    store: &SharedObjectStore,
+    engine: &NamespaceEngine<SharedObjectStore>,
+    namespace_id: &NamespaceId,
+    commit_id: &str,
+) {
+    let stored = store_bytes_as_content(&**store, namespace_id, b"standalone wakeup needle\n")
+        .await
+        .expect("store content");
+    let content_ref = stored.content_ref.clone();
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
+    let result = engine
+        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
+            PathMutationIntent::PutFile {
+                commit_id: CommitId::parse(commit_id).expect("commit id"),
+                absolute_path: AbsolutePath::parse("/note.txt").expect("path"),
+                content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+            vec![prepared],
+        )])
+        .await
+        .pop()
+        .expect("one result");
+    result.expect("publish file");
+}
+
+fn spawn_driver(
+    worker: GrepWorker<SharedObjectStore>,
+    namespace_id: NamespaceId,
+) -> GrepDriverTask {
+    GrepDriver::new(worker, namespace_id, GramIndexBuildPolicy::default())
+        .spawn_on(&tokio::runtime::Handle::current())
+}
+
+fn spawn_poll(
+    store: SharedObjectStore,
+    namespace_id: NamespaceId,
+    driver: loonfs_grep::GrepDriverHandle,
+) -> (JoinHandle<()>, Arc<PollShutdown>) {
+    let shutdown = Arc::new(PollShutdown::new());
+    let poll = tokio::runtime::Handle::current().spawn(poll_namespace(
+        store,
+        namespace_id,
+        driver,
+        TEST_POLL_INTERVAL,
+        shutdown.clone(),
+    ));
+    (poll, shutdown)
+}
+
+async fn wait_for_parked(driver: &loonfs_grep::GrepDriverHandle, expected: GrepDriverParked) {
+    let mut state = driver.subscribe_state();
+    tokio::time::timeout(TEST_TIMEOUT, wait_for_state(&mut state, expected))
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "driver did not reach {expected:?}; state: {:?}",
+                driver.state()
+            )
+        });
+}
+
+async fn wait_for_state(state: &mut watch::Receiver<GrepDriverState>, expected: GrepDriverParked) {
+    loop {
+        if *state.borrow_and_update() == GrepDriverState::Parked(expected) {
+            return;
+        }
+        state
+            .changed()
+            .await
+            .expect("driver state remains observable");
+    }
+}
+
+async fn assert_searchable(store: &SharedObjectStore, namespace_id: &NamespaceId) {
+    let engine = NamespaceEngine::builder(store.clone())
+        .namespace_id(namespace_id.clone())
+        .writer_id("standalone-poll-query")
+        .build()
+        .expect("query engine");
+    let (head, root) = load_namespace_read_anchor(&**store, namespace_id)
+        .await
+        .expect("load read anchor");
+    let context = RuntimeReadContext {
+        head: head.state,
+        head_etag: head.identity.etag,
+        manifest_id: root.state.manifest_id,
+        manifest_object_id: root.state.manifest_object_id,
+        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
+        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+            max_entries: 4,
+            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        })),
+        catalog: None,
+    };
+    let view = engine
+        .load_grep_view_with_runtime_context(&context)
+        .await
+        .expect("load grep view");
+    let service = GrepService::new();
+    let snapshot = GrepIndexSnapshot::from_grep_root(&**store, namespace_id, &service).await;
+    let response = service
+        .query(
+            &GrepRequest {
+                pattern: "wakeup needle".to_owned(),
+                case_insensitive: false,
+                path_prefix: None,
+                cursor: None,
+                limit: None,
+                allow_stale: false,
+                allow_scan: false,
+            },
+            &snapshot,
+            &view,
+            store,
+        )
+        .await
+        .expect("query caught-up index");
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/note.txt");
+}
+
+async fn stop_poll_and_driver(
+    poll: JoinHandle<()>,
+    shutdown: Arc<PollShutdown>,
+    driver: GrepDriverTask,
+) {
+    shutdown.request();
+    poll.await.expect("join namespace poll");
+    driver.shutdown().await.expect("stop grep driver");
+}

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -17,7 +17,7 @@ use loonfs_core::{BootstrapOptions, NamespaceEngine, RuntimeReadContext};
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask,
-    GrepIndexSnapshot, GrepService, GrepWorker,
+    GrepIndexSnapshot, GrepService, GrepStepLimiter, GrepWorker,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
@@ -213,8 +213,13 @@ fn spawn_driver(
     worker: GrepWorker<SharedObjectStore>,
     namespace_id: NamespaceId,
 ) -> GrepDriverTask {
-    GrepDriver::new(worker, namespace_id, GramIndexBuildPolicy::default())
-        .spawn_on(&tokio::runtime::Handle::current())
+    GrepDriver::new(
+        worker,
+        namespace_id,
+        GramIndexBuildPolicy::default(),
+        GrepStepLimiter::new(1),
+    )
+    .spawn_on(&tokio::runtime::Handle::current())
 }
 
 fn spawn_poll(

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -1,6 +1,7 @@
 //! Typed failures for grep root state, encoding, loading, and publication.
 
 use loonfs_api::{IndexSegmentId, NamespaceId};
+use loonfs_core::StoreFailureClass;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -79,7 +80,11 @@ pub enum GrepRootCodecError {
 #[non_exhaustive]
 pub enum GrepRootError {
     #[error("object-store operation failed for grep root `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("grep root `{object_key}` is corrupt: {message}")]
     Corrupt { object_key: String, message: String },
     #[error("grep root `{root_key}` names missing manifest `{manifest_key}`")]

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -1,10 +1,11 @@
 //! The atomic grep root pointer, immutable manifests, and publication boundary.
 //!
 //! One immutable manifest pairs the query-visible segment set with its
-//! `built_through_seq` watermark, lifecycle, in-progress fold, and run
-//! ordinal allocation. Publication writes that manifest create-if-absent,
-//! then installs a tiny pointer in one object-store compare-and-swap, so a
-//! reader never observes a watermark without the segments that implement it.
+//! `(built_through_seq, next_delta_index)` cursor, lifecycle, in-progress
+//! fold, and run ordinal allocation. Publication writes that manifest
+//! create-if-absent, then installs a tiny pointer in one object-store
+//! compare-and-swap, so a reader never observes a cursor without the segments
+//! that implement it.
 //!
 //! Segment and manifest objects are immutable derived data written before
 //! the pointer CAS. A CAS loser therefore leaks only unreachable derived

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -183,8 +183,15 @@ pub struct GrepFoldState {
 pub struct GrepIndexState {
     /// Version of this nested index-state schema.
     pub format_version: u32,
-    /// Changes at or below this sequence are represented by `segments`.
+    /// Sequence of the commit at the index cursor.
     pub built_through_seq: ChangeSeq,
+    /// Offset of the next delta within `built_through_seq`, or zero when the
+    /// cursor is at the commit boundary and the whole commit is represented.
+    ///
+    /// WAL commit deltas retain their durable vector order; incremental
+    /// indexing relies on that stable order when it resumes within a commit.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub next_delta_index: u32,
     /// One in-progress partitioned fold, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fold: Option<GrepFoldState>,
@@ -196,16 +203,22 @@ impl GrepIndexState {
     /// Creates index bookkeeping in the current grep-owned format.
     pub fn new(
         built_through_seq: ChangeSeq,
+        next_delta_index: u32,
         fold: Option<GrepFoldState>,
         next_run_ordinal: u64,
     ) -> Self {
         Self {
             format_version: GREP_INDEX_FORMAT_VERSION,
             built_through_seq,
+            next_delta_index,
             fold,
             next_run_ordinal,
         }
     }
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 /// Query-visible descriptor for one immutable grep segment.

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -14,6 +14,7 @@ use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
 use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs_api::NamespaceId;
+use loonfs_core::StoreFailureClass;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 
 /// A verified grep root pointer and metadata from the same store read.
@@ -371,5 +372,6 @@ fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
     GrepRootError::Store {
         object_key: object_key.to_owned(),
         message: error.message(),
+        class: StoreFailureClass::of(error),
     }
 }

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -7,9 +7,10 @@ use crate::codec::{lookup, Gram, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES};
 use crate::index_read::{
     index_segment_corrupt, load_data_block, load_filter_block, load_index_block,
 };
-use crate::keyspace::segment_key;
+use crate::keyspace::{manifest_key, segment_key};
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
 use crate::root::{load_grep_manifest, load_grep_root_pointer, GrepLifecycle, GrepRootState};
+use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
 use loonfs_api::wire::manifest::hex_decode_bytes;
 use loonfs_api::wire::sst_blocks::{decode_filter_block, index_blocks_for_key_range};
@@ -21,7 +22,7 @@ use loonfs_api::{
 use loonfs_core::content::read_durable_content_bytes;
 use loonfs_core::grep::{LoadedMetadataView, MetadataViewSession};
 use loonfs_core::metadata::RevisionRecord;
-use loonfs_core::{Error as CoreError, MetadataViewError, Result};
+use loonfs_core::{Error as CoreError, MetadataViewError};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -94,15 +95,15 @@ struct GrepQuerySegment {
 
 impl GrepIndexSnapshot {
     /// Captures unreadable grep extension state while preserving error precedence.
-    pub fn from_error(error: CoreError) -> Self {
+    pub fn from_error(error: GrepError) -> Self {
         Self { state: Err(error) }
     }
 
     /// Freshly loads the grep pointer, then loads or reuses its immutable manifest.
     ///
-    /// Missing or corrupt pointers/manifests and disabled or backfilling
-    /// lifecycles all collapse to the same `index.grams` not-materialized
-    /// surface. Grep-private corruption never changes core read behavior.
+    /// Missing or disabled roots and incomplete backfills remain
+    /// not-materialized. Unreadable derived state retains its actionable
+    /// grep-specific failure without changing core read behavior.
     pub async fn from_grep_root<S: ObjectStore + ?Sized>(
         store: &S,
         namespace_id: &NamespaceId,
@@ -110,7 +111,8 @@ impl GrepIndexSnapshot {
     ) -> Self {
         let pointer = match load_grep_root_pointer(store, namespace_id).await {
             Ok(Some(pointer)) => pointer,
-            Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+            Ok(None) => return Self::from_error(GrepError::NotEnabled),
+            Err(error) => return Self::from_error(error.into()),
         };
         let manifest_id = pointer.pointer().manifest_id();
         let cache_key = GrepBlockCacheKey {
@@ -124,11 +126,27 @@ impl GrepIndexSnapshot {
                 DecodedGrepBlock::Filter(_)
                 | DecodedGrepBlock::Index(_)
                 | DecodedGrepBlock::Data(_),
-            ) => return Self::from_error(feature_not_materialized()),
+            ) => {
+                return Self::from_error(GrepError::CorruptIndex {
+                    message: format!(
+                        "grep manifest `{}` resolved to a non-manifest cache entry",
+                        manifest_key(namespace_id, manifest_id)
+                    ),
+                });
+            }
             None => {
                 let manifest = match load_grep_manifest(store, namespace_id, manifest_id).await {
                     Ok(Some(manifest)) => manifest,
-                    Ok(None) | Err(_) => return Self::from_error(feature_not_materialized()),
+                    Ok(None) => {
+                        return Self::from_error(GrepError::CorruptIndex {
+                            message: format!(
+                                "grep root `{}` names missing manifest `{}`",
+                                pointer.object_key(),
+                                manifest_key(namespace_id, manifest_id)
+                            ),
+                        });
+                    }
+                    Err(error) => return Self::from_error(error.into()),
                 };
                 let state = std::sync::Arc::new(manifest.state().clone());
                 service
@@ -138,17 +156,27 @@ impl GrepIndexSnapshot {
             }
         };
         if state.namespace_id() != namespace_id {
-            return Self::from_error(feature_not_materialized());
+            return Self::from_error(GrepError::CorruptIndex {
+                message: format!(
+                    "grep manifest `{}` names namespace `{}` instead of requested namespace `{namespace_id}`",
+                    manifest_key(namespace_id, manifest_id),
+                    state.namespace_id()
+                ),
+            });
         }
         Self::from_state(Some(&state))
     }
 
     fn from_state(root: Option<&GrepRootState>) -> Self {
         let Some(root) = root else {
-            return Self::from_error(feature_not_materialized());
+            return Self::from_error(GrepError::NotEnabled);
         };
-        if !matches!(root.lifecycle(), GrepLifecycle::Steady) {
-            return Self::from_error(feature_not_materialized());
+        match root.lifecycle() {
+            GrepLifecycle::Disabled => return Self::from_error(GrepError::NotEnabled),
+            GrepLifecycle::Backfilling { .. } => {
+                return Self::from_error(GrepError::Backfilling);
+            }
+            GrepLifecycle::Steady => {}
         }
         let segments = root
             .segments()
@@ -173,12 +201,6 @@ impl GrepIndexSnapshot {
 
     fn materialized(&self) -> Result<&MaterializedGrepIndexSnapshot> {
         self.state.as_ref().map_err(Clone::clone)
-    }
-}
-
-fn feature_not_materialized() -> CoreError {
-    CoreError::FeatureNotMaterialized {
-        feature: "index.grams".to_owned(),
     }
 }
 
@@ -369,12 +391,13 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     let mut postings = BTreeSet::new();
     let admitted = match &descriptor.filter_inline {
         Some(inline) => {
-            let filter_bytes = hex_decode_bytes(inline).map_err(|error| {
-                CoreError::NamespaceCorrupt(format!(
-                    "index segment `{}` carries undecodable inline filter hex: {error}",
-                    descriptor.object_key
-                ))
-            })?;
+            let filter_bytes =
+                hex_decode_bytes(inline).map_err(|error| GrepError::CorruptIndex {
+                    message: format!(
+                        "index segment `{}` carries undecodable inline filter hex: {error}",
+                        descriptor.object_key
+                    ),
+                })?;
             let filter =
                 decode_filter_block(&filter_bytes, &descriptor.filter_block).map_err(|error| {
                     index_segment_corrupt(&descriptor.object_key, "filter block", &error)
@@ -553,7 +576,7 @@ async fn derive_visible_path<S: ObjectStore + ?Sized>(
         }
         Ok(_) => Ok(None),
         Err(error) if error.code() == loonfs_api::ErrorCode::PathNotFound => Ok(None),
-        Err(error) => Err(error),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -623,14 +646,15 @@ impl GrepService {
         let limit = match request.limit {
             None => DEFAULT_GREP_PAGE_LIMIT,
             Some(0) => {
-                return Err(CoreError::InvalidQuery(
-                    "limit must be greater than zero".to_owned(),
-                ));
+                return Err(
+                    CoreError::InvalidQuery("limit must be greater than zero".to_owned()).into(),
+                );
             }
             Some(limit) if limit as usize > MAX_GREP_PAGE_LIMIT => {
                 return Err(CoreError::InvalidQuery(format!(
                     "limit {limit} exceeds the maximum of {MAX_GREP_PAGE_LIMIT}"
-                )));
+                ))
+                .into());
             }
             Some(limit) => limit as usize,
         };
@@ -644,13 +668,14 @@ impl GrepService {
                         "the cursor was issued by a different request; replaying it \
                          under new criteria would silently skip results"
                             .to_owned(),
-                    ));
+                    )
+                    .into());
                 }
                 if cursor.head_seq > view.head().seq {
-                    return Err(MetadataViewError::SnapshotUnavailable {
+                    return Err(CoreError::from(MetadataViewError::SnapshotUnavailable {
                         requested_seq: cursor.head_seq,
                         head_seq: view.head().seq,
-                    }
+                    })
                     .into());
                 }
                 Some((cursor.last_inode_id, cursor.last_byte_offset))
@@ -696,7 +721,7 @@ impl GrepService {
                             next_cursor: None,
                         });
                     }
-                    Err(error) => return Err(error),
+                    Err(error) => return Err(error.into()),
                 }
             }
             None => None,
@@ -716,7 +741,8 @@ impl GrepService {
                         "the pattern has no run of at least 3 literal bytes for the \
                          trigram index; set allow_scan to search without it"
                             .to_owned(),
-                    ));
+                    )
+                    .into());
                 }
                 candidates.unfiltered = scan_candidate_inodes(view).await?;
             }
@@ -734,7 +760,8 @@ impl GrepService {
                         .seq
                         .0
                         .saturating_sub(snapshot.built_through_seq.0),
-                });
+                }
+                .into());
             }
         } else {
             candidates.unfiltered.extend(tail);
@@ -887,7 +914,7 @@ impl GrepService {
                     resume_cursor = Some((inode_id, u64::MAX));
                     continue;
                 };
-                let content = content?;
+                let content = content.map_err(CoreError::from)?;
                 if !is_indexable_text_content(&content.bytes) {
                     resume_cursor = Some((inode_id, u64::MAX));
                     continue;
@@ -986,7 +1013,8 @@ async fn scan_candidate_inodes<S: ObjectStore + ?Sized>(
                 "the namespace exceeds the {MAX_GREP_SCAN_FILES}-file scan budget; \
                  give the pattern a run of at least 3 literal bytes so the \
                  trigram index can narrow candidates"
-            )));
+            ))
+            .into());
         }
         if exhausted {
             break;

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -79,6 +79,7 @@ pub struct GrepIndexSnapshot {
 #[derive(Debug, Clone)]
 struct MaterializedGrepIndexSnapshot {
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     segments: Vec<GrepQuerySegment>,
 }
 
@@ -194,6 +195,7 @@ impl GrepIndexSnapshot {
         Self {
             state: Ok(MaterializedGrepIndexSnapshot {
                 built_through_seq: root.index().built_through_seq,
+                next_delta_index: root.index().next_delta_index,
                 segments,
             }),
         }
@@ -464,19 +466,39 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
     Ok(postings)
 }
 
-/// The file revisions committed after the index watermark, newest revision
-/// per inode, from WAL replay — the exhaustive-scan tail.
+/// The file revisions after the index cursor, newest revision per inode, from
+/// WAL replay — the exhaustive-scan tail. A cursor within its watermark
+/// commit includes only that commit's remaining delta-vector suffix.
 async fn tail_revisions<S: ObjectStore + ?Sized>(
     store: &S,
     view: &LoadedMetadataView<'_, S>,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
 ) -> Result<BTreeSet<InodeId>> {
     let mut tail = BTreeMap::new();
-    for record in view
-        .grep_wal_records_after(store, built_through_seq)
-        .await?
-    {
-        for delta in &record.deltas {
+    let after_seq = if next_delta_index == 0 {
+        built_through_seq
+    } else {
+        ChangeSeq(built_through_seq.0.saturating_sub(1))
+    };
+    for record in view.grep_wal_records_after(store, after_seq).await? {
+        let start_delta_index = if record.seq == built_through_seq {
+            usize::try_from(next_delta_index).map_err(|_| {
+                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+            })?
+        } else {
+            0
+        };
+        if start_delta_index > record.deltas.len() {
+            return Err(GrepError::CorruptIndex {
+                message: format!(
+                    "grep delta cursor `{next_delta_index}` exceeds commit `{}` length `{}`",
+                    record.seq,
+                    record.deltas.len()
+                ),
+            });
+        }
+        for delta in record.deltas.iter().skip(start_delta_index) {
             if let WalDelta::AppendFileRevision { inode_id, .. } = &delta.delta {
                 tail.insert(*inode_id, ());
             }
@@ -748,7 +770,13 @@ impl GrepService {
             }
         }
 
-        let tail = tail_revisions(store, view, snapshot.built_through_seq).await?;
+        let tail = tail_revisions(
+            store,
+            view,
+            snapshot.built_through_seq,
+            snapshot.next_delta_index,
+        )
+        .await?;
         let mut tail_scanned = true;
         if tail.len() > MAX_GREP_TAIL_FILES {
             if request.allow_stale {
@@ -764,7 +792,7 @@ impl GrepService {
                 .into());
             }
         } else {
-            candidates.unfiltered.extend(tail);
+            candidates.unfiltered.extend(tail.iter().copied());
         }
 
         let mut matches: Vec<GrepMatch> = Vec::new();
@@ -833,7 +861,7 @@ impl GrepService {
                 // unindexed revision while tail-only files stay invisible
                 // — a mix of two snapshots rather than a stale-but-
                 // consistent one.
-                if !tail_scanned && revision.committed_seq > snapshot.built_through_seq {
+                if !tail_scanned && tail.contains(&inode_id) {
                     rejected_frontier = Some(inode_id);
                     continue;
                 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -11,6 +11,7 @@ use crate::root::{
     GrepLifecycle, GrepRootError, GrepRootState, GrepSegmentRef, LoadedGrepRoot,
 };
 use crate::service::is_indexable_text_content;
+use crate::{GrepError, Result};
 use bytes::Bytes;
 use futures::future::try_join_all;
 use loonfs_api::wire::control::NamespaceState;
@@ -30,7 +31,7 @@ use loonfs_core::grep::{
 };
 use loonfs_core::limits::METADATA_PUBLICATION_BUDGET_MS;
 use loonfs_core::{
-    Error as CoreError, MetadataProjectionLoadError, MonotonicTimer, NamespaceEngine, Result,
+    Error as CoreError, MetadataProjectionLoadError, MonotonicTimer, NamespaceEngine,
     StdMonotonicTimer, StoreFailureClass,
 };
 use loonfs_objectstore::{
@@ -228,7 +229,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     pub async fn enable(&self, namespace_id: &NamespaceId) -> Result<GrepEnableOutcome> {
         if let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
@@ -240,7 +241,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
         let current = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?;
+            .map_err(GrepError::from)?;
         if let Some(current) = &current {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
                 self.release_checkpoint_if_unreferenced(
@@ -274,7 +275,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 let winner = load_grep_root(&self.store, namespace_id)
                     .await
-                    .map_err(core_root_error)?;
+                    .map_err(GrepError::from)?;
                 if winner.as_ref().is_none_or(|root| {
                     !root_names_checkpoint(root.state(), &checkpoint.checkpoint_id)
                 }) {
@@ -284,7 +285,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 }
                 Ok(GrepEnableOutcome::Superseded)
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -294,7 +295,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         ensure_live_namespace(&self.store, namespace_id).await?;
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(GrepDisableOutcome::NotEnabled);
         };
@@ -326,7 +327,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 Ok(GrepDisableOutcome::Disabled)
             }
             Err(GrepRootError::Conflict { .. }) => Ok(GrepDisableOutcome::Superseded),
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -339,7 +340,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         };
@@ -347,7 +348,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         }
         let content_store_id = load_namespace_catalog_entry(&self.store, namespace_id)
-            .await?
+            .await
+            .map_err(CoreError::from)?
             .content_store_id()
             .clone();
 
@@ -416,7 +418,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     }
 
     fn engine(&self, namespace_id: &NamespaceId) -> Result<NamespaceEngine<S>> {
-        NamespaceEngine::builder(self.store.clone())
+        Ok(NamespaceEngine::builder(self.store.clone())
             .namespace_id(namespace_id.clone())
             .writer_id(self.writer_id.clone())
             .writer_session_id(self.writer_session_id.clone())
@@ -424,7 +426,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .build()
             .map_err(|error| {
                 CoreError::Internal(format!("failed to build grep worker engine: {error}"))
-            })
+            })?)
     }
 
     async fn seed_root(&self, state: &GrepRootState) -> crate::root::Result<LoadedGrepRoot> {
@@ -443,12 +445,13 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_api::CreateCheckpointResponse> {
-        self.engine(namespace_id)?
+        Ok(self
+            .engine(namespace_id)?
             .create_checkpoint(
                 GREP_BACKFILL_CHECKPOINT_NAME.to_owned(),
                 Some(GREP_BACKFILL_CHECKPOINT_TTL_MS),
             )
-            .await
+            .await?)
     }
 
     async fn release_checkpoint_if_unreferenced(
@@ -500,7 +503,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 let winner = load_grep_root(&self.store, namespace_id)
                     .await
-                    .map_err(core_root_error)?;
+                    .map_err(GrepError::from)?;
                 if winner.as_ref().is_none_or(|root| {
                     !root_names_checkpoint(root.state(), &checkpoint.checkpoint_id)
                 }) {
@@ -510,7 +513,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 }
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -587,7 +590,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 }
@@ -765,7 +768,8 @@ async fn load_and_fold_revision_contents<S: ObjectStore + ?Sized>(
         let contents = try_join_all(chunk.iter().map(|revision| {
             read_durable_content_bytes(store, content_store_id, &revision.content_ref)
         }))
-        .await?;
+        .await
+        .map_err(CoreError::from)?;
         for (revision, content) in chunk.iter().zip(contents) {
             if !is_indexable_text_content(&content.bytes) {
                 unit.skipped_revisions += 1;
@@ -900,7 +904,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
-            .map_err(core_root_error)?
+            .map_err(GrepError::from)?
         else {
             return Ok(fold_report(namespace_id, GrepFoldOutcome::NotEnabled));
         };
@@ -967,10 +971,10 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     .segments()
                     .iter()
                     .find(|segment| &segment.segment_id == segment_id)
-                    .ok_or_else(|| {
-                        CoreError::NamespaceCorrupt(format!(
+                    .ok_or_else(|| GrepError::CorruptIndex {
+                        message: format!(
                             "grep fold snapshot segment `{segment_id}` is missing from the root"
-                        ))
+                        ),
                     })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1044,7 +1048,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             Err(GrepRootError::Conflict { .. }) => {
                 Ok(fold_report(namespace_id, GrepFoldOutcome::Superseded))
             }
-            Err(error) => Err(core_root_error(error)),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -1245,10 +1249,10 @@ async fn merge_snapshot_range<S: ObjectStore + ?Sized>(
 fn fold_snapshot_row(merged: &mut MergedRange, row: IndexRow, object_key: &str) -> Result<()> {
     let IndexRow::GramPostings { gram, .. } = &row;
     let gram = *gram;
-    let batch = row.postings().map_err(|error| {
-        CoreError::NamespaceCorrupt(format!(
+    let batch = row.postings().map_err(|error| GrepError::CorruptIndex {
+        message: format!(
             "index segment `{object_key}` carries an unreadable posting batch: {error}"
-        ))
+        ),
     })?;
     merged.postings.entry(gram).or_default().extend(batch);
     merged.rows += 1;
@@ -1381,12 +1385,14 @@ async fn ensure_live_namespace<S: ObjectStore + ?Sized>(
     if head.state.state == NamespaceState::Deleted {
         return Err(CoreError::NamespaceDeleted {
             namespace_id: namespace_id.clone(),
-        });
+        }
+        .into());
     }
     if head.state.state != NamespaceState::Active {
         return Err(CoreError::NamespacePartiallyInitialized {
             namespace_id: namespace_id.clone(),
-        });
+        }
+        .into());
     }
     Ok(())
 }
@@ -1474,7 +1480,7 @@ async fn write_immutable_object<S: ObjectStore + ?Sized>(
             if existing_object_matches(store, object_key, expected_bytes).await? {
                 Ok(())
             } else {
-                Err(CoreError::Store {
+                Err(GrepError::StoreUnavailable {
                     object_key: object_key.to_owned(),
                     message: "object already exists with different bytes".to_owned(),
                     class: StoreFailureClass::Other,
@@ -1485,20 +1491,14 @@ async fn write_immutable_object<S: ObjectStore + ?Sized>(
             let message = error.message();
             match existing_object_matches(store, object_key, expected_bytes).await {
                 Ok(true) => Ok(()),
-                Ok(false) => Err(CoreError::Store {
+                Ok(false) => Err(GrepError::StoreUnavailable {
                     object_key: object_key.to_owned(),
                     message: format!(
                         "{message}; immutable object exists with different bytes after transport error"
                     ),
                     class: StoreFailureClass::Other,
                 }),
-                Err(verify_error) => Err(CoreError::Store {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "{message}; failed to verify immutable write after transport error: {verify_error}"
-                    ),
-                    class: StoreFailureClass::Other,
-                }),
+                Err(verify_error) => Err(verify_error),
             }
         }
         Err(error) => Err(core_store_error(object_key, &error)),
@@ -1523,7 +1523,7 @@ async fn existing_object_matches<S: ObjectStore + ?Sized>(
         .get(object_key, None)
         .await
         .map_err(|error| core_store_error(object_key, &error))?
-        .ok_or_else(|| CoreError::Store {
+        .ok_or_else(|| GrepError::StoreUnavailable {
             object_key: object_key.to_owned(),
             message: "object is missing while verifying immutable write".to_owned(),
             class: StoreFailureClass::Other,
@@ -1539,32 +1539,16 @@ fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Re
     Err(CoreError::MetadataPublicationBudgetExceeded {
         elapsed_ms,
         budget_ms: METADATA_PUBLICATION_BUDGET_MS,
-    })
-}
-
-fn core_root_error(error: GrepRootError) -> CoreError {
-    match error {
-        GrepRootError::Store {
-            object_key,
-            message,
-        } => CoreError::Store {
-            object_key,
-            message,
-            class: StoreFailureClass::Other,
-        },
-        GrepRootError::Conflict { object_key } => CoreError::CheckpointUnavailable(format!(
-            "grep root publication conflict for `{object_key}`; retry"
-        )),
-        error => CoreError::NamespaceCorrupt(error.to_string()),
     }
+    .into())
 }
 
-fn core_state_error(error: crate::root::GrepRootStateError) -> CoreError {
-    CoreError::Internal(format!("failed to build grep root state: {error}"))
+fn core_state_error(error: crate::root::GrepRootStateError) -> GrepError {
+    CoreError::Internal(format!("failed to build grep root state: {error}")).into()
 }
 
-fn core_store_error(object_key: &str, error: &ObjectStoreError) -> CoreError {
-    CoreError::Store {
+fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {
+    GrepError::StoreUnavailable {
         object_key: object_key.to_owned(),
         message: error.message(),
         class: StoreFailureClass::of(error),
@@ -1577,5 +1561,7 @@ fn current_time_ms() -> Result<u64> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_millis() as u64)
-        .map_err(|error| CoreError::Internal(format!("system clock before unix epoch: {error}")))
+        .map_err(|error| {
+            CoreError::Internal(format!("system clock before unix epoch: {error}")).into()
+        })
 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -311,6 +311,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepLifecycle::Disabled,
             GrepIndexState::new(
                 current.state().index().built_through_seq,
+                0,
                 None,
                 current.state().index().next_run_ordinal,
             ),
@@ -392,6 +393,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     namespace_id,
                     &content_store_id,
                     current.state().index().built_through_seq,
+                    current.state().index().next_delta_index,
                     policy,
                 )
                 .await?
@@ -562,6 +564,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             lifecycle,
             GrepIndexState::new(
                 unit.built_through_seq,
+                unit.next_delta_index,
                 current.state().index().fold.clone(),
                 next_run_ordinal,
             ),
@@ -614,7 +617,7 @@ fn backfilling_root(
             backfill_cursor: String::new(),
             checkpoint_id: Some(checkpoint_id),
         },
-        GrepIndexState::new(target_seq, None, next_run_ordinal),
+        GrepIndexState::new(target_seq, 0, None, next_run_ordinal),
         Vec::new(),
     )
     .map_err(core_state_error)
@@ -636,6 +639,7 @@ struct CollectedIndexUnit {
     skipped_revisions: u64,
     run_seq: ChangeSeq,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     backfill_cursor: Option<String>,
 }
 
@@ -659,6 +663,7 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
         skipped_revisions: 0,
         run_seq: target_seq,
         built_through_seq: target_seq,
+        next_delta_index: 0,
         backfill_cursor: Some(cursor.to_owned()),
     };
     let mut pending = Vec::new();
@@ -695,9 +700,15 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
     built_through_seq: ChangeSeq,
+    next_delta_index: u32,
     policy: GramIndexBuildPolicy,
 ) -> Result<IncrementalCollection> {
-    let feed = load_grep_change_feed(store, namespace_id, built_through_seq).await?;
+    let after_seq = if next_delta_index == 0 {
+        built_through_seq
+    } else {
+        ChangeSeq(built_through_seq.0.saturating_sub(1))
+    };
+    let feed = load_grep_change_feed(store, namespace_id, after_seq).await?;
     let GrepChangeFeed::Records { records, .. } = feed else {
         return Ok(IncrementalCollection::RebootstrapRequired);
     };
@@ -710,18 +721,24 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
         skipped_revisions: 0,
         run_seq: built_through_seq,
         built_through_seq,
+        next_delta_index,
         backfill_cursor: None,
     };
     let mut pending = Vec::new();
     let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
-    for record in records {
-        if examined_files >= policy.max_files_per_step
-            || planned_content_bytes >= policy.max_content_bytes_per_step
-        {
-            break;
+    'records: for record in records {
+        let start_delta_index = if record.seq == built_through_seq {
+            usize::try_from(next_delta_index).map_err(|_| {
+                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+            })?
+        } else {
+            0
+        };
+        if start_delta_index > record.deltas.len() {
+            return Ok(IncrementalCollection::RebootstrapRequired);
         }
-        for delta in &record.deltas {
+        for (delta_index, delta) in record.deltas.iter().enumerate().skip(start_delta_index) {
             if let WalDelta::AppendFileRevision {
                 inode_id,
                 revision_no,
@@ -729,6 +746,19 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                 ..
             } = &delta.delta
             {
+                let would_exceed_content_budget = planned_content_bytes > 0
+                    && planned_content_bytes.saturating_add(content_ref.size_bytes)
+                        > policy.max_content_bytes_per_step;
+                if examined_files >= policy.max_files_per_step || would_exceed_content_budget {
+                    if delta_index > 0 {
+                        unit.built_through_seq = record.seq;
+                        unit.run_seq = record.seq;
+                        unit.next_delta_index = u32::try_from(delta_index).map_err(|_| {
+                            CoreError::Internal("grep delta cursor overflow".to_owned())
+                        })?;
+                    }
+                    break 'records;
+                }
                 examined_files += 1;
                 if content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
                     unit.skipped_revisions += 1;
@@ -740,12 +770,30 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                         content_ref: content_ref.clone(),
                     });
                 }
+                if examined_files >= policy.max_files_per_step
+                    || planned_content_bytes >= policy.max_content_bytes_per_step
+                {
+                    unit.built_through_seq = record.seq;
+                    unit.run_seq = record.seq;
+                    let next_delta_index = delta_index.checked_add(1).ok_or_else(|| {
+                        CoreError::Internal("grep delta cursor overflow".to_owned())
+                    })?;
+                    if next_delta_index < record.deltas.len() {
+                        unit.next_delta_index = u32::try_from(next_delta_index).map_err(|_| {
+                            CoreError::Internal("grep delta cursor overflow".to_owned())
+                        })?;
+                    } else {
+                        unit.next_delta_index = 0;
+                    }
+                    break 'records;
+                }
             }
         }
         unit.built_through_seq = record.seq;
         unit.run_seq = record.seq;
+        unit.next_delta_index = 0;
     }
-    if unit.built_through_seq == built_through_seq {
+    if unit.built_through_seq == built_through_seq && unit.next_delta_index == next_delta_index {
         return Ok(IncrementalCollection::UpToDate);
     }
     load_and_fold_revision_contents(store, content_store_id, &pending, &mut unit).await?;
@@ -1029,6 +1077,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             current.state().lifecycle().clone(),
             GrepIndexState::new(
                 current.state().index().built_through_seq,
+                current.state().index().next_delta_index,
                 fold,
                 next_run_ordinal,
             ),

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -1,19 +1,29 @@
 #![allow(clippy::panic)]
 //! Per-namespace driver isolation, backoff, and explicit-GC boundaries.
 
+use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
 use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, IndexSegmentId, NamespaceId};
 use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
 use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use loonfs_core::{BootstrapOptions, DeleteNamespaceOptions, NamespaceEngine};
 use loonfs_grep::keyspace::{root_key, segment_key};
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepWorker,
+    GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepStepLimiter,
+    GrepWorker,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::ObjectStore;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::future::Future;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
+use tokio::sync::Notify;
 
 #[tokio::test]
 async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explicit() {
@@ -45,10 +55,21 @@ async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explici
         .expect("poison root");
 
     let runtime = tokio::runtime::Handle::current();
-    let poisoned_task = GrepDriver::new(worker.clone(), poisoned, GramIndexBuildPolicy::default())
-        .spawn_on(&runtime);
-    let healthy_task =
-        GrepDriver::new(worker, healthy, GramIndexBuildPolicy::default()).spawn_on(&runtime);
+    let step_limiter = GrepStepLimiter::new(2);
+    let poisoned_task = GrepDriver::new(
+        worker.clone(),
+        poisoned,
+        GramIndexBuildPolicy::default(),
+        step_limiter.clone(),
+    )
+    .spawn_on(&runtime);
+    let healthy_task = GrepDriver::new(
+        worker,
+        healthy,
+        GramIndexBuildPolicy::default(),
+        step_limiter,
+    )
+    .spawn_on(&runtime);
     assert_eq!(
         healthy_task.handle().wait_for_quiescence().await,
         Some(GrepDriverParked::CaughtUp {
@@ -99,8 +120,13 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
         .await
         .expect("delete namespace");
 
-    let task = GrepDriver::new(worker, namespace_id, GramIndexBuildPolicy::default())
-        .spawn_on(&tokio::runtime::Handle::current());
+    let task = GrepDriver::new(
+        worker,
+        namespace_id,
+        GramIndexBuildPolicy::default(),
+        GrepStepLimiter::new(1),
+    )
+    .spawn_on(&tokio::runtime::Handle::current());
     assert_eq!(
         task.handle().wait_for_quiescence().await,
         Some(GrepDriverParked::NotEnabled)
@@ -108,10 +134,201 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
     task.shutdown().await.expect("stop deleted driver");
 }
 
-async fn bootstrap(
-    store: Arc<LocalFsStore>,
+/// Namespace drivers keep their singleflight ownership but share one FIFO
+/// expensive-step cap. Blocking each namespace's sole backfill content read
+/// makes the number of simultaneously entered build steps directly visible.
+#[tokio::test]
+async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
+    const NAMESPACES: usize = 8;
+    const MAX_CONCURRENT_STEPS: usize = 2;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(StepConcurrencyStore::new(temp_dir.path()));
+    let worker = GrepWorker::new(
+        store.clone(),
+        "concurrency-driver-worker",
+        "concurrency-driver-session",
+        "concurrency-driver/0.1",
+    );
+    let mut namespace_ids = Vec::new();
+    for index in 0..NAMESPACES {
+        let namespace_id =
+            NamespaceId::parse(format!("concurrency-{index}")).expect("namespace id");
+        let engine = bootstrap(store.clone(), &namespace_id).await;
+        put_file(
+            &store,
+            &engine,
+            &namespace_id,
+            &format!("concurrency-put-{index}"),
+        )
+        .await;
+        worker.enable(&namespace_id).await.expect("enable grep");
+        namespace_ids.push(namespace_id);
+    }
+
+    store.pause_content_reads();
+    let limiter = GrepStepLimiter::new(MAX_CONCURRENT_STEPS);
+    let runtime = tokio::runtime::Handle::current();
+    let mut tasks = Vec::new();
+    for namespace_id in namespace_ids {
+        tasks.push(
+            GrepDriver::new(
+                worker.clone(),
+                namespace_id,
+                GramIndexBuildPolicy::default(),
+                limiter.clone(),
+            )
+            .spawn_on(&runtime),
+        );
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        store.wait_for_started(MAX_CONCURRENT_STEPS),
+    )
+    .await
+    .expect("the permitted drivers must enter their build steps");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), store.wait_for_started(3))
+            .await
+            .is_err(),
+        "a third namespace must remain queued while both permits are held"
+    );
+    assert_eq!(store.peak_in_flight(), MAX_CONCURRENT_STEPS);
+
+    store.resume_content_reads();
+    for task in &tasks {
+        assert_eq!(
+            task.handle().wait_for_quiescence().await,
+            Some(GrepDriverParked::CaughtUp {
+                built_through_seq: loonfs_api::ChangeSeq(1),
+            })
+        );
+    }
+    assert!(
+        store.peak_in_flight() <= MAX_CONCURRENT_STEPS,
+        "executing grep steps exceeded the shared cap"
+    );
+    for task in tasks {
+        task.shutdown().await.expect("stop concurrency driver");
+    }
+}
+
+#[derive(Debug)]
+struct StepConcurrencyStore {
+    inner: LocalFsStore,
+    pause_content_reads: AtomicBool,
+    started: AtomicUsize,
+    in_flight: AtomicUsize,
+    peak: AtomicUsize,
+    started_notify: Notify,
+    resume_notify: Notify,
+}
+
+impl StepConcurrencyStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("store"),
+            pause_content_reads: AtomicBool::new(false),
+            started: AtomicUsize::new(0),
+            in_flight: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+            started_notify: Notify::new(),
+            resume_notify: Notify::new(),
+        }
+    }
+
+    fn pause_content_reads(&self) {
+        self.pause_content_reads.store(true, Ordering::Release);
+    }
+
+    fn resume_content_reads(&self) {
+        self.pause_content_reads.store(false, Ordering::Release);
+        self.resume_notify.notify_waiters();
+    }
+
+    fn peak_in_flight(&self) -> usize {
+        self.peak.load(Ordering::Acquire)
+    }
+
+    async fn wait_for_started(&self, target: usize) {
+        loop {
+            let notified = self.started_notify.notified();
+            if self.started.load(Ordering::Acquire) >= target {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn observe_content_read<T>(&self, key: &str, read: impl Future<Output = T>) -> T {
+        if !key.contains("/blobs/sha256/") {
+            return read.await;
+        }
+        let in_flight = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak.fetch_max(in_flight, Ordering::AcqRel);
+        self.started.fetch_add(1, Ordering::AcqRel);
+        self.started_notify.notify_waiters();
+        if self.pause_content_reads.load(Ordering::Acquire) {
+            loop {
+                let notified = self.resume_notify.notified();
+                if !self.pause_content_reads.load(Ordering::Acquire) {
+                    break;
+                }
+                notified.await;
+            }
+        }
+        let result = read.await;
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        result
+    }
+}
+
+#[async_trait]
+impl ObjectStore for StepConcurrencyStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.observe_content_read(key, self.inner.get_with_metadata(key))
+            .await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.observe_content_read(key, self.inner.get(key, range))
+            .await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+async fn bootstrap<S: ObjectStore + Clone>(
+    store: S,
     namespace_id: &NamespaceId,
-) -> NamespaceEngine<Arc<LocalFsStore>> {
+) -> NamespaceEngine<S> {
     let engine = NamespaceEngine::builder(store)
         .namespace_id(namespace_id.clone())
         .writer_id(format!("seed-{namespace_id}"))
@@ -126,17 +343,17 @@ async fn bootstrap(
     engine
 }
 
-async fn put_file(
-    store: &Arc<LocalFsStore>,
-    engine: &NamespaceEngine<Arc<LocalFsStore>>,
+async fn put_file<S: ObjectStore + Clone>(
+    store: &S,
+    engine: &NamespaceEngine<S>,
     namespace_id: &NamespaceId,
     commit_id: &str,
 ) {
-    let stored = store_bytes_as_content(&**store, namespace_id, b"driver needle\n")
+    let stored = store_bytes_as_content(store, namespace_id, b"driver needle\n")
         .await
         .expect("store content");
     let content_ref = stored.content_ref.clone();
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");
     let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -12,12 +12,12 @@ use loonfs_grep::root::{
 // fixtures: changing field names, ordering, enum tags, or omission rules must
 // change them deliberately. Together they represent every lifecycle state.
 const BACKFILLING_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:15277f5e958c561781b58ca8faff30a9284ef154e184bd662d76d1b7d34c6824","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":"revision-00000000000000000007","checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"fold":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:ed1974bcc4b70b0d2df55ca19c9aa1f6080abdebdbbaa873e963af80b32e9124","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_delta_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
 const DISABLED_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
 const ADDITIVE_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","writer_version":"future-writer/9.0","payload_checksum":"sha256:2582065ee15d356cbaf1b40d245207ab8e2b61e3ae2a86a108957baf41336be9","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":1,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
 
 const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:05115c1932ff163b89f566ff9b04601120830830898ec57129e781f19490c30f","payload":{"namespace_id":"docs","manifest_id":"15277f5e958c561781b58ca8faff30a9284ef154e184bd662d76d1b7d34c6824"}}"#;
-const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:f73e1fd3c768a4fd87544c4280554dc445ade14202104c3434b268115650d06d","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad"}}"#;
+const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:073ed9d53d4b99a865e05d0874580488d99f5ff1ff1635e50693958517c0d2e3","payload":{"namespace_id":"docs","manifest_id":"ed1974bcc4b70b0d2df55ca19c9aa1f6080abdebdbbaa873e963af80b32e9124"}}"#;
 const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"loonfs-grep-tests/0.1.1","payload_checksum":"sha256:e5c0fbe19e4bee1cfb5ddf3a99f7c4439a83e4c323b1a6054bfa62e16a9c1d73","payload":{"namespace_id":"docs","manifest_id":"70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c"}}"#;
 const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","writer_version":"future-writer/9.0","payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","future_pointer":true},"future_envelope":{"retained":true}}"#;
 
@@ -25,7 +25,7 @@ const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","
 fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
     let cases = [
         (sample_backfilling_root(), BACKFILLING_V1),
-        (sample_steady_root(ChangeSeq(11)), STEADY_V1),
+        (sample_steady_root(ChangeSeq(11), 5), STEADY_V1),
         (sample_disabled_root(), DISABLED_V1),
     ];
 
@@ -58,7 +58,7 @@ fn decoders_read_frozen_v1_bytes_with_additive_fields() {
     let decoded =
         decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
 
-    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11)));
+    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
     let pointer =
         decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()).expect("decode additive pointer fixture");
     assert_eq!(
@@ -107,7 +107,7 @@ fn decoder_rejects_truncated_payload() {
 
 #[test]
 fn constructor_rejects_fold_segment_mismatch() {
-    let mut index = GrepIndexState::new(ChangeSeq(7), None, 2);
+    let mut index = GrepIndexState::new(ChangeSeq(7), 0, None, 2);
     index.fold = Some(GrepFoldState {
         snapshot_segment_ids: vec![segment_id(9)],
         output_segment_ids: Vec::new(),
@@ -144,7 +144,7 @@ fn sample_backfilling_root() -> GrepRootState {
                     .expect("valid checkpoint id"),
             ),
         },
-        GrepIndexState::new(ChangeSeq(7), Some(fold), 4),
+        GrepIndexState::new(ChangeSeq(7), 0, Some(fold), 4),
         vec![
             segment_ref(1, 1, 0, 0),
             segment_ref(2, 2, 0, 0),
@@ -154,11 +154,11 @@ fn sample_backfilling_root() -> GrepRootState {
     .expect("valid backfilling root")
 }
 
-fn sample_steady_root(built_through_seq: ChangeSeq) -> GrepRootState {
+fn sample_steady_root(built_through_seq: ChangeSeq, next_delta_index: u32) -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, None, 2),
+        GrepIndexState::new(built_through_seq, next_delta_index, None, 2),
         vec![segment_ref(1, 1, 0, 0)],
     )
     .expect("valid steady root")
@@ -168,7 +168,7 @@ fn sample_disabled_root() -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Disabled,
-        GrepIndexState::new(ChangeSeq(15), None, 4),
+        GrepIndexState::new(ChangeSeq(15), 0, None, 4),
         Vec::new(),
     )
     .expect("valid disabled root")

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -137,7 +137,7 @@ fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootStat
     GrepRootState::new(
         namespace_id,
         GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, None, 0),
+        GrepIndexState::new(built_through_seq, 0, None, 0),
         Vec::new(),
     )
     .expect("valid root")

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -124,6 +124,19 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
     assert!(stderr.contains("poll_interval_ms"), "{stderr}");
     assert!(stderr.contains("greater than zero"), "{stderr}");
 
+    let bad_grep_config_path = temp_dir.path().join("bad-grep-worker.toml");
+    write_config(
+        &bad_grep_config_path,
+        &store_root,
+        "",
+        "max_concurrent_steps = 0\n",
+    );
+    let bad = run_once(&bad_grep_config_path, &[&namespace_id]);
+    assert!(!bad.status.success(), "zero step cap must exit nonzero");
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    assert!(stderr.contains("max_concurrent_steps"), "{stderr}");
+    assert!(stderr.contains("greater than zero"), "{stderr}");
+
     let missing_namespace = Command::new(env!("CARGO_BIN_EXE_loonfs-grep"))
         .arg("--config")
         .arg(&config_path)

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tempfile::tempdir;
 
 #[tokio::test]
-async fn standalone_once_advances_the_index_is_idempotent_and_rejects_bad_config() {
+async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idempotent() {
     let temp_dir = tempdir().expect("tempdir");
     let store_root = temp_dir.path().join("store");
     let store = Arc::new(LocalFsStore::new(&store_root).expect("store"));
@@ -33,6 +33,23 @@ async fn standalone_once_advances_the_index_is_idempotent_and_rejects_bad_config
         .await
         .expect("bootstrap namespace");
     put_file(&store, &engine, &namespace_id).await;
+
+    let config_path = temp_dir.path().join("worker.toml");
+    write_config(&config_path, &store_root, "", "");
+    let disabled = run_once(&config_path, &[&namespace_id]);
+    assert!(
+        disabled.status.success(),
+        "disabled one-shot failed: {}",
+        String::from_utf8_lossy(&disabled.stderr)
+    );
+    assert!(
+        load_grep_root(&*store, &namespace_id)
+            .await
+            .expect("load absent root")
+            .is_none(),
+        "a disabled one-shot must leave grep disabled"
+    );
+
     GrepWorker::new(
         store.clone(),
         "standalone-enable",
@@ -43,8 +60,6 @@ async fn standalone_once_advances_the_index_is_idempotent_and_rejects_bad_config
     .await
     .expect("enable grep");
 
-    let config_path = temp_dir.path().join("worker.toml");
-    write_config(&config_path, &store_root, "", "");
     let first = run_once(&config_path, &[&namespace_id]);
     assert!(
         first.status.success(),

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -179,6 +179,8 @@ impl GrepMode {
 #[serde(default, deny_unknown_fields)]
 pub struct GrepConfig {
     pub mode: GrepMode,
+    /// Build or fold steps allowed to execute concurrently across namespaces.
+    pub max_concurrent_steps: usize,
     pub max_files_per_step: usize,
     pub max_content_bytes_per_step: u64,
     pub max_rows_per_segment: usize,
@@ -191,6 +193,7 @@ impl GrepConfig {
     /// Returns the shared bounded-step configuration represented by this table.
     pub fn worker_config(self) -> GrepWorkerConfig {
         GrepWorkerConfig {
+            max_concurrent_steps: self.max_concurrent_steps,
             max_files_per_step: self.max_files_per_step,
             max_content_bytes_per_step: self.max_content_bytes_per_step,
             max_rows_per_segment: self.max_rows_per_segment,
@@ -206,6 +209,7 @@ impl Default for GrepConfig {
         let worker = GrepWorkerConfig::default();
         Self {
             mode: GrepMode::Embedded,
+            max_concurrent_steps: worker.max_concurrent_steps,
             max_files_per_step: worker.max_files_per_step,
             max_content_bytes_per_step: worker.max_content_bytes_per_step,
             max_rows_per_segment: worker.max_rows_per_segment,
@@ -857,6 +861,7 @@ writer_id = "loonfs-server"
 writer_version = "loonfs-server/0.1.0"
 
 [grep]
+max_concurrent_steps = 0
 max_fold_rows_per_step = 0
 
 [store]
@@ -864,7 +869,7 @@ kind = "local-fs"
 root = "/tmp/loonfs-server"
 "#,
         );
-        let error = load_server_config(&path).expect_err("zero gram budget must be rejected");
+        let error = load_server_config(&path).expect_err("zero grep bound must be rejected");
         assert_invalid_field(error, "grep");
     }
 
@@ -1170,6 +1175,7 @@ writer_version = "loonfs-server/0.1.0"
 
 [grep]
 mode = "serve_only"
+max_concurrent_steps = 7
 max_files_per_step = 4096
 max_content_bytes_per_step = 536870912
 max_rows_per_segment = 131072
@@ -1185,6 +1191,7 @@ root = "/tmp/loonfs-server"
 
         let grep = load_server_config(&path).expect("load config").grep;
         assert_eq!(grep.mode, super::GrepMode::ServeOnly);
+        assert_eq!(grep.max_concurrent_steps, 7);
         let policy = grep.worker_config().build_policy();
         assert_eq!(policy.max_files_per_step, 4096);
         assert_eq!(policy.max_content_bytes_per_step, 536_870_912);

--- a/crates/loonfs-server/src/grep_drivers.rs
+++ b/crates/loonfs-server/src/grep_drivers.rs
@@ -3,7 +3,7 @@
 use loonfs::{NamespaceId, RuntimeError, SharedObjectStore};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverHandle, GrepDriverParked, GrepDriverTask,
-    GrepWorker,
+    GrepStepLimiter, GrepWorker,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -16,6 +16,7 @@ pub(crate) struct GrepDrivers {
 struct GrepDriversInner {
     worker: GrepWorker<SharedObjectStore>,
     policy: GramIndexBuildPolicy,
+    step_limiter: GrepStepLimiter,
     runtime: tokio::runtime::Handle,
     tasks: Mutex<HashMap<NamespaceId, GrepDriverTask>>,
     finished: Mutex<Vec<GrepDriverTask>>,
@@ -25,6 +26,7 @@ impl GrepDrivers {
     pub(crate) fn new(
         worker: GrepWorker<SharedObjectStore>,
         policy: GramIndexBuildPolicy,
+        max_concurrent_steps: usize,
     ) -> Result<Self, crate::ServerConfigError> {
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
             crate::ServerConfigError::InvalidField {
@@ -36,6 +38,7 @@ impl GrepDrivers {
             inner: Arc::new(GrepDriversInner {
                 worker,
                 policy,
+                step_limiter: GrepStepLimiter::new(max_concurrent_steps),
                 runtime,
                 tasks: Mutex::new(HashMap::new()),
                 finished: Mutex::new(Vec::new()),
@@ -63,6 +66,7 @@ impl GrepDrivers {
             self.inner.worker.clone(),
             namespace_id.clone(),
             self.inner.policy,
+            self.inner.step_limiter.clone(),
         )
         .spawn_on(&self.inner.runtime);
         let handle = task.handle();

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -284,11 +284,16 @@ async fn start_driver_for_query_if_needed(
     };
     let needs_catch_up = match root.state().lifecycle() {
         GrepLifecycle::Backfilling { .. } => true,
-        GrepLifecycle::Steady => state
-            .admin
-            .namespace_status(namespace_id)
-            .await
-            .is_ok_and(|status| root.state().index().built_through_seq < status.head_seq),
+        GrepLifecycle::Steady => {
+            state
+                .admin
+                .namespace_status(namespace_id)
+                .await
+                .is_ok_and(|status| {
+                    root.state().index().next_delta_index != 0
+                        || root.state().index().built_through_seq < status.head_seq
+                })
+        }
         GrepLifecycle::Disabled => false,
     };
     if needs_catch_up {

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -1,7 +1,7 @@
 //! The `query/v0` plane: derived-index reads.
 
 use super::{authorize, AppJson, AppState, NamespaceIdPath};
-use crate::http::error::ApiResponseError;
+use crate::http::error::{status_for_core_error_code, ApiResponseError};
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
@@ -12,8 +12,10 @@ use loonfs_api::v0::{
 use loonfs_api::ApiError;
 use loonfs_api::FEATURE_QUERY_GREP;
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
-use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome};
+use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const GREP_INDEX_FEATURE: &str = "index.grams";
 
 #[cfg_attr(
     feature = "openapi",
@@ -29,10 +31,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
             (status = 200, description = "One page of matches", body = GrepResponse),
             (status = 400, description = "Invalid pattern, cursor, or an unindexable pattern without allow_scan", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "Grep serving is disabled or the gram index is not materialized on this namespace", body = ApiError),
-            (status = 503, description = "The index trails the head past the scan budget", body = ApiError)
+            (status = 503, description = "The index trails the head past the scan budget", body = ApiError),
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -49,7 +53,7 @@ pub(super) async fn grep(
         .reader
         .grep(&namespace_id, &request)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| map_runtime_grep_error(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -77,9 +81,11 @@ pub(super) async fn grep_not_supported(
         responses(
             (status = 200, description = "Grep root enabled or already enabled", body = EnableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -96,12 +102,7 @@ pub(super) async fn enable_grams_index(
         .expect("grep routes should carry a grep worker")
         .enable(&namespace_id)
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     let response = match outcome {
         GrepEnableOutcome::Enabled { target_seq } => EnableGramsIndexResponse {
             namespace_id: namespace_id.clone(),
@@ -114,11 +115,11 @@ pub(super) async fn enable_grams_index(
             already_enabled: true,
         },
         GrepEnableOutcome::Superseded => {
-            return Err(ApiResponseError::runtime_for_namespace(
+            return Err(map_grep_error(
                 &namespace_id,
-                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
-                    "enabling grep lost a root publication race; retry".to_owned(),
-                )),
+                GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
+                },
             ));
         }
     };
@@ -140,9 +141,11 @@ pub(super) async fn enable_grams_index(
         responses(
             (status = 200, description = "Grep root disabled or already disabled", body = DisableGramsIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
+            (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
-            (status = 503, description = "Lost a grep root-pointer publication race; retry", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -165,12 +168,7 @@ pub(super) async fn disable_grams_index(
         .expect("grep routes should carry a grep worker")
         .disable(&namespace_id)
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     let response = match outcome {
         GrepDisableOutcome::Disabled => DisableGramsIndexResponse {
             namespace_id: namespace_id.clone(),
@@ -181,11 +179,11 @@ pub(super) async fn disable_grams_index(
             was_enabled: false,
         },
         GrepDisableOutcome::Superseded => {
-            return Err(ApiResponseError::runtime_for_namespace(
+            return Err(map_grep_error(
                 &namespace_id,
-                loonfs::RuntimeError::Core(loonfs::CoreError::CheckpointUnavailable(
-                    "disabling grep lost a root publication race; retry".to_owned(),
-                )),
+                GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
+                },
             ));
         }
     };
@@ -204,7 +202,9 @@ pub(super) async fn disable_grams_index(
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError)
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
+            (status = 501, description = "Grep serving is disabled for this deployment", body = ApiError),
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )
     )
 )]
@@ -229,12 +229,7 @@ pub(super) async fn gc_grams_index(
             })?,
         )
         .await
-        .map_err(|error| {
-            ApiResponseError::runtime_for_namespace(
-                &namespace_id,
-                loonfs::RuntimeError::Core(error),
-            )
-        })?;
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(GrepGcResponse {
         namespace_id,
         deleted_segments: report.deleted_segments,
@@ -243,6 +238,38 @@ pub(super) async fn gc_grams_index(
         retained_candidates: report.retained_candidates,
         namespace_degraded: report.namespace_degraded,
     }))
+}
+
+fn map_runtime_grep_error(
+    namespace_id: &loonfs_api::NamespaceId,
+    error: loonfs::RuntimeError,
+) -> ApiResponseError {
+    match error {
+        loonfs::RuntimeError::Grep(error) => map_grep_error(namespace_id, error),
+        error => ApiResponseError::runtime_for_namespace(namespace_id, error),
+    }
+}
+
+fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> ApiResponseError {
+    match error {
+        error @ (GrepError::NotEnabled | GrepError::Backfilling) => {
+            ApiResponseError::not_supported(GREP_INDEX_FEATURE, &error.to_string())
+        }
+        error @ (GrepError::StoreUnavailable { .. }
+        | GrepError::CorruptIndex { .. }
+        | GrepError::PublicationConflict { .. }) => {
+            let code = error.code();
+            ApiResponseError::new(status_for_core_error_code(code), code, &error.to_string())
+        }
+        GrepError::Core(error) => {
+            ApiResponseError::runtime_for_namespace(namespace_id, loonfs::RuntimeError::Core(error))
+        }
+        error => ApiResponseError::new(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            loonfs_api::ErrorCode::ServerError,
+            &error.to_string(),
+        ),
+    }
 }
 
 async fn start_driver_for_query_if_needed(

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -230,6 +230,7 @@ async fn app_with_store_and_transfer_issuer(
                 .expect("driver-running grep mode should serve grep")
                 .clone(),
             config.grep.worker_config().build_policy(),
+            config.grep.max_concurrent_steps,
         )?)
     } else {
         None

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -79,7 +79,8 @@ use loonfs_api::{
     RepairNamespaceOutcome,
 };
 use loonfs_client::{Client, ClientConfig, ClientError, MutationOptions, NamespacePath};
-use loonfs_grep::keyspace::root_key as grep_root_key;
+use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
+use loonfs_grep::root::{encode_grep_root, GrepManifestId, GrepRootEnvelope, GrepRootPointer};
 use loonfs_grep::{GrepDriverParked, GrepWorker};
 use loonfs_objectstore::keys::{metadata_root, namespace_config, wal_head};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -213,6 +214,92 @@ struct BlockGrepRootOnceStore {
     armed: AtomicBool,
     entered: Notify,
     release: Notify,
+}
+
+#[derive(Debug)]
+struct FaultGrepRootStore {
+    inner: LocalFsStore,
+    root_key: String,
+    fail_next_root_read: AtomicBool,
+    conflict_next_root_publication: AtomicBool,
+}
+
+impl FaultGrepRootStore {
+    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
+        Self {
+            inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
+            root_key: grep_root_key(namespace_id),
+            fail_next_root_read: AtomicBool::new(false),
+            conflict_next_root_publication: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_next_root_read(&self) {
+        self.fail_next_root_read.store(true, Ordering::SeqCst);
+    }
+
+    fn conflict_next_root_publication(&self) {
+        self.conflict_next_root_publication
+            .store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FaultGrepRootStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        if key == self.root_key && self.fail_next_root_read.swap(false, Ordering::SeqCst) {
+            return Err(ObjectStoreError::transport(
+                key,
+                "injected grep-root outage",
+            ));
+        }
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key == self.root_key
+            && matches!(
+                &mode,
+                PutMode::CreateIfAbsent | PutMode::CompareAndSwap { .. }
+            )
+            && self
+                .conflict_next_root_publication
+                .swap(false, Ordering::SeqCst)
+        {
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 impl BlockGrepRootOnceStore {
@@ -472,6 +559,213 @@ async fn embedded_publish_observer_nudges_only_the_enabled_namespace_driver() {
         .expect("grep caught-up index");
     assert_eq!(response.matches.len(), 1);
     lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_disabled_root_is_not_materialized_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-disabled");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let worker = grep_error_worker(&store);
+    worker.enable(&namespace_id).await.expect("enable grep");
+    worker.disable(&namespace_id).await.expect("disable grep");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "disabled-server").await;
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                501,
+                ErrorCode::NotSupported,
+                "not materialized",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_mid_backfill_is_not_materialized_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-backfill");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    grep_error_worker(&store)
+        .enable(&namespace_id)
+        .await
+        .expect("leave grep backfilling");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "backfill-server").await;
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                501,
+                ErrorCode::NotSupported,
+                "not materialized",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("grep-error-store");
+    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let store = fault_store.clone() as SharedObjectStore;
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "store-server").await;
+    fault_store.fail_next_root_read();
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                500,
+                ErrorCode::ServerError,
+                "injected grep-root outage",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_corrupt_pointer_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-pointer");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    store
+        .put_overwrite(
+            &grep_root_key(&namespace_id),
+            Bytes::from_static(b"corrupt grep pointer"),
+        )
+        .await
+        .expect("write corrupt grep pointer");
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "pointer-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_missing_manifest_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-missing-manifest");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
+            .expect("manifest id");
+    write_grep_pointer(&*store, &namespace_id, namespace_id.clone(), manifest_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "missing-manifest-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_corrupt_manifest_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-manifest");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("2222222222222222222222222222222222222222222222222222222222222222")
+            .expect("manifest id");
+    store
+        .put_overwrite(
+            &grep_manifest_key(&namespace_id, &manifest_id),
+            Bytes::from_static(b"corrupt grep manifest"),
+        )
+        .await
+        .expect("write corrupt grep manifest");
+    write_grep_pointer(&*store, &namespace_id, namespace_id.clone(), manifest_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "manifest-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_identity_mismatch_is_index_corrupt_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let namespace_id = namespace_id("grep-error-identity");
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    let manifest_id =
+        GrepManifestId::parse("3333333333333333333333333333333333333333333333333333333333333333")
+            .expect("manifest id");
+    write_grep_pointer(
+        &*store,
+        &namespace_id,
+        NamespaceId::parse("different-grep-identity").expect("different namespace id"),
+        manifest_id,
+    )
+    .await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "identity-server").await;
+    assert_index_corrupt_and_core_read(harness, namespace_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_error_publication_conflict_is_stale_head_and_core_reads_survive() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("grep-error-conflict");
+    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let store = fault_store.clone() as SharedObjectStore;
+    let writer = seed_grep_error_namespace(&store, &namespace_id).await;
+    writer.shutdown_background().await.expect("shutdown writer");
+
+    let harness = start_grep_error_server(store, temp_dir.path(), "conflict-server").await;
+    fault_store.conflict_next_root_publication();
+    tokio::task::spawn_blocking({
+        let namespace_id = namespace_id.clone();
+        let client = harness.client.clone();
+        move || {
+            let result = client.enable_grams_index(&namespace_id);
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                409,
+                ErrorCode::StaleHead,
+                "publication conflict",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1579,8 +1873,144 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
     server.abort();
 }
 
+async fn seed_grep_error_namespace(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> FsWriter {
+    let writer = test_runtime(store.clone(), "grep-error-seed").await;
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create grep-error namespace");
+    writer
+        .put_file_bytes(
+            namespace_id,
+            "/core.txt",
+            b"core remains readable",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write core isolation sentinel");
+    writer
+}
+
+fn grep_error_worker(store: &SharedObjectStore) -> GrepWorker<SharedObjectStore> {
+    GrepWorker::new(
+        store.clone(),
+        "grep-error-worker",
+        "grep-error-worker-session",
+        "grep-error-worker/0.1",
+    )
+}
+
+fn grep_error_request() -> GrepRequest {
+    GrepRequest {
+        pattern: "needle".to_owned(),
+        case_insensitive: false,
+        path_prefix: None,
+        cursor: None,
+        limit: None,
+        allow_stale: false,
+        allow_scan: false,
+    }
+}
+
+async fn write_grep_pointer(
+    store: &dyn ObjectStore,
+    stored_namespace_id: &NamespaceId,
+    pointer_namespace_id: NamespaceId,
+    manifest_id: GrepManifestId,
+) {
+    let envelope = GrepRootEnvelope::from_pointer(
+        "grep-error-api-test/0.1",
+        GrepRootPointer::new(pointer_namespace_id, manifest_id),
+    )
+    .expect("build grep pointer");
+    store
+        .put_overwrite(
+            &grep_root_key(stored_namespace_id),
+            Bytes::from(encode_grep_root(&envelope).expect("encode grep pointer")),
+        )
+        .await
+        .expect("write grep pointer");
+}
+
+async fn start_grep_error_server(
+    store: SharedObjectStore,
+    root: &Path,
+    writer_id: &str,
+) -> TestHarness {
+    let mut config = test_config(root, writer_id);
+    config.grep.mode = crate::config::GrepMode::ServeOnly;
+    start_server_with_config(store, config).await
+}
+
+async fn assert_index_corrupt_and_core_read(harness: TestHarness, namespace_id: NamespaceId) {
+    tokio::task::spawn_blocking({
+        let client = harness.client.clone();
+        move || {
+            let result = client.grep(&namespace_id, &grep_error_request());
+            assert_grep_api_error_and_core_read(
+                &client,
+                &namespace_id,
+                result,
+                500,
+                ErrorCode::IndexCorrupt,
+                "disable and re-enable grep to rebuild it",
+            );
+        }
+    })
+    .await
+    .expect("join blocking task");
+    harness.server.abort();
+}
+
+fn assert_grep_api_error_and_core_read<T: std::fmt::Debug>(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    result: Result<T, ClientError>,
+    status: u16,
+    code: ErrorCode,
+    message_fragment: &str,
+) {
+    match result {
+        Err(ClientError::Api {
+            status: actual_status,
+            code: actual_code,
+            feature,
+            message,
+            ..
+        }) => {
+            assert_eq!(actual_status, status);
+            assert_eq!(actual_code, code.as_str());
+            assert!(
+                message.contains(message_fragment),
+                "expected `{message_fragment}` in `{message}`"
+            );
+            if code == ErrorCode::NotSupported {
+                assert_eq!(feature.as_deref(), Some("index.grams"));
+            } else {
+                assert_eq!(feature, None);
+            }
+        }
+        other => panic!(
+            "expected grep api error {status} {}, got {other:?}",
+            code.as_str()
+        ),
+    }
+
+    let target = NamespacePath::parse(namespace_id.as_str(), "/core.txt").expect("core target");
+    let bytes = client
+        .read_file_bytes(&target)
+        .expect("grep failure must not affect core reads");
+    assert_eq!(bytes, b"core remains readable");
+}
+
 async fn start_server(store: SharedObjectStore, root: &Path, writer_id: &str) -> TestHarness {
-    let config = test_config(root, writer_id);
+    start_server_with_config(store, test_config(root, writer_id)).await
+}
+
+async fn start_server_with_config(store: SharedObjectStore, config: ServerConfig) -> TestHarness {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -108,6 +108,17 @@ fn age_metadata(mut metadata: ObjectMetadata) -> ObjectMetadata {
     metadata
 }
 
+/// Raw-request agent with socket inactivity timeouts. A starved or wedged
+/// server must produce a readable transport error, not an indefinite hang
+/// or a panic inside the HTTP client's response path — the failure mode a
+/// loaded CI runner once hit through the default timeout-less agent.
+fn raw_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_read(std::time::Duration::from_secs(30))
+        .timeout_write(std::time::Duration::from_secs(30))
+        .build()
+}
+
 #[async_trait]
 impl ObjectStore for AgedMetadataStore {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
@@ -1257,20 +1268,23 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
 
         // A query value that fails its field type: enveloped invalid_request.
         let changes_url = format!("http://{addr}/v0/namespaces/demo/changes?after_seq=abc");
-        let error = ureq::get(&changes_url)
+        let error = raw_agent()
+            .get(&changes_url)
             .set("authorization", "Bearer test-token")
             .call()
             .expect_err("malformed after_seq should answer 400");
         expect_enveloped(error, 400, "invalid_request");
 
         // The same malformed query without credentials: 401 wins.
-        let error = ureq::get(&changes_url)
+        let error = raw_agent()
+            .get(&changes_url)
             .call()
             .expect_err("unauthorized should answer 401");
         expect_enveloped(error, 401, "unauthorized");
 
         // A missing required query parameter: enveloped invalid_request.
-        let error = ureq::get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
+        let error = raw_agent()
+            .get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
             .set("authorization", "Bearer test-token")
             .call()
             .expect_err("missing path parameter should answer 400");
@@ -1279,13 +1293,15 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         // A malformed JSON body: enveloped invalid_request with credentials,
         // 401 without — the body is not read before authorization.
         let create_url = format!("http://{addr}/v0/namespaces");
-        let error = ureq::post(&create_url)
+        let error = raw_agent()
+            .post(&create_url)
             .set("authorization", "Bearer test-token")
             .set("content-type", "application/json")
             .send_string("{not json")
             .expect_err("malformed body should answer 400");
         expect_enveloped(error, 400, "invalid_request");
-        let error = ureq::post(&create_url)
+        let error = raw_agent()
+            .post(&create_url)
             .set("content-type", "application/json")
             .send_string("{not json")
             .expect_err("unauthorized malformed body should answer 401");
@@ -1416,7 +1432,8 @@ async fn http_unknown_routes_and_methods_answer_in_envelope() {
 
     tokio::task::spawn_blocking(move || {
         // Unknown path: in-envelope 404 instead of axum's empty body.
-        let error = ureq::get(&format!("http://{addr}/v0/nonexistent"))
+        let error = raw_agent()
+            .get(&format!("http://{addr}/v0/nonexistent"))
             .call()
             .expect_err("unknown route should answer 404");
         let ureq::Error::Status(status, response) = error else {
@@ -1429,7 +1446,8 @@ async fn http_unknown_routes_and_methods_answer_in_envelope() {
         assert_eq!(body["code"], "route_not_found");
 
         // Served path, unserved method: in-envelope 405.
-        let error = ureq::delete(&format!("http://{addr}/v0/config"))
+        let error = raw_agent()
+            .delete(&format!("http://{addr}/v0/config"))
             .call()
             .expect_err("wrong method should answer 405");
         let ureq::Error::Status(status, response) = error else {
@@ -1466,7 +1484,8 @@ async fn http_commit_body_over_the_limit_answers_content_too_large() {
         // The limit rejects on size before any parsing, so an oversized
         // JSON-shaped body is enough to exercise it.
         let oversized = format!(r#"{{"filler":"{}"}}"#, "d".repeat(4096));
-        let error = ureq::post(&format!("http://{addr}/v0/namespaces/demo/commits"))
+        let error = raw_agent()
+            .post(&format!("http://{addr}/v0/namespaces/demo/commits"))
             .set("content-type", "application/json")
             .send_string(&oversized)
             .expect_err("unauthorized commit should fail before buffering");
@@ -1475,7 +1494,8 @@ async fn http_commit_body_over_the_limit_answers_content_too_large() {
         };
         assert_eq!(status, 401);
 
-        let error = ureq::post(&format!("http://{addr}/v0/namespaces/demo/commits"))
+        let error = raw_agent()
+            .post(&format!("http://{addr}/v0/namespaces/demo/commits"))
             .set("authorization", "Bearer test-token")
             .set("content-type", "application/json")
             .send_string(&oversized)
@@ -1533,14 +1553,15 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
 
     let cursor = tokio::task::spawn_blocking({
         move || {
-            let response = ureq::get(&format!(
-                "http://{addr}/v0/namespaces/demo/filesystem/revisions"
-            ))
-            .set("authorization", "Bearer test-token")
-            .query("path", "/notes/file.txt")
-            .query("limit", "1")
-            .call()
-            .expect("first revisions page");
+            let response = raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/filesystem/revisions"
+                ))
+                .set("authorization", "Bearer test-token")
+                .query("path", "/notes/file.txt")
+                .query("limit", "1")
+                .call()
+                .expect("first revisions page");
             let body = response.into_string().expect("read revisions body");
             let body: serde_json::Value = serde_json::from_str(&body).expect("json revisions");
             body["next_cursor"]
@@ -1563,15 +1584,16 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
     .await;
 
     tokio::task::spawn_blocking(move || {
-        let error = ureq::get(&format!(
-            "http://{addr}/v0/namespaces/demo/filesystem/revisions"
-        ))
-        .set("authorization", "Bearer test-token")
-        .query("path", "/notes/file.txt")
-        .query("limit", "1")
-        .query("cursor", &cursor)
-        .call()
-        .expect_err("stale cursor should answer rebootstrap_required");
+        let error = raw_agent()
+            .get(&format!(
+                "http://{addr}/v0/namespaces/demo/filesystem/revisions"
+            ))
+            .set("authorization", "Bearer test-token")
+            .query("path", "/notes/file.txt")
+            .query("limit", "1")
+            .query("cursor", &cursor)
+            .call()
+            .expect_err("stale cursor should answer rebootstrap_required");
         let ureq::Error::Status(status, response) = error else {
             panic!("expected a status error for a stale cursor");
         };
@@ -1845,7 +1867,8 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
     let ready_url = format!("http://{addr}/health/ready");
     let url = ready_url.clone();
     tokio::task::spawn_blocking(move || {
-        let body = ureq::get(&url)
+        let body = raw_agent()
+            .get(&url)
             .call()
             .expect("an admitting server is ready")
             .into_string()
@@ -1857,7 +1880,7 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
 
     state.publisher.close_admission();
 
-    tokio::task::spawn_blocking(move || match ureq::get(&ready_url).call() {
+    tokio::task::spawn_blocking(move || match raw_agent().get(&ready_url).call() {
         Err(ureq::Error::Status(503, response)) => {
             let body = response.into_string().expect("readiness body");
             assert!(

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -25,6 +25,17 @@ use tempfile::tempdir;
 
 const TEST_CONTENT_TOKEN_SECRET: &str = "test-content-token-secret";
 
+/// Raw-request agent with socket inactivity timeouts. A starved or wedged
+/// server must produce a readable transport error, not an indefinite hang
+/// or a panic inside the HTTP client's response path — the failure mode a
+/// loaded CI runner once hit through the default timeout-less agent.
+fn raw_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_read(std::time::Duration::from_secs(30))
+        .timeout_write(std::time::Duration::from_secs(30))
+        .build()
+}
+
 fn block_on<T>(future: impl Future<Output = T>) -> T {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -386,7 +397,8 @@ async fn http_namespace_listing_route_is_not_exposed() {
             .create_namespace(&namespace_id("demo"))
             .expect("create demo");
 
-        let response = ureq::get(&format!("{}/v0/namespaces", harness.server_url))
+        let response = raw_agent()
+            .get(&format!("{}/v0/namespaces", harness.server_url))
             .set("authorization", "Bearer test-token")
             .call();
         match response {
@@ -418,18 +430,20 @@ async fn http_rejects_invalid_namespace_ids_in_body_and_path() {
 
     tokio::task::spawn_blocking(move || {
         assert_invalid_namespace_response(
-            ureq::post(&format!("{}/v0/namespaces", harness.server_url))
+            raw_agent()
+                .post(&format!("{}/v0/namespaces", harness.server_url))
                 .set("authorization", "Bearer test-token")
                 .send_json(json!({ "namespace_id": "bad/name" })),
         );
 
         assert_invalid_namespace_response(
-            ureq::get(&format!(
-                "{}/v0/namespaces/bad%25/filesystem/list?path=/",
-                harness.server_url
-            ))
-            .set("authorization", "Bearer test-token")
-            .call(),
+            raw_agent()
+                .get(&format!(
+                    "{}/v0/namespaces/bad%25/filesystem/list?path=/",
+                    harness.server_url
+                ))
+                .set("authorization", "Bearer test-token")
+                .call(),
         );
     })
     .await
@@ -2148,12 +2162,13 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
                     "behavior": behavior,
                 },
             });
-            match ureq::post(&format!(
-                "{}/v0/namespaces/demo/filesystem/operations",
-                harness.server_url
-            ))
-            .set("authorization", "Bearer test-token")
-            .send_json(request)
+            match raw_agent()
+                .post(&format!(
+                    "{}/v0/namespaces/demo/filesystem/operations",
+                    harness.server_url
+                ))
+                .set("authorization", "Bearer test-token")
+                .send_json(request)
             {
                 Err(ureq::Error::Status(status, response)) => {
                     assert_eq!(status, 400);
@@ -2167,13 +2182,14 @@ async fn http_malformed_bodies_fail_inside_the_error_envelope() {
 
         // Malformed upload bodies must also stay inside the envelope — an
         // Option-typed body must reject garbage, not default it to a session.
-        match ureq::post(&format!(
-            "{}/v0/namespaces/demo/uploads",
-            harness.server_url
-        ))
-        .set("authorization", "Bearer test-token")
-        .set("content-type", "application/json")
-        .send_string("{\"mode\": \"direkt_put\"}")
+        match raw_agent()
+            .post(&format!(
+                "{}/v0/namespaces/demo/uploads",
+                harness.server_url
+            ))
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string("{\"mode\": \"direkt_put\"}")
         {
             Err(ureq::Error::Status(status, response)) => {
                 assert_eq!(status, 400);
@@ -2628,7 +2644,9 @@ fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {
 }
 
 fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Result<T, ApiError> {
-    let request = ureq::get(url).set("authorization", &format!("Bearer {auth_token}"));
+    let request = raw_agent()
+        .get(url)
+        .set("authorization", &format!("Bearer {auth_token}"));
     match request.call() {
         Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| ApiError {
             code: "invalid_json".to_owned(),
@@ -2712,7 +2730,9 @@ fn post_admin_json<T: serde::de::DeserializeOwned>(
     url: &str,
     auth_token: &str,
 ) -> Result<T, ApiError> {
-    let request = ureq::post(url).set("authorization", &format!("Bearer {auth_token}"));
+    let request = raw_agent()
+        .post(url)
+        .set("authorization", &format!("Bearer {auth_token}"));
     decode_admin_response(request.call())
 }
 
@@ -2721,7 +2741,9 @@ fn post_admin_json_body<T: serde::de::DeserializeOwned>(
     auth_token: &str,
     body: serde_json::Value,
 ) -> Result<T, ApiError> {
-    let request = ureq::post(url).set("authorization", &format!("Bearer {auth_token}"));
+    let request = raw_agent()
+        .post(url)
+        .set("authorization", &format!("Bearer {auth_token}"));
     decode_admin_response(request.send_json(body))
 }
 
@@ -2778,12 +2800,13 @@ fn send_filesystem_operation(
     namespace_id: &NamespaceId,
     request: &FilesystemOperationRequest,
 ) -> Result<ureq::Response, Box<ureq::Error>> {
-    ureq::post(&format!(
-        "{server_url}/v0/namespaces/{namespace_id}/filesystem/operations"
-    ))
-    .set("authorization", "Bearer test-token")
-    .send_json(request)
-    .map_err(Box::new)
+    raw_agent()
+        .post(&format!(
+            "{server_url}/v0/namespaces/{namespace_id}/filesystem/operations"
+        ))
+        .set("authorization", "Bearer test-token")
+        .send_json(request)
+        .map_err(Box::new)
 }
 
 fn send_commit_submission(
@@ -2799,12 +2822,13 @@ fn send_commit_json(
     namespace_id: &NamespaceId,
     request: &impl serde::Serialize,
 ) -> Result<ureq::Response, Box<ureq::Error>> {
-    ureq::post(&format!(
-        "{server_url}/v0/namespaces/{namespace_id}/commits"
-    ))
-    .set("authorization", "Bearer test-token")
-    .send_json(request)
-    .map_err(Box::new)
+    raw_agent()
+        .post(&format!(
+            "{server_url}/v0/namespaces/{namespace_id}/commits"
+        ))
+        .set("authorization", "Bearer test-token")
+        .send_json(request)
+        .map_err(Box::new)
 }
 
 fn response_bytes(response: ureq::Response) -> Vec<u8> {

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -3,9 +3,9 @@
 
 use super::core::FsCore;
 use crate::{
-    AdvanceRetentionResponse, CheckpointId, CoreError, CreateCheckpointOptions,
-    CreateCheckpointResponse, ErrorCode, FlushWalOutcome, FlushWalResponse, MaintenanceTickOptions,
-    MaintenanceTickOutcome, MaintenanceTickResult, NamespaceId, ReleaseCheckpointResponse,
+    AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
+    ErrorCode, FlushWalOutcome, FlushWalResponse, MaintenanceTickOptions, MaintenanceTickOutcome,
+    MaintenanceTickResult, NamespaceId, ReleaseCheckpointResponse,
 };
 use crate::{Result, RuntimeError};
 use loonfs_api::{DisableGramsIndexResponse, EnableGramsIndexResponse};
@@ -180,7 +180,7 @@ impl FsCore {
             .grep_worker()
             .enable(namespace_id)
             .await
-            .map_err(RuntimeError::Core)?;
+            .map_err(RuntimeError::Grep)?;
         match outcome {
             loonfs_grep::GrepEnableOutcome::Enabled { target_seq } => {
                 Ok(EnableGramsIndexResponse {
@@ -196,11 +196,11 @@ impl FsCore {
                     already_enabled: true,
                 })
             }
-            loonfs_grep::GrepEnableOutcome::Superseded => {
-                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
-                    "enabling grep lost a root publication race; retry".to_owned(),
-                )))
-            }
+            loonfs_grep::GrepEnableOutcome::Superseded => Err(RuntimeError::Grep(
+                loonfs_grep::GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(namespace_id),
+                },
+            )),
         }
     }
 
@@ -214,7 +214,7 @@ impl FsCore {
             .grep_worker()
             .disable(namespace_id)
             .await
-            .map_err(RuntimeError::Core)?;
+            .map_err(RuntimeError::Grep)?;
         match outcome {
             loonfs_grep::GrepDisableOutcome::Disabled => Ok(DisableGramsIndexResponse {
                 namespace_id: namespace_id.clone(),
@@ -224,11 +224,11 @@ impl FsCore {
                 namespace_id: namespace_id.clone(),
                 was_enabled: false,
             }),
-            loonfs_grep::GrepDisableOutcome::Superseded => {
-                Err(RuntimeError::Core(CoreError::CheckpointUnavailable(
-                    "disabling grep lost a root publication race; retry".to_owned(),
-                )))
-            }
+            loonfs_grep::GrepDisableOutcome::Superseded => Err(RuntimeError::Grep(
+                loonfs_grep::GrepError::PublicationConflict {
+                    object_key: loonfs_grep::keyspace::root_key(namespace_id),
+                },
+            )),
         }
     }
 

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -66,6 +66,7 @@ pub use loonfs_core::{
     BootstrapNamespaceError, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind,
     GcConfig, GcReport, WriterFence,
 };
+pub use loonfs_grep::GrepError;
 pub use publisher::PublishObserver;
 
 /// Integration seam: the vocabulary for handing classified mutation work to
@@ -132,6 +133,9 @@ pub enum RuntimeError {
     /// Bootstrapping a namespace failed.
     #[error(transparent)]
     Bootstrap(#[from] BootstrapNamespaceError),
+    /// A grep query or grep-owned maintenance operation failed.
+    #[error(transparent)]
+    Grep(#[from] GrepError),
     /// The runtime configuration is invalid.
     #[error("invalid runtime config: {0}")]
     Config(String),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1016,6 +1016,7 @@ fn runtime_error_to_core(error: RuntimeError) -> CoreError {
     match error {
         RuntimeError::Core(error) => error,
         RuntimeError::Bootstrap(error) => CoreError::Internal(error.to_string()),
+        RuntimeError::Grep(error) => CoreError::Internal(error.to_string()),
         RuntimeError::Config(message) => CoreError::Internal(message),
         RuntimeError::RuntimeTask(message) => CoreError::Internal(message),
     }

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -7,12 +7,12 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs::{
-    ChangeSeq, CreateNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter, GrepRequest,
-    NamespaceId, PutFileOptions,
+    ChangeSeq, CommitId, CommitOp, CommitRequest, CreateNamespaceOptions, ErrorCode, FsAdmin,
+    FsReader, FsWriter, GrepRequest, InodeId, NamespaceId, PutFileOptions,
 };
 use loonfs_api::decode_grep_cursor;
 use loonfs_grep::codec::INDEX_GRAMS_MAX_FILE_BYTES;
-use loonfs_grep::{GramIndexBuildPolicy, GrepWorker};
+use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -380,6 +380,254 @@ async fn a_worker_policy_bounds_each_build_step() {
     writer.shutdown_background().await.expect("writer shutdown");
 }
 
+/// A single legal commit can carry thousands of file revisions. The content
+/// budget must split that one WAL record at a durable delta cursor, queries
+/// must combine the indexed prefix with only its unindexed suffix, and a new
+/// worker must resume without reading the prefix again.
+#[tokio::test]
+async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumable() {
+    const FILES: usize = 1_000;
+    const FILES_PER_STEP: usize = 500;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let raw_store = Arc::new(BuildContentAccountingStore::new(temp_dir.path()));
+    let store: loonfs::SharedObjectStore = raw_store.clone();
+    let namespace_id = NamespaceId::parse("grams-thousand-atomic").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("grams-thousand-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("grams-thousand-admin")
+        .build()
+        .await
+        .expect("build admin");
+    let reader = FsReader::builder_with_store(store.clone())
+        .build()
+        .await
+        .expect("build reader");
+    let first_worker = grep_worker(&store);
+
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    admin
+        .enable_grams_index(&namespace_id)
+        .await
+        .expect("enable");
+    first_worker
+        .build_step(&namespace_id, GramIndexBuildPolicy::default())
+        .await
+        .expect("materialize empty backfill");
+
+    let content_bytes = format!("bounded needle file {:04}\n", 0).len();
+    let max_content_bytes_per_step = (content_bytes * FILES_PER_STEP) as u64;
+    let policy = GramIndexBuildPolicy {
+        max_files_per_step: FILES,
+        max_content_bytes_per_step,
+        max_l0_runs: usize::MAX,
+        ..GramIndexBuildPolicy::default()
+    };
+    let mut ops = Vec::with_capacity(FILES);
+    let mut prepared = Vec::with_capacity(FILES);
+    for index in 0..FILES {
+        let bytes = format!("bounded needle file {index:04}\n");
+        assert_eq!(bytes.len(), content_bytes);
+        let content = writer
+            .prepare_file_bytes(&namespace_id, bytes.as_bytes())
+            .await
+            .expect("prepare atomic-commit content");
+        ops.push(CommitOp::CreateFile {
+            parent_inode_id: InodeId(1),
+            display_name: format!("bounded-{index:04}.txt"),
+            content_ref: content.content_ref().clone(),
+        });
+        prepared.push(content);
+    }
+    let commit = writer
+        .commit_operations_prepared(
+            &namespace_id,
+            CommitRequest {
+                commit_id: CommitId::parse("thousand-file-atomic").expect("commit id"),
+                preconditions: Vec::new(),
+                ops,
+                message: None,
+            },
+            prepared,
+        )
+        .await
+        .expect("publish thousand-file commit");
+
+    raw_store.reset_content_reads();
+    let first = first_worker
+        .build_step(&namespace_id, policy)
+        .await
+        .expect("first bounded build");
+    assert!(matches!(
+        first.outcome,
+        GrepBuildOutcome::Published {
+            indexed_revisions,
+            ..
+        } if indexed_revisions == FILES_PER_STEP as u64
+    ));
+    let first_reads = raw_store.take_content_reads();
+    assert_eq!(first_reads.len(), FILES_PER_STEP);
+    assert!(
+        content_read_bytes(&first_reads) <= max_content_bytes_per_step,
+        "first step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
+        content_read_bytes(&first_reads)
+    );
+
+    let partial = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load partial grep root")
+        .expect("partial grep root");
+    assert_eq!(
+        partial.state().index().built_through_seq,
+        commit.committed_seq
+    );
+    assert!(
+        partial.state().index().next_delta_index > 0,
+        "the first step must stop within the atomic commit"
+    );
+    let prefix_segment_ids: BTreeSet<_> = partial
+        .state()
+        .segments()
+        .iter()
+        .map(|segment| segment.segment_id.clone())
+        .collect();
+
+    assert_grep_paths(
+        &reader,
+        &namespace_id,
+        "file 0000",
+        BTreeSet::from(["/bounded-0000.txt".to_owned()]),
+    )
+    .await;
+    assert_grep_paths(
+        &reader,
+        &namespace_id,
+        "file 0999",
+        BTreeSet::from(["/bounded-0999.txt".to_owned()]),
+    )
+    .await;
+    assert_eq!(
+        collect_grep_paths(&reader, &namespace_id, "bounded needle")
+            .await
+            .len(),
+        FILES,
+        "the indexed prefix and unindexed suffix must produce every file exactly once"
+    );
+
+    // Simulate a crash: the fresh worker has no in-memory collection state and
+    // can resume only from the published manifest cursor.
+    let resumed_worker = GrepWorker::new(
+        store.clone(),
+        "grams-resumed-worker",
+        "grams-resumed-session",
+        "grams-test/0.1",
+    );
+    raw_store.reset_content_reads();
+    let second = resumed_worker
+        .build_step(&namespace_id, policy)
+        .await
+        .expect("resumed bounded build");
+    assert!(matches!(
+        second.outcome,
+        GrepBuildOutcome::Published {
+            indexed_revisions,
+            ..
+        } if indexed_revisions == FILES_PER_STEP as u64
+    ));
+    let second_reads = raw_store.take_content_reads();
+    assert_eq!(second_reads.len(), FILES_PER_STEP);
+    assert!(
+        content_read_bytes(&second_reads) <= max_content_bytes_per_step,
+        "resumed step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
+        content_read_bytes(&second_reads)
+    );
+    let first_keys: BTreeSet<_> = first_reads.iter().map(|(key, _)| key).collect();
+    let second_keys: BTreeSet<_> = second_reads.iter().map(|(key, _)| key).collect();
+    assert!(
+        first_keys.is_disjoint(&second_keys),
+        "the fresh worker must not re-read any indexed-prefix content"
+    );
+    assert_eq!(first_keys.len() + second_keys.len(), FILES);
+
+    let complete = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load complete grep root")
+        .expect("complete grep root");
+    assert_eq!(
+        complete.state().index().built_through_seq,
+        commit.committed_seq
+    );
+    assert_eq!(complete.state().index().next_delta_index, 0);
+    let complete_segment_ids: BTreeSet<_> = complete
+        .state()
+        .segments()
+        .iter()
+        .map(|segment| segment.segment_id.clone())
+        .collect();
+    assert!(
+        prefix_segment_ids.is_subset(&complete_segment_ids),
+        "resume must retain the prefix segments instead of replacing them"
+    );
+    assert_eq!(
+        collect_grep_paths(&reader, &namespace_id, "bounded needle")
+            .await
+            .len(),
+        FILES
+    );
+
+    writer.shutdown_background().await.expect("writer shutdown");
+}
+
+async fn assert_grep_paths(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    pattern: &str,
+    expected: BTreeSet<String>,
+) {
+    assert_eq!(
+        collect_grep_paths(reader, namespace_id, pattern).await,
+        expected
+    );
+}
+
+async fn collect_grep_paths(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    pattern: &str,
+) -> BTreeSet<String> {
+    let mut request = grep_request(pattern);
+    request.limit = Some(1_000);
+    let mut paths = BTreeSet::new();
+    loop {
+        let response = reader
+            .grep(namespace_id, &request)
+            .await
+            .expect("grep bounded atomic commit");
+        paths.extend(
+            response
+                .matches
+                .into_iter()
+                .map(|found| found.absolute_path),
+        );
+        let Some(cursor) = response.next_cursor else {
+            return paths;
+        };
+        request.cursor = Some(cursor);
+    }
+}
+
+fn content_read_bytes(reads: &[(String, usize)]) -> u64 {
+    reads.iter().map(|(_, bytes)| *bytes as u64).sum::<u64>()
+}
+
 /// Ten one-file rounds cross the default delta-fold threshold, so the
 /// worker steps tier the index (delta segments fold into a mid run)
 /// while the rounds run. Grep must answer identically before, across, and
@@ -466,6 +714,94 @@ async fn grep_answers_identically_across_tiered_folds() {
     );
 
     writer.shutdown_background().await.expect("writer shutdown");
+}
+
+/// Accounts full content-blob GETs issued by one explicit worker step.
+#[derive(Debug)]
+struct BuildContentAccountingStore {
+    inner: LocalFsStore,
+    content_reads: Mutex<Vec<(String, usize)>>,
+}
+
+impl BuildContentAccountingStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("create local-fs store"),
+            content_reads: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn reset_content_reads(&self) {
+        self.content_reads
+            .lock()
+            .expect("content read accounting lock")
+            .clear();
+    }
+
+    fn take_content_reads(&self) -> Vec<(String, usize)> {
+        std::mem::take(
+            &mut *self
+                .content_reads
+                .lock()
+                .expect("content read accounting lock"),
+        )
+    }
+
+    fn record_content_read(&self, key: &str, bytes: usize) {
+        if key.contains("/blobs/sha256/") {
+            self.content_reads
+                .lock()
+                .expect("content read accounting lock")
+                .push((key.to_owned(), bytes));
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for BuildContentAccountingStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let body = self.inner.get_with_metadata(key).await?;
+        if let Some(body) = &body {
+            self.record_content_read(key, body.bytes.len());
+        }
+        Ok(body)
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let bytes = self.inner.get(key, range).await?;
+        if let Some(bytes) = &bytes {
+            self.record_content_read(key, bytes.len());
+        }
+        Ok(bytes)
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
 }
 
 /// Counts store GETs against gram index segment objects, so tests can

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -140,8 +140,8 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &invalid_limit)
         .await
         .expect_err("invalid limit must win before the missing feature");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::InvalidRequest);
 
@@ -150,10 +150,11 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("grep without the feature must be refused");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = &error else {
+        panic!("expected a grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::NotEnabled));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     let enabled = admin
         .enable_grams_index(&namespace_id)
@@ -211,10 +212,11 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("grep after disable must be refused");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = &error else {
+        panic!("expected a grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::NotEnabled));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     writer.shutdown_background().await.expect("writer shutdown");
 }
@@ -280,10 +282,11 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("background metadata work must not materialize grep");
-    let loonfs::Error::Core(core) = error else {
-        panic!("expected core error, got {error:?}");
+    let loonfs::Error::Grep(grep) = error else {
+        panic!("expected grep error, got {error:?}");
     };
-    assert_eq!(core.code(), ErrorCode::NotSupported);
+    assert!(matches!(grep, loonfs::GrepError::Backfilling));
+    assert_eq!(grep.code(), ErrorCode::NotSupported);
 
     drive_worker_step(&grep_worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     drive_worker_step(&grep_worker, &namespace_id, GramIndexBuildPolicy::default()).await;
@@ -705,8 +708,8 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .grep(&namespace_id, &grep_request("needle"))
         .await
         .expect_err("a reached candidate's failed read must fail its page");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
 
@@ -735,8 +738,8 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .grep(&namespace_id, &second_page)
         .await
         .expect_err("the deferred read error must surface on the next page");
-    let loonfs::Error::Core(core) = &error else {
-        panic!("expected a core error, got {error:?}");
+    let loonfs::Error::Grep(loonfs::GrepError::Core(core)) = &error else {
+        panic!("expected a grep core passthrough, got {error:?}");
     };
     assert_eq!(core.code(), ErrorCode::NamespaceCorrupt);
 

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -78,7 +78,7 @@ impl ServiceHarness {
         }
     }
 
-    async fn result(&self, grep_request: &GrepRequest) -> loonfs_core::Result<GrepResponse> {
+    async fn result(&self, grep_request: &GrepRequest) -> loonfs_grep::Result<GrepResponse> {
         let context = read_context(&self.store, &self.namespace_id).await;
         let view = self
             .engine

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -913,6 +913,7 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         current_state.lifecycle().clone(),
         GrepIndexState::new(
             current_state.index().built_through_seq,
+            current_state.index().next_delta_index,
             current_state.index().fold.clone(),
             current_state.index().next_run_ordinal + 1,
         ),

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -113,7 +113,7 @@ async fn new_query(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
     grep_request: &GrepRequest,
-) -> loonfs_core::Result<GrepResponse> {
+) -> loonfs_grep::Result<GrepResponse> {
     let engine = NamespaceEngine::builder(store.clone())
         .namespace_id(namespace_id.clone())
         .writer_id("new-query")
@@ -458,17 +458,17 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         .expect("create namespace");
     let worker = worker(&store);
 
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "never enabled",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
     worker.enable(&namespace_id).await.expect("enable");
-    assert_not_materialized_error(
+    assert_backfilling_error(
         "backfilling",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
     worker.disable(&namespace_id).await.expect("disable");
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "disabled",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -477,7 +477,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
             .expect("valid manifest id");
     write_pointer(&*store, &namespace_id, missing_manifest_id).await;
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "missing manifest",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -493,7 +493,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         .await
         .expect("write corrupt manifest");
     write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "corrupt manifest",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -505,7 +505,7 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         )
         .await
         .expect("write corrupt pointer");
-    assert_not_materialized_error(
+    assert_corrupt_index_error(
         "corrupt pointer",
         new_reader.grep(&namespace_id, &request("needle")).await,
     );
@@ -531,9 +531,9 @@ async fn write_pointer(
         .expect("write pointer");
 }
 
-fn assert_not_materialized_error(case: &str, result: loonfs::Result<GrepResponse>) {
+fn assert_not_enabled_error(case: &str, result: loonfs::Result<GrepResponse>) {
     match result {
-        Err(loonfs::Error::Core(error)) => {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::NotEnabled)) => {
             assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
             assert_eq!(
                 error.to_string(),
@@ -542,6 +542,35 @@ fn assert_not_materialized_error(case: &str, result: loonfs::Result<GrepResponse
             );
         }
         outcome => panic!("expected not-materialized error for {case}, got {outcome:?}"),
+    }
+}
+
+fn assert_backfilling_error(case: &str, result: loonfs::Result<GrepResponse>) {
+    match result {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::Backfilling)) => {
+            assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
+            assert_eq!(
+                error.to_string(),
+                "feature `index.grams` is not materialized on this namespace",
+                "error text for {case}"
+            );
+        }
+        outcome => panic!("expected backfilling error for {case}, got {outcome:?}"),
+    }
+}
+
+fn assert_corrupt_index_error(case: &str, result: loonfs::Result<GrepResponse>) {
+    match result {
+        Err(loonfs::Error::Grep(error @ loonfs::GrepError::CorruptIndex { .. })) => {
+            assert_eq!(error.code(), ErrorCode::IndexCorrupt, "code for {case}");
+            assert!(
+                error
+                    .to_string()
+                    .contains("disable and re-enable grep to rebuild it"),
+                "error text for {case}: {error}"
+            );
+        }
+        outcome => panic!("expected corrupt-index error for {case}, got {outcome:?}"),
     }
 }
 
@@ -724,7 +753,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         "fork target must have no grep root until explicitly enabled"
     );
     let target_reader = writer.reader();
-    assert_not_materialized_error(
+    assert_not_enabled_error(
         "fork target",
         target_reader.grep(&target, &request("needle")).await,
     );

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -113,8 +113,11 @@ Segments live under
 `namespaces/{namespace}/extensions/grep/segments/`. The small mutable
 `extensions/grep/root.json` pointer names an immutable, content-derived
 manifest under `extensions/grep/manifests/`; that manifest records the
-query-visible segments, `built_through_seq`, lifecycle, run-ordinal
-allocation, and any in-progress fold snapshot, outputs, and cursor. The
+query-visible segments, the incremental
+`(built_through_seq, next_delta_index)` cursor, lifecycle, run-ordinal
+allocation, and any in-progress fold snapshot, outputs, and cursor. A zero
+or absent `next_delta_index` is the commit boundary; a nonzero value resumes
+at that offset in the watermark commit's durably ordered delta vector. The
 pointer and manifests are independent of the namespace manifest, so core
 never has to understand grep state to read the filesystem.
 
@@ -143,11 +146,14 @@ releases the checkpoint.
 
 One per-namespace driver owns those steps. Starting a driver immediately
 runs backfill and incremental catch-up continuously, yielding between bounded
-steps. Once the root is steady and its watermark reaches the namespace head,
-the driver parks without a timer. A nudge received while active coalesces into
-one more catch-up run; a nudge received while parked wakes it. Step failures
-back off exponentially inside only that namespace's driver, capped at one
-second, so a poisoned root cannot delay a sibling namespace.
+steps. Drivers share one FIFO semaphore, configured by
+`max_concurrent_steps` (default 2), and acquire it only while a build or fold
+step executes; parked drivers hold no permit. Once the root is steady and its
+watermark reaches the namespace head, the driver parks without a timer. A
+nudge received while active coalesces into one more catch-up run; a nudge
+received while parked wakes it. Step failures back off exponentially inside
+only that namespace's driver, capped at one second, so a poisoned root cannot
+delay a sibling namespace.
 
 In server `embedded` mode, enable and re-enable start the namespace driver,
 disable stops it, and successful runtime publications send a non-blocking

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -250,6 +250,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, changed during the operation, condemned pending GC deletion, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `index_lagging` | 503 | The gram index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |
+| `index_corrupt` | 500 | The grep index's derived state failed validation. Disable and re-enable grep on the namespace to rebuild it; core filesystem state remains available. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -350,6 +350,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -360,8 +370,8 @@
               }
             }
           },
-          "501": {
-            "description": "Grep serving is disabled for this deployment",
+          "409": {
+            "description": "Lost a grep root-pointer publication race; retry",
             "content": {
               "application/json": {
                 "schema": {
@@ -370,8 +380,18 @@
               }
             }
           },
-          "503": {
-            "description": "Lost a grep root-pointer publication race; retry",
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
             "content": {
               "application/json": {
                 "schema": {
@@ -423,6 +443,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -433,8 +463,8 @@
               }
             }
           },
-          "501": {
-            "description": "Grep serving is disabled for this deployment",
+          "409": {
+            "description": "Lost a grep root-pointer publication race; retry",
             "content": {
               "application/json": {
                 "schema": {
@@ -443,8 +473,18 @@
               }
             }
           },
-          "503": {
-            "description": "Lost a grep root-pointer publication race; retry",
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Grep serving is disabled for this deployment",
             "content": {
               "application/json": {
                 "schema": {
@@ -488,6 +528,26 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -2268,6 +2328,16 @@
               }
             }
           },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Namespace not found",
             "content": {
@@ -2280,6 +2350,16 @@
           },
           "410": {
             "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Closes the CI-noise issue: a loaded runner once saw the server-busy test die with a panic inside ureq's response path instead of a readable failure.

The investigation found the original storm-based fragility already retired — the concurrency-cap test was redesigned in the retry-policy work into a deterministic permit-hold shape, and the loonfs client applies a universal 60-second socket inactivity timeout to every request. What remained was the raw surface: twenty-three direct ureq calls across the server test suites ran on the library's default agent, which has no timeouts at all, so a starved or wedged server could hang them indefinitely or push them into the library-internal panic the incident hit.

Every raw call now goes through one shared per-file agent with 30-second socket read/write timeouts, with the failure-mode contract stated in its doc comment: overload produces a readable transport error, never a hang or a library-layer panic. Test semantics are unchanged — same requests, same assertions. 