### PR TITLE
refactor(tracing): rename span namespace to loonfs

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -88,7 +88,7 @@ pub(super) struct MetadataSstRows {
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "write_manifest_tables", key_class = "manifest_table")

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -119,7 +119,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
     let publication_started_ms = timer.monotonic_now_ms();
     let projection = load_root_projection(store, namespace_id)
         .instrument(tracing::info_span!(
-            "loon.phase",
+            "loonfs.phase",
             phase = "scan_namespace_state"
         ))
         .await?;
@@ -301,7 +301,7 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
     let replayed = {
-        let _span = tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
+        let _span = tracing::info_span!("loonfs.phase", phase = "project_metadata_state").entered();
         project_validated_wal_tail(
             &manifest_head,
             &MetadataState::default(),

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -166,7 +166,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
         let Some(manifest_bytes) = store
             .get(&manifest_key, None)
             .instrument(tracing::info_span!(
-                "loon.phase",
+                "loonfs.phase",
                 phase = "load_namespace_manifest",
                 key_class = "manifest_table"
             ))
@@ -301,7 +301,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
     let Some(manifest_bytes) = store
         .get(manifest_key, None)
         .instrument(tracing::info_span!(
-            "loon.phase",
+            "loonfs.phase",
             phase = "load_namespace_manifest",
             key_class = "manifest_table"
         ))
@@ -331,7 +331,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "load_manifest_tables", key_class = "manifest_table")

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -27,7 +27,7 @@ pub(super) enum ManifestPublicationOutcome {
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "write_namespace_manifest", key_class = "manifest_table")
@@ -91,7 +91,7 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "publish_metadata_root", key_class = "metadata_root")

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -99,7 +99,7 @@ pub struct MetadataReorganizeReport {
 /// process restarts.
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "reorganize_metadata", key_class = "manifest")

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -323,7 +323,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         })?;
         let replayed = {
             let _span =
-                tracing::info_span!("loon.phase", phase = "project_metadata_state").entered();
+                tracing::info_span!("loonfs.phase", phase = "project_metadata_state").entered();
             project_validated_wal_tail(
                 &manifest_head,
                 &MetadataState::default(),
@@ -350,7 +350,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
 
     #[tracing::instrument(
         level = "info",
-        name = "loon.phase",
+        name = "loonfs.phase",
         err,
         skip_all,
         fields(phase = "walk_path")
@@ -519,7 +519,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
 
     #[tracing::instrument(
         level = "info",
-        name = "loon.phase",
+        name = "loonfs.phase",
         err,
         skip_all,
         fields(phase = "walk_path")
@@ -566,7 +566,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .as_ref()
             .map(|cursor| cursor.last_name_key.as_str());
         let select_span = tracing::info_span!(
-            "loon.phase",
+            "loonfs.phase",
             phase = "list_page_select_children",
             list_page_requested_limit = request.limit.as_usize() as u64,
             list_page_children_returned = tracing::field::Empty,
@@ -599,7 +599,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         };
 
         let build_span = tracing::info_span!(
-            "loon.phase",
+            "loonfs.phase",
             phase = "list_page_build_entries",
             list_page_children_returned = children.len() as u64,
             list_page_visible_child_calls = tracing::field::Empty,

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -119,7 +119,10 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 index,
                 &mut dedup,
             )
-            .instrument(tracing::info_span!("loon.phase", phase = "prepare_commit"))
+            .instrument(tracing::info_span!(
+                "loonfs.phase",
+                phase = "prepare_commit"
+            ))
             .await
             .unwrap_or_else(|error| CandidateAdmission::Settled(Err(error)));
             let candidate_request = match admission {
@@ -148,7 +151,7 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 continue;
             }
             let plan = {
-                let span = tracing::info_span!("loon.phase", phase = "build_commit_plan");
+                let span = tracing::info_span!("loonfs.phase", phase = "build_commit_plan");
                 match build_commit_plan_for_publish(&request, context.now_ms, &validation)
                     .instrument(span)
                     .await
@@ -161,8 +164,8 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 }
             };
             let prepared = {
-                let _span =
-                    tracing::info_span!("loon.phase", phase = "PreparedCommit::prepare").entered();
+                let _span = tracing::info_span!("loonfs.phase", phase = "PreparedCommit::prepare")
+                    .entered();
                 match PreparedCommit::prepare(
                     request,
                     plan.clone(),
@@ -179,12 +182,12 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
             };
             let materialized = {
                 let _span =
-                    tracing::info_span!("loon.phase", phase = "materialize_commit").entered();
+                    tracing::info_span!("loonfs.phase", phase = "materialize_commit").entered();
                 materialize_commit(prepared, context.now_ms)
             };
             let preview = {
                 let _span = tracing::info_span!(
-                    "loon.phase",
+                    "loonfs.phase",
                     phase = "wal_payload_from_materialized_commit"
                 )
                 .entered();
@@ -197,8 +200,9 @@ pub(crate) async fn publish_namespace_mutations_batch_against_publish_view<
                 }
             };
             {
-                let _span = tracing::info_span!("loon.phase", phase = "apply_committed_wal_record")
-                    .entered();
+                let _span =
+                    tracing::info_span!("loonfs.phase", phase = "apply_committed_wal_record")
+                        .entered();
                 session.apply_accepted_commit(&preview, &plan);
             }
             accepted.push((index, materialized));

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -253,7 +253,7 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "write_content_blob", key_class = "content_blob")

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -47,7 +47,7 @@ async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
 
 #[tracing::instrument(
     level = "info",
-    name = "loon.phase",
+    name = "loonfs.phase",
     err,
     skip_all,
     fields(phase = "load_validated_wal_chain", key_class = "wal_segment")

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -645,7 +645,7 @@ impl GrepService {
     /// `head_seq`.
     #[tracing::instrument(
         level = "info",
-        name = "loon.phase",
+        name = "loonfs.phase",
         err,
         skip_all,
         fields(phase = "grep")

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -566,7 +566,7 @@ pub(super) async fn filesystem_operation(
     };
     let response_result = if let Some(payload_class) = put_payload_class {
         let span = tracing::info_span!(
-            "loon.put",
+            "loonfs.put",
             operation = "put",
             mode = "remote",
             store_kind = TraceStoreKind::from(state.config.store.kind()).as_str(),

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -489,7 +489,7 @@ impl FsCore {
 
     #[tracing::instrument(
         level = "info",
-        name = "loon.phase",
+        name = "loonfs.phase",
         skip_all,
         fields(phase = "update_cache")
     )]

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -19,7 +19,7 @@ impl FsCore {
     /// error.
     #[tracing::instrument(
         level = "info",
-        name = "loon.compaction",
+        name = "loonfs.compaction",
         err,
         skip_all,
         fields(
@@ -299,7 +299,7 @@ impl FsCore {
     /// metadata.
     #[tracing::instrument(
         level = "info",
-        name = "loon.compaction",
+        name = "loonfs.compaction",
         err,
         skip_all,
         fields(
@@ -341,7 +341,7 @@ impl FsCore {
     /// checkpoint record.
     #[tracing::instrument(
         level = "info",
-        name = "loon.compaction",
+        name = "loonfs.compaction",
         err,
         skip_all,
         fields(

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -17,7 +17,7 @@ impl FsCore {
     /// head.
     #[tracing::instrument(
         level = "info",
-        name = "loon.stat",
+        name = "loonfs.stat",
         err,
         skip_all,
         fields(

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -17,7 +17,7 @@ impl FsCore {
     /// replace semantics.
     #[tracing::instrument(
         level = "info",
-        name = "loon.put",
+        name = "loonfs.put",
         err,
         skip_all,
         fields(
@@ -49,7 +49,7 @@ impl FsCore {
     /// unmoved head.
     #[tracing::instrument(
         level = "info",
-        name = "loon.prepare",
+        name = "loonfs.prepare",
         err,
         skip_all,
         fields(
@@ -88,7 +88,7 @@ impl FsCore {
     /// selects create-only or replace semantics.
     #[tracing::instrument(
         level = "info",
-        name = "loon.put",
+        name = "loonfs.put",
         err,
         skip_all,
         fields(
@@ -136,7 +136,7 @@ impl FsCore {
     /// [`Self::put_file_prepared`].
     #[tracing::instrument(
         level = "info",
-        name = "loon.put",
+        name = "loonfs.put",
         err,
         skip_all,
         fields(
@@ -173,7 +173,7 @@ impl FsCore {
     /// I/O.
     #[tracing::instrument(
         level = "info",
-        name = "loon.prepare",
+        name = "loonfs.prepare",
         err,
         skip_all,
         fields(
@@ -536,7 +536,7 @@ impl FsCore {
             };
             {
                 let _span = tracing::info_span!(
-                    "loon.phase",
+                    "loonfs.phase",
                     phase = "batch_update_cache",
                     mode = self.inner.config.trace_mode.as_str(),
                     store_kind = self.inner.config.trace_store_kind.as_str(),
@@ -590,7 +590,7 @@ impl FsCore {
             .collect();
         {
             let _span = tracing::info_span!(
-                "loon.phase",
+                "loonfs.phase",
                 phase = "batch_update_cache",
                 mode = self.inner.config.trace_mode.as_str(),
                 store_kind = self.inner.config.trace_store_kind.as_str(),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -688,7 +688,7 @@ impl NamespacePublisher {
         }
 
         let publish_span = tracing::info_span!(
-            "loon.phase",
+            "loonfs.phase",
             phase = "batch_publish",
             mode = self.trace_mode(),
             store_kind = self.trace_store_kind(),


### PR DESCRIPTION
Renames tracing span namespaces from `loon.*` to `loonfs.*` for consistent product naming. No runtime behavior changes.