### PR TITLE
fix(invariants): reject silent normalization

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -17,6 +17,7 @@ use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
 use loonfs_api::{sha256_digest, ChangeSeq, MetadataTableId, NamespaceId};
 use loonfs_objectstore::keys::metadata_table;
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     store: &S,
@@ -24,7 +25,7 @@ pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     run_seq: ChangeSeq,
     level: u32,
     metadata_state: &MetadataState,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Result<Vec<MetadataTableManifest>> {
     build_manifest_tables_from_rows(
         store,
@@ -78,7 +79,7 @@ pub(super) async fn build_manifest_l0_run_tables<S: ObjectStore + ?Sized>(
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum MetadataTableSegmentation {
-    Base { max_rows_per_segment: usize },
+    Base { max_rows_per_segment: NonZeroUsize },
     Full,
 }
 
@@ -233,15 +234,15 @@ pub(super) fn segment_manifest_rows(
         MetadataTableSegmentation::Full => vec![MetadataSstRows { rows }],
         MetadataTableSegmentation::Base {
             max_rows_per_segment,
-        } => segment_rows_by_row_key_range(rows, max_rows_per_segment.max(1)),
+        } => segment_rows_by_row_key_range(rows, max_rows_per_segment),
     }
 }
 
 pub(super) fn segment_rows_by_row_key_range(
     rows: Vec<MetadataRow>,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Vec<MetadataSstRows> {
-    rows.chunks(max_rows_per_segment)
+    rows.chunks(max_rows_per_segment.get())
         .map(|rows| MetadataSstRows {
             rows: rows.to_vec(),
         })

--- a/crates/loonfs-core/src/checkpoint/grep_read.rs
+++ b/crates/loonfs-core/src/checkpoint/grep_read.rs
@@ -13,6 +13,7 @@ use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::{ChangeSeq, CheckpointId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 /// Validated incremental commits after a grep watermark, or an explicit
 /// signal that retention has removed part of the required history.
@@ -107,7 +108,7 @@ pub async fn load_grep_checkpoint_revision_page<S: ObjectStore + ?Sized>(
     checkpoint_id: &CheckpointId,
     now_ms: u64,
     cursor: &str,
-    limit: usize,
+    limit: NonZeroUsize,
 ) -> Result<Option<GrepCheckpointRevisionPage>> {
     let Some(record) = read_checkpoint_record(store, namespace_id, checkpoint_id)
         .await?
@@ -146,7 +147,7 @@ pub async fn load_grep_checkpoint_revision_page<S: ObjectStore + ?Sized>(
             "checkpoint `{checkpoint_id}` basis does not match its manifest"
         )));
     }
-    let limit = limit.max(1);
+    let limit = limit.get();
     let rows = scan_checkpoint_revisions(&tables, cursor, limit).await?;
     let exhausted = rows.len() < limit;
     let mut revisions = Vec::with_capacity(rows.len());

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -139,7 +139,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let previous = tables.manifest();
 
     let l0_runs = l0_run_count(&previous.payload);
-    if l0_runs < policy.max_l0_runs.max(1) {
+    if l0_runs < policy.max_l0_runs.get() {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -5,6 +5,7 @@ use loonfs_api::wire::manifest::{MetadataFileRef, MetadataTableFamily, Namespace
 use loonfs_api::ChangeSeq;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 
 pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
 /// With block-granular reads the segment is no longer the read unit, so
@@ -41,15 +42,17 @@ pub(super) struct MetadataRunManifest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MetadataLsmPolicy {
-    pub max_l0_runs: usize,
-    pub max_rows_per_segment: usize,
+    pub max_l0_runs: NonZeroUsize,
+    pub max_rows_per_segment: NonZeroUsize,
 }
 
 impl Default for MetadataLsmPolicy {
     fn default() -> Self {
         Self {
-            max_l0_runs: DEFAULT_MAX_CHECKPOINT_L0_RUNS,
-            max_rows_per_segment: DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT,
+            max_l0_runs: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_L0_RUNS)
+                .expect("default L0 run limit should be nonzero"),
+            max_rows_per_segment: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT)
+                .expect("default segment row budget should be nonzero"),
         }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -57,7 +57,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
@@ -126,7 +126,7 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
     policy: MetadataLsmPolicy,
 ) -> ManifestId {
     let fold_policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..policy
     };
     loop {
@@ -1500,7 +1500,7 @@ async fn base_rebuild_rejects_divergent_revision_index() {
         .await
         .expect("l0 checkpoint");
     let fold_policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     let mut rebuild_error = None;
@@ -2118,7 +2118,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 2,
+        max_l0_runs: NonZeroUsize::new(2).expect("test run limit should be nonzero"),
         ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -2272,7 +2272,8 @@ async fn manifest_base_run_tables_have_sorted_segment_coverage() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 2,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
         ..MetadataLsmPolicy::default()
     };
     let materialization_before = load_current_projection(&store, &namespace_id)
@@ -2336,7 +2337,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2407,7 +2408,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2550,7 +2551,7 @@ async fn table_range_page_merges_base_and_l0_in_row_key_order() {
         .expect("write c");
 
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2608,7 +2609,7 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2687,7 +2688,7 @@ async fn maintenance_materialization_does_not_populate_metadata_table_cache() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     let manifest_id = checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2857,8 +2858,9 @@ async fn whole_run_compaction_rewrites_base_segments() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
-        max_rows_per_segment: 2,
+        max_l0_runs: NonZeroUsize::MIN,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2957,8 +2959,9 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
-        max_rows_per_segment: 2,
+        max_l0_runs: NonZeroUsize::MIN,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -3600,7 +3603,7 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -5661,7 +5664,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
             (head_seq, flatten_manifest_tables(run_tables))
         }
-        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs => {
+        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs.get() => {
             let mut metadata_files = previous.manifest.payload.metadata_files.clone();
             if previous.manifest.payload.head_seq < head_seq {
                 metadata_files.extend(flatten_manifest_tables(
@@ -5856,7 +5859,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         .state;
 
     let fold_everything = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..Default::default()
     };
     let overrun = SteppingTimer::new(20 * 60 * 1000);

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::keys::{
     namespace_config, wal_head, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 /// GC lifecycle tests pin as one user owner; owner-specific release
 /// rules are exercised in the fork and release suites.
@@ -1060,7 +1061,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     // Reorganization folds the L0 runs into fresh base segments; the
     // superseded run tables then age out on the next pass.
     let fold_policy = crate::checkpoint::MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..Default::default()
     };
     for _ in 0..16 {

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -2,6 +2,7 @@
 
 use crate::GramIndexBuildPolicy;
 use serde::Deserialize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use thiserror::Error;
 
 /// Default cap on concurrently executing grep build or fold steps.
@@ -11,6 +12,10 @@ use thiserror::Error;
 pub const DEFAULT_MAX_CONCURRENT_STEPS: usize = 2;
 
 /// Bounded-work policy shared by embedded and standalone drivers.
+///
+/// Project-wide, zero may disable an explicitly documented cache. Work
+/// budgets and concurrency limits instead reject zero at their construction
+/// boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GrepWorkerConfig {
@@ -32,31 +37,32 @@ pub struct GrepWorkerConfig {
 
 impl GrepWorkerConfig {
     /// Returns the bounded build/fold policy represented by this config.
-    pub fn build_policy(self) -> GramIndexBuildPolicy {
-        GramIndexBuildPolicy {
-            max_files_per_step: self.max_files_per_step,
-            max_content_bytes_per_step: self.max_content_bytes_per_step,
-            max_rows_per_segment: self.max_rows_per_segment,
-            max_l0_runs: self.max_l0_runs,
-            max_mid_runs: self.max_mid_runs,
-            max_fold_rows_per_step: self.max_fold_rows_per_step,
-        }
+    pub fn build_policy(self) -> Result<GramIndexBuildPolicy, GrepWorkerConfigError> {
+        Ok(GramIndexBuildPolicy {
+            max_files_per_step: nonzero_usize("max_files_per_step", self.max_files_per_step)?,
+            max_content_bytes_per_step: nonzero_u64(
+                "max_content_bytes_per_step",
+                self.max_content_bytes_per_step,
+            )?,
+            max_rows_per_segment: nonzero_usize("max_rows_per_segment", self.max_rows_per_segment)?,
+            max_l0_runs: nonzero_usize("max_l0_runs", self.max_l0_runs)?,
+            max_mid_runs: nonzero_usize("max_mid_runs", self.max_mid_runs)?,
+            max_fold_rows_per_step: nonzero_usize(
+                "max_fold_rows_per_step",
+                self.max_fold_rows_per_step,
+            )?,
+        })
+    }
+
+    /// Returns the validated deployment-wide concurrency limit.
+    pub fn concurrent_step_limit(self) -> Result<NonZeroUsize, GrepWorkerConfigError> {
+        nonzero_usize("max_concurrent_steps", self.max_concurrent_steps)
     }
 
     /// Rejects zero step budgets.
     pub fn validate(self) -> Result<(), GrepWorkerConfigError> {
-        if self.max_concurrent_steps == 0 {
-            return Err(GrepWorkerConfigError::InvalidField {
-                field: "max_concurrent_steps",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if let Some(field) = self.build_policy().zero_budget_field() {
-            return Err(GrepWorkerConfigError::InvalidField {
-                field,
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
+        self.concurrent_step_limit()?;
+        self.build_policy()?;
         Ok(())
     }
 }
@@ -66,14 +72,28 @@ impl Default for GrepWorkerConfig {
         let policy = GramIndexBuildPolicy::default();
         Self {
             max_concurrent_steps: DEFAULT_MAX_CONCURRENT_STEPS,
-            max_files_per_step: policy.max_files_per_step,
-            max_content_bytes_per_step: policy.max_content_bytes_per_step,
-            max_rows_per_segment: policy.max_rows_per_segment,
-            max_l0_runs: policy.max_l0_runs,
-            max_mid_runs: policy.max_mid_runs,
-            max_fold_rows_per_step: policy.max_fold_rows_per_step,
+            max_files_per_step: policy.max_files_per_step.get(),
+            max_content_bytes_per_step: policy.max_content_bytes_per_step.get(),
+            max_rows_per_segment: policy.max_rows_per_segment.get(),
+            max_l0_runs: policy.max_l0_runs.get(),
+            max_mid_runs: policy.max_mid_runs.get(),
+            max_fold_rows_per_step: policy.max_fold_rows_per_step.get(),
         }
     }
+}
+
+fn nonzero_usize(field: &'static str, value: usize) -> Result<NonZeroUsize, GrepWorkerConfigError> {
+    NonZeroUsize::new(value).ok_or_else(|| GrepWorkerConfigError::InvalidField {
+        field,
+        reason: "must be greater than zero".to_owned(),
+    })
+}
+
+fn nonzero_u64(field: &'static str, value: u64) -> Result<NonZeroU64, GrepWorkerConfigError> {
+    NonZeroU64::new(value).ok_or_else(|| GrepWorkerConfigError::InvalidField {
+        field,
+        reason: "must be greater than zero".to_owned(),
+    })
 }
 
 /// Invalid grep worker configuration.
@@ -98,7 +118,7 @@ mod tests {
     fn defaults_match_the_build_policy() {
         let config = GrepWorkerConfig::default();
 
-        assert_eq!(config.build_policy(), GramIndexBuildPolicy::default());
+        assert_eq!(config.build_policy(), Ok(GramIndexBuildPolicy::default()));
         assert_eq!(config.validate(), Ok(()));
     }
 
@@ -157,6 +177,62 @@ mod tests {
         ] {
             assert_eq!(
                 config.validate(),
+                Err(GrepWorkerConfigError::InvalidField {
+                    field,
+                    reason: "must be greater than zero".to_owned(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn policy_construction_rejects_each_zero_budget() {
+        for (field, config) in [
+            (
+                "max_files_per_step",
+                GrepWorkerConfig {
+                    max_files_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_content_bytes_per_step",
+                GrepWorkerConfig {
+                    max_content_bytes_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_rows_per_segment",
+                GrepWorkerConfig {
+                    max_rows_per_segment: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_l0_runs",
+                GrepWorkerConfig {
+                    max_l0_runs: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_mid_runs",
+                GrepWorkerConfig {
+                    max_mid_runs: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_fold_rows_per_step",
+                GrepWorkerConfig {
+                    max_fold_rows_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+        ] {
+            assert_eq!(
+                config.build_policy(),
                 Err(GrepWorkerConfigError::InvalidField {
                     field,
                     reason: "must be greater than zero".to_owned(),

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -3,6 +3,7 @@
 use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepFoldOutcome, GrepWorker};
 use loonfs_api::{ChangeSeq, ErrorCode, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,11 +23,10 @@ pub struct GrepStepLimiter {
 }
 
 impl GrepStepLimiter {
-    /// Creates a shared limiter. Direct callers receive the same safe
-    /// normalization as directly supplied build policies; config rejects zero.
-    pub fn new(max_concurrent_steps: usize) -> Self {
+    /// Creates a shared limiter from a validated concurrency limit.
+    pub fn new(max_concurrent_steps: NonZeroUsize) -> Self {
         Self {
-            permits: Arc::new(Semaphore::new(max_concurrent_steps.max(1))),
+            permits: Arc::new(Semaphore::new(max_concurrent_steps.get())),
         }
     }
 

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -125,6 +125,8 @@ async fn run() -> Result<(), StandaloneError> {
     init_tracing()?;
     let args = Args::parse();
     let config = load_config(&args.config)?;
+    let step_limit = config.grep.concurrent_step_limit()?;
+    let build_policy = config.grep.build_policy()?;
     let store = Arc::new(config.store.configured_object_store()?) as SharedObjectStore;
     let worker = GrepWorker::new(
         store.clone(),
@@ -139,13 +141,13 @@ async fn run() -> Result<(), StandaloneError> {
     }
 
     let runtime = tokio::runtime::Handle::current();
-    let step_limiter = GrepStepLimiter::new(config.grep.max_concurrent_steps);
+    let step_limiter = GrepStepLimiter::new(step_limit);
     let mut drivers = Vec::with_capacity(namespace_ids.len());
     for namespace_id in &namespace_ids {
         let task = GrepDriver::new(
             worker.clone(),
             namespace_id.clone(),
-            config.grep.build_policy(),
+            build_policy,
             step_limiter.clone(),
         )
         .spawn_on(&runtime);

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -21,6 +21,7 @@ use loonfs_grep::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -217,7 +218,7 @@ fn spawn_driver(
         worker,
         namespace_id,
         GramIndexBuildPolicy::default(),
-        GrepStepLimiter::new(1),
+        GrepStepLimiter::new(NonZeroUsize::MIN),
     )
     .spawn_on(&tokio::runtime::Handle::current())
 }

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -154,8 +154,7 @@ pub enum GrepLifecycle {
         /// Resume key for the next backfill step; empty means the start.
         backfill_cursor: String,
         /// User-checkpoint pin backing this immutable manifest walk.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        checkpoint_id: Option<CheckpointId>,
+        checkpoint_id: CheckpointId,
     },
     /// Backfill is complete and changes are consumed incrementally.
     Steady,

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -38,6 +38,7 @@ use loonfs_objectstore::{
     ObjectStore, ObjectStoreError, PutMode, PROVIDER_MULTIPART_THRESHOLD_BYTES,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -61,59 +62,32 @@ const INDEX_GRAMS_BASE_LEVEL: u32 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GramIndexBuildPolicy {
     /// Revisions examined per step.
-    pub max_files_per_step: usize,
+    pub max_files_per_step: NonZeroUsize,
     /// Content bytes read per step.
-    pub max_content_bytes_per_step: u64,
+    pub max_content_bytes_per_step: NonZeroU64,
     /// Rows per written grep segment.
-    pub max_rows_per_segment: usize,
+    pub max_rows_per_segment: NonZeroUsize,
     /// Delta-level runs that trigger a fold into a fresh mid run.
-    pub max_l0_runs: usize,
+    pub max_l0_runs: NonZeroUsize,
     /// Mid-level runs that trigger a fold into a fresh base run.
-    pub max_mid_runs: usize,
+    pub max_mid_runs: NonZeroUsize,
     /// Rows one fold step merges before publishing and yielding.
-    pub max_fold_rows_per_step: usize,
-}
-
-impl GramIndexBuildPolicy {
-    /// Names the first zero budget so configuration boundaries can reject it.
-    pub fn zero_budget_field(&self) -> Option<&'static str> {
-        [
-            ("max_files_per_step", self.max_files_per_step == 0),
-            (
-                "max_content_bytes_per_step",
-                self.max_content_bytes_per_step == 0,
-            ),
-            ("max_rows_per_segment", self.max_rows_per_segment == 0),
-            ("max_l0_runs", self.max_l0_runs == 0),
-            ("max_mid_runs", self.max_mid_runs == 0),
-            ("max_fold_rows_per_step", self.max_fold_rows_per_step == 0),
-        ]
-        .into_iter()
-        .find_map(|(field, is_zero)| is_zero.then_some(field))
-    }
-
-    /// Normalizes directly supplied policies to at least one unit per budget.
-    pub fn normalized(self) -> Self {
-        Self {
-            max_files_per_step: self.max_files_per_step.max(1),
-            max_content_bytes_per_step: self.max_content_bytes_per_step.max(1),
-            max_rows_per_segment: self.max_rows_per_segment.max(1),
-            max_l0_runs: self.max_l0_runs.max(1),
-            max_mid_runs: self.max_mid_runs.max(1),
-            max_fold_rows_per_step: self.max_fold_rows_per_step.max(1),
-        }
-    }
+    pub max_fold_rows_per_step: NonZeroUsize,
 }
 
 impl Default for GramIndexBuildPolicy {
     fn default() -> Self {
         Self {
-            max_files_per_step: 256,
-            max_content_bytes_per_step: 64 * 1024 * 1024,
-            max_rows_per_segment: 65_536,
-            max_l0_runs: 8,
-            max_mid_runs: 8,
-            max_fold_rows_per_step: 131_072,
+            max_files_per_step: NonZeroUsize::new(256)
+                .expect("default file budget should be nonzero"),
+            max_content_bytes_per_step: NonZeroU64::new(64 * 1024 * 1024)
+                .expect("default content budget should be nonzero"),
+            max_rows_per_segment: NonZeroUsize::new(65_536)
+                .expect("default segment row budget should be nonzero"),
+            max_l0_runs: NonZeroUsize::new(8).expect("default delta run limit should be nonzero"),
+            max_mid_runs: NonZeroUsize::new(8).expect("default mid run limit should be nonzero"),
+            max_fold_rows_per_step: NonZeroUsize::new(131_072)
+                .expect("default fold row budget should be nonzero"),
         }
     }
 }
@@ -303,7 +277,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             return Ok(GrepDisableOutcome::NotEnabled);
         }
         let checkpoint_id = match current.state().lifecycle() {
-            GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+            GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
         };
         let next = GrepRootState::new(
@@ -338,7 +312,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepBuildReport> {
-        let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
             .map_err(GrepError::from)?
@@ -359,9 +332,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 backfill_cursor,
                 checkpoint_id,
             } => {
-                let Some(checkpoint_id) = checkpoint_id else {
-                    return self.restart_backfill(namespace_id, &current).await;
-                };
                 let page = load_grep_checkpoint_revision_page(
                     &self.store,
                     namespace_id,
@@ -476,7 +446,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         current: &LoadedGrepRoot,
     ) -> Result<GrepBuildReport> {
         let previous_checkpoint_id = match current.state().lifecycle() {
-            GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+            GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
         };
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
@@ -553,7 +523,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     },
                     None,
                 ),
-                None => (GrepLifecycle::Steady, checkpoint_id.clone()),
+                None => (GrepLifecycle::Steady, Some(checkpoint_id.clone())),
             },
             GrepLifecycle::Steady => (GrepLifecycle::Steady, None),
             GrepLifecycle::Disabled => unreachable!("disabled returned before collection"),
@@ -615,7 +585,7 @@ fn backfilling_root(
         namespace_id.clone(),
         GrepLifecycle::Backfilling {
             backfill_cursor: String::new(),
-            checkpoint_id: Some(checkpoint_id),
+            checkpoint_id,
         },
         GrepIndexState::new(target_seq, 0, None, next_run_ordinal),
         Vec::new(),
@@ -627,7 +597,7 @@ fn root_names_checkpoint(root: &GrepRootState, checkpoint_id: &CheckpointId) -> 
     matches!(
         root.lifecycle(),
         GrepLifecycle::Backfilling {
-            checkpoint_id: Some(root_checkpoint_id),
+            checkpoint_id: root_checkpoint_id,
             ..
         } if root_checkpoint_id == checkpoint_id
     )
@@ -683,7 +653,7 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
             }
         }
         unit.backfill_cursor = Some(row_key);
-        if planned_content_bytes >= policy.max_content_bytes_per_step {
+        if planned_content_bytes >= policy.max_content_bytes_per_step.get() {
             budget_reached = true;
             break;
         }
@@ -748,8 +718,9 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
             {
                 let would_exceed_content_budget = planned_content_bytes > 0
                     && planned_content_bytes.saturating_add(content_ref.size_bytes)
-                        > policy.max_content_bytes_per_step;
-                if examined_files >= policy.max_files_per_step || would_exceed_content_budget {
+                        > policy.max_content_bytes_per_step.get();
+                if examined_files >= policy.max_files_per_step.get() || would_exceed_content_budget
+                {
                     if delta_index > 0 {
                         unit.built_through_seq = record.seq;
                         unit.run_seq = record.seq;
@@ -770,8 +741,8 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                         content_ref: content_ref.clone(),
                     });
                 }
-                if examined_files >= policy.max_files_per_step
-                    || planned_content_bytes >= policy.max_content_bytes_per_step
+                if examined_files >= policy.max_files_per_step.get()
+                    || planned_content_bytes >= policy.max_content_bytes_per_step.get()
                 {
                     unit.built_through_seq = record.seq;
                     unit.run_seq = record.seq;
@@ -856,14 +827,14 @@ async fn write_index_segments<S: ObjectStore + ?Sized>(
     run_seq: ChangeSeq,
     run_ordinal: u64,
     rows: Vec<IndexRow>,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
     level: u32,
 ) -> Result<Vec<GrepSegmentRef>> {
     if rows.is_empty() {
         return Ok(Vec::new());
     }
     let mut requests = Vec::new();
-    for (segment_index, segment_rows) in rows.chunks(max_rows_per_segment.max(1)).enumerate() {
+    for (segment_index, segment_rows) in rows.chunks(max_rows_per_segment.get()).enumerate() {
         let segment_index = u32::try_from(segment_index)
             .map_err(|_| CoreError::Internal("index segment index overflow".to_owned()))?;
         requests.push((segment_index, segment_rows.to_vec()));
@@ -949,7 +920,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepFoldReport> {
-        let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
             .map_err(GrepError::from)?
@@ -970,7 +940,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     current.state().segments(),
                     INDEX_GRAMS_MID_LEVEL,
                 );
-                let (snapshot_segment_ids, output_level) = if l0_runs >= policy.max_l0_runs {
+                let (snapshot_segment_ids, output_level) = if l0_runs >= policy.max_l0_runs.get() {
                     (
                         current
                             .state()
@@ -981,7 +951,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                             .collect(),
                         INDEX_GRAMS_MID_LEVEL,
                     )
-                } else if mid_runs >= policy.max_mid_runs {
+                } else if mid_runs >= policy.max_mid_runs.get() {
                     (
                         current
                             .state()
@@ -1032,7 +1002,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             namespace_id,
             &snapshot,
             &fold.row_key_cursor,
-            policy.max_fold_rows_per_step,
+            policy.max_fold_rows_per_step.get(),
         )
         .await?;
         let rows = gram_postings_rows(merged.postings)?;

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -55,7 +56,7 @@ async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explici
         .expect("poison root");
 
     let runtime = tokio::runtime::Handle::current();
-    let step_limiter = GrepStepLimiter::new(2);
+    let step_limiter = GrepStepLimiter::new(nonzero_usize(2));
     let poisoned_task = GrepDriver::new(
         worker.clone(),
         poisoned,
@@ -124,7 +125,7 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
         worker,
         namespace_id,
         GramIndexBuildPolicy::default(),
-        GrepStepLimiter::new(1),
+        GrepStepLimiter::new(NonZeroUsize::MIN),
     )
     .spawn_on(&tokio::runtime::Handle::current());
     assert_eq!(
@@ -167,7 +168,7 @@ async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
     }
 
     store.pause_content_reads();
-    let limiter = GrepStepLimiter::new(MAX_CONCURRENT_STEPS);
+    let limiter = GrepStepLimiter::new(nonzero_usize(MAX_CONCURRENT_STEPS));
     let runtime = tokio::runtime::Handle::current();
     let mut tasks = Vec::new();
     for namespace_id in namespace_ids {
@@ -212,6 +213,10 @@ async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
     for task in tasks {
         task.shutdown().await.expect("stop concurrency driver");
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 #[derive(Debug)]

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -139,10 +139,8 @@ fn sample_backfilling_root() -> GrepRootState {
         namespace_id("docs"),
         GrepLifecycle::Backfilling {
             backfill_cursor: "revision-00000000000000000007".to_owned(),
-            checkpoint_id: Some(
-                CheckpointId::parse("chk_00000000000000000000000000000009")
-                    .expect("valid checkpoint id"),
-            ),
+            checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
+                .expect("valid checkpoint id"),
         },
         GrepIndexState::new(ChangeSeq(7), 0, Some(fold), 4),
         vec![

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -116,27 +116,6 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
         String::from_utf8_lossy(&gc.stderr)
     );
 
-    let bad_config_path = temp_dir.path().join("bad-worker.toml");
-    write_config(&bad_config_path, &store_root, "poll_interval_ms = 0\n", "");
-    let bad = run_once(&bad_config_path, &[&namespace_id]);
-    assert!(!bad.status.success(), "bad config must exit nonzero");
-    let stderr = String::from_utf8_lossy(&bad.stderr);
-    assert!(stderr.contains("poll_interval_ms"), "{stderr}");
-    assert!(stderr.contains("greater than zero"), "{stderr}");
-
-    let bad_grep_config_path = temp_dir.path().join("bad-grep-worker.toml");
-    write_config(
-        &bad_grep_config_path,
-        &store_root,
-        "",
-        "max_concurrent_steps = 0\n",
-    );
-    let bad = run_once(&bad_grep_config_path, &[&namespace_id]);
-    assert!(!bad.status.success(), "zero step cap must exit nonzero");
-    let stderr = String::from_utf8_lossy(&bad.stderr);
-    assert!(stderr.contains("max_concurrent_steps"), "{stderr}");
-    assert!(stderr.contains("greater than zero"), "{stderr}");
-
     let missing_namespace = Command::new(env!("CARGO_BIN_EXE_loonfs-grep"))
         .arg("--config")
         .arg(&config_path)
@@ -147,6 +126,45 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
     let stderr = String::from_utf8_lossy(&missing_namespace.stderr);
     assert!(stderr.contains("--namespace"), "{stderr}");
     assert!(stderr.contains("Usage:"), "{stderr}");
+}
+
+#[test]
+fn standalone_config_rejects_zero_work_limits() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store_root = temp_dir.path().join("store");
+    let namespace_id = NamespaceId::parse("zero-config").expect("namespace id");
+
+    for (filename, root_fields, grep_fields, rejected_field) in [
+        (
+            "poll.toml",
+            "poll_interval_ms = 0\n",
+            "",
+            "poll_interval_ms",
+        ),
+        (
+            "concurrency.toml",
+            "",
+            "max_concurrent_steps = 0\n",
+            "max_concurrent_steps",
+        ),
+        (
+            "budget.toml",
+            "",
+            "max_files_per_step = 0\n",
+            "max_files_per_step",
+        ),
+    ] {
+        let path = temp_dir.path().join(filename);
+        write_config(&path, &store_root, root_fields, grep_fields);
+        let output = run_once(&path, &[&namespace_id]);
+        assert!(
+            !output.status.success(),
+            "zero `{rejected_field}` must exit nonzero"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(rejected_field), "{stderr}");
+        assert!(stderr.contains("greater than zero"), "{stderr}");
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1159,8 +1159,12 @@ root = "/tmp/loonfs-server"
         assert_eq!(config.grep, super::GrepConfig::default());
         assert_eq!(config.grep.mode, super::GrepMode::Embedded);
         assert_eq!(
-            config.grep.worker_config().build_policy(),
-            loonfs_grep::GramIndexBuildPolicy::default()
+            config
+                .grep
+                .worker_config()
+                .build_policy()
+                .expect("valid default grep policy"),
+            loonfs_grep::GramIndexBuildPolicy::default(),
         );
     }
 
@@ -1192,13 +1196,16 @@ root = "/tmp/loonfs-server"
         let grep = load_server_config(&path).expect("load config").grep;
         assert_eq!(grep.mode, super::GrepMode::ServeOnly);
         assert_eq!(grep.max_concurrent_steps, 7);
-        let policy = grep.worker_config().build_policy();
-        assert_eq!(policy.max_files_per_step, 4096);
-        assert_eq!(policy.max_content_bytes_per_step, 536_870_912);
-        assert_eq!(policy.max_rows_per_segment, 131_072);
-        assert_eq!(policy.max_l0_runs, 4);
-        assert_eq!(policy.max_mid_runs, 6);
-        assert_eq!(policy.max_fold_rows_per_step, 262_144);
+        let policy = grep
+            .worker_config()
+            .build_policy()
+            .expect("valid configured grep policy");
+        assert_eq!(policy.max_files_per_step.get(), 4096);
+        assert_eq!(policy.max_content_bytes_per_step.get(), 536_870_912);
+        assert_eq!(policy.max_rows_per_segment.get(), 131_072);
+        assert_eq!(policy.max_l0_runs.get(), 4);
+        assert_eq!(policy.max_mid_runs.get(), 6);
+        assert_eq!(policy.max_fold_rows_per_step.get(), 262_144);
     }
 
     #[test]
@@ -1226,9 +1233,10 @@ root = "/tmp/loonfs-server"
             .expect("load config")
             .grep
             .worker_config()
-            .build_policy();
-        assert_eq!(policy.max_files_per_step, 1024);
-        assert_eq!(policy.max_l0_runs, 3);
+            .build_policy()
+            .expect("valid configured grep policy");
+        assert_eq!(policy.max_files_per_step.get(), 1024);
+        assert_eq!(policy.max_l0_runs.get(), 3);
         assert_eq!(
             policy.max_mid_runs,
             loonfs_grep::GramIndexBuildPolicy::default().max_mid_runs,

--- a/crates/loonfs-server/src/grep_drivers.rs
+++ b/crates/loonfs-server/src/grep_drivers.rs
@@ -6,6 +6,7 @@ use loonfs_grep::{
     GrepStepLimiter, GrepWorker,
 };
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
@@ -26,7 +27,7 @@ impl GrepDrivers {
     pub(crate) fn new(
         worker: GrepWorker<SharedObjectStore>,
         policy: GramIndexBuildPolicy,
-        max_concurrent_steps: usize,
+        max_concurrent_steps: NonZeroUsize,
     ) -> Result<Self, crate::ServerConfigError> {
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
             crate::ServerConfigError::InvalidField {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -224,13 +224,21 @@ async fn app_with_store_and_transfer_issuer(
         )
     });
     let grep_drivers = if config.grep.mode.runs_worker() {
+        let worker_config = config.grep.worker_config();
+        let grep_config_error =
+            |error: loonfs_grep::GrepWorkerConfigError| ServerConfigError::InvalidField {
+                field: "grep",
+                reason: error.to_string(),
+            };
         Some(GrepDrivers::new(
             grep_worker
                 .as_ref()
                 .expect("driver-running grep mode should serve grep")
                 .clone(),
-            config.grep.worker_config().build_policy(),
-            config.grep.max_concurrent_steps,
+            worker_config.build_policy().map_err(grep_config_error)?,
+            worker_config
+                .concurrent_step_limit()
+                .map_err(grep_config_error)?,
         )?)
     } else {
         None

--- a/crates/loonfs-server/tests/grep_modes.rs
+++ b/crates/loonfs-server/tests/grep_modes.rs
@@ -18,6 +18,7 @@ use loonfs_server::{
     app, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
 };
 use serde::de::DeserializeOwned;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -196,7 +197,7 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
         .build_step(
             &backfill,
             GramIndexBuildPolicy {
-                max_files_per_step: 1,
+                max_files_per_step: NonZeroUsize::MIN,
                 ..GramIndexBuildPolicy::default()
             },
         )

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -8,6 +8,7 @@
 use crate::{NamespaceId, Result, RuntimeError};
 use std::collections::BTreeSet;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -40,7 +41,7 @@ pub(crate) struct BackgroundWork {
     /// per-namespace singleflight bounds each namespace to one tick; this
     /// bounds how many namespaces may tick at once, so a write burst across
     /// many namespaces cannot fan out into unbounded maintenance tasks.
-    max_concurrent: usize,
+    max_concurrent: NonZeroUsize,
     state: Mutex<BackgroundState>,
 }
 
@@ -63,14 +64,12 @@ impl BackgroundWork {
     pub(crate) fn new(
         policy: FsBackgroundWork,
         runtime: Option<tokio::runtime::Handle>,
-        max_concurrent: usize,
+        max_concurrent: NonZeroUsize,
     ) -> Self {
         Self {
             policy,
             runtime,
-            // A zero cap would silently disable auto maintenance; the
-            // policy is the switch for that, so the cap stays a bound.
-            max_concurrent: max_concurrent.max(1),
+            max_concurrent,
             state: Mutex::new(BackgroundState {
                 closed: false,
                 inflight: BTreeSet::new(),
@@ -101,10 +100,10 @@ impl BackgroundWork {
             state.pending.insert(namespace_id.clone());
             return false;
         }
-        if state.inflight.len() >= self.max_concurrent {
+        if state.inflight.len() >= self.max_concurrent.get() {
             tracing::debug!(
                 namespace_id = %namespace_id,
-                max_concurrent = self.max_concurrent,
+                max_concurrent = self.max_concurrent.get(),
                 "maintenance tick skipped at the concurrency cap; \
                  the next over-threshold publish reschedules it"
             );
@@ -206,6 +205,10 @@ mod tests {
         NamespaceId::parse("demo").expect("valid namespace id")
     }
 
+    fn concurrency_cap(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test cap should be nonzero")
+    }
+
     /// Sets its flag when dropped, mimicking the claim guard the auto-tick
     /// future carries: a refused spawn must drop the future so the guard
     /// releases the singleflight slot.
@@ -219,7 +222,7 @@ mod tests {
 
     #[test]
     fn a_request_during_an_active_tick_defers_and_reruns_exactly_once() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         assert!(background.try_claim(&namespace_id), "first claim spawns");
@@ -244,7 +247,7 @@ mod tests {
 
     #[test]
     fn shutdown_wins_over_a_deferred_rerun() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         assert!(background.try_claim(&namespace_id));
@@ -258,7 +261,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_after_shut_down_refuses_and_drops_the_future() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         // The racy interleaving a shutdown must win: the claim lands first...
@@ -292,7 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn tasks_spawned_before_shut_down_are_drained() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let ran = Arc::new(AtomicBool::new(false));
         let ran_in_task = ran.clone();
         background.spawn(async move {
@@ -309,7 +312,7 @@ mod tests {
 
     #[tokio::test]
     async fn drain_surfaces_panicked_tasks_as_an_error() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         background.spawn(async {
             panic!("injected background task panic");
         });
@@ -323,7 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn claims_are_singleflight_and_refused_after_shut_down() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
         assert!(background.try_claim(&namespace_id));
         assert!(
@@ -345,13 +348,14 @@ mod tests {
 
     #[tokio::test]
     async fn manual_only_policy_never_claims() {
-        let background = BackgroundWork::new(FsBackgroundWork::ManualOnly, None, 8);
+        let background =
+            BackgroundWork::new(FsBackgroundWork::ManualOnly, None, concurrency_cap(8));
         assert!(!background.try_claim(&namespace_id()));
     }
 
     #[tokio::test]
     async fn claims_stop_at_the_global_concurrency_cap() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 2);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(2));
         let first = NamespaceId::parse("first").expect("valid namespace id");
         let second = NamespaceId::parse("second").expect("valid namespace id");
         let third = NamespaceId::parse("third").expect("valid namespace id");
@@ -367,15 +371,6 @@ mod tests {
         assert!(
             background.try_claim(&third),
             "a released slot admits the waiting namespace"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_zero_cap_is_normalized_to_one_slot() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 0);
-        assert!(
-            background.try_claim(&namespace_id()),
-            "the policy, not the cap, is the off switch"
         );
     }
 }

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -12,6 +12,7 @@ use crate::{
     ReleaseCheckpointResponse, RepairNamespaceResponse, Result, RuntimeCacheConfig,
     RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Administrative and maintenance handle.
@@ -256,7 +257,8 @@ impl FsAdminBuilder {
         let background = BackgroundWork::new(
             FsBackgroundWork::ManualOnly,
             None,
-            crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                .expect("default maintenance concurrency should be nonzero"),
         );
         Ok(FsAdmin {
             core: self.core.open(actor_id, self.actor_version, background)?,

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -12,6 +12,7 @@ use crate::{
     PageRequest, Result, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
     StoreConfig, TraceMode, TraceStoreKind,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Read-only handle for latest namespace views.
@@ -243,7 +244,8 @@ impl FsReaderBuilder {
         let background = BackgroundWork::new(
             FsBackgroundWork::ManualOnly,
             None,
-            crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                .expect("default maintenance concurrency should be nonzero"),
         );
         Ok(FsReader {
             core: self.core.open(

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -16,6 +16,7 @@ use crate::{
     RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
     UndeleteOptions, UploadContentResponse, UploadId,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Write-capable handle for normal application and server use.
@@ -529,8 +530,9 @@ impl FsWriterBuilder {
     /// at most one tick at a time; this bounds the fan-out when many
     /// namespaces cross their thresholds together. Skipped ticks are
     /// rescheduled by the next over-threshold publish. Defaults to
-    /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]; zero is normalized up
-    /// to one (use [`FsBackgroundWork::ManualOnly`] to disable scheduling).
+    /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]. The limit must be
+    /// greater than zero; [`FsBackgroundWork::ManualOnly`] is the only way
+    /// to disable scheduling.
     pub fn max_concurrent_maintenance(mut self, max_concurrent_maintenance: usize) -> Self {
         self.max_concurrent_maintenance = max_concurrent_maintenance;
         self
@@ -610,10 +612,18 @@ impl FsWriterBuilder {
         let writer_id = self
             .writer_id
             .ok_or_else(|| RuntimeError::Config("writer_id is required".to_owned()))?;
+        let max_concurrent_maintenance = NonZeroUsize::new(self.max_concurrent_maintenance)
+            .ok_or_else(|| {
+                RuntimeError::Config(
+                    "`max_concurrent_maintenance` must be greater than zero; \
+                     `FsBackgroundWork::ManualOnly` disables scheduling"
+                        .to_owned(),
+                )
+            })?;
         let background = BackgroundWork::new(
             self.background_work,
             Some(owning_runtime()?),
-            self.max_concurrent_maintenance,
+            max_concurrent_maintenance,
         );
         Ok(FsWriter {
             core: self.core.open(writer_id, self.writer_version, background)?,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1446,7 +1446,8 @@ mod tests {
             BackgroundWork::new(
                 FsBackgroundWork::ManualOnly,
                 None,
-                crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+                std::num::NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                    .expect("default maintenance concurrency should be nonzero"),
             ),
             None,
             None,

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -33,6 +34,10 @@ fn grep_request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 /// Content blob object keys currently in the store, for pinpointing the
@@ -332,7 +337,7 @@ async fn a_worker_policy_bounds_each_build_step() {
         .expect("build admin");
     let grep_worker = grep_worker(&store);
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: 3,
+        max_files_per_step: nonzero_usize(3),
         ..GramIndexBuildPolicy::default()
     };
 
@@ -426,9 +431,10 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
     let content_bytes = format!("bounded needle file {:04}\n", 0).len();
     let max_content_bytes_per_step = (content_bytes * FILES_PER_STEP) as u64;
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: FILES,
-        max_content_bytes_per_step,
-        max_l0_runs: usize::MAX,
+        max_files_per_step: nonzero_usize(FILES),
+        max_content_bytes_per_step: NonZeroU64::new(max_content_bytes_per_step)
+            .expect("content budget should be nonzero"),
+        max_l0_runs: nonzero_usize(usize::MAX),
         ..GramIndexBuildPolicy::default()
     };
     let mut ops = Vec::with_capacity(FILES);

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -22,6 +22,7 @@ use loonfs_grep::GramIndexBuildPolicy;
 use loonfs_grep::{GrepBuildOutcome, GrepFoldOutcome, GrepIndexSnapshot, GrepService, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -35,6 +36,10 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 async fn read_context(store: &SharedObjectStore, namespace_id: &NamespaceId) -> RuntimeReadContext {
@@ -221,8 +226,8 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
         .await
         .expect("build writer");
     let policy = GramIndexBuildPolicy {
-        max_l0_runs: 2,
-        max_mid_runs: 2,
+        max_l0_runs: nonzero_usize(2),
+        max_mid_runs: nonzero_usize(2),
         ..GramIndexBuildPolicy::default()
     };
     let worker = worker(&store);

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -11,7 +11,7 @@ use loonfs::{
     GrepRequest, GrepResponse, NamespaceId, PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
-use loonfs_api::{ChangeSeq, IndexSegmentId};
+use loonfs_api::{sha256_digest, ChangeSeq, IndexSegmentId};
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
     WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
@@ -40,6 +40,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -56,6 +57,10 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 fn worker(store: &SharedObjectStore) -> GrepWorker<SharedObjectStore> {
@@ -260,11 +265,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .await
         .expect("load root")
         .expect("root exists");
-    let GrepLifecycle::Backfilling {
-        checkpoint_id: Some(checkpoint_id),
-        ..
-    } = root.state().lifecycle()
-    else {
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.state().lifecycle() else {
         panic!(
             "enable must publish checkpointed backfill: {:?}",
             root.state()
@@ -273,7 +274,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
     let checkpoint_id = checkpoint_id.clone();
 
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: 1,
+        max_files_per_step: NonZeroUsize::MIN,
         ..GramIndexBuildPolicy::default()
     };
     let first = worker
@@ -413,11 +414,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         .await
         .expect("load restarted root")
         .expect("root exists");
-    let GrepLifecycle::Backfilling {
-        checkpoint_id: Some(checkpoint_id),
-        ..
-    } = root.state().lifecycle()
-    else {
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.state().lifecycle() else {
         panic!("gap must restart checkpointed backfill");
     };
     admin
@@ -512,6 +509,79 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
     writer.shutdown_background().await.expect("shutdown");
 }
 
+#[tokio::test]
+async fn backfilling_root_without_checkpoint_id_is_index_corrupt() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("missing-backfill-checkpoint").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("missing-checkpoint-writer")
+        .build()
+        .await
+        .expect("writer");
+    let reader = writer.reader();
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let worker = worker(&store);
+    worker.enable(&namespace_id).await.expect("enable grep");
+    let root = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load backfilling root")
+        .expect("backfilling root exists");
+    let manifest_bytes = store
+        .get(
+            &manifest_key(&namespace_id, root.manifest_envelope().manifest_id()),
+            None,
+        )
+        .await
+        .expect("read backfilling manifest")
+        .expect("backfilling manifest exists");
+    let corrupt_manifest_id =
+        write_manifest_without_checkpoint_id(&*store, &namespace_id, &manifest_bytes).await;
+    write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
+
+    assert_corrupt_index_error(
+        "backfilling manifest missing checkpoint id",
+        reader.grep(&namespace_id, &request("needle")).await,
+    );
+    writer.shutdown_background().await.expect("shutdown");
+}
+
+async fn write_manifest_without_checkpoint_id(
+    store: &dyn ObjectStore,
+    namespace_id: &NamespaceId,
+    manifest_bytes: &[u8],
+) -> GrepManifestId {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(manifest_bytes).expect("decode valid manifest document");
+    document["payload"]["lifecycle"]
+        .as_object_mut()
+        .expect("backfilling lifecycle is an object")
+        .remove("checkpoint_id")
+        .expect("valid backfilling manifest carries checkpoint id");
+    let payload_bytes =
+        serde_json::to_vec(&document["payload"]).expect("encode corrupt manifest payload");
+    let payload_checksum = sha256_digest(&payload_bytes);
+    document["payload_checksum"] = serde_json::Value::String(payload_checksum.clone());
+    let manifest_id = GrepManifestId::parse(
+        payload_checksum
+            .strip_prefix("sha256:")
+            .expect("sha256 digest should carry its algorithm prefix"),
+    )
+    .expect("checksum is a valid manifest id");
+    store
+        .put_overwrite(
+            &manifest_key(namespace_id, &manifest_id),
+            Bytes::from(serde_json::to_vec(&document).expect("encode corrupt manifest document")),
+        )
+        .await
+        .expect("write manifest missing checkpoint id");
+    manifest_id
+}
+
 async fn write_pointer(
     store: &dyn ObjectStore,
     namespace_id: &NamespaceId,
@@ -592,8 +662,8 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         .expect("create namespace");
     let worker = worker(&store);
     let policy = GramIndexBuildPolicy {
-        max_l0_runs: 2,
-        max_mid_runs: 2,
+        max_l0_runs: nonzero_usize(2),
+        max_mid_runs: nonzero_usize(2),
         ..GramIndexBuildPolicy::default()
     };
     worker.enable(&namespace_id).await.expect("enable");
@@ -849,7 +919,7 @@ async fn checkpoint_backfill_matches_incremental_worker_results() {
         &worker,
         &backfill_namespace,
         GramIndexBuildPolicy {
-            max_files_per_step: 2,
+            max_files_per_step: nonzero_usize(2),
             ..GramIndexBuildPolicy::default()
         },
     )

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -608,6 +608,31 @@ fn builders_require_identity_and_a_runtime() {
 }
 
 #[test]
+fn writer_builder_rejects_zero_maintenance_concurrency() {
+    let temp_dir = tempdir().expect("tempdir");
+    for background_work in [FsBackgroundWork::Enabled, FsBackgroundWork::ManualOnly] {
+        let result = block_on(
+            FsWriter::builder(store_config(temp_dir.path()))
+                .writer_id("handle-test-writer")
+                .background_work(background_work)
+                .max_concurrent_maintenance(0)
+                .build(),
+        );
+
+        match result {
+            Err(RuntimeError::Config(message)) => {
+                assert!(message.contains("`max_concurrent_maintenance`"));
+                assert!(message.contains("`FsBackgroundWork::ManualOnly`"));
+            }
+            Err(other) => {
+                panic!("expected config error for zero maintenance cap, got {other:?}")
+            }
+            Ok(_) => panic!("zero maintenance concurrency must be rejected"),
+        }
+    }
+}
+
+#[test]
 fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();


### PR DESCRIPTION
The repo had two rules for zero-valued budgets — the config layer rejected them while the policy layer beneath silently raised them to one — and one impossible durable state treated as a fallback.

The adopted rule: cache budgets may use zero as disabled (their documented convention, untouched); work budgets and concurrency limits reject zero at every construction boundary and are unrepresentable internally; absent durable required fields are corruption. The sweep classified every .max(1) in the workspace — fourteen sites, including work-budget normalizations in core's checkpoint build and reorganize paths beyond the ones the audit named — removing the silent raisings in favor of NonZero-typed internals behind primitive TOML fields with typed InvalidField errors, keeping the one legitimate cache-arithmetic use, and leaving layout math alone. The writer builder now rejects zero maintenance concurrency at build() with ManualOnly as the only disable mechanism, as the docs always claimed.