### PR TITLE
refactor(objectstore): unify immutable writes

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -17,6 +17,7 @@ use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
 use loonfs_api::{sha256_digest, ChangeSeq, MetadataTableId, NamespaceId};
 use loonfs_objectstore::keys::metadata_table;
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     store: &S,
@@ -24,7 +25,7 @@ pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     run_seq: ChangeSeq,
     level: u32,
     metadata_state: &MetadataState,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Result<Vec<MetadataTableManifest>> {
     build_manifest_tables_from_rows(
         store,
@@ -78,7 +79,7 @@ pub(super) async fn build_manifest_l0_run_tables<S: ObjectStore + ?Sized>(
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum MetadataTableSegmentation {
-    Base { max_rows_per_segment: usize },
+    Base { max_rows_per_segment: NonZeroUsize },
     Full,
 }
 
@@ -233,15 +234,15 @@ pub(super) fn segment_manifest_rows(
         MetadataTableSegmentation::Full => vec![MetadataSstRows { rows }],
         MetadataTableSegmentation::Base {
             max_rows_per_segment,
-        } => segment_rows_by_row_key_range(rows, max_rows_per_segment.max(1)),
+        } => segment_rows_by_row_key_range(rows, max_rows_per_segment),
     }
 }
 
 pub(super) fn segment_rows_by_row_key_range(
     rows: Vec<MetadataRow>,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
 ) -> Vec<MetadataSstRows> {
-    rows.chunks(max_rows_per_segment)
+    rows.chunks(max_rows_per_segment.get())
         .map(|rows| MetadataSstRows {
             rows: rows.to_vec(),
         })

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -8,7 +8,7 @@ use super::runs::{
 };
 use crate::error::{CoreError, Result};
 use crate::metadata::MetadataState;
-use crate::storage::content::write_immutable_object;
+use bytes::Bytes;
 use futures::future::try_join_all;
 use loonfs_api::wire::manifest::{
     hex_encode_bytes, MetadataFileRef, MetadataRow, MetadataTableFamily,
@@ -203,7 +203,9 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
             request.object_key
         ))
     })?;
-    write_immutable_object(store, &request.object_key, &built.bytes).await?;
+    store
+        .put_immutable_verified(&request.object_key, Bytes::from(built.bytes.clone()))
+        .await?;
     let filter_inline = (built.filter.stored_len <= INLINE_SEGMENT_FILTER_MAX_BYTES).then(|| {
         let start = built.filter.offset as usize;
         hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])

--- a/crates/loonfs-core/src/checkpoint/grep_read.rs
+++ b/crates/loonfs-core/src/checkpoint/grep_read.rs
@@ -13,6 +13,7 @@ use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::{ChangeSeq, CheckpointId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 /// Validated incremental commits after a grep watermark, or an explicit
 /// signal that retention has removed part of the required history.
@@ -107,7 +108,7 @@ pub async fn load_grep_checkpoint_revision_page<S: ObjectStore + ?Sized>(
     checkpoint_id: &CheckpointId,
     now_ms: u64,
     cursor: &str,
-    limit: usize,
+    limit: NonZeroUsize,
 ) -> Result<Option<GrepCheckpointRevisionPage>> {
     let Some(record) = read_checkpoint_record(store, namespace_id, checkpoint_id)
         .await?
@@ -146,7 +147,7 @@ pub async fn load_grep_checkpoint_revision_page<S: ObjectStore + ?Sized>(
             "checkpoint `{checkpoint_id}` basis does not match its manifest"
         )));
     }
-    let limit = limit.max(1);
+    let limit = limit.get();
     let rows = scan_checkpoint_revisions(&tables, cursor, limit).await?;
     let exhausted = rows.len() < limit;
     let mut revisions = Vec::with_capacity(rows.len());

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -139,7 +139,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let previous = tables.manifest();
 
     let l0_runs = l0_run_count(&previous.payload);
-    if l0_runs < policy.max_l0_runs.max(1) {
+    if l0_runs < policy.max_l0_runs.get() {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -5,6 +5,7 @@ use loonfs_api::wire::manifest::{MetadataFileRef, MetadataTableFamily, Namespace
 use loonfs_api::ChangeSeq;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 
 pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
 /// With block-granular reads the segment is no longer the read unit, so
@@ -41,15 +42,17 @@ pub(super) struct MetadataRunManifest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MetadataLsmPolicy {
-    pub max_l0_runs: usize,
-    pub max_rows_per_segment: usize,
+    pub max_l0_runs: NonZeroUsize,
+    pub max_rows_per_segment: NonZeroUsize,
 }
 
 impl Default for MetadataLsmPolicy {
     fn default() -> Self {
         Self {
-            max_l0_runs: DEFAULT_MAX_CHECKPOINT_L0_RUNS,
-            max_rows_per_segment: DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT,
+            max_l0_runs: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_L0_RUNS)
+                .expect("default L0 run limit should be nonzero"),
+            max_rows_per_segment: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT)
+                .expect("default segment row budget should be nonzero"),
         }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -57,7 +57,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
@@ -126,7 +126,7 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
     policy: MetadataLsmPolicy,
 ) -> ManifestId {
     let fold_policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..policy
     };
     loop {
@@ -1500,7 +1500,7 @@ async fn base_rebuild_rejects_divergent_revision_index() {
         .await
         .expect("l0 checkpoint");
     let fold_policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     let mut rebuild_error = None;
@@ -2118,7 +2118,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 2,
+        max_l0_runs: NonZeroUsize::new(2).expect("test run limit should be nonzero"),
         ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -2272,7 +2272,8 @@ async fn manifest_base_run_tables_have_sorted_segment_coverage() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 2,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
         ..MetadataLsmPolicy::default()
     };
     let materialization_before = load_current_projection(&store, &namespace_id)
@@ -2336,7 +2337,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2407,7 +2408,7 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2550,7 +2551,7 @@ async fn table_range_page_merges_base_and_l0_in_row_key_order() {
         .expect("write c");
 
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2608,7 +2609,7 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2687,7 +2688,7 @@ async fn maintenance_materialization_does_not_populate_metadata_table_cache() {
             .expect("write file");
     }
     let policy = MetadataLsmPolicy {
-        max_rows_per_segment: 1,
+        max_rows_per_segment: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     let manifest_id = checkpoint_then_reorganize(&store, &namespace_id, &context, policy).await;
@@ -2857,8 +2858,9 @@ async fn whole_run_compaction_rewrites_base_segments() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
-        max_rows_per_segment: 2,
+        max_l0_runs: NonZeroUsize::MIN,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2957,8 +2959,9 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
-        max_rows_per_segment: 2,
+        max_l0_runs: NonZeroUsize::MIN,
+        max_rows_per_segment: NonZeroUsize::new(2)
+            .expect("test segment row budget should be nonzero"),
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -3600,7 +3603,7 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     let policy = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -5661,7 +5664,7 @@ pub(crate) async fn build_namespace_manifest_from_metadata_state<S: ObjectStore 
             debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
             (head_seq, flatten_manifest_tables(run_tables))
         }
-        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs => {
+        Some(previous) if l0_run_count(&previous.manifest.payload) < policy.max_l0_runs.get() => {
             let mut metadata_files = previous.manifest.payload.metadata_files.clone();
             if previous.manifest.payload.head_seq < head_seq {
                 metadata_files.extend(flatten_manifest_tables(
@@ -5856,7 +5859,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         .state;
 
     let fold_everything = MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..Default::default()
     };
     let overrun = SteppingTimer::new(20 * 60 * 1000);

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -12,14 +12,14 @@ use crate::metadata::VisiblePathError;
 use crate::namespace::catalog::NamespaceCatalogLoadError;
 use crate::namespace::control::ControlObjectLoadError;
 use crate::namespace::writer_epoch::WriterEpochAcquireError;
-use crate::storage::content::{DurableContentValidationError, ImmutableObjectWriteError};
+use crate::storage::content::DurableContentValidationError;
 use crate::wal::{WalBuildError, WalChainLoadError, WalReplayError};
 use loonfs_api::wire::control::{CheckpointRecordLifecycle, HeadState};
 use loonfs_api::{
     ChangeSeq, CommitId, CommitIdValidationError, ErrorDetails, GeneratedIdValidationError,
     InodeId, InodeKind, NamespaceId, NamespaceIdValidationError, UploadId, WriterEpoch,
 };
-use loonfs_objectstore::ObjectStoreError;
+use loonfs_objectstore::{ImmutableWriteError, ObjectStoreError};
 use thiserror::Error;
 
 /// Public error type returned by `loonfs-core`.
@@ -274,17 +274,24 @@ impl From<NamespaceCatalogLoadError> for CoreError {
     }
 }
 
-impl From<ImmutableObjectWriteError> for CoreError {
-    fn from(value: ImmutableObjectWriteError) -> Self {
+impl From<ImmutableWriteError> for CoreError {
+    fn from(value: ImmutableWriteError) -> Self {
+        let fallback_object_key = value.object_key().to_owned();
         match value {
-            ImmutableObjectWriteError::Store {
+            ImmutableWriteError::DifferentObject { object_key } => Self::Store {
                 object_key,
-                message,
-                class,
-            } => Self::Store {
+                message: "immutable object already exists with different bytes".to_owned(),
+                class: StoreFailureClass::Other,
+            },
+            ImmutableWriteError::Transport { object_key, source } => Self::Store {
                 object_key,
-                message,
-                class,
+                message: source.message(),
+                class: StoreFailureClass::of(&source),
+            },
+            error => Self::Store {
+                object_key: fallback_object_key,
+                message: error.to_string(),
+                class: StoreFailureClass::Other,
             },
         }
     }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::keys::{
     namespace_config, wal_head, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 
 /// GC lifecycle tests pin as one user owner; owner-specific release
 /// rules are exercised in the fork and release suites.
@@ -1060,7 +1061,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     // Reorganization folds the L0 runs into fresh base segments; the
     // superseded run tables then age out on the next pass.
     let fold_policy = crate::checkpoint::MetadataLsmPolicy {
-        max_l0_runs: 1,
+        max_l0_runs: NonZeroUsize::MIN,
         ..Default::default()
     };
     for _ in 0..16 {

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -16,7 +16,7 @@ use crate::namespace::control::{
     load_content_store_descriptor_control, load_namespace_descriptor_control,
     load_namespace_head_control,
 };
-use crate::storage::content::{probe_durable_content_reference, write_immutable_object};
+use crate::storage::content::probe_durable_content_reference;
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::v0::{
@@ -234,7 +234,9 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
                     return Err(CoreError::UploadContentConflict { upload_id });
                 }
 
-                write_immutable_object(store, &object_key, bytes).await?;
+                store
+                    .put_immutable_verified(&object_key, Bytes::copy_from_slice(bytes))
+                    .await?;
                 state.staged_content_ref = Some(content_ref.clone());
 
                 Ok(UploadSessionUpdate::Replace {

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -1,14 +1,14 @@
 //! Content blob reads and writes: content-addressed storage, reference
 //! validation, and verified read-back.
 
-use crate::error::{CoreError, StoreFailureClass};
+use crate::error::CoreError;
 use crate::invariants::InvariantId;
 use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use loonfs_api::{sha256_digest, ContentRef, ContentRefKind, ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::content_blob;
-use loonfs_objectstore::{ObjectStore, ObjectStoreError, PROVIDER_MULTIPART_THRESHOLD_BYTES};
+use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -72,16 +72,6 @@ pub enum DurableContentValidationError {
     },
     #[error("object store error for `{object_key}`: {message}")]
     Store { object_key: String, message: String },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
-pub(crate) enum ImmutableObjectWriteError {
-    #[error("failed to write immutable object `{object_key}`: {message}")]
-    Store {
-        object_key: String,
-        message: String,
-        class: StoreFailureClass,
-    },
 }
 
 pub async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
@@ -287,7 +277,9 @@ pub async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
     let content_ref = ContentRef::whole_file_v0(bytes);
     let object_key = content_blob(content_store_id.as_str(), &content_ref.digest)
         .map_err(|err| CoreError::Internal(format!("failed to derive content blob key: {err}")))?;
-    write_immutable_object(store, &object_key, bytes).await?;
+    store
+        .put_immutable_verified(&object_key, Bytes::copy_from_slice(bytes))
+        .await?;
 
     Ok(StoredContent {
         content_store_id,
@@ -297,106 +289,6 @@ pub async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
         content_ref,
         _write_acknowledged: StoredContentWriteAcknowledgement,
     })
-}
-
-pub(crate) async fn write_immutable_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_bytes: &[u8],
-) -> Result<(), ImmutableObjectWriteError> {
-    // Payloads large enough for multipart upload are written with overwrite
-    // semantics: providers complete multipart uploads as unconditional
-    // overwrites, so create-if-absent cannot ride them. Overwrite loses
-    // nothing here because every immutable-object key is collision-free by
-    // construction — content blobs are addressed by their own digest, and
-    // table/index objects carry a generated id owned by one writer — so any
-    // writer of the same key carries the same bytes, and reads re-verify
-    // digests regardless. Small payloads keep the create precondition as a
-    // cheap corruption tripwire.
-    let write_result = if expected_bytes.len() as u64 >= PROVIDER_MULTIPART_THRESHOLD_BYTES {
-        store
-            .put_overwrite(object_key, Bytes::copy_from_slice(expected_bytes))
-            .await
-    } else {
-        store
-            .put_if_absent(object_key, Bytes::copy_from_slice(expected_bytes))
-            .await
-    };
-    match write_result {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            if existing_object_matches_expected_bytes(store, object_key, expected_bytes).await? {
-                return Ok(());
-            }
-            Err(ImmutableObjectWriteError::Store {
-                object_key: object_key.to_owned(),
-                message: "object already exists with different bytes".to_owned(),
-                class: StoreFailureClass::Other,
-            })
-        }
-        Err(err @ ObjectStoreError::Transport { .. }) => {
-            let original = err.message();
-            match existing_object_matches_expected_bytes(store, object_key, expected_bytes).await {
-                Ok(true) => Ok(()),
-                Ok(false) => Err(ImmutableObjectWriteError::Store {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "{original}; immutable object exists with different bytes after transport error"
-                    ),
-                    class: StoreFailureClass::Other,
-                }),
-                Err(verify_err) => Err(ImmutableObjectWriteError::Store {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "{original}; failed to verify immutable write after transport error: {verify_err}"
-                    ),
-                    class: StoreFailureClass::Other,
-                }),
-            }
-        }
-        Err(err) => Err(ImmutableObjectWriteError::Store {
-            object_key: object_key.to_owned(),
-            message: err.message(),
-            class: StoreFailureClass::of(&err),
-        }),
-    }
-}
-
-async fn existing_object_matches_expected_bytes<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_bytes: &[u8],
-) -> Result<bool, ImmutableObjectWriteError> {
-    let expected_size = expected_bytes.len() as u64;
-    if let Some(metadata) =
-        store
-            .head(object_key)
-            .await
-            .map_err(|err| ImmutableObjectWriteError::Store {
-                object_key: object_key.to_owned(),
-                message: err.message(),
-                class: StoreFailureClass::of(&err),
-            })?
-    {
-        if metadata.size_bytes != expected_size {
-            return Ok(false);
-        }
-    }
-
-    let existing = store
-        .get(object_key, None)
-        .await
-        .map_err(|err| ImmutableObjectWriteError::Store {
-            object_key: object_key.to_owned(),
-            message: err.message(),
-            class: StoreFailureClass::of(&err),
-        })?
-        .ok_or_else(|| ImmutableObjectWriteError::Store {
-            object_key: object_key.to_owned(),
-            message: "object is missing while verifying immutable write".to_owned(),
-            class: StoreFailureClass::Other,
-        })?;
-    Ok(existing == expected_bytes)
 }
 
 async fn load_required_object<S: ObjectStore + ?Sized>(
@@ -419,8 +311,7 @@ async fn load_required_object<S: ObjectStore + ?Sized>(
 mod tests {
     use super::{
         probe_durable_content_reference, read_durable_content_bytes,
-        validate_durable_content_reference, write_immutable_object, DurableContentValidationError,
-        ImmutableObjectWriteError,
+        validate_durable_content_reference, DurableContentValidationError,
     };
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -428,7 +319,6 @@ mod tests {
     use loonfs_api::{ContentRef, ContentRefKind, ContentStoreId};
     use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
-    use loonfs_objectstore::PROVIDER_MULTIPART_THRESHOLD_BYTES;
     use loonfs_objectstore::{
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };
@@ -591,170 +481,6 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn immutable_write_recovers_when_transport_error_hides_committed_object() {
-        let (_temp_dir, inner, content_store_id) = test_store();
-        let store = TransportOnCreateStore::new(inner, TransportBehavior::WriteThenError);
-        let bytes = b"metadata table bytes";
-        let content_ref = ContentRef::whole_file_v0(bytes);
-        let object_key =
-            content_blob(content_store_id.as_str(), &content_ref.digest).expect("content key");
-
-        write_immutable_object(&store, &object_key, bytes)
-            .await
-            .expect("committed object is accepted after transport error");
-
-        let stored = store
-            .inner
-            .get(&object_key, None)
-            .await
-            .expect("read object")
-            .expect("object exists");
-        assert_eq!(stored, Bytes::copy_from_slice(bytes));
-    }
-
-    #[tokio::test]
-    async fn immutable_write_rejects_transport_error_without_committed_object() {
-        let (_temp_dir, inner, content_store_id) = test_store();
-        let store = TransportOnCreateStore::new(inner, TransportBehavior::ErrorWithoutWrite);
-        let bytes = b"metadata table bytes";
-        let content_ref = ContentRef::whole_file_v0(bytes);
-        let object_key =
-            content_blob(content_store_id.as_str(), &content_ref.digest).expect("content key");
-
-        let err = write_immutable_object(&store, &object_key, bytes)
-            .await
-            .expect_err("missing object after transport error is rejected");
-
-        assert_error_contains(&err, "simulated timeout");
-        assert_error_contains(
-            &err,
-            "failed to verify immutable write after transport error",
-        );
-        assert_error_contains(&err, "object is missing while verifying immutable write");
-    }
-
-    #[tokio::test]
-    async fn immutable_write_rejects_different_existing_bytes_after_transport_error() {
-        let (_temp_dir, inner, content_store_id) = test_store();
-        let expected = b"expected immutable bytes";
-        let different = b"different immutable bytes";
-        let content_ref = ContentRef::whole_file_v0(expected);
-        let object_key =
-            content_blob(content_store_id.as_str(), &content_ref.digest).expect("content key");
-        inner
-            .put_if_absent(&object_key, Bytes::copy_from_slice(different))
-            .await
-            .expect("preload different object");
-        let store = TransportOnCreateStore::new(inner, TransportBehavior::ErrorWithoutWrite);
-
-        let err = write_immutable_object(&store, &object_key, expected)
-            .await
-            .expect_err("different existing bytes are rejected");
-
-        assert_error_contains(&err, "simulated timeout");
-        assert_error_contains(
-            &err,
-            "immutable object exists with different bytes after transport error",
-        );
-    }
-
-    #[tokio::test]
-    async fn immutable_write_mode_routes_by_multipart_threshold() {
-        let (_temp_dir, inner, content_store_id) = test_store();
-        let store = ModeRecordingStore::new(inner);
-
-        let small = b"small immutable bytes".to_vec();
-        let small_ref = ContentRef::whole_file_v0(&small);
-        let small_key =
-            content_blob(content_store_id.as_str(), &small_ref.digest).expect("content key");
-        write_immutable_object(&store, &small_key, &small)
-            .await
-            .expect("small write");
-
-        let large = vec![0u8; usize::try_from(PROVIDER_MULTIPART_THRESHOLD_BYTES).expect("usize")];
-        let large_ref = ContentRef::whole_file_v0(&large);
-        let large_key =
-            content_blob(content_store_id.as_str(), &large_ref.digest).expect("content key");
-        write_immutable_object(&store, &large_key, &large)
-            .await
-            .expect("large write");
-
-        let modes = store.put_modes.lock().expect("modes").clone();
-        assert_eq!(
-            modes,
-            vec![PutMode::CreateIfAbsent, PutMode::Overwrite],
-            "small blobs keep the create precondition; multipart-sized blobs \
-             use overwrite because multipart completion cannot carry one"
-        );
-    }
-
-    fn assert_error_contains(error: &ImmutableObjectWriteError, expected: &str) {
-        let message = error.to_string();
-        assert!(
-            message.contains(expected),
-            "expected error to contain `{expected}`, got `{message}`"
-        );
-    }
-
-    #[derive(Debug)]
-    struct ModeRecordingStore {
-        inner: LocalFsStore,
-        put_modes: std::sync::Mutex<Vec<PutMode>>,
-    }
-
-    impl ModeRecordingStore {
-        fn new(inner: LocalFsStore) -> Self {
-            Self {
-                inner,
-                put_modes: std::sync::Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl ObjectStore for ModeRecordingStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            self.put_modes.lock().expect("modes").push(mode.clone());
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
-    }
-
     fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -775,72 +501,6 @@ mod tests {
             .put_if_absent(&key, Bytes::copy_from_slice(bytes))
             .await
             .expect("put content");
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    enum TransportBehavior {
-        WriteThenError,
-        ErrorWithoutWrite,
-    }
-
-    #[derive(Debug)]
-    struct TransportOnCreateStore {
-        inner: LocalFsStore,
-        behavior: TransportBehavior,
-    }
-
-    impl TransportOnCreateStore {
-        fn new(inner: LocalFsStore, behavior: TransportBehavior) -> Self {
-            Self { inner, behavior }
-        }
-    }
-
-    #[async_trait]
-    impl ObjectStore for TransportOnCreateStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            if mode == PutMode::CreateIfAbsent {
-                if matches!(self.behavior, TransportBehavior::WriteThenError) {
-                    self.inner.put(key, bytes, mode).await?;
-                }
-                return Err(ObjectStoreError::transport(key, "simulated timeout"));
-            }
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
     }
 
     #[derive(Debug)]

--- a/crates/loonfs-grep/src/config.rs
+++ b/crates/loonfs-grep/src/config.rs
@@ -2,6 +2,7 @@
 
 use crate::GramIndexBuildPolicy;
 use serde::Deserialize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use thiserror::Error;
 
 /// Default cap on concurrently executing grep build or fold steps.
@@ -11,6 +12,10 @@ use thiserror::Error;
 pub const DEFAULT_MAX_CONCURRENT_STEPS: usize = 2;
 
 /// Bounded-work policy shared by embedded and standalone drivers.
+///
+/// Project-wide, zero may disable an explicitly documented cache. Work
+/// budgets and concurrency limits instead reject zero at their construction
+/// boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GrepWorkerConfig {
@@ -32,31 +37,32 @@ pub struct GrepWorkerConfig {
 
 impl GrepWorkerConfig {
     /// Returns the bounded build/fold policy represented by this config.
-    pub fn build_policy(self) -> GramIndexBuildPolicy {
-        GramIndexBuildPolicy {
-            max_files_per_step: self.max_files_per_step,
-            max_content_bytes_per_step: self.max_content_bytes_per_step,
-            max_rows_per_segment: self.max_rows_per_segment,
-            max_l0_runs: self.max_l0_runs,
-            max_mid_runs: self.max_mid_runs,
-            max_fold_rows_per_step: self.max_fold_rows_per_step,
-        }
+    pub fn build_policy(self) -> Result<GramIndexBuildPolicy, GrepWorkerConfigError> {
+        Ok(GramIndexBuildPolicy {
+            max_files_per_step: nonzero_usize("max_files_per_step", self.max_files_per_step)?,
+            max_content_bytes_per_step: nonzero_u64(
+                "max_content_bytes_per_step",
+                self.max_content_bytes_per_step,
+            )?,
+            max_rows_per_segment: nonzero_usize("max_rows_per_segment", self.max_rows_per_segment)?,
+            max_l0_runs: nonzero_usize("max_l0_runs", self.max_l0_runs)?,
+            max_mid_runs: nonzero_usize("max_mid_runs", self.max_mid_runs)?,
+            max_fold_rows_per_step: nonzero_usize(
+                "max_fold_rows_per_step",
+                self.max_fold_rows_per_step,
+            )?,
+        })
+    }
+
+    /// Returns the validated deployment-wide concurrency limit.
+    pub fn concurrent_step_limit(self) -> Result<NonZeroUsize, GrepWorkerConfigError> {
+        nonzero_usize("max_concurrent_steps", self.max_concurrent_steps)
     }
 
     /// Rejects zero step budgets.
     pub fn validate(self) -> Result<(), GrepWorkerConfigError> {
-        if self.max_concurrent_steps == 0 {
-            return Err(GrepWorkerConfigError::InvalidField {
-                field: "max_concurrent_steps",
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
-        if let Some(field) = self.build_policy().zero_budget_field() {
-            return Err(GrepWorkerConfigError::InvalidField {
-                field,
-                reason: "must be greater than zero".to_owned(),
-            });
-        }
+        self.concurrent_step_limit()?;
+        self.build_policy()?;
         Ok(())
     }
 }
@@ -66,14 +72,28 @@ impl Default for GrepWorkerConfig {
         let policy = GramIndexBuildPolicy::default();
         Self {
             max_concurrent_steps: DEFAULT_MAX_CONCURRENT_STEPS,
-            max_files_per_step: policy.max_files_per_step,
-            max_content_bytes_per_step: policy.max_content_bytes_per_step,
-            max_rows_per_segment: policy.max_rows_per_segment,
-            max_l0_runs: policy.max_l0_runs,
-            max_mid_runs: policy.max_mid_runs,
-            max_fold_rows_per_step: policy.max_fold_rows_per_step,
+            max_files_per_step: policy.max_files_per_step.get(),
+            max_content_bytes_per_step: policy.max_content_bytes_per_step.get(),
+            max_rows_per_segment: policy.max_rows_per_segment.get(),
+            max_l0_runs: policy.max_l0_runs.get(),
+            max_mid_runs: policy.max_mid_runs.get(),
+            max_fold_rows_per_step: policy.max_fold_rows_per_step.get(),
         }
     }
+}
+
+fn nonzero_usize(field: &'static str, value: usize) -> Result<NonZeroUsize, GrepWorkerConfigError> {
+    NonZeroUsize::new(value).ok_or_else(|| GrepWorkerConfigError::InvalidField {
+        field,
+        reason: "must be greater than zero".to_owned(),
+    })
+}
+
+fn nonzero_u64(field: &'static str, value: u64) -> Result<NonZeroU64, GrepWorkerConfigError> {
+    NonZeroU64::new(value).ok_or_else(|| GrepWorkerConfigError::InvalidField {
+        field,
+        reason: "must be greater than zero".to_owned(),
+    })
 }
 
 /// Invalid grep worker configuration.
@@ -98,7 +118,7 @@ mod tests {
     fn defaults_match_the_build_policy() {
         let config = GrepWorkerConfig::default();
 
-        assert_eq!(config.build_policy(), GramIndexBuildPolicy::default());
+        assert_eq!(config.build_policy(), Ok(GramIndexBuildPolicy::default()));
         assert_eq!(config.validate(), Ok(()));
     }
 
@@ -157,6 +177,62 @@ mod tests {
         ] {
             assert_eq!(
                 config.validate(),
+                Err(GrepWorkerConfigError::InvalidField {
+                    field,
+                    reason: "must be greater than zero".to_owned(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn policy_construction_rejects_each_zero_budget() {
+        for (field, config) in [
+            (
+                "max_files_per_step",
+                GrepWorkerConfig {
+                    max_files_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_content_bytes_per_step",
+                GrepWorkerConfig {
+                    max_content_bytes_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_rows_per_segment",
+                GrepWorkerConfig {
+                    max_rows_per_segment: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_l0_runs",
+                GrepWorkerConfig {
+                    max_l0_runs: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_mid_runs",
+                GrepWorkerConfig {
+                    max_mid_runs: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+            (
+                "max_fold_rows_per_step",
+                GrepWorkerConfig {
+                    max_fold_rows_per_step: 0,
+                    ..GrepWorkerConfig::default()
+                },
+            ),
+        ] {
+            assert_eq!(
+                config.build_policy(),
                 Err(GrepWorkerConfigError::InvalidField {
                     field,
                     reason: "must be greater than zero".to_owned(),

--- a/crates/loonfs-grep/src/driver.rs
+++ b/crates/loonfs-grep/src/driver.rs
@@ -3,6 +3,7 @@
 use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepFoldOutcome, GrepWorker};
 use loonfs_api::{ChangeSeq, ErrorCode, NamespaceId};
 use loonfs_objectstore::ObjectStore;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,11 +23,10 @@ pub struct GrepStepLimiter {
 }
 
 impl GrepStepLimiter {
-    /// Creates a shared limiter. Direct callers receive the same safe
-    /// normalization as directly supplied build policies; config rejects zero.
-    pub fn new(max_concurrent_steps: usize) -> Self {
+    /// Creates a shared limiter from a validated concurrency limit.
+    pub fn new(max_concurrent_steps: NonZeroUsize) -> Self {
         Self {
-            permits: Arc::new(Semaphore::new(max_concurrent_steps.max(1))),
+            permits: Arc::new(Semaphore::new(max_concurrent_steps.get())),
         }
     }
 

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -125,6 +125,8 @@ async fn run() -> Result<(), StandaloneError> {
     init_tracing()?;
     let args = Args::parse();
     let config = load_config(&args.config)?;
+    let step_limit = config.grep.concurrent_step_limit()?;
+    let build_policy = config.grep.build_policy()?;
     let store = Arc::new(config.store.configured_object_store()?) as SharedObjectStore;
     let worker = GrepWorker::new(
         store.clone(),
@@ -139,13 +141,13 @@ async fn run() -> Result<(), StandaloneError> {
     }
 
     let runtime = tokio::runtime::Handle::current();
-    let step_limiter = GrepStepLimiter::new(config.grep.max_concurrent_steps);
+    let step_limiter = GrepStepLimiter::new(step_limit);
     let mut drivers = Vec::with_capacity(namespace_ids.len());
     for namespace_id in &namespace_ids {
         let task = GrepDriver::new(
             worker.clone(),
             namespace_id.clone(),
-            config.grep.build_policy(),
+            build_policy,
             step_limiter.clone(),
         )
         .spawn_on(&runtime);

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -21,6 +21,7 @@ use loonfs_grep::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -217,7 +218,7 @@ fn spawn_driver(
         worker,
         namespace_id,
         GramIndexBuildPolicy::default(),
-        GrepStepLimiter::new(1),
+        GrepStepLimiter::new(NonZeroUsize::MIN),
     )
     .spawn_on(&tokio::runtime::Handle::current())
 }

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -154,8 +154,7 @@ pub enum GrepLifecycle {
         /// Resume key for the next backfill step; empty means the start.
         backfill_cursor: String,
         /// User-checkpoint pin backing this immutable manifest walk.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        checkpoint_id: Option<CheckpointId>,
+        checkpoint_id: CheckpointId,
     },
     /// Backfill is complete and changes are consumed incrementally.
     Steady,

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -15,7 +15,9 @@ use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs_api::NamespaceId;
 use loonfs_core::StoreFailureClass;
-use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
+use loonfs_objectstore::{
+    ImmutableWriteError, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
 
 /// A verified grep root pointer and metadata from the same store read.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,33 +291,11 @@ async fn write_grep_manifest<S: ObjectStore + ?Sized>(
     let object_key = manifest_key(state.namespace_id(), envelope.manifest_id());
     let bytes =
         Bytes::from(encode_grep_manifest(&envelope).map_err(|error| corrupt(&object_key, error))?);
-    match store.put_if_absent(&object_key, bytes.clone()).await {
-        Ok(_) => Ok(WrittenGrepManifest { envelope, bytes }),
-        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
-            let existing = load_grep_manifest(store, state.namespace_id(), envelope.manifest_id())
-                .await?
-                .ok_or_else(|| GrepRootError::MissingManifest {
-                    root_key: root_key(state.namespace_id()),
-                    manifest_key: object_key.clone(),
-                })?;
-            if existing.payload_checksum() == envelope.payload_checksum() {
-                Ok(WrittenGrepManifest {
-                    envelope: existing,
-                    bytes,
-                })
-            } else {
-                Err(GrepRootError::Corrupt {
-                    object_key,
-                    message: format!(
-                        "manifest conflict: expected payload checksum {}, actual {}",
-                        envelope.payload_checksum(),
-                        existing.payload_checksum()
-                    ),
-                })
-            }
-        }
-        Err(error) => Err(store_error(&object_key, &error)),
-    }
+    store
+        .put_immutable_verified(&object_key, bytes.clone())
+        .await
+        .map_err(immutable_write_error)?;
+    Ok(WrittenGrepManifest { envelope, bytes })
 }
 
 async fn verify_and_heal_advanced_manifest<S: ObjectStore + ?Sized>(
@@ -332,33 +312,10 @@ async fn verify_and_heal_advanced_manifest<S: ObjectStore + ?Sized>(
     {
         return Ok(());
     }
-    match store
-        .put_if_absent(&object_key, written.bytes.clone())
+    store
+        .put_immutable_verified(&object_key, written.bytes.clone())
         .await
-    {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. } | ObjectStoreError::Conflict { .. }) => {
-            let existing = load_grep_manifest(store, namespace_id, written.envelope.manifest_id())
-                .await?
-                .ok_or_else(|| GrepRootError::MissingManifest {
-                    root_key: root_key(namespace_id),
-                    manifest_key: object_key.clone(),
-                })?;
-            if existing.payload_checksum() == written.envelope.payload_checksum() {
-                Ok(())
-            } else {
-                Err(GrepRootError::Corrupt {
-                    object_key,
-                    message: format!(
-                        "manifest heal conflict: expected payload checksum {}, actual {}",
-                        written.envelope.payload_checksum(),
-                        existing.payload_checksum()
-                    ),
-                })
-            }
-        }
-        Err(error) => Err(store_error(&object_key, &error)),
-    }
+        .map_err(immutable_write_error)
 }
 
 fn corrupt(object_key: &str, error: impl ToString) -> GrepRootError {
@@ -373,5 +330,20 @@ fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
         object_key: object_key.to_owned(),
         message: error.message(),
         class: StoreFailureClass::of(error),
+    }
+}
+
+fn immutable_write_error(error: ImmutableWriteError) -> GrepRootError {
+    let fallback_object_key = error.object_key().to_owned();
+    match error {
+        ImmutableWriteError::DifferentObject { object_key } => GrepRootError::Corrupt {
+            object_key,
+            message: "immutable object contains different bytes".to_owned(),
+        },
+        ImmutableWriteError::Transport { object_key, source } => store_error(&object_key, &source),
+        error => GrepRootError::Corrupt {
+            object_key: fallback_object_key,
+            message: error.to_string(),
+        },
     }
 }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -38,6 +38,7 @@ use loonfs_objectstore::{
     ObjectStore, ObjectStoreError, PutMode, PROVIDER_MULTIPART_THRESHOLD_BYTES,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -61,59 +62,32 @@ const INDEX_GRAMS_BASE_LEVEL: u32 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GramIndexBuildPolicy {
     /// Revisions examined per step.
-    pub max_files_per_step: usize,
+    pub max_files_per_step: NonZeroUsize,
     /// Content bytes read per step.
-    pub max_content_bytes_per_step: u64,
+    pub max_content_bytes_per_step: NonZeroU64,
     /// Rows per written grep segment.
-    pub max_rows_per_segment: usize,
+    pub max_rows_per_segment: NonZeroUsize,
     /// Delta-level runs that trigger a fold into a fresh mid run.
-    pub max_l0_runs: usize,
+    pub max_l0_runs: NonZeroUsize,
     /// Mid-level runs that trigger a fold into a fresh base run.
-    pub max_mid_runs: usize,
+    pub max_mid_runs: NonZeroUsize,
     /// Rows one fold step merges before publishing and yielding.
-    pub max_fold_rows_per_step: usize,
-}
-
-impl GramIndexBuildPolicy {
-    /// Names the first zero budget so configuration boundaries can reject it.
-    pub fn zero_budget_field(&self) -> Option<&'static str> {
-        [
-            ("max_files_per_step", self.max_files_per_step == 0),
-            (
-                "max_content_bytes_per_step",
-                self.max_content_bytes_per_step == 0,
-            ),
-            ("max_rows_per_segment", self.max_rows_per_segment == 0),
-            ("max_l0_runs", self.max_l0_runs == 0),
-            ("max_mid_runs", self.max_mid_runs == 0),
-            ("max_fold_rows_per_step", self.max_fold_rows_per_step == 0),
-        ]
-        .into_iter()
-        .find_map(|(field, is_zero)| is_zero.then_some(field))
-    }
-
-    /// Normalizes directly supplied policies to at least one unit per budget.
-    pub fn normalized(self) -> Self {
-        Self {
-            max_files_per_step: self.max_files_per_step.max(1),
-            max_content_bytes_per_step: self.max_content_bytes_per_step.max(1),
-            max_rows_per_segment: self.max_rows_per_segment.max(1),
-            max_l0_runs: self.max_l0_runs.max(1),
-            max_mid_runs: self.max_mid_runs.max(1),
-            max_fold_rows_per_step: self.max_fold_rows_per_step.max(1),
-        }
-    }
+    pub max_fold_rows_per_step: NonZeroUsize,
 }
 
 impl Default for GramIndexBuildPolicy {
     fn default() -> Self {
         Self {
-            max_files_per_step: 256,
-            max_content_bytes_per_step: 64 * 1024 * 1024,
-            max_rows_per_segment: 65_536,
-            max_l0_runs: 8,
-            max_mid_runs: 8,
-            max_fold_rows_per_step: 131_072,
+            max_files_per_step: NonZeroUsize::new(256)
+                .expect("default file budget should be nonzero"),
+            max_content_bytes_per_step: NonZeroU64::new(64 * 1024 * 1024)
+                .expect("default content budget should be nonzero"),
+            max_rows_per_segment: NonZeroUsize::new(65_536)
+                .expect("default segment row budget should be nonzero"),
+            max_l0_runs: NonZeroUsize::new(8).expect("default delta run limit should be nonzero"),
+            max_mid_runs: NonZeroUsize::new(8).expect("default mid run limit should be nonzero"),
+            max_fold_rows_per_step: NonZeroUsize::new(131_072)
+                .expect("default fold row budget should be nonzero"),
         }
     }
 }
@@ -303,7 +277,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             return Ok(GrepDisableOutcome::NotEnabled);
         }
         let checkpoint_id = match current.state().lifecycle() {
-            GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+            GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
         };
         let next = GrepRootState::new(
@@ -338,7 +312,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepBuildReport> {
-        let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
             .map_err(GrepError::from)?
@@ -359,9 +332,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 backfill_cursor,
                 checkpoint_id,
             } => {
-                let Some(checkpoint_id) = checkpoint_id else {
-                    return self.restart_backfill(namespace_id, &current).await;
-                };
                 let page = load_grep_checkpoint_revision_page(
                     &self.store,
                     namespace_id,
@@ -476,7 +446,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         current: &LoadedGrepRoot,
     ) -> Result<GrepBuildReport> {
         let previous_checkpoint_id = match current.state().lifecycle() {
-            GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+            GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
         };
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
@@ -553,7 +523,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     },
                     None,
                 ),
-                None => (GrepLifecycle::Steady, checkpoint_id.clone()),
+                None => (GrepLifecycle::Steady, Some(checkpoint_id.clone())),
             },
             GrepLifecycle::Steady => (GrepLifecycle::Steady, None),
             GrepLifecycle::Disabled => unreachable!("disabled returned before collection"),
@@ -615,7 +585,7 @@ fn backfilling_root(
         namespace_id.clone(),
         GrepLifecycle::Backfilling {
             backfill_cursor: String::new(),
-            checkpoint_id: Some(checkpoint_id),
+            checkpoint_id,
         },
         GrepIndexState::new(target_seq, 0, None, next_run_ordinal),
         Vec::new(),
@@ -627,7 +597,7 @@ fn root_names_checkpoint(root: &GrepRootState, checkpoint_id: &CheckpointId) -> 
     matches!(
         root.lifecycle(),
         GrepLifecycle::Backfilling {
-            checkpoint_id: Some(root_checkpoint_id),
+            checkpoint_id: root_checkpoint_id,
             ..
         } if root_checkpoint_id == checkpoint_id
     )
@@ -683,7 +653,7 @@ async fn collect_backfill_unit<S: ObjectStore + ?Sized>(
             }
         }
         unit.backfill_cursor = Some(row_key);
-        if planned_content_bytes >= policy.max_content_bytes_per_step {
+        if planned_content_bytes >= policy.max_content_bytes_per_step.get() {
             budget_reached = true;
             break;
         }
@@ -748,8 +718,9 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
             {
                 let would_exceed_content_budget = planned_content_bytes > 0
                     && planned_content_bytes.saturating_add(content_ref.size_bytes)
-                        > policy.max_content_bytes_per_step;
-                if examined_files >= policy.max_files_per_step || would_exceed_content_budget {
+                        > policy.max_content_bytes_per_step.get();
+                if examined_files >= policy.max_files_per_step.get() || would_exceed_content_budget
+                {
                     if delta_index > 0 {
                         unit.built_through_seq = record.seq;
                         unit.run_seq = record.seq;
@@ -770,8 +741,8 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
                         content_ref: content_ref.clone(),
                     });
                 }
-                if examined_files >= policy.max_files_per_step
-                    || planned_content_bytes >= policy.max_content_bytes_per_step
+                if examined_files >= policy.max_files_per_step.get()
+                    || planned_content_bytes >= policy.max_content_bytes_per_step.get()
                 {
                     unit.built_through_seq = record.seq;
                     unit.run_seq = record.seq;
@@ -856,14 +827,14 @@ async fn write_index_segments<S: ObjectStore + ?Sized>(
     run_seq: ChangeSeq,
     run_ordinal: u64,
     rows: Vec<IndexRow>,
-    max_rows_per_segment: usize,
+    max_rows_per_segment: NonZeroUsize,
     level: u32,
 ) -> Result<Vec<GrepSegmentRef>> {
     if rows.is_empty() {
         return Ok(Vec::new());
     }
     let mut requests = Vec::new();
-    for (segment_index, segment_rows) in rows.chunks(max_rows_per_segment.max(1)).enumerate() {
+    for (segment_index, segment_rows) in rows.chunks(max_rows_per_segment.get()).enumerate() {
         let segment_index = u32::try_from(segment_index)
             .map_err(|_| CoreError::Internal("index segment index overflow".to_owned()))?;
         requests.push((segment_index, segment_rows.to_vec()));
@@ -949,7 +920,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepFoldReport> {
-        let policy = policy.normalized();
         let Some(current) = load_grep_root(&self.store, namespace_id)
             .await
             .map_err(GrepError::from)?
@@ -970,7 +940,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     current.state().segments(),
                     INDEX_GRAMS_MID_LEVEL,
                 );
-                let (snapshot_segment_ids, output_level) = if l0_runs >= policy.max_l0_runs {
+                let (snapshot_segment_ids, output_level) = if l0_runs >= policy.max_l0_runs.get() {
                     (
                         current
                             .state()
@@ -981,7 +951,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                             .collect(),
                         INDEX_GRAMS_MID_LEVEL,
                     )
-                } else if mid_runs >= policy.max_mid_runs {
+                } else if mid_runs >= policy.max_mid_runs.get() {
                     (
                         current
                             .state()
@@ -1032,7 +1002,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             namespace_id,
             &snapshot,
             &fold.row_key_cursor,
-            policy.max_fold_rows_per_step,
+            policy.max_fold_rows_per_step.get(),
         )
         .await?;
         let rows = gram_postings_rows(merged.postings)?;

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -12,7 +12,6 @@ use crate::root::{
 };
 use crate::service::is_indexable_text_content;
 use crate::{GrepError, Result};
-use bytes::Bytes;
 use futures::future::try_join_all;
 use loonfs_api::wire::control::NamespaceState;
 use loonfs_api::wire::manifest::hex_encode_bytes;
@@ -34,9 +33,7 @@ use loonfs_core::{
     Error as CoreError, MetadataProjectionLoadError, MonotonicTimer, NamespaceEngine,
     StdMonotonicTimer, StoreFailureClass,
 };
-use loonfs_objectstore::{
-    ObjectStore, ObjectStoreError, PutMode, PROVIDER_MULTIPART_THRESHOLD_BYTES,
-};
+use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
@@ -893,7 +890,10 @@ async fn write_index_segment<S: ObjectStore + ?Sized>(
             "failed to build index segment `{object_key}`: {error}"
         ))
     })?;
-    write_immutable_object(store, &object_key, &built.bytes).await?;
+    store
+        .put_immutable_verified(&object_key, bytes::Bytes::from(built.bytes.clone()))
+        .await
+        .map_err(grep_immutable_write_error)?;
     let filter_inline = (built.filter.stored_len <= INLINE_INDEX_FILTER_MAX_BYTES).then(|| {
         let start = built.filter.offset as usize;
         hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])
@@ -1475,81 +1475,6 @@ fn count_deleted_key(key: &str, report: &mut GrepGcReport) {
     }
 }
 
-async fn write_immutable_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_bytes: &[u8],
-) -> Result<()> {
-    let write_result = if expected_bytes.len() as u64 >= PROVIDER_MULTIPART_THRESHOLD_BYTES {
-        store
-            .put_overwrite(object_key, Bytes::copy_from_slice(expected_bytes))
-            .await
-    } else {
-        store
-            .put(
-                object_key,
-                Bytes::copy_from_slice(expected_bytes),
-                PutMode::CreateIfAbsent,
-            )
-            .await
-    };
-    match write_result {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            if existing_object_matches(store, object_key, expected_bytes).await? {
-                Ok(())
-            } else {
-                Err(GrepError::StoreUnavailable {
-                    object_key: object_key.to_owned(),
-                    message: "object already exists with different bytes".to_owned(),
-                    class: StoreFailureClass::Other,
-                })
-            }
-        }
-        Err(error @ ObjectStoreError::Transport { .. }) => {
-            let message = error.message();
-            match existing_object_matches(store, object_key, expected_bytes).await {
-                Ok(true) => Ok(()),
-                Ok(false) => Err(GrepError::StoreUnavailable {
-                    object_key: object_key.to_owned(),
-                    message: format!(
-                        "{message}; immutable object exists with different bytes after transport error"
-                    ),
-                    class: StoreFailureClass::Other,
-                }),
-                Err(verify_error) => Err(verify_error),
-            }
-        }
-        Err(error) => Err(core_store_error(object_key, &error)),
-    }
-}
-
-async fn existing_object_matches<S: ObjectStore + ?Sized>(
-    store: &S,
-    object_key: &str,
-    expected_bytes: &[u8],
-) -> Result<bool> {
-    if let Some(metadata) = store
-        .head(object_key)
-        .await
-        .map_err(|error| core_store_error(object_key, &error))?
-    {
-        if metadata.size_bytes != expected_bytes.len() as u64 {
-            return Ok(false);
-        }
-    }
-    let existing = store
-        .get(object_key, None)
-        .await
-        .map_err(|error| core_store_error(object_key, &error))?
-        .ok_or_else(|| GrepError::StoreUnavailable {
-            object_key: object_key.to_owned(),
-            message: "object is missing while verifying immutable write".to_owned(),
-            class: StoreFailureClass::Other,
-        })?;
-    Ok(existing.as_ref() == expected_bytes)
-}
-
 fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Result<()> {
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
     if elapsed_ms <= METADATA_PUBLICATION_BUDGET_MS {
@@ -1571,6 +1496,21 @@ fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {
         object_key: object_key.to_owned(),
         message: error.message(),
         class: StoreFailureClass::of(error),
+    }
+}
+
+fn grep_immutable_write_error(error: ImmutableWriteError) -> GrepError {
+    let object_key = error.object_key().to_owned();
+    match error {
+        ImmutableWriteError::DifferentObject { object_key } => GrepError::CorruptIndex {
+            message: format!("immutable object `{object_key}` contains different bytes"),
+        },
+        ImmutableWriteError::Transport { object_key, source } => {
+            core_store_error(&object_key, &source)
+        }
+        error => GrepError::CorruptIndex {
+            message: format!("{object_key}: {error}"),
+        },
     }
 }
 

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -55,7 +56,7 @@ async fn poisoned_driver_backs_off_while_sibling_catches_up_and_gc_stays_explici
         .expect("poison root");
 
     let runtime = tokio::runtime::Handle::current();
-    let step_limiter = GrepStepLimiter::new(2);
+    let step_limiter = GrepStepLimiter::new(nonzero_usize(2));
     let poisoned_task = GrepDriver::new(
         worker.clone(),
         poisoned,
@@ -124,7 +125,7 @@ async fn tombstoned_namespace_driver_parks_as_not_enabled() {
         worker,
         namespace_id,
         GramIndexBuildPolicy::default(),
-        GrepStepLimiter::new(1),
+        GrepStepLimiter::new(NonZeroUsize::MIN),
     )
     .spawn_on(&tokio::runtime::Handle::current());
     assert_eq!(
@@ -167,7 +168,7 @@ async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
     }
 
     store.pause_content_reads();
-    let limiter = GrepStepLimiter::new(MAX_CONCURRENT_STEPS);
+    let limiter = GrepStepLimiter::new(nonzero_usize(MAX_CONCURRENT_STEPS));
     let runtime = tokio::runtime::Handle::current();
     let mut tasks = Vec::new();
     for namespace_id in namespace_ids {
@@ -212,6 +213,10 @@ async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
     for task in tasks {
         task.shutdown().await.expect("stop concurrency driver");
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 #[derive(Debug)]

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -139,10 +139,8 @@ fn sample_backfilling_root() -> GrepRootState {
         namespace_id("docs"),
         GrepLifecycle::Backfilling {
             backfill_cursor: "revision-00000000000000000007".to_owned(),
-            checkpoint_id: Some(
-                CheckpointId::parse("chk_00000000000000000000000000000009")
-                    .expect("valid checkpoint id"),
-            ),
+            checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
+                .expect("valid checkpoint id"),
         },
         GrepIndexState::new(ChangeSeq(7), 0, Some(fold), 4),
         vec![

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -52,12 +52,27 @@ async fn seed_succeeds_once_and_second_seed_conflicts() {
     let store = LocalFsStore::new(temp_dir.path()).expect("local store");
     let state = root(namespace_id("docs"), ChangeSeq(0));
 
+    seed_grep_root(&store, &state, "seed")
+        .await
+        .expect("first seed succeeds");
+    assert!(matches!(
+        seed_grep_root(&store, &state, "seed").await,
+        Err(GrepRootError::Conflict { .. })
+    ));
+}
+
+#[tokio::test]
+async fn same_manifest_id_with_different_envelope_bytes_is_corrupt() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let state = root(namespace_id("docs"), ChangeSeq(0));
+
     seed_grep_root(&store, &state, "seed-one")
         .await
         .expect("first seed succeeds");
     assert!(matches!(
         seed_grep_root(&store, &state, "seed-two").await,
-        Err(GrepRootError::Conflict { .. })
+        Err(GrepRootError::Corrupt { .. })
     ));
 }
 

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -116,27 +116,6 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
         String::from_utf8_lossy(&gc.stderr)
     );
 
-    let bad_config_path = temp_dir.path().join("bad-worker.toml");
-    write_config(&bad_config_path, &store_root, "poll_interval_ms = 0\n", "");
-    let bad = run_once(&bad_config_path, &[&namespace_id]);
-    assert!(!bad.status.success(), "bad config must exit nonzero");
-    let stderr = String::from_utf8_lossy(&bad.stderr);
-    assert!(stderr.contains("poll_interval_ms"), "{stderr}");
-    assert!(stderr.contains("greater than zero"), "{stderr}");
-
-    let bad_grep_config_path = temp_dir.path().join("bad-grep-worker.toml");
-    write_config(
-        &bad_grep_config_path,
-        &store_root,
-        "",
-        "max_concurrent_steps = 0\n",
-    );
-    let bad = run_once(&bad_grep_config_path, &[&namespace_id]);
-    assert!(!bad.status.success(), "zero step cap must exit nonzero");
-    let stderr = String::from_utf8_lossy(&bad.stderr);
-    assert!(stderr.contains("max_concurrent_steps"), "{stderr}");
-    assert!(stderr.contains("greater than zero"), "{stderr}");
-
     let missing_namespace = Command::new(env!("CARGO_BIN_EXE_loonfs-grep"))
         .arg("--config")
         .arg(&config_path)
@@ -147,6 +126,45 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
     let stderr = String::from_utf8_lossy(&missing_namespace.stderr);
     assert!(stderr.contains("--namespace"), "{stderr}");
     assert!(stderr.contains("Usage:"), "{stderr}");
+}
+
+#[test]
+fn standalone_config_rejects_zero_work_limits() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store_root = temp_dir.path().join("store");
+    let namespace_id = NamespaceId::parse("zero-config").expect("namespace id");
+
+    for (filename, root_fields, grep_fields, rejected_field) in [
+        (
+            "poll.toml",
+            "poll_interval_ms = 0\n",
+            "",
+            "poll_interval_ms",
+        ),
+        (
+            "concurrency.toml",
+            "",
+            "max_concurrent_steps = 0\n",
+            "max_concurrent_steps",
+        ),
+        (
+            "budget.toml",
+            "",
+            "max_files_per_step = 0\n",
+            "max_files_per_step",
+        ),
+    ] {
+        let path = temp_dir.path().join(filename);
+        write_config(&path, &store_root, root_fields, grep_fields);
+        let output = run_once(&path, &[&namespace_id]);
+        assert!(
+            !output.status.success(),
+            "zero `{rejected_field}` must exit nonzero"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(rejected_field), "{stderr}");
+        assert!(stderr.contains("greater than zero"), "{stderr}");
+    }
 }
 
 #[tokio::test]

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -1,0 +1,197 @@
+//! Verified writes for objects whose keys name immutable bytes.
+
+use crate::retry::{
+    transport_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
+};
+use crate::timing::StdMonotonicTimer;
+use crate::{
+    ObjectMetadata, ObjectStore, ObjectStoreError, PutMode, PROVIDER_MULTIPART_THRESHOLD_BYTES,
+};
+use bytes::Bytes;
+use thiserror::Error;
+
+/// Failure to establish that an immutable key contains the requested bytes.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ImmutableWriteError {
+    /// The key names bytes other than the immutable payload supplied here.
+    #[error("immutable object `{object_key}` already exists with different bytes")]
+    DifferentObject { object_key: String },
+    /// The storage boundary failed before byte identity could be established.
+    #[error("immutable write transport failed for `{object_key}`: {source}")]
+    Transport {
+        object_key: String,
+        #[source]
+        source: ObjectStoreError,
+    },
+}
+
+impl ImmutableWriteError {
+    /// Returns the immutable object key whose byte identity was not established.
+    pub fn object_key(&self) -> &str {
+        match self {
+            Self::DifferentObject { object_key } | Self::Transport { object_key, .. } => object_key,
+        }
+    }
+}
+
+pub(crate) async fn put<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    bytes: Bytes,
+) -> std::result::Result<(), ImmutableWriteError> {
+    let timer = StdMonotonicTimer::default();
+    let retry_policy = TransportRetryPolicy::DEFAULT;
+    let mode = if bytes.len() as u64 >= PROVIDER_MULTIPART_THRESHOLD_BYTES {
+        PutMode::Overwrite
+    } else {
+        PutMode::CreateIfAbsent
+    };
+    let deadline = OperationDeadline::start(&timer, retry_policy.op_deadline);
+    let mut retries = 0;
+    let mut ambiguous_transport = None;
+
+    loop {
+        match store.put(key, bytes.clone(), mode.clone()).await {
+            Ok(_) => return Ok(()),
+            Err(
+                error @ (ObjectStoreError::PreconditionFailed { .. }
+                | ObjectStoreError::Conflict { .. }),
+            ) => {
+                return resolve_readback(store, key, &bytes, ambiguous_transport.unwrap_or(error))
+                    .await;
+            }
+            Err(error @ ObjectStoreError::Transport { .. }) => {
+                ambiguous_transport = Some(error);
+            }
+            Err(error) if ambiguous_transport.is_some() => {
+                return resolve_readback(store, key, &bytes, error).await;
+            }
+            Err(error) => return Err(transport(key, error)),
+        }
+
+        let error = ambiguous_transport
+            .as_ref()
+            .expect("transport branch should retain its ambiguous error");
+        let Some(remaining) = deadline.remaining() else {
+            return resolve_readback(
+                store,
+                key,
+                &bytes,
+                ambiguous_transport.expect("transport error should be retained"),
+            )
+            .await;
+        };
+        if retries >= retry_policy.max_retries {
+            return resolve_readback(
+                store,
+                key,
+                &bytes,
+                ambiguous_transport.expect("transport error should be retained"),
+            )
+            .await;
+        }
+        retries += 1;
+        let backoff = transport_retry_backoff(&retry_policy, retries).min(remaining);
+        tracing::info!(
+            object_key = key,
+            operation = "put_immutable_verified",
+            retry = retries,
+            max_retries = retry_policy.max_retries,
+            backoff_ms = u64::try_from(backoff.as_millis()).unwrap_or(u64::MAX),
+            error = %error,
+            "transient immutable write failure, backing off before retry",
+        );
+        transport_retry_pause(backoff).await;
+    }
+}
+
+async fn resolve_readback<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    expected: &Bytes,
+    original: ObjectStoreError,
+) -> std::result::Result<(), ImmutableWriteError> {
+    match readback(store, key, expected).await {
+        Ok(ImmutableReadback::Identical(_)) => Ok(()),
+        Ok(ImmutableReadback::Different) => Err(ImmutableWriteError::DifferentObject {
+            object_key: key.to_owned(),
+        }),
+        Ok(ImmutableReadback::Missing) => Err(transport(key, original)),
+        Err(verify_error @ ObjectStoreError::Transport { .. }) => {
+            let source = ObjectStoreError::transport(
+                key,
+                format!(
+                    "{}; failed to verify immutable write outcome: {verify_error}",
+                    original.message()
+                ),
+            );
+            Err(transport(key, source))
+        }
+        Err(verify_error) => Err(transport(key, verify_error)),
+    }
+}
+
+pub(crate) enum ImmutableReadback {
+    Identical(ObjectMetadata),
+    Different,
+    Missing,
+}
+
+pub(crate) async fn readback<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    expected: &Bytes,
+) -> std::result::Result<ImmutableReadback, ObjectStoreError> {
+    match store.get_with_metadata(key).await? {
+        Some(body) if body.bytes.as_slice() == expected.as_ref() => {
+            Ok(ImmutableReadback::Identical(body.metadata))
+        }
+        Some(_) => Ok(ImmutableReadback::Different),
+        None => Ok(ImmutableReadback::Missing),
+    }
+}
+
+fn transport(key: &str, source: ObjectStoreError) -> ImmutableWriteError {
+    ImmutableWriteError::Transport {
+        object_key: key.to_owned(),
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timing::MonotonicTimer;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct SteppingTimer {
+        now_ms: AtomicU64,
+        step_ms: u64,
+    }
+
+    impl SteppingTimer {
+        fn new(step_ms: u64) -> Self {
+            Self {
+                now_ms: AtomicU64::new(0),
+                step_ms,
+            }
+        }
+    }
+
+    impl MonotonicTimer for SteppingTimer {
+        fn monotonic_now_ms(&self) -> u64 {
+            self.now_ms.fetch_add(self.step_ms, Ordering::SeqCst)
+        }
+    }
+
+    #[test]
+    fn immutable_retry_deadline_is_one_budget_across_attempts() {
+        let timer = SteppingTimer::new(70_000);
+        let deadline = OperationDeadline::start(&timer, Duration::from_secs(120));
+        assert_eq!(deadline.remaining(), Some(Duration::from_secs(50)));
+        assert_eq!(deadline.remaining(), None);
+    }
+}

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod abs;
 mod configured;
 pub mod gcs;
+mod immutable_write;
 pub mod keys;
 mod keyspace;
 pub mod layout;
@@ -21,6 +22,7 @@ pub mod presign;
 pub mod provider;
 mod provider_object_store;
 pub mod r2;
+mod retry;
 pub mod s3;
 mod s3_compatible;
 mod secret;
@@ -30,6 +32,7 @@ pub mod timing;
 mod transfer_timeouts;
 
 pub use configured::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
+pub use immutable_write::ImmutableWriteError;
 pub use object_store::ObjectStoreError as Error;
 pub use object_store::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode, Result,

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -176,6 +176,22 @@ pub trait ObjectStore: Send + Sync + Debug {
         self.put(key, bytes, PutMode::CreateIfAbsent).await
     }
 
+    /// Writes `bytes` under an immutable `key` and accepts success only when
+    /// the key contains exactly those bytes.
+    ///
+    /// Payloads below 8 MiB use create-if-absent; payloads at or above 8 MiB
+    /// use the store's multipart-capable overwrite path. Transport retries
+    /// are safe only because every writer allowed to name this immutable key
+    /// must supply identical bytes. Mutable keys must use [`Self::put`] and
+    /// own their protocol-specific ambiguity resolution.
+    async fn put_immutable_verified(
+        &self,
+        key: &str,
+        bytes: Bytes,
+    ) -> std::result::Result<(), crate::ImmutableWriteError> {
+        crate::immutable_write::put(self, key, bytes).await
+    }
+
     async fn compare_and_swap(
         &self,
         key: &str,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -1,11 +1,15 @@
-//! The shared provider transport: timeouts, per-operation deadlines,
-//! bounded retry loops for idempotent-safe writes, and multipart upload for
-//! large immutable payloads.
+//! The shared provider transport: timeouts, bounded retries for replay-safe
+//! delete and multipart stages, and multipart upload for large immutable
+//! payloads.
 
+use crate::immutable_write::{readback, ImmutableReadback};
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
 use crate::object_store::Result;
+use crate::retry::{
+    transport_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
+};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use crate::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode};
 use async_trait::async_trait;
@@ -38,8 +42,8 @@ pub const PROVIDER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Hard deadline for one logical object-store operation, consumed across
 /// every retry of that operation rather than restarting per attempt. Reads
-/// get it as the provider client's retry timeout; single-request writes and
-/// deletes get it through `TransportRetryPolicy`. The deadline gates
+/// get it as the provider client's retry timeout; verified immutable writes
+/// and deletes share it through `TransportRetryPolicy`. The deadline gates
 /// starting another attempt, and one outer attempt may itself contain the
 /// inner client's full retry budget for status-code retries — so one
 /// operation's total wall time is bounded by the deadline plus the inner
@@ -119,83 +123,6 @@ pub(crate) fn provider_retry_config() -> provider_store::RetryConfig {
         retry_timeout: PROVIDER_OP_DEADLINE,
         ..Default::default()
     }
-}
-
-/// Bounded retry for transient write failures, mirroring the retry budget the
-/// provider client already applies to reads.
-///
-/// The provider client retries transport errors on reads because GET is
-/// idempotent by method, but it refuses to re-send a PUT or DELETE that may
-/// already have reached the store. LoonFS knows more than the HTTP layer:
-/// overwrite puts, create-if-absent puts, and deletes are idempotent-safe at
-/// this contract's semantics, so they get the same bounded retry reads have.
-/// Both attempt count and elapsed time bound the loop: `op_deadline` is one
-/// deadline for the whole logical operation, never restarted per attempt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TransportRetryPolicy {
-    max_retries: u32,
-    initial_backoff: Duration,
-    max_backoff: Duration,
-    op_deadline: Duration,
-}
-
-impl TransportRetryPolicy {
-    /// Matches the provider client's read retry budget: up to 10 retries with
-    /// exponential backoff from 100ms capped at 15s, all inside one
-    /// operation deadline.
-    const DEFAULT: Self = Self {
-        max_retries: 10,
-        initial_backoff: Duration::from_millis(100),
-        max_backoff: Duration::from_secs(15),
-        op_deadline: PROVIDER_OP_DEADLINE,
-    };
-}
-
-fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32) -> Duration {
-    // Deterministic doubling: workspace policy avoids ambient randomness, and
-    // a bounded per-operation retry does not need jitter.
-    let doublings = retry.saturating_sub(1).min(16);
-    policy
-        .initial_backoff
-        .saturating_mul(1u32 << doublings)
-        .min(policy.max_backoff)
-}
-
-/// Elapsed-time state for one logical operation's retry loop: refuses new
-/// attempts once the deadline is consumed and never sleeps past it.
-struct OperationDeadline<'timer> {
-    timer: &'timer dyn MonotonicTimer,
-    started_ms: u64,
-    deadline: Duration,
-}
-
-impl<'timer> OperationDeadline<'timer> {
-    fn start(timer: &'timer dyn MonotonicTimer, deadline: Duration) -> Self {
-        Self {
-            timer,
-            started_ms: timer.monotonic_now_ms(),
-            deadline,
-        }
-    }
-
-    fn remaining(&self) -> Option<Duration> {
-        let elapsed_ms = self
-            .timer
-            .monotonic_now_ms()
-            .saturating_sub(self.started_ms);
-        let deadline_ms = u64::try_from(self.deadline.as_millis()).unwrap_or(u64::MAX);
-        if elapsed_ms >= deadline_ms {
-            return None;
-        }
-        Some(Duration::from_millis(deadline_ms - elapsed_ms))
-    }
-}
-
-#[allow(clippy::disallowed_methods)]
-async fn transport_retry_pause(backoff: Duration) {
-    // Write retries intentionally wait an isolated async timer between
-    // attempts, mirroring the backoff the provider client applies to reads.
-    tokio::time::sleep(backoff).await;
 }
 
 /// The size routing for multipart writes: payloads at or above the
@@ -338,17 +265,17 @@ impl ProviderObjectStore {
     /// retried in place on transient failures (part indices are stable, so a
     /// retry re-sends the same part), and a best-effort abort so a failed
     /// upload does not strand parts. An ambiguous completion — a transport
-    /// failure whose attempt may have landed — is resolved by reading the
-    /// object back and comparing bytes
+    /// failure whose attempt may have landed — is resolved by the immutable
+    /// operation's shared exact-byte read-back
     /// ([`MultipartWrite::resolve_ambiguous_completion`]).
     ///
     /// There is deliberately no whole-operation clock: every part attempt is
     /// individually bounded and every retry loop is count-bounded, so a
     /// healthy transfer takes as long as the link needs while a stuck one
-    /// still fails within one part's retry budget. Only overwrite puts route
-    /// here — providers complete multipart uploads as unconditional
-    /// overwrites, so the conditional modes stay on the single-request path
-    /// where real provider preconditions exist.
+    /// still fails within one part's retry budget. Completion itself is one
+    /// attempt: only [`ObjectStore::put_immutable_verified`] may replay an
+    /// object-publishing write. Conditional modes stay on the single-request
+    /// path where real provider preconditions exist.
     async fn put_large_multipart(
         &self,
         multipart: &dyn MultipartStore,
@@ -555,46 +482,17 @@ impl MultipartWrite<'_> {
         bytes: &Bytes,
     ) -> Result<ObjectMetadata> {
         let size_bytes = bytes.len() as u64;
-        let mut retries: u32 = 0;
-        // True once an attempt failed after possibly reaching the store, so
-        // no later failure can rule out that this completion landed.
-        let mut ambiguous_outcome = false;
-        loop {
-            let err = match self
-                .multipart
-                .complete_multipart(self.path, upload_id, parts.clone())
-                .await
-            {
-                Ok(result) => return Ok(ProviderObjectStore::from_put_result(result, size_bytes)),
-                Err(err) => err,
-            };
-            if !provider_transport_retryable(&err) {
-                if !ambiguous_outcome {
-                    return Err(map_provider_error(self.key, err));
-                }
-                // A definite refusal after an ambiguous attempt is not a
-                // definite failure: the ambiguous attempt may have landed
-                // and taken the upload id with it, in which case the
-                // provider reports the completed upload as gone. Only the
-                // object can say which happened.
-                return self
-                    .resolve_ambiguous_completion(upload_id, bytes, err)
-                    .await;
+        match self
+            .multipart
+            .complete_multipart(self.path, upload_id, parts)
+            .await
+        {
+            Ok(result) => Ok(ProviderObjectStore::from_put_result(result, size_bytes)),
+            Err(err) if provider_transport_retryable(&err) => {
+                self.resolve_ambiguous_completion(upload_id, bytes, err)
+                    .await
             }
-            ambiguous_outcome = true;
-            let Some(backoff) = self.store.next_write_backoff(
-                self.key,
-                "complete_multipart",
-                size_bytes,
-                &mut retries,
-                None,
-                &err,
-            ) else {
-                return self
-                    .resolve_ambiguous_completion(upload_id, bytes, err)
-                    .await;
-            };
-            transport_retry_pause(backoff).await;
+            Err(err) => Err(map_provider_error(self.key, err)),
         }
     }
 
@@ -616,36 +514,17 @@ impl MultipartWrite<'_> {
         bytes: &Bytes,
         final_err: provider_store::Error,
     ) -> Result<ObjectMetadata> {
-        match self.store.get_with_metadata(self.key).await {
-            Ok(Some(body)) if body.bytes.as_slice() == bytes.as_ref() => {
+        match readback(self.store, self.key, bytes).await {
+            Ok(ImmutableReadback::Identical(metadata)) => {
                 self.abort(upload_id).await;
-                Ok(body.metadata)
+                Ok(metadata)
             }
-            Ok(readback) => {
-                let outcome = match readback {
-                    Some(_) => "the object at the key does not hold the payload bytes",
-                    None => "no object exists at the key",
-                };
-                tracing::warn!(
-                    object_key = self.key,
-                    operation = "complete_multipart",
-                    outcome,
-                    "ambiguous multipart completion did not land",
-                );
-                // An upload-gone rejection maps to `NotFound`, which would
-                // misreport this write failure as a missing object; it
-                // surfaces as transport instead, so callers classify the
-                // unproven outcome as safe to retry. Every other final
-                // error keeps its own classification.
-                Err(match map_provider_error(self.key, final_err) {
-                    ObjectStoreError::NotFound { .. } => ObjectStoreError::transport(
-                        self.key,
-                        format!(
-                            "multipart upload is gone without a provable completion: {outcome}"
-                        ),
-                    ),
-                    other => other,
-                })
+            Ok(ImmutableReadback::Different) => self.unproven_completion(
+                final_err,
+                "the object at the key does not hold the payload bytes",
+            ),
+            Ok(ImmutableReadback::Missing) => {
+                self.unproven_completion(final_err, "no object exists at the key")
             }
             Err(verify_err) => {
                 let original = map_provider_error(self.key, final_err).message();
@@ -657,6 +536,20 @@ impl MultipartWrite<'_> {
                 ))
             }
         }
+    }
+
+    fn unproven_completion(
+        &self,
+        final_err: provider_store::Error,
+        outcome: &'static str,
+    ) -> Result<ObjectMetadata> {
+        tracing::warn!(
+            object_key = self.key,
+            operation = "complete_multipart",
+            outcome,
+            "ambiguous multipart completion did not land",
+        );
+        Err(map_provider_error(self.key, final_err))
     }
 
     async fn abort(&self, upload_id: &provider_store::MultipartId) {
@@ -788,31 +681,6 @@ impl ObjectStore for ProviderObjectStore {
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         let path = self.to_path(key)?;
         let size_bytes = bytes.len() as u64;
-
-        if matches!(mode, PutMode::CompareAndSwap { .. }) {
-            // Compare-and-swap is deliberately a single attempt: after an
-            // ambiguous transport failure the first attempt may have landed
-            // and changed the etag, so a blind re-send would report a false
-            // conflict for our own write. Callers own precondition semantics
-            // and recover by re-reading.
-            let options = PutOptions {
-                mode: map_put_mode(mode),
-                ..Default::default()
-            };
-            return match self
-                .inner
-                .put_opts(&path, PutPayload::from(bytes), options)
-                .await
-            {
-                Ok(result) => Ok(Self::from_put_result(result, size_bytes)),
-                Err(err) if provider_not_found(&err) => Err(ObjectStoreError::PreconditionFailed {
-                    object_key: key.to_owned(),
-                }),
-                Err(err) => Err(map_provider_error(key, err)),
-            };
-        }
-
-        let create_if_absent = matches!(mode, PutMode::CreateIfAbsent);
         if matches!(mode, PutMode::Overwrite)
             && size_bytes >= self.multipart_geometry.threshold_bytes
         {
@@ -822,62 +690,27 @@ impl ObjectStore for ProviderObjectStore {
                     .await;
             }
         }
-        let deadline =
-            OperationDeadline::start(self.timer.as_ref(), self.transport_retry.op_deadline);
-        let mut retries: u32 = 0;
-        // True once an attempt failed after possibly reaching the store, so a
-        // later "already exists" may be our own first attempt having landed.
-        let mut ambiguous_outcome = false;
-        loop {
-            let options = PutOptions {
-                mode: map_put_mode(mode.clone()),
-                ..Default::default()
-            };
-            let err = match self
-                .inner
-                .put_opts(&path, PutPayload::from(bytes.clone()), options)
-                .await
-            {
-                Ok(result) => return Ok(Self::from_put_result(result, size_bytes)),
-                Err(err) => err,
-            };
-
-            if create_if_absent && ambiguous_outcome && provider_precondition(&err) {
-                match self.get_with_metadata(key).await? {
-                    Some(body) if body.bytes.as_slice() == bytes.as_ref() => {
-                        // Our earlier attempt landed: report it as the
-                        // successful write it was, not a conflict.
-                        return Ok(body.metadata);
-                    }
-                    Some(_) => {
-                        return Err(ObjectStoreError::PreconditionFailed {
-                            object_key: key.to_owned(),
-                        })
-                    }
-                    // The conflicting object vanished, so the create can be
-                    // re-attempted within the remaining retry budget.
-                    None => {}
-                }
-            } else if provider_transport_retryable(&err) {
-                ambiguous_outcome = true;
-            } else {
-                return Err(map_provider_error(key, err));
+        // Raw flat writes are deliberately one attempt. In particular, a
+        // mutable overwrite cannot be replayed after an ambiguous transport
+        // outcome without changing write ordering. Immutable callers use
+        // `put_immutable_verified`, whose name supplies the retry invariant.
+        let compare_and_swap = matches!(mode, PutMode::CompareAndSwap { .. });
+        let options = PutOptions {
+            mode: map_put_mode(mode),
+            ..Default::default()
+        };
+        match self
+            .inner
+            .put_opts(&path, PutPayload::from(bytes), options)
+            .await
+        {
+            Ok(result) => Ok(Self::from_put_result(result, size_bytes)),
+            Err(err) if compare_and_swap && provider_not_found(&err) => {
+                Err(ObjectStoreError::PreconditionFailed {
+                    object_key: key.to_owned(),
+                })
             }
-
-            // The operation deadline is consumed across attempts, never
-            // restarted: no new attempt starts once it is spent, and the
-            // backoff never sleeps past it.
-            let Some(backoff) = self.next_write_backoff(
-                key,
-                "put",
-                size_bytes,
-                &mut retries,
-                Some(&deadline),
-                &err,
-            ) else {
-                return Err(map_provider_error(key, err));
-            };
-            transport_retry_pause(backoff).await;
+            Err(err) => Err(map_provider_error(key, err)),
         }
     }
 
@@ -961,13 +794,6 @@ enum RangedGet {
 
 fn provider_not_found(err: &provider_store::Error) -> bool {
     matches!(err, provider_store::Error::NotFound { .. })
-}
-
-fn provider_precondition(err: &provider_store::Error) -> bool {
-    matches!(
-        err,
-        provider_store::Error::AlreadyExists { .. } | provider_store::Error::Precondition { .. }
-    )
 }
 
 fn provider_transport_retryable(err: &provider_store::Error) -> bool {
@@ -1240,7 +1066,6 @@ mod tests {
 
     #[derive(Debug)]
     enum ReadScript {
-        NotFound,
         Transport,
     }
 
@@ -1336,10 +1161,6 @@ mod tests {
             self.gets.fetch_add(1, Ordering::SeqCst);
             let script = self.get_script.lock().expect("get script").pop_front();
             match script {
-                Some(ReadScript::NotFound) => Err(provider_store::Error::NotFound {
-                    path: location.to_string(),
-                    source: "scripted not found".into(),
-                }),
                 Some(ReadScript::Transport) => Err(transport_glitch()),
                 None => self.inner.get_opts(location, options).await,
             }
@@ -1609,7 +1430,116 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overwrite_put_retries_transient_transport_failures() {
+    async fn mutable_overwrite_transport_failure_is_not_retried() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        script_puts(&flaky, [WriteScript::FailWithoutLanding]);
+        let key = "namespaces/demo/uploads/upl_1.json";
+
+        let error = store
+            .put_overwrite(key, Bytes::from_static(b"session"))
+            .await
+            .expect_err("mutable overwrite must surface an ambiguous outcome");
+
+        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn immutable_small_write_uses_create_if_absent() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let key = "namespaces/demo/uploads/upl_2.json";
+
+        store
+            .put_immutable_verified(key, Bytes::from_static(b"immutable bytes"))
+            .await
+            .expect("small immutable write");
+
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.multipart_creates.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            store.get(key, None).await.expect("get"),
+            Some(Bytes::from_static(b"immutable bytes"))
+        );
+    }
+
+    #[tokio::test]
+    async fn immutable_already_present_identical_is_accepted_without_rewrite() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let key = "namespaces/demo/wal/00000001.cbor.zst";
+        let bytes = Bytes::from_static(b"identical immutable bytes");
+        seed_scoped_object(&flaky, key, bytes.clone()).await;
+
+        store
+            .put_immutable_verified(key, bytes)
+            .await
+            .expect("identical object is accepted");
+
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn immutable_different_bytes_at_key_are_corruption_class() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let key = "namespaces/demo/wal/00000002.cbor.zst";
+        seed_scoped_object(&flaky, key, Bytes::from_static(b"theirs")).await;
+
+        let error = store
+            .put_immutable_verified(key, Bytes::from_static(b"mine"))
+            .await
+            .expect_err("different immutable bytes are rejected");
+
+        assert!(matches!(
+            error,
+            crate::ImmutableWriteError::DifferentObject { object_key } if object_key == key
+        ));
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn immutable_ambiguous_landed_write_is_accepted_by_readback() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        script_puts(&flaky, [WriteScript::LandThenFail]);
+        let key = "namespaces/demo/uploads/upl_3.json";
+
+        store
+            .put_immutable_verified(key, Bytes::from_static(b"payload"))
+            .await
+            .expect("readback proves the first attempt landed");
+
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn immutable_ambiguous_outcome_rejects_different_readback() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let key = "namespaces/demo/wal/00000003.cbor.zst";
+        seed_scoped_object(&flaky, key, Bytes::from_static(b"theirs")).await;
+        script_puts(&flaky, [WriteScript::FailWithoutLanding]);
+
+        let error = store
+            .put_immutable_verified(key, Bytes::from_static(b"mine"))
+            .await
+            .expect_err("ambiguous write cannot adopt different bytes");
+
+        assert!(matches!(
+            error,
+            crate::ImmutableWriteError::DifferentObject { .. }
+        ));
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn immutable_transport_failures_retry_inside_the_operation() {
         let flaky = Arc::new(FlakyStore::default());
         let store = retrying_store(Arc::clone(&flaky));
         script_puts(
@@ -1619,107 +1549,38 @@ mod tests {
                 WriteScript::FailWithoutLanding,
             ],
         );
-        let key = "namespaces/demo/uploads/upl_1.json";
+        let key = "namespaces/demo/uploads/upl_4.json";
 
-        let metadata = store
-            .put_overwrite(key, Bytes::from_static(b"session"))
+        store
+            .put_immutable_verified(key, Bytes::from_static(b"payload"))
             .await
-            .expect("put succeeds after transient failures");
+            .expect("transient failures are retried");
 
         assert_eq!(flaky.puts.load(Ordering::SeqCst), 3);
-        assert!(metadata.etag.is_some());
-        assert_eq!(
-            store.get(key, None).await.expect("get"),
-            Some(Bytes::from_static(b"session"))
-        );
-    }
-
-    #[tokio::test]
-    async fn create_put_resolves_landed_first_attempt_as_success() {
-        let flaky = Arc::new(FlakyStore::default());
-        let store = retrying_store(Arc::clone(&flaky));
-        script_puts(&flaky, [WriteScript::LandThenFail]);
-        let key = "namespaces/demo/uploads/upl_2.json";
-
-        let metadata = store
-            .put_if_absent(key, Bytes::from_static(b"upload session"))
-            .await
-            .expect("landed first attempt reported as success");
-
-        assert_eq!(flaky.puts.load(Ordering::SeqCst), 2);
-        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
-        let head = store.head(key).await.expect("head").expect("object exists");
-        assert_eq!(metadata.etag, head.etag);
-    }
-
-    #[tokio::test]
-    async fn create_put_reports_real_conflict_after_transport_failure() {
-        let flaky = Arc::new(FlakyStore::default());
-        let store = retrying_store(Arc::clone(&flaky));
-        let key = "namespaces/demo/wal/00000001.json";
-        store
-            .put_overwrite(key, Bytes::from_static(b"theirs"))
-            .await
-            .expect("seed conflicting object");
-        script_puts(&flaky, [WriteScript::FailWithoutLanding]);
-
-        let error = store
-            .put_if_absent(key, Bytes::from_static(b"mine"))
-            .await
-            .expect_err("conflicting object is still a conflict");
-
-        assert!(matches!(
-            error,
-            ObjectStoreError::PreconditionFailed { object_key } if object_key == key
-        ));
-        assert_eq!(flaky.puts.load(Ordering::SeqCst), 3);
-        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            store.get(key, None).await.expect("get"),
-            Some(Bytes::from_static(b"theirs"))
-        );
-    }
-
-    #[tokio::test]
-    async fn create_put_without_ambiguity_keeps_precondition_semantics() {
-        let flaky = Arc::new(FlakyStore::default());
-        let store = retrying_store(Arc::clone(&flaky));
-        let key = "namespaces/demo/wal/00000002.json";
-        store
-            .put_overwrite(key, Bytes::from_static(b"theirs"))
-            .await
-            .expect("seed existing object");
-
-        let error = store
-            .put_if_absent(key, Bytes::from_static(b"mine"))
-            .await
-            .expect_err("existing object fails the create precondition");
-
-        assert!(matches!(error, ObjectStoreError::PreconditionFailed { .. }));
-        assert_eq!(flaky.puts.load(Ordering::SeqCst), 2);
         assert_eq!(flaky.gets.load(Ordering::SeqCst), 0);
     }
 
-    #[tokio::test]
-    async fn create_put_retries_when_conflicting_object_vanishes() {
+    #[tokio::test(start_paused = true)]
+    async fn immutable_transport_failure_surfaces_after_the_retry_budget() {
         let flaky = Arc::new(FlakyStore::default());
         let store = retrying_store(Arc::clone(&flaky));
-        script_puts(&flaky, [WriteScript::LandThenFail]);
-        flaky
-            .get_script
-            .lock()
-            .expect("get script")
-            .push_back(ReadScript::NotFound);
-        let key = "namespaces/demo/uploads/upl_3.json";
+        script_puts(&flaky, (0..11).map(|_| WriteScript::FailWithoutLanding));
+        let key = "namespaces/demo/uploads/upl_9.json";
 
-        let metadata = store
-            .put_if_absent(key, Bytes::from_static(b"payload"))
+        let error = store
+            .put_immutable_verified(key, Bytes::from_static(b"payload"))
             .await
-            .expect("create succeeds once the conflicting object vanishes");
+            .expect_err("persistent failure exhausts the immutable retry budget");
 
-        assert_eq!(flaky.puts.load(Ordering::SeqCst), 3);
-        assert_eq!(flaky.gets.load(Ordering::SeqCst), 2);
-        assert!(metadata.etag.is_some());
+        assert!(matches!(
+            error,
+            crate::ImmutableWriteError::Transport {
+                source: ObjectStoreError::Transport { .. },
+                ..
+            }
+        ));
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 11);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -1744,48 +1605,6 @@ mod tests {
         assert_eq!(
             store.get(key, None).await.expect("get"),
             Some(Bytes::from_static(b"one"))
-        );
-    }
-
-    #[tokio::test]
-    async fn write_retries_are_bounded_by_policy() {
-        let flaky = Arc::new(FlakyStore::default());
-        let store = retrying_store(Arc::clone(&flaky));
-        script_puts(&flaky, (0..6).map(|_| WriteScript::FailWithoutLanding));
-        let key = "namespaces/demo/uploads/upl_4.json";
-
-        let error = store
-            .put_overwrite(key, Bytes::from_static(b"payload"))
-            .await
-            .expect_err("persistent transport failure surfaces after the retry budget");
-
-        assert!(matches!(error, ObjectStoreError::Transport { .. }));
-        assert_eq!(flaky.puts.load(Ordering::SeqCst), 5);
-    }
-
-    /// The operation deadline is one budget across every retry: once the
-    /// elapsed observations consume it, the loop refuses further attempts
-    /// even though the count budget has room.
-    #[tokio::test]
-    async fn write_retries_stop_once_the_operation_deadline_is_spent() {
-        let flaky = Arc::new(FlakyStore::default());
-        // Each timer reading advances 45s against a 120s deadline: the
-        // deadline check after the second failed attempt finds it spent.
-        let store = retrying_store(Arc::clone(&flaky))
-            .with_monotonic_timer(Arc::new(SteppingTimer::new(45_000)));
-        script_puts(&flaky, (0..6).map(|_| WriteScript::FailWithoutLanding));
-        let key = "namespaces/demo/uploads/upl_9.json";
-
-        let error = store
-            .put_overwrite(key, Bytes::from_static(b"payload"))
-            .await
-            .expect_err("deadline exhaustion surfaces the transport failure");
-
-        assert!(matches!(error, ObjectStoreError::Transport { .. }));
-        let attempts = flaky.puts.load(Ordering::SeqCst);
-        assert!(
-            attempts < 5,
-            "deadline must stop the loop before the count budget ({attempts} attempts)"
         );
     }
 
@@ -1818,16 +1637,6 @@ mod tests {
             attempts < 5,
             "deadline must stop the loop before the count budget ({attempts} attempts)"
         );
-    }
-
-    #[test]
-    fn operation_deadline_remaining_caps_at_zero() {
-        let timer = SteppingTimer::new(70_000);
-        let deadline = OperationDeadline::start(&timer, Duration::from_secs(120));
-        // First reading after start: 70s elapsed, 50s left.
-        assert_eq!(deadline.remaining(), Some(Duration::from_secs(50)));
-        // Second reading: 140s elapsed, spent.
-        assert_eq!(deadline.remaining(), None);
     }
 
     #[tokio::test]
@@ -1961,6 +1770,51 @@ mod tests {
         )
         .await
         .expect("seed object");
+    }
+
+    #[tokio::test]
+    async fn immutable_large_write_routes_through_existing_multipart_path() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let payload =
+            multipart_payload(usize::try_from(PROVIDER_MULTIPART_THRESHOLD_BYTES).expect("usize"));
+
+        store
+            .put_immutable_verified(MULTIPART_KEY, Bytes::from(payload.clone()))
+            .await
+            .expect("large immutable write");
+
+        assert_eq!(flaky.puts.load(Ordering::SeqCst), 0);
+        assert_eq!(flaky.multipart_creates.load(Ordering::SeqCst), 1);
+        assert_eq!(part_attempts(&flaky, 0), 1);
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store.get(MULTIPART_KEY, None).await.expect("get"),
+            Some(Bytes::from(payload))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn immutable_large_write_owns_completion_retry() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = retrying_store(Arc::clone(&flaky));
+        let payload =
+            multipart_payload(usize::try_from(PROVIDER_MULTIPART_THRESHOLD_BYTES).expect("usize"));
+        script_complete(&flaky, [WriteScript::FailWithoutLanding]);
+
+        store
+            .put_immutable_verified(MULTIPART_KEY, Bytes::from(payload.clone()))
+            .await
+            .expect("immutable operation retries the whole multipart write");
+
+        assert_eq!(flaky.multipart_creates.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store.get(MULTIPART_KEY, None).await.expect("get"),
+            Some(Bytes::from(payload))
+        );
     }
 
     #[tokio::test]
@@ -2134,8 +1988,8 @@ mod tests {
 
         assert_eq!(
             flaky.multipart_completes.load(Ordering::SeqCst),
-            2,
-            "the retry finds the landed completion's upload gone"
+            1,
+            "completion is attempted once before byte-identity resolution"
         );
         assert_eq!(
             flaky.gets.load(Ordering::SeqCst),
@@ -2164,28 +2018,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multipart_complete_failure_without_landing_retries_the_completion() {
+    async fn raw_multipart_complete_failure_without_landing_is_not_retried() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
         script_complete(&flaky, [WriteScript::FailWithoutLanding]);
         let payload = multipart_payload(1300);
 
-        store
+        let error = store
             .put_overwrite(MULTIPART_KEY, Bytes::from(payload.clone()))
             .await
-            .expect("completion retried after a transient failure");
+            .expect_err("raw overwrite surfaces the ambiguous completion");
 
-        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
-        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            flaky.gets.load(Ordering::SeqCst),
-            0,
-            "a completion that succeeds on retry needs no read-back"
-        );
-        assert_eq!(
-            store.get(MULTIPART_KEY, None).await.expect("get"),
-            Some(Bytes::from(payload))
-        );
+        assert!(matches!(error, ObjectStoreError::Transport { .. }));
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
+        assert!(store.head(MULTIPART_KEY).await.expect("head").is_none());
     }
 
     /// The regression this fix exists for: an unproven completion must
@@ -2193,12 +2041,12 @@ mod tests {
     /// reconciled by size identity and reported success for bytes that were
     /// never written.
     #[tokio::test]
-    async fn multipart_complete_exhaustion_rejects_stale_same_size_object() {
+    async fn multipart_complete_rejects_stale_same_size_object() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
         let stale = Bytes::from(vec![0xAA_u8; 1300]);
         seed_scoped_object(&flaky, MULTIPART_KEY, stale.clone()).await;
-        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+        script_complete(&flaky, [WriteScript::FailWithoutLanding]);
 
         let error = store
             .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
@@ -2208,8 +2056,8 @@ mod tests {
         assert!(matches!(error, ObjectStoreError::Transport { .. }));
         assert_eq!(
             flaky.multipart_completes.load(Ordering::SeqCst),
-            5,
-            "1 attempt + max_retries"
+            1,
+            "raw overwrite does not replay completion"
         );
         assert_eq!(
             flaky.gets.load(Ordering::SeqCst),
@@ -2233,12 +2081,12 @@ mod tests {
     /// postcondition even though this upload's completion never landed —
     /// and the dangling upload is reclaimed rather than stranded.
     #[tokio::test]
-    async fn multipart_complete_exhaustion_accepts_identical_object_and_aborts() {
+    async fn multipart_complete_accepts_identical_object_and_aborts() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
         let payload = multipart_payload(1300);
         seed_scoped_object(&flaky, MULTIPART_KEY, Bytes::from(payload.clone())).await;
-        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+        script_complete(&flaky, [WriteScript::FailWithoutLanding]);
 
         let metadata = store
             .put_overwrite(MULTIPART_KEY, Bytes::from(payload))
@@ -2259,10 +2107,8 @@ mod tests {
     }
 
     /// The lifecycle-abort race: the upload vanishes while the completion's
-    /// outcome is ambiguous and a stale object sits at the key. The gone
-    /// upload maps to not-found, which must surface as a retry-safe
-    /// transport failure about this write — not as a missing object, and
-    /// never as success.
+    /// outcome is ambiguous and a stale object sits at the key. The stale
+    /// object is never accepted as this write.
     #[tokio::test]
     async fn multipart_complete_gone_upload_with_stale_object_fails_as_transport() {
         let flaky = Arc::new(FlakyStore::default());
@@ -2277,12 +2123,7 @@ mod tests {
             .expect_err("a vanished upload with a stale object is a failed write");
 
         assert!(matches!(error, ObjectStoreError::Transport { .. }));
-        let message = error.message();
-        assert!(
-            message.contains("without a provable completion"),
-            "message names the unproven outcome: {message}"
-        );
-        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
         assert_eq!(flaky.gets.load(Ordering::SeqCst), 1);
         assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
         assert_eq!(
@@ -2290,34 +2131,6 @@ mod tests {
             Some(stale),
             "the stale object is untouched"
         );
-    }
-
-    /// A definite refusal that follows an ambiguous attempt verifies before
-    /// failing, and a disproven completion surfaces the refusal under its
-    /// own classification instead of as network weather.
-    #[tokio::test]
-    async fn multipart_complete_definite_rejection_after_ambiguity_keeps_its_class() {
-        let flaky = Arc::new(FlakyStore::default());
-        let store = multipart_test_store(Arc::clone(&flaky));
-        seed_scoped_object(&flaky, MULTIPART_KEY, Bytes::from(vec![0xAA_u8; 1300])).await;
-        script_complete(
-            &flaky,
-            [WriteScript::FailWithoutLanding, WriteScript::FailAuth],
-        );
-
-        let error = store
-            .put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)))
-            .await
-            .expect_err("auth rejection surfaces after the outcome is disproven");
-
-        assert!(matches!(error, ObjectStoreError::PermissionDenied { .. }));
-        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 2);
-        assert_eq!(
-            flaky.gets.load(Ordering::SeqCst),
-            1,
-            "the ambiguous prior attempt forces a read-back first"
-        );
-        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
     }
 
     /// A first-attempt refusal is definite: nothing can have landed, so no
@@ -2346,7 +2159,7 @@ mod tests {
     async fn multipart_complete_unverifiable_outcome_surfaces_both_failures() {
         let flaky = Arc::new(FlakyStore::default());
         let store = multipart_test_store(Arc::clone(&flaky));
-        script_complete(&flaky, (0..5).map(|_| WriteScript::FailWithoutLanding));
+        script_complete(&flaky, [WriteScript::FailWithoutLanding]);
         flaky
             .get_script
             .lock()

--- a/crates/loonfs-objectstore/src/retry.rs
+++ b/crates/loonfs-objectstore/src/retry.rs
@@ -1,0 +1,66 @@
+//! Shared bounded-backoff machinery for replay-safe store operations.
+
+use crate::timing::MonotonicTimer;
+use crate::PROVIDER_OP_DEADLINE;
+use std::time::Duration;
+
+/// Bounded retry configuration matching the provider client's read budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TransportRetryPolicy {
+    pub(crate) max_retries: u32,
+    pub(crate) initial_backoff: Duration,
+    pub(crate) max_backoff: Duration,
+    pub(crate) op_deadline: Duration,
+}
+
+impl TransportRetryPolicy {
+    pub(crate) const DEFAULT: Self = Self {
+        max_retries: 10,
+        initial_backoff: Duration::from_millis(100),
+        max_backoff: Duration::from_secs(15),
+        op_deadline: PROVIDER_OP_DEADLINE,
+    };
+}
+
+pub(crate) fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32) -> Duration {
+    let doublings = retry.saturating_sub(1).min(16);
+    policy
+        .initial_backoff
+        .saturating_mul(1u32 << doublings)
+        .min(policy.max_backoff)
+}
+
+/// Elapsed-time state for one logical operation's retry loop.
+pub(crate) struct OperationDeadline<'timer> {
+    timer: &'timer dyn MonotonicTimer,
+    started_ms: u64,
+    deadline: Duration,
+}
+
+impl<'timer> OperationDeadline<'timer> {
+    pub(crate) fn start(timer: &'timer dyn MonotonicTimer, deadline: Duration) -> Self {
+        Self {
+            timer,
+            started_ms: timer.monotonic_now_ms(),
+            deadline,
+        }
+    }
+
+    pub(crate) fn remaining(&self) -> Option<Duration> {
+        let elapsed_ms = self
+            .timer
+            .monotonic_now_ms()
+            .saturating_sub(self.started_ms);
+        let deadline_ms = u64::try_from(self.deadline.as_millis()).unwrap_or(u64::MAX);
+        if elapsed_ms >= deadline_ms {
+            return None;
+        }
+        Some(Duration::from_millis(deadline_ms - elapsed_ms))
+    }
+}
+
+#[allow(clippy::disallowed_methods)]
+pub(crate) async fn transport_retry_pause(backoff: Duration) {
+    // Replay-safe operations wait at this isolated timer boundary between attempts.
+    tokio::time::sleep(backoff).await;
+}

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1159,8 +1159,12 @@ root = "/tmp/loonfs-server"
         assert_eq!(config.grep, super::GrepConfig::default());
         assert_eq!(config.grep.mode, super::GrepMode::Embedded);
         assert_eq!(
-            config.grep.worker_config().build_policy(),
-            loonfs_grep::GramIndexBuildPolicy::default()
+            config
+                .grep
+                .worker_config()
+                .build_policy()
+                .expect("valid default grep policy"),
+            loonfs_grep::GramIndexBuildPolicy::default(),
         );
     }
 
@@ -1192,13 +1196,16 @@ root = "/tmp/loonfs-server"
         let grep = load_server_config(&path).expect("load config").grep;
         assert_eq!(grep.mode, super::GrepMode::ServeOnly);
         assert_eq!(grep.max_concurrent_steps, 7);
-        let policy = grep.worker_config().build_policy();
-        assert_eq!(policy.max_files_per_step, 4096);
-        assert_eq!(policy.max_content_bytes_per_step, 536_870_912);
-        assert_eq!(policy.max_rows_per_segment, 131_072);
-        assert_eq!(policy.max_l0_runs, 4);
-        assert_eq!(policy.max_mid_runs, 6);
-        assert_eq!(policy.max_fold_rows_per_step, 262_144);
+        let policy = grep
+            .worker_config()
+            .build_policy()
+            .expect("valid configured grep policy");
+        assert_eq!(policy.max_files_per_step.get(), 4096);
+        assert_eq!(policy.max_content_bytes_per_step.get(), 536_870_912);
+        assert_eq!(policy.max_rows_per_segment.get(), 131_072);
+        assert_eq!(policy.max_l0_runs.get(), 4);
+        assert_eq!(policy.max_mid_runs.get(), 6);
+        assert_eq!(policy.max_fold_rows_per_step.get(), 262_144);
     }
 
     #[test]
@@ -1226,9 +1233,10 @@ root = "/tmp/loonfs-server"
             .expect("load config")
             .grep
             .worker_config()
-            .build_policy();
-        assert_eq!(policy.max_files_per_step, 1024);
-        assert_eq!(policy.max_l0_runs, 3);
+            .build_policy()
+            .expect("valid configured grep policy");
+        assert_eq!(policy.max_files_per_step.get(), 1024);
+        assert_eq!(policy.max_l0_runs.get(), 3);
         assert_eq!(
             policy.max_mid_runs,
             loonfs_grep::GramIndexBuildPolicy::default().max_mid_runs,

--- a/crates/loonfs-server/src/grep_drivers.rs
+++ b/crates/loonfs-server/src/grep_drivers.rs
@@ -6,6 +6,7 @@ use loonfs_grep::{
     GrepStepLimiter, GrepWorker,
 };
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
@@ -26,7 +27,7 @@ impl GrepDrivers {
     pub(crate) fn new(
         worker: GrepWorker<SharedObjectStore>,
         policy: GramIndexBuildPolicy,
-        max_concurrent_steps: usize,
+        max_concurrent_steps: NonZeroUsize,
     ) -> Result<Self, crate::ServerConfigError> {
         let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
             crate::ServerConfigError::InvalidField {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -224,13 +224,21 @@ async fn app_with_store_and_transfer_issuer(
         )
     });
     let grep_drivers = if config.grep.mode.runs_worker() {
+        let worker_config = config.grep.worker_config();
+        let grep_config_error =
+            |error: loonfs_grep::GrepWorkerConfigError| ServerConfigError::InvalidField {
+                field: "grep",
+                reason: error.to_string(),
+            };
         Some(GrepDrivers::new(
             grep_worker
                 .as_ref()
                 .expect("driver-running grep mode should serve grep")
                 .clone(),
-            config.grep.worker_config().build_policy(),
-            config.grep.max_concurrent_steps,
+            worker_config.build_policy().map_err(grep_config_error)?,
+            worker_config
+                .concurrent_step_limit()
+                .map_err(grep_config_error)?,
         )?)
     } else {
         None

--- a/crates/loonfs-server/tests/grep_modes.rs
+++ b/crates/loonfs-server/tests/grep_modes.rs
@@ -18,6 +18,7 @@ use loonfs_server::{
     app, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
 };
 use serde::de::DeserializeOwned;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -196,7 +197,7 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
         .build_step(
             &backfill,
             GramIndexBuildPolicy {
-                max_files_per_step: 1,
+                max_files_per_step: NonZeroUsize::MIN,
                 ..GramIndexBuildPolicy::default()
             },
         )

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -8,6 +8,7 @@
 use crate::{NamespaceId, Result, RuntimeError};
 use std::collections::BTreeSet;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -40,7 +41,7 @@ pub(crate) struct BackgroundWork {
     /// per-namespace singleflight bounds each namespace to one tick; this
     /// bounds how many namespaces may tick at once, so a write burst across
     /// many namespaces cannot fan out into unbounded maintenance tasks.
-    max_concurrent: usize,
+    max_concurrent: NonZeroUsize,
     state: Mutex<BackgroundState>,
 }
 
@@ -63,14 +64,12 @@ impl BackgroundWork {
     pub(crate) fn new(
         policy: FsBackgroundWork,
         runtime: Option<tokio::runtime::Handle>,
-        max_concurrent: usize,
+        max_concurrent: NonZeroUsize,
     ) -> Self {
         Self {
             policy,
             runtime,
-            // A zero cap would silently disable auto maintenance; the
-            // policy is the switch for that, so the cap stays a bound.
-            max_concurrent: max_concurrent.max(1),
+            max_concurrent,
             state: Mutex::new(BackgroundState {
                 closed: false,
                 inflight: BTreeSet::new(),
@@ -101,10 +100,10 @@ impl BackgroundWork {
             state.pending.insert(namespace_id.clone());
             return false;
         }
-        if state.inflight.len() >= self.max_concurrent {
+        if state.inflight.len() >= self.max_concurrent.get() {
             tracing::debug!(
                 namespace_id = %namespace_id,
-                max_concurrent = self.max_concurrent,
+                max_concurrent = self.max_concurrent.get(),
                 "maintenance tick skipped at the concurrency cap; \
                  the next over-threshold publish reschedules it"
             );
@@ -206,6 +205,10 @@ mod tests {
         NamespaceId::parse("demo").expect("valid namespace id")
     }
 
+    fn concurrency_cap(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test cap should be nonzero")
+    }
+
     /// Sets its flag when dropped, mimicking the claim guard the auto-tick
     /// future carries: a refused spawn must drop the future so the guard
     /// releases the singleflight slot.
@@ -219,7 +222,7 @@ mod tests {
 
     #[test]
     fn a_request_during_an_active_tick_defers_and_reruns_exactly_once() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         assert!(background.try_claim(&namespace_id), "first claim spawns");
@@ -244,7 +247,7 @@ mod tests {
 
     #[test]
     fn shutdown_wins_over_a_deferred_rerun() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         assert!(background.try_claim(&namespace_id));
@@ -258,7 +261,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_after_shut_down_refuses_and_drops_the_future() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
 
         // The racy interleaving a shutdown must win: the claim lands first...
@@ -292,7 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn tasks_spawned_before_shut_down_are_drained() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let ran = Arc::new(AtomicBool::new(false));
         let ran_in_task = ran.clone();
         background.spawn(async move {
@@ -309,7 +312,7 @@ mod tests {
 
     #[tokio::test]
     async fn drain_surfaces_panicked_tasks_as_an_error() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         background.spawn(async {
             panic!("injected background task panic");
         });
@@ -323,7 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn claims_are_singleflight_and_refused_after_shut_down() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 8);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
         let namespace_id = namespace_id();
         assert!(background.try_claim(&namespace_id));
         assert!(
@@ -345,13 +348,14 @@ mod tests {
 
     #[tokio::test]
     async fn manual_only_policy_never_claims() {
-        let background = BackgroundWork::new(FsBackgroundWork::ManualOnly, None, 8);
+        let background =
+            BackgroundWork::new(FsBackgroundWork::ManualOnly, None, concurrency_cap(8));
         assert!(!background.try_claim(&namespace_id()));
     }
 
     #[tokio::test]
     async fn claims_stop_at_the_global_concurrency_cap() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 2);
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(2));
         let first = NamespaceId::parse("first").expect("valid namespace id");
         let second = NamespaceId::parse("second").expect("valid namespace id");
         let third = NamespaceId::parse("third").expect("valid namespace id");
@@ -367,15 +371,6 @@ mod tests {
         assert!(
             background.try_claim(&third),
             "a released slot admits the waiting namespace"
-        );
-    }
-
-    #[tokio::test]
-    async fn a_zero_cap_is_normalized_to_one_slot() {
-        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, 0);
-        assert!(
-            background.try_claim(&namespace_id()),
-            "the policy, not the cap, is the off switch"
         );
     }
 }

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -12,6 +12,7 @@ use crate::{
     ReleaseCheckpointResponse, RepairNamespaceResponse, Result, RuntimeCacheConfig,
     RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Administrative and maintenance handle.
@@ -256,7 +257,8 @@ impl FsAdminBuilder {
         let background = BackgroundWork::new(
             FsBackgroundWork::ManualOnly,
             None,
-            crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                .expect("default maintenance concurrency should be nonzero"),
         );
         Ok(FsAdmin {
             core: self.core.open(actor_id, self.actor_version, background)?,

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -12,6 +12,7 @@ use crate::{
     PageRequest, Result, RevisionNo, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
     StoreConfig, TraceMode, TraceStoreKind,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Read-only handle for latest namespace views.
@@ -243,7 +244,8 @@ impl FsReaderBuilder {
         let background = BackgroundWork::new(
             FsBackgroundWork::ManualOnly,
             None,
-            crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                .expect("default maintenance concurrency should be nonzero"),
         );
         Ok(FsReader {
             core: self.core.open(

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -16,6 +16,7 @@ use crate::{
     RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
     UndeleteOptions, UploadContentResponse, UploadId,
 };
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 /// Write-capable handle for normal application and server use.
@@ -529,8 +530,9 @@ impl FsWriterBuilder {
     /// at most one tick at a time; this bounds the fan-out when many
     /// namespaces cross their thresholds together. Skipped ticks are
     /// rescheduled by the next over-threshold publish. Defaults to
-    /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]; zero is normalized up
-    /// to one (use [`FsBackgroundWork::ManualOnly`] to disable scheduling).
+    /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]. The limit must be
+    /// greater than zero; [`FsBackgroundWork::ManualOnly`] is the only way
+    /// to disable scheduling.
     pub fn max_concurrent_maintenance(mut self, max_concurrent_maintenance: usize) -> Self {
         self.max_concurrent_maintenance = max_concurrent_maintenance;
         self
@@ -610,10 +612,18 @@ impl FsWriterBuilder {
         let writer_id = self
             .writer_id
             .ok_or_else(|| RuntimeError::Config("writer_id is required".to_owned()))?;
+        let max_concurrent_maintenance = NonZeroUsize::new(self.max_concurrent_maintenance)
+            .ok_or_else(|| {
+                RuntimeError::Config(
+                    "`max_concurrent_maintenance` must be greater than zero; \
+                     `FsBackgroundWork::ManualOnly` disables scheduling"
+                        .to_owned(),
+                )
+            })?;
         let background = BackgroundWork::new(
             self.background_work,
             Some(owning_runtime()?),
-            self.max_concurrent_maintenance,
+            max_concurrent_maintenance,
         );
         Ok(FsWriter {
             core: self.core.open(writer_id, self.writer_version, background)?,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1446,7 +1446,8 @@ mod tests {
             BackgroundWork::new(
                 FsBackgroundWork::ManualOnly,
                 None,
-                crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+                std::num::NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
+                    .expect("default maintenance concurrency should be nonzero"),
             ),
             None,
             None,

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -18,6 +18,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -33,6 +34,10 @@ fn grep_request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 /// Content blob object keys currently in the store, for pinpointing the
@@ -332,7 +337,7 @@ async fn a_worker_policy_bounds_each_build_step() {
         .expect("build admin");
     let grep_worker = grep_worker(&store);
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: 3,
+        max_files_per_step: nonzero_usize(3),
         ..GramIndexBuildPolicy::default()
     };
 
@@ -426,9 +431,10 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
     let content_bytes = format!("bounded needle file {:04}\n", 0).len();
     let max_content_bytes_per_step = (content_bytes * FILES_PER_STEP) as u64;
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: FILES,
-        max_content_bytes_per_step,
-        max_l0_runs: usize::MAX,
+        max_files_per_step: nonzero_usize(FILES),
+        max_content_bytes_per_step: NonZeroU64::new(max_content_bytes_per_step)
+            .expect("content budget should be nonzero"),
+        max_l0_runs: nonzero_usize(usize::MAX),
         ..GramIndexBuildPolicy::default()
     };
     let mut ops = Vec::with_capacity(FILES);

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -22,6 +22,7 @@ use loonfs_grep::GramIndexBuildPolicy;
 use loonfs_grep::{GrepBuildOutcome, GrepFoldOutcome, GrepIndexSnapshot, GrepService, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -35,6 +36,10 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 async fn read_context(store: &SharedObjectStore, namespace_id: &NamespaceId) -> RuntimeReadContext {
@@ -221,8 +226,8 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
         .await
         .expect("build writer");
     let policy = GramIndexBuildPolicy {
-        max_l0_runs: 2,
-        max_mid_runs: 2,
+        max_l0_runs: nonzero_usize(2),
+        max_mid_runs: nonzero_usize(2),
         ..GramIndexBuildPolicy::default()
     };
     let worker = worker(&store);

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -11,7 +11,7 @@ use loonfs::{
     GrepRequest, GrepResponse, NamespaceId, PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
-use loonfs_api::{ChangeSeq, IndexSegmentId};
+use loonfs_api::{sha256_digest, ChangeSeq, IndexSegmentId};
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
     WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
@@ -40,6 +40,7 @@ use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -56,6 +57,10 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
+}
+
+fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 fn worker(store: &SharedObjectStore) -> GrepWorker<SharedObjectStore> {
@@ -260,11 +265,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .await
         .expect("load root")
         .expect("root exists");
-    let GrepLifecycle::Backfilling {
-        checkpoint_id: Some(checkpoint_id),
-        ..
-    } = root.state().lifecycle()
-    else {
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.state().lifecycle() else {
         panic!(
             "enable must publish checkpointed backfill: {:?}",
             root.state()
@@ -273,7 +274,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
     let checkpoint_id = checkpoint_id.clone();
 
     let policy = GramIndexBuildPolicy {
-        max_files_per_step: 1,
+        max_files_per_step: NonZeroUsize::MIN,
         ..GramIndexBuildPolicy::default()
     };
     let first = worker
@@ -413,11 +414,7 @@ async fn retention_gap_and_vanished_checkpoint_restart_fresh_backfill() {
         .await
         .expect("load restarted root")
         .expect("root exists");
-    let GrepLifecycle::Backfilling {
-        checkpoint_id: Some(checkpoint_id),
-        ..
-    } = root.state().lifecycle()
-    else {
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.state().lifecycle() else {
         panic!("gap must restart checkpointed backfill");
     };
     admin
@@ -512,6 +509,79 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
     writer.shutdown_background().await.expect("shutdown");
 }
 
+#[tokio::test]
+async fn backfilling_root_without_checkpoint_id_is_index_corrupt() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("missing-backfill-checkpoint").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("missing-checkpoint-writer")
+        .build()
+        .await
+        .expect("writer");
+    let reader = writer.reader();
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let worker = worker(&store);
+    worker.enable(&namespace_id).await.expect("enable grep");
+    let root = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load backfilling root")
+        .expect("backfilling root exists");
+    let manifest_bytes = store
+        .get(
+            &manifest_key(&namespace_id, root.manifest_envelope().manifest_id()),
+            None,
+        )
+        .await
+        .expect("read backfilling manifest")
+        .expect("backfilling manifest exists");
+    let corrupt_manifest_id =
+        write_manifest_without_checkpoint_id(&*store, &namespace_id, &manifest_bytes).await;
+    write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
+
+    assert_corrupt_index_error(
+        "backfilling manifest missing checkpoint id",
+        reader.grep(&namespace_id, &request("needle")).await,
+    );
+    writer.shutdown_background().await.expect("shutdown");
+}
+
+async fn write_manifest_without_checkpoint_id(
+    store: &dyn ObjectStore,
+    namespace_id: &NamespaceId,
+    manifest_bytes: &[u8],
+) -> GrepManifestId {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(manifest_bytes).expect("decode valid manifest document");
+    document["payload"]["lifecycle"]
+        .as_object_mut()
+        .expect("backfilling lifecycle is an object")
+        .remove("checkpoint_id")
+        .expect("valid backfilling manifest carries checkpoint id");
+    let payload_bytes =
+        serde_json::to_vec(&document["payload"]).expect("encode corrupt manifest payload");
+    let payload_checksum = sha256_digest(&payload_bytes);
+    document["payload_checksum"] = serde_json::Value::String(payload_checksum.clone());
+    let manifest_id = GrepManifestId::parse(
+        payload_checksum
+            .strip_prefix("sha256:")
+            .expect("sha256 digest should carry its algorithm prefix"),
+    )
+    .expect("checksum is a valid manifest id");
+    store
+        .put_overwrite(
+            &manifest_key(namespace_id, &manifest_id),
+            Bytes::from(serde_json::to_vec(&document).expect("encode corrupt manifest document")),
+        )
+        .await
+        .expect("write manifest missing checkpoint id");
+    manifest_id
+}
+
 async fn write_pointer(
     store: &dyn ObjectStore,
     namespace_id: &NamespaceId,
@@ -592,8 +662,8 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         .expect("create namespace");
     let worker = worker(&store);
     let policy = GramIndexBuildPolicy {
-        max_l0_runs: 2,
-        max_mid_runs: 2,
+        max_l0_runs: nonzero_usize(2),
+        max_mid_runs: nonzero_usize(2),
         ..GramIndexBuildPolicy::default()
     };
     worker.enable(&namespace_id).await.expect("enable");
@@ -849,7 +919,7 @@ async fn checkpoint_backfill_matches_incremental_worker_results() {
         &worker,
         &backfill_namespace,
         GramIndexBuildPolicy {
-            max_files_per_step: 2,
+            max_files_per_step: nonzero_usize(2),
             ..GramIndexBuildPolicy::default()
         },
     )

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -608,6 +608,31 @@ fn builders_require_identity_and_a_runtime() {
 }
 
 #[test]
+fn writer_builder_rejects_zero_maintenance_concurrency() {
+    let temp_dir = tempdir().expect("tempdir");
+    for background_work in [FsBackgroundWork::Enabled, FsBackgroundWork::ManualOnly] {
+        let result = block_on(
+            FsWriter::builder(store_config(temp_dir.path()))
+                .writer_id("handle-test-writer")
+                .background_work(background_work)
+                .max_concurrent_maintenance(0)
+                .build(),
+        );
+
+        match result {
+            Err(RuntimeError::Config(message)) => {
+                assert!(message.contains("`max_concurrent_maintenance`"));
+                assert!(message.contains("`FsBackgroundWork::ManualOnly`"));
+            }
+            Err(other) => {
+                panic!("expected config error for zero maintenance cap, got {other:?}")
+            }
+            Ok(_) => panic!("zero maintenance concurrency must be rejected"),
+        }
+    }
+}
+
+#[test]
 fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -2352,7 +2352,7 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
 }
 
 #[test]
-fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands() {
+fn put_file_bytes_retries_a_transient_content_write_failure() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
@@ -2362,50 +2362,20 @@ fn put_file_bytes_content_write_failure_leaves_nothing_visible_and_a_retry_lands
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
-    let commit_id = CommitId::parse("overlap-put-retry").expect("valid commit id");
     raw_store.fail_next_content_blob_puts(1);
-    let error = fs
-        .put_file_bytes_blocking(
-            &namespace_id,
-            "/docs/report.txt",
-            b"overlap survives",
-            PutFileOptions {
-                behavior: DestinationBehavior::NoReplace,
-                commit_id: Some(commit_id.clone()),
-            },
-        )
-        .expect_err("put should surface the failed content write");
-    // A put reports its own write's error, not publish plumbing.
-    assert!(
-        error.to_string().contains("injected content write failure"),
-        "unexpected error: {error}"
-    );
-
-    // Content is staged before the publish is submitted, so the failed write
-    // stopped the put with the head unmoved and nothing visible.
-    let error = fs
-        .stat_path_blocking(&namespace_id, "/docs/report.txt")
-        .expect_err("failed put should leave the path unbound");
-    assert!(matches!(
-        error,
-        RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
-    ));
-
-    // The failed attempt never committed, so the same commit id retries
-    // cleanly instead of resolving as a duplicate.
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/report.txt",
         b"overlap survives",
         PutFileOptions {
             behavior: DestinationBehavior::NoReplace,
-            commit_id: Some(commit_id),
+            commit_id: Some(CommitId::parse("overlap-put-retry").expect("valid commit id")),
         },
     )
-    .expect("same-commit-id retry should land");
+    .expect("immutable write retries the transient failure");
     let read = fs
         .read_file_bytes_blocking(&namespace_id, "/docs/report.txt")
-        .expect("read retried file");
+        .expect("read file");
     assert_eq!(read.bytes, b"overlap survives");
 }
 
@@ -2628,7 +2598,7 @@ fn zero_interval_publishes_sequential_submissions_immediately() {
 }
 
 #[test]
-fn concurrent_put_content_write_failure_leaves_the_other_put_committed() {
+fn concurrent_puts_both_commit_after_one_transient_content_failure() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id();
     let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
@@ -2639,9 +2609,8 @@ fn concurrent_put_content_write_failure_leaves_the_other_put_committed() {
             .await
             .expect("create namespace");
 
-        // Exactly one of the two concurrent content writes fails. Content is
-        // staged before a submission enters the commit window, so only the
-        // put whose own upload failed errors; the other publishes normally.
+        // One content write fails once before either submission enters the
+        // commit window. Its immutable retry is independent of its peer.
         raw_store.fail_next_content_blob_puts(1);
         let (a, b) = tokio::join!(
             fs.put_file_bytes(
@@ -2658,59 +2627,18 @@ fn concurrent_put_content_write_failure_leaves_the_other_put_committed() {
             ),
         );
 
-        let mut failed = Vec::new();
         for (path, bytes, result) in [
             ("/docs/a.txt", b"alpha" as &[u8], a),
             ("/docs/b.txt", b"beta" as &[u8], b),
         ] {
-            match result {
-                Ok(_) => {
-                    let read = fs
-                        .reader
-                        .read_file_bytes(&namespace_id, path)
-                        .await
-                        .expect("read the committed peer");
-                    assert_eq!(read.bytes, bytes);
-                }
-                Err(error) => {
-                    // The failing member reports its own write's error, and
-                    // its path stays unbound behind an unmoved head.
-                    assert!(
-                        error.to_string().contains("injected content write failure"),
-                        "unexpected error: {error}"
-                    );
-                    let error = fs
-                        .reader
-                        .stat_path(&namespace_id, path)
-                        .await
-                        .expect_err("failed put should leave the path unbound");
-                    assert!(matches!(
-                        error,
-                        RuntimeError::Core(error) if error.code() == loonfs::ErrorCode::PathNotFound
-                    ));
-                    failed.push((path, bytes));
-                }
-            }
+            result.expect("both puts survive the transient content failure");
+            let read = fs
+                .reader
+                .read_file_bytes(&namespace_id, path)
+                .await
+                .expect("read committed file");
+            assert_eq!(read.bytes, bytes);
         }
-        let [(failed_path, failed_bytes)] = failed[..] else {
-            panic!("exactly one put should fail its own content write");
-        };
-
-        // The failed member retries cleanly; its peer never needed one.
-        fs.put_file_bytes(
-            &namespace_id,
-            failed_path,
-            failed_bytes,
-            PutFileOptions::default(),
-        )
-        .await
-        .expect("retried put");
-        let read = fs
-            .reader
-            .read_file_bytes(&namespace_id, failed_path)
-            .await
-            .expect("read retried file");
-        assert_eq!(read.bytes, failed_bytes);
     });
 }
 


### PR DESCRIPTION
Core and grep each carried their own copy of the same subtle protocol — create-if-absent for small immutable objects, multipart for large, ambiguous-outcome resolution by read-back, exact-byte acceptance — plus the provider layer's own retry and ambiguity loops. Correctness logic this subtle drifts; now there is one place for it. ObjectStore::put_immutable_verified owns size routing on the established 8 MiB geometry (absorbing, not reimplementing, the multipart byte-identity completion), the read-back verification, and the retry budget that only immutability justifies — stated in its doc comment, because the name and the comment are the design. The error has two variants: a different object at the key (corruption-class; each consumer decides severity) and classified transport; Ok covers written and already-present-identical alike. 

Both local implementations are deleted (core's writer and verifier, grep's segment writer, manifest conflict protocol, and verify-and-heal re-put), each mapping the typed error into its own vocabulary: core store classes, grep's CorruptIndex and StoreUnavailable. One deliberate strengthening rides along: acceptance requires full byte identity, so equal payload checksums with different envelope bytes are now corruption rather than a match.

The retry audit found the hazard was real: the provider retried every non-CAS flat write on a replay-safety argument that only holds for immutable identical-bytes keys. Raw mutable overwrites are now single-attempt — pinned by tests for flat and multipart-completion paths — while multipart create and part uploads keep their retries because they never publish the object key. The accounting suites confirm the happy path is unchanged: one content PUT, no verification reads; only conflicted or ambiguous writes pay the read-back.